### PR TITLE
Enable refreshing of MatrixFree geometry data for changed mapping

### DIFF
--- a/doc/news/changes/minor/20200225MartinKronbichler
+++ b/doc/news/changes/minor/20200225MartinKronbichler
@@ -1,0 +1,6 @@
+New: There is now a new function MatrixFree::update_mapping() that allows to
+refresh the stored geometry data when the mapping has changed, for example
+through a Eulerian mesh motion, while keeping all other data structures such
+as vector exchange pattern or dof indices alive.
+<br>
+(Martin Kronbichler, 2020/02/25)

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -146,6 +146,12 @@ namespace internal
         unsigned int n_q_points;
 
         /**
+         * Original one-dimensional quadrature formula applied on the given
+         * cell or face.
+         */
+        Quadrature<1> quadrature_1d;
+
+        /**
          * Quadrature formula applied on the given cell or face.
          */
         Quadrature<structdim> quadrature;
@@ -266,6 +272,12 @@ namespace internal
       AlignedVector<Point<spacedim, VectorizedArrayType>> quadrature_points;
 
       /**
+       * Clears all data fields except the descriptor vector.
+       */
+      void
+      clear_data_fields();
+
+      /**
        * Returns the quadrature index for a given number of quadrature
        * points. If not in hp mode or if the index is not found, this
        * function always returns index 0. Hence, this function does not
@@ -281,7 +293,7 @@ namespace internal
       template <typename StreamType>
       void
       print_memory_consumption(StreamType &    out,
-                               const SizeInfo &task_info) const;
+                               const TaskInfo &task_info) const;
 
       /**
        * Returns the memory consumption in bytes.
@@ -325,6 +337,20 @@ namespace internal
         const UpdateFlags update_flags_faces_by_cells);
 
       /**
+       * Update the information in the given cells and faces that is the
+       * result of a change in the given `mapping` class, keeping the cells,
+       * quadrature formulas and other unknowns unchanged. This call is only
+       * valid if MappingInfo::initialize() has been called before.
+       */
+      void
+      update_mapping(
+        const dealii::Triangulation<dim> &                        tria,
+        const std::vector<std::pair<unsigned int, unsigned int>> &cells,
+        const FaceInfo<VectorizedArrayType::n_array_elements> &   faces,
+        const std::vector<unsigned int> &active_fe_index,
+        const Mapping<dim> &             mapping);
+
+      /**
        * Return the type of a given cell as detected during initialization.
        */
       GeometryType
@@ -350,6 +376,29 @@ namespace internal
       void
       print_memory_consumption(StreamType &    out,
                                const TaskInfo &task_info) const;
+
+      /**
+       * The given update flags for computing the geometry on the cells.
+       */
+      UpdateFlags update_flags_cells;
+
+      /**
+       * The given update flags for computing the geometry on the boundary
+       * faces.
+       */
+      UpdateFlags update_flags_boundary_faces;
+
+      /**
+       * The given update flags for computing the geometry on the interior
+       * faces.
+       */
+      UpdateFlags update_flags_inner_faces;
+
+      /**
+       * The given update flags for computing the geometry on the faces for
+       * cell-centric loops.
+       */
+      UpdateFlags update_flags_faces_by_cells;
 
       /**
        * Stores whether a cell is Cartesian (cell type 0), has constant
@@ -400,10 +449,8 @@ namespace internal
       initialize_cells(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const std::vector<unsigned int> &              active_fe_index,
-        const Mapping<dim> &                           mapping,
-        const std::vector<dealii::hp::QCollection<1>> &quad,
-        const UpdateFlags                              update_flags_cells);
+        const std::vector<unsigned int> &active_fe_index,
+        const Mapping<dim> &             mapping);
 
       /**
        * Computes the information in the given faces, called within
@@ -415,10 +462,7 @@ namespace internal
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
         const std::vector<
           FaceToCellTopology<VectorizedArrayType::n_array_elements>> &faces,
-        const Mapping<dim> &                                          mapping,
-        const std::vector<dealii::hp::QCollection<1>> &               quad,
-        const UpdateFlags update_flags_boundary_faces,
-        const UpdateFlags update_flags_inner_faces);
+        const Mapping<dim> &                                          mapping);
 
       /**
        * Computes the information in the given faces, called within
@@ -428,9 +472,7 @@ namespace internal
       initialize_faces_by_cells(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const Mapping<dim> &                                      mapping,
-        const std::vector<dealii::hp::QCollection<1>> &           quad,
-        const UpdateFlags update_flags_faces_by_cells);
+        const Mapping<dim> &                                      mapping);
 
       /**
        * Helper function to determine which update flags must be set in the

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -685,6 +685,18 @@ public:
     const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free_base);
 
   /**
+   * Refreshes the geometry data stored in the MappingInfo fields when the
+   * underlying geometry has changed (e.g. by a mapping that can deform
+   * through a change in the spatial configuration like MappingFEField)
+   * whereas the topology of the mesh and unknowns have remained the
+   * same. Compared to reinit(), this operation only has to re-generate the
+   * geometry arrays and can thus be significantly cheaper (depending on the
+   * cost to evaluate the geometry).
+   */
+  void
+  update_mapping(const Mapping<dim> &mapping);
+
+  /**
    * Clear all data fields and brings the class into a condition similar to
    * after having called the default constructor.
    */

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -681,6 +681,25 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
 }
 
 
