### PR TITLE
Add rank 2 tensor orthogonalization function

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -2631,7 +2631,7 @@ cofactor(const Tensor<2, dim, Number> &t)
  * @relatesalso Tensor
  */
 template <int dim, typename Number>
-constexpr Tensor<2, dim, Number>
+Tensor<2, dim, Number>
 project_onto_orthogonal_tensors(const Tensor<2, dim, Number> &tensor,
                                 const double                  tolerance)
 {

--- a/tests/ad_common_tests/tensor_functions_01.h
+++ b/tests/ad_common_tests/tensor_functions_01.h
@@ -61,7 +61,8 @@ test_tensor()
   const Tensor<2, dim, ADNumberType> A_T         = transpose(A);
   const Tensor<2, dim, ADNumberType> A_adj       = adjugate(A);
   const Tensor<2, dim, ADNumberType> A_cof       = cofactor(A);
-  const ADNumberType                 A_l1_norm   = l1_norm(A);
+  const Tensor<2, dim, ADNumberType> A_orth      = orthogonalize(A);
+  const ADNumberType                 A_l1_norm   = l1_norm(A, 1e-8);
   const ADNumberType                 A_linf_norm = linfty_norm(A);
 
   const ADNumberType A_ddot_B = double_contract<0, 0, 1, 1>(A, B);

--- a/tests/ad_common_tests/tensor_functions_01.h
+++ b/tests/ad_common_tests/tensor_functions_01.h
@@ -55,15 +55,16 @@ test_tensor()
   const Tensor<2, dim, ADNumberType> C5 = A * a;
   const Tensor<2, dim, ADNumberType> C6 = A / a;
 
-  const ADNumberType                 det_A       = determinant(A);
-  const ADNumberType                 tr_A        = trace(A);
-  const Tensor<2, dim, ADNumberType> A_inv       = invert(A);
-  const Tensor<2, dim, ADNumberType> A_T         = transpose(A);
-  const Tensor<2, dim, ADNumberType> A_adj       = adjugate(A);
-  const Tensor<2, dim, ADNumberType> A_cof       = cofactor(A);
-  const Tensor<2, dim, ADNumberType> A_orth      = orthogonalize(A);
-  const ADNumberType                 A_l1_norm   = l1_norm(A, 1e-8);
-  const ADNumberType                 A_linf_norm = linfty_norm(A);
+  const ADNumberType                 det_A = determinant(A);
+  const ADNumberType                 tr_A  = trace(A);
+  const Tensor<2, dim, ADNumberType> A_inv = invert(A);
+  const Tensor<2, dim, ADNumberType> A_T   = transpose(A);
+  const Tensor<2, dim, ADNumberType> A_adj = adjugate(A);
+  const Tensor<2, dim, ADNumberType> A_cof = cofactor(A);
+  const Tensor<2, dim, ADNumberType> A_orth =
+    project_onto_orthogonal_tensors(A);
+  const ADNumberType A_l1_norm   = l1_norm(A, 1e-8);
+  const ADNumberType A_linf_norm = linfty_norm(A);
 
   const ADNumberType A_ddot_B = double_contract<0, 0, 1, 1>(A, B);
   const Tensor<2, dim, ADNumberType> A_dot_B = contract<1, 0>(A, B);

--- a/tests/ad_common_tests/tensor_functions_01.h
+++ b/tests/ad_common_tests/tensor_functions_01.h
@@ -55,16 +55,14 @@ test_tensor()
   const Tensor<2, dim, ADNumberType> C5 = A * a;
   const Tensor<2, dim, ADNumberType> C6 = A / a;
 
-  const ADNumberType                 det_A = determinant(A);
-  const ADNumberType                 tr_A  = trace(A);
-  const Tensor<2, dim, ADNumberType> A_inv = invert(A);
-  const Tensor<2, dim, ADNumberType> A_T   = transpose(A);
-  const Tensor<2, dim, ADNumberType> A_adj = adjugate(A);
-  const Tensor<2, dim, ADNumberType> A_cof = cofactor(A);
-  const Tensor<2, dim, ADNumberType> A_orth =
-    project_onto_orthogonal_tensors(A);
-  const ADNumberType A_l1_norm   = l1_norm(A, 1e-8);
-  const ADNumberType A_linf_norm = linfty_norm(A);
+  const ADNumberType                 det_A       = determinant(A);
+  const ADNumberType                 tr_A        = trace(A);
+  const Tensor<2, dim, ADNumberType> A_inv       = invert(A);
+  const Tensor<2, dim, ADNumberType> A_T         = transpose(A);
+  const Tensor<2, dim, ADNumberType> A_adj       = adjugate(A);
+  const Tensor<2, dim, ADNumberType> A_cof       = cofactor(A);
+  const ADNumberType                 A_l1_norm   = l1_norm(A);
+  const ADNumberType                 A_linf_norm = linfty_norm(A);
 
   const ADNumberType A_ddot_B = double_contract<0, 0, 1, 1>(A, B);
   const Tensor<2, dim, ADNumberType> A_dot_B = contract<1, 0>(A, B);

--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -181,7 +181,7 @@ main()
     DEAL_II_CONSTEXPR const auto dummy_8 = cofactor(a);
     deallog << "Deteriminant before orthogonalization: " << determinant(a)
             << std::endl;
-    const auto dummy_9 = orthogonalize(a, 1e-8);
+    const auto dummy_9 = project_onto_orthogonal_tensors(a, 1e-8);
     deallog << "Deteriminant after  orthogonalization: " << determinant(dummy_9)
             << std::endl;
     Assert(determinant(dummy_9) - 1. < 1e-8, ExcInternalError());
@@ -194,7 +194,7 @@ main()
 
     deallog << "Deteriminant before orthogonalization: "
             << determinant(non_orthogonal) << std::endl;
-    const auto dummy_10 = orthogonalize(non_orthogonal, 1e-8);
+    const auto dummy_10 = project_onto_orthogonal_tensors(non_orthogonal, 1e-8);
     deallog << "Deteriminant after  orthogonalization: "
             << determinant(dummy_10) << std::endl;
     Assert(determinant(dummy_10) - 1. < 1e-8, ExcInternalError());

--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -186,6 +186,19 @@ main()
             << std::endl;
     Assert(determinant(dummy_9) - 1. < 1e-8, ExcInternalError());
 
+    // check wheter the output is the same as the input. For example, it could
+    // have been transposed.
+    Vector<double> unrolled_a(9);
+    a.unroll<double>(unrolled_a);
+    Vector<double> unrolled_dummy_9(9);
+    dummy_9.unroll<double>(unrolled_dummy_9);
+    for (size_t i = 0; i < unrolled_a.size(); i++)
+      {
+        Assert(std::fabs(unrolled_a[i] - unrolled_dummy_9[i]) < 1e-8,
+               ExcInternalError());
+      }
+
+
 
     constexpr double       non_orthogonal_init[3][3] = {{1., 2., 3.},
                                                   {1., 1.5, 2.},

--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -17,6 +17,8 @@
 
 #include <deal.II/base/tensor.h>
 
+#include <deal.II/lac/full_matrix.h>
+
 #include "../tests.h"
 
 template <int rank, int dim, typename Number>
@@ -177,6 +179,25 @@ main()
     DEAL_II_CONSTEXPR const auto dummy_6 = contract3(a, middle, a);
     DEAL_II_CONSTEXPR const auto dummy_7 = adjugate(a);
     DEAL_II_CONSTEXPR const auto dummy_8 = cofactor(a);
+    deallog << "Deteriminant before orthogonalization: " << determinant(a)
+            << std::endl;
+    const auto dummy_9 = orthogonalize(a, 1e-8);
+    deallog << "Deteriminant after  orthogonalization: " << determinant(dummy_9)
+            << std::endl;
+    Assert(determinant(dummy_9) - 1. < 1e-8, ExcInternalError());
+
+
+    constexpr double       non_orthogonal_init[3][3] = {{1., 2., 3.},
+                                                  {1., 1.5, 2.},
+                                                  {2., 0., 1}};
+    constexpr Tensor<2, 3> non_orthogonal{non_orthogonal_init};
+
+    deallog << "Deteriminant before orthogonalization: "
+            << determinant(non_orthogonal) << std::endl;
+    const auto dummy_10 = orthogonalize(non_orthogonal, 1e-8);
+    deallog << "Deteriminant after  orthogonalization: "
+            << determinant(dummy_10) << std::endl;
+    Assert(determinant(dummy_10) - 1. < 1e-8, ExcInternalError());
   }
 
   {

--- a/tests/tensors/constexpr_tensor.cc
+++ b/tests/tensors/constexpr_tensor.cc
@@ -181,7 +181,7 @@ main()
     DEAL_II_CONSTEXPR const auto dummy_8 = cofactor(a);
     deallog << "Deteriminant before orthogonalization: " << determinant(a)
             << std::endl;
-    const auto dummy_9 = project_onto_orthogonal_tensors(a, 1e-8);
+    const auto dummy_9 = project_onto_orthogonal_tensors(a, 0);
     deallog << "Deteriminant after  orthogonalization: " << determinant(dummy_9)
             << std::endl;
     Assert(determinant(dummy_9) - 1. < 1e-8, ExcInternalError());

--- a/tests/tensors/constexpr_tensor.output
+++ b/tests/tensors/constexpr_tensor.output
@@ -166,4 +166,8 @@ DEAL::Using Tensor within constexpr functions
 DEAL::15.2000
 DEAL::116.000
 DEAL::Used memory: 72
+DEAL::Deteriminant before orthogonalization: 1.00000
+DEAL::Deteriminant after  orthogonalization: 1.00000
+DEAL::Deteriminant before orthogonalization: -1.50000
+DEAL::Deteriminant after  orthogonalization: -1.00000
 DEAL::OK


### PR DESCRIPTION
I am needing this function for a aspect project and I thought it might be useful for deal.ii as well. It orthogonalizes a rank 2 tensor by returning the nearest orthogonal tensor through computing a SVD decomposition of the tensor and putting the parts together as `((U*I)*V^T)^T`. I be happy to learn how to improve this implementation.

I included a test to show that is works. It is related to #8739.