### PR TITLE
fix 64bit overflow in refine_and_coarsen_fixed_number

### DIFF
--- a/include/deal.II/distributed/grid_refinement.h
+++ b/include/deal.II/distributed/grid_refinement.h
@@ -131,10 +131,10 @@ namespace parallel
       refine_and_coarsen_fixed_number(
         parallel::distributed::Triangulation<dim, spacedim> &tria,
         const dealii::Vector<Number> &                       criteria,
-        const double       top_fraction_of_cells,
-        const double       bottom_fraction_of_cells,
-        const unsigned int max_n_cells =
-          std::numeric_limits<unsigned int>::max());
+        const double                  top_fraction_of_cells,
+        const double                  bottom_fraction_of_cells,
+        const types::global_dof_index max_n_cells =
+          std::numeric_limits<types::global_dof_index>::max());
 
       /**
        * Like dealii::GridRefinement::refine_and_coarsen_fixed_fraction, but

--- a/include/deal.II/grid/grid_refinement.h
+++ b/include/deal.II/grid/grid_refinement.h
@@ -87,10 +87,10 @@ namespace GridRefinement
   template <int dim>
   std::pair<double, double>
   adjust_refine_and_coarsen_number_fraction(
-    const unsigned int current_n_cells,
-    const unsigned int max_n_cells,
-    const double       top_fraction_of_cells,
-    const double       bottom_fraction_of_cells);
+    const types::global_dof_index current_n_cells,
+    const types::global_dof_index max_n_cells,
+    const double                  top_fraction_of_cells,
+    const double                  bottom_fraction_of_cells);
 
   /**
    * This function provides a strategy to mark cells for refinement and

--- a/source/distributed/grid_refinement.cc
+++ b/source/distributed/grid_refinement.cc
@@ -434,9 +434,9 @@ namespace parallel
       refine_and_coarsen_fixed_number(
         parallel::distributed::Triangulation<dim, spacedim> &tria,
         const dealii::Vector<Number> &                       criteria,
-        const double       top_fraction_of_cells,
-        const double       bottom_fraction_of_cells,
-        const unsigned int max_n_cells)
+        const double                  top_fraction_of_cells,
+        const double                  bottom_fraction_of_cells,
+        const types::global_dof_index max_n_cells)
       {
         Assert(criteria.size() == tria.n_active_cells(),
                ExcDimensionMismatch(criteria.size(), tria.n_active_cells()));

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -69,7 +69,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
             const dealii::Vector<S> &,
             const double,
             const double,
-            const unsigned int);
+            const types::global_dof_index);
 
           template void
           refine_and_coarsen_fixed_fraction<deal_II_dimension,
@@ -100,7 +100,7 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
             const dealii::Vector<S> &,
             const double,
             const double,
-            const unsigned int);
+            const types::global_dof_index);
 
           template void refine_and_coarsen_fixed_fraction<deal_II_dimension - 1,
                                                           S,

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -110,10 +110,10 @@ GridRefinement::coarsen(Triangulation<dim, spacedim> &tria,
 template <int dim>
 std::pair<double, double>
 GridRefinement::adjust_refine_and_coarsen_number_fraction(
-  const unsigned int current_n_cells,
-  const unsigned int max_n_cells,
-  const double       top_fraction,
-  const double       bottom_fraction)
+  const types::global_dof_index current_n_cells,
+  const types::global_dof_index max_n_cells,
+  const double                  top_fraction,
+  const double                  bottom_fraction)
 {
   Assert(top_fraction >= 0, ExcInvalidParameterValue());
   Assert(top_fraction <= 1, ExcInvalidParameterValue());
@@ -166,7 +166,7 @@ GridRefinement::adjust_refine_and_coarsen_number_fraction(
   // again, this is true for isotropically
   // refined cells. we take this as an
   // approximation of a mixed refinement.
-  else if (static_cast<unsigned int>(
+  else if (static_cast<types::global_dof_index>(
              current_n_cells + refine_cells * cell_increase_on_refine -
              coarsen_cells * cell_decrease_on_coarsen) > max_n_cells)
     {

--- a/source/grid/grid_refinement.inst.in
+++ b/source/grid/grid_refinement.inst.in
@@ -97,7 +97,10 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template std::pair<double, double> GridRefinement::
-      adjust_refine_and_coarsen_number_fraction<deal_II_dimension>(
-        const unsigned int, const unsigned int, const double, const double);
+    template std::pair<double, double>
+    GridRefinement::adjust_refine_and_coarsen_number_fraction<
+      deal_II_dimension>(const types::global_dof_index,
+                         const types::global_dof_index,
+                         const double,
+                         const double);
   }


### PR DESCRIPTION
The argument max_n_cells (that probably nobody uses) was declared as an
unsigned int, meaning that we can not correctly refine over 4 billion cells with
this function. This is now fixed.

part of #9547
