### PR TITLE
step-47: Add derivation for the simply supported plates to result section.

### DIFF
--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -230,7 +230,10 @@ As mentioned, this method relies on the use of $C^0$ Lagrange finite
 elements where the $C^1$ continuity requirement is relaxed and has
 been replaced with interior penalty techniques. To derive this method,
 we consider a $C^0$ shape function $v_h$ which vanishes on
-$\partial\Omega$. Since the higher order derivatives of $v_h$ have two
+$\partial\Omega$. We introduce notation $ \mathbb{F} $ as the set of
+all faces of $\mathbb{T}$, $ \mathbb{F}^b $ as the set of boundary faces,
+and $ \mathbb{F}^i $ as the set of interior faces for use further down below.
+Since the higher order derivatives of $v_h$ have two
 values on each interface $e\in \mathbb{F}$ (shared by the two cells
 $K_{+},K_{-} \in \mathbb{T}$), we cope with this discontinuity by
 defining the following single-valued functions on $e$:

--- a/examples/step-47/doc/results.dox
+++ b/examples/step-47/doc/results.dox
@@ -213,10 +213,10 @@ make sense:
   same spirit as we used for the assembly of the linear system.
 
 
-  <h3> Derivation for the simply supported plates </h3>
+  <h4> Derivation for the simply supported plates </h3>
 
-  Similar to the “clamped” boundary condition addressed in the implementation,
-  we will derive the $C^0$ IP finite element scheme for the simply supported plates:
+  Similar to the "clamped" boundary condition addressed in the implementation,
+  we will derive the $C^0$ IP finite element scheme for simply supported plates:
   @f{align*}{
     \Delta^2 u(\mathbf x) &= f(\mathbf x)
     \qquad \qquad &&\forall \mathbf x \in \Omega,
@@ -225,7 +225,7 @@ make sense:
     \Delta u(\mathbf x) &= h(\mathbf x) \qquad \qquad
     &&\forall \mathbf x \in \partial\Omega.
   @f}
-  We multiply the biharmonic equation by the test function $v_h$ and integrate over $\Omega$ and get:
+  We multiply the biharmonic equation by the test function $v_h$ and integrate over $ K $ and get:
   @f{align*}{
     \int_K v_h (\Delta^2 u_h)
      &= \int_K (D^2 v_h) : (D^2 u_h)
@@ -233,11 +233,12 @@ make sense:
        -\int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}).
   @f}
 
-  Summing up over all cells $K \in  \mathbb{T}$,
+  Summing up over all cells $K \in  \mathbb{T}$,since normal directions of $\Delta u_h$ are pointing at
+  opposite directions on each interior edge shared by two cells and $v_h = 0$ on $\partial \Omega$,
   @f{align*}{
   \sum_{K \in \mathbb{T}} \int_{\partial K} v_h \frac{\partial (\Delta u_h)}{\partial \mathbf{n}} = 0,
   @f}
-  and by the definition of jump over cells,
+  and by the definition of jump over cell interfaces,
   @f{align*}{
   -\sum_{K \in \mathbb{T}} \int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}) = -\sum_{e \in \mathbb{F}} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}}).
   @f}
@@ -246,7 +247,7 @@ make sense:
   -\sum_{K \in \mathbb{T}} \int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}) = -\sum_{e \in \mathbb{F}^i} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}})
   - \sum_{e \in \partial \Omega} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} h,
   @f}
-  Where $\mathbb{F}^i$ is the set of interior faces.
+  where $\mathbb{F}^i$ is the set of interior faces.
   This leads us to
   @f{align*}{
   \sum_{K \in \mathbb{T}} \int_K (D^2 v_h) : (D^2 u_h) \ dx - \sum_{e \in \mathbb{F}^i} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}}) \ ds
@@ -285,7 +286,10 @@ make sense:
   and
   @f{align*}{
   \mathcal{F}(v_h)&:=\sum_{K \in \mathbb{T}}\int_{K} v_h f \ dx
-  -
+  +
   \sum_{e\subset\partial\Omega}
-  \int_e \jump{\frac{\partial v_h}{\partial \mathbf n^2}} h \ ds.
+  \int_e \jump{\frac{\partial v_h}{\partial \mathbf n}} h \ ds.
   @f}
+  The implementation of this boundary case is similar to "clamped" version
+  except for `boundary_worker` is no longer needed for system assembling
+  and the right hand side is changed according to the formulation.

--- a/examples/step-47/doc/results.dox
+++ b/examples/step-47/doc/results.dox
@@ -211,3 +211,81 @@ make sense:
   addition should not be overly difficult using, for example, the
   FEInterfaceValues class combined with MeshWorker::mesh_loop() in the
   same spirit as we used for the assembly of the linear system.
