### PR TITLE
Update FE_BernardiRaugel to use physical normal vectors

### DIFF
--- a/include/deal.II/fe/fe_bernardi_raugel.h
+++ b/include/deal.II/fe/fe_bernardi_raugel.h
@@ -130,6 +130,24 @@ private:
    */
   void
   initialize_support_points();
+
+  /**
+   * Fill the values Bernardi-Raugel polynomials, but replace the normal
+   * vector from the PolynomialsBernardiRaugel class with the physical
+   * normal vector from @p cell.
+   */
+  virtual void
+  fill_fe_values(
+    const typename Triangulation<dim, dim>::cell_iterator &cell,
+    const CellSimilarity::Similarity                       cell_similarity,
+    const Quadrature<dim> &                                quadrature,
+    const Mapping<dim, dim> &                              mapping,
+    const typename Mapping<dim, dim>::InternalDataBase &   mapping_internal,
+    const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, dim>
+      &                                                       mapping_data,
+    const typename FiniteElement<dim, dim>::InternalDataBase &fe_internal,
+    dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim>
+      &output_data) const override;
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_bernardi_raugel.h
+++ b/include/deal.II/fe/fe_bernardi_raugel.h
@@ -133,8 +133,8 @@ private:
 
   /**
    * Fill the values Bernardi-Raugel polynomials, but replace the normal
-   * vector from the PolynomialsBernardiRaugel class with the physical
-   * normal vector from @p cell.
+   * vector on the reference cell from the PolynomialsBernardiRaugel class
+   * with the normal vector on the physical cell.
    */
   virtual void
   fill_fe_values(

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -206,7 +206,7 @@ FE_BernardiRaugel<dim>::fill_fe_values(
      mapping_data,
      fe_internal,
      output_data);
-  std::cout << "Length of mapping_data.normal_vectors" << normal_vectors.size() << std::endl;
+  std::cout << "Length of mapping_data.normal_vectors" << mapping_data.normal_vectors.size() << std::endl;
 
   // Convert to the correct internal data class for this FE class.
   // Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -206,8 +206,8 @@ FE_BernardiRaugel<dim>::fill_fe_values(
   std::cout << "Length of mapping_data.normal_vectors: " << mapping_data.normal_vectors.size() << std::endl;
 
   // Convert to the correct internal data class for this FE class.
-  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-      ExcInternalError());
+  //Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+  //    ExcInternalError());
   const typename FE_PolyTensor<dim>::InternalData &fe_data =
     static_cast<const typename FE_PolyTensor<dim>::InternalData &>(fe_internal);
 

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -206,7 +206,7 @@ FE_BernardiRaugel<dim>::fill_fe_values(
      mapping_data,
      fe_internal,
      output_data);
-  std::cout << "Length of mapping_data.normal_vectors" << mapping_data.normal_vectors.size() << std::endl;
+  std::cout << "Length of mapping_data.normal_vectors: " << mapping_data.normal_vectors.size() << std::endl;
 
   // Convert to the correct internal data class for this FE class.
   // Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
