### PR TITLE
Fix 64bit GridRefinement overflow

### DIFF
--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -57,7 +57,7 @@ namespace internal
           number
           compute_threshold(const dealii::Vector<number> &   criteria,
                             const std::pair<double, double> &global_min_and_max,
-                            const unsigned int               n_target_cells,
+                            const types::global_dof_index    n_target_cells,
                             MPI_Comm                         mpi_communicator);
         } // namespace RefineAndCoarsenFixedNumber
 

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -34,7 +34,7 @@ for (S : REAL_SCALARS)
               template S
               compute_threshold<S>(const dealii::Vector<S> &,
                                    const std::pair<double, double> &,
-                                   const unsigned int,
+                                   const types::global_dof_index,
                                    MPI_Comm);
             \}
             namespace RefineAndCoarsenFixedFraction


### PR DESCRIPTION
GridRefinement::refine_and_coarsen_fixed_fraction causes overflow with
more than 2^32 global active cells. This is now fixed.

part of #9547