### PR TITLE
Fix bug in FEEvaluation for constraints in face integrals

### DIFF
--- a/doc/news/changes/minor/20200303MartinKronbichlerNiklasFehn
+++ b/doc/news/changes/minor/20200303MartinKronbichlerNiklasFehn
@@ -1,0 +1,6 @@
+Fixed: FEFaceEvaluation::read_dof_values() and
+FEFaceEvaluation::distribute_local_to_global() would not correctly represent
+cases with boundary integrals and constraints on the same boundary. This is
+now fixed.
+<br>
+(Niklas Fehn, Martin Kronbichler, 2020/03/03)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3899,7 +3899,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
           Assert(cells[v] < dof_info->row_starts.size() - 1,
                  ExcInternalError());
           has_constraints =
-            has_constraints &&
+            has_constraints ||
             dof_info
                 ->row_starts[cells[v] * n_fe_components +
                              first_selected_component + n_components]

--- a/tests/matrix_free/matrix_vector_faces_27.cc
+++ b/tests/matrix_free/matrix_vector_faces_27.cc
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Matrix-free face evaluation with continuous elements. Same test as
+// matrix_vector_faces_05 but also using Dirichlet constraints on a part of
+// the boundary.
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+std::ofstream logfile("output");
+
+#include "matrix_vector_faces_common.h"
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.begin()->face(0)->set_boundary_id(1);
+  tria.refine_global(5 - dim);
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  do_test<dim, fe_degree, fe_degree + 1, double>(dof, constraints, false);
+}

--- a/tests/matrix_free/matrix_vector_faces_27.output
+++ b/tests/matrix_free/matrix_vector_faces_27.output
@@ -1,0 +1,13 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference:          0
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(1)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::
+DEAL:3d::Testing FE_Q<3>(2)
+DEAL:3d::Norm of difference:          0
+DEAL:3d::

--- a/tests/matrix_free/matrix_vector_faces_common.h
+++ b/tests/matrix_free/matrix_vector_faces_common.h
@@ -815,6 +815,11 @@ do_test(const DoFHandler<dim> &          dof,
 
   matrix.vmult(out, in);
 
+  // zero constrained dofs
+  for (unsigned int i = 0; i < dof.n_dofs(); ++i)
+    if (constraints.is_constrained(i))
+      out(i) = 0;
+
   MatrixFree<dim, number, VectorizedArrayType> mf_data;
   const QGauss<1> quad(n_q_points_1d > 0 ? n_q_points_1d :
                                            dof.get_fe().degree + 1);


### PR DESCRIPTION
The bug was "just" mixing a `||` with a `&&`, but we ran into trouble nonetheless.

FYI @nfehn 