+
+
+  <h3> Derivation for the simply supported plates </h3>
+
+  Similar to the “clamped” boundary condition addressed in the implementation,
+  we will derive the $C^0$ IP finite element scheme for the simply supported plates:
+  @f{align*}{
+    \Delta^2 u(\mathbf x) &= f(\mathbf x)
+    \qquad \qquad &&\forall \mathbf x \in \Omega,
+    u(\mathbf x) &= g(\mathbf x) \qquad \qquad
+    &&\forall \mathbf x \in \partial\Omega, \\
+    \Delta u(\mathbf x) &= h(\mathbf x) \qquad \qquad
+    &&\forall \mathbf x \in \partial\Omega.
+  @f}
+  We multiply the biharmonic equation by the test function $v_h$ and integrate over $\Omega$ and get:
+  @f{align*}{
+    \int_K v_h (\Delta^2 u_h)
+     &= \int_K (D^2 v_h) : (D^2 u_h)
+       + \int_{\partial K} v_h \frac{\partial (\Delta u_h)}{\partial \mathbf{n}}
+       -\int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}).
+  @f}
+
+  Summing up over all cells $K \in  \mathbb{T}$,
+  @f{align*}{
+  \sum_{K \in \mathbb{T}} \int_{\partial K} v_h \frac{\partial (\Delta u_h)}{\partial \mathbf{n}} = 0,
+  @f}
+  and by the definition of jump over cells,
+  @f{align*}{
+  -\sum_{K \in \mathbb{T}} \int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}) = -\sum_{e \in \mathbb{F}} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}}).
+  @f}
+  We separate interior faces and boundary faces of the domain,
+  @f{align*}{
+  -\sum_{K \in \mathbb{T}} \int_{\partial K} (\nabla v_h) \cdot (\frac{\partial \nabla u_h}{\partial \mathbf{n}}) = -\sum_{e \in \mathbb{F}^i} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}})
+  - \sum_{e \in \partial \Omega} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} h,
+  @f}
+  Where $\mathbb{F}^i$ is the set of interior faces.
+  This leads us to
+  @f{align*}{
+  \sum_{K \in \mathbb{T}} \int_K (D^2 v_h) : (D^2 u_h) \ dx - \sum_{e \in \mathbb{F}^i} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} (\frac{\partial^2 u_h}{\partial \mathbf{n^2}}) \ ds
+  = \sum_{K \in \mathbb{T}}\int_{K} v_h f  \ dx + \sum_{e\subset\partial\Omega} \int_{e} \jump{\frac{\partial v_h}{\partial \mathbf{n}} h \ ds.
+  @f}
+
+  In order to symmetrize and stabilize the discrete problem,
+  we add symmetrization and stabilization term.
+  We finally get the $C^0$ IP finite element scheme for the biharmonic equation:
+  find $u_h$ such that $u_h =g$ on $\partial \Omega$ and
+  @f{align*}{
+  \mathcal{A}(v_h,u_h)&=\mathcal{F}(v_h) \quad \text{holds for all test functions } v_h,
+  @f}
+  where
+  @f{align*}{
+  \mathcal{A}(v_h,u_h)&=\mathcal{F}(v_h) \quad \text{holds for all test functions } v_h,
+  @f}
+  where
+  @f{align*}{
+  \mathcal{A}(v_h,u_h):=&\sum_{K \in \mathbb{T}}\int_K D^2v_h:D^2u_h \ dx
+  \\
+  &
+   -\sum_{e \in \mathbb{F}^i} \int_{e}
+    \jump{\frac{\partial v_h}{\partial \mathbf n}}
+    \average{\frac{\partial^2 u_h}{\partial \mathbf n^2}} \ ds
+   -\sum_{e \in \mathbb{F}^i} \int_{e}
+   \average{\frac{\partial^2 v_h}{\partial \mathbf n^2}}
+   \jump{\frac{\partial u_h}{\partial \mathbf n}} \ ds
+  \\
+  &+ \sum_{e \in \mathbb{F}^i}
+   \frac{\gamma}{h_e}
+   \int_e
+   \jump{\frac{\partial v_h}{\partial \mathbf n}}
+   \jump{\frac{\partial u_h}{\partial \mathbf n}} \ ds,
+  @f}
+  and
+  @f{align*}{
+  \mathcal{F}(v_h)&:=\sum_{K \in \mathbb{T}}\int_{K} v_h f \ dx
+  -
+  \sum_{e\subset\partial\Omega}
+  \int_e \jump{\frac{\partial v_h}{\partial \mathbf n^2}} h \ ds.
+  @f}

--- a/examples/step-47/doc/results.dox
+++ b/examples/step-47/doc/results.dox
@@ -213,7 +213,7 @@ make sense:
   same spirit as we used for the assembly of the linear system.
 
 
-  <h4> Derivation for the simply supported plates </h3>
+  <h4> Derivation for the simply supported plates </h4>
 
   Similar to the "clamped" boundary condition addressed in the implementation,
   we will derive the $C^0$ IP finite element scheme for simply supported plates:


### PR DESCRIPTION
Fixes #9426.
The results of this case is similar to the "clamped case".
The only difference is the set of faces we integrate. In this case, the sums take place over interior faces. I have a question of how to deal with values boundary faces.
I suppose " u = g " is the essential boundary and " \Delta u = h " is the natural boundary.
So " \Delta u = h " will be calculated on the RHS. It comes from the 2nd term on the LHS.
In the 2nd term, faces of the mesh are separated to interior faces and boundary faces.
Then the boundary faces are calculated on the RHS, and " \frac{\partial^2 u_h}{\partial^2 \mathbf{n}} = h ". This is the part I'm not sure. Is it correct? Does it relate to anything about the tangential component of gradient of continuous function? 