### PR TITLE
Convert explicit loops over faces to range-based loops.

### DIFF
--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1425,9 +1425,8 @@ namespace FETools
             if (cell->is_ghost())
               {
                 cell->get_dof_indices(indices);
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (!cell->at_boundary(face))
                     {
                       const typename DoFHandler<dim, spacedim>::cell_iterator

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -176,9 +176,7 @@ namespace FETools
              (constraints.n_constraints() == 0));
 
           if (hanging_nodes_not_allowed)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               Assert(cell1->at_boundary(face) ||
                        cell1->neighbor(face)->level() == cell1->level(),
                      ExcHangingNodesNotAllowed());
@@ -334,9 +332,7 @@ namespace FETools
             (cell->get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
 
           if (hanging_nodes_not_allowed)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               Assert(cell->at_boundary(face) ||
                        cell->neighbor(face)->level() == cell->level(),
                      ExcHangingNodesNotAllowed());
@@ -671,9 +667,7 @@ namespace FETools
           (subdomain_id == numbers::invalid_subdomain_id))
         {
           if (hanging_nodes_not_allowed)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               Assert(cell->at_boundary(face) ||
                        cell->neighbor(face)->level() == cell->level(),
                      ExcHangingNodesNotAllowed());

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3243,9 +3243,8 @@ namespace GridTools
     std::vector<typename MeshType::active_cell_iterator> &active_neighbors)
   {
     active_neighbors.clear();
-    for (unsigned int n = 0;
-         n < GeometryInfo<MeshType::dimension>::faces_per_cell;
-         ++n)
+    for (const unsigned int n :
+         GeometryInfo<MeshType::dimension>::face_indices())
       if (!cell->at_boundary(n))
         {
           if (MeshType::dimension == 1)

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -117,7 +117,7 @@ namespace internal
     template <int structdim>
     inline TriaObject<structdim>::TriaObject()
     {
-      for (unsigned int i = 0; i < GeometryInfo<structdim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<structdim>::face_indices())
         faces[i] = -1;
     }
 

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1963,9 +1963,7 @@ namespace internal
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
           for (unsigned int i = 0; i < cell_type.size(); ++i)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               {
                 if (cell_type[i] <= affine)
                   {

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1147,9 +1147,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                    cell != dof_handler.end(additional_data.mg_level + 1);
                    ++cell)
                 if (cell->level_subdomain_id() == task_info.my_pid)
-                  for (unsigned int f = 0;
-                       f < GeometryInfo<dim>::faces_per_cell;
-                       ++f)
+                  for (const unsigned int f : GeometryInfo<dim>::face_indices())
                     if ((cell->at_boundary(f) == false ||
                          cell->has_periodic_neighbor(f) == true) &&
                         cell->level() >

--- a/include/deal.II/meshworker/loop.h
+++ b/include/deal.II/meshworker/loop.h
@@ -245,11 +245,8 @@ namespace MeshWorker
     info.post_cell(dof_info);
 
     if (integrate_interior_face || integrate_boundary)
-      for (unsigned int face_no = 0;
-           face_no <
-           GeometryInfo<
-             ITERATOR::AccessorType::Container::dimension>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<
+             ITERATOR::AccessorType::Container::dimension>::face_indices())
         {
           typename ITERATOR::AccessorType::Container::face_iterator face =
             cell->face(face_no);

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -293,10 +293,9 @@ namespace MeshWorker
         cell_worker(cell, scratch, copy);
 
       if (flags & (work_on_faces | work_on_boundary))
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<CellIteratorBaseType::AccessorType::
-                                      Container::dimension>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no :
+             GeometryInfo<CellIteratorBaseType::AccessorType::Container::
+                            dimension>::face_indices())
           {
             if (cell->at_boundary(face_no) &&
                 !cell->has_periodic_neighbor(face_no))

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1195,7 +1195,7 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
 
   // adjust patch neighbors
   for (unsigned int i = old_n_patches; i < patches.size(); ++i)
-    for (unsigned int n = 0; n < GeometryInfo<patch_dim>::faces_per_cell; ++n)
+    for (const unsigned int n : GeometryInfo<patch_dim>::face_indices())
       if (patches[i].neighbors[n] != Patch::no_neighbor)
         patches[i].neighbors[n] += old_n_patches;
 }

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1350,9 +1350,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
          (cell->material_id() == material_id)))
       {
         // loop over all faces of this cell
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             Assert(face_integrals.find(cell->face(face_no)) !=
                      face_integrals.end(),

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -2828,9 +2828,8 @@ namespace VectorTools
                  cell = dof.begin_active();
                cell != dof.end();
                ++cell)
-            for (unsigned int direction = 0;
-                 direction < GeometryInfo<dim>::faces_per_cell;
-                 ++direction)
+            for (const unsigned int direction :
+                 GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(direction) &&
                   (function_map.find(cell->face(direction)->boundary_id()) !=
                    function_map.end()))
@@ -2954,9 +2953,8 @@ namespace VectorTools
             endc = dof.end();
           for (; cell != endc; ++cell)
             if (!cell->is_artificial())
-              for (unsigned int face_no = 0;
-                   face_no < GeometryInfo<dim>::faces_per_cell;
-                   ++face_no)
+              for (const unsigned int face_no :
+                   GeometryInfo<dim>::face_indices())
                 {
                   const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
@@ -4914,9 +4912,8 @@ namespace VectorTools
           {
             for (; cell != dof_handler.end(); ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // if the FE is a
@@ -4990,9 +4987,7 @@ namespace VectorTools
             const unsigned int    degree = superdegree - 1;
             hp::QCollection<dim>  edge_quadrature_collection;
 
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               for (unsigned int line = 0;
                    line < GeometryInfo<dim>::lines_per_face;
                    ++line)
@@ -5012,9 +5007,8 @@ namespace VectorTools
 
             for (; cell != dof_handler.end(); ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // if the FE is a
@@ -5149,9 +5143,8 @@ namespace VectorTools
           {
             for (; cell != dof_handler.end(); ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // if the FE is a FE_Nothing object there is no work to do
@@ -5220,9 +5213,8 @@ namespace VectorTools
                 const QGauss<dim - 2> reference_edge_quadrature(
                   2 * fe_collection[i].degree);
 
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   for (unsigned int line = 0;
                        line < GeometryInfo<dim>::lines_per_face;
                        ++line)
@@ -5243,9 +5235,8 @@ namespace VectorTools
 
             for (; cell != dof_handler.end(); ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // if the FE is a FE_Nothing object there is no work to do
@@ -6115,9 +6106,8 @@ namespace VectorTools
                 {
                   if (cell->at_boundary() && cell->is_locally_owned())
                     {
-                      for (unsigned int face = 0;
-                           face < GeometryInfo<dim>::faces_per_cell;
-                           ++face)
+                      for (const unsigned int face :
+                           GeometryInfo<dim>::face_indices())
                         {
                           if (cell->face(face)->boundary_id() ==
                               boundary_component)
@@ -6212,9 +6202,8 @@ namespace VectorTools
                 {
                   const QGauss<dim - 2> reference_edge_quadrature(
                     2 * fe_collection[i].degree + 1);
-                  for (unsigned int face = 0;
-                       face < GeometryInfo<dim>::faces_per_cell;
-                       ++face)
+                  for (const unsigned int face :
+                       GeometryInfo<dim>::face_indices())
                     {
                       for (unsigned int line = 0;
                            line < GeometryInfo<dim>::lines_per_face;
@@ -6241,9 +6230,8 @@ namespace VectorTools
                 {
                   if (cell->at_boundary() && cell->is_locally_owned())
                     {
-                      for (unsigned int face = 0;
-                           face < GeometryInfo<dim>::faces_per_cell;
-                           ++face)
+                      for (const unsigned int face :
+                           GeometryInfo<dim>::face_indices())
                         {
                           if (cell->face(face)->boundary_id() ==
                               boundary_component)
@@ -6668,9 +6656,8 @@ namespace VectorTools
                  cell != dof_handler.end();
                  ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // if the FE is a
@@ -6741,9 +6728,8 @@ namespace VectorTools
                  cell != dof_handler.end();
                  ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // This is only implemented, if the FE is a
@@ -6847,9 +6833,8 @@ namespace VectorTools
                  cell != dof_handler.end();
                  ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // This is only
@@ -6905,9 +6890,8 @@ namespace VectorTools
                  cell != dof_handler.end();
                  ++cell)
               if (cell->at_boundary() && cell->is_locally_owned())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->boundary_id() == boundary_component)
                     {
                       // This is only
@@ -7064,9 +7048,7 @@ namespace VectorTools
     std::set<types::boundary_id>::iterator b_id;
     for (; cell != endc; ++cell)
       if (!cell->is_artificial())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           if ((b_id = boundary_ids.find(cell->face(face_no)->boundary_id())) !=
               boundary_ids.end())
             {
@@ -7664,9 +7646,7 @@ namespace VectorTools
          cell != dof_handler.end();
          ++cell)
       if (!cell->is_artificial())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           if ((b_id = boundary_ids.find(cell->face(face_no)->boundary_id())) !=
               boundary_ids.end())
             {

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1114,9 +1114,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs() const
     {
       if (cell->is_locally_owned() && cell->at_boundary())
         {
-          for (unsigned int iface = 0;
-               iface < dealii::GeometryInfo<dim>::faces_per_cell;
-               ++iface)
+          for (const unsigned int iface :
+               dealii::GeometryInfo<dim>::face_indices())
             {
               const auto face = cell->face(iface);
               if (face->at_boundary())
@@ -1172,9 +1171,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs(
     {
       if (cell->is_locally_owned() && cell->at_boundary())
         {
-          for (unsigned int iface = 0;
-               iface < dealii::GeometryInfo<dim>::faces_per_cell;
-               ++iface)
+          for (const unsigned int iface :
+               dealii::GeometryInfo<dim>::face_indices())
             {
               const auto         face        = cell->face(iface);
               const unsigned int boundary_id = face->boundary_id();

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -289,8 +289,7 @@ namespace internal
 
           // for the four sides
           if (dof_handler.get_fe().dofs_per_line > 0)
-            for (unsigned int side = 0; side < GeometryInfo<2>::faces_per_cell;
-                 ++side)
+            for (const unsigned int side : GeometryInfo<2>::face_indices())
               {
                 const typename DoFHandler<2, spacedim>::line_iterator line =
                   cell->line(side);
@@ -2208,8 +2207,7 @@ namespace internal
 
           // for the four sides
           if (cell->get_fe().dofs_per_line > 0)
-            for (unsigned int side = 0; side < GeometryInfo<2>::faces_per_cell;
-                 ++side)
+            for (const unsigned int side : GeometryInfo<2>::face_indices())
               {
                 typename DoFHandler<dim, spacedim>::line_iterator line =
                   cell->line(side);
@@ -3211,9 +3209,8 @@ namespace internal
               for (cell = dof_handler.begin(level); cell != endc; ++cell)
                 if (cell->level_subdomain_id() !=
                     numbers::artificial_subdomain_id)
-                  for (unsigned int line = 0;
-                       line < GeometryInfo<2>::faces_per_cell;
-                       ++line)
+                  for (const unsigned int line :
+                       GeometryInfo<2>::face_indices())
                     cell->face(line)->set_user_flag();
 
               for (typename DoFHandler<2, spacedim>::cell_iterator cell =

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -705,9 +705,8 @@ namespace DoFTools
       // only work on cells that are either locally owned or at least ghost
       // cells
       if (cell->is_artificial() == false)
-        for (unsigned int face = 0;
-             face < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-             ++face)
+        for (const unsigned int face :
+             GeometryInfo<DoFHandlerType::dimension>::face_indices())
           if (cell->at_boundary(face))
             if (!check_boundary_id ||
                 (boundary_ids.find(cell->face(face)->boundary_id()) !=
@@ -810,9 +809,8 @@ namespace DoFTools
            dof_handler.begin_active();
          cell != dof_handler.end();
          ++cell)
-      for (unsigned int face = 0;
-           face < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-           ++face)
+      for (const unsigned int face :
+           GeometryInfo<DoFHandlerType::dimension>::face_indices())
         if (cell->at_boundary(face))
           if (!check_boundary_id ||
               (boundary_ids.find(cell->face(face)->boundary_id()) !=
@@ -993,9 +991,7 @@ namespace DoFTools
         for (const auto &cell : dof_handler.active_cell_iterators())
           if (!cell->is_artificial())
             {
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 if (cell->face(face)->has_children())
                   {
                     const typename dealii::DoFHandler<dim,
@@ -2140,9 +2136,8 @@ namespace DoFTools
                                                     dof_handler.begin_active(),
                                                   endc = dof_handler.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0;
-           f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-           ++f)
+      for (const unsigned int f :
+           GeometryInfo<DoFHandlerType::dimension>::face_indices())
         if (cell->at_boundary(f))
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
@@ -2186,9 +2181,8 @@ namespace DoFTools
                                                     dof_handler.begin_active(),
                                                   endc = dof_handler.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0;
-           f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-           ++f)
+      for (const unsigned int f :
+           GeometryInfo<DoFHandlerType::dimension>::face_indices())
         if (boundary_ids.find(cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
@@ -2580,9 +2574,8 @@ namespace DoFTools
             std::fill(exclude.begin(), exclude.end(), false);
             const unsigned int dpf = fe.dofs_per_face;
 
-            for (unsigned int face = 0;
-                 face < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face :
+                 GeometryInfo<DoFHandlerType::dimension>::face_indices())
               if (cell->at_boundary(face) ||
                   cell->neighbor(face)->level() != cell->level())
                 for (unsigned int i = 0; i < dpf; ++i)
@@ -2655,10 +2648,8 @@ namespace DoFTools
                 // Now remove all degrees of freedom on the domain boundary
                 // from the exclusion list
                 if (boundary_dofs)
-                  for (unsigned int face = 0;
-                       face <
-                       GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-                       ++face)
+                  for (const unsigned int face :
+                       GeometryInfo<DoFHandlerType::dimension>::face_indices())
                     if (cell->at_boundary(face))
                       for (unsigned int i = 0; i < dpf; ++i)
                         exclude[fe.face_to_cell_index(i, face)] = false;

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3444,9 +3444,7 @@ namespace DoFTools
           cell_dofs.resize(fe.dofs_per_cell);
           cell->get_dof_indices(cell_dofs);
 
-          for (unsigned int face_no = 0;
-               face_no < GeometryInfo<dim>::faces_per_cell;
-               ++face_no)
+          for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
             {
               const typename DoFHandlerType<dim, spacedim>::face_iterator face =
                 cell->face(face_no);

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -399,9 +399,8 @@ namespace DoFTools
     typename DoFHandlerType::active_cell_iterator cell = dof.begin_active(),
                                                   endc = dof.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0;
-           f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-           ++f)
+      for (const unsigned int f :
+           GeometryInfo<DoFHandlerType::dimension>::face_indices())
         if (cell->at_boundary(f))
           {
             const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
@@ -494,9 +493,8 @@ namespace DoFTools
     typename DoFHandlerType::active_cell_iterator cell = dof.begin_active(),
                                                   endc = dof.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0;
-           f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-           ++f)
+      for (const unsigned int f :
+           GeometryInfo<DoFHandlerType::dimension>::face_indices())
         if (boundary_ids.find(cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
@@ -578,9 +576,8 @@ namespace DoFTools
                                                   sparsity,
                                                   keep_constrained_dofs);
 
-          for (unsigned int face = 0;
-               face < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-               ++face)
+          for (const unsigned int face :
+               GeometryInfo<DoFHandlerType::dimension>::face_indices())
             {
               typename DoFHandlerType::face_iterator cell_face =
                 cell->face(face);
@@ -817,9 +814,8 @@ namespace DoFTools
                                                       keep_constrained_dofs,
                                                       bool_int_dof_mask);
               // Loop over all interior neighbors
-              for (unsigned int face_n = 0;
-                   face_n < GeometryInfo<dim>::faces_per_cell;
-                   ++face_n)
+              for (const unsigned int face_n :
+                   GeometryInfo<dim>::face_indices())
                 {
                   const typename DoFHandler<dim, spacedim>::face_iterator
                     cell_face = cell->face(face_n);
@@ -1147,9 +1143,7 @@ namespace DoFTools
                 bool_int_and_flux_dof_mask[cell->active_fe_index()]);
 
               // Loop over interior faces
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   const typename dealii::hp::DoFHandler<dim,
                                                         spacedim>::face_iterator

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3528,9 +3528,7 @@ FE_Nedelec<dim>::convert_generalized_support_point_values_to_dof_values(
                                                 {2, 3, 0, 1},
                                                 {6, 7, 4, 5}};
 
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   // Set up the right hand side
                   // for the horizontal shape

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -123,8 +123,7 @@ FE_RannacherTurek<dim>::convert_generalized_support_point_values_to_dof_values(
 
   std::vector<Vector<double>>::const_iterator value =
     support_point_values.begin();
-  for (unsigned int face = 0; face < dealii::GeometryInfo<dim>::faces_per_cell;
-       ++face)
+  for (const unsigned int face : dealii::GeometryInfo<dim>::face_indices())
     {
       for (unsigned int q = 0; q < q_points_per_face; ++q)
         {

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -581,7 +581,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::compute_face_data(
             dim - 1, std::vector<Tensor<1, spacedim>>(n_original_q_points));
 
           // Compute tangentials to the unit cell.
-          for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<dim>::face_indices())
             {
               data.unit_tangentials[i].resize(n_original_q_points);
               std::fill(data.unit_tangentials[i].begin(),

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -117,7 +117,7 @@ MappingManifold<dim, spacedim>::InternalData::initialize_face(
                      std::vector<Tensor<1, spacedim>>(n_original_q_points));
 
           // Compute tangentials to the unit cell.
-          for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<dim>::face_indices())
             {
               unit_tangentials[i].resize(n_original_q_points);
               std::fill(unit_tangentials[i].begin(),

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -841,7 +841,7 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize_face(
                      std::vector<Tensor<1, spacedim>>(n_original_q_points));
 
           // Compute tangentials to the unit cell.
-          for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<dim>::face_indices())
             {
               unit_tangentials[i].resize(n_original_q_points);
               std::fill(unit_tangentials[i].begin(),

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2402,9 +2402,7 @@ namespace GridGenerator
                                                           endc = tria.end();
         for (; cell != endc; ++cell)
           {
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               {
                 if (cell->face(face)->at_boundary())
                   cell->face(face)->set_boundary_id(face);
@@ -3372,9 +3370,7 @@ namespace GridGenerator
         // grid around the cylinder to the new TFI manifold id.
         if (cell->manifold_id() == tfi_manifold_id)
           {
-            for (unsigned int face_n = 0;
-                 face_n < GeometryInfo<2>::faces_per_cell;
-                 ++face_n)
+            for (const unsigned int face_n : GeometryInfo<2>::face_indices())
               {
                 const auto &face = cell->face(face_n);
                 if (face->at_boundary() &&
@@ -3398,8 +3394,7 @@ namespace GridGenerator
       std::numeric_limits<double>::epsilon() * 10000;
     if (colorize)
       for (const auto &cell : tria.active_cell_iterators())
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           {
             const auto face = cell->face(face_n);
             if (face->at_boundary())
@@ -3582,8 +3577,7 @@ namespace GridGenerator
     for (const auto &cell : cylinder_tria.active_cell_iterators())
       {
         cell->set_manifold_id(tfi_manifold_id);
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           if (!cell->face(face_n)->at_boundary())
             cell->face(face_n)->set_manifold_id(tfi_manifold_id);
       }
@@ -6649,9 +6643,7 @@ namespace GridGenerator
       };
     if (colorize)
       for (const auto &cell : triangulation.active_cell_iterators())
-        for (unsigned int face_n = 0;
-             face_n < GeometryInfo<dim>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
           {
             auto face = cell->face(face_n);
             if (face->at_boundary())

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -4069,9 +4069,8 @@ namespace internal
             // cell is at boundary and we are to treat curved boundaries. so
             // loop over all faces and draw them as small pieces of lines
             {
-              for (unsigned int face_no = 0;
-                   face_no < GeometryInfo<dim>::faces_per_cell;
-                   ++face_no)
+              for (const unsigned int face_no :
+                   GeometryInfo<dim>::face_indices())
                 {
                   const typename dealii::Triangulation<dim,
                                                        spacedim>::face_iterator
@@ -4221,9 +4220,8 @@ namespace internal
             }
           else
             {
-              for (unsigned int face_no = 0;
-                   face_no < GeometryInfo<dim>::faces_per_cell;
-                   ++face_no)
+              for (const unsigned int face_no :
+                   GeometryInfo<dim>::face_indices())
                 {
                   const typename dealii::Triangulation<dim,
                                                        spacedim>::face_iterator
@@ -4541,9 +4539,8 @@ namespace internal
                   // generate the info from
                   // them
                   for (const auto &cell : tria.active_cell_iterators())
-                    for (unsigned int face_no = 0;
-                         face_no < GeometryInfo<dim>::faces_per_cell;
-                         ++face_no)
+                    for (const unsigned int face_no :
+                         GeometryInfo<dim>::face_indices())
                       {
                         const typename dealii::Triangulation<dim, spacedim>::
                           face_iterator face = cell->face(face_no);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -682,9 +682,7 @@ namespace GridTools
         // Save face data
         if (dim > 1)
           {
-            for (unsigned int face_n = 0;
-                 face_n < GeometryInfo<dim>::faces_per_cell;
-                 ++face_n)
+            for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
               face_data.insert_face_data(cell->face(face_n));
           }
         // Save line data
@@ -1482,9 +1480,7 @@ namespace GridTools
           endc = triangulation.end();
         for (; cell != endc; ++cell)
           if (!cell->is_artificial())
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               if (cell->face(face)->has_children() &&
                   !cell->face(face)->at_boundary())
                 {
@@ -3566,8 +3562,7 @@ namespace GridTools
           Iterator::AccessorType::structure_dimension;
 
         double diameter = object->diameter();
-        for (unsigned int f = 0; f < GeometryInfo<structdim>::faces_per_cell;
-             ++f)
+        for (const unsigned int f : GeometryInfo<structdim>::face_indices())
           for (unsigned int e = f + 1;
                e < GeometryInfo<structdim>::faces_per_cell;
                ++e)

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -1403,9 +1403,8 @@ namespace GridTools
 
     std::vector<typename MeshType::active_cell_iterator> patch;
     patch.push_back(cell);
-    for (unsigned int face_number = 0;
-         face_number < GeometryInfo<MeshType::dimension>::faces_per_cell;
-         ++face_number)
+    for (const unsigned int face_number :
+         GeometryInfo<MeshType::dimension>::face_indices())
       if (cell->face(face_number)->at_boundary() == false)
         {
           if (cell->neighbor(face_number)->has_children() == false)
@@ -1816,9 +1815,8 @@ namespace GridTools
             // face (or line).
 
             // Take care of dofs on neighbor faces
-            for (unsigned int f = 0;
-                 f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-                 ++f)
+            for (const unsigned int f :
+                 GeometryInfo<DoFHandlerType::dimension>::face_indices())
               {
                 if (cell->face(f)->has_children())
                   {

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1864,8 +1864,7 @@ namespace
           make_array_view(weights.begin(), weights.end());
         const auto points_view = make_array_view(points.begin(), points.end());
 
-        for (unsigned int face = 0; face < GeometryInfo<3>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<3>::face_indices())
           {
             const double       my_weight = linear_shapes[face];
             const unsigned int face_even = face - face % 2;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2020,9 +2020,7 @@ namespace internal
                                                 vertex,
                                                 triangulation.vertices.size()));
 
-            for (unsigned int line = 0;
-                 line < GeometryInfo<dim>::faces_per_cell;
-                 ++line)
+            for (const unsigned int line : GeometryInfo<dim>::face_indices())
               {
                 // given a line vertex number (0,1) on a specific line
                 // we get the cell vertex number (0-4) through the
@@ -2568,9 +2566,7 @@ namespace internal
                                                                          0)]);
               }
 
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               {
                 // set up a list of the lines to be
                 // used for this face. check the
@@ -2794,9 +2790,7 @@ namespace internal
               bool face_orientation[GeometryInfo<dim>::faces_per_cell];
               bool face_flip[GeometryInfo<dim>::faces_per_cell];
               bool face_rotation[GeometryInfo<dim>::faces_per_cell];
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   for (unsigned int l = 0;
                        l < GeometryInfo<dim>::lines_per_face;
@@ -2970,9 +2964,7 @@ namespace internal
 
               // set orientation flag for
               // each of the faces
-              for (unsigned int quad = 0;
-                   quad < GeometryInfo<dim>::faces_per_cell;
-                   ++quad)
+              for (const unsigned int quad : GeometryInfo<dim>::face_indices())
                 {
                   cell->set_face_orientation(quad, face_orientation[quad]);
                   cell->set_face_flip(quad, face_flip[quad]);
@@ -3003,9 +2995,7 @@ namespace internal
               // coinciding lines once)
               std::multimap<unsigned int, std::pair<unsigned int, unsigned int>>
                 cell_to_face_lines;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 for (unsigned int line = 0;
                      line < GeometryInfo<dim>::lines_per_face;
                      ++line)
@@ -3779,9 +3769,7 @@ namespace internal
         // can delete them. first for quads (and
         // their inner lines).
 
-        for (unsigned int quad_no = 0;
-             quad_no < GeometryInfo<dim>::faces_per_cell;
-             ++quad_no)
+        for (const unsigned int quad_no : GeometryInfo<dim>::face_indices())
           {
             typename Triangulation<dim, spacedim>::quad_iterator quad =
               cell->face(quad_no);
@@ -3976,9 +3964,8 @@ namespace internal
                                      h < triangulation.levels[l]
                                            ->cells.cells.size();
                                      ++h)
-                                  for (unsigned int q = 0;
-                                       q < GeometryInfo<dim>::faces_per_cell;
-                                       ++q)
+                                  for (const unsigned int q :
+                                       GeometryInfo<dim>::face_indices())
                                     {
                                       const int index = triangulation.levels[l]
                                                           ->cells.cells[h]
@@ -4473,9 +4460,7 @@ namespace internal
             // lines 0-7 already exist, create only the four interior
             // lines 8-11
             unsigned int l = 0;
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               for (unsigned int c = 0; c < 2; ++c, ++l)
                 new_lines[l] = cell->line(face_no)->child(c);
             Assert(l == 8, ExcInternalError());
@@ -5036,9 +5021,8 @@ namespace internal
                   // refine them is rather difficult for lines so we
                   // only flag them and after visiting all cells, we
                   // decide which lines need refinement;
-                  for (unsigned int line_no = 0;
-                       line_no < GeometryInfo<dim>::faces_per_cell;
-                       ++line_no)
+                  for (const unsigned int line_no :
+                       GeometryInfo<dim>::face_indices())
                     {
                       if (GeometryInfo<dim>::face_refinement_case(
                             cell->refine_flag_set(), line_no) ==
@@ -5396,9 +5380,8 @@ namespace internal
                   // these is difficult so we only flag them and after
                   // visiting all cells, we decide which faces need
                   // which refinement;
-                  for (unsigned int face = 0;
-                       face < GeometryInfo<dim>::faces_per_cell;
-                       ++face)
+                  for (const unsigned int face :
+                       GeometryInfo<dim>::face_indices())
                     {
                       typename Triangulation<dim, spacedim>::face_iterator
                         aface = acell->face(face);
@@ -6088,9 +6071,8 @@ namespace internal
                                    h <
                                    triangulation.levels[l]->cells.cells.size();
                                    ++h)
-                                for (unsigned int q = 0;
-                                     q < GeometryInfo<dim>::faces_per_cell;
-                                     ++q)
+                                for (const unsigned int q :
+                                     GeometryInfo<dim>::face_indices())
                                   {
                                     const int face_index =
                                       triangulation.levels[l]
@@ -6806,9 +6788,8 @@ namespace internal
                       // face_rotation flags. however, the latter two
                       // are set to false by default as this is the
                       // standard value
-                      for (unsigned int f = 0;
-                           f < GeometryInfo<dim>::faces_per_cell;
-                           ++f)
+                      for (const unsigned int f :
+                           GeometryInfo<dim>::face_indices())
                         {
                           new_hexes[i]->set_face_orientation(f, true);
                           new_hexes[i]->set_face_flip(f, false);
@@ -9684,9 +9665,7 @@ namespace internal
                   // face_orientation, face_flip and face_rotation,
                   // which are inherited from the corresponding face
                   // of the mother cube
-                  for (unsigned int f = 0;
-                       f < GeometryInfo<dim>::faces_per_cell;
-                       ++f)
+                  for (const unsigned int f : GeometryInfo<dim>::face_indices())
                     for (unsigned int s = 0;
                          s < std::max(GeometryInfo<dim - 1>::n_children(
                                         GeometryInfo<dim>::face_refinement_case(
@@ -9779,9 +9758,8 @@ namespace internal
               // anisotropic refinement. Therefore, we have a closer
               // look
               const RefinementCase<dim> ref_case = cell->refine_flag_set();
-              for (unsigned int face_no = 0;
-                   face_no < GeometryInfo<dim>::faces_per_cell;
-                   ++face_no)
+              for (const unsigned int face_no :
+                   GeometryInfo<dim>::face_indices())
                 if (cell->face(face_no)->at_boundary())
                   {
                     // this is the critical face at the boundary.
@@ -14038,9 +14016,7 @@ namespace
             // there were any unrefined neighbors at all, see if any
             // of those will have to be refined as well
             if (unrefined_neighbors > 0)
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 if (!cell->at_boundary(face) &&
                     (face_will_be_refined_by_neighbor(cell, face) == false) &&
                     (cell->neighbor(face)->has_children() == false) &&
@@ -14311,9 +14287,8 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
                     // cycle
                     unsigned int unrefined_neighbors = 0, total_neighbors = 0;
 
-                    for (unsigned int n = 0;
-                         n < GeometryInfo<dim>::faces_per_cell;
-                         ++n)
+                    for (const unsigned int n :
+                         GeometryInfo<dim>::face_indices())
                       {
                         const cell_iterator neighbor = cell->neighbor(n);
                         if (neighbor.state() == IteratorState::valid)

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2232,9 +2232,7 @@ CellAccessor<dim, spacedim>::neighbor_of_neighbor_internal(
     // neighbors and find the number
     // the hard way
     {
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         if (neighbor_cell->face_index(face_no) == this_face_index)
           return face_no;
 
@@ -2325,9 +2323,7 @@ CellAccessor<dim, spacedim>::neighbor_of_coarser_neighbor(
           // we need to loop over all faces
           // and subfaces and find the
           // number the hard way
-          for (unsigned int face_no = 0;
-               face_no < GeometryInfo<2>::faces_per_cell;
-               ++face_no)
+          for (const unsigned int face_no : GeometryInfo<2>::face_indices())
             {
               if (face_no != face_no_guess)
                 {
@@ -2398,9 +2394,7 @@ CellAccessor<dim, spacedim>::neighbor_of_coarser_neighbor(
 
           // if the guess was false, then we need to loop over all faces and
           // subfaces and find the number the hard way
-          for (unsigned int face_no = 0;
-               face_no < GeometryInfo<3>::faces_per_cell;
-               ++face_no)
+          for (const unsigned int face_no : GeometryInfo<3>::face_indices())
             {
               if (face_no == face_no_guess)
                 continue;

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -476,9 +476,7 @@ namespace TriangulationDescription
                   cell_info.id = cell->id().template to_binary<dim>();
 
                   // save boundary_ids of each face of this cell
-                  for (unsigned int f = 0;
-                       f < GeometryInfo<dim>::faces_per_cell;
-                       ++f)
+                  for (const unsigned int f : GeometryInfo<dim>::face_indices())
                     {
                       types::boundary_id boundary_ind =
                         cell->face(f)->boundary_id();

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -447,9 +447,8 @@ namespace internal
 
             for (const auto &cell : dof_handler.active_cell_iterators())
               if (!cell->is_artificial())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (cell->face(face)->user_flag_set() == false)
                     {
                       // Ok, face has not been visited. So we need to
@@ -539,9 +538,8 @@ namespace internal
 
             for (const auto &cell : dof_handler.active_cell_iterators())
               if (!cell->is_artificial())
-                for (unsigned int face = 0;
-                     face < GeometryInfo<dim>::faces_per_cell;
-                     ++face)
+                for (const unsigned int face :
+                     GeometryInfo<dim>::face_indices())
                   if (!cell->face(face)->user_flag_set())
                     {
                       // Same decision tree as before

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -1325,9 +1325,7 @@ namespace MGTools
             const unsigned int        level = cell->level();
             local_dofs.resize(fe.dofs_per_face);
 
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face_no) == true)
                 {
                   const typename DoFHandler<dim, spacedim>::face_iterator face =
@@ -1354,9 +1352,7 @@ namespace MGTools
           if (dof.get_triangulation().locally_owned_subdomain() ==
                 numbers::invalid_subdomain_id ||
               cell->level_subdomain_id() != numbers::artificial_subdomain_id)
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               {
                 if (cell->at_boundary(face_no) == false)
                   continue;
@@ -1487,9 +1483,7 @@ namespace MGTools
                   cell_dofs_interface.end(),
                   false);
 
-        for (unsigned int face_nr = 0;
-             face_nr < GeometryInfo<dim>::faces_per_cell;
-             ++face_nr)
+        for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
           {
             const typename DoFHandler<dim, spacedim>::face_iterator face =
               cell->face(face_nr);
@@ -1568,9 +1562,7 @@ namespace MGTools
 
         std::fill(cell_dofs.begin(), cell_dofs.end(), false);
 
-        for (unsigned int face_nr = 0;
-             face_nr < GeometryInfo<dim>::faces_per_cell;
-             ++face_nr)
+        for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
           {
             const typename DoFHandler<dim, spacedim>::face_iterator face =
               cell->face(face_nr);

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -791,9 +791,8 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
     }
 
 
-  for (unsigned int f = 0;
-       f < GeometryInfo<DoFHandlerType::dimension>::faces_per_cell;
-       ++f)
+  for (const unsigned int f :
+       GeometryInfo<DoFHandlerType::dimension>::face_indices())
     {
       // let's look up whether the neighbor behind that face is noted in the
       // table of cells which we treat. this can only happen if the neighbor

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -424,7 +424,7 @@ DataOutFaces<dim, DoFHandlerType>::first_face()
     cell = this->triangulation->begin_active();
   for (; cell != this->triangulation->end(); ++cell)
     if (cell->is_locally_owned())
-      for (unsigned int f = 0; f < GeometryInfo<dimension>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dimension>::face_indices())
         if (!surface_only || cell->face(f)->at_boundary())
           return FaceDescriptor(cell, f);
 
@@ -471,8 +471,7 @@ DataOutFaces<dim, DoFHandlerType>::next_face(const FaceDescriptor &old_face)
       // check all the faces of this active cell. but skip it altogether
       // if it isn't locally owned
       if (active_cell->is_locally_owned())
-        for (unsigned int f = 0; f < GeometryInfo<dimension>::faces_per_cell;
-             ++f)
+        for (const unsigned int f : GeometryInfo<dimension>::face_indices())
           if (!surface_only || active_cell->face(f)->at_boundary())
             {
               face.first  = active_cell;

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -834,8 +834,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1275,8 +1274,7 @@ namespace Step44
                   Assert(i_group <= J_dof, ExcInternalError());
               }
           }
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->boundary_id() == 6)
             {

--- a/tests/ad_common_tests/step-44-helper_scalar_01.h
+++ b/tests/ad_common_tests/step-44-helper_scalar_01.h
@@ -1237,8 +1237,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1827,8 +1826,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -800,8 +800,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1206,8 +1205,7 @@ namespace Step44
               lqph[q_point]->get_Psi(F, p_tilde[q_point], J_tilde[q_point]) *
               JxW;
           }
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->boundary_id() == 6)
             {

--- a/tests/ad_common_tests/step-44-helper_vector_01.h
+++ b/tests/ad_common_tests/step-44-helper_vector_01.h
@@ -835,8 +835,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1295,8 +1294,7 @@ namespace Step44
                   Assert(i_group <= J_dof, ExcInternalError());
               }
           }
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->boundary_id() == 6)
             {

--- a/tests/adolc/step-44.cc
+++ b/tests/adolc/step-44.cc
@@ -1072,8 +1072,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1636,8 +1635,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/aniso/mesh_3d_21.cc
+++ b/tests/aniso/mesh_3d_21.cc
@@ -63,8 +63,7 @@ void check_this(Triangulation<3> &tria)
 
   DoFHandler<3>::active_cell_iterator cell = dof_handler.begin_active();
   for (; cell != dof_handler.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no) && cell->face(face_no)->has_children())
         for (unsigned int subface_no = 0;
              subface_no < cell->face(face_no)->number_of_children();

--- a/tests/base/functions_04.cc
+++ b/tests/base/functions_04.cc
@@ -57,7 +57,7 @@ check_function(const Functions::FlowFunction<dim> &f,
             patches[0].vertices[vertex_number](2) = -1. + 2. * iz;
           ++vertex_number;
         }
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     patches[0].neighbors[i] = numbers::invalid_unsigned_int;
   patches[0].patch_index          = 0;
   patches[0].n_subdivisions       = sub;

--- a/tests/base/functions_singularity.cc
+++ b/tests/base/functions_singularity.cc
@@ -97,7 +97,7 @@ check_function_derivative(const Functions::FlowFunction<dim> &f,
             patches[0].vertices[vertex_number](2) = -1. + 2. * iz;
           ++vertex_number;
         }
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     patches[0].neighbors[i] = numbers::invalid_unsigned_int;
   patches[0].patch_index          = 0;
   patches[0].n_subdivisions       = sub;

--- a/tests/base/geometry_info_1.cc
+++ b/tests/base/geometry_info_1.cc
@@ -34,7 +34,7 @@ void
 test()
 {
   // Output normal directions for each face
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face " << f << ": n = ( ";
       for (unsigned int d = 0; d < dim; ++d)

--- a/tests/base/geometry_info_10.cc
+++ b/tests/base/geometry_info_10.cc
@@ -24,7 +24,7 @@ template <int dim>
 void
 test()
 {
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       const Tensor<1, dim> unit_normal_vector =
         GeometryInfo<dim>::unit_normal_vector[i];

--- a/tests/base/geometry_info_2.cc
+++ b/tests/base/geometry_info_2.cc
@@ -48,12 +48,12 @@ test()
   deallog << "quads_per_face    " << GeometryInfo<dim>::quads_per_face
           << std::endl;
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     deallog << "face normal" << f << ' '
             << (GeometryInfo<dim>::unit_normal_orientation[f] > 0. ? '+' : '-')
             << "x" << GeometryInfo<dim>::unit_normal_direction[f] << std::endl;
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "face_children" << f << "[true ]";
       for (unsigned int v = 0; v < GeometryInfo<dim>::max_children_per_face;
@@ -71,7 +71,7 @@ test()
       deallog << std::endl;
     }
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "face_vertices" << f << "[true ]";
       for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
@@ -83,7 +83,7 @@ test()
       deallog << std::endl;
     }
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "face_lines" << f << "[true ]";
       for (unsigned int v = 1; v <= GeometryInfo<dim>::lines_per_face; ++v)

--- a/tests/base/geometry_info_3.cc
+++ b/tests/base/geometry_info_3.cc
@@ -29,7 +29,7 @@ test()
 {
   deallog << "Checking in " << dim << "d" << std::endl;
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
       {
         deallog << "Face " << f << ", vertex=" << v << ": ";
@@ -38,7 +38,7 @@ test()
       }
 
   if (dim == 3)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
         {
           deallog << "Face " << f << ", vertex=" << v

--- a/tests/base/geometry_info_7.cc
+++ b/tests/base/geometry_info_7.cc
@@ -38,7 +38,7 @@ test()
     for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         Point<dim> face_vertices[GeometryInfo<dim>::vertices_per_face];
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
@@ -67,7 +67,7 @@ test()
         vertices[v][0] /= 10;
       }
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         Point<dim> face_vertices[GeometryInfo<dim>::vertices_per_face];
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
@@ -117,7 +117,7 @@ test()
           }
       }
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         Point<dim> face_vertices[GeometryInfo<dim>::vertices_per_face];
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
@@ -156,7 +156,7 @@ test()
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     vertices[1] /= 10;
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         Point<dim> face_vertices[GeometryInfo<dim>::vertices_per_face];
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
@@ -179,7 +179,7 @@ test()
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     std::swap(vertices[0], vertices[1]);
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         Point<dim> face_vertices[GeometryInfo<dim>::vertices_per_face];
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)

--- a/tests/base/geometry_info_8.cc
+++ b/tests/base/geometry_info_8.cc
@@ -33,7 +33,7 @@ test_vertices()
 {
   deallog << dim << "D:" << std::endl;
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "face " << i << ":" << std::endl;
 
@@ -66,7 +66,7 @@ test_lines()
 {
   deallog << dim << "D:" << std::endl;
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "face " << i << ":" << std::endl;
 

--- a/tests/base/geometry_info_9.cc
+++ b/tests/base/geometry_info_9.cc
@@ -30,7 +30,7 @@ template <int dim>
 void
 test()
 {
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       const Tensor<1, dim> unit_normal_vector =
         GeometryInfo<dim>::unit_normal_vector[i];

--- a/tests/base/qprojector.cc
+++ b/tests/base/qprojector.cc
@@ -56,7 +56,7 @@ void check_face(Quadrature<1> &q1)
   deallog << "Checking dim " << dim << " 1d-points " << q1.size() << std::endl;
 
   Quadrature<dim - 1> subquadrature(q1);
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face " << f << std::endl;
 
@@ -66,7 +66,7 @@ void check_face(Quadrature<1> &q1)
         deallog << quadrature.point(k) << std::endl;
     }
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     for (unsigned int s = 0; s < GeometryInfo<dim>::max_children_per_face; ++s)
       {
         deallog << "Face " << f << " subface " << s << std::endl;
@@ -91,7 +91,7 @@ void check_faces(Quadrature<1> &q1)
 
   Quadrature<dim> faces = QProjector<dim>::project_to_all_faces(subquadrature);
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face " << f << " orientation false" << std::endl;
 

--- a/tests/bits/cone_03.cc
+++ b/tests/bits/cone_03.cc
@@ -57,8 +57,7 @@ check<2>()
 
   const typename Triangulation<dim>::active_cell_iterator cell =
     triangulation.begin_active();
-  for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-       ++face_no)
+  for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
     {
       const typename Triangulation<dim>::face_iterator face =
         cell->face(face_no);
@@ -88,8 +87,7 @@ check<3>()
 
   const typename Triangulation<dim>::active_cell_iterator cell =
     triangulation.begin_active();
-  for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-       ++face_no)
+  for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
     {
       const typename Triangulation<dim>::face_iterator face =
         cell->face(face_no);

--- a/tests/bits/cone_04.cc
+++ b/tests/bits/cone_04.cc
@@ -40,8 +40,7 @@ check()
   triangulation.refine_global(2);
 
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       {
         const auto face = cell->face(face_no);
         if (face->boundary_id() == 0)

--- a/tests/bits/distorted_cells_06.cc
+++ b/tests/bits/distorted_cells_06.cc
@@ -83,7 +83,7 @@ check()
   GridGenerator::subdivided_hyper_rectangle(coarse_grid, sub, p1, p2, true);
 
   // set bottom middle edge to use MyManifold
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     for (unsigned int e = 0; e < GeometryInfo<dim - 1>::faces_per_cell; ++e)
       if (coarse_grid.begin_active()->face(f)->line(e)->center()[0] == 0)
         if (coarse_grid.begin_active()->face(f)->line(e)->center()[1] == 0.5)

--- a/tests/bits/find_cell_6.cc
+++ b/tests/bits/find_cell_6.cc
@@ -91,7 +91,7 @@ check1()
       for (Triangulation<3>::active_cell_iterator cell = tria.begin_active();
            cell != tria.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<3>::face_indices())
           {
             if (cell->face(f)->at_boundary() && (Testing::rand() % 5) == 1)
               cell->set_refine_flag();

--- a/tests/bits/neighboring_cells_at_two_faces.cc
+++ b/tests/bits/neighboring_cells_at_two_faces.cc
@@ -84,7 +84,7 @@ void
 check_neighbors(const Triangulation<2> &tria)
 {
   Triangulation<2>::cell_iterator cell = tria.begin();
-  for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<2>::face_indices())
     if (cell->neighbor(f).state() == IteratorState::valid)
       {
         const unsigned int neighbor_neighbor = cell->neighbor_of_neighbor(f);

--- a/tests/bits/normals_1.cc
+++ b/tests/bits/normals_1.cc
@@ -63,7 +63,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_face_values.reinit(cell, f);
           for (unsigned int q = 0; q < q_face.size(); ++q)
@@ -75,7 +75,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         for (unsigned int sf = 0; sf < GeometryInfo<dim>::max_children_per_face;
              ++sf)
           {

--- a/tests/bits/normals_2.cc
+++ b/tests/bits/normals_2.cc
@@ -72,7 +72,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_face_values.reinit(cell, f);
           for (unsigned int q = 0; q < q_face.size(); ++q)
@@ -84,7 +84,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         for (unsigned int sf = 0; sf < GeometryInfo<dim>::max_children_per_face;
              ++sf)
           {

--- a/tests/bits/normals_3.cc
+++ b/tests/bits/normals_3.cc
@@ -69,7 +69,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_face_values.reinit(cell, f);
           for (unsigned int q = 0; q < q_face.size(); ++q)
@@ -81,7 +81,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         for (unsigned int sf = 0; sf < GeometryInfo<dim>::max_children_per_face;
              ++sf)
           {

--- a/tests/bits/normals_4.cc
+++ b/tests/bits/normals_4.cc
@@ -69,7 +69,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_face_values.reinit(cell, f);
           for (unsigned int q = 0; q < q_face.size(); ++q)
@@ -81,7 +81,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         for (unsigned int sf = 0; sf < GeometryInfo<dim>::max_children_per_face;
              ++sf)
           {

--- a/tests/bits/q_point_sum_1.cc
+++ b/tests/bits/q_point_sum_1.cc
@@ -59,7 +59,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -69,7 +69,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/q_point_sum_2.cc
+++ b/tests/bits/q_point_sum_2.cc
@@ -66,7 +66,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -76,7 +76,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/q_point_sum_3.cc
+++ b/tests/bits/q_point_sum_3.cc
@@ -66,7 +66,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -76,7 +76,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/q_point_sum_4.cc
+++ b/tests/bits/q_point_sum_4.cc
@@ -66,7 +66,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -76,7 +76,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/q_points.cc
+++ b/tests/bits/q_points.cc
@@ -92,7 +92,7 @@ void check(Triangulation<3> &tria)
   for (DoFHandler<3>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(f))
         {
           const unsigned int nn = cell->neighbor_of_neighbor(f);

--- a/tests/bits/roy_1.cc
+++ b/tests/bits/roy_1.cc
@@ -33,7 +33,7 @@ template <int dim>
 void
 check(const FiniteElement<dim> &fe)
 {
-  for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; face++)
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     for (unsigned int i = 0; i < fe.dofs_per_cell; i++)
       if (fe.has_support_on_face(i, face))
         deallog << "Basis function " << i << " has support on face " << face

--- a/tests/bits/rt_2.cc
+++ b/tests/bits/rt_2.cc
@@ -79,7 +79,7 @@ void evaluate_normal(DoFHandler<2> &dof_handler, Vector<double> &solution)
 
   for (; cell != endc; ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<2>::face_indices())
         {
           if (!cell->face(f)->at_boundary())
             {

--- a/tests/bits/static_condensation.cc
+++ b/tests/bits/static_condensation.cc
@@ -392,8 +392,7 @@ HelmholtzProblem<dim>::assemble_system(const bool do_reconstruct)
                             rhs_values[q_point] * fe_values.JxW(q_point));
         }
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary() &&
             (cell->face(face)->boundary_id() == 1))
           {
@@ -637,9 +636,7 @@ HelmholtzProblem<dim>::run()
                                                        triangulation.begin(),
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               if ((cell->face(face)->center()(0) == -1) ||
                   (cell->face(face)->center()(1) == -1))
                 cell->face(face)->set_boundary_id(1);

--- a/tests/bits/step-10-high-order.cc
+++ b/tests/bits/step-10-high-order.cc
@@ -156,9 +156,7 @@ compute_pi_by_perimeter()
                                                      endc = dof_handler.end();
       long double perimeter                               = 0;
       for (; cell != endc; ++cell)
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           if (cell->face(face_no)->at_boundary())
             {
               x_fe_face_values.reinit(cell, face_no);

--- a/tests/bits/step-10.cc
+++ b/tests/bits/step-10.cc
@@ -193,9 +193,7 @@ compute_pi_by_perimeter()
             endc                = dof_handler.end();
           long double perimeter = 0;
           for (; cell != endc; ++cell)
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->face(face_no)->at_boundary())
                 {
                   x_fe_face_values.reinit(cell, face_no);

--- a/tests/bits/step-12.cc
+++ b/tests/bits/step-12.cc
@@ -462,9 +462,7 @@ DGMethod<dim>::assemble_system1()
 
       cell->get_dof_indices(dofs);
 
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
 
@@ -637,9 +635,7 @@ DGMethod<dim>::assemble_system2()
 
       cell->get_dof_indices(dofs);
 
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
 

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -1638,9 +1638,7 @@ namespace LaplaceSolver
     for (active_cell_iterator cell = dual_solver.dof_handler.begin_active();
          cell != dual_solver.dof_handler.end();
          ++cell)
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         face_integrals[cell->face(face_no)] = -1e20;
 
     error_indicators.reinit(
@@ -1661,9 +1659,7 @@ namespace LaplaceSolver
     for (active_cell_iterator cell = dual_solver.dof_handler.begin_active();
          cell != dual_solver.dof_handler.end();
          ++cell, ++present_cell)
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           Assert(face_integrals.find(cell->face(face_no)) !=
                    face_integrals.end(),
@@ -1717,9 +1713,7 @@ namespace LaplaceSolver
                             cell_data,
                             error_indicators);
 
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(face_no)->at_boundary())
               {

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -443,8 +443,7 @@ namespace Step51
       , fe_local_support_on_face(GeometryInfo<dim>::faces_per_cell)
       , fe_support_on_face(GeometryInfo<dim>::faces_per_cell)
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe_local.dofs_per_cell; ++i)
           {
             if (fe_local.has_support_on_face(i, face))
@@ -453,8 +452,7 @@ namespace Step51
               }
           }
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
           {
             if (fe.has_support_on_face(i, face))
@@ -635,8 +633,7 @@ namespace Step51
           }
       }
 
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       {
         scratch.fe_face_values_local.reinit(loc_cell, face);
         scratch.fe_face_values.reinit(cell, face);
@@ -976,8 +973,7 @@ namespace Step51
     typename Triangulation<dim>::cell_iterator cell = triangulation.begin(),
                                                endc = triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary())
           for (unsigned int d = 0; d < dim; ++d)
             if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -443,8 +443,7 @@ namespace Step51
       , fe_local_support_on_face(GeometryInfo<dim>::faces_per_cell)
       , fe_support_on_face(GeometryInfo<dim>::faces_per_cell)
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe_local.dofs_per_cell; ++i)
           {
             if (fe_local.has_support_on_face(i, face))
@@ -453,8 +452,7 @@ namespace Step51
               }
           }
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
           {
             if (fe.has_support_on_face(i, face))
@@ -635,8 +633,7 @@ namespace Step51
           }
       }
 
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       {
         scratch.fe_face_values_local.reinit(loc_cell, face);
         scratch.fe_face_values.reinit(cell, face);
@@ -974,8 +971,7 @@ namespace Step51
     typename Triangulation<dim>::cell_iterator cell = triangulation.begin(),
                                                endc = triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary())
           for (unsigned int d = 0; d < dim; ++d)
             if ((std::fabs(cell->face(face)->center()(d) - (1)) < 1e-12))

--- a/tests/bits/step-7.cc
+++ b/tests/bits/step-7.cc
@@ -330,8 +330,7 @@ HelmholtzProblem<dim>::assemble_system()
                             rhs_values[q_point] * fe_values.JxW(q_point));
           }
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary() &&
             (cell->face(face)->boundary_id() == 1))
           {
@@ -502,9 +501,7 @@ HelmholtzProblem<dim>::run()
                                                        triangulation.begin(),
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               if ((cell->face(face)->center()(0) == -1) ||
                   (cell->face(face)->center()(1) == -1))
                 cell->face(face)->set_boundary_id(1);

--- a/tests/bits/volume_1.cc
+++ b/tests/bits/volume_1.cc
@@ -66,7 +66,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -78,7 +78,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/volume_2.cc
+++ b/tests/bits/volume_2.cc
@@ -77,7 +77,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -89,7 +89,7 @@ check(const Triangulation<dim> &tria, const unsigned int order)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/volume_3.cc
+++ b/tests/bits/volume_3.cc
@@ -74,7 +74,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -86,7 +86,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/bits/volume_4.cc
+++ b/tests/bits/volume_4.cc
@@ -74,7 +74,7 @@ check(const Triangulation<dim> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
             fe_face_values.reinit(cell, f);
@@ -86,7 +86,7 @@ check(const Triangulation<dim> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           for (unsigned int sf = 0;
                sf < GeometryInfo<dim>::max_children_per_face;

--- a/tests/codim_one/boundary_indicator_01.cc
+++ b/tests/codim_one/boundary_indicator_01.cc
@@ -74,7 +74,7 @@ main()
          ++cell)
       {
         bool done = false;
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f))
             {
               cell->face(f)->set_boundary_id(1);

--- a/tests/codim_one/extract_boundary_mesh_03.cc
+++ b/tests/codim_one/extract_boundary_mesh_03.cc
@@ -111,7 +111,7 @@ main()
            volume_mesh.begin_active();
          cell != volume_mesh.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           cell->face(f)->set_all_boundary_ids(1);
     GridTools::copy_boundary_to_manifold_id(volume_mesh);

--- a/tests/codim_one/extract_boundary_mesh_04.cc
+++ b/tests/codim_one/extract_boundary_mesh_04.cc
@@ -111,7 +111,7 @@ main()
            volume_mesh.begin_active();
          cell != volume_mesh.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f) && (cell->center()[dim - 1] > 0))
           cell->face(f)->set_all_boundary_ids(1);
 

--- a/tests/codim_one/extract_boundary_mesh_11.cc
+++ b/tests/codim_one/extract_boundary_mesh_11.cc
@@ -44,7 +44,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->face(f)->at_boundary())
         {
           if (cell->face(f)->boundary_id() == 0)

--- a/tests/codim_one/extract_boundary_mesh_13.cc
+++ b/tests/codim_one/extract_boundary_mesh_13.cc
@@ -44,7 +44,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->face(f)->at_boundary())
         {
           if (cell->face(f)->boundary_id() == 0)

--- a/tests/codim_one/hanging_nodes_02.cc
+++ b/tests/codim_one/hanging_nodes_02.cc
@@ -68,8 +68,7 @@ main()
       deallog << "Cell = " << cell << std::endl;
       deallog << "  direction_flag = " << cell->direction_flag() << std::endl;
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           deallog << "  face = " << face
                   << "  (neighbor = " << cell->neighbor(face) << ")"

--- a/tests/codim_one/hanging_nodes_03.cc
+++ b/tests/codim_one/hanging_nodes_03.cc
@@ -60,8 +60,7 @@ main()
       deallog << "Cell = " << cell << std::endl;
       deallog << "  direction_flag = " << cell->direction_flag() << std::endl;
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           deallog << "  face = " << face
                   << "  (neighbor = " << cell->neighbor(face) << ")"

--- a/tests/codim_one/interpolate_boundary_values_01.cc
+++ b/tests/codim_one/interpolate_boundary_values_01.cc
@@ -64,7 +64,7 @@ test(std::string filename)
          dof_handler.begin_active();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
           for (unsigned int i = 0; i < fe.dofs_per_vertex; ++i)

--- a/tests/codim_one/interpolate_boundary_values_01_vector_valued.cc
+++ b/tests/codim_one/interpolate_boundary_values_01_vector_valued.cc
@@ -81,7 +81,7 @@ test(std::string filename)
          dof_handler.begin_active();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face; ++v)
           for (unsigned int i = 0; i < fe.dofs_per_vertex; ++i)

--- a/tests/codim_one/interpolate_boundary_values_02.cc
+++ b/tests/codim_one/interpolate_boundary_values_02.cc
@@ -68,7 +68,7 @@ test()
              dof_handler.begin_active();
            cell != dof_handler.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f) &&
               (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;

--- a/tests/codim_one/interpolate_boundary_values_02_vector_valued.cc
+++ b/tests/codim_one/interpolate_boundary_values_02_vector_valued.cc
@@ -86,7 +86,7 @@ test()
              dof_handler.begin_active();
            cell != dof_handler.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f) &&
               (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;

--- a/tests/codim_one/interpolate_boundary_values_03.cc
+++ b/tests/codim_one/interpolate_boundary_values_03.cc
@@ -75,7 +75,7 @@ test()
              dof_handler.begin_active();
            cell != dof_handler.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f) &&
               (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;

--- a/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
+++ b/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
@@ -84,7 +84,7 @@ test()
              dof_handler.begin_active();
            cell != dof_handler.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f) &&
               (cell->face(f)->boundary_id() == boundary_id))
             for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;

--- a/tests/cuda/matrix_free_no_index_initialize.cu
+++ b/tests/cuda/matrix_free_no_index_initialize.cu
@@ -118,7 +118,7 @@ test()
   Triangulation<dim>           tria;
   GridGenerator::hyper_ball(tria);
   for (const auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/data_out/data_out_base.cc
+++ b/tests/data_out/data_out_base.cc
@@ -167,7 +167,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
           p.vertices[i](j) =
             PatchInfo<dim>::vertices[i][j] + PatchInfo<dim>::offsets[c][j];
 
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         p.neighbors[i] = (unsigned int)PatchInfo<dim>::neighbors[c][i];
 
       unsigned int ndata = 1;

--- a/tests/data_out/data_out_curved_cells.cc
+++ b/tests/data_out/data_out_curved_cells.cc
@@ -171,9 +171,7 @@ curved_grid(std::ofstream &out)
         }
 
       if (cell->at_boundary())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<2>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<2>::face_indices())
           {
             face = cell->face(face_no);
             // insert a modifiued value for

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -98,7 +98,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);
@@ -168,7 +168,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
   Triangulation<3>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<3>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
       if (cell_1->face(j)->center()(2) > 2.9)
         face_1 = cell_1->face(j);
@@ -218,7 +218,7 @@ print_matching(DoFHandler<dim> &dof_handler,
        cell != dof_handler.end(0);
        ++cell)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(j)->center()(dim == 2 ? 1 : 2) > 2.9)
             face_1 = cell->face(j);

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -98,7 +98,7 @@ void generate_grid(Triangulation<2> &triangulation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -132,7 +132,7 @@ void generate_grid(Triangulation<2> &triangulation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -97,7 +97,7 @@ void generate_grid(Triangulation<2> &triangulation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -101,7 +101,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);
@@ -172,7 +172,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
   Triangulation<3>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<3>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
       if (cell_1->face(j)->center()(2) > 2.9)
         face_1 = cell_1->face(j);
@@ -223,7 +223,7 @@ print_matching(DoFHandler<dim> &dof_handler,
        cell != dof_handler.end(0);
        ++cell)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(j)->center()(dim == 2 ? 1 : 2) > 2.9)
             face_1 = cell->face(j);

--- a/tests/dofs/dof_tools_common.h
+++ b/tests/dofs/dof_tools_common.h
@@ -72,7 +72,7 @@ template <int dim>
 void
 set_boundary_ids(Triangulation<dim> &tria)
 {
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     tria.begin_active()->face(f)->set_boundary_id(f);
 }
 

--- a/tests/dofs/range_based_for_tria_face.cc
+++ b/tests/dofs/range_based_for_tria_face.cc
@@ -39,8 +39,7 @@ check()
     face->set_manifold_id(42);
 
   for (const auto &cell : tr.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       Assert(cell->face(face_n)->manifold_id() == 42, ExcInternalError());
 
   deallog << "OK" << std::endl;

--- a/tests/fail/circular_01.cc
+++ b/tests/fail/circular_01.cc
@@ -795,7 +795,7 @@ LaplaceProblem<3>::create_coarse_grid()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if ((cell->face(f)->center()[2] != -4) &&
           (cell->face(f)->center()[2] != 7) && (cell->face(f)->at_boundary()))
         cell->face(f)->set_boundary_id(1);

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -1659,9 +1659,7 @@ namespace LaplaceSolver
     for (active_cell_iterator cell = dual_solver.dof_handler.begin_active();
          cell != dual_solver.dof_handler.end();
          ++cell)
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         face_integrals[cell->face(face_no)] = -1e20;
 
     error_indicators.reinit(
@@ -1684,9 +1682,7 @@ namespace LaplaceSolver
     for (active_cell_iterator cell = dual_solver.dof_handler.begin_active();
          cell != dual_solver.dof_handler.end();
          ++cell, ++present_cell)
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           Assert(face_integrals.find(cell->face(face_no)) !=
                    face_integrals.end(),
@@ -1738,9 +1734,7 @@ namespace LaplaceSolver
                             cell_data,
                             error_indicators);
 
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(face_no)->at_boundary())
               {

--- a/tests/fe/abf_01.cc
+++ b/tests/fe/abf_01.cc
@@ -475,7 +475,7 @@ project(const Mapping<dim> &             mapping,
                                                      endc = dof.end();
       std::vector<types::global_dof_index> face_dof_indices(fe.dofs_per_face);
       for (; cell != endc; ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->face(f)->at_boundary())
             {
               cell->face(f)->get_dof_indices(face_dof_indices);

--- a/tests/fe/abf_02.cc
+++ b/tests/fe/abf_02.cc
@@ -456,7 +456,7 @@ project(const Mapping<dim> &             mapping,
                                                      endc = dof.end();
       std::vector<types::global_dof_index> face_dof_indices(fe.dofs_per_face);
       for (; cell != endc; ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->face(f)->at_boundary())
             {
               cell->face(f)->get_dof_indices(face_dof_indices);

--- a/tests/fe/cell_similarity_01.cc
+++ b/tests/fe/cell_similarity_01.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_02.cc
+++ b/tests/fe/cell_similarity_02.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_03.cc
+++ b/tests/fe/cell_similarity_03.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_04.cc
+++ b/tests/fe/cell_similarity_04.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_05.cc
+++ b/tests/fe/cell_similarity_05.cc
@@ -158,7 +158,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_06.cc
+++ b/tests/fe/cell_similarity_06.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_07.cc
+++ b/tests/fe/cell_similarity_07.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_08.cc
+++ b/tests/fe/cell_similarity_08.cc
@@ -159,7 +159,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_09.cc
+++ b/tests/fe/cell_similarity_09.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_10.cc
+++ b/tests/fe/cell_similarity_10.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_11.cc
+++ b/tests/fe/cell_similarity_11.cc
@@ -114,7 +114,7 @@ test()
 
   for (Triangulation<dim>::cell_iterator cell = tr.begin(); cell != tr.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->face(f)->at_boundary() &&
           std::abs(cell->face(f)->center()[0] + 1.) < 1e-12 &&
           std::abs(cell->face(f)->center()[1]) < 1e-12)

--- a/tests/fe/cell_similarity_dgp_monomial_01.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_01.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_02.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_02.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_03.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_03.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_04.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_04.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_05.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_05.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_06.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_06.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_07.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_07.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_08.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_08.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_09.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_09.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_monomial_10.cc
+++ b/tests/fe/cell_similarity_dgp_monomial_10.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_01.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_01.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_02.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_02.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_03.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_03.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_04.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_04.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_05.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_05.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_06.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_06.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_07.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_07.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_08.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_08.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_manifold_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_09.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_09.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/cell_similarity_dgp_nonparametric_10.cc
+++ b/tests/fe/cell_similarity_dgp_nonparametric_10.cc
@@ -157,7 +157,7 @@ test()
   tr.set_manifold(1, boundary);
 
   // set boundary id on cell 1
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (tr.begin_active()->at_boundary(f))
       tr.begin_active()->face(f)->set_boundary_id(1);
 

--- a/tests/fe/deformed_projection.h
+++ b/tests/fe/deformed_projection.h
@@ -530,7 +530,7 @@ project(const Mapping<dim> &             mapping,
                                                      endc = dof.end();
       std::vector<types::global_dof_index> face_dof_indices(fe.dofs_per_face);
       for (; cell != endc; ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->face(f)->at_boundary())
             {
               cell->face(f)->get_dof_indices(face_dof_indices);
@@ -665,7 +665,7 @@ void plot_shapes(DoFHandler<2> &dof_handler)
   std::vector<types::global_dof_index> face_dof_indices(
     dof_handler.get_fe().dofs_per_face);
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<2>::face_indices())
       {
         cell->face(f)->get_dof_indices(face_dof_indices);
         for (unsigned int i = 0; i < dof_handler.get_fe().dofs_per_face; ++i)

--- a/tests/fe/derivatives_face.cc
+++ b/tests/fe/derivatives_face.cc
@@ -56,7 +56,7 @@ plot_derivatives(Mapping<dim> &      mapping,
                        finel,
                        q,
                        UpdateFlags(update_gradients | update_hessians));
-  for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       fe.reinit(c, face);
 

--- a/tests/fe/fe_abf_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_abf_gradient_divergence_theorem.cc
@@ -111,9 +111,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_data_test.cc
+++ b/tests/fe/fe_data_test.cc
@@ -263,7 +263,7 @@ test_fe_datas()
       for (unsigned int i = 0; i < fe_data->dofs_per_face; ++i)
         deallog << ' ' << fe_data->face_to_cell_index(i, 0);
       deallog << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           deallog << "face_to_cell_index:";
           for (unsigned int i = 0; i < fe_data->dofs_per_face; ++i)
@@ -271,7 +271,7 @@ test_fe_datas()
           deallog << std::endl;
         }
 
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           deallog << "support on face " << f << ':';
           for (unsigned int s = 0; s < fe_data->dofs_per_cell; ++s)

--- a/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
@@ -113,9 +113,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<3, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<3, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_dgq_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_gradient_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_dgq_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_hessian_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<2, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_enriched_03.cc
+++ b/tests/fe/fe_enriched_03.cc
@@ -97,8 +97,7 @@ test2()
                                                    dof_handler.begin_active(),
                                                  endc = dof_handler.end();
   for (; cell != endc; ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       {
         fe_face_values.reinit(cell, face);
         const unsigned int                     n_q_points = quadrature.size();

--- a/tests/fe/fe_enriched_compare_to_fe_system.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system.cc
@@ -244,8 +244,7 @@ test(const FiniteElement<dim> & fe1,
             fe_values_system.shape_grad_component(i, q_point, 1),
             fe_values_system.shape_hessian_component(i, q_point, 1));
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           fe_face_values_enriched.reinit(cell_enriched, face);
           fe_face_values_system.reinit(cell_system, face);

--- a/tests/fe/fe_enriched_compare_to_fe_system_2.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system_2.cc
@@ -331,8 +331,7 @@ test(const FiniteElement<dim> & fe_base,
             fe_values_system.shape_grad_component(i, q_point, 3),
             fe_values_system.shape_hessian_component(i, q_point, 3));
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           fe_face_values_enriched.reinit(cell_enriched, face);
           fe_face_values_system.reinit(cell_system, face);

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -390,7 +390,7 @@ namespace Step36
          cell != dof_handler.end();
          ++cell)
       if (cell_is_pou(cell))
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (!cell->at_boundary(f))
             {
               bool face_is_on_interface = false;

--- a/tests/fe/fe_face_values_1d.cc
+++ b/tests/fe/fe_face_values_1d.cc
@@ -65,8 +65,7 @@ plot_faces(Mapping<dim> &                           mapping,
                                           update_gradients | update_hessians |
                                           update_normal_vectors));
 
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face=" << face_nr << std::endl;
       fe_values.reinit(cell, face_nr);
@@ -108,8 +107,7 @@ plot_subfaces(Mapping<dim> &                           mapping,
     q,
     UpdateFlags(update_quadrature_points | update_JxW_values | update_values |
                 update_gradients | update_hessians | update_normal_vectors));
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     for (unsigned int sub_nr = 0;
          sub_nr < GeometryInfo<dim>::max_children_per_face;
          ++sub_nr)

--- a/tests/fe/fe_nedelec_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_gradient_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<2, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_nedelec_sz_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_sz_gradient_divergence_theorem.cc
@@ -109,9 +109,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -333,8 +333,7 @@ test(const FiniteElement<dim> &fe,
                 }
             }
 
-          for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-               ++face)
+          for (const unsigned int face : GeometryInfo<dim>::face_indices())
             {
               fe_face_values.reinit(cell, face);
               const std::vector<double> &face_JxW_values =

--- a/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<3, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -590,9 +590,7 @@ namespace Step22
           for (unsigned int j = i + 1; j < dofs_per_cell; ++j)
             local_matrix(i, j) = local_matrix(j, i);
 
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
             if (face->at_boundary() == false)

--- a/tests/fe/fe_q_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_q_gradient_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_q_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_q_hessian_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<2, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
@@ -113,9 +113,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<3, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_rt_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_rt_gradient_divergence_theorem.cc
@@ -110,9 +110,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<1, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_rt_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_rt_hessian_divergence_theorem.cc
@@ -104,9 +104,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<2, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_support_points_common.h
+++ b/tests/fe/fe_support_points_common.h
@@ -69,7 +69,7 @@ check_support(const FiniteElement<dim> &finel, const char *name)
 
   Quadrature<dim - 1> q(face_points, dummy_weights);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       std::vector<Point<dim>> q_points(q.get_points().size());
       QProjector<dim>::project_to_face(q, i, q_points);
@@ -96,7 +96,7 @@ check_support(const FiniteElement<dim> &finel, const char *name)
 
   Quadrature<dim - 1> qg(face_g_points, dummy_g_weights);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       std::vector<Point<dim>> q_points(qg.get_points().size());
       QProjector<dim>::project_to_face(qg, i, q_points);

--- a/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
@@ -112,9 +112,7 @@ test(const Triangulation<dim> &tr,
                 }
 
               Tensor<3, dim> boundary_integral;
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   fe_face_values.reinit(cell, face);
                   for (unsigned int q = 0;

--- a/tests/fe/fe_values_no_mapping.cc
+++ b/tests/fe/fe_values_no_mapping.cc
@@ -110,7 +110,7 @@ test()
         fe_val_m.get_function_values(interpolant, values_m);
         Assert(values[0] == values_m[0], ExcInternalError())
 
-          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_f_val.reinit(cell, f);
           fe_f_val_m.reinit(cell, f);

--- a/tests/fe/jacobians_face.cc
+++ b/tests/fe/jacobians_face.cc
@@ -59,7 +59,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -97,7 +97,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -135,7 +135,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -178,7 +178,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -224,7 +224,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -270,7 +270,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -320,7 +320,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -369,7 +369,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 

--- a/tests/fe/jacobians_face_cartesian.cc
+++ b/tests/fe/jacobians_face_cartesian.cc
@@ -57,7 +57,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -95,7 +95,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -133,7 +133,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -176,7 +176,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -222,7 +222,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -268,7 +268,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -318,7 +318,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -367,7 +367,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 

--- a/tests/fe/jacobians_face_fe_field.cc
+++ b/tests/fe/jacobians_face_fe_field.cc
@@ -75,7 +75,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -113,7 +113,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -151,7 +151,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -194,7 +194,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -240,7 +240,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -286,7 +286,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -336,7 +336,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 
@@ -385,7 +385,7 @@ test()
                                                         tria.begin_active(),
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           fe_val.reinit(cell, f);
 

--- a/tests/fe/nedelec_2.cc
+++ b/tests/fe/nedelec_2.cc
@@ -135,8 +135,7 @@ plot(const Triangulation<dim> &tr, const unsigned int p)
   for (typename DoFHandler<dim>::active_cell_iterator c = dof.begin_active();
        c != dof.end();
        ++c)
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       {
         deallog << "cell " << c << " face " << face;
         if (c->at_boundary(face))

--- a/tests/fe/rt_normal_02.cc
+++ b/tests/fe/rt_normal_02.cc
@@ -101,7 +101,7 @@ void EvaluateNormal2(DoFHandler<2> *dof_handler, Vector<double> &solution)
       cell->get_dof_indices(local_dof_indices);
       fe_v.reinit(cell);
 
-      for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<2>::face_indices())
         {
           if (!cell->face(f)->at_boundary())
             {
@@ -199,7 +199,7 @@ void EvaluateNormal(DoFHandler<2> *dof_handler, Vector<double> &solution)
     {
       cell->get_dof_indices(local_dof_indices);
 
-      for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<2>::face_indices())
         {
           if (!cell->face(f)->at_boundary())
             {

--- a/tests/fe/rtdiff.cc
+++ b/tests/fe/rtdiff.cc
@@ -61,7 +61,7 @@ initialize_node_matrix(const FiniteElement<dim> &other,
   // the normal component of the
   // shape function, possibly
   // pointing in negative direction.
-  for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     for (unsigned int k = 0; k < other.dofs_per_face; ++k)
       {
         for (unsigned int i = 0; i < n_dofs; ++i)

--- a/tests/fe/rtn_1.cc
+++ b/tests/fe/rtn_1.cc
@@ -103,7 +103,7 @@ check_face_support_points(const FiniteElement<dim> &fe)
   UpdateFlags       flags = update_values | update_gradients;
   FEFaceValues<dim> vals(mapping, fe, sub_quadrature, flags);
 
-  for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       QProjector<dim>::project_to_face(sub_quadrature, face, points);
       vals.reinit(dof.begin_active(), face);

--- a/tests/fe/shapes.h
+++ b/tests/fe/shapes.h
@@ -171,7 +171,7 @@ plot_face_shape_functions(Mapping<dim> &      mapping,
   sprintf(fname, "Face%dd-%s", dim, name);
   deallog.push(fname);
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       if (!c->face(f)->has_children())
         {

--- a/tests/feinterface/face_orientation_01.cc
+++ b/tests/feinterface/face_orientation_01.cc
@@ -62,7 +62,7 @@ test()
 
 
       for (auto cell : dofh.active_cell_iterators())
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f) == false)
             {
               fiv.reinit(cell,

--- a/tests/feinterface/fe_interface_values_01.cc
+++ b/tests/feinterface/fe_interface_values_01.cc
@@ -118,7 +118,7 @@ test()
 
   deallog << "** interface between cell 0 and 1 **\n";
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         fiv.reinit(cell,

--- a/tests/feinterface/fe_interface_values_02.cc
+++ b/tests/feinterface/fe_interface_values_02.cc
@@ -82,7 +82,7 @@ test(unsigned int fe_degree)
 
   auto cell = dofh.begin();
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         fiv.reinit(cell,

--- a/tests/feinterface/fe_interface_values_03.cc
+++ b/tests/feinterface/fe_interface_values_03.cc
@@ -85,7 +85,7 @@ test(unsigned int fe_degree)
   auto cell = dofh.begin(1);
   ++cell;
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         if (!cell->neighbor_is_coarser(f))

--- a/tests/feinterface/fe_interface_values_05.cc
+++ b/tests/feinterface/fe_interface_values_05.cc
@@ -118,7 +118,7 @@ test()
 
   deallog << "** interface between cell 0 and 1 **\n";
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         fiv.reinit(cell,

--- a/tests/feinterface/fe_interface_values_06.cc
+++ b/tests/feinterface/fe_interface_values_06.cc
@@ -85,7 +85,7 @@ test(unsigned int fe_degree)
   auto cell = dofh.begin(1);
   ++cell;
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         if (!cell->neighbor_is_coarser(f))

--- a/tests/feinterface/fe_interface_values_07.cc
+++ b/tests/feinterface/fe_interface_values_07.cc
@@ -83,7 +83,7 @@ test(unsigned int fe_degree)
 
   auto cell = dofh.begin();
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         fiv.reinit(cell,

--- a/tests/feinterface/fe_interface_values_08.cc
+++ b/tests/feinterface/fe_interface_values_08.cc
@@ -116,7 +116,7 @@ test(const FiniteElement<dim> &fe)
   }
 
 
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     if (!cell->at_boundary(f))
       {
         fiv.reinit(cell,

--- a/tests/fullydistributed_grids/copy_serial_tria_04.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_04.cc
@@ -48,9 +48,7 @@ test(const int n_refinements, const int n_subdivisions, MPI_Comm comm)
     auto cell = tria.begin();
     auto endc = tria.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face_number = 0;
-           face_number < GeometryInfo<dim>::faces_per_cell;
-           ++face_number)
+      for (const unsigned int face_number : GeometryInfo<dim>::face_indices())
         if (std::fabs(cell->face(face_number)->center()(0) - left) < 1e-12)
           cell->face(face_number)->set_all_boundary_ids(1);
         else if (std::fabs(cell->face(face_number)->center()(0) - right) <

--- a/tests/grid/accessor_01.cc
+++ b/tests/grid/accessor_01.cc
@@ -44,7 +44,7 @@ test()
 
   for (auto &cell : tria.active_cell_iterators())
     {
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           if (mymap.find(cell->face(i)) == mymap.end())
             {

--- a/tests/grid/concentric_hyper_shell_01.cc
+++ b/tests/grid/concentric_hyper_shell_01.cc
@@ -39,13 +39,11 @@ main()
                 << std::endl;
 
         bool manifold_ids_are_zero = cell->manifold_id() == 0;
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           manifold_ids_are_zero &= cell->face(face_n)->manifold_id() == 0;
         AssertThrow(manifold_ids_are_zero, ExcInternalError());
 
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           if (cell->face(face_n)->at_boundary())
             deallog << "boundary face center distance to origin: "
                     << (cell->face(face_n)->center(/*respect_manifold*/ true) -
@@ -71,13 +69,11 @@ main()
                 << cell->vertex(6) << ", " << cell->vertex(7) << std::endl;
 
         bool manifold_ids_are_zero = cell->manifold_id() == 0;
-        for (unsigned int face_n = 0; face_n < GeometryInfo<3>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<3>::face_indices())
           manifold_ids_are_zero &= cell->face(face_n)->manifold_id() == 0;
         AssertThrow(manifold_ids_are_zero, ExcInternalError());
 
-        for (unsigned int face_n = 0; face_n < GeometryInfo<3>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<3>::face_indices())
           if (cell->face(face_n)->at_boundary())
             deallog << "boundary face center distance to origin: "
                     << (cell->face(face_n)->center(/*respect_manifold*/ true) -

--- a/tests/grid/concentric_hyper_shell_02.cc
+++ b/tests/grid/concentric_hyper_shell_02.cc
@@ -39,13 +39,11 @@ main()
                 << std::endl;
 
         bool manifold_ids_are_zero = cell->manifold_id() == 0;
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           manifold_ids_are_zero &= cell->face(face_n)->manifold_id() == 0;
         AssertThrow(manifold_ids_are_zero, ExcInternalError());
 
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           if (cell->face(face_n)->at_boundary())
             deallog << "boundary face center distance to origin: "
                     << (cell->face(face_n)->center(true) - center).norm()
@@ -69,13 +67,11 @@ main()
                 << cell->vertex(6) << ", " << cell->vertex(7) << std::endl;
 
         bool manifold_ids_are_zero = cell->manifold_id() == 0;
-        for (unsigned int face_n = 0; face_n < GeometryInfo<3>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<3>::face_indices())
           manifold_ids_are_zero &= cell->face(face_n)->manifold_id() == 0;
         AssertThrow(manifold_ids_are_zero, ExcInternalError());
 
-        for (unsigned int face_n = 0; face_n < GeometryInfo<3>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<3>::face_indices())
           if (cell->face(face_n)->at_boundary())
             {
               deallog << "boundary face center distance to origin: "

--- a/tests/grid/extrude_copy_manifold.cc
+++ b/tests/grid/extrude_copy_manifold.cc
@@ -33,8 +33,7 @@ test()
     if (cell->at_boundary())
       {
         cell->set_manifold_id(1);
-        for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-             ++face_n)
+        for (const unsigned int face_n : GeometryInfo<2>::face_indices())
           if (!cell->face(face_n)->at_boundary())
             cell->face(face_n)->set_manifold_id(1);
       }
@@ -62,8 +61,7 @@ test()
   for (const auto &cell : triangulation_3.active_cell_iterators())
     {
       cell_centers[cell->manifold_id()].push_back(cell->center());
-      for (unsigned int face_n = 0; face_n < GeometryInfo<3>::faces_per_cell;
-           ++face_n)
+      for (const unsigned int face_n : GeometryInfo<3>::face_indices())
         face_centers[cell->face(face_n)->manifold_id()].push_back(
           cell->face(face_n)->center());
       for (unsigned int line_n = 0; line_n < GeometryInfo<3>::lines_per_cell;

--- a/tests/grid/extrude_orientation_01.cc
+++ b/tests/grid/extrude_orientation_01.cc
@@ -47,7 +47,7 @@ test(std::ostream &out)
     {
       deallog << "2d cell " << c
               << " has the following face orientations:" << std::endl;
-      for (unsigned int l = 0; l < GeometryInfo<2>::faces_per_cell; ++l)
+      for (const unsigned int l : GeometryInfo<2>::face_indices())
         deallog << "    " << (c->face_orientation(l) ? "true" : "false")
                 << std::endl;
     }
@@ -63,7 +63,7 @@ test(std::ostream &out)
         << "3d cell " << c
         << " has the following face orientation/flips and edge orientations:"
         << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         deallog << "    face=" << f
                 << (c->face_orientation(f) ? " -> true" : " -> false")
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;

--- a/tests/grid/extrude_orientation_02.cc
+++ b/tests/grid/extrude_orientation_02.cc
@@ -40,7 +40,7 @@ test()
     {
       deallog << "2d cell " << c
               << " has the following face orientations:" << std::endl;
-      for (unsigned int l = 0; l < GeometryInfo<2>::faces_per_cell; ++l)
+      for (const unsigned int l : GeometryInfo<2>::face_indices())
         deallog << "    " << (c->face_orientation(l) ? "true" : "false")
                 << std::endl;
     }
@@ -56,7 +56,7 @@ test()
         << "3d cell " << c
         << " has the following face orientation/flips and edge orientations:"
         << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         deallog << "    face=" << f
                 << (c->face_orientation(f) ? " -> true" : " -> false")
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;

--- a/tests/grid/extrude_orientation_03.cc
+++ b/tests/grid/extrude_orientation_03.cc
@@ -38,7 +38,7 @@ test()
     {
       deallog << "2d cell " << c
               << " has the following face orientations:" << std::endl;
-      for (unsigned int l = 0; l < GeometryInfo<2>::faces_per_cell; ++l)
+      for (const unsigned int l : GeometryInfo<2>::face_indices())
         deallog << "    " << (c->face_orientation(l) ? "true" : "false")
                 << std::endl;
     }
@@ -55,7 +55,7 @@ test()
         << "3d cell " << c
         << " has the following face orientation/flips and edge orientations:"
         << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         deallog << "    face=" << f
                 << (c->face_orientation(f) ? " -> true" : " -> false")
                 << (c->face_flip(f) ? "/true" : "/false") << std::endl;

--- a/tests/grid/face_orientations_3d.cc
+++ b/tests/grid/face_orientations_3d.cc
@@ -48,7 +48,7 @@ test(const char *filename)
   for (Triangulation<3>::active_cell_iterator cell = tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (cell->face_orientation(f) == false)
         {
           ++misoriented_faces;

--- a/tests/grid/filtered_iterator_06.cc
+++ b/tests/grid/filtered_iterator_06.cc
@@ -53,8 +53,7 @@ test()
   std::set<typename Triangulation<dim, spacedim>::active_face_iterator>
     face_set;
   for (const auto &cell : tria.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       if (cell->face(face_n)->at_boundary() &&
           cell->face(face_n)->manifold_id() == manifold_id)
         face_set.insert(cell->face(face_n));

--- a/tests/grid/grid_generator_10.cc
+++ b/tests/grid/grid_generator_10.cc
@@ -95,8 +95,7 @@ check_grid()
   for (; cell != endc; ++cell)
     {
       deallog << cell << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           deallog << face << ": "
                   << (cell->face_orientation(face) ? "true " : "false ")

--- a/tests/grid/grid_generator_airfoil_01.cc
+++ b/tests/grid/grid_generator_airfoil_01.cc
@@ -36,7 +36,7 @@ print_triangulation(const Triangulation<dim, dim> &tria)
     {
       deallog << cell.material_id() << " ";
 
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << (cell.face(f)->at_boundary() ? cell.face(f)->boundary_id() :
                                                   -1)
                 << " ";

--- a/tests/grid/grid_generator_half_hyper_shell.cc
+++ b/tests/grid/grid_generator_half_hyper_shell.cc
@@ -38,7 +38,7 @@ dim_test()
 
   for (; cell != tr.end(); ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(f)->at_boundary())
             deallog << "half_hyper_shell<" << dim << ">:: cell "

--- a/tests/grid/grid_generator_hyper_cube_slit_01.cc
+++ b/tests/grid/grid_generator_hyper_cube_slit_01.cc
@@ -38,8 +38,7 @@ test()
     {
       deallog << "cell:" << std::endl;
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() &&
               cell->face(face)->boundary_id() != 0)

--- a/tests/grid/grid_generator_plate_with_a_hole.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole.cc
@@ -42,8 +42,7 @@ test()
   std::vector<Tuple> boundary_faces;
 
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       if (cell->face(face_n)->at_boundary())
         boundary_faces.push_back(
           std::make_tuple(cell->face(face_n)->center(),

--- a/tests/grid/grid_generator_plate_with_a_hole_2.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole_2.cc
@@ -46,8 +46,7 @@ test()
   std::vector<Tuple> boundary_faces;
 
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       if (cell->face(face_n)->at_boundary())
         boundary_faces.push_back(
           std::make_tuple(cell->face(face_n)->center(),

--- a/tests/grid/grid_generator_plate_with_a_hole_3.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole_3.cc
@@ -46,8 +46,7 @@ test()
   std::vector<Tuple> boundary_faces;
 
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       if (cell->face(face_n)->at_boundary())
         boundary_faces.push_back(
           std::make_tuple(cell->face(face_n)->center(),

--- a/tests/grid/grid_generator_plate_with_a_hole_4.cc
+++ b/tests/grid/grid_generator_plate_with_a_hole_4.cc
@@ -42,8 +42,7 @@ test()
   std::vector<Tuple> boundary_faces;
 
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int face_n = 0; face_n < GeometryInfo<dim>::faces_per_cell;
-         ++face_n)
+    for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
       if (cell->face(face_n)->at_boundary())
         boundary_faces.push_back(
           std::make_tuple(cell->face(face_n)->center(),

--- a/tests/grid/grid_hyper_shell.cc
+++ b/tests/grid/grid_hyper_shell.cc
@@ -52,7 +52,7 @@ check(double r1, double r2, unsigned int n)
            tria.begin_active();
          c != tria.end();
          ++c)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (c->face(f)->at_boundary())
           for (unsigned int e = 0; e < GeometryInfo<dim>::lines_per_face; ++e)
             c->face(f)->line(e)->set_manifold_id(0);

--- a/tests/grid/grid_hyper_shell_05.cc
+++ b/tests/grid/grid_hyper_shell_05.cc
@@ -51,7 +51,7 @@ check(const unsigned int n)
          tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       AssertThrow(cell->face(f)->at_boundary() == cell->at_boundary(f),
                   ExcInternalError());
 
@@ -61,7 +61,7 @@ check(const unsigned int n)
          tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         deallog << cell->face(f) << ' ' << (int)cell->face(f)->boundary_id()
                 << ' ' << cell->face(f)->center().norm() << std::endl;

--- a/tests/grid/grid_hyper_shell_06.cc
+++ b/tests/grid/grid_hyper_shell_06.cc
@@ -44,7 +44,7 @@ check(double r1, double r2, unsigned int n)
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->face(f)->at_boundary())
         for (unsigned int l = 0; l < GeometryInfo<dim>::lines_per_face; ++l)
           AssertThrow(cell->face(f)->line(l)->boundary_id() ==

--- a/tests/grid/grid_in_gmsh_01_v4.cc
+++ b/tests/grid/grid_in_gmsh_01_v4.cc
@@ -66,7 +66,7 @@ gmsh_grid(const char *name_v2, const char *name_v4)
           AssertThrow((cell_v2->vertex(i) - cell_v4->vertex(i)).norm() < 1.e-10,
                       ExcInternalError());
         }
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           AssertThrow(cell_v2->face(i)->boundary_id() ==
                         cell_v4->face(i)->boundary_id(),

--- a/tests/grid/grid_in_gmsh_01_v41.cc
+++ b/tests/grid/grid_in_gmsh_01_v41.cc
@@ -67,7 +67,7 @@ gmsh_grid(const char *name_v2, const char *name_v41)
                         1.e-10,
                       ExcInternalError());
         }
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           AssertThrow(cell_v2->face(i)->boundary_id() ==
                         cell_v41->face(i)->boundary_id(),

--- a/tests/grid/grid_in_msh_version_4.cc
+++ b/tests/grid/grid_in_msh_version_4.cc
@@ -115,7 +115,7 @@ gmsh_grid(const char *name_v2, const char *name_v4)
       AssertThrow(vertices_v2 == vertices_v4, ExcInternalError());
       std::map<Point<dim>, types::boundary_id, PointComparator<dim>> faces_v2;
       std::map<Point<dim>, types::boundary_id, PointComparator<dim>> faces_v4;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           faces_v2[cell_v2->face(i)->center()] =
             cell_v2->face(i)->boundary_id();

--- a/tests/grid/grid_in_ucd_01.cc
+++ b/tests/grid/grid_in_ucd_01.cc
@@ -60,7 +60,7 @@ main()
   cell = tria.begin_active();
   for (; cell != endc; ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<2>::face_indices())
         if (cell->face(f)->manifold_id() != numbers::flat_manifold_id)
           deallog << cell << " (" << f << ")  "
                   << int(cell->face(f)->manifold_id()) << std::endl;

--- a/tests/grid/grid_in_ucd_02.cc
+++ b/tests/grid/grid_in_ucd_02.cc
@@ -45,9 +45,7 @@ test(const std::string &filename)
     {
       deallog << "cell->manifold_id: " << cell->manifold_id() << std::endl;
       if (dim > 1)
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           deallog << "cell->face(" << face_no
                   << ")->manifold_id: " << cell->face(face_no)->manifold_id()
                   << std::endl;

--- a/tests/grid/grid_in_vtk_3d_04.cc
+++ b/tests/grid/grid_in_vtk_3d_04.cc
@@ -50,7 +50,7 @@ check_file(const std::string name, typename GridIn<dim>::Format format)
          tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         deallog << cell << ' ' << f << ": " << (int)cell->face(f)->boundary_id()
                 << std::endl;

--- a/tests/grid/grid_out_in_vtk_01.cc
+++ b/tests/grid/grid_out_in_vtk_01.cc
@@ -75,7 +75,7 @@ check(Triangulation<dim, spacedim> &tria)
             AssertDimension(obj1->boundary_id(), obj2->boundary_id());
           }
       if (dim > 1)
-        for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::face_indices())
           {
             auto obj1 = cell1->face(i);
             auto obj2 = cell2->face(i);

--- a/tests/grid/grid_parallelepiped_04.cc
+++ b/tests/grid/grid_parallelepiped_04.cc
@@ -91,8 +91,7 @@ check_parallelepiped(bool colorize, bool log, const unsigned int (&subd)[dim])
                                                         triangulation.end();
     for (; cell != endc; ++cell)
       {
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(face)->at_boundary())
               {

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -72,7 +72,7 @@ void generate_grid(Triangulation<2> &triangulation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);
@@ -134,7 +134,7 @@ void generate_grid(Triangulation<3> &triangulation)
   Triangulation<3>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<3>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
       if (cell_1->face(j)->center()(2) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -76,7 +76,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
   Triangulation<2>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<2>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::face_indices())
     {
       if (cell_1->face(j)->center()(1) > 2.9)
         face_1 = cell_1->face(j);
@@ -146,7 +146,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
   Triangulation<3>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<3>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::face_indices())
     {
       if (cell_1->face(j)->center()(2) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/grid/grid_transform.cc
+++ b/tests/grid/grid_transform.cc
@@ -66,9 +66,7 @@ main()
   for (; cell != endc; ++cell)
     {
       if (cell->at_boundary())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             face = cell->face(face_no);
             if (face->at_boundary())

--- a/tests/grid/grid_transform_02.cc
+++ b/tests/grid/grid_transform_02.cc
@@ -77,8 +77,7 @@ main()
 
   for (; cell != endc; ++cell)
     if (cell->at_boundary() == true)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary() == true)
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;
                ++v)

--- a/tests/grid/grid_transform_03.cc
+++ b/tests/grid/grid_transform_03.cc
@@ -104,8 +104,7 @@ main()
 
   for (; cell != endc; ++cell)
     if (cell->at_boundary() == true)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary() == true)
           for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_face;
                ++v)

--- a/tests/grid/grid_transform_3d.cc
+++ b/tests/grid/grid_transform_3d.cc
@@ -77,8 +77,7 @@ main()
 
   Triangulation<dim>::face_iterator face;
   for (cell = tria.begin_active(); cell != endc; ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       {
         face = cell->face(face_no);
         if (face->at_boundary())

--- a/tests/grid/grid_transform_coefficient.cc
+++ b/tests/grid/grid_transform_coefficient.cc
@@ -73,9 +73,7 @@ main()
   for (; cell != endc; ++cell)
     {
       if (cell->at_boundary())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             face = cell->face(face_no);
             if (face->at_boundary())

--- a/tests/grid/merge_triangulations_02.cc
+++ b/tests/grid/merge_triangulations_02.cc
@@ -46,8 +46,7 @@ mesh_info(const Triangulation<dim> &tria)
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
       {
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(face)->at_boundary())
               boundary_count[cell->face(face)->boundary_id()]++;

--- a/tests/grid/merge_triangulations_03.cc
+++ b/tests/grid/merge_triangulations_03.cc
@@ -93,8 +93,7 @@ mesh_info(const Triangulation<dim> &tria, const std::string &filename)
                                                       endc = tria.end();
     for (; cell != endc; ++cell)
       {
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           {
             if (cell->face(face)->at_boundary())
               boundary_count[cell->face(face)->boundary_id()]++;

--- a/tests/grid/merge_triangulations_04.cc
+++ b/tests/grid/merge_triangulations_04.cc
@@ -106,9 +106,7 @@ main()
       if (cell->material_id() == 2)
         {
           cell->set_manifold_id(tfi_id);
-          for (unsigned int face_n = 0;
-               face_n < GeometryInfo<2>::faces_per_cell;
-               ++face_n)
+          for (const unsigned int face_n : GeometryInfo<2>::face_indices())
             {
               if (cell->face(face_n)->at_boundary())
                 cell->face(face_n)->set_manifold_id(polar_id);
@@ -127,8 +125,7 @@ main()
   std::vector<Point<2> *> inner_pointers;
   for (const auto &cell : result_2.active_cell_iterators())
     {
-      for (unsigned int face_n = 0; face_n < GeometryInfo<2>::faces_per_cell;
-           ++face_n)
+      for (const unsigned int face_n : GeometryInfo<2>::face_indices())
         {
           if (cell->face(face_n)->manifold_id() == polar_id)
             {
@@ -157,9 +154,7 @@ main()
     {
       if (cell->at_boundary())
         {
-          for (unsigned int face_n = 0;
-               face_n < GeometryInfo<2>::faces_per_cell;
-               ++face_n)
+          for (const unsigned int face_n : GeometryInfo<2>::face_indices())
             {
               auto face = cell->face(face_n);
               if (face->at_boundary())

--- a/tests/grid/merge_triangulations_07.cc
+++ b/tests/grid/merge_triangulations_07.cc
@@ -48,7 +48,7 @@ main()
 
   unsigned int boundary_face_count = 0;
   for (const auto &cell : tria_2.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<spacedim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<spacedim>::face_indices())
       if (cell->face(f)->at_boundary())
         ++boundary_face_count;
 

--- a/tests/grid/mesh_3d_10.cc
+++ b/tests/grid/mesh_3d_10.cc
@@ -46,7 +46,7 @@ void check_this(Triangulation<3> &tria)
        ++cell)
     {
       std::set<unsigned int> vertices;
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         {
           vertices.insert(cell->face(f)->vertex_index(0));
           vertices.insert(cell->face(f)->vertex_index(1));

--- a/tests/grid/mesh_3d_11.cc
+++ b/tests/grid/mesh_3d_11.cc
@@ -45,14 +45,14 @@ void check_this(Triangulation<3> &tria)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary())
         {
           const Triangulation<3>::cell_iterator neighbor = cell->neighbor(f);
           const unsigned int nb_nb = cell->neighbor_of_neighbor(f);
 
           bool found = false;
-          for (unsigned int ff = 0; ff < GeometryInfo<3>::faces_per_cell; ++ff)
+          for (const unsigned int ff : GeometryInfo<3>::face_indices())
             if (neighbor->neighbor(ff) == cell)
               {
                 AssertThrow(found == false, ExcInternalError());

--- a/tests/grid/mesh_3d_13.cc
+++ b/tests/grid/mesh_3d_13.cc
@@ -42,8 +42,7 @@ void check_this(Triangulation<3> &tria)
 {
   Triangulation<3>::active_cell_iterator cell = tria.begin_active();
   for (; cell != tria.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no) &&
           cell->neighbor(face_no)->has_children())
         for (unsigned int subface_no = 0;

--- a/tests/grid/mesh_3d_14.cc
+++ b/tests/grid/mesh_3d_14.cc
@@ -60,8 +60,7 @@ void check_this(Triangulation<3> &tria)
 
   DoFHandler<3>::active_cell_iterator cell = dof_handler.begin_active();
   for (; cell != dof_handler.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no) &&
           cell->neighbor(face_no)->has_children())
         for (unsigned int subface_no = 0;

--- a/tests/grid/mesh_3d_15.cc
+++ b/tests/grid/mesh_3d_15.cc
@@ -50,8 +50,7 @@ void check_this(Triangulation<3> &tria)
 
   DoFHandler<3>::active_cell_iterator cell = dof_handler.begin_active();
   for (; cell != dof_handler.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no) &&
           cell->neighbor(face_no)->has_children())
         for (unsigned int subface_no = 0;

--- a/tests/grid/mesh_3d_16.cc
+++ b/tests/grid/mesh_3d_16.cc
@@ -63,7 +63,7 @@ void check(Triangulation<3> &tria)
       // and make sure that the
       // result of the integration is
       // close to zero
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         {
           fe_face_values.reinit(cell, f);
           for (unsigned int q = 0; q < q_face.size(); ++q)
@@ -75,7 +75,7 @@ void check(Triangulation<3> &tria)
 
       // now same for subface
       // integration
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         for (unsigned int sf = 0; sf < GeometryInfo<3>::max_children_per_face;
              ++sf)
           {

--- a/tests/grid/mesh_3d_17.cc
+++ b/tests/grid/mesh_3d_17.cc
@@ -61,8 +61,7 @@ void check(Triangulation<3> &tria)
   // active cells on the refined side don't
   // have any children)
   for (unsigned int cell_no = 0; cell != endc; ++cell, ++cell_no)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       {
         const Triangulation<dim>::face_iterator face = cell->face(face_no);
 

--- a/tests/grid/mesh_3d_20.cc
+++ b/tests/grid/mesh_3d_20.cc
@@ -61,7 +61,7 @@ void check_this(Triangulation<3> &tria)
   for (DoFHandler<3>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(f))
         {
           const unsigned int nn = cell->neighbor_of_neighbor(f);

--- a/tests/grid/mesh_3d_21.cc
+++ b/tests/grid/mesh_3d_21.cc
@@ -46,8 +46,7 @@ void check_this(Triangulation<3> &tria)
 
   DoFHandler<3>::active_cell_iterator cell = dof_handler.begin_active();
   for (; cell != dof_handler.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no))
         {
           if (cell->neighbor(face_no)->has_children())

--- a/tests/grid/mesh_3d_4.cc
+++ b/tests/grid/mesh_3d_4.cc
@@ -40,7 +40,7 @@ count_wrong_faces(const Triangulation<3> &tria)
   for (Triangulation<3>::active_cell_iterator cell = tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (cell->face_orientation(f) == false)
         ++count;
   return count;

--- a/tests/grid/mesh_3d_5.cc
+++ b/tests/grid/mesh_3d_5.cc
@@ -36,7 +36,7 @@ void check_this(Triangulation<3> &tria)
   // active ones
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (cell->has_children())
         for (unsigned int c = 0; c < GeometryInfo<3>::max_children_per_face;
              ++c)

--- a/tests/grid/mesh_3d_6.cc
+++ b/tests/grid/mesh_3d_6.cc
@@ -55,7 +55,7 @@ void check_this(Triangulation<3> &tria)
   for (DoFHandler<3>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(f))
         {
           const unsigned int nn = cell->neighbor_of_neighbor(f);

--- a/tests/grid/mesh_3d_7.cc
+++ b/tests/grid/mesh_3d_7.cc
@@ -58,7 +58,7 @@ void check_this(Triangulation<3> &tria)
   for (DoFHandler<3>::cell_iterator cell = dof_handler.begin();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(f))
         {
           const unsigned int nn = cell->neighbor_of_neighbor(f);

--- a/tests/grid/n_faces_01.cc
+++ b/tests/grid/n_faces_01.cc
@@ -44,7 +44,7 @@ test()
   unsigned int face_counter = 0;
   for (auto &cell : tria.active_cell_iterators())
     {
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           auto face = cell->face(i);
           if (mymap.find(cell->face(i)) == mymap.end())

--- a/tests/grid/normal_vector_01.cc
+++ b/tests/grid/normal_vector_01.cc
@@ -72,8 +72,7 @@ main()
       create_triangulation(case_no, tria);
       const Triangulation<3>::active_cell_iterator cell = tria.begin_active();
       Triangulation<3>::face_iterator              face;
-      for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<3>::face_indices())
         {
           face = cell->face(face_no);
           boundary.get_normals_at_vertices(face, normals);

--- a/tests/grid/normal_vector_01_2d.cc
+++ b/tests/grid/normal_vector_01_2d.cc
@@ -72,8 +72,7 @@ main()
       create_triangulation(case_no, tria);
       const Triangulation<2>::active_cell_iterator cell = tria.begin_active();
       Triangulation<2>::face_iterator              face;
-      for (unsigned int face_no = 0; face_no < GeometryInfo<2>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<2>::face_indices())
         {
           face = cell->face(face_no);
           boundary.get_normals_at_vertices(face, normals);

--- a/tests/grid/normal_vector_02.cc
+++ b/tests/grid/normal_vector_02.cc
@@ -43,8 +43,7 @@ main()
 
   Triangulation<3>::active_cell_iterator cell = tria.begin_active();
   for (; cell != tria.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (cell->at_boundary(face_no))
         {
           Triangulation<3>::face_iterator face = cell->face(face_no);

--- a/tests/grid/normal_vector_02_2d.cc
+++ b/tests/grid/normal_vector_02_2d.cc
@@ -43,8 +43,7 @@ main()
 
   Triangulation<2>::active_cell_iterator cell = tria.begin_active();
   for (; cell != tria.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<2>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<2>::face_indices())
       if (cell->at_boundary(face_no))
         {
           Triangulation<2>::face_iterator face = cell->face(face_no);

--- a/tests/grid/normal_vector_03.cc
+++ b/tests/grid/normal_vector_03.cc
@@ -76,8 +76,7 @@ main()
       create_triangulation(case_no, tria);
       const Triangulation<3>::active_cell_iterator cell = tria.begin_active();
       Triangulation<3>::face_iterator              face;
-      for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<3>::face_indices())
         {
           face = cell->face(face_no);
           boundary.get_normals_at_vertices(face, normals);

--- a/tests/grid/normal_vector_03_2d.cc
+++ b/tests/grid/normal_vector_03_2d.cc
@@ -76,8 +76,7 @@ main()
       create_triangulation(case_no, tria);
       const Triangulation<2>::active_cell_iterator cell = tria.begin_active();
       Triangulation<2>::face_iterator              face;
-      for (unsigned int face_no = 0; face_no < GeometryInfo<2>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<2>::face_indices())
         {
           face = cell->face(face_no);
           boundary.get_normals_at_vertices(face, normals);

--- a/tests/grid/normals_at_vertices_01.cc
+++ b/tests/grid/normals_at_vertices_01.cc
@@ -71,8 +71,7 @@ main()
       create_triangulation(case_no, tria);
       const Triangulation<3>::active_cell_iterator cell = tria.begin_active();
       Triangulation<3>::face_iterator              face;
-      for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<3>::face_indices())
         {
           deallog << " Face" << face_no << std::endl;
           face = cell->face(face_no);

--- a/tests/grid/normals_at_vertices_02.cc
+++ b/tests/grid/normals_at_vertices_02.cc
@@ -43,8 +43,7 @@ main()
 
   Triangulation<3>::active_cell_iterator cell = tria.begin_active();
   for (; cell != tria.end(); ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<3>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (cell->at_boundary(face_no))
         {
           deallog << " Face" << face_no << std::endl;

--- a/tests/grid/periodicity_01.cc
+++ b/tests/grid/periodicity_01.cc
@@ -67,7 +67,7 @@ test()
   unsigned int neighbor_count = 0;
 
   for (const auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->has_periodic_neighbor(f))
         ++neighbor_count;
 

--- a/tests/grid/subcelldata.cc
+++ b/tests/grid/subcelldata.cc
@@ -74,7 +74,7 @@ test()
   if (dim == 2)
     {
       subcelldata.boundary_lines.resize(GeometryInfo<dim>::faces_per_cell);
-      for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::face_indices())
         {
           subcelldata.boundary_lines[i].vertices[0] = i;
           subcelldata.boundary_lines[i].vertices[1] = (i + 1) % 4;
@@ -84,7 +84,7 @@ test()
   else if (dim == 3)
     {
       subcelldata.boundary_quads.resize(GeometryInfo<dim>::faces_per_cell);
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_face;
                ++i)

--- a/tests/grid/user_data_01.cc
+++ b/tests/grid/user_data_01.cc
@@ -55,7 +55,7 @@ check_user_pointers(Triangulation<dim> &tr)
     for (typename Triangulation<dim>::cell_iterator it = tr.begin();
          it != tr.end();
          ++it)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (it->face(f)->user_flag_set() == false)
           {
             deallog << '.';
@@ -107,7 +107,7 @@ check_user_indices(Triangulation<dim> &tr)
     for (typename Triangulation<dim>::cell_iterator it = tr.begin();
          it != tr.end();
          ++it)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (it->face(f)->user_flag_set() == false)
           {
             deallog << '.';
@@ -156,7 +156,7 @@ user_pointers(Triangulation<dim> &tr)
     for (typename Triangulation<dim>::cell_iterator it = tr.begin();
          it != tr.end();
          ++it)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (it->face(f)->user_flag_set() == false)
           {
             it->face(f)->set_user_pointer(p++);
@@ -213,7 +213,7 @@ user_indices(Triangulation<dim> &tr)
       it->clear_user_index();
 
       if (dim > 1)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           it->face(f)->clear_user_index();
 
       if (dim > 2)
@@ -236,7 +236,7 @@ user_indices(Triangulation<dim> &tr)
     for (typename Triangulation<dim>::cell_iterator it = tr.begin();
          it != tr.end();
          ++it)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (it->face(f)->user_flag_set() == false)
           {
             it->face(f)->set_user_index(p++);

--- a/tests/hp/accessor_0.cc
+++ b/tests/hp/accessor_0.cc
@@ -107,9 +107,7 @@ main()
           deallog << "cell uses fe index " << fe_index << ": "
                   << index_is_active << std::endl;
 
-          for (unsigned int face_n = 0;
-               face_n < GeometryInfo<1>::faces_per_cell;
-               ++face_n)
+          for (const unsigned int face_n : GeometryInfo<1>::face_indices())
             {
               AssertThrow(&cell->face(face_n)->get_fe(fe_index) ==
                             &fe_collection[fe_index],

--- a/tests/hp/crash_10.cc
+++ b/tests/hp/crash_10.cc
@@ -74,7 +74,7 @@ test()
 
   cell = dof_handler.begin_active();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         deallog << "cell=" << cell << ", face=" << f
                 << ", fe_index=" << cell->active_fe_index() << ", dofs=";

--- a/tests/hp/crash_14.cc
+++ b/tests/hp/crash_14.cc
@@ -74,8 +74,7 @@ test()
              dof_handler.begin_active();
            cell != dof_handler.end();
            ++cell)
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           if (!cell->at_boundary(face))
             {
               Assert(cell->get_fe().dofs_per_face ==

--- a/tests/hp/hp_constraints_neither_dominate_01.cc
+++ b/tests/hp/hp_constraints_neither_dominate_01.cc
@@ -192,7 +192,7 @@ test2cells(const unsigned int p1 = 2, const unsigned int p2 = 1)
     {
       const unsigned int fe_index = cell->active_fe_index();
       local_face_dof_indices.resize(fe_collection[fe_index].dofs_per_face);
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (!cell->at_boundary(f)) // that's enough for our simple mesh
           {
             deallog << "cell=" << cell << " face=" << f << std::endl;

--- a/tests/hp/hp_constraints_neither_dominate_02.cc
+++ b/tests/hp/hp_constraints_neither_dominate_02.cc
@@ -243,7 +243,7 @@ test2cells(const FiniteElement<dim> &fe_0,
     {
       const unsigned int fe_index = cell->active_fe_index();
       local_face_dof_indices.resize(fe_collection[fe_index].dofs_per_face);
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (std::abs(cell->face(f)->center()[0]) < 0.1)
           {
             // deallog << "cell="<<cell<<" face="<<f<<std::endl;

--- a/tests/hp/n_active_fe_indices.cc
+++ b/tests/hp/n_active_fe_indices.cc
@@ -69,7 +69,7 @@ check_faces(const hp::DoFHandler<dim> &dof_handler)
          dof_handler.begin_active();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         deallog << "face=" << cell->face(f) << std::endl;
         deallog << "n=" << cell->face(f)->n_active_fe_indices() << std::endl;

--- a/tests/hp/step-10.cc
+++ b/tests/hp/step-10.cc
@@ -193,9 +193,7 @@ compute_pi_by_perimeter()
             endc                = dof_handler.end();
           long double perimeter = 0;
           for (; cell != endc; ++cell)
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->face(face_no)->at_boundary())
                 {
                   x_fe_face_values.reinit(cell, face_no);

--- a/tests/hp/step-12.cc
+++ b/tests/hp/step-12.cc
@@ -536,9 +536,7 @@ DGMethod<dim>::assemble_system1()
 
       cell->get_dof_indices(dofs);
 
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           typename hp::DoFHandler<dim>::face_iterator face =
             cell->face(face_no);
@@ -715,9 +713,7 @@ DGMethod<dim>::assemble_system2()
 
       cell->get_dof_indices(dofs);
 
-      for (unsigned int face_no = 0;
-           face_no < GeometryInfo<dim>::faces_per_cell;
-           ++face_no)
+      for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
         {
           typename hp::DoFHandler<dim>::face_iterator face =
             cell->face(face_no);

--- a/tests/hp/step-7.cc
+++ b/tests/hp/step-7.cc
@@ -328,8 +328,7 @@ HelmholtzProblem<dim>::assemble_system()
                             rhs_values[q_point] * fe_values.JxW(q_point));
           }
 
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary() &&
             (cell->face(face)->boundary_id() == 1))
           {
@@ -500,9 +499,7 @@ HelmholtzProblem<dim>::run()
                                                        triangulation.begin(),
                                                      endc = triangulation.end();
           for (; cell != endc; ++cell)
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               if ((cell->face(face)->center()(0) == -1) ||
                   (cell->face(face)->center()(1) == -1))
                 cell->face(face)->set_boundary_id(1);

--- a/tests/integrators/advection_01.cc
+++ b/tests/integrators/advection_01.cc
@@ -277,7 +277,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fef1.reinit(cell1, i);

--- a/tests/integrators/divergence_01.cc
+++ b/tests/integrators/divergence_01.cc
@@ -200,7 +200,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fv, FiniteElement<dim> &fs)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fev1.reinit(cell1, i);

--- a/tests/integrators/elasticity_01.cc
+++ b/tests/integrators/elasticity_01.cc
@@ -258,7 +258,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fef1.reinit(cell1, i);

--- a/tests/integrators/elasticity_02.cc
+++ b/tests/integrators/elasticity_02.cc
@@ -99,7 +99,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fef1.reinit(cell1, i);

--- a/tests/integrators/grad_div_01.cc
+++ b/tests/integrators/grad_div_01.cc
@@ -258,7 +258,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fef1.reinit(cell1, i);

--- a/tests/integrators/laplacian_01.cc
+++ b/tests/integrators/laplacian_01.cc
@@ -312,7 +312,7 @@ test_fe(Triangulation<dim> &tr, FiniteElement<dim> &fe)
                          face_quadrature,
                          update_values | update_gradients |
                            update_normal_vectors | update_JxW_values);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "boundary_matrix " << i << std::endl;
       fef1.reinit(cell1, i);

--- a/tests/integrators/maxwell_curl.cc
+++ b/tests/integrators/maxwell_curl.cc
@@ -90,7 +90,7 @@ TestMaxwellCurl(Triangulation<dim> &tr)
   deallog << "curl_matrix" << std::endl;
   curl_check.print(deallog, 10);
 
-  for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell; ++face)
+  for (const unsigned int face : GeometryInfo<dim>::face_indices())
     {
       fe_face_values.reinit(cell, face);
       nitsche_curl_matrix<dim>(

--- a/tests/lac/constraints_block_01.cc
+++ b/tests/lac/constraints_block_01.cc
@@ -244,7 +244,7 @@ main()
       if (int(cell->material_id()) == 1)
         {
           // Only loop over cells in the fluid region
-          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
             {
               if (!cell->at_boundary(f))
                 {

--- a/tests/lac/schur_complement_03.cc
+++ b/tests/lac/schur_complement_03.cc
@@ -376,7 +376,7 @@ namespace Step22
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->center()[dim - 1] == 0)
           cell->face(f)->set_all_boundary_ids(1);
     triangulation.refine_global(4 - dim);

--- a/tests/manifold/chart_manifold_02.cc
+++ b/tests/manifold/chart_manifold_02.cc
@@ -87,7 +87,7 @@ test(unsigned int ref = 1)
 
       // check that FlatManifold returns the middle of the cell.
       deallog << "Cell: " << cell << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           const typename Triangulation<dim, spacedim>::face_iterator &face =
             cell->face(f);

--- a/tests/manifold/chart_manifold_02_embedded.cc
+++ b/tests/manifold/chart_manifold_02_embedded.cc
@@ -95,7 +95,7 @@ test(unsigned int ref = 1)
 
       // check that FlatManifold returns the middle of the cell.
       deallog << "Cell: " << cell << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           const typename Triangulation<dim, spacedim>::face_iterator &face =
             cell->face(f);

--- a/tests/manifold/copy_boundary_to_manifold_id_01.cc
+++ b/tests/manifold/copy_boundary_to_manifold_id_01.cc
@@ -36,7 +36,7 @@ print_info(Triangulation<dim, spacedim> &tria)
 
   for (cell = tria.begin_active(); cell != tria.end(); ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           deallog << "face: " << cell->face(f)
                   << ", boundary_id: " << (int)cell->face(f)->boundary_id()

--- a/tests/manifold/copy_material_to_manifold_id_01.cc
+++ b/tests/manifold/copy_material_to_manifold_id_01.cc
@@ -39,7 +39,7 @@ print_info(Triangulation<dim, spacedim> &tria)
       deallog << "cell: " << cell << ", material_id: " << cell->material_id()
               << ", manifold_id: " << cell->manifold_id() << std::endl;
 
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "face: " << cell->face(f)
                 << ", boundary_id: " << cell->face(f)->boundary_id()
                 << ", manifold_id: " << cell->face(f)->manifold_id()

--- a/tests/manifold/flat_manifold_02.cc
+++ b/tests/manifold/flat_manifold_02.cc
@@ -43,7 +43,7 @@ test(unsigned int ref = 1)
     {
       // check that FlatManifold returns the middle of the cell.
       deallog << "Cell: " << cell << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           const typename Triangulation<dim, spacedim>::face_iterator &face =
             cell->face(f);

--- a/tests/manifold/flat_manifold_09.cc
+++ b/tests/manifold/flat_manifold_09.cc
@@ -105,8 +105,7 @@ check(Triangulation<dim> &tria)
   Tensor<1, dim> n;
   for (const auto &cell : tria.active_cell_iterators())
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->face(face)->at_boundary())
           {
             fe_face_values.reinit(cell, face);

--- a/tests/manifold/manifold_id_01.cc
+++ b/tests/manifold/manifold_id_01.cc
@@ -45,7 +45,7 @@ test(unsigned int ref = 1)
     {
       deallog << "C: " << cell << ", mid: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "f: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/manifold_id_02.cc
+++ b/tests/manifold/manifold_id_02.cc
@@ -54,7 +54,7 @@ test(unsigned int ref = 1)
     {
       deallog << "C: " << cell << ", mid: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "f: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/manifold_id_03.cc
+++ b/tests/manifold/manifold_id_03.cc
@@ -51,7 +51,7 @@ test(unsigned int ref = 1)
     {
       deallog << "C: " << cell << ", mid: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "f: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/manifold_id_04.cc
+++ b/tests/manifold/manifold_id_04.cc
@@ -42,7 +42,7 @@ test(unsigned int ref = 1)
 
 
   tria.begin_active()->set_manifold_id(3);
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     tria.begin_active()->face(f)->set_manifold_id(2);
 
   tria.refine_global(1);
@@ -51,7 +51,7 @@ test(unsigned int ref = 1)
     {
       deallog << "C: " << cell << ", mid: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "f: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/manifold_id_05.cc
+++ b/tests/manifold/manifold_id_05.cc
@@ -51,7 +51,7 @@ test(unsigned int ref = 1)
   for (cell = tria.begin_active(); cell != tria.end(); ++cell)
     {
       deallog << "C: " << cell << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "F: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/manifold_id_06.cc
+++ b/tests/manifold/manifold_id_06.cc
@@ -51,7 +51,7 @@ test(unsigned int ref = 1)
     if (dim < spacedim && cell->center().distance(center) < radius)
       cell->set_all_manifold_ids(1);
     else
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->center().distance(center) < radius)
           cell->face(f)->set_all_manifold_ids(1);
 

--- a/tests/manifold/manifold_id_07.cc
+++ b/tests/manifold/manifold_id_07.cc
@@ -53,7 +53,7 @@ test(unsigned int ref = 1)
   for (cell = tria.begin_active(); cell != tria.end(); ++cell)
     {
       deallog << "C: " << cell << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "F: " << cell->face(f)
                 << ", mid: " << (int)cell->face(f)->manifold_id() << std::endl;
     }

--- a/tests/manifold/map_boundary_to_manifold_id_01.cc
+++ b/tests/manifold/map_boundary_to_manifold_id_01.cc
@@ -35,7 +35,7 @@ print_info(const Triangulation<dim, spacedim> &tria)
     {
       deallog << "C: " << cell << ", manifold id: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           deallog << "f: " << cell->face(f)
                   << ", boundary id: " << (int)cell->face(f)->boundary_id()

--- a/tests/manifold/map_boundary_to_manifold_id_02.cc
+++ b/tests/manifold/map_boundary_to_manifold_id_02.cc
@@ -35,7 +35,7 @@ print_info(const Triangulation<dim, spacedim> &tria)
     {
       deallog << "C: " << cell << ", manifold id: " << (int)cell->manifold_id()
               << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           deallog << "f: " << cell->face(f)
                   << ", boundary id: " << (int)cell->face(f)->boundary_id()
@@ -75,7 +75,7 @@ test()
            e < static_cast<signed int>(GeometryInfo<dim>::lines_per_cell);
            ++e)
         cell->line(e)->set_manifold_id(e);
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           cell->face(f)->set_boundary_id(f);
           for (signed int e = 0;

--- a/tests/manifold/set_all_manifold_ids_01.cc
+++ b/tests/manifold/set_all_manifold_ids_01.cc
@@ -38,7 +38,7 @@ print_info(Triangulation<dim, spacedim> &tria)
               << ", material_id: " << (int)cell->material_id()
               << ", manifold_id: " << (int)cell->manifold_id() << std::endl;
 
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "face: " << cell->face(f)
                 << ", boundary_id: " << (int)cell->face(f)->boundary_id()
                 << ", manifold_id: " << (int)cell->face(f)->manifold_id()

--- a/tests/manifold/set_all_manifold_ids_02.cc
+++ b/tests/manifold/set_all_manifold_ids_02.cc
@@ -38,7 +38,7 @@ print_info(Triangulation<dim, spacedim> &tria)
               << ", material_id: " << (int)cell->material_id()
               << ", manifold_id: " << (int)cell->manifold_id() << std::endl;
 
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << "face: " << cell->face(f)
                 << ", boundary_id: " << (int)cell->face(f)->boundary_id()
                 << ", manifold_id: " << (int)cell->face(f)->manifold_id()

--- a/tests/manifold/spherical_manifold_09.cc
+++ b/tests/manifold/spherical_manifold_09.cc
@@ -41,7 +41,7 @@ main()
   tria.set_manifold(0, spherical);
 
   for (auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         {
           if (std::abs(cell->face(f)->vertex(1).norm() - 1.) < 1e-1)
@@ -80,7 +80,7 @@ main()
             }
         }
   for (auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         {
           // the first choice will contain perturbations in the normal because

--- a/tests/manifold/spherical_manifold_10.cc
+++ b/tests/manifold/spherical_manifold_10.cc
@@ -55,7 +55,7 @@ main()
                               update_normal_vectors | update_quadrature_points);
 
   for (auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         fe_values.reinit(cell, f);
 

--- a/tests/manifold/spherical_manifold_12.cc
+++ b/tests/manifold/spherical_manifold_12.cc
@@ -58,7 +58,7 @@ main()
                               update_normal_vectors | update_quadrature_points);
 
   for (auto &cell : tria.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         {
           fe_values.reinit(cell, f);

--- a/tests/manifold/transfinite_manifold_01.cc
+++ b/tests/manifold/transfinite_manifold_01.cc
@@ -39,13 +39,11 @@ do_test(const Triangulation<dim, spacedim> &tria)
         deallog << cell->line(line)->center(/*respect_manifold=*/true)
                 << std::endl;
       deallog << "Faces on cell with center: " << cell->center() << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         deallog << cell->face(face)->center(/*respect_manifold=*/true)
                 << std::endl;
       deallog << "Center with manifold: " << cell->center(true) << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             std::vector<Point<spacedim>> points;
@@ -140,8 +138,7 @@ test_cylinder(unsigned int ref = 1)
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             bool cell_at_surfaces = true;

--- a/tests/manifold/transfinite_manifold_02.cc
+++ b/tests/manifold/transfinite_manifold_02.cc
@@ -45,8 +45,7 @@ do_test(const Triangulation<dim, spacedim> &tria)
                   << std::endl;
         }
       deallog << "Faces on cell with center: " << cell->center() << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           deallog << cell->face(face)->center(/*respect_manifold=*/true)
                   << std::endl;
@@ -56,8 +55,7 @@ do_test(const Triangulation<dim, spacedim> &tria)
 
       deallog << "Center with manifold: " << cell->center(true) << std::endl;
       deallog << "Manifold id: " << cell->manifold_id() << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             std::vector<Point<spacedim>> points;
@@ -169,8 +167,7 @@ test_cylinder(unsigned int ref = 1)
     {
       if (cell->at_boundary())
         cell->set_all_manifold_ids(1);
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             bool cell_at_surfaces = true;

--- a/tests/manifold/transfinite_manifold_03.cc
+++ b/tests/manifold/transfinite_manifold_03.cc
@@ -124,8 +124,7 @@ test_cylinder(unsigned int ref = 1)
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             bool cell_at_surfaces = true;

--- a/tests/manifold/transfinite_manifold_04.cc
+++ b/tests/manifold/transfinite_manifold_04.cc
@@ -40,13 +40,11 @@ do_test(const Triangulation<dim, spacedim> &tria)
         deallog << cell->line(line)->center(/*respect_manifold=*/true)
                 << std::endl;
       deallog << "Faces on cell with center: " << cell->center() << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         deallog << cell->face(face)->center(/*respect_manifold=*/true)
                 << std::endl;
       deallog << "Center with manifold: " << cell->center(true) << std::endl;
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(face))
           {
             std::vector<Point<spacedim>> points;

--- a/tests/manifold/transfinite_manifold_05.cc
+++ b/tests/manifold/transfinite_manifold_05.cc
@@ -42,7 +42,7 @@ main()
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           bool face_at_sphere_boundary = true;
           for (unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell;

--- a/tests/manifold/transfinite_manifold_06.cc
+++ b/tests/manifold/transfinite_manifold_06.cc
@@ -44,7 +44,7 @@ main()
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           bool face_at_sphere_boundary = true;
           for (unsigned int v = 0; v < GeometryInfo<dim - 1>::vertices_per_cell;

--- a/tests/manifold/transfinite_manifold_07.cc
+++ b/tests/manifold/transfinite_manifold_07.cc
@@ -242,7 +242,7 @@ void concentric_disks(Triangulation<2> &         tria,
         1); // not faces ... for Transfinite interpolation
       for (unsigned int k = 0; k < gp.n_balls; ++k)
         {
-          for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<2>::face_indices())
             {
               const Point<2> p0 = cell->face(f)->vertex(0),
                              p1 = cell->face(f)->vertex(1);

--- a/tests/manifold/transfinite_manifold_08.cc
+++ b/tests/manifold/transfinite_manifold_08.cc
@@ -137,7 +137,7 @@ main()
       for (auto &cell : tria.active_cell_iterators())
         {
           deallog << "Face centers:" << std::endl;
-          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
             deallog << cell->face(f)->center(true) << std::endl;
           deallog << std::endl;
         }

--- a/tests/manifold/transfinite_manifold_09.cc
+++ b/tests/manifold/transfinite_manifold_09.cc
@@ -75,7 +75,7 @@ main()
   for (auto &cell : tria.active_cell_iterators())
     {
       deallog << "Face centers:" << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         deallog << cell->face(f)->center(true) << std::endl;
       deallog << std::endl;
     }

--- a/tests/manifold/transfinite_manifold_10.cc
+++ b/tests/manifold/transfinite_manifold_10.cc
@@ -148,7 +148,7 @@ main()
   for (auto &cell : tria.cell_iterators())
     {
       bool cell_at_boundary = false;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           cell_at_boundary = true;
       if (cell_at_boundary == false)

--- a/tests/manifold/tria_accessor_point_01.cc
+++ b/tests/manifold/tria_accessor_point_01.cc
@@ -54,7 +54,7 @@ test(unsigned int ref = 1)
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           deallog << "Center: " << cell->face(f)->center(true)
                   << ", Norm: " << cell->face(f)->center(true).norm()

--- a/tests/manifold/tria_accessor_point_02.cc
+++ b/tests/manifold/tria_accessor_point_02.cc
@@ -54,7 +54,7 @@ test(unsigned int ref = 1)
        cell != tria.end();
        ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           deallog << "Center: " << cell->face(f)->center(true, true)
                   << ", Norm: " << cell->face(f)->center(true, true).norm()

--- a/tests/manifold/tria_boundary_id_01.cc
+++ b/tests/manifold/tria_boundary_id_01.cc
@@ -40,8 +40,7 @@ print_triangulation_data(Stream &                  stream,
   std::map<int, int> manifold_id_count;
   for (const auto &cell : triangulation.active_cell_iterators())
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary())
             {
@@ -100,8 +99,7 @@ main()
   const types::manifold_id curved_manifold_id = 1;
   for (const auto &cell : tria.active_cell_iterators())
     {
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary())
             {

--- a/tests/mappings/fe_face_values_1d_mapping_cartesian.cc
+++ b/tests/mappings/fe_face_values_1d_mapping_cartesian.cc
@@ -64,8 +64,7 @@ plot_faces(Mapping<dim> &                           mapping,
                                           update_gradients | update_hessians |
                                           update_normal_vectors));
 
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face=" << face_nr << std::endl;
       fe_values.reinit(cell, face_nr);
@@ -107,8 +106,7 @@ plot_subfaces(Mapping<dim> &                           mapping,
     q,
     UpdateFlags(update_quadrature_points | update_JxW_values | update_values |
                 update_gradients | update_hessians | update_normal_vectors));
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     for (unsigned int sub_nr = 0;
          sub_nr < GeometryInfo<dim>::max_children_per_face;
          ++sub_nr)

--- a/tests/mappings/fe_face_values_1d_mapping_q2.cc
+++ b/tests/mappings/fe_face_values_1d_mapping_q2.cc
@@ -64,8 +64,7 @@ plot_faces(Mapping<dim> &                           mapping,
                                           update_gradients | update_hessians |
                                           update_normal_vectors));
 
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     {
       deallog << "Face=" << face_nr << std::endl;
       fe_values.reinit(cell, face_nr);
@@ -107,8 +106,7 @@ plot_subfaces(Mapping<dim> &                           mapping,
     q,
     UpdateFlags(update_quadrature_points | update_JxW_values | update_values |
                 update_gradients | update_hessians | update_normal_vectors));
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     for (unsigned int sub_nr = 0;
          sub_nr < GeometryInfo<dim>::max_children_per_face;
          ++sub_nr)

--- a/tests/mappings/mapping.cc
+++ b/tests/mappings/mapping.cc
@@ -104,8 +104,7 @@ plot_faces(Mapping<dim> &                           mapping,
                                           update_JxW_values |
                                           update_normal_vectors));
 
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     {
       fe_values.reinit(cell, face_nr);
 
@@ -148,8 +147,7 @@ plot_subfaces(Mapping<dim> &                           mapping,
                                  q,
                                  UpdateFlags(update_quadrature_points |
                                              update_normal_vectors));
-  for (unsigned int face_nr = 0; face_nr < GeometryInfo<dim>::faces_per_cell;
-       ++face_nr)
+  for (const unsigned int face_nr : GeometryInfo<dim>::face_indices())
     for (unsigned int sub_nr = 0;
          sub_nr < GeometryInfo<dim>::max_children_per_face;
          ++sub_nr)

--- a/tests/mappings/mapping_c1.cc
+++ b/tests/mappings/mapping_c1.cc
@@ -91,7 +91,7 @@ main()
   for (DoFHandler<2>::active_cell_iterator cell = dof_handler.begin_active();
        cell != dof_handler.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<2>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<2>::face_indices())
       if (cell->face(f)->at_boundary())
         {
           c1_values.reinit(cell, f);

--- a/tests/mappings/mapping_manifold_05.cc
+++ b/tests/mappings/mapping_manifold_05.cc
@@ -72,7 +72,7 @@ test()
 
   typename Triangulation<dim, spacedim>::active_cell_iterator cell =
     triangulation.begin_active();
-  for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<dim>::face_indices())
     {
       fe_values_mapping.reinit(cell, f);
       fe_values_q.reinit(cell, f);

--- a/tests/mappings/mapping_manifold_06.cc
+++ b/tests/mappings/mapping_manifold_06.cc
@@ -66,7 +66,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         const double xc = cell->face(f)->center()[0] - 1.5;
         const double yc = cell->face(f)->center()[1] - 2.5;
@@ -100,7 +100,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         const double xc = cell->face(f)->center()[0] - 1.5;
         const double yc = cell->face(f)->center()[1] - 2.5;

--- a/tests/mappings/mapping_manifold_07.cc
+++ b/tests/mappings/mapping_manifold_07.cc
@@ -65,7 +65,7 @@ test()
              triangulation.begin_active();
            cell != triangulation.end();
            ++cell)
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           if (cell->face(f)->at_boundary())
             {
               fe_v.reinit(cell, f);

--- a/tests/mappings/mapping_project_01.cc
+++ b/tests/mappings/mapping_project_01.cc
@@ -49,7 +49,7 @@ dim2_grid()
           << ", and unit coordinates: "
           << mapping.transform_real_to_unit_cell(cell, testp) << std::endl;
   for (; cell != endc; ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<2>::faces_per_cell; ++face)
+    for (const unsigned int face : GeometryInfo<2>::face_indices())
       {
         deallog << "For face: " << face << ", the test point projects to: "
                 << mapping.project_real_point_to_unit_point_on_face(cell,
@@ -80,7 +80,7 @@ dim3_grid()
           << ", and unit coordinates: "
           << mapping.transform_real_to_unit_cell(cell, testp) << std::endl;
   for (; cell != endc; ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<3>::faces_per_cell; ++face)
+    for (const unsigned int face : GeometryInfo<3>::face_indices())
       {
         deallog << "For face: " << face << ", the test point projects to: "
                 << mapping.project_real_point_to_unit_point_on_face(cell,
@@ -115,7 +115,7 @@ dim3_parallelepiped_grid()
           << mapping.transform_real_to_unit_cell(cell, testp) << std::endl;
 
   for (; cell != endc; ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<3>::faces_per_cell; ++face)
+    for (const unsigned int face : GeometryInfo<3>::face_indices())
       {
         deallog << "For face: " << face << ", the test point projects to: "
                 << mapping.project_real_point_to_unit_point_on_face(cell,

--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -136,7 +136,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -193,7 +193,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -177,7 +177,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -270,8 +270,7 @@ private:
           local_diagonal_vector[phif.static_dofs_per_cell];
         for (unsigned int i = 0; i < phif.static_dofs_per_cell; ++i)
           local_diagonal_vector[i] = 0.;
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           {
             phif.reinit(cell, face);
             VectorizedArray<number> sigmaF =

--- a/tests/matrix_free/get_functions_circle.cc
+++ b/tests/matrix_free/get_functions_circle.cc
@@ -38,7 +38,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/get_functions_gl.cc
+++ b/tests/matrix_free/get_functions_gl.cc
@@ -41,7 +41,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/get_functions_mappingq.cc
+++ b/tests/matrix_free/get_functions_mappingq.cc
@@ -39,7 +39,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/get_functions_notempl.cc
+++ b/tests/matrix_free/get_functions_notempl.cc
@@ -61,7 +61,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/get_functions_q_hierarchical.cc
+++ b/tests/matrix_free/get_functions_q_hierarchical.cc
@@ -47,7 +47,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/get_functions_rect.cc
+++ b/tests/matrix_free/get_functions_rect.cc
@@ -61,7 +61,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -159,7 +159,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -247,7 +247,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/inverse_mass_01.cc
+++ b/tests/matrix_free/inverse_mass_01.cc
@@ -180,7 +180,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/inverse_mass_03.cc
+++ b/tests/matrix_free/inverse_mass_03.cc
@@ -195,7 +195,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/inverse_mass_05.cc
+++ b/tests/matrix_free/inverse_mass_05.cc
@@ -181,7 +181,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/inverse_mass_06.cc
+++ b/tests/matrix_free/inverse_mass_06.cc
@@ -172,7 +172,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_07.cc
+++ b/tests/matrix_free/matrix_vector_07.cc
@@ -44,7 +44,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_14.cc
+++ b/tests/matrix_free/matrix_vector_14.cc
@@ -42,7 +42,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_14_notempl.cc
+++ b/tests/matrix_free/matrix_vector_14_notempl.cc
@@ -39,7 +39,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_14b.cc
+++ b/tests/matrix_free/matrix_vector_14b.cc
@@ -38,7 +38,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_15.cc
+++ b/tests/matrix_free/matrix_vector_15.cc
@@ -193,7 +193,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -199,7 +199,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_17.cc
+++ b/tests/matrix_free/matrix_vector_17.cc
@@ -41,7 +41,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_curl.cc
+++ b/tests/matrix_free/matrix_vector_curl.cc
@@ -115,7 +115,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_faces_14.cc
+++ b/tests/matrix_free/matrix_vector_faces_14.cc
@@ -53,7 +53,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
   std::vector<

--- a/tests/matrix_free/matrix_vector_faces_16.cc
+++ b/tests/matrix_free/matrix_vector_faces_16.cc
@@ -51,7 +51,7 @@ test()
 
   parallel::distributed::Triangulation<mydim> tria(MPI_COMM_WORLD);
   GridGenerator::hyper_cube(tria);
-  for (unsigned int f = 0; f < GeometryInfo<mydim>::faces_per_cell; ++f)
+  for (const unsigned int f : GeometryInfo<mydim>::face_indices())
     tria.begin_active()->face(f)->set_all_boundary_ids(f);
   std::vector<
     GridTools::PeriodicFacePair<typename Triangulation<mydim>::cell_iterator>>

--- a/tests/matrix_free/matrix_vector_faces_18.cc
+++ b/tests/matrix_free/matrix_vector_faces_18.cc
@@ -117,7 +117,7 @@ test()
            triangulation.begin();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           {
             if (std::abs(cell->face(f)->center()[2]) < 1e-12)

--- a/tests/matrix_free/matrix_vector_faces_20.cc
+++ b/tests/matrix_free/matrix_vector_faces_20.cc
@@ -55,7 +55,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
   std::vector<

--- a/tests/matrix_free/matrix_vector_faces_21.cc
+++ b/tests/matrix_free/matrix_vector_faces_21.cc
@@ -56,7 +56,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
   std::vector<

--- a/tests/matrix_free/matrix_vector_faces_22.cc
+++ b/tests/matrix_free/matrix_vector_faces_22.cc
@@ -54,7 +54,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
   std::vector<

--- a/tests/matrix_free/matrix_vector_faces_23.cc
+++ b/tests/matrix_free/matrix_vector_faces_23.cc
@@ -56,7 +56,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
   std::vector<

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -119,7 +119,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -44,7 +44,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -325,8 +325,7 @@ private:
             phi.integrate(false, true);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           {
             phif.reinit(cell, face);
             VectorizedArray<number> sigmaF =

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -190,7 +190,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -100,9 +100,7 @@ public:
             const FiniteElement<dim> &fe = cell->get_fe();
             local_dofs.resize(fe.dofs_per_face);
 
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face_no) == true)
                 {
                   const typename DoFHandler<dim>::face_iterator face =

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -103,9 +103,7 @@ public:
             const FiniteElement<dim> &fe = cell->get_fe();
             local_dofs.resize(fe.dofs_per_face);
 
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face_no) == true)
                 {
                   const typename DoFHandler<dim>::face_iterator face =

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -99,9 +99,7 @@ public:
             const FiniteElement<dim> &fe = cell->get_fe();
             local_dofs.resize(fe.dofs_per_face);
 
-            for (unsigned int face_no = 0;
-                 face_no < GeometryInfo<dim>::faces_per_cell;
-                 ++face_no)
+            for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face_no) == true)
                 {
                   const typename DoFHandler<dim>::face_iterator face =

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -56,7 +56,7 @@ test()
   typename Triangulation<dim>::active_cell_iterator cell = tria.begin_active(),
                                                     endc = tria.end();
   for (; cell != endc; ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(0);
   tria.set_manifold(0, manifold);

--- a/tests/matrix_free/read_cell_data_02.cc
+++ b/tests/matrix_free/read_cell_data_02.cc
@@ -122,9 +122,7 @@ private:
                    ExcInternalError());
             // deallog << "c " << cell_data[lane] << std::endl;
 
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               {
                 fe_eval_m.reinit(cell, face);
                 fe_eval_p.reinit(cell, face);

--- a/tests/meshworker/scratch_data_03.cc
+++ b/tests/meshworker/scratch_data_03.cc
@@ -204,7 +204,7 @@ test()
     constraints.distribute_local_to_global(
       c.matrices[0], c.vectors[0], c.local_dof_indices[0], matrix, rhs);
 
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       constraints.distribute_local_to_global(c.matrices[1 + f],
                                              c.local_dof_indices[0],
                                              c.local_dof_indices[1 + f],

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -244,9 +244,7 @@ namespace LinearAdvectionTest
       {
         if (current_cell->is_locally_owned())
           {
-            for (unsigned int face_n = 0;
-                 face_n < GeometryInfo<dim>::faces_per_cell;
-                 ++face_n)
+            for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
               {
                 const int neighbor_index = current_cell->neighbor_index(face_n);
                 if (neighbor_index != -1) // interior face

--- a/tests/mpi/fe_field_function_02.cc
+++ b/tests/mpi/fe_field_function_02.cc
@@ -82,7 +82,7 @@ test()
          tr.begin_active();
        cell != tr.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_manifold_ids(numbers::flat_manifold_id);
   //  static const SphericalManifold<dim> boundary_shell;

--- a/tests/mpi/hp_constraints_consistent_01.cc
+++ b/tests/mpi/hp_constraints_consistent_01.cc
@@ -91,7 +91,7 @@ test(const unsigned int degree_center,
         // verify that our scenario is initialized correctly
         // by checking the number of neighbors of the center cell
         unsigned int n_neighbors = 0;
-        for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::face_indices())
           if (static_cast<unsigned int>(cell->neighbor_index(i)) !=
               numbers::invalid_unsigned_int)
             ++n_neighbors;

--- a/tests/mpi/hp_constraints_consistent_02.cc
+++ b/tests/mpi/hp_constraints_consistent_02.cc
@@ -91,7 +91,7 @@ test(const unsigned int degree_center,
         // verify that our scenario is initialized correctly
         // by checking the number of neighbors of the center cell
         unsigned int n_neighbors = 0;
-        for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::face_indices())
           if (static_cast<unsigned int>(cell->neighbor_index(i)) !=
               numbers::invalid_unsigned_int)
             ++n_neighbors;

--- a/tests/mpi/hp_constraints_consistent_03.cc
+++ b/tests/mpi/hp_constraints_consistent_03.cc
@@ -93,7 +93,7 @@ test(const unsigned int degree_center,
             // verify that our scenario is initialized correctly
             // by checking the number of neighbors of the center cell
             unsigned int n_neighbors = 0;
-            for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+            for (const unsigned int i : GeometryInfo<dim>::face_indices())
               if (static_cast<unsigned int>(cell->neighbor_index(i)) !=
                   numbers::invalid_unsigned_int)
                 ++n_neighbors;
@@ -103,7 +103,7 @@ test(const unsigned int degree_center,
         else if (cell->id().to_string() == "0_0:")
           {
             // set different boundary id on leftmost cell
-            for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : GeometryInfo<dim>::face_indices())
               if (cell->face(f)->at_boundary())
                 cell->face(f)->set_boundary_id(1);
 

--- a/tests/mpi/mg_05.cc
+++ b/tests/mpi/mg_05.cc
@@ -126,8 +126,7 @@ test()
               {
                 if (cell->level_subdomain_id() != tr.locally_owned_subdomain())
                   continue;
-                for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell;
-                     ++f)
+                for (const unsigned int f : GeometryInfo<dim>::face_indices())
                   {
                     if (cell->at_boundary(f))
                       continue;

--- a/tests/mpi/mg_06.cc
+++ b/tests/mpi/mg_06.cc
@@ -131,8 +131,7 @@ test()
               {
                 if (cell->level_subdomain_id() != tr.locally_owned_subdomain())
                   continue;
-                for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell;
-                     ++f)
+                for (const unsigned int f : GeometryInfo<dim>::face_indices())
                   {
                     if (cell->at_boundary(f))
                       continue;

--- a/tests/mpi/mg_ghost_dofs_periodic_01.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_01.cc
@@ -55,8 +55,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(face))
         {
           if (face >= 2)

--- a/tests/mpi/mg_ghost_dofs_periodic_03.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_03.cc
@@ -52,8 +52,7 @@ test()
       for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
            cell != tria.end();
            ++cell)
-        for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-             ++face)
+        for (const unsigned int face : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(face))
             cell->face(face)->set_all_boundary_ids(face);
 

--- a/tests/mpi/mg_ghost_dofs_periodic_04.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_04.cc
@@ -56,8 +56,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(face))
         {
           if (face >= 2)

--- a/tests/mpi/mg_ghost_dofs_periodic_05.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_05.cc
@@ -53,7 +53,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (f / 2 != 1 && cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f + 10);
 

--- a/tests/mpi/mg_ghost_dofs_periodic_06.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_06.cc
@@ -52,7 +52,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f + 10);
 

--- a/tests/mpi/mg_ghost_dofs_periodic_07.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_07.cc
@@ -54,7 +54,7 @@ test()
   for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
        cell != tria.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (cell->at_boundary(f))
         cell->face(f)->set_all_boundary_ids(f);
 

--- a/tests/mpi/p4est_2d_ghost_01.cc
+++ b/tests/mpi/p4est_2d_ghost_01.cc
@@ -73,7 +73,7 @@ test()
               continue;
             }
 
-          for (unsigned int n = 0; n < GeometryInfo<dim>::faces_per_cell; ++n)
+          for (const unsigned int n : GeometryInfo<dim>::face_indices())
             {
               if (cell->at_boundary(n))
                 continue;

--- a/tests/mpi/p4est_2d_ghost_02.cc
+++ b/tests/mpi/p4est_2d_ghost_02.cc
@@ -78,8 +78,7 @@ test()
                   continue;
                 }
 
-              for (unsigned int n = 0; n < GeometryInfo<dim>::faces_per_cell;
-                   ++n)
+              for (const unsigned int n : GeometryInfo<dim>::face_indices())
                 {
                   if (cell->at_boundary(n))
                     continue;

--- a/tests/mpi/p4est_3d_ghost_01.cc
+++ b/tests/mpi/p4est_3d_ghost_01.cc
@@ -82,7 +82,7 @@ test()
                           ExcInternalError());
             }
           else
-            for (unsigned int n = 0; n < GeometryInfo<dim>::faces_per_cell; ++n)
+            for (const unsigned int n : GeometryInfo<dim>::face_indices())
               {
                 if (cell->at_boundary(n))
                   continue;

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -566,9 +566,7 @@ namespace Step22
     // first collect all points locally
     for (; cell != endc; ++cell)
       if (cell->is_locally_owned() && cell->at_boundary())
-        for (unsigned int face_no = 0;
-             face_no < GeometryInfo<dim>::faces_per_cell;
-             ++face_no)
+        for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
           {
             const typename DoFHandler<dim>::face_iterator face =
               cell->face(face_no);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -49,7 +49,7 @@ set_periodicity(parallel::distributed::Triangulation<dim> &triangulation,
   typename Triangulation<dim>::face_iterator face_2;
 
   // Look for the two outermost faces:
-  for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<dim>::face_indices())
     {
       if (cell_1->face(j)->center()(dim - 1) > 2.9)
         face_1 = cell_1->face(j);

--- a/tests/mpi/periodicity_05.cc
+++ b/tests/mpi/periodicity_05.cc
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
     endc = triangulation.end();
   for (; cell != endc; ++cell)
     {
-      for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<3>::face_indices())
         {
           const Point<3> face_center = cell->face(f)->center();
           if (cell->face(f)->at_boundary())

--- a/tests/mpi/periodicity_06.cc
+++ b/tests/mpi/periodicity_06.cc
@@ -81,7 +81,7 @@ test(const unsigned numRefinementLevels = 2)
 
   // mark faces
   for (auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         const Point<dim> &face_center = cell->face(f)->center();
         if (cell->face(f)->at_boundary())

--- a/tests/mpi/periodicity_07.cc
+++ b/tests/mpi/periodicity_07.cc
@@ -54,7 +54,7 @@ test(const unsigned numRefinementLevels = 2)
 
   // mark faces
   for (auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       {
         const Point<dim> &face_center = cell->face(f)->center();
         if (cell->face(f)->at_boundary())

--- a/tests/mpi/renumber_cuthill_mckee_03.cc
+++ b/tests/mpi/renumber_cuthill_mckee_03.cc
@@ -79,7 +79,7 @@ test()
   std::set<types::global_dof_index> starting_indices;
   for (const auto &cell : dofh.active_cell_iterators())
     if (cell->is_locally_owned())
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (!cell->at_boundary(f) && cell->neighbor(f)->is_ghost())
           {
             // we've identified a subdomain interface. use these DoFs

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -161,9 +161,7 @@ namespace Step40
         {
           if (cell->is_locally_owned())
             {
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   if ((cell->face(face)->at_boundary()) ||
                       (cell->neighbor(face)->is_active() &&

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -162,9 +162,7 @@ namespace Step40
         {
           if (cell->is_locally_owned())
             {
-              for (unsigned int face = 0;
-                   face < GeometryInfo<dim>::faces_per_cell;
-                   ++face)
+              for (const unsigned int face : GeometryInfo<dim>::face_indices())
                 {
                   if ((cell->face(face)->at_boundary()) ||
                       (cell->neighbor(face)->is_active() &&

--- a/tests/multigrid/constrained_dofs_05.cc
+++ b/tests/multigrid/constrained_dofs_05.cc
@@ -96,9 +96,7 @@ check()
       for (const auto level_cell : dof_handler.cell_iterators_on_level(level))
         {
           // Iterate over all faces
-          for (unsigned int i_face = 0;
-               i_face < GeometryInfo<dim>::faces_per_cell;
-               ++i_face)
+          for (const unsigned int i_face : GeometryInfo<dim>::face_indices())
             {
               if ((level_cell->at_boundary(i_face) &&
                    !level_cell->has_periodic_neighbor(i_face)) ||
@@ -131,9 +129,7 @@ check()
       for (const auto level_cell : dof_handler.cell_iterators_on_level(level))
         {
           // Iterate over all faces
-          for (unsigned int i_face = 0;
-               i_face < GeometryInfo<dim>::faces_per_cell;
-               ++i_face)
+          for (const unsigned int i_face : GeometryInfo<dim>::face_indices())
             {
               if (!level_cell->has_periodic_neighbor(i_face) ||
                   level_cell->periodic_neighbor(i_face)->level() !=

--- a/tests/multigrid/dof_02.cc
+++ b/tests/multigrid/dof_02.cc
@@ -56,7 +56,7 @@ dofs(const DoFHandler<dim> &dof)
       indices.resize(cell->get_fe().dofs_per_face);
 
       deallog << "Level " << cell->level() << std::endl;
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         {
           typename DoFHandler<dim>::face_iterator face = cell->face(f);
           face->get_mg_dof_indices(cell->level(), indices);

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -131,7 +131,7 @@ initialize(const DoFHandler<dim> &dof, MGLevelObject<Vector<double>> &u)
            ++cell)
         {
           cell->get_mg_dof_indices(dof_indices);
-          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
             {
               cell->face(f)->get_mg_dof_indices(cell->level(), face_indices);
               if (cell->face(f)->at_boundary())

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -131,7 +131,7 @@ initialize(const DoFHandler<dim> &dof, MGLevelObject<Vector<double>> &u)
            ++cell)
         {
           cell->get_mg_dof_indices(dof_indices);
-          for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+          for (const unsigned int f : GeometryInfo<dim>::face_indices())
             {
               cell->face(f)->get_mg_dof_indices(cell->level(), face_indices);
               if (cell->face(f)->at_boundary())

--- a/tests/numerics/kelly_crash_02.cc
+++ b/tests/numerics/kelly_crash_02.cc
@@ -207,7 +207,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if ((cell->face(f)->center()[2] != -4) &&
           (cell->face(f)->center()[2] != 7) && (cell->face(f)->at_boundary()))
         cell->face(f)->set_boundary_id(1);
@@ -218,8 +218,7 @@ test()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       AssertThrow(cell->at_boundary(face_no) ==
                     cell->face(face_no)->at_boundary(),
                   ExcInternalError());

--- a/tests/numerics/no_flux_01.cc
+++ b/tests/numerics/no_flux_01.cc
@@ -46,7 +46,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -69,7 +69,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/no_flux_02.cc
+++ b/tests/numerics/no_flux_02.cc
@@ -47,7 +47,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -70,7 +70,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/no_flux_05.cc
+++ b/tests/numerics/no_flux_05.cc
@@ -57,7 +57,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   DoFRenumbering::component_wise(dof);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 

--- a/tests/numerics/no_flux_10.cc
+++ b/tests/numerics/no_flux_10.cc
@@ -63,7 +63,7 @@ void colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
   Triangulation<3>::cell_iterator cell = tria.begin();
 
   for (; cell != tria.end(); ++cell)
-    for (unsigned int f = 0; f < GeometryInfo<3>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<3>::face_indices())
       {
         if (!cell->face(f)->at_boundary())
           continue;

--- a/tests/numerics/no_flux_11.cc
+++ b/tests/numerics/no_flux_11.cc
@@ -61,9 +61,7 @@ run()
       {
         if (cell->is_locally_owned())
           {
-            for (unsigned int face = 0;
-                 face < GeometryInfo<dim>::faces_per_cell;
-                 ++face)
+            for (const unsigned int face : GeometryInfo<dim>::face_indices())
               {
                 if (cell->face(face)->at_boundary())
                   {

--- a/tests/numerics/no_flux_hp_01.cc
+++ b/tests/numerics/no_flux_hp_01.cc
@@ -42,7 +42,7 @@ test(const Triangulation<dim> &tr, const hp::FECollection<dim> &fe)
   hp::DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe[0].get_name() << ", case=" << i << std::endl;
 
@@ -65,7 +65,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/no_flux_hp_02.cc
+++ b/tests/numerics/no_flux_hp_02.cc
@@ -43,7 +43,7 @@ test(const Triangulation<dim> &tr, const hp::FECollection<dim> &fe)
   hp::DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe[0].get_name() << ", case=" << i << std::endl;
 
@@ -66,7 +66,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/no_flux_hp_05.cc
+++ b/tests/numerics/no_flux_hp_05.cc
@@ -49,7 +49,7 @@ test(const Triangulation<dim> &tr, const hp::FECollection<dim> &fe)
 
   DoFRenumbering::component_wise(dof);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe[0].get_name() << ", case=" << i << std::endl;
 

--- a/tests/numerics/normal_flux_01.cc
+++ b/tests/numerics/normal_flux_01.cc
@@ -46,7 +46,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -69,7 +69,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/normal_flux_02.cc
+++ b/tests/numerics/normal_flux_02.cc
@@ -47,7 +47,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   DoFHandler<dim> dof(tr);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -70,7 +70,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/normal_flux_hp_01.cc
+++ b/tests/numerics/normal_flux_hp_01.cc
@@ -47,7 +47,7 @@ test(const Triangulation<dim> &tr, const hp::FECollection<dim> &fe)
     cell->set_active_fe_index(cell->index() % 2);
   dof.distribute_dofs(fe);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe[0].get_name() << ", case=" << i << std::endl;
 
@@ -70,7 +70,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/normal_flux_inhom_01.cc
+++ b/tests/numerics/normal_flux_inhom_01.cc
@@ -49,10 +49,10 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   Functions::ConstantFunction<dim> constant_function(1., dim);
   std::map<types::boundary_id, const Function<dim> *> function_map;
-  for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<dim>::face_indices())
     function_map[j] = &constant_function;
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -77,8 +77,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active(),
                                                  endc = dof.end();
   for (; cell != endc; ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       if (cell->face(face_no)->at_boundary())
         {
           typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
@@ -104,7 +103,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/numerics/project_bv_div_conf_03.cc
+++ b/tests/numerics/project_bv_div_conf_03.cc
@@ -168,9 +168,7 @@ test_boundary_values(const FiniteElement<dim> &fe)
       std::vector<double>         cell_pres_values(face_quadrature.size());
       for (const auto &cell : dof_handler.active_cell_iterators())
         {
-          for (unsigned int face_n = 0;
-               face_n < GeometryInfo<dim>::faces_per_cell;
-               ++face_n)
+          for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
             {
               auto face = cell->face(face_n);
               if (face->at_boundary())

--- a/tests/numerics/tangential_flux_inhom_01.cc
+++ b/tests/numerics/tangential_flux_inhom_01.cc
@@ -50,10 +50,10 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
 
   Functions::ConstantFunction<dim> constant_function(1., dim);
   std::map<types::boundary_id, const Function<dim> *> function_map;
-  for (unsigned int j = 0; j < GeometryInfo<dim>::faces_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<dim>::face_indices())
     function_map[j] = &constant_function;
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     {
       deallog << "FE=" << fe.get_name() << ", case=" << i << std::endl;
 
@@ -78,8 +78,7 @@ test(const Triangulation<dim> &tr, const FiniteElement<dim> &fe)
   typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active(),
                                                  endc = dof.end();
   for (; cell != endc; ++cell)
-    for (unsigned int face_no = 0; face_no < GeometryInfo<dim>::faces_per_cell;
-         ++face_no)
+    for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
       if (cell->face(face_no)->at_boundary())
         {
           typename DoFHandler<dim>::face_iterator face = cell->face(face_no);
@@ -105,7 +104,7 @@ test_hyper_cube()
   Triangulation<dim> tr;
   GridGenerator::hyper_cube(tr);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::faces_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::face_indices())
     tr.begin_active()->face(i)->set_boundary_id(i);
 
   tr.refine_global(2);

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -1103,8 +1103,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1803,8 +1802,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -328,7 +328,7 @@ namespace Step18
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           {
             const Point<dim> face_center = cell->face(f)->center();

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -344,7 +344,7 @@ namespace Step18
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+      for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->face(f)->at_boundary())
           {
             const Point<dim> face_center = cell->face(f)->center();

--- a/tests/physics/step-44-standard_tensors-material_push_forward.cc
+++ b/tests/physics/step-44-standard_tensors-material_push_forward.cc
@@ -1268,8 +1268,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1829,8 +1828,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/physics/step-44-standard_tensors-spatial.cc
+++ b/tests/physics/step-44-standard_tensors-spatial.cc
@@ -1068,8 +1068,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1629,8 +1628,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/physics/step-44.cc
+++ b/tests/physics/step-44.cc
@@ -1081,8 +1081,7 @@ namespace Step44
                                                       endc =
                                                         triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-           ++face)
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {
           if (cell->face(face)->at_boundary() == true &&
               cell->face(face)->center()[1] == 1.0 * parameters.scale)
@@ -1640,8 +1639,7 @@ namespace Step44
               Assert(i_group <= J_dof, ExcInternalError());
           }
       }
-    for (unsigned int face = 0; face < GeometryInfo<dim>::faces_per_cell;
-         ++face)
+    for (const unsigned int face : GeometryInfo<dim>::face_indices())
       if (cell->face(face)->at_boundary() == true &&
           cell->face(face)->boundary_id() == 6)
         {

--- a/tests/serialization/dof_handler_01.cc
+++ b/tests/serialization/dof_handler_01.cc
@@ -51,7 +51,7 @@ namespace dealii
               return false;
           }
 
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           {
             if (c1->face(f)->at_boundary() != c2->face(f)->at_boundary())
               return false;
@@ -102,7 +102,7 @@ namespace dealii
             if (local_dofs_1 != local_dofs_2)
               return false;
 
-            for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : GeometryInfo<dim>::face_indices())
               {
                 std::vector<types::global_dof_index> local_dofs_1(
                   c1->get_fe().dofs_per_face);
@@ -139,7 +139,7 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 {
   typename Triangulation<dim, spacedim>::cell_iterator c1 = t1.begin();
   for (; c1 != t1.end(); ++c1)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (c1->at_boundary(f))
         c1->face(f)->set_boundary_id(42);
 }

--- a/tests/serialization/hp_dof_handler_01.cc
+++ b/tests/serialization/hp_dof_handler_01.cc
@@ -52,7 +52,7 @@ namespace dealii
               return false;
           }
 
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           {
             if (c1->face(f)->at_boundary() != c2->face(f)->at_boundary())
               return false;
@@ -109,7 +109,7 @@ namespace dealii
             if (local_dofs_1 != local_dofs_2)
               return false;
 
-            for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+            for (const unsigned int f : GeometryInfo<dim>::face_indices())
               {
                 std::vector<types::global_dof_index> local_dofs_1(
                   c1->get_fe().dofs_per_face);
@@ -148,7 +148,7 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 {
   typename Triangulation<dim, spacedim>::cell_iterator c1 = t1.begin();
   for (; c1 != t1.end(); ++c1)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (c1->at_boundary(f))
         c1->face(f)->set_boundary_id(42);
 }

--- a/tests/serialization/triangulation_01.cc
+++ b/tests/serialization/triangulation_01.cc
@@ -53,7 +53,7 @@ namespace dealii
               return false;
           }
 
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           {
             if (c1->face(f)->at_boundary() != c2->face(f)->at_boundary())
               return false;
@@ -126,7 +126,7 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 {
   typename Triangulation<dim, spacedim>::cell_iterator c1 = t1.begin();
   for (; c1 != t1.end(); ++c1)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (c1->at_boundary(f))
         {
           c1->face(f)->set_boundary_id(42);

--- a/tests/serialization/triangulation_02.cc
+++ b/tests/serialization/triangulation_02.cc
@@ -55,7 +55,7 @@ namespace dealii
               return false;
           }
 
-        for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+        for (const unsigned int f : GeometryInfo<dim>::face_indices())
           {
             if (c1->face(f)->at_boundary() != c2->face(f)->at_boundary())
               return false;
@@ -128,7 +128,7 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 {
   typename Triangulation<dim, spacedim>::cell_iterator c1 = t1.begin();
   for (; c1 != t1.end(); ++c1)
-    for (unsigned int f = 0; f < GeometryInfo<dim>::faces_per_cell; ++f)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
       if (c1->at_boundary(f))
         c1->face(f)->set_boundary_id(42);
 }

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -237,9 +237,7 @@ namespace LinearAdvectionTest
       {
         if (current_cell->is_locally_owned())
           {
-            for (unsigned int face_n = 0;
-                 face_n < GeometryInfo<dim>::faces_per_cell;
-                 ++face_n)
+            for (const unsigned int face_n : GeometryInfo<dim>::face_indices())
               {
                 const int neighbor_index = current_cell->neighbor_index(face_n);
                 if (neighbor_index != -1) // interior face


### PR DESCRIPTION
This is a follow-up to #9415, #9467, #9476, and 9477. 

I did this by:
* Telling clang-format to use a line length limit of 800 
* Converting these lines using a perl script
* Converting everything back to line lengths of 80
* Going around a few more times because I'm making mistakes in the process.
It might be the first thing I found clang-format to actually be useful for ;-)

/rebuild