### PR TITLE
Eliminate two places with unsigned long long int

### DIFF
--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -133,8 +133,8 @@ namespace internal
     /**
      * Abbreviation for the data type stored by this object.
      */
-    using value_type = boost::
-      variant<int, unsigned int, unsigned long long int, double, std::string>;
+    using value_type =
+      boost::variant<int, unsigned int, std::uint64_t, double, std::string>;
 
     /**
      * Stored value.
@@ -829,8 +829,7 @@ namespace internal
         char c = 's';
         ar &c &*p;
       }
-    else if (const unsigned long long int *p =
-               boost::get<unsigned long long int>(&value))
+    else if (const std::uint64_t *p = boost::get<std::uint64_t>(&value))
       {
         char c = 'l';
         ar &c &*p;
@@ -888,8 +887,8 @@ namespace internal
 
         case 'l':
           {
-            unsigned long long int val;
-            ar &                   val;
+            std::uint64_t val;
+            ar &          val;
             value = val;
             break;
           }

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -578,16 +578,16 @@ namespace Utilities
    * $p_i\in [0,N)$ and $p_i\neq p_j$ for $i\neq j$), produce the reverse
    * permutation $q_i=N-1-p_i$.
    */
-  std::vector<unsigned long long int>
-  reverse_permutation(const std::vector<unsigned long long int> &permutation);
+  std::vector<std::uint64_t>
+  reverse_permutation(const std::vector<std::uint64_t> &permutation);
 
   /**
    * Given a permutation vector (i.e. a vector $p_0\ldots p_{N-1}$ where each
    * $p_i\in [0,N)$ and $p_i\neq p_j$ for $i\neq j$), produce the inverse
    * permutation $q_0\ldots q_{N-1}$ so that $q_{p_i}=p_{q_i}=i$.
    */
