### PR TITLE
Fix use of array concatenation in checkdoxygen.py

### DIFF
--- a/contrib/utilities/checkdoxygen.py
+++ b/contrib/utilities/checkdoxygen.py
@@ -119,7 +119,7 @@ if 'intro.dox' in args[0]:
     fstep.close()
 
     fres = open(resultsname)
-    lines.append(fres.readlines())
+    lines += fres.readlines()
     fres.close()
     
     # check the file group


### PR DESCRIPTION
I incorrectly used `array.append()` in #9505 instead of the += operator, but this actually fixes it. Now `checkdoxygen.py` will also correctly search the `results.dox` files for repeated headers as well.