### PR TITLE
Redefine Assert as AssertThrow in tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -127,6 +127,8 @@ IncludeCategories:
 # should not be caught here
   - Regex: "<[a-z_]+>"
     Priority: 100000
+  - Regex: "\\.\\./tests\\.h"
+    Priority: 200000
 
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash

--- a/.clang-format
+++ b/.clang-format
@@ -127,6 +127,8 @@ IncludeCategories:
 # should not be caught here
   - Regex: "<[a-z_]+>"
     Priority: 100000
+# make sure that "../tests.h" appears before all other local include files
+# such that replacing Assert in tests also applies to the testing header files.
   - Regex: "\\.\\./tests\\.h"
     Priority: 200000
 

--- a/tests/adolc/helper_scalar_coupled_2_components_01_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_01_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_02_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_02_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_02_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_02_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_03_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_03_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_03_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_03_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_04_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_04_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_04_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_04_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_05_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_05_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_05_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_05_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_06_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_06_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_06_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_06_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_07_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_07_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_07_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_07_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_08_1.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_08_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_2_components_08_2.cc
+++ b/tests/adolc/helper_scalar_coupled_2_components_08_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_coupled_3_components_01_1.cc
+++ b/tests/adolc/helper_scalar_coupled_3_components_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/helper_scalar_coupled_3_components_01_2.cc
+++ b/tests/adolc/helper_scalar_coupled_3_components_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/helper_scalar_coupled_3_components_01_tapeless_only_2.cc
+++ b/tests/adolc/helper_scalar_coupled_3_components_01_tapeless_only_2.cc
@@ -23,8 +23,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/helper_scalar_coupled_4_components_01_1.cc
+++ b/tests/adolc/helper_scalar_coupled_4_components_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/helper_scalar_coupled_4_components_01_2.cc
+++ b/tests/adolc/helper_scalar_coupled_4_components_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/helper_scalar_single_component_01_1.cc
+++ b/tests/adolc/helper_scalar_single_component_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_01_2.cc
+++ b/tests/adolc/helper_scalar_single_component_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_02_1.cc
+++ b/tests/adolc/helper_scalar_single_component_02_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_02_2.cc
+++ b/tests/adolc/helper_scalar_single_component_02_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_03_1.cc
+++ b/tests/adolc/helper_scalar_single_component_03_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_03_2.cc
+++ b/tests/adolc/helper_scalar_single_component_03_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_04_1.cc
+++ b/tests/adolc/helper_scalar_single_component_04_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/adolc/helper_scalar_single_component_04_2.cc
+++ b/tests/adolc/helper_scalar_single_component_04_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_1_indep_1_dep_vars_01_1.cc
+++ b/tests/adolc/helper_vector_1_indep_1_dep_vars_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_1_indep_1_dep_vars_01_2.cc
+++ b/tests/adolc/helper_vector_1_indep_1_dep_vars_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_1_indep_2_dep_vars_01_1.cc
+++ b/tests/adolc/helper_vector_1_indep_2_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_1_indep_2_dep_vars_01_2.cc
+++ b/tests/adolc/helper_vector_1_indep_2_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_2_indep_1_dep_vars_01_1.cc
+++ b/tests/adolc/helper_vector_2_indep_1_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_2_indep_1_dep_vars_01_2.cc
+++ b/tests/adolc/helper_vector_2_indep_1_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_2_indep_2_dep_vars_01_1.cc
+++ b/tests/adolc/helper_vector_2_indep_2_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/helper_vector_2_indep_2_dep_vars_01_2.cc
+++ b/tests/adolc/helper_vector_2_indep_2_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_01_1.cc
+++ b/tests/adolc/physics_functions_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_01_2.cc
+++ b/tests/adolc/physics_functions_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_02_1.cc
+++ b/tests/adolc/physics_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_02_2.cc
+++ b/tests/adolc/physics_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_03_1.cc
+++ b/tests/adolc/physics_functions_03_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/adolc/physics_functions_03_2.cc
+++ b/tests/adolc/physics_functions_03_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/adolc/step-44-helper_res_lin_01_1.cc
+++ b/tests/adolc/step-44-helper_res_lin_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/step-44-helper_res_lin_01_2.cc
+++ b/tests/adolc/step-44-helper_res_lin_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/step-44-helper_scalar_01_1.cc
+++ b/tests/adolc/step-44-helper_scalar_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/step-44-helper_scalar_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_scalar_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/step-44-helper_var_form_01_1.cc
+++ b/tests/adolc/step-44-helper_var_form_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/step-44-helper_var_form_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_var_form_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/step-44-helper_vector_01_1.cc
+++ b/tests/adolc/step-44-helper_vector_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/step-44-helper_vector_01_2.cc
+++ b/tests/adolc/step-44-helper_vector_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/adolc/symmetric_tensor_functions_01_1.cc
+++ b/tests/adolc/symmetric_tensor_functions_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_01_2.cc
+++ b/tests/adolc/symmetric_tensor_functions_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_02_1.cc
+++ b/tests/adolc/symmetric_tensor_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_02_2.cc
+++ b/tests/adolc/symmetric_tensor_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_03_1.cc
+++ b/tests/adolc/symmetric_tensor_functions_03_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_03_2.cc
+++ b/tests/adolc/symmetric_tensor_functions_03_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_04_1.cc
+++ b/tests/adolc/symmetric_tensor_functions_04_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/adolc/symmetric_tensor_functions_04_2.cc
+++ b/tests/adolc/symmetric_tensor_functions_04_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/adolc/tensor_functions_01_1.cc
+++ b/tests/adolc/tensor_functions_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/adolc/tensor_functions_01_2.cc
+++ b/tests/adolc/tensor_functions_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/adolc/tensor_functions_02_1.cc
+++ b/tests/adolc/tensor_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C taped
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/adolc/tensor_functions_02_2.cc
+++ b/tests/adolc/tensor_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: ADOL-C tapeless
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/aniso/mesh_3d_21.cc
+++ b/tests/aniso/mesh_3d_21.cc
@@ -35,8 +35,9 @@
 
 #include <deal.II/lac/vector.h>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 
 // declare these global in order to reduce time needed upon construction of

--- a/tests/base/derivative_forms_01.cc
+++ b/tests/base/derivative_forms_01.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/derivative_form.h>
 
 #include "../tests.h"
+
 #include "Sacado.hpp"
 
 // Compute the derivative of F: R^dim -> R^spacedim

--- a/tests/base/functions_01.cc
+++ b/tests/base/functions_01.cc
@@ -33,6 +33,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "functions.h"
 
 template <typename FunctionType, typename... Args>

--- a/tests/base/functions_04.cc
+++ b/tests/base/functions_04.cc
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "functions.h"
 
 template <int dim>

--- a/tests/base/functions_singularity.cc
+++ b/tests/base/functions_singularity.cc
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "functions.h"
 
 template <int dim>

--- a/tests/base/quadrature_simplex_01.cc
+++ b/tests/base/quadrature_simplex_01.cc
@@ -21,6 +21,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 template <int dim>

--- a/tests/base/quadrature_simplex_02.cc
+++ b/tests/base/quadrature_simplex_02.cc
@@ -22,6 +22,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 void

--- a/tests/base/quadrature_simplex_03.cc
+++ b/tests/base/quadrature_simplex_03.cc
@@ -22,6 +22,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 void

--- a/tests/base/quadrature_simplex_04.cc
+++ b/tests/base/quadrature_simplex_04.cc
@@ -22,6 +22,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 void

--- a/tests/base/quadrature_simplex_05.cc
+++ b/tests/base/quadrature_simplex_05.cc
@@ -22,6 +22,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 template <int dim, typename stream_type>

--- a/tests/base/simplex.h
+++ b/tests/base/simplex.h
@@ -23,6 +23,7 @@
 #include <numeric>
 
 #include "../tests.h"
+
 #include "simplex.h"
 
 

--- a/tests/bits/coarsening_3d.cc
+++ b/tests/bits/coarsening_3d.cc
@@ -24,8 +24,9 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 
 

--- a/tests/bits/deal_solver_04.cc
+++ b/tests/bits/deal_solver_04.cc
@@ -31,8 +31,9 @@
 
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/bits/deal_solver_05.cc
+++ b/tests/bits/deal_solver_05.cc
@@ -30,8 +30,9 @@
 
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/bits/face_interpolation.cc
+++ b/tests/bits/face_interpolation.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_02.cc
+++ b/tests/bits/fe_tools_02.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_03.cc
+++ b/tests/bits/fe_tools_03.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_04.cc
+++ b/tests/bits/fe_tools_04.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_04_overwrite.cc
+++ b/tests/bits/fe_tools_04_overwrite.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_05.cc
+++ b/tests/bits/fe_tools_05.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_06.cc
+++ b/tests/bits/fe_tools_06.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_06b.cc
+++ b/tests/bits/fe_tools_06b.cc
@@ -18,6 +18,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_06c.cc
+++ b/tests/bits/fe_tools_06c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_06d.cc
+++ b/tests/bits/fe_tools_06d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_07.cc
+++ b/tests/bits/fe_tools_07.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_08.cc
+++ b/tests/bits/fe_tools_08.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_09.cc
+++ b/tests/bits/fe_tools_09.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_10.cc
+++ b/tests/bits/fe_tools_10.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_11.cc
+++ b/tests/bits/fe_tools_11.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_12.cc
+++ b/tests/bits/fe_tools_12.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_14.cc
+++ b/tests/bits/fe_tools_14.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_cpfqpm_01.cc
+++ b/tests/bits/fe_tools_cpfqpm_01.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_cpfqpm_02.cc
+++ b/tests/bits/fe_tools_cpfqpm_02.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_cpfqpm_03.cc
+++ b/tests/bits/fe_tools_cpfqpm_03.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/fe_tools_cpfqpm_04.cc
+++ b/tests/bits/fe_tools_cpfqpm_04.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/quadrature_lib.h>
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/bits/find_cell_3.cc
+++ b/tests/bits/find_cell_3.cc
@@ -24,8 +24,9 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 
 

--- a/tests/bits/find_cell_alt_3.cc
+++ b/tests/bits/find_cell_alt_3.cc
@@ -26,8 +26,9 @@
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 
 

--- a/tests/bits/subface_interpolation.cc
+++ b/tests/bits/subface_interpolation.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_tools_common.h"
 
 // check

--- a/tests/cuda/matrix_free_matrix_vector_01.cu
+++ b/tests/cuda/matrix_free_matrix_vector_01.cu
@@ -21,6 +21,7 @@
 // constraints
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree, typename Number>

--- a/tests/cuda/matrix_free_matrix_vector_02.cu
+++ b/tests/cuda/matrix_free_matrix_vector_02.cu
@@ -21,6 +21,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree, typename Number>

--- a/tests/cuda/matrix_free_matrix_vector_03.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03.cu
@@ -23,6 +23,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree, typename Number>

--- a/tests/cuda/matrix_free_matrix_vector_03b.cu
+++ b/tests/cuda/matrix_free_matrix_vector_03b.cu
@@ -24,6 +24,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree, typename Number>

--- a/tests/cuda/matrix_free_matrix_vector_04.cu
+++ b/tests/cuda/matrix_free_matrix_vector_04.cu
@@ -20,6 +20,7 @@
 // type: 2)
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 

--- a/tests/cuda/matrix_free_matrix_vector_05.cu
+++ b/tests/cuda/matrix_free_matrix_vector_05.cu
@@ -21,6 +21,7 @@
 // type: 1 = linear).
 
 #include "../tests.h"
+
 #include "matrix_vector_common.h"
 
 

--- a/tests/cuda/matrix_free_matrix_vector_06.cu
+++ b/tests/cuda/matrix_free_matrix_vector_06.cu
@@ -24,6 +24,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 #include "matrix_vector_common.h"
 

--- a/tests/cuda/matrix_free_matrix_vector_06a.cu
+++ b/tests/cuda/matrix_free_matrix_vector_06a.cu
@@ -20,6 +20,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 #include "matrix_vector_common.h"
 

--- a/tests/cuda/matrix_free_matrix_vector_06b.cu
+++ b/tests/cuda/matrix_free_matrix_vector_06b.cu
@@ -19,6 +19,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 #include "matrix_vector_common.h"
 

