### PR TITLE
doxygen: do not remove multiline code comments

### DIFF
--- a/doc/doxygen/scripts/program2doxygen
+++ b/doc/doxygen/scripts/program2doxygen
@@ -38,11 +38,6 @@ print " * \n";
 
 do {
 
-    # Make sure that we don't output comment end markers that might confuse
-    # doxygen.
-    s!/\*!/ \*!g;
-    s!\*/!\* /!g;
-
     # substitute tabs
     s/\t/        /g;
 


### PR DESCRIPTION
Code in tutorials that contains multiline comments like
```
/*keep_constrained_dofs = */ false
```
were being replaced by
```
/ *keep_constrained_dofs = * / false
```
I don't see why this is necessary. The documentation looks correct to
me with this change.

fixes #9554