### PR TITLE
Avoid a bunch of warnings in release mode.

### DIFF
--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -164,13 +164,10 @@ namespace FETools
                  ExcDimensionMismatch(cell1->get_fe().n_components(),
                                       cell2->get_fe().n_components()));
 
-          // for continuous elements on
-          // grids with hanging nodes we
-          // need hanging node
-          // constraints. Consequently,
-          // if there are no constraints
-          // then hanging nodes are not
-          // allowed.
+#ifdef DEBUG
+          // For continuous elements on grids with hanging nodes we need
+          // hanging node constraints. Consequently, when the elements are
+          // continuous no hanging node constraints are allowed.
           const bool hanging_nodes_not_allowed =
             ((cell2->get_fe().dofs_per_vertex != 0) &&
              (constraints.n_constraints() == 0));
@@ -180,7 +177,7 @@ namespace FETools
               Assert(cell1->at_boundary(face) ||
                        cell1->neighbor(face)->level() == cell1->level(),
                      ExcHangingNodesNotAllowed());
-
+#endif
 
           const unsigned int dofs_per_cell1 = cell1->get_fe().dofs_per_cell;
           const unsigned int dofs_per_cell2 = cell2->get_fe().dofs_per_cell;
@@ -325,6 +322,7 @@ namespace FETools
       if ((cell->subdomain_id() == subdomain_id) ||
           (subdomain_id == numbers::invalid_subdomain_id))
         {
+#ifdef DEBUG
           // For continuous elements on grids with hanging nodes we need
           // hanging node constraints. Consequently, when the elements are
           // continuous no hanging node constraints are allowed.
@@ -336,6 +334,7 @@ namespace FETools
               Assert(cell->at_boundary(face) ||
                        cell->neighbor(face)->level() == cell->level(),
                      ExcHangingNodesNotAllowed());
+#endif
 
           const unsigned int dofs_per_cell1 = cell->get_fe().dofs_per_cell;
 
@@ -637,16 +636,6 @@ namespace FETools
                       " index sets."));
 #endif
 
-    // For continuous elements on grids
-    // with hanging nodes we need
-    // hanging node
-    // constraints. Consequently, when
-    // the elements are continuous no
-    // hanging node constraints are
-    // allowed.
-    const bool hanging_nodes_not_allowed =
-      (dof1.get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
-
     const unsigned int dofs_per_cell = dof1.get_fe().dofs_per_cell;
 
     Vector<typename OutVector::value_type> u1_local(dofs_per_cell);
@@ -666,11 +655,19 @@ namespace FETools
       if ((cell->subdomain_id() == subdomain_id) ||
           (subdomain_id == numbers::invalid_subdomain_id))
         {
+#ifdef DEBUG
+          // For continuous elements on grids with hanging nodes we need
+          // hanging node constraints. Consequently, when the elements are
+          // continuous no hanging node constraints are allowed.
+          const bool hanging_nodes_not_allowed =
+            (dof1.get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
+
           if (hanging_nodes_not_allowed)
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
               Assert(cell->at_boundary(face) ||
                        cell->neighbor(face)->level() == cell->level(),
                      ExcHangingNodesNotAllowed());
+#endif
 
           cell->get_dof_values(u1, u1_local);
           difference_matrix.vmult(u1_diff_local, u1_local);


### PR DESCRIPTION
Fixes #9609, I believe. At least I don't see any more warnings after this patch when compiling the release library.

/rebuild