### PR TITLE
Deprecate another function in DoFTools.

### DIFF
--- a/doc/news/changes/incompatibilities/20200225Bangerth
+++ b/doc/news/changes/incompatibilities/20200225Bangerth
@@ -1,0 +1,6 @@
+Deprecated: The DoFTools::extract_locally_relevant_dofs() function
+returned an IndexSet object through a reference argument. This version
+of the function has now been deprecated and replaced by one that
+returns the IndexSet object as a regular function return value.
+<br>
+(Wolfgang Bangerth, 2020/02/25)

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -816,7 +816,8 @@ namespace Step18
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // The next thing is to store some information for later use on how many
     // cells or degrees of freedom the present processor, or any of the

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1883,16 +1883,16 @@ namespace Step32
     // that actually set up the matrices, and at the end also resize the
     // various vectors we keep around in this program.
     std::vector<IndexSet> stokes_partitioning, stokes_relevant_partitioning;
-    IndexSet              temperature_partitioning(n_T),
-      temperature_relevant_partitioning(n_T);
-    IndexSet stokes_relevant_set;
+    IndexSet              temperature_partitioning(n_T);
+    IndexSet              temperature_relevant_partitioning(n_T);
+
+    const IndexSet stokes_relevant_set =
+      DoFTools::extract_locally_relevant_dofs(stokes_dof_handler);
     {
-      IndexSet stokes_index_set = stokes_dof_handler.locally_owned_dofs();
+      const IndexSet stokes_index_set = stokes_dof_handler.locally_owned_dofs();
       stokes_partitioning.push_back(stokes_index_set.get_view(0, n_u));
       stokes_partitioning.push_back(stokes_index_set.get_view(n_u, n_u + n_p));
 
-      DoFTools::extract_locally_relevant_dofs(stokes_dof_handler,
-                                              stokes_relevant_set);
       stokes_relevant_partitioning.push_back(
         stokes_relevant_set.get_view(0, n_u));
       stokes_relevant_partitioning.push_back(
@@ -3224,9 +3224,8 @@ namespace Step32
 
     joint_solution.compress(VectorOperation::insert);
 
-    IndexSet locally_relevant_joint_dofs(joint_dof_handler.n_dofs());
-    DoFTools::extract_locally_relevant_dofs(joint_dof_handler,
-                                            locally_relevant_joint_dofs);
+    const IndexSet locally_relevant_joint_dofs =
+      DoFTools::extract_locally_relevant_dofs(joint_dof_handler);
     TrilinosWrappers::MPI::Vector locally_relevant_joint_solution;
     locally_relevant_joint_solution.reinit(locally_relevant_joint_dofs,
                                            MPI_COMM_WORLD);

--- a/examples/step-37/doc/results.dox
+++ b/examples/step-37/doc/results.dox
@@ -427,8 +427,8 @@ temporary vector and LinearAlgebra::distributed::Vector::copy_locally_owned_data
 as shown below.
 
 @code
-IndexSet locally_relevant_dofs;
-DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+const IndexSet locally_relevant_dofs
+  = DoFTools::extract_locally_relevant_dofs(dof_handler);
 LinearAlgebra::distributed::Vector<double> copy_vec(solution);
 solution.reinit(dof_handler.locally_owned_dofs(),
                 locally_relevant_dofs,

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -790,8 +790,8 @@ namespace Step37
     pcout << "Number of degrees of freedom: " << dof_handler.n_dofs()
           << std::endl;
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -247,7 +247,8 @@ namespace Step40
     // around the locally owned cells; we need all of these degrees of
     // freedom, for example, to estimate the error on the local cells).
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // Next, let us initialize the solution and right hand side vectors. As
     // mentioned above, the solution vector we seek does not only store

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -976,9 +976,8 @@ namespace Step42
       dof_handler.distribute_dofs(fe);
 
       locally_owned_dofs = dof_handler.locally_owned_dofs();
-      locally_relevant_dofs.clear();
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
     }
 
     /* setup hanging nodes and Dirichlet constraints */

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -374,9 +374,8 @@ namespace Step45
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -424,7 +424,8 @@ namespace Step48
     // access in MPI-local numbers that need to match between the vector and
     // MatrixFree), so we just ask it to initialize the vectors to be sure the
     // ghost exchange is properly handled.
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -252,7 +252,7 @@ namespace Step50
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_set);
+    locally_relevant_set = DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     solution.reinit(dof_handler.locally_owned_dofs(), mpi_communicator);
     system_rhs.reinit(dof_handler.locally_owned_dofs(), mpi_communicator);

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -379,8 +379,8 @@ namespace Step55
     owned_partitioning[1] =
       dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     relevant_partitioning.resize(2);
     relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
     relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -747,7 +747,8 @@ namespace step62
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -395,7 +395,8 @@ namespace Step64
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     system_rhs_dev.reinit(locally_owned_dofs, mpi_communicator);
 
     constraints.clear();

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1791,7 +1791,7 @@ namespace DoFTools
   /**
    * Extract the set of global DoF indices that are active on the current
    * DoFHandler. For regular DoFHandlers, these are all DoF indices, but for
-   * DoFHandler objects built on parallel::distributed::Triangulation this set
+   * DoFHandler objects built on parallel::Triangulation this set
    * is a superset of DoFHandler::locally_owned_dofs() and contains all DoF
    * indices that live on all locally owned cells (including on the interface
    * to ghost cells). However, it does not contain the DoF indices that are
@@ -1808,19 +1808,26 @@ namespace DoFTools
                               IndexSet &            dof_set);
 
   /**
-   * Extract the set of global DoF indices that are active on the current
-   * DoFHandler. For regular DoFHandlers, these are all DoF indices, but for
-   * DoFHandler objects built on parallel::distributed::Triangulation this set
-   * is the union of DoFHandler::locally_owned_dofs() and the DoF indices on
-   * all ghost cells. In essence, it is the DoF indices on all cells that are
-   * not artificial (see
+   * Extract the set of global DoF indices that are locally relevant to the
+   * current DoFHandler. For regular DoFHandlers, these are all DoF indices, but
+   * for DoFHandler objects built on parallel::Triangulation, this set is the
+   * union of DoFHandler::locally_owned_dofs() and the DoF indices on all ghost
+   * cells. In essence, it is the DoF indices on all cells that are not
+   * artificial (see
    * @ref GlossArtificialCell "the glossary").
    */
   template <typename DoFHandlerType>
-  void
+  IndexSet
+  extract_locally_relevant_dofs(const DoFHandlerType &dof_handler);
+
+  /**
+   * Same as the previous function, but return the set of locally
+   * relevant DoF indices through the second argument.
+   */
+  template <typename DoFHandlerType>
+  DEAL_II_DEPRECATED void
   extract_locally_relevant_dofs(const DoFHandlerType &dof_handler,
                                 IndexSet &            dof_set);
-
 
   /**
    * Extract the set of locally owned DoF indices for each component within the

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1183,8 +1183,18 @@ namespace DoFTools
   extract_locally_relevant_dofs(const DoFHandlerType &dof_handler,
                                 IndexSet &            dof_set)
   {
-    // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_dofs();
+    // Just call the non-deprecated function:
+    dof_set = extract_locally_relevant_dofs(dof_handler);
+  }
+
+
+
+  template <typename DoFHandlerType>
+  IndexSet
+  extract_locally_relevant_dofs(const DoFHandlerType &dof_handler)
+  {
+    // Start by collecting all the locally owned dofs
+    IndexSet dof_set = dof_handler.locally_owned_dofs();
 
     // now add the DoF on the adjacent ghost cells to the IndexSet
 
@@ -1197,10 +1207,7 @@ namespace DoFTools
     std::vector<types::global_dof_index> dof_indices;
     std::vector<types::global_dof_index> dofs_on_ghosts;
 
-    typename DoFHandlerType::active_cell_iterator cell =
-                                                    dof_handler.begin_active(),
-                                                  endc = dof_handler.end();
-    for (; cell != endc; ++cell)
+    for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_ghost())
         {
           dof_indices.resize(cell->get_fe().dofs_per_cell);
@@ -1216,6 +1223,8 @@ namespace DoFTools
                         std::unique(dofs_on_ghosts.begin(),
                                     dofs_on_ghosts.end()));
     dof_set.compress();
+
+    return dof_set;
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -20,12 +20,20 @@ for (DoFHandler : DOFHANDLER_TEMPLATES;
 #if deal_II_dimension <= deal_II_space_dimension
     namespace DoFTools
     \{
+      // Deprecated function:
       template void
       extract_locally_relevant_dofs<
         DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension>
           &       dof_handler,
         IndexSet &dof_set);
+
+      // Non-deprecated function:
+      template IndexSet
+      extract_locally_relevant_dofs<
+        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &dof_handler);
 
       template void
       extract_locally_relevant_level_dofs<


### PR DESCRIPTION
It's again a function that returns by-argument instead of by-value. Replace it by a function that returns by-value.

Also replace the usage of this function in the examples.