### PR TITLE
doxygen: skip license header in step-xxb

### DIFF
--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -14,10 +14,11 @@
 ## ---------------------------------------------------------------------
 
 
-# skip header lines at the top of the file, such as copyright notices 
-# and license information, if the file is a step-xx.cc tutorial. don't
-# skip for other files such as code-gallery files
-if ($ARGV[0] =~ /step-\d+.[cc|cu]/)
+# Skip header lines at the top of the file, such as copyright notices and
+# license information, if the file is a step-xx.cc or .cu tutorial. Here, xx
+# is either a number like step-32 or a number plus a letter like step-12b.
+# Don't skip for other files such as code-gallery files
+if ($ARGV[0] =~ /step-\d+[a-z]?.[cc|cu]/)
 {
   $_ = <>;
   while ( m!^/\*!  ||  m!\s*\*! || m/^$/ ) {


### PR DESCRIPTION
We introduced tutorials like step-12b but we incorrectly print the
license header at the beginning of the "commented program". Filter those
out as well.