-  std::vector<unsigned long long int>
-  invert_permutation(const std::vector<unsigned long long int> &permutation);
+  std::vector<std::uint64_t>
+  invert_permutation(const std::vector<std::uint64_t> &permutation);
 
   /**
    * Given an arbitrary object of type T, use boost::serialization utilities

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -55,10 +55,10 @@ namespace internal
     catch (...)
       {}
 
-    // ... then with unsigned long long int...
+    // ... then with std::uint64_t...
     try
       {
-        return boost::get<unsigned long long int>(value);
+        return boost::get<std::uint64_t>(value);
       }
     catch (...)
       {}

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -868,79 +868,6 @@ namespace Utilities
 
 
 
-  std::vector<unsigned int>
-  reverse_permutation(const std::vector<unsigned int> &permutation)
-  {
-    const unsigned int n = permutation.size();
-
-    std::vector<unsigned int> out(n);
-    for (unsigned int i = 0; i < n; ++i)
-      out[i] = n - 1 - permutation[i];
-
-    return out;
-  }
-
-
-
-  std::vector<unsigned int>
-  invert_permutation(const std::vector<unsigned int> &permutation)
-  {
-    const unsigned int n = permutation.size();
-
-    std::vector<unsigned int> out(n, numbers::invalid_unsigned_int);
-
-    for (unsigned int i = 0; i < n; ++i)
-      {
-        AssertIndexRange(permutation[i], n);
-        out[permutation[i]] = i;
-      }
-
-    // check that we have actually reached
-    // all indices
-    for (unsigned int i = 0; i < n; ++i)
-      Assert(out[i] != numbers::invalid_unsigned_int,
-             ExcMessage("The given input permutation had duplicate entries!"));
-
-    return out;
-  }
-
-  std::vector<std::uint64_t>
-  reverse_permutation(const std::vector<std::uint64_t> &permutation)
-  {
-    const std::uint64_t n = permutation.size();
-
-    std::vector<std::uint64_t> out(n);
-    for (std::uint64_t i = 0; i < n; ++i)
-      out[i] = n - 1 - permutation[i];
-
-    return out;
-  }
-
-
-
-  std::vector<std::uint64_t>
-  invert_permutation(const std::vector<std::uint64_t> &permutation)
-  {
-    const std::uint64_t n = permutation.size();
-
-    std::vector<std::uint64_t> out(n, numbers::invalid_dof_index);
-
-    for (std::uint64_t i = 0; i < n; ++i)
-      {
-        AssertIndexRange(permutation[i], n);
-        out[permutation[i]] = i;
-      }
-
-    // check that we have actually reached
-    // all indices
-    for (std::uint64_t i = 0; i < n; ++i)
-      Assert(out[i] != numbers::invalid_unsigned_int,
-             ExcMessage("The given input permutation had duplicate entries!"));
-
-    return out;
-  }
-
-
   template <typename Integer>
   std::vector<Integer>
   reverse_permutation(const std::vector<Integer> &permutation)
@@ -977,6 +904,38 @@ namespace Utilities
              ExcMessage("The given input permutation had duplicate entries!"));
 
     return out;
+  }
+
+
+
+  std::vector<unsigned int>
+  reverse_permutation(const std::vector<unsigned int> &permutation)
+  {
+    return reverse_permutation<unsigned int>(permutation);
+  }
+
+
+
+  std::vector<unsigned int>
+  invert_permutation(const std::vector<unsigned int> &permutation)
+  {
+    return invert_permutation<unsigned int>(permutation);
+  }
+
+
+
+  std::vector<std::uint64_t>
+  reverse_permutation(const std::vector<std::uint64_t> &permutation)
+  {
+    return reverse_permutation<std::uint64_t>(permutation);
+  }
+
+
+
+  std::vector<std::uint64_t>
+  invert_permutation(const std::vector<std::uint64_t> &permutation)
+  {
+    return invert_permutation<std::uint64_t>(permutation);
   }
 
 

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -904,13 +904,13 @@ namespace Utilities
     return out;
   }
 
-  std::vector<unsigned long long int>
-  reverse_permutation(const std::vector<unsigned long long int> &permutation)
+  std::vector<std::uint64_t>
+  reverse_permutation(const std::vector<std::uint64_t> &permutation)
   {
-    const unsigned long long int n = permutation.size();
+    const std::uint64_t n = permutation.size();
 
-    std::vector<unsigned long long int> out(n);
-    for (unsigned long long int i = 0; i < n; ++i)
+    std::vector<std::uint64_t> out(n);
+    for (std::uint64_t i = 0; i < n; ++i)
       out[i] = n - 1 - permutation[i];
 
     return out;
@@ -918,14 +918,14 @@ namespace Utilities
 
 
 
-  std::vector<unsigned long long int>
-  invert_permutation(const std::vector<unsigned long long int> &permutation)
+  std::vector<std::uint64_t>
+  invert_permutation(const std::vector<std::uint64_t> &permutation)
   {
-    const unsigned long long int n = permutation.size();
+    const std::uint64_t n = permutation.size();
 
-    std::vector<unsigned long long int> out(n, numbers::invalid_unsigned_int);
+    std::vector<std::uint64_t> out(n, numbers::invalid_dof_index);
 
-    for (unsigned long long int i = 0; i < n; ++i)
+    for (std::uint64_t i = 0; i < n; ++i)
       {
         AssertIndexRange(permutation[i], n);
         out[permutation[i]] = i;
@@ -933,7 +933,7 @@ namespace Utilities
 
     // check that we have actually reached
     // all indices
-    for (unsigned long long int i = 0; i < n; ++i)
+    for (std::uint64_t i = 0; i < n; ++i)
       Assert(out[i] != numbers::invalid_unsigned_int,
              ExcMessage("The given input permutation had duplicate entries!"));
 
@@ -945,10 +945,10 @@ namespace Utilities
   std::vector<Integer>
   reverse_permutation(const std::vector<Integer> &permutation)
   {
-    const unsigned int n = permutation.size();
+    const std::size_t n = permutation.size();
 
     std::vector<Integer> out(n);
-    for (unsigned int i = 0; i < n; ++i)
+    for (std::size_t i = 0; i < n; ++i)
       out[i] = n - 1 - permutation[i];
 
     return out;
@@ -960,11 +960,11 @@ namespace Utilities
   std::vector<Integer>
   invert_permutation(const std::vector<Integer> &permutation)
   {
-    const unsigned int n = permutation.size();
+    const std::size_t n = permutation.size();
 
     std::vector<Integer> out(n, numbers::invalid_unsigned_int);
 
-    for (unsigned int i = 0; i < n; ++i)
+    for (std::size_t i = 0; i < n; ++i)
       {
         AssertIndexRange(permutation[i], n);
         out[permutation[i]] = i;

--- a/tests/base/convergence_table_05.cc
+++ b/tests/base/convergence_table_05.cc
@@ -24,7 +24,7 @@
 #include "../tests.h"
 
 // test the method evaluate_convergence_rates with key column given by
-// unsigned long long int
+// 64 bit dof indices
 
 int
 main()
@@ -33,8 +33,8 @@ main()
 
   ConvergenceTable t;
 
-  const unsigned long long int t1 = 100;
-  const unsigned long long int t2 = 400;
+  const std::uint64_t t1 = 100;
+  const std::uint64_t t2 = 400;
   t.add_value("cells", t1);
   t.add_value("error", 0.1);
   t.add_value("cells", t2);


### PR DESCRIPTION
Now that we switched to `std::uint64_t`, we should also address two users of those indices in `TableHandler` and `Utilities`. This addresses the compile error reported in #9588 but not yet the warnings.

Now the only place left where I found `unsigned long long int` by grepping is `include/deal.II/lac/cuda_atomic.h` where we must use `ull` because the interface with CUDA requires it (but then again the assumption is to alias a double with a 64-bit integer - but that is up to CUDA to decide, not us).