+
+template <int dim, typename Number, typename VectorizedArrayType>
+void
+MatrixFree<dim, Number, VectorizedArrayType>::update_mapping(
+  const Mapping<dim> &mapping)
+{
+  AssertDimension(shape_info.size(1), mapping_info.cell_data.size());
+  mapping_info.update_mapping(
+    dof_handlers.active_dof_handler == DoFHandlers::hp ?
+      dof_handlers.hp_dof_handler[0]->get_triangulation() :
+      dof_handlers.dof_handler[0]->get_triangulation(),
+    cell_level_index,
+    face_info,
+    dof_info[0].cell_active_fe_index,
+    mapping);
+}
+
+
+
 template <int dim, typename Number, typename VectorizedArrayType>
 template <int spacedim>
 bool

--- a/tests/matrix_free/matrix_vector_faces_28.cc
+++ b/tests/matrix_free/matrix_vector_faces_28.cc
@@ -1,0 +1,174 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that MatrixFree::update_mapping() works as expected. The test is
+// otherwise similar to matrix_vector_faces_03.
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_fe_field.h>
+
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+#include "create_mesh.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_faces_common.h"
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  create_mesh(tria);
+
+  tria.begin_active()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  typename Triangulation<dim>::active_cell_iterator cell, endc;
+  cell = tria.begin_active();
+  endc = tria.end();
+  for (; cell != endc; ++cell)
+    if (cell->center().norm() < 0.5)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  // if (fe_degree == 1)
+  //  tria.refine_global(1);
+  cell = tria.begin_active();
+  for (unsigned int i = 0; i < 9 - 3 * dim; ++i)
+    {
+      cell                 = tria.begin_active();
+      endc                 = tria.end();
+      unsigned int counter = 0;
+      for (; cell != endc; ++cell, ++counter)
+        if (counter % (7 - i) == 0)
+          cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  deallog << "Degree of element: " << fe_degree << std::endl;
+
+  FE_DGQ<dim>     fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  FESystem<dim>   fe_grid(FE_Q<dim>(dof.get_fe().degree), dim);
+  DoFHandler<dim> dof_grid(tria);
+  dof_grid.distribute_dofs(fe_grid);
+  Vector<double> euler;
+  euler.reinit(dof_grid.n_dofs());
+  const ComponentMask mask(dim, true);
+  VectorTools::get_position_vector(dof_grid, euler, mask);
+
+  MappingFEField<dim> mapping(dof_grid, euler, mask);
+
+  Vector<double> in(dof.n_dofs()), out(dof.n_dofs());
+  Vector<double> out_dist(out);
+
+  // Set random seed for reproducibility
+  Testing::srand(42);
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    {
+      if (constraints.is_constrained(i))
+        continue;
+      const double entry = Testing::rand() / (double)RAND_MAX;
+      in(i)              = entry;
+    }
+
+  auto create_reference_result = [&]() {
+    // assemble sparse matrix with MeshWorker
+    SparsityPattern      sparsity;
+    SparseMatrix<double> matrix;
+    {
+      DynamicSparsityPattern d_sparsity(dof.n_dofs());
+      DoFTools::make_flux_sparsity_pattern(dof, d_sparsity);
+      sparsity.copy_from(d_sparsity);
+    }
+    const unsigned int n_q_points_1d = dof.get_fe().degree + 1;
+    matrix.reinit(sparsity);
+    MeshWorker::IntegrationInfoBox<dim> info_box;
+    UpdateFlags                         update_flags =
+      update_values | update_gradients | update_jacobians;
+    info_box.add_update_flags_all(update_flags);
+    info_box.initialize_gauss_quadrature(n_q_points_1d,
+                                         n_q_points_1d,
+                                         n_q_points_1d);
+    info_box.initialize(dof.get_fe(), mapping);
+
+    MeshWorker::DoFInfo<dim> dof_info(dof);
+
+    MeshWorker::Assembler::MatrixSimple<SparseMatrix<double>> assembler;
+    assembler.initialize(matrix);
+
+    MatrixIntegrator<dim> integrator;
+    MeshWorker::integration_loop<dim, dim>(
+      dof.begin_active(), dof.end(), dof_info, info_box, integrator, assembler);
+
+    matrix.vmult(out, in);
+  };
+
+  MatrixFree<dim>                          mf_data;
+  const QGauss<1>                          quad(dof.get_fe().degree + 1);
+  typename MatrixFree<dim>::AdditionalData data;
+  data.tasks_parallel_scheme = MatrixFree<dim>::AdditionalData::none;
+  data.tasks_block_size      = 3;
+  data.mapping_update_flags_inner_faces =
+    (update_gradients | update_JxW_values);
+  data.mapping_update_flags_boundary_faces =
+    (update_gradients | update_JxW_values);
+
+  mf_data.reinit(mapping, dof, constraints, quad, data);
+
+  MatrixFreeTest<dim, fe_degree, fe_degree + 1, double, Vector<double>, 1> mf(
+    mf_data);
+  mf.vmult(out_dist, in);
+  create_reference_result();
+
+  out_dist -= out;
+  double diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+  deallog << "Norm of difference:           " << diff_norm << std::endl;
+
+  // deform the geometry slightly
+  euler(0) += 0.001;
+  euler(euler.size() - 1) += 0.001;
+
+  mf.vmult(out_dist, in);
+  create_reference_result();
+
+  out_dist -= out;
+  diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+  deallog << "Norm of difference no update: " << diff_norm << std::endl;
+
+  mf_data.update_mapping(mapping);
+  mf.vmult(out_dist, in);
+  out_dist -= out;
+  diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+  deallog << "Norm of difference w update:  " << diff_norm << std::endl;
+}

