### PR TITLE
CI: fix check_indentation.sh script

### DIFF
--- a/contrib/utilities/check_indentation.sh
+++ b/contrib/utilities/check_indentation.sh
@@ -36,6 +36,6 @@ fi
 
 ./contrib/utilities/indent-all || exit $?
 git diff
-git diff-files --quiet 
+git diff-files --quiet || exit $?
 
 ./contrib/utilities/check_doxygen.sh || exit $?


### PR DESCRIPTION
Due to the addition of check_doxygen.sh we were not checking the return
value of git diff. This means the travis check would pass even though
there was a diff.