### PR TITLE
Handle special case for PolarManifold::normal_vector

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -111,7 +111,7 @@ public:
   push_forward_gradient(const Point<spacedim> &chart_point) const override;
 
   /**
-   * Return the (normalized) normal vector at the point @p p.
+   * @copydoc Manifold::normal_vector()
    */
   virtual Tensor<1, spacedim>
   normal_vector(
@@ -263,7 +263,7 @@ public:
                      const Point<spacedim> &x2) const override;
 
   /**
-   * Return the (normalized) normal vector at the point @p p.
+   * @copydoc Manifold::normal_vector()
    */
   virtual Tensor<1, spacedim>
   normal_vector(

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -111,6 +111,14 @@ public:
   push_forward_gradient(const Point<spacedim> &chart_point) const override;
 
   /**
+   * Return the (normalized) normal vector at the point @p p.
+   */
+  virtual Tensor<1, spacedim>
+  normal_vector(
+    const typename Triangulation<dim, spacedim>::face_iterator &face,
+    const Point<spacedim> &p) const override;
+
+  /**
    * The center of the spherical coordinate system.
    */
   const Point<spacedim> center;

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -325,7 +325,7 @@ PolarManifold<dim, spacedim>::normal_vector(
   // (tangential to the sphere).  In this case, the normal vector is
   // easy to compute since it is proportional to the vector from the
   // center to the point 'p'.
-  if (spherical_face_is_horizontal<dim,spacedim>(face, center))
+  if (spherical_face_is_horizontal<dim, spacedim>(face, center))
     {
       // So, if this is a "horizontal" face, then just compute the normal
       // vector as the one from the center to the point 'p', adequately
@@ -340,7 +340,7 @@ PolarManifold<dim, spacedim>::normal_vector(
     // base class.
     return Manifold<dim, spacedim>::normal_vector(face, p);
 
-  return Tensor<1,spacedim>();
+  return Tensor<1, spacedim>();
 }
 
 
@@ -494,7 +494,7 @@ SphericalManifold<dim, spacedim>::normal_vector(
   // (tangential to the sphere).  In this case, the normal vector is
   // easy to compute since it is proportional to the vector from the
   // center to the point 'p'.
-  if (spherical_face_is_horizontal<dim,spacedim>(face, center))
+  if (spherical_face_is_horizontal<dim, spacedim>(face, center))
     {
       // So, if this is a "horizontal" face, then just compute the normal
       // vector as the one from the center to the point 'p', adequately
@@ -509,7 +509,7 @@ SphericalManifold<dim, spacedim>::normal_vector(
     // base class.
     return Manifold<dim, spacedim>::normal_vector(face, p);
 
-  return Tensor<1,spacedim>();
+  return Tensor<1, spacedim>();
 }
 
 
@@ -547,12 +547,14 @@ SphericalManifold<dim, spacedim>::get_normals_at_vertices(
   // (tangential to the sphere).  In this case, the normal vector is
   // easy to compute since it is proportional to the vector from the
   // center to the point 'p'.
-  if (spherical_face_is_horizontal<dim,spacedim>(face,center))
+  if (spherical_face_is_horizontal<dim, spacedim>(face, center))
     {
       // So, if this is a "horizontal" face, then just compute the normal
       // vector as the one from the center to the point 'p', adequately
       // scaled.
-      for (unsigned int vertex = 0; vertex < GeometryInfo<spacedim>::vertices_per_face; ++vertex)
+      for (unsigned int vertex = 0;
+           vertex < GeometryInfo<spacedim>::vertices_per_face;
+           ++vertex)
         face_vertex_normals[vertex] = face->vertex(vertex) - center;
     }
   else

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -274,6 +274,58 @@ PolarManifold<dim, spacedim>::push_forward_gradient(
 
 
 
+template <int dim, int spacedim>
+Tensor<1, spacedim>
+PolarManifold<dim, spacedim>::normal_vector(
+  const typename Triangulation<dim, spacedim>::face_iterator &face,
+  const Point<spacedim> &                                     p) const
+{
+  // Let us first test whether we are on a "horizontal" face.
+  // In that case, the normal vector is easy to compute
+  // since it is proportional to the vector from the center to the
+  // point 'p'.
+  //
+  // We test whether that is the case by checking that the vertices
+  // all have roughly the same distance from the center: If the
+  // maximum deviation for the distances from the vertices to the
+  // center is less than 1.e-5 of the distance between vertices (as
+  // measured by the minimum distance from any of the other vertices
+  // to the first vertex), then we call this a horizontal face.
+  constexpr unsigned int n_vertices = GeometryInfo<spacedim>::vertices_per_face;
+  std::array<double, n_vertices>     distances_to_center;
+  std::array<double, n_vertices - 1> distances_to_first_vertex;
+  distances_to_center[0] = (face->vertex(0) - center).norm_square();
+  for (unsigned int i = 1; i < n_vertices; ++i)
+    {
+      distances_to_center[i] = (face->vertex(i) - center).norm_square();
+      distances_to_first_vertex[i - 1] =
+        (face->vertex(i) - face->vertex(0)).norm_square();
+    }
+  const auto minmax_distance =
+    std::minmax_element(distances_to_center.begin(), distances_to_center.end());
+  const auto min_distance_to_first_vertex =
+    std::min_element(distances_to_first_vertex.begin(),
+                     distances_to_first_vertex.end());
+
+  // So, if this is a horizontal face, then just compute the normal
+  // vector as the one from the center to the point 'p', adequately
+  // scaled.
+  if (*minmax_distance.second - *minmax_distance.first <
+      1.e-10 * *min_distance_to_first_vertex)
+    {
+      const Tensor<1, spacedim> unnormalized_spherical_normal = p - center;
+      const Tensor<1, spacedim> normalized_spherical_normal =
+        unnormalized_spherical_normal / unnormalized_spherical_normal.norm();
+      return normalized_spherical_normal;
+    }
+
+  // If it is not a horizontal face, just use the machinery of the
+  // base class.
+  return Manifold<dim, spacedim>::normal_vector(face, p);
+}
+
+
+
 // ============================================================
 // SphericalManifold
 // ============================================================

--- a/tests/manifold/polar_manifold_09.cc
+++ b/tests/manifold/polar_manifold_09.cc
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Check PolarManifold for normal vector issues. The PolarManifold
+// should produce the same normal vector as the SphericalManifold in 2D,
+// in particular for points at the same radius.
+
+#include <deal.II/base/geometry_info.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+
+#include "../tests.h"
+
+
+int
+main()
+{
+  initlog();
+
+  // Center and radius of the Ball
+
+  const PolarManifold<2, 2>     polar_manifold;
+  const SphericalManifold<2, 2> spherical_manifold;
+
+  Triangulation<2, 2> tria;
+  GridGenerator::hyper_shell(tria, Point<2>(), .3, .6, 12);
+
+  tria.set_manifold(1, polar_manifold);
+
+  for (typename Triangulation<2, 2>::active_cell_iterator cell =
+         tria.begin_active();
+       cell != tria.end();
+       ++cell)
+    {
+      cell->set_all_manifold_ids(1);
+    }
+
+  for (typename Triangulation<2, 2>::active_cell_iterator cell =
+         tria.begin_active();
+       cell != tria.end();
+       ++cell)
+    {
+      for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+        {
+          const Point<2>     position = cell->face(f)->center();
+          const Tensor<1, 2> polar_normal =
+            polar_manifold.normal_vector(cell->face(f), position);
+          const Tensor<1, 2> spherical_normal =
+            spherical_manifold.normal_vector(cell->face(f), position);
+          deallog << "Position: " << position << std::endl;
+          deallog << "Polar normal: " << polar_normal << std::endl;
+          deallog << "Spherical normal: " << spherical_normal << std::endl;
+          deallog << "Relative difference: "
+                  << (polar_normal - spherical_normal).norm() /
+                       polar_normal.norm()
+                  << std::endl
+                  << std::endl;
+        }
+    }
+
+  return 0;
+}

--- a/tests/manifold/polar_manifold_09.output
+++ b/tests/manifold/polar_manifold_09.output
@@ -1,0 +1,241 @@
+
+DEAL::Position: 0.450000 0.00000
+DEAL::Polar normal: 0.00000 1.00000
+DEAL::Spherical normal: 0.00000 1.00000
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.389711 0.225000
+DEAL::Polar normal: -0.500000 0.866025
+DEAL::Spherical normal: -0.500000 0.866025
+DEAL::Relative difference: 5.55112e-17
+DEAL::
+DEAL::Position: 0.559808 0.150000
+DEAL::Polar normal: 0.965926 0.258819
+DEAL::Spherical normal: 0.965926 0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.279904 0.0750000
+DEAL::Polar normal: 0.965926 0.258819
+DEAL::Spherical normal: 0.965926 0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.389711 0.225000
+DEAL::Polar normal: -0.500000 0.866025
+DEAL::Spherical normal: -0.500000 0.866025
+DEAL::Relative difference: 5.55112e-17
+DEAL::
+DEAL::Position: 0.225000 0.389711
+DEAL::Polar normal: -0.866025 0.500000
+DEAL::Spherical normal: -0.866025 0.500000
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 0.409808 0.409808
+DEAL::Polar normal: 0.707107 0.707107
+DEAL::Spherical normal: 0.707107 0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.204904 0.204904
+DEAL::Polar normal: 0.707107 0.707107
+DEAL::Spherical normal: 0.707107 0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.225000 0.389711
+DEAL::Polar normal: -0.866025 0.500000
+DEAL::Spherical normal: -0.866025 0.500000
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 2.75546e-17 0.450000
+DEAL::Polar normal: -1.00000 6.12323e-17
+DEAL::Spherical normal: -1.00000 6.12323e-17
+DEAL::Relative difference: 1.23260e-32
+DEAL::
+DEAL::Position: 0.150000 0.559808
+DEAL::Polar normal: 0.258819 0.965926
+DEAL::Spherical normal: 0.258819 0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.0750000 0.279904
+DEAL::Polar normal: 0.258819 0.965926
+DEAL::Spherical normal: 0.258819 0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 2.75546e-17 0.450000
+DEAL::Polar normal: -1.00000 6.12323e-17
+DEAL::Spherical normal: -1.00000 6.12323e-17
+DEAL::Relative difference: 1.23260e-32
+DEAL::
+DEAL::Position: -0.225000 0.389711
+DEAL::Polar normal: -0.866025 -0.500000
+DEAL::Spherical normal: -0.866025 -0.500000
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.150000 0.559808
+DEAL::Polar normal: -0.258819 0.965926
+DEAL::Spherical normal: -0.258819 0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.0750000 0.279904
+DEAL::Polar normal: -0.258819 0.965926
+DEAL::Spherical normal: -0.258819 0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.225000 0.389711
+DEAL::Polar normal: -0.866025 -0.500000
+DEAL::Spherical normal: -0.866025 -0.500000
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.389711 0.225000
+DEAL::Polar normal: -0.500000 -0.866025
+DEAL::Spherical normal: -0.500000 -0.866025
+DEAL::Relative difference: 5.55112e-17
+DEAL::
+DEAL::Position: -0.409808 0.409808
+DEAL::Polar normal: -0.707107 0.707107
+DEAL::Spherical normal: -0.707107 0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.204904 0.204904
+DEAL::Polar normal: -0.707107 0.707107
+DEAL::Spherical normal: -0.707107 0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.389711 0.225000
+DEAL::Polar normal: -0.500000 -0.866025
+DEAL::Spherical normal: -0.500000 -0.866025
+DEAL::Relative difference: 5.55112e-17
+DEAL::
+DEAL::Position: -0.450000 5.51091e-17
+DEAL::Polar normal: -1.22465e-16 -1.00000
+DEAL::Spherical normal: -1.22465e-16 -1.00000
+DEAL::Relative difference: 2.46519e-32
+DEAL::
+DEAL::Position: -0.559808 0.150000
+DEAL::Polar normal: -0.965926 0.258819
+DEAL::Spherical normal: -0.965926 0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.279904 0.0750000
+DEAL::Polar normal: -0.965926 0.258819
+DEAL::Spherical normal: -0.965926 0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.450000 5.51091e-17
+DEAL::Polar normal: -1.22465e-16 -1.00000
+DEAL::Spherical normal: -1.22465e-16 -1.00000
+DEAL::Relative difference: 2.46519e-32
+DEAL::
+DEAL::Position: -0.389711 -0.225000
+DEAL::Polar normal: 0.500000 -0.866025
+DEAL::Spherical normal: 0.500000 -0.866025
+DEAL::Relative difference: 4.00297e-16
+DEAL::
+DEAL::Position: -0.559808 -0.150000
+DEAL::Polar normal: -0.965926 -0.258819
+DEAL::Spherical normal: -0.965926 -0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.279904 -0.0750000
+DEAL::Polar normal: -0.965926 -0.258819
+DEAL::Spherical normal: -0.965926 -0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.389711 -0.225000
+DEAL::Polar normal: 0.500000 -0.866025
+DEAL::Spherical normal: 0.500000 -0.866025
+DEAL::Relative difference: 4.00297e-16
+DEAL::
+DEAL::Position: -0.225000 -0.389711
+DEAL::Polar normal: 0.866025 -0.500000
+DEAL::Spherical normal: 0.866025 -0.500000
+DEAL::Relative difference: 8.95090e-16
+DEAL::
+DEAL::Position: -0.409808 -0.409808
+DEAL::Polar normal: -0.707107 -0.707107
+DEAL::Spherical normal: -0.707107 -0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.204904 -0.204904
+DEAL::Polar normal: -0.707107 -0.707107
+DEAL::Spherical normal: -0.707107 -0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.225000 -0.389711
+DEAL::Polar normal: 0.866025 -0.500000
+DEAL::Spherical normal: 0.866025 -0.500000
+DEAL::Relative difference: 8.95090e-16
+DEAL::
+DEAL::Position: -8.26637e-17 -0.450000
+DEAL::Polar normal: 1.00000 -1.83697e-16
+DEAL::Spherical normal: 1.00000 -1.83697e-16
+DEAL::Relative difference: 2.46519e-32
+DEAL::
+DEAL::Position: -0.150000 -0.559808
+DEAL::Polar normal: -0.258819 -0.965926
+DEAL::Spherical normal: -0.258819 -0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -0.0750000 -0.279904
+DEAL::Polar normal: -0.258819 -0.965926
+DEAL::Spherical normal: -0.258819 -0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: -8.26637e-17 -0.450000
+DEAL::Polar normal: 1.00000 -1.83697e-16
+DEAL::Spherical normal: 1.00000 -1.83697e-16
+DEAL::Relative difference: 2.46519e-32
+DEAL::
+DEAL::Position: 0.225000 -0.389711
+DEAL::Polar normal: 0.866025 0.500000
+DEAL::Spherical normal: 0.866025 0.500000
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 0.150000 -0.559808
+DEAL::Polar normal: 0.258819 -0.965926
+DEAL::Spherical normal: 0.258819 -0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.0750000 -0.279904
+DEAL::Polar normal: 0.258819 -0.965926
+DEAL::Spherical normal: 0.258819 -0.965926
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.225000 -0.389711
+DEAL::Polar normal: 0.866025 0.500000
+DEAL::Spherical normal: 0.866025 0.500000
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 0.389711 -0.225000
+DEAL::Polar normal: 0.500000 0.866025
+DEAL::Spherical normal: 0.500000 0.866025
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 0.409808 -0.409808
+DEAL::Polar normal: 0.707107 -0.707107
+DEAL::Spherical normal: 0.707107 -0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.204904 -0.204904
+DEAL::Polar normal: 0.707107 -0.707107
+DEAL::Spherical normal: 0.707107 -0.707107
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.389711 -0.225000
+DEAL::Polar normal: 0.500000 0.866025
+DEAL::Spherical normal: 0.500000 0.866025
+DEAL::Relative difference: 1.11022e-16
+DEAL::
+DEAL::Position: 0.450000 0.00000
+DEAL::Polar normal: 0.00000 1.00000
+DEAL::Spherical normal: 0.00000 1.00000
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.559808 -0.150000
+DEAL::Polar normal: 0.965926 -0.258819
+DEAL::Spherical normal: 0.965926 -0.258819
+DEAL::Relative difference: 0.00000
+DEAL::
+DEAL::Position: 0.279904 -0.0750000
+DEAL::Polar normal: 0.965926 -0.258819
+DEAL::Spherical normal: 0.965926 -0.258819
+DEAL::Relative difference: 0.00000
+DEAL::


### PR DESCRIPTION
This copies a special case from `SphericalManifold::normal_vector` to `PolarManifold`. The issue at hand is that for horizontal boundaries in spheres (i.e. r=const.) and when using a Q1 mapping the radius of the point `p` that is handed over to the function can differ significantly from the radius at the cell vertices that are used to compute the normal vector in `Manifold::normal_vector`. This in particular leads to issues when computing normal flux constraints, because the normal vector is not normal to the radial surface (see geodynamics/aspect#3359 for a bug report related to this behavior). For comparison this is some of the output of the included testcase without the fix (the normal from spherical manifold and polar manifold should be identical):
```
DEAL::Position: 0.559808 0.150000
DEAL::Polar normal: 0.922712 0.385489
DEAL::Spherical normal: 0.965926 0.258819
DEAL::Relative difference: 0.133838
DEAL::
DEAL::Position: 0.279904 0.0750000
DEAL::Polar normal: 0.922712 0.385489
DEAL::Spherical normal: 0.965926 0.258819
DEAL::Relative difference: 0.133838
```
