### PR TITLE
Add overload for logstream's << for uint64_t

### DIFF
--- a/tests/tests.h
+++ b/tests/tests.h
@@ -766,15 +766,15 @@ DEAL_II_NAMESPACE_CLOSE
 LogStream &
 operator<<(LogStream &out, const std::vector<unsigned int> &v)
 {
-  for (unsigned int i = 0; i < v.size(); ++i)
+  for (std::size_t i = 0; i < v.size(); ++i)
     out << v[i] << (i == v.size() - 1 ? "" : " ");
   return out;
 }
 
 LogStream &
-operator<<(LogStream &out, const std::vector<long long unsigned int> &v)
+operator<<(LogStream &out, const std::vector<std::uint64_t> &v)
 {
-  for (unsigned int i = 0; i < v.size(); ++i)
+  for (std::size_t i = 0; i < v.size(); ++i)
     out << v[i] << (i == v.size() - 1 ? "" : " ");
   return out;
 }
@@ -782,7 +782,7 @@ operator<<(LogStream &out, const std::vector<long long unsigned int> &v)
 LogStream &
 operator<<(LogStream &out, const std::vector<double> &v)
 {
-  for (unsigned int i = 0; i < v.size(); ++i)
+  for (std::size_t i = 0; i < v.size(); ++i)
     out << v[i] << (i == v.size() - 1 ? "" : " ");
   return out;
 }


### PR DESCRIPTION
It turned out that we had another issue in the test suite with #9581 as revealed by the new failures here:
https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=4665
We use an overload of `LogStream::operator<<` for `std::vector<long long unsigned int>` (I missed it yesterday when searching for unsigned long long int) that should be switched to `std::uint64_t`. I ran all MPI tests again with this fix and they work now.