--- a/tests/cuda/matrix_free_matrix_vector_09.cu
+++ b/tests/cuda/matrix_free_matrix_vector_09.cu
@@ -22,6 +22,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 #include "matrix_vector_common.h"
 

--- a/tests/cuda/matrix_free_matrix_vector_10.cu
+++ b/tests/cuda/matrix_free_matrix_vector_10.cu
@@ -45,6 +45,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/cuda/matrix_free_matrix_vector_10a.cu
+++ b/tests/cuda/matrix_free_matrix_vector_10a.cu
@@ -40,6 +40,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/cuda/matrix_free_matrix_vector_19.cu
+++ b/tests/cuda/matrix_free_matrix_vector_19.cu
@@ -41,6 +41,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/cuda/matrix_vector_common.h
+++ b/tests/cuda/matrix_vector_common.h
@@ -45,6 +45,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/cuda/precondition_01.cu
+++ b/tests/cuda/precondition_01.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_control.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename Number>
 void

--- a/tests/cuda/precondition_02.cu
+++ b/tests/cuda/precondition_02.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_control.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename Number>
 void

--- a/tests/cuda/precondition_03.cu
+++ b/tests/cuda/precondition_03.cu
@@ -46,6 +46,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/cuda/solver_01.cu
+++ b/tests/cuda/solver_01.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_02.cu
+++ b/tests/cuda/solver_02.cu
@@ -24,8 +24,9 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 void

--- a/tests/cuda/solver_03.cu
+++ b/tests/cuda/solver_03.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_04.cu
+++ b/tests/cuda/solver_04.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_control.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_05.cu
+++ b/tests/cuda/solver_05.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_06.cu
+++ b/tests/cuda/solver_06.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_fire.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_07.cu
+++ b/tests/cuda/solver_07.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_minres.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_08.cu
+++ b/tests/cuda/solver_08.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_qmrs.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 test(Utilities::CUDA::Handle &cuda_handle)

--- a/tests/cuda/solver_09.cu
+++ b/tests/cuda/solver_09.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_richardson.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename MatrixType>
 class PreconditionOperator

--- a/tests/cuda/solver_10.cu
+++ b/tests/cuda/solver_10.cu
@@ -25,8 +25,9 @@
 #include <deal.II/lac/solver_relaxation.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <typename MatrixType>

--- a/tests/cuda/sparse_matrix_01.cu
+++ b/tests/cuda/sparse_matrix_01.cu
@@ -22,8 +22,9 @@
 #include <deal.II/lac/read_write_vector.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 void

--- a/tests/cuda/sparse_matrix_02.cu
+++ b/tests/cuda/sparse_matrix_02.cu
@@ -20,8 +20,9 @@
 
 #include <deal.II/lac/cuda_sparse_matrix.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 void

--- a/tests/data_out/data_out_01.cc
+++ b/tests/data_out/data_out_01.cc
@@ -19,6 +19,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_02.cc
+++ b/tests/data_out/data_out_02.cc
@@ -22,6 +22,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_03.cc
+++ b/tests/data_out/data_out_03.cc
@@ -23,6 +23,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_04.cc
+++ b/tests/data_out/data_out_04.cc
@@ -26,6 +26,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_05.cc
+++ b/tests/data_out/data_out_05.cc
@@ -28,6 +28,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_06.cc
+++ b/tests/data_out/data_out_06.cc
@@ -21,6 +21,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_07.cc
+++ b/tests/data_out/data_out_07.cc
@@ -21,6 +21,7 @@
 #include <deal.II/numerics/data_out.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_base_dx.cc
+++ b/tests/data_out/data_out_base_dx.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube.

--- a/tests/data_out/data_out_base_eps.cc
+++ b/tests/data_out/data_out_base_eps.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_gmv.cc
+++ b/tests/data_out/data_out_base_gmv.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_gnuplot.cc
+++ b/tests/data_out/data_out_base_gnuplot.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_gnuplot_02.cc
+++ b/tests/data_out/data_out_base_gnuplot_02.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_gnuplot_labels.cc
+++ b/tests/data_out/data_out_base_gnuplot_labels.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_gnuplot_labels_02.cc
+++ b/tests/data_out/data_out_base_gnuplot_labels_02.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_povray.cc
+++ b/tests/data_out/data_out_base_povray.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_pvd.cc
+++ b/tests/data_out/data_out_base_pvd.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 

--- a/tests/data_out/data_out_base_pvtu.cc
+++ b/tests/data_out/data_out_base_pvtu.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 

