### PR TITLE
Fix two 64 bit warnings by converting to long long unsigned

### DIFF
--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -592,15 +592,14 @@ namespace LinearAlgebra
 
     // Other version of the following
     //  out << size() << std::endl << '[';
-    // Reason: operator<< seems to use some resources  that lead to problems in
-    // a multithreaded environment.
-    const size_type sz = this->size();
-    char            buf[16];
-#ifdef DEAL_II_WITH_64BIT_INDICES
+    // Reason: operator<< seems to use some resources that lead to problems in
+    // a multithreaded environment.  We convert the size index to
+    // unsigned long long int that is at least 64 bits to be able to output it
+    // on all platforms, since std::uint64_t is not in C.
+    const unsigned long long int sz = this->size();
+    char                         buf[16];
+
     std::sprintf(buf, "%llu", sz);
-#else
-    std::sprintf(buf, "%u", sz);
-#endif
     std::strcat(buf, "\n[");
 
     out.write(buf, std::strlen(buf));

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -920,18 +920,15 @@ Vector<Number>::block_write(std::ostream &out) const
 
   // other version of the following
   //  out << size() << std::endl << '[';
-  // reason: operator<< seems to use
-  // some resources that lead to
-  // problems in a multithreaded
-  // environment
-  const size_type sz = size();
-  char            buf[16];
 
-#ifdef DEAL_II_WITH_64BIT_INDICES
+  // reason: operator<< seems to use some resources that lead to problems in a
+  // multithreaded environment. We convert the size index to
+  // unsigned long long int that is at least 64 bits to be able to output it on
+  // all platforms, since std::uint64_t is not in C.
+  const unsigned long long int sz = size();
+  char                         buf[16];
+
   std::sprintf(buf, "%llu", sz);
-#else
-  std::sprintf(buf, "%u", sz);
-#endif
   std::strcat(buf, "\n[");
 
   out.write(buf, std::strlen(buf));


### PR DESCRIPTION
Together with #9590 this fixes #9588.

As discussed in #9588, we should explicitly convert the variables to `unsigned long long int` before we use the c function `sprintf`. I do this now also for the 32 bit case as it makes code easier to read (and added a comment why). I checked `tests/lac/la_vector_output` which seems the only test to use the block write function.