--- a/tests/matrix_free/matrix_vector_faces_28.output
+++ b/tests/matrix_free/matrix_vector_faces_28.output
@@ -1,0 +1,17 @@
+
+DEAL:2d::Degree of element: 1
+DEAL:2d::Norm of difference:           4.87e-16
+DEAL:2d::Norm of difference no update: 0.0179
+DEAL:2d::Norm of difference w update:  4.87e-16
+DEAL:2d::Degree of element: 2
+DEAL:2d::Norm of difference:           1.92e-15
+DEAL:2d::Norm of difference no update: 0.00672
+DEAL:2d::Norm of difference w update:  2.50e-15
+DEAL:3d::Degree of element: 1
+DEAL:3d::Norm of difference:           1.88e-16
+DEAL:3d::Norm of difference no update: 5.11e-05
+DEAL:3d::Norm of difference w update:  1.88e-16
+DEAL:3d::Degree of element: 2
+DEAL:3d::Norm of difference:           1.06e-16
+DEAL:3d::Norm of difference no update: 5.82e-05
+DEAL:3d::Norm of difference w update:  1.06e-16


### PR DESCRIPTION
In certain applications, one wants to impose a grid motion (e.g. through an Euler vector with `MappingFEField`) during the course of a simulation, and still keep alive all other data structures in `MatrixFree`, like shared pointers and the like. This commit adds a new function `MatrixFree::update_mapping(const Mapping<dim>&)` that can perform this step. To make the update stable in `MatrixFreeFunctions::MappingInfo`, I reworked the initialization routines a bit to separate the constant data (like quadrature formula) from the geometry-dependent one and let me separately compute the latter again.

This passes all tests `ctest -R matrix_free` (when combined with #9564).

@nfehn FYI.