--- a/tests/data_out/data_out_base_tecplot.cc
+++ b/tests/data_out/data_out_base_tecplot.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_tecplot_bin.cc
+++ b/tests/data_out/data_out_base_tecplot_bin.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtk.cc
+++ b/tests/data_out/data_out_base_vtk.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtk_02.cc
+++ b/tests/data_out/data_out_base_vtk_02.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtk_cycle.cc
+++ b/tests/data_out/data_out_base_vtk_cycle.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtk_time.cc
+++ b/tests/data_out/data_out_base_vtk_time.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtk_time_and_cycle.cc
+++ b/tests/data_out/data_out_base_vtk_time_and_cycle.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtu.cc
+++ b/tests/data_out/data_out_base_vtu.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtu_02.cc
+++ b/tests/data_out/data_out_base_vtu_02.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtu_compression_levels.cc
+++ b/tests/data_out/data_out_base_vtu_compression_levels.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Check that the compression levels supported by VtkFlags are valid (that is,

--- a/tests/data_out/data_out_base_vtu_cycle.cc
+++ b/tests/data_out/data_out_base_vtu_cycle.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtu_time.cc
+++ b/tests/data_out/data_out_base_vtu_time.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_base_vtu_time_and_cycle.cc
+++ b/tests/data_out/data_out_base_vtu_time_and_cycle.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // Output data on repetitions of the unit hypercube

--- a/tests/data_out/data_out_faces_01.cc
+++ b/tests/data_out/data_out_faces_01.cc
@@ -19,6 +19,7 @@
 #include <deal.II/numerics/data_out_faces.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_faces_02.cc
+++ b/tests/data_out/data_out_faces_02.cc
@@ -21,6 +21,7 @@
 #include <deal.II/numerics/data_out_faces.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_faces_03.cc
+++ b/tests/data_out/data_out_faces_03.cc
@@ -23,6 +23,7 @@
 #include <deal.II/numerics/data_out_faces.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_faces_04.cc
+++ b/tests/data_out/data_out_faces_04.cc
@@ -26,6 +26,7 @@
 #include <deal.II/numerics/data_out_faces.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_faces_05.cc
+++ b/tests/data_out/data_out_faces_05.cc
@@ -21,6 +21,7 @@
 #include <deal.II/numerics/data_out_faces.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_reader_01.cc
+++ b/tests/data_out/data_out_reader_01.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "patches.h"
 
 // test DataOutReader::merge

--- a/tests/data_out/data_out_rotation_01.cc
+++ b/tests/data_out/data_out_rotation_01.cc
@@ -19,6 +19,7 @@
 #include <deal.II/numerics/data_out_rotation.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_rotation_02.cc
+++ b/tests/data_out/data_out_rotation_02.cc
@@ -22,6 +22,7 @@
 #include <deal.II/numerics/data_out_rotation.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_rotation_03.cc
+++ b/tests/data_out/data_out_rotation_03.cc
@@ -23,6 +23,7 @@
 #include <deal.II/numerics/data_out_rotation.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_rotation_04.cc
+++ b/tests/data_out/data_out_rotation_04.cc
@@ -26,6 +26,7 @@
 #include <deal.II/numerics/data_out_rotation.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_rotation_05.cc
+++ b/tests/data_out/data_out_rotation_05.cc
@@ -21,6 +21,7 @@
 #include <deal.II/numerics/data_out_rotation.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_stack_01.cc
+++ b/tests/data_out/data_out_stack_01.cc
@@ -19,6 +19,7 @@
 #include <deal.II/numerics/data_out_stack.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/data_out/data_out_stack_02.cc
+++ b/tests/data_out/data_out_stack_02.cc
@@ -23,6 +23,7 @@
 #include <deal.II/numerics/data_out_stack.h>
 
 #include "../tests.h"
+
 #include "data_out_common.h"
 
 

--- a/tests/distributed_grids/2d_coarse_grid_01.cc
+++ b/tests/distributed_grids/2d_coarse_grid_01.cc
@@ -26,6 +26,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarse_grid_02.cc
+++ b/tests/distributed_grids/2d_coarse_grid_02.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarse_grid_03.cc
+++ b/tests/distributed_grids/2d_coarse_grid_03.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarse_grid_04.cc
+++ b/tests/distributed_grids/2d_coarse_grid_04.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarsening_01.cc
+++ b/tests/distributed_grids/2d_coarsening_01.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarsening_02.cc
+++ b/tests/distributed_grids/2d_coarsening_02.cc
@@ -43,6 +43,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarsening_03.cc
+++ b/tests/distributed_grids/2d_coarsening_03.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_coarsening_05.cc
+++ b/tests/distributed_grids/2d_coarsening_05.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_dofhandler_01.cc
+++ b/tests/distributed_grids/2d_dofhandler_01.cc
@@ -34,6 +34,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_01.cc
+++ b/tests/distributed_grids/2d_refinement_01.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_02.cc
+++ b/tests/distributed_grids/2d_refinement_02.cc
@@ -46,6 +46,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_03.cc
+++ b/tests/distributed_grids/2d_refinement_03.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_04.cc
+++ b/tests/distributed_grids/2d_refinement_04.cc
@@ -35,6 +35,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_05.cc
+++ b/tests/distributed_grids/2d_refinement_05.cc
@@ -35,6 +35,7 @@
 #include <ostream>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_06.cc
+++ b/tests/distributed_grids/2d_refinement_06.cc
@@ -31,6 +31,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/2d_refinement_07.cc
+++ b/tests/distributed_grids/2d_refinement_07.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_01.cc
+++ b/tests/distributed_grids/3d_coarse_grid_01.cc
@@ -26,6 +26,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_02.cc
+++ b/tests/distributed_grids/3d_coarse_grid_02.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_03.cc
+++ b/tests/distributed_grids/3d_coarse_grid_03.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_04.cc
+++ b/tests/distributed_grids/3d_coarse_grid_04.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_05.cc
+++ b/tests/distributed_grids/3d_coarse_grid_05.cc
@@ -32,6 +32,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarse_grid_06.cc
+++ b/tests/distributed_grids/3d_coarse_grid_06.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarsening_01.cc
+++ b/tests/distributed_grids/3d_coarsening_01.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarsening_02.cc
+++ b/tests/distributed_grids/3d_coarsening_02.cc
@@ -43,6 +43,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarsening_03.cc
+++ b/tests/distributed_grids/3d_coarsening_03.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarsening_04.cc
+++ b/tests/distributed_grids/3d_coarsening_04.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_coarsening_05.cc
+++ b/tests/distributed_grids/3d_coarsening_05.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_01.cc
+++ b/tests/distributed_grids/3d_refinement_01.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_02.cc
+++ b/tests/distributed_grids/3d_refinement_02.cc
@@ -46,6 +46,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_03.cc
+++ b/tests/distributed_grids/3d_refinement_03.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_04.cc
+++ b/tests/distributed_grids/3d_refinement_04.cc
@@ -35,6 +35,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_05.cc
+++ b/tests/distributed_grids/3d_refinement_05.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_06.cc
+++ b/tests/distributed_grids/3d_refinement_06.cc
@@ -34,6 +34,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_07.cc
+++ b/tests/distributed_grids/3d_refinement_07.cc
@@ -31,6 +31,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_08.cc
+++ b/tests/distributed_grids/3d_refinement_08.cc
@@ -30,6 +30,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/3d_refinement_09.cc
+++ b/tests/distributed_grids/3d_refinement_09.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/anisotropic.cc
+++ b/tests/distributed_grids/anisotropic.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/codim_01.cc
+++ b/tests/distributed_grids/codim_01.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/hp_2d_dofhandler_01.cc
+++ b/tests/distributed_grids/hp_2d_dofhandler_01.cc
@@ -41,6 +41,7 @@
 #include <fstream>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/solution_transfer_01.cc
+++ b/tests/distributed_grids/solution_transfer_01.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/solution_transfer_02.cc
+++ b/tests/distributed_grids/solution_transfer_02.cc
@@ -37,6 +37,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/solution_transfer_03.cc
+++ b/tests/distributed_grids/solution_transfer_03.cc
@@ -37,6 +37,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 template <int dim>

--- a/tests/distributed_grids/solution_transfer_04.cc
+++ b/tests/distributed_grids/solution_transfer_04.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/tria_settings_01.cc
+++ b/tests/distributed_grids/tria_settings_01.cc
@@ -32,6 +32,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/distributed_grids/update_number_cache_01.cc
+++ b/tests/distributed_grids/update_number_cache_01.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "coarse_grid_common.h"
 
 

--- a/tests/dofs/dof_tools_00a.cc
+++ b/tests/dofs/dof_tools_00a.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01a.cc
+++ b/tests/dofs/dof_tools_01a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01a_constraints_false.cc
+++ b/tests/dofs/dof_tools_01a_constraints_false.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01a_constraints_true.cc
+++ b/tests/dofs/dof_tools_01a_constraints_true.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01a_subdomain.cc
+++ b/tests/dofs/dof_tools_01a_subdomain.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01b.cc
+++ b/tests/dofs/dof_tools_01b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01c.cc
+++ b/tests/dofs/dof_tools_01c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_01d.cc
+++ b/tests/dofs/dof_tools_01d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02a.cc
+++ b/tests/dofs/dof_tools_02a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02a_constraints_false.cc
+++ b/tests/dofs/dof_tools_02a_constraints_false.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02a_constraints_true.cc
+++ b/tests/dofs/dof_tools_02a_constraints_true.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02a_subdomain.cc
+++ b/tests/dofs/dof_tools_02a_subdomain.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02b.cc
+++ b/tests/dofs/dof_tools_02b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02c.cc
+++ b/tests/dofs/dof_tools_02c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_02d.cc
+++ b/tests/dofs/dof_tools_02d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_03.cc
+++ b/tests/dofs/dof_tools_03.cc
@@ -18,6 +18,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_04.cc
+++ b/tests/dofs/dof_tools_04.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_05.cc
+++ b/tests/dofs/dof_tools_05.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_06.cc
+++ b/tests/dofs/dof_tools_06.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_07.cc
+++ b/tests/dofs/dof_tools_07.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_08.cc
+++ b/tests/dofs/dof_tools_08.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_09.cc
+++ b/tests/dofs/dof_tools_09.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_10.cc
+++ b/tests/dofs/dof_tools_10.cc
@@ -17,6 +17,7 @@
 #include <deal.II/fe/mapping_q.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_12.cc
+++ b/tests/dofs/dof_tools_12.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 //#include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_13.cc
+++ b/tests/dofs/dof_tools_13.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_13a.cc
+++ b/tests/dofs/dof_tools_13a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_14.cc
+++ b/tests/dofs/dof_tools_14.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_15a.cc
+++ b/tests/dofs/dof_tools_15a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_15b.cc
+++ b/tests/dofs/dof_tools_15b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_15c.cc
+++ b/tests/dofs/dof_tools_15c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_15d.cc
+++ b/tests/dofs/dof_tools_15d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_16a.cc
+++ b/tests/dofs/dof_tools_16a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_16b.cc
+++ b/tests/dofs/dof_tools_16b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_16c.cc
+++ b/tests/dofs/dof_tools_16c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_16d.cc
+++ b/tests/dofs/dof_tools_16d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_17a.cc
+++ b/tests/dofs/dof_tools_17a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_17b.cc
+++ b/tests/dofs/dof_tools_17b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_17c.cc
+++ b/tests/dofs/dof_tools_17c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_17d.cc
+++ b/tests/dofs/dof_tools_17d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_18a.cc
+++ b/tests/dofs/dof_tools_18a.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_18b.cc
+++ b/tests/dofs/dof_tools_18b.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_18c.cc
+++ b/tests/dofs/dof_tools_18c.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_18d.cc
+++ b/tests/dofs/dof_tools_18d.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/block_sparsity_pattern.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_19.cc
+++ b/tests/dofs/dof_tools_19.cc
@@ -25,6 +25,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_20.cc
+++ b/tests/dofs/dof_tools_20.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/dof_tools_21.cc
+++ b/tests/dofs/dof_tools_21.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 
 #include "../tests.h"
+
 #include "dof_tools_periodic.h"
 
 // A simple test for

--- a/tests/dofs/dof_tools_23.cc
+++ b/tests/dofs/dof_tools_23.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 
 #include "../tests.h"
+
 #include "dof_tools_periodic.h"
 
 // A simple test for

--- a/tests/dofs/hp_constraints_are_implemented.cc
+++ b/tests/dofs/hp_constraints_are_implemented.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/dofs/n_dofs_per_object.cc
+++ b/tests/dofs/n_dofs_per_object.cc
@@ -17,6 +17,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "dof_tools_common.h"
 #include "dof_tools_common_fake_hp.h"
 

--- a/tests/fail/rt_crash_01.cc
+++ b/tests/fail/rt_crash_01.cc
@@ -25,8 +25,9 @@
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/vector_tools.h>
 
-#include "../bits/dof_tools_common.h"
 #include "../tests.h"
+
+#include "../bits/dof_tools_common.h"
 
 // check an abort in FEPolyTensor when used with RaviartThomas
 // elements, when computing some sort of edge directions. This is the

--- a/tests/fail/scalapack_15_b.cc
+++ b/tests/fail/scalapack_15_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned
 // int> &, const bool) for the largest eigenvalues with eigenvectors

--- a/tests/fe/fe_prolongation_bdm.cc
+++ b/tests/fe/fe_prolongation_bdm.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_dgp.cc
+++ b/tests/fe/fe_prolongation_dgp.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_dgq.cc
+++ b/tests/fe/fe_prolongation_dgq.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_nedelec.cc
+++ b/tests/fe/fe_prolongation_nedelec.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_q.cc
+++ b/tests/fe/fe_prolongation_q.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_q_bubbles.cc
+++ b/tests/fe/fe_prolongation_q_bubbles.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_q_dg0.cc
+++ b/tests/fe/fe_prolongation_q_dg0.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_q_hierarchical.cc
+++ b/tests/fe/fe_prolongation_q_hierarchical.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_q_iso_q1.cc
+++ b/tests/fe/fe_prolongation_q_iso_q1.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_rt.cc
+++ b/tests/fe/fe_prolongation_rt.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_01.cc
+++ b/tests/fe/fe_prolongation_sys_01.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_02.cc
+++ b/tests/fe/fe_prolongation_sys_02.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_03.cc
+++ b/tests/fe/fe_prolongation_sys_03.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_04.cc
+++ b/tests/fe/fe_prolongation_sys_04.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_05.cc
+++ b/tests/fe/fe_prolongation_sys_05.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_06.cc
+++ b/tests/fe/fe_prolongation_sys_06.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_07.cc
+++ b/tests/fe/fe_prolongation_sys_07.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_08.cc
+++ b/tests/fe/fe_prolongation_sys_08.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_09.cc
+++ b/tests/fe/fe_prolongation_sys_09.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_prolongation_sys_10.cc
+++ b/tests/fe/fe_prolongation_sys_10.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_prolongation_common.h"
 
 

--- a/tests/fe/fe_restriction_bdm.cc
+++ b/tests/fe/fe_restriction_bdm.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_dgp.cc
+++ b/tests/fe/fe_restriction_dgp.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_dgq.cc
+++ b/tests/fe/fe_restriction_dgq.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_nedelec.cc
+++ b/tests/fe/fe_restriction_nedelec.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_q.cc
+++ b/tests/fe/fe_restriction_q.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_q_bubbles.cc
+++ b/tests/fe/fe_restriction_q_bubbles.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_q_dg0.cc
+++ b/tests/fe/fe_restriction_q_dg0.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_q_hierarchical.cc
+++ b/tests/fe/fe_restriction_q_hierarchical.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_q_iso_q1.cc
+++ b/tests/fe/fe_restriction_q_iso_q1.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_rt.cc
+++ b/tests/fe/fe_restriction_rt.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_01.cc
+++ b/tests/fe/fe_restriction_sys_01.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_02.cc
+++ b/tests/fe/fe_restriction_sys_02.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_03.cc
+++ b/tests/fe/fe_restriction_sys_03.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_04.cc
+++ b/tests/fe/fe_restriction_sys_04.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_05.cc
+++ b/tests/fe/fe_restriction_sys_05.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_06.cc
+++ b/tests/fe/fe_restriction_sys_06.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_07.cc
+++ b/tests/fe/fe_restriction_sys_07.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_08.cc
+++ b/tests/fe/fe_restriction_sys_08.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_09.cc
+++ b/tests/fe/fe_restriction_sys_09.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_restriction_sys_10.cc
+++ b/tests/fe/fe_restriction_sys_10.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_restriction_common.h"
 
 

--- a/tests/fe/fe_support_points_bdm.cc
+++ b/tests/fe/fe_support_points_bdm.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_nedelec.cc
+++ b/tests/fe/fe_support_points_nedelec.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_q.cc
+++ b/tests/fe/fe_support_points_q.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_q_bubbles.cc
+++ b/tests/fe/fe_support_points_q_bubbles.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_q_dg0.cc
+++ b/tests/fe/fe_support_points_q_dg0.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_q_hierarchical.cc
+++ b/tests/fe/fe_support_points_q_hierarchical.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_q_iso_q1.cc
+++ b/tests/fe/fe_support_points_q_iso_q1.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_rt.cc
+++ b/tests/fe/fe_support_points_rt.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_01.cc
+++ b/tests/fe/fe_support_points_sys_01.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_02.cc
+++ b/tests/fe/fe_support_points_sys_02.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_03.cc
+++ b/tests/fe/fe_support_points_sys_03.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_04.cc
+++ b/tests/fe/fe_support_points_sys_04.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_05.cc
+++ b/tests/fe/fe_support_points_sys_05.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_06.cc
+++ b/tests/fe/fe_support_points_sys_06.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_07.cc
+++ b/tests/fe/fe_support_points_sys_07.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_08.cc
+++ b/tests/fe/fe_support_points_sys_08.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_09.cc
+++ b/tests/fe/fe_support_points_sys_09.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/fe_support_points_sys_10.cc
+++ b/tests/fe/fe_support_points_sys_10.cc
@@ -15,6 +15,7 @@
 
 
 #include "../tests.h"
+
 #include "fe_support_points_common.h"
 
 

--- a/tests/fe/nedelec_crash_01.cc
+++ b/tests/fe/nedelec_crash_01.cc
@@ -22,8 +22,9 @@
 
 #include <deal.II/fe/fe_nedelec.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 
 int

--- a/tests/fe/shapes_bernstein.cc
+++ b/tests/fe/shapes_bernstein.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 //#include "../../include/fe_bernstein.h"
 

--- a/tests/fe/shapes_dgp.cc
+++ b/tests/fe/shapes_dgp.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_dgp_monomial.cc
+++ b/tests/fe/shapes_dgp_monomial.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_dgp_nonparametric.cc
+++ b/tests/fe/shapes_dgp_nonparametric.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_dgq.cc
+++ b/tests/fe/shapes_dgq.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_faceq.cc
+++ b/tests/fe/shapes_faceq.cc
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_nedelec.cc
+++ b/tests/fe/shapes_nedelec.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_q.cc
+++ b/tests/fe/shapes_q.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_q_bubbles.cc
+++ b/tests/fe/shapes_q_bubbles.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 7

--- a/tests/fe/shapes_q_dg0.cc
+++ b/tests/fe/shapes_q_dg0.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_q_hierarchical.cc
+++ b/tests/fe/shapes_q_hierarchical.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_q_iso_q1.cc
+++ b/tests/fe/shapes_q_iso_q1.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_system.cc
+++ b/tests/fe/shapes_system.cc
@@ -24,6 +24,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_system_02.cc
+++ b/tests/fe/shapes_system_02.cc
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/fe/shapes_traceq.cc
+++ b/tests/fe/shapes_traceq.cc
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "../tests.h"
+
 #include "shapes.h"
 
 #define PRECISION 8

--- a/tests/full_matrix/complex_complex_full_matrix_01.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_01.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_02.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_02.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_03.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_03.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_04.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_04.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_06.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_06.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_07.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_07.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_08.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_08.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_10.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_10.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_11.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_11.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_12.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_12.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_13.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_13.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_14.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_14.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_15.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_15.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_16.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_16.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_17.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_17.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_18.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_18.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_19.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_19.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_20.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_20.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_21.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_21.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_22.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_22.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_23.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_23.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_24.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_24.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_25.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_25.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_26.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_26.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_27.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_27.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_28.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_28.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_29.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_29.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_30.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_30.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_31.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_31.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_32.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_32.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_33.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_33.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_34.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_34.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_36.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_36.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_37.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_37.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_38.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_38.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_39.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_39.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_40.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_40.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_41.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_41.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_42.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_42.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_43.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_43.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_44.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_44.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_45.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_45.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_46.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_46.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_47.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_47.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_48.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_48.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_49.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_49.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_50.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_50.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_51.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_51.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_complex_full_matrix_52.cc
+++ b/tests/full_matrix/complex_complex_full_matrix_52.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_01.cc
+++ b/tests/full_matrix/complex_real_full_matrix_01.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_02.cc
+++ b/tests/full_matrix/complex_real_full_matrix_02.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_03.cc
+++ b/tests/full_matrix/complex_real_full_matrix_03.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_04.cc
+++ b/tests/full_matrix/complex_real_full_matrix_04.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_05.cc
+++ b/tests/full_matrix/complex_real_full_matrix_05.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_06.cc
+++ b/tests/full_matrix/complex_real_full_matrix_06.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_07.cc
+++ b/tests/full_matrix/complex_real_full_matrix_07.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_08.cc
+++ b/tests/full_matrix/complex_real_full_matrix_08.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_09.cc
+++ b/tests/full_matrix/complex_real_full_matrix_09.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_10.cc
+++ b/tests/full_matrix/complex_real_full_matrix_10.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_11.cc
+++ b/tests/full_matrix/complex_real_full_matrix_11.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_12.cc
+++ b/tests/full_matrix/complex_real_full_matrix_12.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_13.cc
+++ b/tests/full_matrix/complex_real_full_matrix_13.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_14.cc
+++ b/tests/full_matrix/complex_real_full_matrix_14.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_15.cc
+++ b/tests/full_matrix/complex_real_full_matrix_15.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_16.cc
+++ b/tests/full_matrix/complex_real_full_matrix_16.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_17.cc
+++ b/tests/full_matrix/complex_real_full_matrix_17.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_18.cc
+++ b/tests/full_matrix/complex_real_full_matrix_18.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_19.cc
+++ b/tests/full_matrix/complex_real_full_matrix_19.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_20.cc
+++ b/tests/full_matrix/complex_real_full_matrix_20.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_21.cc
+++ b/tests/full_matrix/complex_real_full_matrix_21.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_22.cc
+++ b/tests/full_matrix/complex_real_full_matrix_22.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_23.cc
+++ b/tests/full_matrix/complex_real_full_matrix_23.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_24.cc
+++ b/tests/full_matrix/complex_real_full_matrix_24.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_25.cc
+++ b/tests/full_matrix/complex_real_full_matrix_25.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_26.cc
+++ b/tests/full_matrix/complex_real_full_matrix_26.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_27.cc
+++ b/tests/full_matrix/complex_real_full_matrix_27.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_28.cc
+++ b/tests/full_matrix/complex_real_full_matrix_28.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_29.cc
+++ b/tests/full_matrix/complex_real_full_matrix_29.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_30.cc
+++ b/tests/full_matrix/complex_real_full_matrix_30.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_31.cc
+++ b/tests/full_matrix/complex_real_full_matrix_31.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_32.cc
+++ b/tests/full_matrix/complex_real_full_matrix_32.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_33.cc
+++ b/tests/full_matrix/complex_real_full_matrix_33.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_34.cc
+++ b/tests/full_matrix/complex_real_full_matrix_34.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_36.cc
+++ b/tests/full_matrix/complex_real_full_matrix_36.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_37.cc
+++ b/tests/full_matrix/complex_real_full_matrix_37.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_38.cc
+++ b/tests/full_matrix/complex_real_full_matrix_38.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_39.cc
+++ b/tests/full_matrix/complex_real_full_matrix_39.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_40.cc
+++ b/tests/full_matrix/complex_real_full_matrix_40.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_41.cc
+++ b/tests/full_matrix/complex_real_full_matrix_41.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_42.cc
+++ b/tests/full_matrix/complex_real_full_matrix_42.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_43.cc
+++ b/tests/full_matrix/complex_real_full_matrix_43.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_44.cc
+++ b/tests/full_matrix/complex_real_full_matrix_44.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_45.cc
+++ b/tests/full_matrix/complex_real_full_matrix_45.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_46.cc
+++ b/tests/full_matrix/complex_real_full_matrix_46.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_47.cc
+++ b/tests/full_matrix/complex_real_full_matrix_47.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_48.cc
+++ b/tests/full_matrix/complex_real_full_matrix_48.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_49.cc
+++ b/tests/full_matrix/complex_real_full_matrix_49.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_50.cc
+++ b/tests/full_matrix/complex_real_full_matrix_50.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_51.cc
+++ b/tests/full_matrix/complex_real_full_matrix_51.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/complex_real_full_matrix_52.cc
+++ b/tests/full_matrix/complex_real_full_matrix_52.cc
@@ -21,6 +21,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_01.cc
+++ b/tests/full_matrix/full_matrix_01.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_12.cc
+++ b/tests/full_matrix/full_matrix_12.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_13.cc
+++ b/tests/full_matrix/full_matrix_13.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_14.cc
+++ b/tests/full_matrix/full_matrix_14.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_15.cc
+++ b/tests/full_matrix/full_matrix_15.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_16.cc
+++ b/tests/full_matrix/full_matrix_16.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_17.cc
+++ b/tests/full_matrix/full_matrix_17.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_18.cc
+++ b/tests/full_matrix/full_matrix_18.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_19.cc
+++ b/tests/full_matrix/full_matrix_19.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_20.cc
+++ b/tests/full_matrix/full_matrix_20.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_21.cc
+++ b/tests/full_matrix/full_matrix_21.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_22.cc
+++ b/tests/full_matrix/full_matrix_22.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_23.cc
+++ b/tests/full_matrix/full_matrix_23.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_24.cc
+++ b/tests/full_matrix/full_matrix_24.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_25.cc
+++ b/tests/full_matrix/full_matrix_25.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_26.cc
+++ b/tests/full_matrix/full_matrix_26.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_27.cc
+++ b/tests/full_matrix/full_matrix_27.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_28.cc
+++ b/tests/full_matrix/full_matrix_28.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_29.cc
+++ b/tests/full_matrix/full_matrix_29.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_30.cc
+++ b/tests/full_matrix/full_matrix_30.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_31.cc
+++ b/tests/full_matrix/full_matrix_31.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_32.cc
+++ b/tests/full_matrix/full_matrix_32.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_33.cc
+++ b/tests/full_matrix/full_matrix_33.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_34.cc
+++ b/tests/full_matrix/full_matrix_34.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_36.cc
+++ b/tests/full_matrix/full_matrix_36.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_37.cc
+++ b/tests/full_matrix/full_matrix_37.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_38.cc
+++ b/tests/full_matrix/full_matrix_38.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_39.cc
+++ b/tests/full_matrix/full_matrix_39.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_40.cc
+++ b/tests/full_matrix/full_matrix_40.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_41.cc
+++ b/tests/full_matrix/full_matrix_41.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_42.cc
+++ b/tests/full_matrix/full_matrix_42.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_43.cc
+++ b/tests/full_matrix/full_matrix_43.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_44.cc
+++ b/tests/full_matrix/full_matrix_44.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_45.cc
+++ b/tests/full_matrix/full_matrix_45.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_46.cc
+++ b/tests/full_matrix/full_matrix_46.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_47.cc
+++ b/tests/full_matrix/full_matrix_47.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_48.cc
+++ b/tests/full_matrix/full_matrix_48.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_49.cc
+++ b/tests/full_matrix/full_matrix_49.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_50.cc
+++ b/tests/full_matrix/full_matrix_50.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_51.cc
+++ b/tests/full_matrix/full_matrix_51.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_52.cc
+++ b/tests/full_matrix/full_matrix_52.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_53.cc
+++ b/tests/full_matrix/full_matrix_53.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_54.cc
+++ b/tests/full_matrix/full_matrix_54.cc
@@ -20,6 +20,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_55.cc
+++ b/tests/full_matrix/full_matrix_55.cc
@@ -20,6 +20,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_56.cc
+++ b/tests/full_matrix/full_matrix_56.cc
@@ -18,6 +18,7 @@
 // check FullMatrix::cholesky for correct functionality
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_57.cc
+++ b/tests/full_matrix/full_matrix_57.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_59.cc
+++ b/tests/full_matrix/full_matrix_59.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_60.cc
+++ b/tests/full_matrix/full_matrix_60.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_61.cc
+++ b/tests/full_matrix/full_matrix_61.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_62.cc
+++ b/tests/full_matrix/full_matrix_62.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_63.cc
+++ b/tests/full_matrix/full_matrix_63.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_64.cc
+++ b/tests/full_matrix/full_matrix_64.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_65.cc
+++ b/tests/full_matrix/full_matrix_65.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_66.cc
+++ b/tests/full_matrix/full_matrix_66.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_67.cc
+++ b/tests/full_matrix/full_matrix_67.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_68.cc
+++ b/tests/full_matrix/full_matrix_68.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_determinant_01.cc
+++ b/tests/full_matrix/full_matrix_determinant_01.cc
@@ -20,6 +20,7 @@
 #include <sstream>
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/full_matrix/full_matrix_invert_01.cc
+++ b/tests/full_matrix/full_matrix_invert_01.cc
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include "../tests.h"
+
 #include "full_matrix_common.h"
 
 

--- a/tests/ginkgo/solver.cc
+++ b/tests/ginkgo/solver.cc
@@ -23,8 +23,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/gla/block_mat_01.cc
+++ b/tests/gla/block_mat_01.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA, int dim>

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -49,6 +49,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA, int dim>

--- a/tests/gla/block_vec_01.cc
+++ b/tests/gla/block_vec_01.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/block_vec_02.cc
+++ b/tests/gla/block_vec_02.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/block_vec_03.cc
+++ b/tests/gla/block_vec_03.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/block_vec_04.cc
+++ b/tests/gla/block_vec_04.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/mat_01.cc
+++ b/tests/gla/mat_01.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/mat_02.cc
+++ b/tests/gla/mat_02.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/mat_03.cc
+++ b/tests/gla/mat_03.cc
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA, int dim>

--- a/tests/gla/mat_04.cc
+++ b/tests/gla/mat_04.cc
@@ -40,6 +40,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA, int dim>

--- a/tests/gla/mat_05.cc
+++ b/tests/gla/mat_05.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/mat_06.cc
+++ b/tests/gla/mat_06.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_00.cc
+++ b/tests/gla/vec_00.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_01.cc
+++ b/tests/gla/vec_01.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_02.cc
+++ b/tests/gla/vec_02.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_03.cc
+++ b/tests/gla/vec_03.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_04.cc
+++ b/tests/gla/vec_04.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_05.cc
+++ b/tests/gla/vec_05.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_06.cc
+++ b/tests/gla/vec_06.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_07.cc
+++ b/tests/gla/vec_07.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/gla/vec_all_zero_01.cc
+++ b/tests/gla/vec_all_zero_01.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "../tests.h"
+
 #include "gla.h"
 
 template <class LA>

--- a/tests/grid/mesh_3d_1.cc
+++ b/tests/grid/mesh_3d_1.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_10.cc
+++ b/tests/grid/mesh_3d_10.cc
@@ -37,6 +37,7 @@
 #include <set>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 void check_this(Triangulation<3> &tria)

--- a/tests/grid/mesh_3d_11.cc
+++ b/tests/grid/mesh_3d_11.cc
@@ -38,6 +38,7 @@
 #include <set>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 void check_this(Triangulation<3> &tria)

--- a/tests/grid/mesh_3d_12.cc
+++ b/tests/grid/mesh_3d_12.cc
@@ -40,6 +40,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_13.cc
+++ b/tests/grid/mesh_3d_13.cc
@@ -33,6 +33,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_14.cc
+++ b/tests/grid/mesh_3d_14.cc
@@ -36,6 +36,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_15.cc
+++ b/tests/grid/mesh_3d_15.cc
@@ -36,6 +36,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_16.cc
+++ b/tests/grid/mesh_3d_16.cc
@@ -34,6 +34,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_2.cc
+++ b/tests/grid/mesh_3d_2.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_20.cc
+++ b/tests/grid/mesh_3d_20.cc
@@ -35,8 +35,9 @@
 
 #include <deal.II/numerics/data_out.h>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 
 void check_this(Triangulation<3> &tria)

--- a/tests/grid/mesh_3d_21.cc
+++ b/tests/grid/mesh_3d_21.cc
@@ -33,6 +33,7 @@
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_25.cc
+++ b/tests/grid/mesh_3d_25.cc
@@ -41,8 +41,9 @@
 
 #include <vector>
 
-#include "../grid/mesh_3d.h"
 #include "../tests.h"
+
+#include "../grid/mesh_3d.h"
 
 using namespace dealii;
 using namespace std;

--- a/tests/grid/mesh_3d_3.cc
+++ b/tests/grid/mesh_3d_3.cc
@@ -28,6 +28,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_4.cc
+++ b/tests/grid/mesh_3d_4.cc
@@ -25,6 +25,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_5.cc
+++ b/tests/grid/mesh_3d_5.cc
@@ -25,6 +25,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_6.cc
+++ b/tests/grid/mesh_3d_6.cc
@@ -33,6 +33,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_7.cc
+++ b/tests/grid/mesh_3d_7.cc
@@ -32,6 +32,7 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 

--- a/tests/grid/mesh_3d_8.cc
+++ b/tests/grid/mesh_3d_8.cc
@@ -36,6 +36,7 @@
 #include <set>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 void check_this(Triangulation<3> &tria)

--- a/tests/grid/mesh_3d_9.cc
+++ b/tests/grid/mesh_3d_9.cc
@@ -37,6 +37,7 @@
 #include <set>
 
 #include "../tests.h"
+
 #include "mesh_3d.h"
 
 void check_this(Triangulation<3> &tria)

--- a/tests/integrators/advection_01.cc
+++ b/tests/integrators/advection_01.cc
@@ -24,8 +24,9 @@
 #include <deal.II/integrators/advection.h>
 #include <deal.II/integrators/laplace.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Advection;
 

--- a/tests/integrators/cells_and_faces_01.cc
+++ b/tests/integrators/cells_and_faces_01.cc
@@ -30,6 +30,7 @@
 #include <functional>
 
 #include "../tests.h"
+
 #include "empty_info.h"
 
 using namespace dealii;

--- a/tests/integrators/cochain_01.cc
+++ b/tests/integrators/cochain_01.cc
@@ -47,8 +47,9 @@
 #include <deal.II/meshworker/integration_info.h>
 #include <deal.II/meshworker/loop.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators;
 

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -25,8 +25,9 @@
 
 #include <deal.II/integrators/divergence.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Divergence;
 

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -25,8 +25,9 @@
 
 #include <deal.II/integrators/elasticity.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Elasticity;
 

--- a/tests/integrators/elasticity_02.cc
+++ b/tests/integrators/elasticity_02.cc
@@ -25,8 +25,9 @@
 
 #include <deal.II/integrators/elasticity.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Elasticity;
 

--- a/tests/integrators/functional_01.cc
+++ b/tests/integrators/functional_01.cc
@@ -28,6 +28,7 @@
 #include <functional>
 
 #include "../tests.h"
+
 #include "empty_info.h"
 
 using namespace dealii;

--- a/tests/integrators/grad_div_01.cc
+++ b/tests/integrators/grad_div_01.cc
@@ -25,8 +25,9 @@
 
 #include <deal.II/integrators/grad_div.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::GradDiv;
 

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -23,8 +23,9 @@
 
 #include <deal.II/integrators/laplace.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Laplace;
 

--- a/tests/integrators/laplacian_02.cc
+++ b/tests/integrators/laplacian_02.cc
@@ -26,8 +26,9 @@
 
 #include <deal.II/integrators/laplace.h>
 
-#include "../test_grids.h"
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 using namespace LocalIntegrators::Laplace;
 

--- a/tests/lac/bicgstab_early.cc
+++ b/tests/lac/bicgstab_early.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/lac/bicgstab_large.cc
+++ b/tests/lac/bicgstab_large.cc
@@ -21,8 +21,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/lac/eigen.cc
+++ b/tests/lac/eigen.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main()

--- a/tests/lac/linear_operator_15.cc
+++ b/tests/lac/linear_operator_15.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 using namespace dealii;
 

--- a/tests/lac/linear_operator_16.cc
+++ b/tests/lac/linear_operator_16.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 using namespace dealii;
 

--- a/tests/lac/precondition_chebyshev_03.cc
+++ b/tests/lac/precondition_chebyshev_03.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 

--- a/tests/lac/precondition_chebyshev_05.cc
+++ b/tests/lac/precondition_chebyshev_05.cc
@@ -25,8 +25,9 @@
 #include <deal.II/lac/trilinos_vector.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 

--- a/tests/lac/solver.cc
+++ b/tests/lac/solver.cc
@@ -28,8 +28,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/lac/solver_02.cc
+++ b/tests/lac/solver_02.cc
@@ -28,8 +28,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType>
 void

--- a/tests/lac/solver_control_01.cc
+++ b/tests/lac/solver_control_01.cc
@@ -30,8 +30,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename MatrixType, typename VectorType, class PRECONDITION>
 void

--- a/tests/lac/solver_control_02.cc
+++ b/tests/lac/solver_control_02.cc
@@ -30,8 +30,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename MatrixType, typename VectorType, class PRECONDITION>
 void

--- a/tests/lac/solver_control_03.cc
+++ b/tests/lac/solver_control_03.cc
@@ -30,8 +30,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename MatrixType, typename VectorType, class PRECONDITION>
 void

--- a/tests/lac/solver_control_04.cc
+++ b/tests/lac/solver_control_04.cc
@@ -30,8 +30,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename MatrixType, typename VectorType, class PRECONDITION>
 void

--- a/tests/lac/solver_memorytest.cc
+++ b/tests/lac/solver_memorytest.cc
@@ -33,8 +33,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType, typename MatrixType, typename VectorType>
 void

--- a/tests/lac/solver_monitor.cc
+++ b/tests/lac/solver_monitor.cc
@@ -29,8 +29,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 SolverControl::State

--- a/tests/lac/solver_monitor_disconnect.cc
+++ b/tests/lac/solver_monitor_disconnect.cc
@@ -30,8 +30,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 SolverControl::State

--- a/tests/lac/solver_relaxation_01.cc
+++ b/tests/lac/solver_relaxation_01.cc
@@ -25,8 +25,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/lac/solver_relaxation_02.cc
+++ b/tests/lac/solver_relaxation_02.cc
@@ -26,8 +26,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/lac/solver_relaxation_03.cc
+++ b/tests/lac/solver_relaxation_03.cc
@@ -27,8 +27,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <typename SolverType,
           typename MatrixType,

--- a/tests/lac/solver_relaxation_04.cc
+++ b/tests/lac/solver_relaxation_04.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <typename SolverType,

--- a/tests/lac/solver_selector_01.cc
+++ b/tests/lac/solver_selector_01.cc
@@ -21,8 +21,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <typename MatrixType, typename VectorType>

--- a/tests/lac/solver_selector_02.cc
+++ b/tests/lac/solver_selector_02.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 class MySolverControl : public SolverControl

--- a/tests/lac/solver_selector_03.cc
+++ b/tests/lac/solver_selector_03.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_memory.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <typename MatrixType, typename VectorType>

--- a/tests/lac/solver_signals.cc
+++ b/tests/lac/solver_signals.cc
@@ -29,8 +29,9 @@
 #include <complex>
 #include <string>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 void

--- a/tests/lac/sparse_ilu.cc
+++ b/tests/lac/sparse_ilu.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 // TODO:[WB] find test that is less sensitive to floating point accuracy
 

--- a/tests/lac/sparse_ilu_inverse.cc
+++ b/tests/lac/sparse_ilu_inverse.cc
@@ -23,8 +23,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/lac/sparse_ilu_t.cc
+++ b/tests/lac/sparse_ilu_t.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 // TODO:[WB] find test that is less sensitive to floating point accuracy
 

--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -27,8 +27,9 @@
 #include <deal.II/lac/sparse_matrix_ez.templates.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 

--- a/tests/lac/sparse_matrix_move.cc
+++ b/tests/lac/sparse_matrix_move.cc
@@ -17,8 +17,9 @@
 
 #include <deal.II/lac/sparse_matrix.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 void

--- a/tests/lac/sparse_mic.cc
+++ b/tests/lac/sparse_mic.cc
@@ -22,8 +22,9 @@
 #include <deal.II/lac/sparse_mic.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 // TODO:[WB] find test that is less sensitive to floating point accuracy
 

--- a/tests/lac/tensor_product_matrix_01.cc
+++ b/tests/lac/tensor_product_matrix_01.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim>

--- a/tests/lac/tensor_product_matrix_02.cc
+++ b/tests/lac/tensor_product_matrix_02.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim, int size>

--- a/tests/lac/tensor_product_matrix_03.cc
+++ b/tests/lac/tensor_product_matrix_03.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim, int size>

--- a/tests/lac/tensor_product_matrix_04.cc
+++ b/tests/lac/tensor_product_matrix_04.cc
@@ -21,8 +21,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim>

--- a/tests/lac/tensor_product_matrix_05.cc
+++ b/tests/lac/tensor_product_matrix_05.cc
@@ -21,8 +21,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim, int size>

--- a/tests/lac/tensor_product_matrix_06.cc
+++ b/tests/lac/tensor_product_matrix_06.cc
@@ -21,8 +21,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 template <int dim, int size>

--- a/tests/lac/tensor_product_matrix_vectorized_01.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_01.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <int dim>
 void

--- a/tests/lac/tensor_product_matrix_vectorized_02.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_02.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <int dim, int size>
 void

--- a/tests/lac/tensor_product_matrix_vectorized_03.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_03.cc
@@ -24,8 +24,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <int dim, int size>
 void

--- a/tests/lac/tensor_product_matrix_vectorized_04.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_04.cc
@@ -25,8 +25,9 @@
 #include <deal.II/lac/tensor_product_matrix.h>
 #include <deal.II/lac/vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <int dim>
 void

--- a/tests/lac/utilities_01.cc
+++ b/tests/lac/utilities_01.cc
@@ -29,9 +29,10 @@
 #include <iostream>
 #include <typeinfo>
 
+#include "../tests.h"
+
 #include "../slepc/testmatrix.h"
 #include "../testmatrix.h"
-#include "../tests.h"
 
 int
 main(int argc, char **argv)

--- a/tests/lapack/full_matrix_15.cc
+++ b/tests/lapack/full_matrix_15.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_16.cc
+++ b/tests/lapack/full_matrix_16.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_17.cc
+++ b/tests/lapack/full_matrix_17.cc
@@ -24,6 +24,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_18.cc
+++ b/tests/lapack/full_matrix_18.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_19.cc
+++ b/tests/lapack/full_matrix_19.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_20.cc
+++ b/tests/lapack/full_matrix_20.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_21.cc
+++ b/tests/lapack/full_matrix_21.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_22.cc
+++ b/tests/lapack/full_matrix_22.cc
@@ -29,6 +29,7 @@ ans =  0.055556
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_23.cc
+++ b/tests/lapack/full_matrix_23.cc
@@ -42,6 +42,7 @@ ans =
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_24.cc
+++ b/tests/lapack/full_matrix_24.cc
@@ -42,6 +42,7 @@ ans =
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_25.cc
+++ b/tests/lapack/full_matrix_25.cc
@@ -35,6 +35,7 @@ ans =
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_27.cc
+++ b/tests/lapack/full_matrix_27.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_28.cc
+++ b/tests/lapack/full_matrix_28.cc
@@ -54,6 +54,7 @@ R1 =
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_29.cc
+++ b/tests/lapack/full_matrix_29.cc
@@ -65,6 +65,7 @@ R2 =
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 

--- a/tests/lapack/full_matrix_31.cc
+++ b/tests/lapack/full_matrix_31.cc
@@ -25,6 +25,7 @@
 #include <tuple>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 DeclException5(ExcEl,

--- a/tests/lapack/full_matrix_32.cc
+++ b/tests/lapack/full_matrix_32.cc
@@ -24,6 +24,7 @@
 #include <tuple>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 DeclException5(ExcEl,

--- a/tests/lapack/full_matrix_33.cc
+++ b/tests/lapack/full_matrix_33.cc
@@ -24,6 +24,7 @@
 #include <tuple>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 DeclException5(ExcEl,

--- a/tests/lapack/full_matrix_34.cc
+++ b/tests/lapack/full_matrix_34.cc
@@ -24,6 +24,7 @@
 #include <tuple>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 DeclException5(ExcEl,

--- a/tests/lapack/full_matrix_36.cc
+++ b/tests/lapack/full_matrix_36.cc
@@ -22,6 +22,7 @@
 #include <tuple>
 
 #include "../tests.h"
+
 #include "create_matrix.h"
 
 template <typename T>

--- a/tests/lapack/solver_cg.cc
+++ b/tests/lapack/solver_cg.cc
@@ -26,8 +26,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 void
 output_double_number(double input, const std::string &text)

--- a/tests/matrix_free/cell_categorization.cc
+++ b/tests/matrix_free/cell_categorization.cc
@@ -29,6 +29,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -36,6 +36,7 @@
 #include <deal.II/multigrid/mg_constrained_dofs.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -41,6 +41,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 template <int dim,

--- a/tests/matrix_free/compress_constraints.cc
+++ b/tests/matrix_free/compress_constraints.cc
@@ -35,6 +35,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/compress_mapping.cc
+++ b/tests/matrix_free/compress_mapping.cc
@@ -34,6 +34,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/get_functions_float.cc
+++ b/tests/matrix_free/get_functions_float.cc
@@ -23,6 +23,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -44,6 +44,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/interpolate_constant.cc
+++ b/tests/matrix_free/interpolate_constant.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_q.h>
 
 #include "../tests.h"
+
 #include "interpolate_functions_common.h"
 
 

--- a/tests/matrix_free/interpolate_cubic.cc
+++ b/tests/matrix_free/interpolate_cubic.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_q.h>
 
 #include "../tests.h"
+
 #include "interpolate_functions_common.h"
 
 

--- a/tests/matrix_free/interpolate_linear.cc
+++ b/tests/matrix_free/interpolate_linear.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_q.h>
 
 #include "../tests.h"
+
 #include "interpolate_functions_common.h"
 
 

--- a/tests/matrix_free/interpolate_quadratic.cc
+++ b/tests/matrix_free/interpolate_quadratic.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/fe_q.h>
 
 #include "../tests.h"
+
 #include "interpolate_functions_common.h"
 
 

--- a/tests/matrix_free/jxw_values.cc
+++ b/tests/matrix_free/jxw_values.cc
@@ -31,6 +31,7 @@
 #include <deal.II/matrix_free/matrix_free.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_06.cc
+++ b/tests/matrix_free/matrix_vector_06.cc
@@ -24,6 +24,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_06_notempl.cc
+++ b/tests/matrix_free/matrix_vector_06_notempl.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_08.cc
+++ b/tests/matrix_free/matrix_vector_08.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_09.cc
+++ b/tests/matrix_free/matrix_vector_09.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_10.cc
+++ b/tests/matrix_free/matrix_vector_10.cc
@@ -47,6 +47,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_11.cc
+++ b/tests/matrix_free/matrix_vector_11.cc
@@ -40,6 +40,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_19.cc
+++ b/tests/matrix_free/matrix_vector_19.cc
@@ -41,6 +41,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_24.cc
+++ b/tests/matrix_free/matrix_vector_24.cc
@@ -37,6 +37,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_blocks.cc
+++ b/tests/matrix_free/matrix_vector_blocks.cc
@@ -40,6 +40,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_common.h
+++ b/tests/matrix_free/matrix_vector_common.h
@@ -42,6 +42,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_03.cc
+++ b/tests/matrix_free/matrix_vector_faces_03.cc
@@ -26,6 +26,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_06.cc
+++ b/tests/matrix_free/matrix_vector_faces_06.cc
@@ -25,6 +25,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_07.cc
+++ b/tests/matrix_free/matrix_vector_faces_07.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_08.cc
+++ b/tests/matrix_free/matrix_vector_faces_08.cc
@@ -27,6 +27,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_09.cc
+++ b/tests/matrix_free/matrix_vector_faces_09.cc
@@ -26,6 +26,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_10.cc
+++ b/tests/matrix_free/matrix_vector_faces_10.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_11.cc
+++ b/tests/matrix_free/matrix_vector_faces_11.cc
@@ -31,6 +31,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_12.cc
+++ b/tests/matrix_free/matrix_vector_faces_12.cc
@@ -26,6 +26,7 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_13.cc
+++ b/tests/matrix_free/matrix_vector_faces_13.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_15.cc
+++ b/tests/matrix_free/matrix_vector_faces_15.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_16.cc
+++ b/tests/matrix_free/matrix_vector_faces_16.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_17.cc
+++ b/tests/matrix_free/matrix_vector_faces_17.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_19.cc
+++ b/tests/matrix_free/matrix_vector_faces_19.cc
@@ -30,6 +30,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_faces_24.cc
+++ b/tests/matrix_free/matrix_vector_faces_24.cc
@@ -31,6 +31,7 @@
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/matrix_vector_large_degree_02.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_02.cc
@@ -41,6 +41,7 @@
 #include <iostream>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/pre_and_post_loops_01.cc
+++ b/tests/matrix_free/pre_and_post_loops_01.cc
@@ -37,6 +37,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/pre_and_post_loops_02.cc
+++ b/tests/matrix_free/pre_and_post_loops_02.cc
@@ -39,6 +39,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/pre_and_post_loops_03.cc
+++ b/tests/matrix_free/pre_and_post_loops_03.cc
@@ -39,6 +39,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/pre_and_post_loops_04.cc
+++ b/tests/matrix_free/pre_and_post_loops_04.cc
@@ -39,6 +39,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/pre_and_post_loops_05.cc
+++ b/tests/matrix_free/pre_and_post_loops_05.cc
@@ -39,6 +39,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
 #include "../tests.h"
+
 #include "matrix_vector_mf.h"
 
 

--- a/tests/matrix_free/thread_correctness.cc
+++ b/tests/matrix_free/thread_correctness.cc
@@ -21,6 +21,7 @@
 #include <deal.II/base/function.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/matrix_free/thread_correctness_dg.cc
+++ b/tests/matrix_free/thread_correctness_dg.cc
@@ -23,6 +23,7 @@
 #include <deal.II/fe/fe_dgq.h>
 
 #include "../tests.h"
+
 #include "create_mesh.h"
 
 std::ofstream logfile("output");

--- a/tests/mpi/blockvec_02.cc
+++ b/tests/mpi/blockvec_02.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <vector>
 
-#include "../distributed_grids/coarse_grid_common.h"
 #include "../tests.h"
+
+#include "../distributed_grids/coarse_grid_common.h"
 
 void
 test()

--- a/tests/mpi/collective_sparse_matrix_01.cc
+++ b/tests/mpi/collective_sparse_matrix_01.cc
@@ -20,8 +20,9 @@
 
 #include <deal.II/lac/sparse_matrix.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 

--- a/tests/numerics/generalized_interpolation_02.cc
+++ b/tests/numerics/generalized_interpolation_02.cc
@@ -22,6 +22,7 @@
 #include <deal.II/fe/fe_system.h>
 
 #include "../tests.h"
+
 #include "generalized_interpolation.h"
 
 int

--- a/tests/numerics/generalized_interpolation_03.cc
+++ b/tests/numerics/generalized_interpolation_03.cc
@@ -20,6 +20,7 @@
 #include <deal.II/fe/fe_raviart_thomas.h>
 
 #include "../tests.h"
+
 #include "generalized_interpolation.h"
 
 int

--- a/tests/numerics/generalized_interpolation_04.cc
+++ b/tests/numerics/generalized_interpolation_04.cc
@@ -22,6 +22,7 @@
 #include <deal.II/fe/fe_system.h>
 
 #include "../tests.h"
+
 #include "generalized_interpolation.h"
 
 int

--- a/tests/numerics/generalized_interpolation_05.cc
+++ b/tests/numerics/generalized_interpolation_05.cc
@@ -22,6 +22,7 @@
 #include <deal.II/fe/fe_system.h>
 
 #include "../tests.h"
+
 #include "generalized_interpolation.h"
 
 int

--- a/tests/numerics/project_parallel_qp_q_01.cc
+++ b/tests/numerics/project_parallel_qp_q_01.cc
@@ -18,6 +18,7 @@
 // FE_Q on a mesh without hanging nodes.
 
 #include "../tests.h"
+
 #include "project_parallel_qp_common.h"
 
 namespace LA

--- a/tests/numerics/project_parallel_qp_q_02.cc
+++ b/tests/numerics/project_parallel_qp_q_02.cc
@@ -18,6 +18,7 @@
 // FE_Q on a mesh with hanging nodes.
 
 #include "../tests.h"
+
 #include "project_parallel_qp_common.h"
 
 namespace LA

--- a/tests/numerics/project_parallel_qpmf_q_01.cc
+++ b/tests/numerics/project_parallel_qpmf_q_01.cc
@@ -19,6 +19,7 @@
 
 
 #include "../tests.h"
+
 #include "project_parallel_qpmf_common.h"
 
 template <int dim>

--- a/tests/numerics/project_parallel_qpmf_q_02.cc
+++ b/tests/numerics/project_parallel_qpmf_q_02.cc
@@ -18,6 +18,7 @@
 // FE_Q on a mesh with hanging nodes.
 
 #include "../tests.h"
+
 #include "project_parallel_qpmf_common.h"
 
 template <int dim>

--- a/tests/numerics/project_parallel_qpmf_q_03.cc
+++ b/tests/numerics/project_parallel_qpmf_q_03.cc
@@ -18,6 +18,7 @@
 // FE_Q on a mesh with hanging nodes and specified fe_component
 
 #include "../tests.h"
+
 #include "project_parallel_qpmf_common.h"
 
 template <int dim>

--- a/tests/optimization/step-44-with_line_search.cc
+++ b/tests/optimization/step-44-with_line_search.cc
@@ -19,6 +19,7 @@
 // for the function to be minimized is computed.
 
 #include "../tests.h"
+
 #include "step-44.h"
 
 int

--- a/tests/optimization/step-44-with_line_search_ptrb.cc
+++ b/tests/optimization/step-44-with_line_search_ptrb.cc
@@ -20,6 +20,7 @@
 // be minimized.
 
 #include "../tests.h"
+
 #include "step-44.h"
 
 int

--- a/tests/optimization/step-44-without_line_search.cc
+++ b/tests/optimization/step-44-without_line_search.cc
@@ -18,6 +18,7 @@
 // optimization/step-44-with_line_search.cc .
 
 #include "../tests.h"
+
 #include "step-44.h"
 
 int

--- a/tests/petsc/deal_solver_01.cc
+++ b/tests/petsc/deal_solver_01.cc
@@ -31,8 +31,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/deal_solver_02.cc
+++ b/tests/petsc/deal_solver_02.cc
@@ -33,8 +33,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/deal_solver_03.cc
+++ b/tests/petsc/deal_solver_03.cc
@@ -33,8 +33,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/deal_solver_04.cc
+++ b/tests/petsc/deal_solver_04.cc
@@ -32,8 +32,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/deal_solver_05.cc
+++ b/tests/petsc/deal_solver_05.cc
@@ -31,8 +31,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_01.cc
+++ b/tests/petsc/solver_01.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/petsc/solver_02.cc
+++ b/tests/petsc/solver_02.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/petsc/solver_03.cc
+++ b/tests/petsc/solver_03.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_mf.cc
+++ b/tests/petsc/solver_03_mf.cc
@@ -27,6 +27,7 @@
 #include <typeinfo>
 
 #include "../tests.h"
+
 #include "petsc_mf_testmatrix.h"
 
 

--- a/tests/petsc/solver_03_precondition_boomeramg.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg.cc
@@ -27,8 +27,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
+++ b/tests/petsc/solver_03_precondition_boomeramg_symmetric.cc
@@ -28,8 +28,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_eisenstat.cc
+++ b/tests/petsc/solver_03_precondition_eisenstat.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_icc.cc
+++ b/tests/petsc/solver_03_precondition_icc.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_ilu.cc
+++ b/tests/petsc/solver_03_precondition_ilu.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_lu.cc
+++ b/tests/petsc/solver_03_precondition_lu.cc
@@ -27,8 +27,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_parasails.cc
+++ b/tests/petsc/solver_03_precondition_parasails.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_sor.cc
+++ b/tests/petsc/solver_03_precondition_sor.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_03_precondition_ssor.cc
+++ b/tests/petsc/solver_03_precondition_ssor.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_04.cc
+++ b/tests/petsc/solver_04.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_05.cc
+++ b/tests/petsc/solver_05.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_06.cc
+++ b/tests/petsc/solver_06.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_07.cc
+++ b/tests/petsc/solver_07.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_08.cc
+++ b/tests/petsc/solver_08.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_09.cc
+++ b/tests/petsc/solver_09.cc
@@ -30,8 +30,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_10.cc
+++ b/tests/petsc/solver_10.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_11.cc
+++ b/tests/petsc/solver_11.cc
@@ -20,8 +20,9 @@
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/petsc/solver_12.cc
+++ b/tests/petsc/solver_12.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/solver_13.cc
+++ b/tests/petsc/solver_13.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/petsc/sparse_direct_mumps.cc
+++ b/tests/petsc/sparse_direct_mumps.cc
@@ -26,8 +26,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 

--- a/tests/petsc_complex/solver_real_01.cc
+++ b/tests/petsc_complex/solver_real_01.cc
@@ -23,8 +23,9 @@
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/petsc_complex/solver_real_02.cc
+++ b/tests/petsc_complex/solver_real_02.cc
@@ -23,8 +23,9 @@
 #include <deal.II/lac/petsc_sparse_matrix.h>
 #include <deal.II/lac/petsc_vector.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/petsc_complex/solver_real_03.cc
+++ b/tests/petsc_complex/solver_real_03.cc
@@ -27,8 +27,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
 void

--- a/tests/petsc_complex/solver_real_03_mf.cc
+++ b/tests/petsc_complex/solver_real_03_mf.cc
@@ -18,8 +18,9 @@
 
 // Note: This is (almost) a clone of the tests/petsc/solver_03_mf.cc
 
-#include "../petsc/petsc_mf_testmatrix.h" // It is tempting to copy
 #include "../tests.h"
+
+#include "../petsc/petsc_mf_testmatrix.h" // It is tempting to copy
 // ../petsc/petsc_mf_testmatrix.h
 // into this directory and
 // play with it, but, by

--- a/tests/petsc_complex/solver_real_04.cc
+++ b/tests/petsc_complex/solver_real_04.cc
@@ -27,8 +27,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 template <class SOLVER, class MATRIX, class VECTOR, class PRECONDITION>
 void

--- a/tests/sacado/helper_scalar_coupled_2_components_01_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_01_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_01_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_01_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_02_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_02_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_02_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_02_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_02_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_02_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_02_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_02_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_03_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_03_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_03_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_03_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_03_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_03_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_03_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_03_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_04_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_04_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_04_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_04_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_04_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_04_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_04_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_04_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_05_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_05_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_05_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_05_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_05_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_05_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_05_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_05_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_05.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_06_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_06_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_06_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_06_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_06_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_06_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_06_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_06_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_06.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_07_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_07_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_07_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_07_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_07_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_07_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_07_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_07_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_07.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_08_1.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_08_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_08_2.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_08_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_08_3.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_08_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_2_components_08_4.cc
+++ b/tests/sacado/helper_scalar_coupled_2_components_08_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_2_components_08.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_coupled_3_components_01_1.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_2.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_3.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_4.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_1.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_1.cc
@@ -23,8 +23,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_2.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_2.cc
@@ -23,8 +23,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_3.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_3.cc
@@ -23,8 +23,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_4.cc
+++ b/tests/sacado/helper_scalar_coupled_3_components_01_tapeless_only_4.cc
@@ -23,8 +23,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_4_components_01_1.cc
+++ b/tests/sacado/helper_scalar_coupled_4_components_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_4_components_01_2.cc
+++ b/tests/sacado/helper_scalar_coupled_4_components_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_4_components_01_3.cc
+++ b/tests/sacado/helper_scalar_coupled_4_components_01_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_coupled_4_components_01_4.cc
+++ b/tests/sacado/helper_scalar_coupled_4_components_01_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_coupled_4_components_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/helper_scalar_single_component_01_1.cc
+++ b/tests/sacado/helper_scalar_single_component_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_01_2.cc
+++ b/tests/sacado/helper_scalar_single_component_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_01_3.cc
+++ b/tests/sacado/helper_scalar_single_component_01_3.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_01_4.cc
+++ b/tests/sacado/helper_scalar_single_component_01_4.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_01.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_02_1.cc
+++ b/tests/sacado/helper_scalar_single_component_02_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_02_2.cc
+++ b/tests/sacado/helper_scalar_single_component_02_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_02_3.cc
+++ b/tests/sacado/helper_scalar_single_component_02_3.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_02_4.cc
+++ b/tests/sacado/helper_scalar_single_component_02_4.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_02.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_03_1.cc
+++ b/tests/sacado/helper_scalar_single_component_03_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_03_2.cc
+++ b/tests/sacado/helper_scalar_single_component_03_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_03_3.cc
+++ b/tests/sacado/helper_scalar_single_component_03_3.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_03_4.cc
+++ b/tests/sacado/helper_scalar_single_component_03_4.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_03.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_04_1.cc
+++ b/tests/sacado/helper_scalar_single_component_04_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_04_2.cc
+++ b/tests/sacado/helper_scalar_single_component_04_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_04_3.cc
+++ b/tests/sacado/helper_scalar_single_component_04_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/sacado/helper_scalar_single_component_04_4.cc
+++ b/tests/sacado/helper_scalar_single_component_04_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_scalar_single_component_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_scalar_single_component_04.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_1_dep_vars_01_1.cc
+++ b/tests/sacado/helper_vector_1_indep_1_dep_vars_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_1_dep_vars_01_2.cc
+++ b/tests/sacado/helper_vector_1_indep_1_dep_vars_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_1_dep_vars_01_3.cc
+++ b/tests/sacado/helper_vector_1_indep_1_dep_vars_01_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_1_dep_vars_01_4.cc
+++ b/tests/sacado/helper_vector_1_indep_1_dep_vars_01_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_2_dep_vars_01_1.cc
+++ b/tests/sacado/helper_vector_1_indep_2_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_2_dep_vars_01_2.cc
+++ b/tests/sacado/helper_vector_1_indep_2_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_2_dep_vars_01_3.cc
+++ b/tests/sacado/helper_vector_1_indep_2_dep_vars_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_1_indep_2_dep_vars_01_4.cc
+++ b/tests/sacado/helper_vector_1_indep_2_dep_vars_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_1_dep_vars_01_1.cc
+++ b/tests/sacado/helper_vector_2_indep_1_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_1_dep_vars_01_2.cc
+++ b/tests/sacado/helper_vector_2_indep_1_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_1_dep_vars_01_3.cc
+++ b/tests/sacado/helper_vector_2_indep_1_dep_vars_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_1_dep_vars_01_4.cc
+++ b/tests/sacado/helper_vector_2_indep_1_dep_vars_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_2_dep_vars_01_1.cc
+++ b/tests/sacado/helper_vector_2_indep_2_dep_vars_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_2_dep_vars_01_2.cc
+++ b/tests/sacado/helper_vector_2_indep_2_dep_vars_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_2_dep_vars_01_3.cc
+++ b/tests/sacado/helper_vector_2_indep_2_dep_vars_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/helper_vector_2_indep_2_dep_vars_01_4.cc
+++ b/tests/sacado/helper_vector_2_indep_2_dep_vars_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_01_1.cc
+++ b/tests/sacado/physics_functions_01_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_01_2.cc
+++ b/tests/sacado/physics_functions_01_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_01_3.cc
+++ b/tests/sacado/physics_functions_01_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_01_4.cc
+++ b/tests/sacado/physics_functions_01_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/physics_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_01.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_02_1.cc
+++ b/tests/sacado/physics_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_02_2.cc
+++ b/tests/sacado/physics_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_02_3.cc
+++ b/tests/sacado/physics_functions_02_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_02_4.cc
+++ b/tests/sacado/physics_functions_02_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/physics_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_02.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_03_1.cc
+++ b/tests/sacado/physics_functions_03_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_03_2.cc
+++ b/tests/sacado/physics_functions_03_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_03_3.cc
+++ b/tests/sacado/physics_functions_03_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/sacado/physics_functions_03_4.cc
+++ b/tests/sacado/physics_functions_03_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/physics_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/physics_functions_03.h"
 
 int
 main()

--- a/tests/sacado/step-44-helper_res_lin_01_1.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_res_lin_01_2.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_res_lin_01_3.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_3.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_res_lin_01_4.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_4.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_res_lin_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_scalar_01_1.cc
+++ b/tests/sacado/step-44-helper_scalar_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/step-44-helper_scalar_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_scalar_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_scalar_01_2.cc
+++ b/tests/sacado/step-44-helper_scalar_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/step-44-helper_scalar_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_scalar_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_var_form_01_1.cc
+++ b/tests/sacado/step-44-helper_var_form_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/step-44-helper_var_form_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_var_form_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_var_form_01_2.cc
+++ b/tests/sacado/step-44-helper_var_form_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/step-44-helper_var_form_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_var_form_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_vector_01_1.cc
+++ b/tests/sacado/step-44-helper_vector_01_1.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_vector_01_2.cc
+++ b/tests/sacado/step-44-helper_vector_01_2.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_vector_01_3.cc
+++ b/tests/sacado/step-44-helper_vector_01_3.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/step-44-helper_vector_01_4.cc
+++ b/tests/sacado/step-44-helper_vector_01_4.cc
@@ -18,8 +18,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/step-44-helper_vector_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/step-44-helper_vector_01.h"
 
 int
 main(int argc, char **argv)

--- a/tests/sacado/symmetric_tensor_functions_01_1.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_01_2.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_01_3.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_01_4.cc
+++ b/tests/sacado/symmetric_tensor_functions_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_02_1.cc
+++ b/tests/sacado/symmetric_tensor_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_02_2.cc
+++ b/tests/sacado/symmetric_tensor_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_02_3.cc
+++ b/tests/sacado/symmetric_tensor_functions_02_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_02_4.cc
+++ b/tests/sacado/symmetric_tensor_functions_02_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_03_1.cc
+++ b/tests/sacado/symmetric_tensor_functions_03_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_03_2.cc
+++ b/tests/sacado/symmetric_tensor_functions_03_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_03_3.cc
+++ b/tests/sacado/symmetric_tensor_functions_03_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_03_4.cc
+++ b/tests/sacado/symmetric_tensor_functions_03_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_03.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_04_1.cc
+++ b/tests/sacado/symmetric_tensor_functions_04_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_04_2.cc
+++ b/tests/sacado/symmetric_tensor_functions_04_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_04_3.cc
+++ b/tests/sacado/symmetric_tensor_functions_04_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/sacado/symmetric_tensor_functions_04_4.cc
+++ b/tests/sacado/symmetric_tensor_functions_04_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/symmetric_tensor_functions_04.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_01_1.cc
+++ b/tests/sacado/tensor_functions_01_1.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_01_2.cc
+++ b/tests/sacado/tensor_functions_01_2.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_01_3.cc
+++ b/tests/sacado/tensor_functions_01_3.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_01_4.cc
+++ b/tests/sacado/tensor_functions_01_4.cc
@@ -19,8 +19,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/tensor_functions_01.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_01.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_02_1.cc
+++ b/tests/sacado/tensor_functions_02_1.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_02_2.cc
+++ b/tests/sacado/tensor_functions_02_2.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado DFad-DFad
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_02_3.cc
+++ b/tests/sacado/tensor_functions_02_3.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/sacado/tensor_functions_02_4.cc
+++ b/tests/sacado/tensor_functions_02_4.cc
@@ -20,8 +20,9 @@
 //
 // AD number type: Sacado Rad-DFad
 
-#include "../ad_common_tests/tensor_functions_02.h"
 #include "../tests.h"
+
+#include "../ad_common_tests/tensor_functions_02.h"
 
 int
 main()

--- a/tests/scalapack/scalapack_02.cc
+++ b/tests/scalapack/scalapack_02.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test Cholesky decomposition in ScaLAPACK vs FullMatrix
 

--- a/tests/scalapack/scalapack_03.cc
+++ b/tests/scalapack/scalapack_03.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 /*
  * test inverse via Cholesky decomposition in ScaLAPACK vs FullMatrix

--- a/tests/scalapack/scalapack_03_b.cc
+++ b/tests/scalapack/scalapack_03_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 /*
  * test inverse via LU decomposition in ScaLAPACK vs FullMatrix for general

--- a/tests/scalapack/scalapack_03_c.cc
+++ b/tests/scalapack/scalapack_03_c.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 /*
  * test inverse of triangular matrix using pXtrtri in ScaLAPACK vs FullMatrix

--- a/tests/scalapack/scalapack_04.cc
+++ b/tests/scalapack/scalapack_04.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test norms of ScaLAPACK vs FullMatrix
 

--- a/tests/scalapack/scalapack_04_b.cc
+++ b/tests/scalapack/scalapack_04_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test norms of ScaLAPACK vs FullMatrix for general matrices
 

--- a/tests/scalapack/scalapack_05.cc
+++ b/tests/scalapack/scalapack_05.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test reciprocal_condition_number()
 

--- a/tests/scalapack/scalapack_06.cc
+++ b/tests/scalapack/scalapack_06.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index(const std::pair<unsigned int,unsigned int>
 // &, const bool) for all eigenvalues with eigenvectors

--- a/tests/scalapack/scalapack_06a.cc
+++ b/tests/scalapack/scalapack_06a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index(const std::pair<unsigned int,unsigned int>
 // &, const bool) for all eigenvalues without eigenvectors

--- a/tests/scalapack/scalapack_06b.cc
+++ b/tests/scalapack/scalapack_06b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index(const std::pair<unsigned int,unsigned int>
 // &, const bool) for some eigenvalues with eigenvectors

--- a/tests/scalapack/scalapack_06c.cc
+++ b/tests/scalapack/scalapack_06c.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index(const std::pair<unsigned int,unsigned int>
 // &, const bool) for some eigenvalues without eigenvectors

--- a/tests/scalapack/scalapack_07.cc
+++ b/tests/scalapack/scalapack_07.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test copying of distributed ScaLAPACKMatrices using ScaLAPACK routine
 // p_gemr2d

--- a/tests/scalapack/scalapack_08.cc
+++ b/tests/scalapack/scalapack_08.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test compute_SVD(ScaLAPACKMatrix<NumberType>*,ScaLAPACKMatrix<NumberType>*)
 

--- a/tests/scalapack/scalapack_10.cc
+++ b/tests/scalapack/scalapack_10.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test saving and loading of distributed ScaLAPACKMatrices
 

--- a/tests/scalapack/scalapack_10_a.cc
+++ b/tests/scalapack/scalapack_10_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // A test for saving and loading of distributed ScaLAPACKMatrices.
 // By using a 1x1 grid a call to save_serial() and load_serial() is mimicked.

--- a/tests/scalapack/scalapack_10_b.cc
+++ b/tests/scalapack/scalapack_10_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test saving and loading of distributed ScaLAPACKMatrices with prescribed
 // chunk sizes

--- a/tests/scalapack/scalapack_10_c.cc
+++ b/tests/scalapack/scalapack_10_c.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test saving and loading of the State and Property of distributed
 // ScaLAPACKMatrices

--- a/tests/scalapack/scalapack_10_d.cc
+++ b/tests/scalapack/scalapack_10_d.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test loading of distributed ScaLAPACKMatrices by call to constructor
 

--- a/tests/scalapack/scalapack_11.cc
+++ b/tests/scalapack/scalapack_11.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test copying submatrices of distributed ScaLAPACKMatrices using ScaLAPACK
 // routine p_gemr2d

--- a/tests/scalapack/scalapack_12_a.cc
+++ b/tests/scalapack/scalapack_12_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test multiplication of distributed ScaLAPACKMatrices: C = b A*B + c C
 

--- a/tests/scalapack/scalapack_12_b.cc
+++ b/tests/scalapack/scalapack_12_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test multiplication of distributed ScaLAPACKMatrices: C = alpha A^T*B + beta
 // C

--- a/tests/scalapack/scalapack_12_c.cc
+++ b/tests/scalapack/scalapack_12_c.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test multiplication of distributed ScaLAPACKMatrices: C = alpha A * B^T +
 // beta C

--- a/tests/scalapack/scalapack_12_d.cc
+++ b/tests/scalapack/scalapack_12_d.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test multiplication of distributed ScaLAPACKMatrices: C = alpha A^T * B^T +
 // beta C

--- a/tests/scalapack/scalapack_13_a.cc
+++ b/tests/scalapack/scalapack_13_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test addition of distributed ScaLAPACKMatrices: A = alpha A + beta B
 

--- a/tests/scalapack/scalapack_13_b.cc
+++ b/tests/scalapack/scalapack_13_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test addition of distributed ScaLAPACKMatrices: A = alpha A + beta B^T
 

--- a/tests/scalapack/scalapack_14_a.cc
+++ b/tests/scalapack/scalapack_14_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test scaling of rows of distributed ScaLAPACKMatrices
 

--- a/tests/scalapack/scalapack_14_b.cc
+++ b/tests/scalapack/scalapack_14_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test scaling of columns of distributed ScaLAPACKMatrices
 

--- a/tests/scalapack/scalapack_15.cc
+++ b/tests/scalapack/scalapack_15.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned
 // int> &, const bool) for all eigenvalues with eigenvectors

--- a/tests/scalapack/scalapack_15_a.cc
+++ b/tests/scalapack/scalapack_15_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test eigenpairs_symmetric_by_index_MRRR(const std::pair<unsigned int,unsigned
 // int> &, const bool) for all eigenvalues without eigenvectors

--- a/tests/scalapack/scalapack_16.cc
+++ b/tests/scalapack/scalapack_16.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test pseudo_inverse(const NumberType ratio) for symmetric matrices
 

--- a/tests/scalapack/scalapack_16_a.cc
+++ b/tests/scalapack/scalapack_16_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test pseudo_inverse(const NumberType ratio) for rectangular matrices
 

--- a/tests/scalapack/scalapack_17_a.cc
+++ b/tests/scalapack/scalapack_17_a.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test ScaLAPACKMatrix::operator = (const LAPACKFullMatrix<NumberType> &)
 

--- a/tests/scalapack/scalapack_17_b.cc
+++ b/tests/scalapack/scalapack_17_b.cc
@@ -13,8 +13,9 @@
 //
 // ---------------------------------------------------------------------
 
-#include "../lapack/create_matrix.h"
 #include "../tests.h"
+
+#include "../lapack/create_matrix.h"
 
 // test ScaLAPACKMatrix::copy_to (LAPACKFullMatrix<NumberType> &matrix)
 

--- a/tests/serialization/tensor.cc
+++ b/tests/serialization/tensor.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 
 #include "../tests.h"
+
 #include "serialization.h"
 
 

--- a/tests/serialization/tensor_base_scalar.cc
+++ b/tests/serialization/tensor_base_scalar.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/tensor.h>
 
 #include "../tests.h"
+
 #include "serialization.h"
 
 

--- a/tests/slepc/solve_01.cc
+++ b/tests/slepc/solve_01.cc
@@ -30,8 +30,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 #include "testmatrix.h"
 
 template <typename SolverType, typename MatrixType, typename VectorType>

--- a/tests/slepc/solve_04.cc
+++ b/tests/slepc/solve_04.cc
@@ -30,8 +30,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 #include "testmatrix.h"
 
 template <typename SolverType, typename MatrixType, typename VectorType>

--- a/tests/sparsity/sparsity_pattern.cc
+++ b/tests/sparsity/sparsity_pattern.cc
@@ -20,8 +20,9 @@
 #include <list>
 #include <set>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/sparsity/sparsity_pattern_common.h
+++ b/tests/sparsity/sparsity_pattern_common.h
@@ -30,8 +30,9 @@
 #include <set>
 #include <sstream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 const unsigned int N = 15;

--- a/tests/sparsity/sparsity_pattern_copy_from_01.cc
+++ b/tests/sparsity/sparsity_pattern_copy_from_01.cc
@@ -24,8 +24,9 @@
 #include <list>
 #include <set>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/symengine/symengine_number_type_01.cc
+++ b/tests/symengine/symengine_number_type_01.cc
@@ -32,8 +32,9 @@
 #include <fstream>
 #include <iomanip>
 
-#include "../serialization/serialization.h"
 #include "../tests.h"
+
+#include "../serialization/serialization.h"
 
 using namespace dealii;
 namespace SD = Differentiation::SD;

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -64,6 +64,10 @@ struct DisableWindowsDebugRuntimeDialog
 } deal_II_windows_crt_dialog;
 #endif
 
+// Redefine Assert as AssertThrow to make sure that the code is tested similarly
+// in Release mode and in Debug mode. clang-format makes sure that this file is
+// included after all regular header files but before all the other local header
+// files.
 #undef Assert
 #define Assert AssertThrow
 

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -64,6 +64,9 @@ struct DisableWindowsDebugRuntimeDialog
 } deal_II_windows_crt_dialog;
 #endif
 
+#undef Assert
+#define Assert AssertThrow
+
 // implicitly use the deal.II namespace everywhere, without us having to say
 // so in each and every testcase
 using namespace dealii;

--- a/tests/trilinos/deal_solver_01.cc
+++ b/tests/trilinos/deal_solver_01.cc
@@ -33,8 +33,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/deal_solver_02.cc
+++ b/tests/trilinos/deal_solver_02.cc
@@ -35,8 +35,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/deal_solver_03.cc
+++ b/tests/trilinos/deal_solver_03.cc
@@ -35,8 +35,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/deal_solver_04.cc
+++ b/tests/trilinos/deal_solver_04.cc
@@ -34,8 +34,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/deal_solver_05.cc
+++ b/tests/trilinos/deal_solver_05.cc
@@ -33,8 +33,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/deal_solver_06.cc
+++ b/tests/trilinos/deal_solver_06.cc
@@ -33,8 +33,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_03.cc
+++ b/tests/trilinos/solver_03.cc
@@ -28,8 +28,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_05.cc
+++ b/tests/trilinos/solver_05.cc
@@ -28,8 +28,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_07.cc
+++ b/tests/trilinos/solver_07.cc
@@ -28,8 +28,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_control_01.cc
+++ b/tests/trilinos/solver_control_01.cc
@@ -29,8 +29,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_control_02.cc
+++ b/tests/trilinos/solver_control_02.cc
@@ -29,8 +29,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_control_03.cc
+++ b/tests/trilinos/solver_control_03.cc
@@ -29,8 +29,9 @@
 #include <iostream>
 #include <typeinfo>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 
 int

--- a/tests/trilinos/solver_control_04.cc
+++ b/tests/trilinos/solver_control_04.cc
@@ -29,8 +29,9 @@
 
 #include <iostream>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 int
 main(int argc, char **argv)

--- a/tests/trilinos/sparsity_pattern_common.h
+++ b/tests/trilinos/sparsity_pattern_common.h
@@ -19,8 +19,9 @@
 
 #include <deal.II/lac/trilinos_sparsity_pattern.h>
 
-#include "../testmatrix.h"
 #include "../tests.h"
+
+#include "../testmatrix.h"
 
 const unsigned int N = 15;
 


### PR DESCRIPTION
Implementing option 2 in https://github.com/dealii/dealii/pull/9502#issuecomment-584141754. Our clang-format options already make sure that `"../tests.h"` is always the last header file to include.