### PR TITLE
Add chang-log entry for ConsensusAlgorithm

### DIFF
--- a/doc/news/changes/major/20190603PeterMunch
+++ b/doc/news/changes/major/20190603PeterMunch
@@ -1,0 +1,5 @@
+New: The namespace Utilities::MPI::ConsensusAlgorithms has been added. It 
+provides efficient implementations for communication patterns (PEX and NBX) to 
+retrieve data from other processes in a dynamic-sparse way.
+<br>
+(Peter Munch, Martin Kronbichler, 2019/06/03)


### PR DESCRIPTION
I think `Utilities::MPI::ConsensusAlgorithm` deserves a change-log entry of its own. On the one hand it is "only" general-purpose (MPI) infrastructure and not limited to FEM (and with high probability user most users will never use it directly), but it has become a key ingredient for large scale simulations. 

ping @kronbichler 