@@ -232,7 +232,7 @@ FE_BernardiRaugel<dim>::fill_fe_values(
     {
       double psi = 0;
       unsigned int f = i - dim*GeometryInfo<dim>::vertices_per_cell;
-      Tensor<1,dim> normal = (*cell)->face(f)->normal_vector(k);
+      //Tensor<1,dim> normal = (*cell)->face(f)->normal_vector(k);
 
       for (unsigned int d = 0; d < dim; ++d)
         psi += fe_data.shape_values[i][k][d]*fe_data.shape_values[i][k][d];
@@ -241,8 +241,8 @@ FE_BernardiRaugel<dim>::fill_fe_values(
 
       for (unsigned int d = 0; d < dim; ++d)
       {
-        output_data.shape_values(first + d, k) =
-          normal[d]*psi;
+//        output_data.shape_values(first + d, k) =
+//          normal[d]*psi;
       }
 
     }

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -43,7 +43,7 @@ FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
       FiniteElementData<dim>(get_dpo_vector(),
                              dim,
                              2,
-                             FiniteElementData<dim>::H1),
+                             FiniteElementData<dim>::Hdiv),
       std::vector<bool>(PolynomialsBernardiRaugel<dim>::n_polynomials(p), true),
       std::vector<ComponentMask>(PolynomialsBernardiRaugel<dim>::n_polynomials(
                                    p),
@@ -193,9 +193,6 @@ FE_BernardiRaugel<dim>::fill_fe_values(
   dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim>
     &output_data) const
 {
-  std::cout << "fill_fe_values called!" << std::endl;
-  std::cout << "Calling FE_PolyTensor<dim, dim>::fill_fe_values" << std::endl;
-
   // Call the base implementation then we'll touch up the data slightly
   FE_PolyTensor<dim, dim>::fill_fe_values(
      cell,
@@ -209,8 +206,8 @@ FE_BernardiRaugel<dim>::fill_fe_values(
   std::cout << "Length of mapping_data.normal_vectors: " << mapping_data.normal_vectors.size() << std::endl;
 
   // Convert to the correct internal data class for this FE class.
-  // Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
-  //    ExcInternalError());
+  Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,
+      ExcInternalError());
   const typename FE_PolyTensor<dim>::InternalData &fe_data =
     static_cast<const typename FE_PolyTensor<dim>::InternalData &>(fe_internal);
 
@@ -230,14 +227,10 @@ FE_BernardiRaugel<dim>::fill_fe_values(
 
     for (unsigned int k = 0; k < n_q_points; ++k)
     {
-      double psi = 0;
+      const double psi = std::sqrt(fe_data.shape_values[i][k] * fe_data.shape_values[i][k]);
+
       unsigned int f = i - dim*GeometryInfo<dim>::vertices_per_cell;
-      //Tensor<1,dim> normal = (*cell)->face(f)->normal_vector(k);
-
-      for (unsigned int d = 0; d < dim; ++d)
-        psi += fe_data.shape_values[i][k][d]*fe_data.shape_values[i][k][d];
-
-      psi = sqrt(psi);
+      //Tensor<1,dim> normal = cell->face(f);
 
       for (unsigned int d = 0; d < dim; ++d)
       {

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -177,6 +177,48 @@ FE_BernardiRaugel<dim>::initialize_support_points()
     }
 }
 
+
+
+template <int dim>
+void
+FE_BernardiRaugel<dim>::fill_fe_values(
+  const typename Triangulation<dim, dim>::cell_iterator &cell,
+  const CellSimilarity::Similarity                       cell_similarity,
+  const Quadrature<dim> &                                quadrature,
+  const Mapping<dim, dim> &                              mapping,
+  const typename Mapping<dim, dim>::InternalDataBase &   mapping_internal,
+  const dealii::internal::FEValuesImplementation::MappingRelatedData<dim, dim>
+    &                                                       mapping_data,
+  const typename FiniteElement<dim, dim>::InternalDataBase &fe_internal,
+  dealii::internal::FEValuesImplementation::FiniteElementRelatedData<dim, dim>
+    &output_data) const
+{
+  FE_PolyTensor<PolynomialsBernardiRaugel<dim>, dim, dim>::fill_fe_values(
+    cell,
+    cell_similarity,
+    quadrature,
+    mapping,
+    mapping_internal,
+    mapping_data,
+    fe_internal,
+    output_data);
+
+  std::cout << "fill_fe_values called!" << std::endl;
+  std::cout << "Is the finite element primitive?" << this->is_primitive() << std::endl;
+  for(unsigned int k=0; k < this->dofs_per_cell; ++k)
+  {
+    std::cout << "dof " << k << std::endl;
+    for(unsigned int i=0; i < quadrature.size(); ++i)
+      std::cout << "qp " << i << ": " << output_data.shape_values[k][i] << std::endl;
+  }
+
+  for(unsigned int i=0; i < this->dofs_per_cell; ++i)
+    for(unsigned int d=0; d < dim; ++d)
+      std::cout << "Result of fe.get_nonzero_components(" << i << ")[" << d << "] = " << this->get_nonzero_components(i)[d] << std::endl;
+
+  //this->n_nonzero_components(0);
+}
+
 template class FE_BernardiRaugel<2>;
 template class FE_BernardiRaugel<3>;
 

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -206,6 +206,7 @@ FE_BernardiRaugel<dim>::fill_fe_values(
      mapping_data,
      fe_internal,
      output_data);
+  std::cout << "Length of mapping_data.normal_vectors" << normal_vectors.size() << std::endl;
 
   // Convert to the correct internal data class for this FE class.
   // Assert(dynamic_cast<const InternalData *>(&fe_internal) != nullptr,


### PR DESCRIPTION
I'm opening the PR now because I want a little bit of feedback before I continue. I have a couple things I want to accomplish and I'd like to ask for feedback:
 1. I'd like to access the physical (not necessarily outward) normal vector information by using `Triangulation<dim, dim>::cell_iterator &cell`. Since it's an iterator, I need to dereference it to get an accessor to access a face and then its normal, correct? What would that look like? My current implementation isn't right (I currently use `Tensor<1,dim> normal = (*cell)->face(f)->normal_vector(k);`).
 2. I will likely need to implement a sign-flip convention similar to `FE_RaviartThomas` or `FE_Nedelec`. The easiest way to do this is implicitly by having each normal oriented with the edge/face's natural normal direction instead of being an outward normal.
 3. Add a test

(I'll also make sure to remove those print statements when I'm done :stuck_out_tongue:)

This closes #8776.