### PR TITLE
Use uint64_t instead of 'unsigned long long int'.

### DIFF
--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <cstddef>
+#include <cstdint>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -45,13 +46,13 @@ namespace types
   /**
    * The type used for global indices of vertices.
    */
-  using global_vertex_index = unsigned long long int;
+  using global_vertex_index = uint64_t;
 
   /**
    * An identifier that denotes the MPI type associated with
    * types::global_vertex_index.
    */
-#define DEAL_II_VERTEX_INDEX_MPI_TYPE MPI_UNSIGNED_LONG_LONG
+#define DEAL_II_VERTEX_INDEX_MPI_TYPE MPI_UINT64_T
 
 #ifdef DEAL_II_WITH_64BIT_INDICES
   /**
@@ -67,15 +68,14 @@ namespace types
    * @ref GlobalDoFIndex
    * page for guidance on when this type should or should not be used.
    */
-  // TODO: we should check that unsigned long long int
-  // has the same size as uint64_t
-  using global_dof_index = unsigned long long int;
+  using global_dof_index = uint64_t;
 
   /**
    * An identifier that denotes the MPI type associated with
    * types::global_dof_index.
    */
-#  define DEAL_II_DOF_INDEX_MPI_TYPE MPI_UNSIGNED_LONG_LONG
+#  define DEAL_II_DOF_INDEX_MPI_TYPE MPI_UINT64_T
+
 #else
   /**
    * The type used for global indices of degrees of freedom. While in
@@ -100,7 +100,7 @@ namespace types
    * The type used for coarse-cell ids. See the glossary
    * entry on @ref GlossCoarseCellId "coarse cell IDs" for more information.
    */
-  using coarse_cell_id = unsigned long long int;
+  using coarse_cell_id = uint64_t;
 #else
   /**
    * The type used for coarse-cell ids. See the glossary
@@ -162,7 +162,7 @@ namespace TrilinosWrappers
     /**
      * Declare type of integer used in the Epetra package of Trilinos.
      */
-    using int_type = long long;
+    using int_type = long long int;
 #else
     /**
      * Declare type of integer used in the Epetra package of Trilinos.

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -24,6 +24,8 @@
 
 #include <deal.II/particles/property_pool.h>
 
+#include <cstdint>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace types
@@ -42,15 +44,16 @@ namespace types
    *
    * The data type always indicates an unsigned integer type.
    */
-  using particle_index = unsigned long long int;
+  using particle_index = uint64_t;
 
 #  ifdef DEAL_II_WITH_MPI
   /**
    * An identifier that denotes the MPI type associated with
    * types::global_dof_index.
    */
-#    define DEAL_II_PARTICLE_INDEX_MPI_TYPE MPI_UNSIGNED_LONG_LONG
+#    define DEAL_II_PARTICLE_INDEX_MPI_TYPE MPI_UINT64_T
 #  endif
+
 #else
   /**
    * The type used for indices of particles. While in


### PR DESCRIPTION
I wanted to do #9550, but before I get there, I realized that there is a worthwhile cleanup: We have historically used `unsigned long long int` for `global_dof_index` in 64-bit mode. That is what worked in the past if one wanted to get a 64-bit integer, but it is absolutely not easy to understand that that is what it actually is. It's also not documented in the standard -- like `int`, a compiler might choose something different in the same way as a `long int` on 32-bit platforms typically is the same as `int`. This leads to endless confusion.

But, C++11 introduces `uint64_t`, and we should absolutely use it because it documents exactly what we want. Even more interesting to me was that MPI version 2.2 (and maybe earlier) have a matching `MPI_UINT64_T` that we can use in that case.

Do so.

/rebuild