### PR TITLE
Introduce GeometryInfo::vertex_indices()

### DIFF
--- a/doc/news/changes/minor/20200304Bangerth
+++ b/doc/news/changes/minor/20200304Bangerth
@@ -1,0 +1,5 @@
+New: There are new functions GeometryInfo::face_indices() and
+GeometryInfo::vertex_indices() that make writing range-based for loops
+over all faces or vertices of a cell much simpler.
+<br>
+(Wolfgang Bangerth, 2020/03/04)

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -1302,6 +1302,27 @@ struct GeometryInfo<0>
   static constexpr unsigned int vertices_per_cell = 1;
 
   /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to `vertices_per_cell`. This allows to write code
+   * using range-based for loops of the following kind:
+   * @code
+   *   for (auto &cell : triangulation.active_cell_iterators())
+   *     for (auto vertex_index : GeometryInfo<dim>::vertex_indices())
+   *       if (cell->vertex(vertex_index) satisfies some condition)
+   *         ... do something ...
+   * @endcode
+   * Here, we are looping over all vertices of all cells, with `vertex_index`
+   * taking on all valid indices.
+   *
+   * Of course, since this class is for the case `dim==0`, the
+   * returned object is a array with just one entry: zero. That's
+   * because an of dimension zero is really just a single point,
+   * corresponding to a vertex itself.
+   */
+  static std::array<unsigned int, vertices_per_cell>
+  vertex_indices();
+
+  /**
    * Number of vertices each face has. Since this is not useful in one
    * dimension, we provide a useless number (in the hope that a compiler may
    * warn when it sees constructs like <tt>for (i=0; i<vertices_per_face;
@@ -1943,6 +1964,22 @@ struct GeometryInfo
    * Number of vertices of a cell.
    */
   static constexpr unsigned int vertices_per_cell = 1 << dim;
+
+  /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to `vertices_per_cell`. This allows to write code
+   * using range-based for loops of the following kind:
+   * @code
+   *   for (auto &cell : triangulation.active_cell_iterators())
+   *     for (auto vertex_index : GeometryInfo<dim>::vertex_indices())
+   *       if (cell->vertex(vertex_index) satisfies some condition)
+   *         ... do something ...
+   * @endcode
+   * Here, we are looping over all vertices of all cells, with `vertex_index`
+   * taking on all valid indices.
+   */
+  static boost::integer_range<unsigned int>
+  vertex_indices();
 
   /**
    * Number of vertices on each face.
@@ -2787,11 +2824,28 @@ GeometryInfo<0>::face_indices()
 
 
 
+inline std::array<unsigned int, 1>
+GeometryInfo<0>::vertex_indices()
+{
+  return {{0}};
+}
+
+
+
 template <int dim>
 inline boost::integer_range<unsigned int>
 GeometryInfo<dim>::face_indices()
 {
   return boost::irange(0U, faces_per_cell);
+}
+
+
+
+template <int dim>
+inline boost::integer_range<unsigned int>
+GeometryInfo<dim>::vertex_indices()
+{
+  return boost::irange(0U, vertices_per_cell);
 }
 
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1407,9 +1407,7 @@ namespace internal
         std::vector<types::global_dof_index>::const_iterator next =
           dof_indices.begin();
 
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<1>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<1>::vertex_indices())
           for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
@@ -1435,9 +1433,7 @@ namespace internal
         std::vector<types::global_dof_index>::const_iterator next =
           dof_indices.begin();
 
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<2>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
           for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
@@ -1470,9 +1466,7 @@ namespace internal
         std::vector<types::global_dof_index>::const_iterator next =
           dof_indices.begin();
 
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<3>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
           for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
@@ -1950,8 +1944,7 @@ namespace internal
         handler.get_fe(fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
-      for (unsigned int vertex = 0; vertex < GeometryInfo<1>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<1>::vertex_indices())
         for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
@@ -1978,8 +1971,7 @@ namespace internal
         handler.get_fe(fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
-      for (unsigned int vertex = 0; vertex < GeometryInfo<2>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
         for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
@@ -2011,8 +2003,7 @@ namespace internal
         handler.get_fe(fe_index);
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
-      for (unsigned int vertex = 0; vertex < GeometryInfo<3>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
         for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
@@ -2990,9 +2981,7 @@ namespace internal
 
         unsigned int index = 0;
 
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
           for (unsigned int d = 0; d < dofs_per_vertex; ++d, ++index)
             accessor.set_vertex_dof_index(vertex,
                                           d,

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -227,9 +227,8 @@ namespace FETools
       // for each shape function, copy the flags from the base element to this
       // one, taking into account multiplicities, and other complications
       unsigned int total_index = 0;
-      for (unsigned int vertex_number = 0;
-           vertex_number < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_number)
+      for (const unsigned int vertex_number :
+           GeometryInfo<dim>::vertex_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
@@ -419,9 +418,8 @@ namespace FETools
       // to this one, taking into account multiplicities, multiple components in
       // base elements, and other complications
       unsigned int total_index = 0;
-      for (unsigned int vertex_number = 0;
-           vertex_number < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_number)
+      for (const unsigned int vertex_number :
+           GeometryInfo<dim>::vertex_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -663,9 +661,8 @@ namespace FETools
       // the first vertex in the order of the base elements, then of the second
       // vertex, etc
       total_index = 0;
-      for (unsigned int vertex_number = 0;
-           vertex_number < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_number)
+      for (const unsigned int vertex_number :
+           GeometryInfo<dim>::vertex_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fe.n_base_elements(); ++base)

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -400,7 +400,7 @@ MappingManifold<dim, spacedim>::InternalData::store_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
   vertices.resize(GeometryInfo<dim>::vertices_per_cell);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     vertices[i] = cell->vertex(i);
   this->cell = cell;
 }
@@ -415,7 +415,7 @@ MappingManifold<dim, spacedim>::InternalData::
     quad.size(), std::vector<double>(GeometryInfo<dim>::vertices_per_cell));
   for (unsigned int q = 0; q < quad.size(); ++q)
     {
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           cell_manifold_quadrature_weights[q][i] =
             GeometryInfo<dim>::d_linear_shape_function(quad.point(q), i);

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3145,7 +3145,7 @@ namespace GridTools
       cell = triangulation.begin_active(),
       endc = triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (treated_vertices[cell->vertex_index(v)] == false)
           {
             // transform this vertex
@@ -3464,29 +3464,25 @@ namespace GridTools
           xi[d] = 0.5;
 
         Point<spacedim> x_k;
-        for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell;
-             ++i)
+        for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
           x_k += object->vertex(i) *
                  GeometryInfo<structdim>::d_linear_shape_function(xi, i);
 
         do
           {
             Tensor<1, structdim> F_k;
-            for (unsigned int i = 0;
-                 i < GeometryInfo<structdim>::vertices_per_cell;
-                 ++i)
+            for (const unsigned int i :
+                 GeometryInfo<structdim>::vertex_indices())
               F_k +=
                 (x_k - trial_point) * object->vertex(i) *
                 GeometryInfo<structdim>::d_linear_shape_function_gradient(xi,
                                                                           i);
 
             Tensor<2, structdim> H_k;
-            for (unsigned int i = 0;
-                 i < GeometryInfo<structdim>::vertices_per_cell;
-                 ++i)
-              for (unsigned int j = 0;
-                   j < GeometryInfo<structdim>::vertices_per_cell;
-                   ++j)
+            for (const unsigned int i :
+                 GeometryInfo<structdim>::vertex_indices())
+              for (const unsigned int j :
+                   GeometryInfo<structdim>::vertex_indices())
                 {
                   Tensor<2, structdim> tmp = outer_product(
                     GeometryInfo<structdim>::d_linear_shape_function_gradient(
@@ -3500,9 +3496,8 @@ namespace GridTools
             xi += delta_xi;
 
             x_k = Point<spacedim>();
-            for (unsigned int i = 0;
-                 i < GeometryInfo<structdim>::vertices_per_cell;
-                 ++i)
+            for (const unsigned int i :
+                 GeometryInfo<structdim>::vertex_indices())
               x_k += object->vertex(i) *
                      GeometryInfo<structdim>::d_linear_shape_function(xi, i);
 
@@ -3920,8 +3915,7 @@ namespace GridTools
       if (cell->is_locally_owned())
         {
           std::set<dealii::types::subdomain_id> send_to;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               const std::map<unsigned int,
                              std::set<dealii::types::subdomain_id>>::

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2166,7 +2166,7 @@ TriaAccessor<structdim, dim, spacedim>::enclosing_ball() const
   // For each vertex that is found to be geometrically outside the ball
   // enlarge the ball  so that the new ball contains both the previous ball
   // and the given vertex.
-  for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
     if (!is_initial_guess_vertex[v])
       {
         const double distance = center.distance(this->vertex(v));
@@ -2188,7 +2188,7 @@ TriaAccessor<structdim, dim, spacedim>::enclosing_ball() const
 
   // Set all_vertices_within_ball false if any of the vertices of the object
   // are geometrically outside the ball
-  for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
     if (center.distance(this->vertex(v)) >
         radius + 100. * std::numeric_limits<double>::epsilon())
       {
@@ -2214,9 +2214,7 @@ TriaAccessor<structdim, dim, spacedim>::minimum_vertex_distance() const
       case 3:
         {
           double min = std::numeric_limits<double>::max();
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
             for (unsigned int j = i + 1;
                  j < GeometryInfo<structdim>::vertices_per_cell;
                  ++j)

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1185,8 +1185,7 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
   // perform shift, if so desired
   if (shift != Point<patch_space_dim>())
     for (unsigned int i = old_n_patches; i < patches.size(); ++i)
-      for (unsigned int v = 0; v < GeometryInfo<patch_dim>::vertices_per_cell;
-           ++v)
+      for (const unsigned int v : GeometryInfo<patch_dim>::vertex_indices())
         patches[i].vertices[v] += shift;
 
   // adjust patch numbers

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -1772,7 +1772,7 @@ namespace DataOutBase
   {
     // TODO: make tolerance relative
     const double epsilon = 3e-16;
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       if (vertices[i].distance(patch.vertices[i]) > epsilon)
         return false;
 
@@ -1868,7 +1868,7 @@ namespace DataOutBase
 
     // TODO: make tolerance relative
     const double epsilon = 3e-16;
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       if (vertices[i].distance(patch.vertices[i]) > epsilon)
         return false;
 
@@ -8594,7 +8594,7 @@ namespace DataOutBase
         << '\n';
 
     // then write all the data that is in this patch
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       out << patch.vertices[GeometryInfo<dim>::ucd_to_deal[i]] << ' ';
     out << '\n';
 
@@ -8643,7 +8643,7 @@ namespace DataOutBase
 
 
     // then read all the data that is in this patch
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       in >> patch.vertices[GeometryInfo<dim>::ucd_to_deal[i]];
 
     for (unsigned int i : GeometryInfo<dim>::face_indices())

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -58,7 +58,7 @@ namespace
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           ++vertex_touch_count[cell->vertex_index(v)];
           vertex_to_cell[cell->vertex_index(v)].emplace_back(cell, v);
@@ -147,7 +147,7 @@ namespace
         const unsigned int index =
           coarse_cell_to_p4est_tree_permutation[cell->index()];
 
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (set_vertex_info == true)
               connectivity
@@ -349,7 +349,7 @@ namespace
         // important: only assign the level_subdomain_id if it is a ghost cell
         // even though we could fill in all.
         bool used = false;
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (marked_vertices[dealii_cell->level()]
                                [dealii_cell->vertex_index(v)])
@@ -375,8 +375,7 @@ namespace
             dealii_cell->is_artificial() == false &&
             dealii_cell->level() + 1 < static_cast<int>(marked_vertices.size()))
           {
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               {
                 if (marked_vertices[dealii_cell->level() + 1]
                                    [dealii_cell->vertex_index(v)])
@@ -391,8 +390,7 @@ namespace
         if (!used && dealii_cell->is_active() &&
             dealii_cell->is_artificial() == false && dealii_cell->level() > 0)
           {
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               {
                 if (marked_vertices[dealii_cell->level() - 1]
                                    [dealii_cell->vertex_index(v)])
@@ -2442,8 +2440,7 @@ namespace parallel
           if (dealii_cell->is_locally_owned())
             {
               std::set<dealii::types::subdomain_id> send_to;
-              for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                 {
                   const std::map<unsigned int,
                                  std::set<dealii::types::subdomain_id>>::
@@ -2466,9 +2463,8 @@ namespace parallel
                 {
                   std::vector<unsigned int>            vertex_indices;
                   std::vector<dealii::Point<spacedim>> local_vertices;
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<dim>::vertices_per_cell;
-                       ++v)
+                  for (const unsigned int v :
+                       GeometryInfo<dim>::vertex_indices())
                     if (vertex_locally_moved[dealii_cell->vertex_index(v)])
                       {
                         vertex_indices.push_back(v);
@@ -3305,18 +3301,16 @@ namespace parallel
             for (; cell != endc; ++cell)
               {
                 if (cell->refine_flag_set())
-                  for (unsigned int vertex = 0;
-                       vertex < GeometryInfo<dim>::vertices_per_cell;
-                       ++vertex)
+                  for (const unsigned int vertex :
+                       GeometryInfo<dim>::vertex_indices())
                     vertex_level[topological_vertex_numbering
                                    [cell->vertex_index(vertex)]] =
                       std::max(vertex_level[topological_vertex_numbering
                                               [cell->vertex_index(vertex)]],
                                cell->level() + 1);
                 else if (!cell->coarsen_flag_set())
-                  for (unsigned int vertex = 0;
-                       vertex < GeometryInfo<dim>::vertices_per_cell;
-                       ++vertex)
+                  for (const unsigned int vertex :
+                       GeometryInfo<dim>::vertex_indices())
                     vertex_level[topological_vertex_numbering
                                    [cell->vertex_index(vertex)]] =
                       std::max(vertex_level[topological_vertex_numbering
@@ -3331,9 +3325,8 @@ namespace parallel
                     // to correct this by iterating over the entire
                     // process until we are converged
                     Assert(cell->coarsen_flag_set(), ExcInternalError());
-                    for (unsigned int vertex = 0;
-                         vertex < GeometryInfo<dim>::vertices_per_cell;
-                         ++vertex)
+                    for (const unsigned int vertex :
+                         GeometryInfo<dim>::vertex_indices())
                       vertex_level[topological_vertex_numbering
                                      [cell->vertex_index(vertex)]] =
                         std::max(vertex_level[topological_vertex_numbering
@@ -3356,9 +3349,8 @@ namespace parallel
             for (cell = tria.last_active(); cell != endc; --cell)
               if (cell->refine_flag_set() == false)
                 {
-                  for (unsigned int vertex = 0;
-                       vertex < GeometryInfo<dim>::vertices_per_cell;
-                       ++vertex)
+                  for (const unsigned int vertex :
+                       GeometryInfo<dim>::vertex_indices())
                     if (vertex_level[topological_vertex_numbering
                                        [cell->vertex_index(vertex)]] >=
                         cell->level() + 1)
@@ -3376,9 +3368,8 @@ namespace parallel
                             cell->set_refine_flag();
                             continue_iterating = true;
 
-                            for (unsigned int v = 0;
-                                 v < GeometryInfo<dim>::vertices_per_cell;
-                                 ++v)
+                            for (const unsigned int v :
+                                 GeometryInfo<dim>::vertex_indices())
                               vertex_level[topological_vertex_numbering
                                              [cell->vertex_index(v)]] =
                                 std::max(
@@ -4050,9 +4041,8 @@ namespace parallel
                       (cell->level_subdomain_id() ==
                        numbers::artificial_subdomain_id);
                     bool need_to_know = false;
-                    for (unsigned int vertex = 0;
-                         vertex < GeometryInfo<dim>::vertices_per_cell;
-                         ++vertex)
+                    for (const unsigned int vertex :
+                         GeometryInfo<dim>::vertex_indices())
                       if (active_verts[cell->vertex_index(vertex)])
                         {
                           need_to_know = true;
@@ -4509,8 +4499,7 @@ namespace parallel
       cell_iterator     cell = this->begin(level), endc = this->end(level);
       for (; cell != endc; ++cell)
         if (cell->level_subdomain_id() == this->locally_owned_subdomain())
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             marked_vertices[cell->vertex_index(v)] = true;
 
       /**

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -376,7 +376,7 @@ namespace parallel
     std::vector<bool> vertex_of_own_cell(this->n_vertices(), false);
     for (const auto &cell : this->active_cell_iterators())
       if (cell->is_locally_owned())
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           vertex_of_own_cell[cell->vertex_index(v)] = true;
 
     // 3) for each vertex belonging to a locally owned cell all ghost
@@ -390,8 +390,7 @@ namespace parallel
           const types::subdomain_id owner = cell->subdomain_id();
 
           // loop over all its vertices
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               // set owner if vertex belongs to a local cell
               if (vertex_of_own_cell[cell->vertex_index(v)])

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -427,9 +427,7 @@ namespace internal
           {
             const unsigned int level = cell->level();
 
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<1>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<1>::vertex_indices())
               {
                 const unsigned int vertex_index = cell->vertex_index(vertex);
 
@@ -503,9 +501,7 @@ namespace internal
           {
             const unsigned int level = cell->level();
 
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
               {
                 const unsigned int vertex_index = cell->vertex_index(vertex);
 
@@ -580,9 +576,7 @@ namespace internal
           {
             const unsigned int level = cell->level();
 
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<3>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
               {
                 const unsigned int vertex_index = cell->vertex_index(vertex);
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -235,8 +235,7 @@ namespace internal
         {
           // distribute dofs of vertices
           if (dof_handler.get_fe().dofs_per_vertex > 0)
-            for (unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<1>::vertex_indices())
               {
                 if (cell->vertex_dof_index(v, 0) == numbers::invalid_dof_index)
                   for (unsigned int d = 0;
@@ -275,9 +274,7 @@ namespace internal
         {
           if (dof_handler.get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
               if (cell->vertex_dof_index(vertex, 0) ==
@@ -326,9 +323,7 @@ namespace internal
         {
           if (dof_handler.get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<3>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
               // check whether dofs for this vertex have been distributed
               // (checking the first dof should be good enough)
               if (cell->vertex_dof_index(vertex, 0) ==
@@ -404,9 +399,7 @@ namespace internal
           // (only check the first dof), and if this isn't the case
           // distribute new ones there
           if (fe.dofs_per_vertex > 0)
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<1>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<1>::vertex_indices())
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
                   numbers::invalid_dof_index)
                 for (unsigned int d = 0; d < fe.dofs_per_vertex;
@@ -454,9 +447,7 @@ namespace internal
           // (only check the first dof), and if this isn't the case
           // distribute new ones there
           if (fe.dofs_per_vertex > 0)
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
                   numbers::invalid_dof_index)
                 for (unsigned int d = 0; d < fe.dofs_per_vertex;
@@ -520,9 +511,7 @@ namespace internal
           // (only check the first dof), and if this isn't the case
           // distribute new ones there
           if (fe.dofs_per_vertex > 0)
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<3>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
               if (cell->vertex_dof_index(vertex, 0, fe_index) ==
                   numbers::invalid_dof_index)
                 for (unsigned int d = 0; d < fe.dofs_per_vertex;
@@ -1439,9 +1428,7 @@ namespace internal
                 &dof_handler.get_triangulation()) != nullptr)
             for (const auto &cell : dof_handler.active_cell_iterators())
               if (cell->is_ghost())
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   include_vertex[cell->vertex_index(v)] = true;
 
           // loop over all vertices and see which one we need to work on
@@ -2117,8 +2104,7 @@ namespace internal
         {
           // distribute dofs of vertices
           if (cell->get_fe().dofs_per_vertex > 0)
-            for (unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<1>::vertex_indices())
               {
                 typename DoFHandler<dim, spacedim>::level_cell_iterator
                   neighbor = cell->neighbor(v);
@@ -2190,9 +2176,7 @@ namespace internal
         {
           if (cell->get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
               // check whether dofs for this
               // vertex have been distributed
               // (only check the first dof)
@@ -2246,9 +2230,7 @@ namespace internal
         {
           if (cell->get_fe().dofs_per_vertex > 0)
             // number dofs on vertices
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<3>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex : GeometryInfo<3>::vertex_indices())
               // check whether dofs for this vertex have been distributed
               // (only check the first dof)
               if (cell->mg_vertex_dof_index(cell->level(), vertex, 0) ==
@@ -4932,9 +4914,7 @@ namespace internal
           for (const auto &cell : dof_handler->active_cell_iterators())
             if (cell->is_locally_owned())
               {
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   if (vertices_with_ghost_neighbors.find(cell->vertex_index(
                         v)) != vertices_with_ghost_neighbors.end())
                     {

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2720,9 +2720,8 @@ namespace DoFTools
     // Identify all vertices active on this level and remember some data
     // about them
     for (cell = dof_handler.begin(level); cell != endc; ++cell)
-      for (unsigned int v = 0;
-           v < GeometryInfo<DoFHandlerType::dimension>::vertices_per_cell;
-           ++v)
+      for (const unsigned int v :
+           GeometryInfo<DoFHandlerType::dimension>::vertex_indices())
         {
           const unsigned int vg = cell->vertex_index(v);
           vertex_dof_count[vg] += cell->get_fe().dofs_per_cell;
@@ -2777,9 +2776,8 @@ namespace DoFTools
         indices.resize(fe.dofs_per_cell);
         cell->get_mg_dof_indices(indices);
 
-        for (unsigned int v = 0;
-             v < GeometryInfo<DoFHandlerType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<DoFHandlerType::dimension>::vertex_indices())
           {
             const unsigned int vg    = cell->vertex_index(v);
             const unsigned int block = vertex_mapping[vg];

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -1076,15 +1076,13 @@ namespace ColorEnriched
       // Mark vertices that belong to cells in subdomain 1
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (predicate_1(cell)) // True ==> part of subdomain 1
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             vertices_subdomain_1[cell->vertex_index(v)] = true;
 
       // Find if cells in subdomain 2 and subdomain 1 share vertices.
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (predicate_2(cell)) // True ==> part of subdomain 2
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             if (vertices_subdomain_1[cell->vertex_index(v)] == true)
               {
                 return true;

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -2261,7 +2261,7 @@ FE_Q_Hierarchical<dim>::get_embedding_dofs(const unsigned int sub_degree) const
     {
       std::vector<unsigned int> embedding_dofs(
         GeometryInfo<dim>::vertices_per_cell);
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         embedding_dofs[i] = i;
 
       return embedding_dofs;
@@ -2386,7 +2386,7 @@ std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_Q_Hierarchical<dim>::get_constant_modes() const
 {
   Table<2, bool> constant_modes(1, this->dofs_per_cell);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     constant_modes(0, i) = true;
   for (unsigned int i = GeometryInfo<dim>::vertices_per_cell;
        i < this->dofs_per_cell;

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -29,7 +29,7 @@ Mapping<dim, spacedim>::get_vertices(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
 {
   std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell> vertices;
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       vertices[i] = cell->vertex(i);
     }

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -201,7 +201,7 @@ namespace
     if (quad.size() == 0)
       {
         std::vector<Point<dim>> points(GeometryInfo<dim>::vertices_per_cell);
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           points[i] = GeometryInfo<dim>::unit_cell_vertex(i);
         quad = Quadrature<dim>(points);
       }
@@ -405,8 +405,7 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_vertices(
           typename VectorType::value_type value =
             internal::ElementAccess<VectorType>::get(vector, dof_indices[i]);
           if (euler_dof_handler->get_fe().is_primitive(i))
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               vertices[v][comp] += fe_values.shape_value(i, v) * value;
           else
             Assert(false, ExcNotImplemented());

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -178,7 +178,7 @@ MappingManifold<dim, spacedim>::transform_unit_to_real_cell(
   std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell> vertices;
   std::array<double, GeometryInfo<dim>::vertices_per_cell>          weights;
 
-  for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
     {
       vertices[v] = cell->vertex(v);
       weights[v]  = GeometryInfo<dim>::d_linear_shape_function(p, v);
@@ -416,9 +416,8 @@ namespace internal
                     const Point<dim> np(p + L * ei);
 
                     // Get the weights to compute the np point in real space
-                    for (unsigned int j = 0;
-                         j < GeometryInfo<dim>::vertices_per_cell;
-                         ++j)
+                    for (const unsigned int j :
+                         GeometryInfo<dim>::vertex_indices())
                       data.vertex_weights[j] =
                         GeometryInfo<dim>::d_linear_shape_function(np, j);
 

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -81,7 +81,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
     shiftmap_dof_handler->get_fe().dofs_per_cell);
   dof_cell->get_dof_values(*euler_transform_vectors, mapping_values);
 
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<spacedim> shift_vector;
 
@@ -109,7 +109,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::compute_mapping_support_points(
     vertices = this->get_vertices(cell);
 
   std::vector<Point<spacedim>> a(GeometryInfo<dim>::vertices_per_cell);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     a[i] = vertices[i];
 
   return a;

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -1101,7 +1101,7 @@ namespace internal
         output[0].reinit(polynomial_degree - 1,
                          GeometryInfo<1>::vertices_per_cell);
         for (unsigned int q = 0; q < polynomial_degree - 1; ++q)
-          for (unsigned int i = 0; i < GeometryInfo<1>::vertices_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<1>::vertex_indices())
             output[0](q, i) =
               GeometryInfo<1>::d_linear_shape_function(quadrature.point(q + 1),
                                                        i);
@@ -1135,8 +1135,7 @@ namespace internal
                                           GeometryInfo<dim>::vertices_per_cell,
                                         GeometryInfo<dim>::vertices_per_cell);
         for (unsigned int q = 0; q < output.size(0); ++q)
-          for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
             output(q, i) = GeometryInfo<dim>::d_linear_shape_function(
               quadrature.point(h2l[q + GeometryInfo<dim>::vertices_per_cell]),
               i);
@@ -2598,7 +2597,7 @@ MappingQGeneric<dim, spacedim>::transform_real_to_unit_cell(
         this->compute_mapping_support_points(cell);
       a.resize(GeometryInfo<dim>::vertices_per_cell);
       std::vector<CellData<dim>> cells(1);
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         cells[0].vertices[i] = i;
       Triangulation<dim, spacedim> tria;
       tria.create_triangulation(a, cells, SubCellData());
@@ -3951,7 +3950,7 @@ MappingQGeneric<3, 3>::add_quad_support_points(
       boost::container::small_vector<Point<3>, 200> tmp_points(
         GeometryInfo<2>::vertices_per_cell +
         GeometryInfo<2>::lines_per_cell * (polynomial_degree - 1));
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         tmp_points[v] = a[GeometryInfo<3>::face_to_cell_vertices(face_no, v)];
       if (polynomial_degree > 1)
         for (unsigned int line = 0; line < GeometryInfo<2>::lines_per_cell;
@@ -3983,7 +3982,7 @@ MappingQGeneric<2, 3>::add_quad_support_points(
   std::vector<Point<3>> &                   a) const
 {
   std::array<Point<3>, GeometryInfo<2>::vertices_per_cell> vertices;
-  for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<2>::vertex_indices())
     vertices[i] = cell->vertex(i);
 
   Table<2, double> weights(Utilities::fixed_power<2>(polynomial_degree - 1),
@@ -3993,7 +3992,7 @@ MappingQGeneric<2, 3>::add_quad_support_points(
       {
         Point<2> point(line_support_points.point(q1 + 1)[0],
                        line_support_points.point(q2 + 1)[0]);
-        for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<2>::vertex_indices())
           weights(q, i) = GeometryInfo<2>::d_linear_shape_function(point, i);
       }
 
@@ -4025,7 +4024,7 @@ MappingQGeneric<dim, spacedim>::compute_mapping_support_points(
   // get the vertices first
   std::vector<Point<spacedim>> a;
   a.reserve(Utilities::fixed_power<dim>(polynomial_degree + 1));
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     a.push_back(cell->vertex(i));
 
   if (this->polynomial_degree > 1)

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -961,8 +961,7 @@ namespace GridGenerator
 
           // loop over vertices of all cells
           for (auto &cell : tria)
-            for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<2>::vertex_indices())
               {
                 // vertex has been already processed: nothing to do
                 if (vertex_processed[cell.vertex_index(v)])
@@ -1567,7 +1566,7 @@ namespace GridGenerator
 
     // Prepare cell data
     std::vector<CellData<dim>> cells(1);
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       cells[0].vertices[i] = i;
     cells[0].material_id = 0;
 
@@ -2064,7 +2063,7 @@ namespace GridGenerator
 
     typename Triangulation<dim, spacedim>::active_cell_iterator cell =
       tria.begin_active();
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       cell->vertex(i) = vertices[i];
 
     // Check that the order of the vertices makes sense, i.e., the volume of the
@@ -3535,9 +3534,8 @@ namespace GridGenerator
 
         if (cylinder_triangulation_offset == Tensor<1, 2>())
           {
-            for (unsigned int vertex_n = 0;
-                 vertex_n < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex_n)
+            for (const unsigned int vertex_n :
+                 GeometryInfo<2>::vertex_indices())
               if (cell->vertex(vertex_n) == Point<2>())
                 {
                   // cylinder_tria is centered at zero, so we need to
@@ -3563,9 +3561,7 @@ namespace GridGenerator
     // and right sides of cylinder_tria inwards so that it fits in
     // bulk_tria:
     for (const auto &cell : cylinder_tria.active_cell_iterators())
-      for (unsigned int vertex_n = 0;
-           vertex_n < GeometryInfo<2>::vertices_per_cell;
-           ++vertex_n)
+      for (const unsigned int vertex_n : GeometryInfo<2>::vertex_indices())
         {
           if (std::abs(cell->vertex(vertex_n)[0] - -0.41 / 4.0) < 1e-10)
             cell->vertex(vertex_n)[0] = -0.1;
@@ -3633,7 +3629,7 @@ namespace GridGenerator
       const double shift =
         std::min(0.125 + shell_region_width * 0.5, 0.1 * 4. / 3.);
       for (const auto &cell : tria.active_cell_iterators())
-        for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<2>::vertex_indices())
           if (cell->vertex(v).distance(Point<2>(0.1, 0.205)) < 1e-10)
             cell->vertex(v) = Point<2>(0.2 - shift, 0.205);
           else if (cell->vertex(v).distance(Point<2>(0.3, 0.205)) < 1e-10)
@@ -3777,7 +3773,7 @@ namespace GridGenerator
 
     std::vector<CellData<dim>> cells(n_cells);
     // Vertices of the center cell
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         Point<spacedim> p;
         for (unsigned int d = 0; d < dim; ++d)
@@ -4048,12 +4044,12 @@ namespace GridGenerator
                                          std::end(vertices_tmp));
     unsigned int cell_vertices[1][GeometryInfo<2>::vertices_per_cell];
 
-    for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<2>::vertex_indices())
       cell_vertices[0][i] = i;
 
     std::vector<CellData<2>> cells(1, CellData<2>());
 
-    for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<2>::vertex_indices())
       cells[0].vertices[i] = cell_vertices[0][i];
 
     cells[0].material_id = 0;
@@ -4976,7 +4972,7 @@ namespace GridGenerator
 
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<3>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
         cells[i].manifold_id = i == 0 ? numbers::flat_manifold_id : 1;
@@ -5380,8 +5376,7 @@ namespace GridGenerator
 
         for (unsigned int i = 0; i < n_cells; ++i)
           {
-            for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell;
-                 ++j)
+            for (const unsigned int j : GeometryInfo<3>::vertex_indices())
               cells[i].vertices[j] = cell_vertices[i][j];
             cells[i].material_id = 0;
           }
@@ -5454,8 +5449,7 @@ namespace GridGenerator
         for (const auto &cell : tmp.active_cell_iterators())
           {
             const unsigned int cell_index = cell->active_cell_index();
-            for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<3>::vertex_indices())
               cells[cell_index].vertices[v] = cell->vertex_index(v);
             cells[cell_index].material_id = 0;
           }
@@ -6155,8 +6149,7 @@ namespace GridGenerator
                    "all cells are on the same refinement level."));
 
           CellData<dim> this_cell;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             this_cell.vertices[v] = cell->vertex_index(v);
           this_cell.material_id = cell->material_id();
           cells.push_back(this_cell);
@@ -6313,9 +6306,8 @@ namespace GridGenerator
         for (std::size_t slice_n = 0; slice_n < n_slices - 1; ++slice_n)
           {
             CellData<3> this_cell;
-            for (unsigned int vertex_n = 0;
-                 vertex_n < GeometryInfo<2>::vertices_per_cell;
-                 ++vertex_n)
+            for (const unsigned int vertex_n :
+                 GeometryInfo<2>::vertex_indices())
               {
                 this_cell.vertices[vertex_n] =
                   cell->vertex_index(vertex_n) + slice_n * input.n_vertices();
@@ -6819,7 +6811,7 @@ namespace GridGenerator
 
     for (unsigned int id = 0; cell != endc; ++cell, ++id)
       {
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           cells[id].vertices[i] = cell->vertex_index(i);
         cells[id].material_id = cell->material_id();
         cells[id].manifold_id = cell->manifold_id();
@@ -6978,9 +6970,8 @@ namespace GridGenerator
             {
               CellData<boundary_dim> c_data;
 
-              for (unsigned int j = 0;
-                   j < GeometryInfo<boundary_dim>::vertices_per_cell;
-                   ++j)
+              for (const unsigned int j :
+                   GeometryInfo<boundary_dim>::vertex_indices())
                 {
                   const unsigned int v_index = face->vertex_index(j);
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -595,14 +595,12 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           cells.emplace_back();
 
           AssertThrow(in, ExcIO());
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               v++)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             in >> cells.back().vertices[v];
 
           cells.back().material_id = 0;
 
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               v++)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             cells.back().vertices[v] = vertex_indices[cells.back().vertices[v]];
 
           cell_indices[no] = no_cell;
@@ -820,8 +818,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
         {
           // allocate and read indices
           cells.emplace_back();
-          for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
             in >> cells.back().vertices[i];
 
           // to make sure that the cast won't fail
@@ -841,8 +838,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
 
           // transform from ucd to
           // consecutive numbering
-          for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
             if (vertex_indices.find(cells.back().vertices[i]) !=
                 vertex_indices.end())
               // vertex with this index exists
@@ -1188,7 +1184,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
       // read in vertex numbers. they
       // are 1-based, so subtract one
       cells.emplace_back();
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           in >> cells.back().vertices[i];
 
@@ -1832,9 +1828,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
 
                 // allocate and read indices
                 cells.emplace_back();
-                for (unsigned int i = 0;
-                     i < GeometryInfo<dim>::vertices_per_cell;
-                     ++i)
+                for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
                   in >> cells.back().vertices[i];
 
                 // to make sure that the cast won't fail
@@ -1853,9 +1847,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
 
                 // transform from ucd to
                 // consecutive numbering
-                for (unsigned int i = 0;
-                     i < GeometryInfo<dim>::vertices_per_cell;
-                     ++i)
+                for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
                   {
                     AssertThrow(
                       vertex_indices.find(cells.back().vertices[i]) !=
@@ -3058,8 +3050,7 @@ GridIn<dim, spacedim>::read_assimp(const std::string &filename,
         {
           if (mFaces[i].mNumIndices == GeometryInfo<dim>::vertices_per_cell)
             {
-              for (unsigned int f = 0; f < GeometryInfo<dim>::vertices_per_cell;
-                   ++f)
+              for (const unsigned int f : GeometryInfo<dim>::vertex_indices())
                 {
                   cells[valid_cell].vertices[f] =
                     mFaces[i].mIndices[f] + v_offset;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -849,8 +849,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
 
       for (const auto &cell : tria.active_cell_iterators())
         {
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             out
               << '\t'
               << renumber[cell->vertex_index(GeometryInfo<dim>::dx_to_deal[v])];
@@ -1147,9 +1146,7 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
 
       // Vertex numbering follows UCD conventions.
 
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[vertex]) + 1
             << ' ';
       out << '\n';
@@ -1268,9 +1265,7 @@ GridOut::write_ucd(const Triangulation<dim, spacedim> &tria,
       // May, 1992, p. E6
       //
       // note: vertex numbers are 1-base
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[vertex]) + 1
             << ' ';
       out << '\n';
@@ -2924,8 +2919,7 @@ GridOut::write_mathgl(const Triangulation<dim, spacedim> &tria,
           //   out << "\nfalse";
 
           out << "\nlist " << axes[i] << cell->active_cell_index() << " ";
-          for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell;
-               ++j)
+          for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
             out << cell->vertex(j)[i] << " ";
         }
       out << '\n';
@@ -2981,7 +2975,7 @@ namespace
         patch.n_subdivisions = 1;
         patch.data.reinit(5, GeometryInfo<dim>::vertices_per_cell);
 
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             patch.vertices[v] = cell->vertex(v);
             patch.data(0, v)  = cell->level();
@@ -3231,7 +3225,7 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
     for (const auto &cell : tria.active_cell_iterators())
       {
         out << GeometryInfo<dim>::vertices_per_cell;
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           {
             out << ' ' << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[i]);
           }
@@ -4055,8 +4049,7 @@ namespace internal
               // write out the four sides of this cell by putting the four
               // points (+ the initial point again) in a row and lifting the
               // drawing pencil at the end
-              for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
-                   ++i)
+              for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
                 out << cell->vertex(GeometryInfo<dim>::ucd_to_deal[i]) << ' '
                     << cell->level() << ' '
                     << static_cast<unsigned int>(cell->material_id()) << '\n';
@@ -4830,9 +4823,8 @@ namespace internal
           // doing this multiply
           std::set<unsigned int> treated_vertices;
           for (const auto &cell : tria.active_cell_iterators())
-            for (unsigned int vertex = 0;
-                 vertex < GeometryInfo<dim>::vertices_per_cell;
-                 ++vertex)
+            for (const unsigned int vertex :
+                 GeometryInfo<dim>::vertex_indices())
               if (treated_vertices.find(cell->vertex_index(vertex)) ==
                   treated_vertices.end())
                 {

--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -386,7 +386,7 @@ namespace
      */
     Cell(const CellData<dim> &c, const std::vector<Edge<dim>> &edge_list)
     {
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         vertex_indices[i] = c.vertices[i];
 
       // now for each of the edges of this cell, find the location inside the
@@ -922,13 +922,11 @@ namespace
 
             unsigned int
               temp_vertex_indices[GeometryInfo<dim>::vertices_per_cell];
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               temp_vertex_indices[v] =
                 raw_cells[cell_index]
                   .vertices[cube_permutations[origin_vertex_of_cell][v]];
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               raw_cells[cell_index].vertices[v] = temp_vertex_indices[v];
 
             break;
@@ -1037,9 +1035,9 @@ namespace
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
     for (auto &cell : cells)
       {
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           tmp[i] = cell.vertices[i];
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           cell.vertices[i] = tmp[GeometryInfo<3>::ucd_to_deal[i]];
       }
   }
@@ -1065,9 +1063,9 @@ namespace
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
     for (auto &cell : cells)
       {
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           tmp[i] = cell.vertices[i];
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           cell.vertices[GeometryInfo<3>::ucd_to_deal[i]] = tmp[i];
       }
   }
@@ -1159,7 +1157,7 @@ GridReordering<2>::invert_all_cells_of_negative_grid(
       // GridTools::cell_measure
       // requires the vertices to be
       // in lexicographic ordering
-      for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<2>::vertex_indices())
         vertices_lex[GeometryInfo<2>::ucd_to_deal[i]] = cell.vertices[i];
       if (GridTools::cell_measure<2>(all_vertices, vertices_lex) < 0)
         {
@@ -1169,7 +1167,7 @@ GridReordering<2>::invert_all_cells_of_negative_grid(
           // Check whether the resulting cell is now ok.
           // If not, then the grid is seriously broken and
           // we just give up.
-          for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<2>::vertex_indices())
             vertices_lex[GeometryInfo<2>::ucd_to_deal[i]] = cell.vertices[i];
           AssertThrow(GridTools::cell_measure<2>(all_vertices, vertices_lex) >
                         0,
@@ -1225,7 +1223,7 @@ GridReordering<3>::invert_all_cells_of_negative_grid(
       // GridTools::cell_measure
       // requires the vertices to be
       // in lexicographic ordering
-      for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<3>::vertex_indices())
         vertices_lex[GeometryInfo<3>::ucd_to_deal[i]] = cell.vertices[i];
       if (GridTools::cell_measure<3>(all_vertices, vertices_lex) < 0)
         {
@@ -1237,7 +1235,7 @@ GridReordering<3>::invert_all_cells_of_negative_grid(
           // Check whether the resulting cell is now ok.
           // If not, then the grid is seriously broken and
           // we just give up.
-          for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+          for (const unsigned int i : GeometryInfo<3>::vertex_indices())
             vertices_lex[GeometryInfo<3>::ucd_to_deal[i]] = cell.vertices[i];
           AssertThrow(GridTools::cell_measure<3>(all_vertices, vertices_lex) >
                         0,

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -650,9 +650,8 @@ namespace GridTools
 
     unsigned int max_level_0_vertex_n = 0;
     for (const auto &cell : tria.cell_iterators_on_level(0))
-      for (unsigned int cell_vertex_n = 0;
-           cell_vertex_n < GeometryInfo<dim>::vertices_per_cell;
-           ++cell_vertex_n)
+      for (const unsigned int cell_vertex_n :
+           GeometryInfo<dim>::vertex_indices())
         max_level_0_vertex_n =
           std::max(cell->vertex_index(cell_vertex_n), max_level_0_vertex_n);
     vertices.resize(max_level_0_vertex_n + 1);
@@ -664,9 +663,8 @@ namespace GridTools
       {
         // Save cell data
         CellData<dim> cell_data;
-        for (unsigned int cell_vertex_n = 0;
-             cell_vertex_n < GeometryInfo<dim>::vertices_per_cell;
-             ++cell_vertex_n)
+        for (const unsigned int cell_vertex_n :
+             GeometryInfo<dim>::vertex_indices())
           {
             Assert(cell->vertex_index(cell_vertex_n) < vertices.size(),
                    ExcInternalError());
@@ -712,9 +710,8 @@ namespace GridTools
     {
       std::vector<bool> used_vertices(vertices.size());
       for (const CellData<dim> &cell_data : cells)
-        for (unsigned int cell_vertex_n = 0;
-             cell_vertex_n < GeometryInfo<dim>::vertices_per_cell;
-             ++cell_vertex_n)
+        for (const unsigned int cell_vertex_n :
+             GeometryInfo<dim>::vertex_indices())
           used_vertices[cell_data.vertices[cell_vertex_n]] = true;
       Assert(std::find(used_vertices.begin(), used_vertices.end(), false) ==
                used_vertices.end(),
@@ -753,7 +750,7 @@ namespace GridTools
     // first check which vertices are actually used
     std::vector<bool> vertex_used(vertices.size(), false);
     for (unsigned int c = 0; c < cells.size(); ++c)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           Assert(cells[c].vertices[v] < vertices.size(),
                  ExcMessage("Invalid vertex index encountered! cells[" +
@@ -782,13 +779,13 @@ namespace GridTools
 
     // next replace old vertex numbers by the new ones
     for (unsigned int c = 0; c < cells.size(); ++c)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         cells[c].vertices[v] = new_vertex_numbers[cells[c].vertices[v]];
 
     // same for boundary data
     for (unsigned int c = 0; c < subcelldata.boundary_lines.size(); // NOLINT
          ++c)
-      for (unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<1>::vertex_indices())
         {
           Assert(subcelldata.boundary_lines[c].vertices[v] <
                    new_vertex_numbers.size(),
@@ -808,7 +805,7 @@ namespace GridTools
 
     for (unsigned int c = 0; c < subcelldata.boundary_quads.size(); // NOLINT
          ++c)
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         {
           Assert(subcelldata.boundary_quads[c].vertices[v] <
                    new_vertex_numbers.size(),
@@ -1183,9 +1180,7 @@ namespace GridTools
       {
         // loop over all vertices of the cell and see if it is listed in the map
         // given as first argument of the function
-        for (unsigned int vertex_no = 0;
-             vertex_no < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex_no)
+        for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
           {
             const unsigned int vertex_index = cell->vertex_index(vertex_no);
             const Point<dim> & vertex_point = cell->vertex(vertex_no);
@@ -1218,9 +1213,7 @@ namespace GridTools
     // according to the computed values
     std::vector<bool> vertex_touched(triangulation.n_vertices(), false);
     for (const auto &cell : dof_handler.active_cell_iterators())
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         if (vertex_touched[cell->vertex_index(vertex_no)] == false)
           {
             Point<dim> &v = cell->vertex(vertex_no);
@@ -1382,9 +1375,8 @@ namespace GridTools
              ++cell)
           if (cell->is_locally_owned())
             {
-              for (unsigned int vertex_no = 0;
-                   vertex_no < GeometryInfo<dim>::vertices_per_cell;
-                   ++vertex_no)
+              for (const unsigned int vertex_no :
+                   GeometryInfo<dim>::vertex_indices())
                 {
                   const unsigned global_vertex_no =
                     cell->vertex_index(vertex_no);
@@ -1458,9 +1450,8 @@ namespace GridTools
                triangulation.begin_active();
              cell != triangulation.end();
              ++cell)
-          for (unsigned int vertex_no = 0;
-               vertex_no < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex_no)
+          for (const unsigned int vertex_no :
+               GeometryInfo<dim>::vertex_indices())
             cell->vertex(vertex_no) =
               new_vertex_locations[cell->vertex_index(vertex_no)];
       }
@@ -1700,7 +1691,7 @@ namespace GridTools
     // list, but std::set throws out those cells already entered
     for (const auto &cell : mesh.active_cell_iterators())
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; v++)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           if (cell->vertex_index(v) == vertex)
             {
               // OK, we found a cell that contains
@@ -2070,9 +2061,8 @@ namespace GridTools
 
         for (; i < active_cells.size(); ++i)
           if (predicate(active_cells[i]))
-            for (unsigned int v = 0;
-                 v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v :
+                 GeometryInfo<MeshType::dimension>::vertex_indices())
               for (unsigned int d = 0; d < spacedim; ++d)
                 {
                   minp[d] = std::min(minp[d], active_cells[i]->vertex(v)[d]);
@@ -2344,7 +2334,7 @@ namespace GridTools
       cell = triangulation.begin_active(),
       endc = triangulation.end();
     for (; cell != endc; ++cell)
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         vertex_to_cell_map[cell->vertex_index(i)].insert(cell);
 
     // Take care of hanging nodes
@@ -2429,8 +2419,7 @@ namespace GridTools
       {
         if (cell->is_locally_owned())
           {
-            for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell;
-                 ++i)
+            for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
               {
                 types::subdomain_id lowest_subdomain_id = cell->subdomain_id();
                 typename std::set<active_cell_iterator>::iterator
@@ -2799,7 +2788,7 @@ namespace GridTools
          cell != triangulation.end();
          ++cell)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           vertex_to_cell[cell->vertex_index(v)].push_back(
             cell->active_cell_index());
       }
@@ -2811,7 +2800,7 @@ namespace GridTools
          cell != triangulation.end();
          ++cell)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           for (unsigned int n = 0;
                n < vertex_to_cell[cell->vertex_index(v)].size();
                ++n)
@@ -2835,7 +2824,7 @@ namespace GridTools
          cell != triangulation.end(level);
          ++cell)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           vertex_to_cell[cell->vertex_index(v)].push_back(cell->index());
       }
 
@@ -2846,7 +2835,7 @@ namespace GridTools
          cell != triangulation.end(level);
          ++cell)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           for (unsigned int n = 0;
                n < vertex_to_cell[cell->vertex_index(v)].size();
                ++n)
@@ -3271,8 +3260,7 @@ namespace GridTools
         if (cell->is_artificial() ||
             (cell->is_ghost() &&
              (cell->subdomain_id() < tr->locally_owned_subdomain())))
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             locally_owned_vertices[cell->vertex_index(v)] = false;
 
     return locally_owned_vertices;
@@ -3412,8 +3400,7 @@ namespace GridTools
         Tensor<spacedim - structdim, spacedim>
           parent_alternating_forms[GeometryInfo<structdim>::vertices_per_cell];
 
-        for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell;
-             ++i)
+        for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
           parent_vertices[i] = object->vertex(i);
 
         GeometryInfo<structdim>::alternating_form_at_vertices(
@@ -3441,9 +3428,7 @@ namespace GridTools
           [GeometryInfo<structdim>::vertices_per_cell];
 
         for (unsigned int c = 0; c < object->n_children(); ++c)
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
             child_vertices[c][i] = object->child(c)->vertex(i);
 
         // replace mid-object
@@ -3472,9 +3457,7 @@ namespace GridTools
         // objective function
         double objective = 0;
         for (unsigned int c = 0; c < object->n_children(); ++c)
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
             objective +=
               (child_alternating_forms[c][i] -
                average_parent_alternating_form / std::pow(2., 1. * structdim))
@@ -3689,8 +3672,7 @@ namespace GridTools
 
         Point<spacedim>
           parent_vertices[GeometryInfo<structdim>::vertices_per_cell];
-        for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell;
-             ++i)
+        for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
           parent_vertices[i] = object->vertex(i);
 
         Tensor<spacedim - structdim, spacedim>
@@ -3703,9 +3685,7 @@ namespace GridTools
                         [GeometryInfo<structdim>::vertices_per_cell];
 
         for (unsigned int c = 0; c < object->n_children(); ++c)
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
             child_vertices[c][i] = object->child(c)->vertex(i);
 
         Tensor<spacedim - structdim, spacedim> child_alternating_forms
@@ -3719,12 +3699,9 @@ namespace GridTools
         old_min_product =
           child_alternating_forms[0][0] * parent_alternating_forms[0];
         for (unsigned int c = 0; c < object->n_children(); ++c)
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
-            for (unsigned int j = 0;
-                 j < GeometryInfo<structdim>::vertices_per_cell;
-                 ++j)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
+            for (const unsigned int j :
+                 GeometryInfo<structdim>::vertex_indices())
               old_min_product = std::min<double>(old_min_product,
                                                  child_alternating_forms[c][i] *
                                                    parent_alternating_forms[j]);
@@ -3746,12 +3723,9 @@ namespace GridTools
         new_min_product =
           child_alternating_forms[0][0] * parent_alternating_forms[0];
         for (unsigned int c = 0; c < object->n_children(); ++c)
-          for (unsigned int i = 0;
-               i < GeometryInfo<structdim>::vertices_per_cell;
-               ++i)
-            for (unsigned int j = 0;
-                 j < GeometryInfo<structdim>::vertices_per_cell;
-                 ++j)
+          for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
+            for (const unsigned int j :
+                 GeometryInfo<structdim>::vertex_indices())
               new_min_product = std::min<double>(new_min_product,
                                                  child_alternating_forms[c][i] *
                                                    parent_alternating_forms[j]);
@@ -4414,8 +4388,7 @@ namespace GridTools
         if (cells_to_remove[cell->active_cell_index()] == false)
           {
             CellData<dim> c;
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               c.vertices[v] = cell->vertex_index(v);
             c.manifold_id = cell->manifold_id();
             c.material_id = cell->material_id();
@@ -4437,18 +4410,14 @@ namespace GridTools
               CellData<1> line;
               if (dim == 2)
                 {
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<1>::vertices_per_cell;
-                       ++v)
+                  for (const unsigned int v : GeometryInfo<1>::vertex_indices())
                     line.vertices[v] = face->vertex_index(v);
                   line.boundary_id = face->boundary_id();
                   line.manifold_id = face->manifold_id();
                 }
               else
                 {
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<1>::vertices_per_cell;
-                       ++v)
+                  for (const unsigned int v : GeometryInfo<1>::vertex_indices())
                     line.vertices[v] = face->line(l)->vertex_index(v);
                   line.boundary_id = face->line(l)->boundary_id();
                   line.manifold_id = face->line(l)->manifold_id();
@@ -4458,8 +4427,7 @@ namespace GridTools
           if (dim == 3)
             {
               CellData<2> quad;
-              for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<2>::vertex_indices())
                 quad.vertices[v] = face->vertex_index(v);
               quad.boundary_id = face->boundary_id();
               quad.manifold_id = face->manifold_id();

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -253,7 +253,7 @@ namespace GridTools
     // list, but std::set throws out those cells already entered
     for (; cell != endc; ++cell)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; v++)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           if (cell->vertex_index(v) == vertex)
             {
               // OK, we found a cell that contains
@@ -748,9 +748,8 @@ namespace GridTools
     // the halo layer
     for (const auto &cell : mesh.active_cell_iterators())
       if (predicate(cell)) // True predicate --> Part of subdomain
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           locally_active_vertices_on_subdomain[cell->vertex_index(v)] = true;
 
     // Find the cells that do not conform to the predicate
@@ -758,9 +757,8 @@ namespace GridTools
     // These comprise the halo layer
     for (const auto &cell : mesh.active_cell_iterators())
       if (!predicate(cell)) // False predicate --> Potential halo cell
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           if (locally_active_vertices_on_subdomain[cell->vertex_index(v)] ==
               true)
             {
@@ -792,9 +790,8 @@ namespace GridTools
          cell != mesh.end(level);
          ++cell)
       if (predicate(cell)) // True predicate --> Part of subdomain
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           locally_active_vertices_on_level_subdomain[cell->vertex_index(v)] =
             true;
 
@@ -805,9 +802,8 @@ namespace GridTools
          cell != mesh.end(level);
          ++cell)
       if (!predicate(cell)) // False predicate --> Potential halo cell
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           if (locally_active_vertices_on_level_subdomain[cell->vertex_index(
                 v)] == true)
             {
@@ -906,9 +902,8 @@ namespace GridTools
     for (const auto &cell : mesh.active_cell_iterators())
       if (!predicate(cell)) // Negation of predicate --> Not Part of subdomain
         {
-          for (unsigned int v = 0;
-               v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v :
+               GeometryInfo<MeshType::dimension>::vertex_indices())
             vertices_outside_subdomain[cell->vertex_index(v)] = true;
           n_non_predicate_cells++;
         }
@@ -926,9 +921,8 @@ namespace GridTools
     for (const auto &cell : mesh.active_cell_iterators())
       if (predicate(cell)) // True predicate --> Potential boundary cell of the
                            // subdomain
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           if (vertices_outside_subdomain[cell->vertex_index(v)] == true)
             {
               subdomain_boundary_cells.push_back(cell);
@@ -1093,9 +1087,8 @@ namespace GridTools
     // if it belongs to the predicate domain, extend the bounding box.
     for (const auto &cell : mesh.active_cell_iterators())
       if (predicate(cell)) // True predicate --> Part of subdomain
-        for (unsigned int v = 0;
-             v < GeometryInfo<MeshType::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<MeshType::dimension>::vertex_indices())
           if (locally_active_vertices_on_subdomain[cell->vertex_index(v)] ==
               false)
             {
@@ -1238,7 +1231,7 @@ namespace GridTools
                                                            mesh_2.begin(0),
                                                          endc = mesh_1.end(0);
     for (; cell_1 != endc; ++cell_1, ++cell_2)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (cell_1->vertex(v) != cell_2->vertex(v))
           return false;
 
@@ -1513,9 +1506,8 @@ namespace GridTools
          uniform_cell != uniform_cells.end();
          ++uniform_cell)
       {
-        for (unsigned int v = 0;
-             v < GeometryInfo<Container::dimension>::vertices_per_cell;
-             ++v)
+        for (const unsigned int v :
+             GeometryInfo<Container::dimension>::vertex_indices())
           {
             Point<Container::space_dimension> position =
               (*uniform_cell)->vertex(v);
@@ -1594,10 +1586,8 @@ namespace GridTools
                     {
                       // adjust the cell vertices of the local_triangulation to
                       // match cell vertices of the global triangulation
-                      for (unsigned int v = 0;
-                           v < GeometryInfo<
-                                 Container::dimension>::vertices_per_cell;
-                           ++v)
+                      for (const unsigned int v :
+                           GeometryInfo<Container::dimension>::vertex_indices())
                         active_tria_cell->vertex(v) = patch[i]->vertex(v);
 
                       Assert(active_tria_cell->center().distance(

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -902,16 +902,14 @@ FlatManifold<dim, spacedim>::normal_vector(
   while (true)
     {
       Point<spacedim> F;
-      for (unsigned int v = 0; v < GeometryInfo<facedim>::vertices_per_cell;
-           ++v)
+      for (const unsigned int v : GeometryInfo<facedim>::vertex_indices())
         F += face->vertex(v) *
              GeometryInfo<facedim>::d_linear_shape_function(xi, v);
 
       for (unsigned int i = 0; i < facedim; ++i)
         {
           grad_F[i] = 0;
-          for (unsigned int v = 0; v < GeometryInfo<facedim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<facedim>::vertex_indices())
             grad_F[i] +=
               face->vertex(v) *
               GeometryInfo<facedim>::d_linear_shape_function_gradient(xi, v)[i];

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1740,7 +1740,7 @@ namespace
 
     Point<spacedim> new_point;
     if (cell_is_flat)
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         new_point += weights_vertices[v] * vertices[v];
     else
       {
@@ -1798,7 +1798,7 @@ namespace
           }
 
         // subtract contribution from the vertices (second line in formula)
-        for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<2>::vertex_indices())
           new_point -= weights_vertices[v] * vertices[v];
       }
 
@@ -1932,8 +1932,7 @@ namespace
               }
             else
               {
-                for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<2>::vertex_indices())
                   points[v] = vertices[face_to_cell_vertices_3d[face][v]];
                 weights[0] =
                   linear_shapes[face_even + 2] * linear_shapes[face_even + 4];
@@ -2000,7 +1999,7 @@ namespace
           }
 
         // finally add the contribution of the
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           new_point += weights_vertices[v] * vertices[v];
       }
     return new_point;
@@ -2243,9 +2242,7 @@ TransfiniteInterpolationManifold<dim, spacedim>::
 
       std::array<Point<spacedim>, GeometryInfo<dim>::vertices_per_cell>
         vertices;
-      for (unsigned int vertex_n = 0;
-           vertex_n < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_n)
+      for (const unsigned int vertex_n : GeometryInfo<dim>::vertex_indices())
         {
           vertices[vertex_n] = cell->vertex(vertex_n);
         }
@@ -2254,11 +2251,11 @@ TransfiniteInterpolationManifold<dim, spacedim>::
       // center of the loop, we can skip the expensive part below (this assumes
       // that the manifold does not deform the grid too much)
       Point<spacedim> center;
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         center += vertices[v];
       center *= 1. / GeometryInfo<dim>::vertices_per_cell;
       double radius_square = 0.;
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         radius_square =
           std::max(radius_square, (center - vertices[v]).norm_square());
       bool inside_circle = true;
@@ -2531,8 +2528,7 @@ TransfiniteInterpolationManifold<dim, spacedim>::compute_chart_points(
                 triangulation, level_coarse, nearby_cells[b]);
               message << "Looking at cell " << cell->id()
                       << " with vertices: " << std::endl;
-              for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                 message << cell->vertex(v) << "    ";
               message << std::endl;
               message << "Transformation to chart coordinates: " << std::endl;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -60,7 +60,7 @@ template <int structdim>
 bool
 CellData<structdim>::operator==(const CellData<structdim> &other) const
 {
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; i++)
+  for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
     if (vertices[i] != other.vertices[i])
       return false;
 
@@ -439,7 +439,7 @@ namespace
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           min_adjacent_cell_level[cell->vertex_index(v)] =
             std::min<unsigned int>(
@@ -547,9 +547,9 @@ namespace
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
     for (auto &cell : cells)
       {
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           tmp[i] = cell.vertices[i];
-        for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<3>::vertex_indices())
           cell.vertices[GeometryInfo<3>::ucd_to_deal[i]] = tmp[i];
       }
 
@@ -691,13 +691,13 @@ namespace
          ++cell)
       {
         Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           vertices[i] = cell->vertex(i);
 
         Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
         GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
 
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           if (determinants[i] <= 1e-9 * std::pow(cell->diameter(), 1. * dim))
             {
               distorted_cells.distorted_cells.push_back(cell);
@@ -727,13 +727,13 @@ namespace
     for (unsigned int c = 0; c < cell->n_children(); ++c)
       {
         Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           vertices[i] = cell->child(c)->vertex(i);
 
         Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
         GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
 
-        for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+        for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
           if (determinants[i] <=
               1e-9 * std::pow(cell->child(c)->diameter(), 1. * dim))
             return true;
@@ -1894,9 +1894,7 @@ namespace internal
         // for all lines
         for (; line != triangulation.end(); ++line)
           // for each of the two vertices
-          for (unsigned int vertex = 0;
-               vertex < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex)
+          for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
             // if first cell adjacent to
             // this vertex is the present
             // one, then the neighbor is
@@ -13318,8 +13316,7 @@ Triangulation<dim, spacedim>::max_adjacent_cells() const
   // vertices used on level 0
   unsigned int max_vertex_index = 0;
   for (; cell != endc; ++cell)
-    for (unsigned int vertex = 0; vertex < GeometryInfo<dim>::vertices_per_cell;
-         ++vertex)
+    for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
       if (cell->vertex_index(vertex) > max_vertex_index)
         max_vertex_index = cell->vertex_index(vertex);
 
@@ -13332,8 +13329,7 @@ Triangulation<dim, spacedim>::max_adjacent_cells() const
   // every time we find an adjacent
   // element
   for (cell = begin(); cell != endc; ++cell)
-    for (unsigned int vertex = 0; vertex < GeometryInfo<dim>::vertices_per_cell;
-         ++vertex)
+    for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
       ++usage_count[cell->vertex_index(vertex)];
 
   return std::max(GeometryInfo<dim>::vertices_per_cell,
@@ -13684,16 +13680,14 @@ Triangulation<dim, spacedim>::fix_coarsen_flags()
           for (; cell != endc; ++cell)
             {
               if (cell->refine_flag_set())
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   vertex_level[cell->vertex_index(vertex)] =
                     std::max(vertex_level[cell->vertex_index(vertex)],
                              cell->level() + 1);
               else if (!cell->coarsen_flag_set())
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   vertex_level[cell->vertex_index(vertex)] =
                     std::max(vertex_level[cell->vertex_index(vertex)],
                              cell->level());
@@ -13706,9 +13700,8 @@ Triangulation<dim, spacedim>::fix_coarsen_flags()
                   // to correct this by iterating over the entire
                   // process until we are converged
                   Assert(cell->coarsen_flag_set(), ExcInternalError());
-                  for (unsigned int vertex = 0;
-                       vertex < GeometryInfo<dim>::vertices_per_cell;
-                       ++vertex)
+                  for (const unsigned int vertex :
+                       GeometryInfo<dim>::vertex_indices())
                     vertex_level[cell->vertex_index(vertex)] =
                       std::max(vertex_level[cell->vertex_index(vertex)],
                                cell->level() - 1);
@@ -13728,9 +13721,8 @@ Triangulation<dim, spacedim>::fix_coarsen_flags()
           for (cell = last_active(); cell != endc; --cell)
             if (cell->refine_flag_set() == false)
               {
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   if (vertex_level[cell->vertex_index(vertex)] >=
                       cell->level() + 1)
                     {
@@ -13745,9 +13737,8 @@ Triangulation<dim, spacedim>::fix_coarsen_flags()
                         {
                           cell->set_refine_flag();
 
-                          for (unsigned int v = 0;
-                               v < GeometryInfo<dim>::vertices_per_cell;
-                               ++v)
+                          for (const unsigned int v :
+                               GeometryInfo<dim>::vertex_indices())
                             vertex_level[cell->vertex_index(v)] =
                               std::max(vertex_level[cell->vertex_index(v)],
                                        cell->level() + 1);
@@ -14356,16 +14347,14 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
           for (const auto &cell : active_cell_iterators())
             {
               if (cell->refine_flag_set())
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   vertex_level[cell->vertex_index(vertex)] =
                     std::max(vertex_level[cell->vertex_index(vertex)],
                              cell->level() + 1);
               else if (!cell->coarsen_flag_set())
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   vertex_level[cell->vertex_index(vertex)] =
                     std::max(vertex_level[cell->vertex_index(vertex)],
                              cell->level());
@@ -14376,9 +14365,8 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
                   // always true (the coarsen flag could be removed
                   // again) and so we may make an error here
                   Assert(cell->coarsen_flag_set(), ExcInternalError());
-                  for (unsigned int vertex = 0;
-                       vertex < GeometryInfo<dim>::vertices_per_cell;
-                       ++vertex)
+                  for (const unsigned int vertex :
+                       GeometryInfo<dim>::vertex_indices())
                     vertex_level[cell->vertex_index(vertex)] =
                       std::max(vertex_level[cell->vertex_index(vertex)],
                                cell->level() - 1);
@@ -14398,9 +14386,8 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
           for (active_cell_iterator cell = last_active(); cell != end(); --cell)
             if (cell->refine_flag_set() == false)
               {
-                for (unsigned int vertex = 0;
-                     vertex < GeometryInfo<dim>::vertices_per_cell;
-                     ++vertex)
+                for (const unsigned int vertex :
+                     GeometryInfo<dim>::vertex_indices())
                   if (vertex_level[cell->vertex_index(vertex)] >=
                       cell->level() + 1)
                     {
@@ -14415,9 +14402,8 @@ Triangulation<dim, spacedim>::prepare_coarsening_and_refinement()
                         {
                           cell->set_refine_flag();
 
-                          for (unsigned int v = 0;
-                               v < GeometryInfo<dim>::vertices_per_cell;
-                               ++v)
+                          for (const unsigned int v :
+                               GeometryInfo<dim>::vertex_indices())
                             vertex_level[cell->vertex_index(v)] =
                               std::max(vertex_level[cell->vertex_index(v)],
                                        cell->level() + 1);

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1265,7 +1265,7 @@ namespace
   measure(const TriaAccessor<2, 2, 2> &accessor)
   {
     unsigned int vertex_indices[GeometryInfo<2>::vertices_per_cell];
-    for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<2>::vertex_indices())
       vertex_indices[i] = accessor.vertex_index(i);
 
     return GridTools::cell_measure<2>(
@@ -1277,7 +1277,7 @@ namespace
   measure(const TriaAccessor<3, 3, 3> &accessor)
   {
     unsigned int vertex_indices[GeometryInfo<3>::vertices_per_cell];
-    for (unsigned int i = 0; i < GeometryInfo<3>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<3>::vertex_indices())
       vertex_indices[i] = accessor.vertex_index(i);
 
     return GridTools::cell_measure<3>(
@@ -1570,7 +1570,7 @@ TriaAccessor<structdim, dim, spacedim>::intermediate_point(
   std::array<Point<spacedim>, GeometryInfo<structdim>::vertices_per_cell> p;
   std::array<double, GeometryInfo<structdim>::vertices_per_cell>          w;
 
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
     {
       p[i] = this->vertex(i);
       w[i] = GeometryInfo<structdim>::d_linear_shape_function(coordinates, i);
@@ -1690,17 +1690,16 @@ TriaAccessor<structdim, dim, spacedim>::real_to_unit_cell_affine_approximation(
   // copy vertices to avoid expensive resolution of vertex index inside loop
   std::array<Point<spacedim>, GeometryInfo<structdim>::vertices_per_cell>
     vertices;
-  for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
     vertices[v] = this->vertex(v);
   for (unsigned int d = 0; d < spacedim; ++d)
-    for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell;
-         ++v)
+    for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
       for (unsigned int e = 0; e < structdim; ++e)
         A[d][e] += vertices[v][d] * TransformR2UAffine<structdim>::KA[v][e];
 
   // b = vertex * Kb
   Tensor<1, spacedim> b = point;
-  for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
     b -= vertices[v] * TransformR2UAffine<structdim>::Kb[v];
 
   DerivativeForm<1, spacedim, structdim> A_inv = A.covariant_form().transpose();
@@ -1718,8 +1717,7 @@ TriaAccessor<structdim, dim, spacedim>::center(
     {
       Assert(use_interpolation == false, ExcNotImplemented());
       Point<spacedim> p;
-      for (unsigned int v = 0; v < GeometryInfo<structdim>::vertices_per_cell;
-           ++v)
+      for (const unsigned int v : GeometryInfo<structdim>::vertex_indices())
         p += vertex(v);
       return p / GeometryInfo<structdim>::vertices_per_cell;
     }

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -164,8 +164,7 @@ namespace TriangulationDescription
           TriaIterator<CellAccessor<dim, spacedim>> &cell,
           std::vector<bool> &vertices_owned_by_locally_owned_cells) {
           // add local vertices
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               vertices_owned_by_locally_owned_cells[cell->vertex_index(v)] =
                 true;
@@ -204,8 +203,7 @@ namespace TriangulationDescription
           auto is_locally_relevant = [&](
                                        TriaIterator<CellAccessor<dim, spacedim>>
                                          &cell) {
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (vertices_owned_by_locally_owned_cells[cell->vertex_index(v)])
                 return true;
             return false;
@@ -228,16 +226,12 @@ namespace TriangulationDescription
                 dealii::CellData<dim> cell_data;
                 cell_data.material_id = cell->material_id();
                 cell_data.manifold_id = cell->manifold_id();
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   cell_data.vertices[v] = cell->vertex_index(v);
                 construction_data.coarse_cells.push_back(cell_data);
 
                 // b) save indices of each vertex of this cell
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   vertices_locally_relevant[cell->vertex_index(v)] =
                     numbers::invalid_unsigned_int;
 
@@ -304,8 +298,7 @@ namespace TriangulationDescription
 
           // 4) correct vertices of cells (make them local)
           for (auto &cell : construction_data.coarse_cells)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               cell.vertices[v] = vertices_locally_relevant[cell.vertices[v]];
         }
       else
@@ -347,9 +340,8 @@ namespace TriangulationDescription
               // owned cell)
               auto is_locally_relevant_on_level =
                 [&](TriaIterator<CellAccessor<dim, spacedim>> &cell) {
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<dim>::vertices_per_cell;
-                       ++v)
+                  for (const unsigned int v :
+                       GeometryInfo<dim>::vertex_indices())
                     if (vertices_owned_by_locally_owned_cells_on_level
                           [cell->vertex_index(v)])
                       return true;
@@ -376,16 +368,12 @@ namespace TriangulationDescription
                 dealii::CellData<dim> cell_data;
                 cell_data.material_id = cell->material_id();
                 cell_data.manifold_id = cell->manifold_id();
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   cell_data.vertices[v] = cell->vertex_index(v);
                 construction_data.coarse_cells.push_back(cell_data);
 
                 // save indices of each vertex of this cell
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   vertices_locally_relevant[cell->vertex_index(v)] =
                     numbers::invalid_unsigned_int;
 
@@ -405,8 +393,7 @@ namespace TriangulationDescription
 
             // c) correct vertices of cells (make them local)
             for (auto &cell : construction_data.coarse_cells)
-              for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                 cell.vertices[v] = vertices_locally_relevant[cell.vertices[v]];
           }
 
@@ -428,9 +415,7 @@ namespace TriangulationDescription
           auto is_locally_relevant_on_active_level =
             [&](TriaIterator<CellAccessor<dim, spacedim>> &cell) {
               if (cell->active())
-                for (unsigned int v = 0;
-                     v < GeometryInfo<dim>::vertices_per_cell;
-                     ++v)
+                for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                   if (vertices_owned_by_locally_owned_active_cells
                         [cell->vertex_index(v)])
                     return true;
@@ -454,9 +439,8 @@ namespace TriangulationDescription
               // on level
               auto is_locally_relevant_on_level =
                 [&](TriaIterator<CellAccessor<dim, spacedim>> &cell) {
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<dim>::vertices_per_cell;
-                       ++v)
+                  for (const unsigned int v :
+                       GeometryInfo<dim>::vertex_indices())
                     if (vertices_owned_by_locally_owned_cells_on_level
                           [cell->vertex_index(v)])
                       return true;

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -178,8 +178,7 @@ namespace internal
                cell != dof_handler.end();
                ++cell)
             if (!cell->is_artificial())
-              for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                 locally_used_vertices[cell->vertex_index(v)] = true;
 
           std::vector<std::vector<bool>> vertex_fe_association(
@@ -191,8 +190,7 @@ namespace internal
                cell != dof_handler.end();
                ++cell)
             if (!cell->is_artificial())
-              for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                   ++v)
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
                 vertex_fe_association[cell->active_fe_index()]
                                      [cell->vertex_index(v)] = true;
 

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -102,9 +102,8 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
   // set the vertices of the patch. if the mapping does not preserve locations
   // (e.g. MappingQEulerian), we need to compute the offset of the vertex for
   // the graphical output. Otherwise, we can just use the vertex info.
-  for (unsigned int vertex = 0;
-       vertex < GeometryInfo<DoFHandlerType::dimension>::vertices_per_cell;
-       ++vertex)
+  for (const unsigned int vertex :
+       GeometryInfo<DoFHandlerType::dimension>::vertex_indices())
     if (scratch_data.mapping_collection[0].preserves_vertex_locations())
       patch.vertices[vertex] = cell_and_index->first->vertex(vertex);
     else

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -159,9 +159,8 @@ DataOutRotation<dim, DoFHandlerType>::build_one_patch(
 
           case 2:
             {
-              for (unsigned int vertex = 0;
-                   vertex < GeometryInfo<dimension>::vertices_per_cell;
-                   ++vertex)
+              for (const unsigned int vertex :
+                   GeometryInfo<dimension>::vertex_indices())
                 {
                   const Point<dimension> v = (*cell)->vertex(vertex);
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1106,8 +1106,7 @@ namespace Particles
     for (const auto &cell : triangulation->active_cell_iterators())
       {
         if (cell->is_ghost())
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
               cell->subdomain_id());
       }
@@ -1117,8 +1116,7 @@ namespace Particles
         if (!cell->is_ghost())
           {
             std::set<unsigned int> cell_to_neighbor_subdomain;
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               {
                 cell_to_neighbor_subdomain.insert(
                   vertex_to_neighbor_subdomain[cell->vertex_index(v)].begin(),

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -714,8 +714,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/ad_common_tests/step-44-helper_scalar_01.h
+++ b/tests/ad_common_tests/step-44-helper_scalar_01.h
@@ -994,8 +994,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -680,8 +680,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/ad_common_tests/step-44-helper_vector_01.h
+++ b/tests/ad_common_tests/step-44-helper_vector_01.h
@@ -715,8 +715,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/adolc/step-44.cc
+++ b/tests/adolc/step-44.cc
@@ -829,8 +829,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/base/geometry_info_2.cc
+++ b/tests/base/geometry_info_2.cc
@@ -99,7 +99,7 @@ test()
   for (unsigned int f = 0; f < GeometryInfo<dim>::lines_per_cell; ++f)
     {
       deallog << "line_vertices" << f;
-      for (unsigned int v = 0; v < GeometryInfo<1>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<1>::vertex_indices())
         deallog << ' ' << GeometryInfo<dim>::line_to_cell_vertices(f, v);
       deallog << std::endl;
     }

--- a/tests/base/geometry_info_4.cc
+++ b/tests/base/geometry_info_4.cc
@@ -30,8 +30,8 @@ test()
   deallog << "Checking in " << dim << "d" << std::endl;
 
   // check phi_i(v_j) = delta_{ij}
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         const double phi_i = GeometryInfo<dim>::d_linear_shape_function(
           GeometryInfo<dim>::unit_cell_vertex(v), i);
@@ -44,10 +44,10 @@ test()
   //    sum_i phi_i(x) == 1
   // at all points. do so at every
   // vertex, and then at the center
-  for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
     {
       double s = 0;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         s += GeometryInfo<dim>::d_linear_shape_function(
           GeometryInfo<dim>::unit_cell_vertex(v), i);
       AssertThrow(s == 1, ExcInternalError());
@@ -60,7 +60,7 @@ test()
       center[i] = 0.5;
 
     double s = 0;
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       s += GeometryInfo<dim>::d_linear_shape_function(center, i);
     AssertThrow(s == 1, ExcInternalError());
 

--- a/tests/base/geometry_info_5.cc
+++ b/tests/base/geometry_info_5.cc
@@ -30,8 +30,8 @@ test()
   deallog << "Checking in " << dim << "d" << std::endl;
 
   // check phi_i(v_j) = delta_{ij}
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         const Tensor<1, dim> phi_i_grad =
           GeometryInfo<dim>::d_linear_shape_function_gradient(
@@ -46,10 +46,10 @@ test()
   // gradient of the sum of shape functions
   // is zero. do so at every vertex, and then
   // at the center
-  for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
     {
       Tensor<1, dim> s;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         s += GeometryInfo<dim>::d_linear_shape_function_gradient(
           GeometryInfo<dim>::unit_cell_vertex(v), i);
       AssertThrow(s.norm() == 0, ExcInternalError());
@@ -62,7 +62,7 @@ test()
       center[i] = 0.5;
 
     Tensor<1, dim> s;
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       s += GeometryInfo<dim>::d_linear_shape_function_gradient(center, i);
     AssertThrow(s.norm() == 0, ExcInternalError());
 

--- a/tests/base/geometry_info_6.cc
+++ b/tests/base/geometry_info_6.cc
@@ -35,12 +35,12 @@ test()
   // that case
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
 
     Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
     GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         deallog << "Reference cell: " << determinants[v] << std::endl;
         AssertThrow(static_cast<double>(determinants[v]) == 1,
@@ -52,7 +52,7 @@ test()
   // in the x-direction by a factor of 10
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
         vertices[v][0] /= 10;
@@ -60,7 +60,7 @@ test()
 
     Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
     GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         deallog << "Squashed cell: " << determinants[v] << std::endl;
         AssertThrow(static_cast<double>(determinants[v]) == 0.1,
@@ -75,7 +75,7 @@ test()
   // 1d)
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
         vertices[v][0] /= 10;
@@ -89,7 +89,7 @@ test()
 
     Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
     GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         deallog << "Squashed+rotated cell: " << determinants[v] << std::endl;
         AssertThrow(static_cast<double>(determinants[v]) == 0.1,
@@ -100,13 +100,13 @@ test()
   // pinched cell
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     vertices[1] /= 10;
 
     Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
     GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       deallog << "Pinched cell: " << determinants[v] << std::endl;
   }
 
@@ -114,13 +114,13 @@ test()
   // inverted cell
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     std::swap(vertices[0], vertices[1]);
 
     Tensor<0, dim> determinants[GeometryInfo<dim>::vertices_per_cell];
     GeometryInfo<dim>::alternating_form_at_vertices(vertices, determinants);
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       deallog << "Inverted cell: " << determinants[v] << std::endl;
   }
 }

--- a/tests/base/geometry_info_7.cc
+++ b/tests/base/geometry_info_7.cc
@@ -35,7 +35,7 @@ test()
   // that case
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
 
     for (const unsigned int f : GeometryInfo<dim>::face_indices())
@@ -61,7 +61,7 @@ test()
   // in the x-direction by a factor of 10
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
         vertices[v][0] /= 10;
@@ -105,7 +105,7 @@ test()
   // 1d)
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
         vertices[v][0] /= 10;
@@ -152,7 +152,7 @@ test()
   // pinched cell
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     vertices[1] /= 10;
 
@@ -175,7 +175,7 @@ test()
   // inverted cell
   {
     Point<dim> vertices[GeometryInfo<dim>::vertices_per_cell];
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       vertices[v] = GeometryInfo<dim>::unit_cell_vertex(v);
     std::swap(vertices[0], vertices[1]);
 

--- a/tests/bits/cylinder_01.cc
+++ b/tests/bits/cylinder_01.cc
@@ -56,7 +56,7 @@ check<2>()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       deallog << cell->vertex(i) << std::endl;
 }
 
@@ -76,7 +76,7 @@ check<3>()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       deallog << cell->vertex(i) << std::endl;
 }
 

--- a/tests/bits/cylinder_02.cc
+++ b/tests/bits/cylinder_02.cc
@@ -73,7 +73,7 @@ check()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       deallog << cell->vertex(i) << std::endl;
 }
 

--- a/tests/bits/cylinder_03.cc
+++ b/tests/bits/cylinder_03.cc
@@ -67,7 +67,7 @@ check()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       deallog << cell->vertex(i) << std::endl;
 }
 

--- a/tests/bits/cylinder_04.cc
+++ b/tests/bits/cylinder_04.cc
@@ -70,7 +70,7 @@ check()
          triangulation.begin_active();
        cell != triangulation.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       deallog << cell->vertex(i) << std::endl;
 }
 

--- a/tests/bits/distorted_cells_01.cc
+++ b/tests/bits/distorted_cells_01.cc
@@ -42,7 +42,7 @@ void
 check(const unsigned int testcase)
 {
   std::vector<Point<dim>> vertices;
-  for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
     vertices.push_back(GeometryInfo<dim>::unit_cell_vertex(v));
 
   switch (testcase)
@@ -63,7 +63,7 @@ check(const unsigned int testcase)
   std::vector<CellData<dim>> cells;
   {
     CellData<dim> cell;
-    for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+    for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
       cell.vertices[j] = j;
     cells.push_back(cell);
   }

--- a/tests/bits/distorted_cells_07.cc
+++ b/tests/bits/distorted_cells_07.cc
@@ -42,7 +42,7 @@ void
 check(const unsigned int testcase)
 {
   std::vector<Point<dim>> vertices;
-  for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
     vertices.push_back(GeometryInfo<dim>::unit_cell_vertex(v));
 
   switch (testcase)
@@ -59,7 +59,7 @@ check(const unsigned int testcase)
   std::vector<CellData<dim>> cells;
   {
     CellData<dim> cell;
-    for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+    for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
       cell.vertices[j] = j;
     cells.push_back(cell);
   }

--- a/tests/bits/find_cell_1.cc
+++ b/tests/bits/find_cell_1.cc
@@ -37,7 +37,7 @@ void check(Triangulation<2> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<2>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -68,7 +68,7 @@ void create_coarse_grid(Triangulation<2> &coarse_grid)
   std::vector<CellData<2>> cells(n_cells, CellData<2>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<2>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/bits/find_cell_2.cc
+++ b/tests/bits/find_cell_2.cc
@@ -36,7 +36,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_3.cc
+++ b/tests/bits/find_cell_3.cc
@@ -38,7 +38,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_4.cc
+++ b/tests/bits/find_cell_4.cc
@@ -38,7 +38,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_5.cc
+++ b/tests/bits/find_cell_5.cc
@@ -40,7 +40,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_8.cc
+++ b/tests/bits/find_cell_8.cc
@@ -53,7 +53,7 @@ void create_coarse_grid(Triangulation<2> &coarse_grid)
   std::vector<CellData<2>> cells(n_cells, CellData<2>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<2>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }
@@ -70,7 +70,7 @@ void check(Triangulation<2> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<2>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_9.cc
+++ b/tests/bits/find_cell_9.cc
@@ -56,7 +56,7 @@ void create_coarse_grid(Triangulation<2> &coarse_grid)
   std::vector<CellData<2>> cells(n_cells, CellData<2>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<2>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }
@@ -73,7 +73,7 @@ void check(Triangulation<2> &tria)
     GridTools::find_active_cell_around_point(tria, p);
 
   deallog << cell << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<2>::vertex_indices())
     deallog << "<" << cell->vertex(v) << "> ";
   deallog << std::endl;
 

--- a/tests/bits/find_cell_alt_1.cc
+++ b/tests/bits/find_cell_alt_1.cc
@@ -42,7 +42,7 @@ void check(Triangulation<2> &tria)
     GridTools::find_active_cell_around_point(map, tria, p);
 
   deallog << cell.first << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<2>::vertex_indices())
     deallog << "<" << cell.first->vertex(v) << "> ";
   deallog << "[ " << cell.second << "] ";
   deallog << std::endl;

--- a/tests/bits/find_cell_alt_2.cc
+++ b/tests/bits/find_cell_alt_2.cc
@@ -40,7 +40,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(map, tria, p);
 
   deallog << cell.first << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell.first->vertex(v) << "> " << std::endl;
   deallog << "[ " << cell.second << "] ";
 

--- a/tests/bits/find_cell_alt_3.cc
+++ b/tests/bits/find_cell_alt_3.cc
@@ -42,7 +42,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(map, tria, p);
 
   deallog << cell.first << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell.first->vertex(v) << "> ";
   deallog << "[ " << cell.second << "] ";
   deallog << std::endl;

--- a/tests/bits/find_cell_alt_4.cc
+++ b/tests/bits/find_cell_alt_4.cc
@@ -40,7 +40,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(map, tria, p);
 
   deallog << cell.first << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell.first->vertex(v) << "> ";
   deallog << "[ " << cell.second << "] ";
   deallog << std::endl;

--- a/tests/bits/find_cell_alt_5.cc
+++ b/tests/bits/find_cell_alt_5.cc
@@ -39,7 +39,7 @@ void check(Triangulation<3> &tria)
     GridTools::find_active_cell_around_point(map, tria, p);
 
   deallog << cell.first << std::endl;
-  for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+  for (const unsigned int v : GeometryInfo<3>::vertex_indices())
     deallog << "<" << cell.first->vertex(v) << "> ";
   deallog << "[ " << cell.second << "] ";
   deallog << std::endl;

--- a/tests/bits/find_cell_alt_6.cc
+++ b/tests/bits/find_cell_alt_6.cc
@@ -52,7 +52,7 @@ void check(Triangulation<2> &tria)
         GridTools::find_active_cell_around_point(map, tria, v[i]);
 
       deallog << "Vertex <" << v[i] << "> found in cell ";
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         deallog << "<" << cell.first->vertex(v) << "> ";
       deallog << " [local: " << cell.second << "]" << std::endl;
     }

--- a/tests/bits/find_cell_alt_7.cc
+++ b/tests/bits/find_cell_alt_7.cc
@@ -48,7 +48,7 @@ void check(Triangulation<2> &tria)
         GridTools::find_active_cell_around_point(map, tria, p);
 
       deallog << cell.first << std::endl;
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         deallog << "< " << cell.first->vertex(v) << " > ";
       deallog << "[ " << cell.second << " ] ";
 

--- a/tests/bits/find_cells_adjacent_to_vertex_1.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_1.cc
@@ -51,7 +51,7 @@ void check(Triangulation<2> &tria)
 
       for (unsigned c = 0; c < cells.size(); c++)
         {
-          for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+          for (const unsigned int v : GeometryInfo<2>::vertex_indices())
             deallog << "<" << cells[c]->vertex(v) << "> ";
           deallog << std::endl;
         }

--- a/tests/bits/step-13.cc
+++ b/tests/bits/step-13.cc
@@ -138,9 +138,7 @@ namespace Evaluation
                                                    endc = dof_handler.end();
     bool evaluation_point_found                         = false;
     for (; (cell != endc) && !evaluation_point_found; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex) == evaluation_point)
           {
             point_value = solution(cell->vertex_dof_index(vertex, 0));

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -135,9 +135,7 @@ namespace Evaluation
                                                    endc = dof_handler.end();
     bool evaluation_point_found                         = false;
     for (; (cell != endc) && !evaluation_point_found; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex).distance(evaluation_point) <
             cell->diameter() * 1e-8)
           {
@@ -201,9 +199,7 @@ namespace Evaluation
                                                    endc = dof_handler.end();
     unsigned int evaluation_point_hits                  = 0;
     for (; cell != endc; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex) == evaluation_point)
           {
             fe_values.reinit(cell);
@@ -1087,7 +1083,7 @@ namespace Data
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       };
@@ -1150,9 +1146,7 @@ namespace DualFunctional
                                                      dof_handler.begin_active(),
                                                    endc = dof_handler.end();
     for (; cell != endc; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex).distance(evaluation_point) <
             cell->diameter() * 1e-8)
           {

--- a/tests/bits/step-2.cc
+++ b/tests/bits/step-2.cc
@@ -59,9 +59,7 @@ void make_grid(Triangulation<2> &triangulation)
                                              endc = triangulation.end();
 
       for (; cell != endc; ++cell)
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<2>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
           {
             const double distance_from_center =
               center.distance(cell->vertex(vertex));

--- a/tests/codim_one/extract_boundary_mesh_02.cc
+++ b/tests/codim_one/extract_boundary_mesh_02.cc
@@ -55,11 +55,11 @@ test_vertices_orientation(
       face = surface_to_volume_mapping[cell];
 
       deallog << "Surface cell: " << cell << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         deallog << "  " << cell->vertex(k) << std::endl;
 
       deallog << "Volume face: " << face << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         deallog << "  " << face->vertex(k) << std::endl;
 
       Point<spacedim> diff(face->center());

--- a/tests/codim_one/extract_boundary_mesh_03.cc
+++ b/tests/codim_one/extract_boundary_mesh_03.cc
@@ -54,7 +54,7 @@ test_vertices_orientation(
       Assert(face->at_boundary(), ExcInternalError());
 
       deallog << "Surface cell: " << cell << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         {
           deallog << "  " << cell->vertex(k) << std::endl;
           Assert(std::fabs(cell->vertex(k).distance(Point<spacedim>()) - 1) <
@@ -63,7 +63,7 @@ test_vertices_orientation(
         }
 
       deallog << "Volume face: " << face << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         {
           deallog << "  " << face->vertex(k) << std::endl;
           Assert(std::fabs(face->vertex(k).distance(Point<spacedim>()) - 1) <

--- a/tests/codim_one/extract_boundary_mesh_04.cc
+++ b/tests/codim_one/extract_boundary_mesh_04.cc
@@ -54,7 +54,7 @@ test_vertices_orientation(
       Assert(face->at_boundary(), ExcInternalError());
 
       deallog << "Surface cell: " << cell << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         {
           deallog << "  " << cell->vertex(k) << std::endl;
           Assert(std::fabs(cell->vertex(k).distance(Point<spacedim>()) - 1) <
@@ -63,7 +63,7 @@ test_vertices_orientation(
         }
 
       deallog << "Volume face: " << face << " with vertices:" << std::endl;
-      for (unsigned int k = 0; k < GeometryInfo<s_dim>::vertices_per_cell; ++k)
+      for (const unsigned int k : GeometryInfo<s_dim>::vertex_indices())
         {
           deallog << "  " << face->vertex(k) << std::endl;
           Assert(std::fabs(face->vertex(k).distance(Point<spacedim>()) - 1) <

--- a/tests/data_out/data_out_curved_cells.cc
+++ b/tests/data_out/data_out_curved_cells.cc
@@ -162,9 +162,7 @@ curved_grid(std::ofstream &out)
   for (; cell != endc; ++cell)
     {
       // fix all vertices
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<2>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<2>::vertex_indices())
         {
           for (unsigned int i = 0; i < 2; ++i)
             m[i][cell->vertex_dof_index(vertex_no, 0)] = 0.;

--- a/tests/data_out/data_out_hdf5_02.cc
+++ b/tests/data_out/data_out_hdf5_02.cc
@@ -41,7 +41,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
       const unsigned int nsubp = nsub + 1;
 
       patch.n_subdivisions = nsub;
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         for (unsigned int d = 0; d < spacedim; ++d)
           patch.vertices[v](d) =
             p + cell_coordinates[d][v] + ((d >= dim) ? v : 0);

--- a/tests/data_out/patches.h
+++ b/tests/data_out/patches.h
@@ -35,7 +35,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
       const unsigned int nsubp = nsub + 1;
 
       patch.n_subdivisions = nsub;
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         for (unsigned int d = 0; d < spacedim; ++d)
           patch.vertices[v](d) =
             p + cell_coordinates[d][v] + ((d >= dim) ? v : 0);

--- a/tests/distributed_grids/3d_coarse_grid_05.cc
+++ b/tests/distributed_grids/3d_coarse_grid_05.cc
@@ -81,7 +81,7 @@ create_disconnected_mesh(Triangulation<dim> &tria)
       }
 
     // Prepare cell data
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       cells[0].vertices[i] = i;
     cells[0].material_id = 0;
   }
@@ -133,7 +133,7 @@ create_disconnected_mesh(Triangulation<dim> &tria)
       }
 
     // Prepare cell data
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       cells[1].vertices[i] = GeometryInfo<dim>::vertices_per_cell + i;
     cells[1].material_id = 0;
   }

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -82,7 +82,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
     {7, 6, 5, 4},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];
@@ -151,7 +151,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
     {15, 13, 14, 12, 11, 9, 10, 8},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -82,7 +82,7 @@ void generate_grid(Triangulation<2> &triangulation)
   /* cell 1 */
   int cell_vertices_1[GeometryInfo<2>::vertices_per_cell] = {7, 6, 5, 4};
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[j];

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -116,7 +116,7 @@ void generate_grid(Triangulation<2> &triangulation)
   /* cell 1 */
   int cell_vertices_1[GeometryInfo<2>::vertices_per_cell] = {7, 6, 5, 4};
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[j];

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -80,7 +80,7 @@ void generate_grid(Triangulation<2> &triangulation)
   /* cell 1 */
   int cell_vertices_1[GeometryInfo<2>::vertices_per_cell] = {7, 6, 5, 4};
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[j];

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -85,7 +85,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
     {7, 6, 5, 4},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];
@@ -155,7 +155,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
     {15, 13, 14, 12, 11, 9, 10, 8},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];

--- a/tests/fail/circular_01.cc
+++ b/tests/fail/circular_01.cc
@@ -618,7 +618,7 @@ LaplaceProblem<2>::create_coarse_grid()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }
@@ -784,7 +784,7 @@ LaplaceProblem<3>::create_coarse_grid()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -136,9 +136,7 @@ namespace Evaluation
                                                        endc = dof_handler.end();
     bool evaluation_point_found                             = false;
     for (; (cell != endc) && !evaluation_point_found; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex).distance(evaluation_point) <
             cell->diameter() * 1e-8)
           {
@@ -202,9 +200,7 @@ namespace Evaluation
                                                        endc = dof_handler.end();
     unsigned int evaluation_point_hits                      = 0;
     for (; cell != endc; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex) == evaluation_point)
           {
             fe_values.reinit(cell);
@@ -1096,7 +1092,7 @@ namespace Data
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       };
@@ -1161,9 +1157,7 @@ namespace DualFunctional
                                                                 .begin_active(),
                                                        endc = dof_handler.end();
     for (; cell != endc; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex).distance(evaluation_point) <
             cell->diameter() * 1e-8)
           {

--- a/tests/fe/fe_abf_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_abf_gradient_divergence_theorem.cc
@@ -85,7 +85,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)
@@ -159,7 +159,7 @@ test_hyper_cube(const double tolerance)
   GridGenerator::hyper_cube(tr);
 
   typename Triangulation<dim>::active_cell_iterator cell = tr.begin_active();
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
       if (std::abs(point(dim - 1) - 1.0) < 1e-5)

--- a/tests/fe/fe_br.cc
+++ b/tests/fe/fe_br.cc
@@ -76,7 +76,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)
@@ -115,7 +115,7 @@ test_hyper_cube(const double tolerance)
   GridGenerator::hyper_cube(tr);
 
   typename Triangulation<dim>::active_cell_iterator cell = tr.begin_active();
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
       if (std::abs(point(dim - 1) - 1.0) < 1e-5)

--- a/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgp_3rd_derivative_divergence_theorem.cc
@@ -83,7 +83,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_3rd_derivative_divergence_theorem.cc
@@ -82,7 +82,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_dgq_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_gradient_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_dgq_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_dgq_hessian_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_face_orientation_nedelec_0.cc
+++ b/tests/fe/fe_face_orientation_nedelec_0.cc
@@ -93,7 +93,7 @@ void create_triangulation(Triangulation<3> &triangulation)
   std::vector<CellData<3>> cells(n_cells, CellData<3>());
   for (unsigned i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<3>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/fe/fe_nedelec_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_gradient_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_hessian_divergence_theorem.cc
@@ -89,7 +89,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << i << ": ( " << cell->vertex(i) << " )" << std::endl;
 
       bool cell_ok = true;

--- a/tests/fe/fe_nedelec_sz_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_nedelec_sz_gradient_divergence_theorem.cc
@@ -83,7 +83,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -154,7 +154,7 @@ void create_tria(Triangulation<2> &triangulation,
   std::vector<CellData<2>> cells(n_cells, CellData<2>());
   for (unsigned i = 0; i < cells.size(); ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<2>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -216,7 +216,7 @@ void create_tria(Triangulation<3> &triangulation,
   std::vector<CellData<3>> cells(n_cells, CellData<3>());
   for (unsigned i = 0; i < cells.size(); ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<3>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_3rd_derivative_divergence_theorem.cc
@@ -82,7 +82,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_q_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_q_gradient_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_q_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_q_hessian_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_q_hierarchical_3rd_derivative_divergence_theorem.cc
@@ -83,7 +83,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fe/fe_rt_gradient_divergence_theorem.cc
+++ b/tests/fe/fe_rt_gradient_divergence_theorem.cc
@@ -84,7 +84,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)
@@ -160,7 +160,7 @@ test_hyper_cube(const double tolerance)
   GridGenerator::hyper_cube(tr);
 
   typename Triangulation<dim>::active_cell_iterator cell = tr.begin_active();
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
       if (std::abs(point(dim - 1) - 1.0) < 1e-5)

--- a/tests/fe/fe_rt_hessian_divergence_theorem.cc
+++ b/tests/fe/fe_rt_hessian_divergence_theorem.cc
@@ -83,7 +83,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << i << ": (" << cell->vertex(i) << ")" << std::endl;
 
       bool cell_ok = true;
@@ -158,7 +158,7 @@ test_hyper_cube(const double tolerance)
   GridGenerator::hyper_cube(tr);
 
   typename Triangulation<dim>::active_cell_iterator cell = tr.begin_active();
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> &point = cell->vertex(i);
       if (std::abs(point(dim - 1) - 1.0) < 1e-5)

--- a/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
+++ b/tests/fe/fe_system_3rd_derivative_divergence_theorem.cc
@@ -82,7 +82,7 @@ test(const Triangulation<dim> &tr,
       fe_values.reinit(cell);
 
       deallog << "Cell nodes:" << std::endl;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           deallog << i << ": ( ";
           for (unsigned int d = 0; d < dim; ++d)

--- a/tests/fullydistributed_grids/copy_serial_tria_03.cc
+++ b/tests/fullydistributed_grids/copy_serial_tria_03.cc
@@ -54,7 +54,7 @@ test(int n_refinements, const int n_subdivisions, MPI_Comm comm)
       for (auto &cell : basetria.active_cell_iterators())
         {
           // if(cell->is_locally_owned ())
-          for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+          for (const unsigned int v : GeometryInfo<2>::vertex_indices())
             {
               const double distance_from_center =
                 center.distance(cell->vertex(v));

--- a/tests/gmsh/create_tria_01.cc
+++ b/tests/gmsh/create_tria_01.cc
@@ -40,7 +40,7 @@ gmsh_grid(const char *name)
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/build_triangulation_from_patch_01.cc
+++ b/tests/grid/build_triangulation_from_patch_01.cc
@@ -75,8 +75,7 @@ test()
           deallog << "   " << tria_cell << " user flag check:  "
                   << (tria_cell->user_flag_set() ? " (+) " : " (-) ")
                   << std::endl;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               deallog << "  vertices for cell  " << tria_cell << " : "
                       << tria_cell->vertex(v) << std::endl;

--- a/tests/grid/build_triangulation_from_patch_02.cc
+++ b/tests/grid/build_triangulation_from_patch_02.cc
@@ -77,8 +77,7 @@ test()
           deallog << "   " << tria_cell << " user flag check:  "
                   << (tria_cell->user_flag_set() ? " (+) " : " (-) ")
                   << std::endl;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               deallog << "  vertices for cell  " << tria_cell << " : "
                       << tria_cell->vertex(v) << std::endl;

--- a/tests/grid/build_triangulation_from_patch_03.cc
+++ b/tests/grid/build_triangulation_from_patch_03.cc
@@ -82,8 +82,7 @@ test()
           deallog << "   " << tria_cell << " user flag check:  "
                   << (tria_cell->user_flag_set() ? " (+) " : " (-) ")
                   << std::endl;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               deallog << "  vertices for cell  " << tria_cell << " : "
                       << tria_cell->vertex(v) << std::endl;

--- a/tests/grid/build_triangulation_from_patch_04.cc
+++ b/tests/grid/build_triangulation_from_patch_04.cc
@@ -88,8 +88,7 @@ test()
           deallog << "   " << tria_cell << " user flag check:  "
                   << (tria_cell->user_flag_set() ? " (+) " : " (-) ")
                   << std::endl;
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               deallog << "  vertices for cell  " << tria_cell << " : "
                       << tria_cell->vertex(v) << std::endl;

--- a/tests/grid/coarsening_02.cc
+++ b/tests/grid/coarsening_02.cc
@@ -49,7 +49,7 @@ satisfies_level1_at_vertex_rule(const Triangulation<dim> &tr)
          tr.begin_active();
        cell != tr.end();
        ++cell)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         min_adjacent_cell_level[cell->vertex_index(v)] =
           std::min<unsigned int>(min_adjacent_cell_level[cell->vertex_index(v)],

--- a/tests/grid/coarsening_02_1d.cc
+++ b/tests/grid/coarsening_02_1d.cc
@@ -50,7 +50,7 @@ satisfies_level1_at_vertex_rule(const Triangulation<dim> &tr)
          tr.begin_active();
        cell != tr.end();
        ++cell)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         min_adjacent_cell_level[cell->vertex_index(v)] =
           std::min<unsigned int>(min_adjacent_cell_level[cell->vertex_index(v)],

--- a/tests/grid/coarsening_03.cc
+++ b/tests/grid/coarsening_03.cc
@@ -46,7 +46,7 @@ satisfies_level1_at_vertex_rule(const Triangulation<dim> &tr)
          tr.begin_active();
        cell != tr.end();
        ++cell)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         min_adjacent_cell_level[cell->vertex_index(v)] =
           std::min<unsigned int>(min_adjacent_cell_level[cell->vertex_index(v)],

--- a/tests/grid/enclosing_sphere_01.cc
+++ b/tests/grid/enclosing_sphere_01.cc
@@ -193,7 +193,7 @@ test()
 
       // Check that all the vertices are within the sphere
       // (sphere with thickness 100. *std::numeric_limits<double>::epsilon())
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         AssertThrow(std::fabs(center.distance(tria.begin_active()->vertex(v))) <
                       radius + 100. * std::numeric_limits<double>::epsilon(),
                     ExcInternalError());

--- a/tests/grid/grid_generator_airfoil_01.cc
+++ b/tests/grid/grid_generator_airfoil_01.cc
@@ -41,7 +41,7 @@ print_triangulation(const Triangulation<dim, dim> &tria)
                                                   -1)
                 << " ";
 
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         deallog << cell.vertex(v) << " ";
 
       deallog << std::endl;

--- a/tests/grid/grid_in.cc
+++ b/tests/grid/grid_in.cc
@@ -89,7 +89,7 @@ test2()
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << hash << std::endl;
 }

--- a/tests/grid/grid_in_3d.cc
+++ b/tests/grid/grid_in_3d.cc
@@ -59,7 +59,7 @@ test(const char *filename)
   for (Triangulation<dim>::active_cell_iterator c = tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_3d_02.cc
+++ b/tests/grid/grid_in_3d_02.cc
@@ -62,7 +62,7 @@ test(const char *filename)
   for (Triangulation<dim>::active_cell_iterator c = tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 

--- a/tests/grid/grid_in_abaqus_01.cc
+++ b/tests/grid/grid_in_abaqus_01.cc
@@ -44,7 +44,7 @@ abaqus_grid(const char *name)
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_abaqus_02.cc
+++ b/tests/grid/grid_in_abaqus_02.cc
@@ -50,7 +50,7 @@ abaqus_grid(const std::string path_and_name,
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 

--- a/tests/grid/grid_in_gmsh_01.cc
+++ b/tests/grid/grid_in_gmsh_01.cc
@@ -44,7 +44,7 @@ gmsh_grid(const char *name)
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_gmsh_01_v4.cc
+++ b/tests/grid/grid_in_gmsh_01_v4.cc
@@ -61,7 +61,7 @@ gmsh_grid(const char *name_v2, const char *name_v4)
     {
       AssertThrow(cell_v2->material_id() == cell_v4->material_id(),
                   ExcInternalError());
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           AssertThrow((cell_v2->vertex(i) - cell_v4->vertex(i)).norm() < 1.e-10,
                       ExcInternalError());

--- a/tests/grid/grid_in_gmsh_01_v41.cc
+++ b/tests/grid/grid_in_gmsh_01_v41.cc
@@ -61,7 +61,7 @@ gmsh_grid(const char *name_v2, const char *name_v41)
     {
       AssertThrow(cell_v2->material_id() == cell_v41->material_id(),
                   ExcInternalError());
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           AssertThrow((cell_v2->vertex(i) - cell_v41->vertex(i)).norm() <
                         1.e-10,

--- a/tests/grid/grid_in_msh_version_4.cc
+++ b/tests/grid/grid_in_msh_version_4.cc
@@ -99,7 +99,7 @@ gmsh_grid(const char *name_v2, const char *name_v4)
                   ExcInternalError());
       std::set<unsigned int> vertices_v2;
       std::set<unsigned int> vertices_v4;
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           AssertThrow((tria_v2.get_vertices()[cell_v2->vertex_index(i)] -
                        tria_v4.get_vertices()[cell_v2->vertex_index(i)])

--- a/tests/grid/grid_invert.cc
+++ b/tests/grid/grid_invert.cc
@@ -43,7 +43,7 @@ test(bool second_case = false)
       vertices[7](0) = 1;
     }
   std::vector<CellData<dim>> cells(1);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     cells[0].vertices[i] = i;
 
   if (dim == 3 && second_case)

--- a/tests/grid/grid_out_08.cc
+++ b/tests/grid/grid_out_08.cc
@@ -63,7 +63,7 @@ test()
 
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/grid/grid_out_09.cc
+++ b/tests/grid/grid_out_09.cc
@@ -63,7 +63,7 @@ test()
 
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/grid/grid_out_in_vtk_01.cc
+++ b/tests/grid/grid_out_in_vtk_01.cc
@@ -56,7 +56,7 @@ check(Triangulation<dim, spacedim> &tria)
       AssertDimension(cell1->material_id(), cell2->material_id());
       AssertDimension(cell1->manifold_id(), cell2->manifold_id());
 
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           auto obj1 = cell1->vertex_index(i);
           auto obj2 = cell2->vertex_index(i);

--- a/tests/grid/grid_out_svg_01.cc
+++ b/tests/grid/grid_out_svg_01.cc
@@ -48,7 +48,7 @@ create_grid()
 
   for (; cell != endc; ++cell)
     {
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         {
           const double distance_from_center = center.distance(cell->vertex(v));
 

--- a/tests/grid/grid_out_svg_02.cc
+++ b/tests/grid/grid_out_svg_02.cc
@@ -49,7 +49,7 @@ create_grid()
 
       for (; cell != endc; ++cell)
         {
-          for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+          for (const unsigned int v : GeometryInfo<2>::vertex_indices())
             {
               const double distance_from_center =
                 center.distance(cell->vertex(v));

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -56,7 +56,7 @@ void generate_grid(Triangulation<2> &triangulation)
   /* cell 1 */
   int cell_vertices_1[GeometryInfo<2>::vertices_per_cell] = {4, 5, 6, 7};
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[j];
@@ -117,7 +117,7 @@ void generate_grid(Triangulation<3> &triangulation)
   int cell_vertices_1[GeometryInfo<3>::vertices_per_cell] = {
     8, 9, 10, 11, 12, 13, 14, 15};
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[j];

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -60,7 +60,7 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
     {7, 6, 5, 4},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];
@@ -129,7 +129,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
     {15, 13, 14, 12, 11, 9, 10, 8},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];

--- a/tests/grid/grid_tools_compute_mesh_predicate_bounding_box_1.cc
+++ b/tests/grid/grid_tools_compute_mesh_predicate_bounding_box_1.cc
@@ -93,7 +93,7 @@ test_hypercube(unsigned int ref, unsigned int max_bbox)
   // Looking if every point is at least inside a bounding box
   for (; cell < endc; ++cell)
     if (cell->is_locally_owned())
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           bool inside_a_box = false;
           for (unsigned int i = 0; i < local_bbox.size(); ++i)

--- a/tests/grid/merge_triangulations_03.cc
+++ b/tests/grid/merge_triangulations_03.cc
@@ -61,7 +61,7 @@ flatten_triangulation(Triangulation<dim> &tria_in, Triangulation<dim> &tria_out)
   unsigned int cell_counter = 0;
   for (; cell != endc; ++cell)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         {
           cells[cell_counter].vertices[j] = cell->vertex_index(j);
         }

--- a/tests/grid/merge_triangulations_04.cc
+++ b/tests/grid/merge_triangulations_04.cc
@@ -43,9 +43,7 @@ main()
 
       if (cylinder_triangulation_offset == Point<2>())
         {
-          for (unsigned int vertex_n = 0;
-               vertex_n < GeometryInfo<2>::vertices_per_cell;
-               ++vertex_n)
+          for (const unsigned int vertex_n : GeometryInfo<2>::vertex_indices())
             if (cell->vertex(vertex_n) == Point<2>())
               {
                 // skip two cells in the bottom left corner

--- a/tests/grid/mesh_3d_3.cc
+++ b/tests/grid/mesh_3d_3.cc
@@ -46,7 +46,7 @@ main()
 
   // output all vertices
   for (unsigned int c = 0; c < 2; ++c)
-    for (unsigned int v = 0; v < GeometryInfo<3>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<3>::vertex_indices())
       deallog << "Cell " << c << ", vertex " << v << ": "
               << cells[c]->vertex_index(v) << "  @  " << cells[c]->vertex(v)
               << std::endl;

--- a/tests/grid/oned_vertex_manifold.cc
+++ b/tests/grid/oned_vertex_manifold.cc
@@ -43,9 +43,7 @@ main()
       deallog << "current cell manifold id: " << cell->manifold_id()
               << std::endl;
 
-      for (unsigned int vertex_n = 0;
-           vertex_n < GeometryInfo<1>::vertices_per_cell;
-           ++vertex_n)
+      for (const unsigned int vertex_n : GeometryInfo<1>::vertex_indices())
         {
           deallog << "current vertex: " << cell->vertex(vertex_n) << std::endl;
           deallog << "current vertex manifold id: "

--- a/tests/grid/project_to_object_01.cc
+++ b/tests/grid/project_to_object_01.cc
@@ -46,9 +46,7 @@ main()
                std::cos(weights[2]);
       };
     Tensor<1, GeometryInfo<structdim>::vertices_per_cell> c0;
-    for (unsigned int row_n = 0;
-         row_n < GeometryInfo<structdim>::vertices_per_cell;
-         ++row_n)
+    for (const unsigned int row_n : GeometryInfo<structdim>::vertex_indices())
       c0[row_n] = 1.0;
 
     const std::array<double, 3> exact{

--- a/tests/grid/subcelldata.cc
+++ b/tests/grid/subcelldata.cc
@@ -66,7 +66,7 @@ test()
     }
 
   std::vector<CellData<dim>> cells(1);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     cells[0].vertices[i] = i;
   cells[0].material_id = 0;
 

--- a/tests/hp/crash_17.cc
+++ b/tests/hp/crash_17.cc
@@ -615,7 +615,7 @@ LaplaceProblem<2>::create_coarse_grid()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/hp/crash_18.cc
+++ b/tests/hp/crash_18.cc
@@ -623,7 +623,7 @@ LaplaceProblem<2>::create_coarse_grid()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/hp/distribute_dofs_linear_time.cc
+++ b/tests/hp/distribute_dofs_linear_time.cc
@@ -88,9 +88,8 @@ ladutenko_circle(Triangulation<dim> &triangulation,
     {
       if (cell->center().distance(center) < 1e-10)
         {
-          for (unsigned int vertex_n = 0;
-               vertex_n < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex_n)
+          for (const unsigned int vertex_n :
+               GeometryInfo<dim>::vertex_indices())
             {
               cell->vertex(vertex_n) *=
                 core_radius / center.distance(cell->vertex(vertex_n));
@@ -110,7 +109,7 @@ ladutenko_circle(Triangulation<dim> &triangulation,
   cell = triangulation.begin_active();
   for (; cell != endc; ++cell)
     {
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           const double dist = center.distance(cell->vertex(v));
           if (dist > core_radius * 1.0001 && dist < radius - 1.0e-5)

--- a/tests/hp/project_01.cc
+++ b/tests/hp/project_01.cc
@@ -86,7 +86,7 @@ test()
          dh.begin_active();
        cell != dh.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         // check that the error is
         // somewhat small. it won't

--- a/tests/hp/project_01_curved_boundary.cc
+++ b/tests/hp/project_01_curved_boundary.cc
@@ -163,7 +163,7 @@ test()
            dh.begin_active();
          cell != dh.end();
          ++cell)
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << cell->vertex(i) << ' '
                 << v(cell->vertex_dof_index(i, 0, cell->active_fe_index()))
                 << std::endl;
@@ -189,7 +189,7 @@ test()
            dh.begin_active();
          cell != dh.end();
          ++cell)
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << cell->vertex(i) << ' '
                 << v(cell->vertex_dof_index(i, 0, cell->active_fe_index()))
                 << std::endl;

--- a/tests/hp/project_02.cc
+++ b/tests/hp/project_02.cc
@@ -89,7 +89,7 @@ test()
          dh.begin_active();
        cell != dh.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         // check that the error is
         // somewhat small. it won't

--- a/tests/hp/step-13.cc
+++ b/tests/hp/step-13.cc
@@ -136,9 +136,7 @@ namespace Evaluation
                                                        endc = dof_handler.end();
     bool evaluation_point_found                             = false;
     for (; (cell != endc) && !evaluation_point_found; ++cell)
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(vertex) == evaluation_point)
           {
             point_value = solution(

--- a/tests/hp/step-2.cc
+++ b/tests/hp/step-2.cc
@@ -55,9 +55,7 @@ void make_grid(Triangulation<2> &triangulation)
                                              endc = triangulation.end();
 
       for (; cell != endc; ++cell)
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<2>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<2>::vertex_indices())
           {
             const double distance_from_center =
               center.distance(cell->vertex(vertex));

--- a/tests/hp/step-27.cc
+++ b/tests/hp/step-27.cc
@@ -422,7 +422,7 @@ namespace Step27
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       }

--- a/tests/lac/constraints_c1.cc
+++ b/tests/lac/constraints_c1.cc
@@ -50,8 +50,7 @@ setup_constraints(const DoFHandler<dim> &dof_handler)
     std::vector<std::vector<double>>(
       dim + 1, std::vector<double>(fe.dofs_per_cell, 0.)));
 
-  for (unsigned int vertex = 0; vertex < GeometryInfo<dim>::vertices_per_cell;
-       ++vertex)
+  for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
     {
       Point<dim> v;
       for (unsigned int d = 0; d < dim; ++d)

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -596,7 +596,7 @@ LaplaceProblem<2>::create_coarse_grid()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/manifold/flat_manifold_08.cc
+++ b/tests/manifold/flat_manifold_08.cc
@@ -35,7 +35,7 @@ test(unsigned int ref = 1)
 {
   std::vector<Point<spacedim>> vertices(GeometryInfo<dim>::vertices_per_cell);
   std::vector<CellData<dim>>   cells(1);
-  for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+  for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
     cells[0].vertices[i] = i;
   cells[0].material_id = 0;
 

--- a/tests/manifold/flat_manifold_09.cc
+++ b/tests/manifold/flat_manifold_09.cc
@@ -135,8 +135,7 @@ test()
       std::cout << "step " << step << std::endl;
       for (auto &cell : tria.active_cell_iterators())
         {
-          for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-               ++v)
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             {
               if (p.distance(cell->vertex(v)) < 0.03 / (1 << step))
                 {

--- a/tests/mappings/mapping_q_eulerian_09.cc
+++ b/tests/mappings/mapping_q_eulerian_09.cc
@@ -191,9 +191,7 @@ test()
                                             endc = dof_handler.end();
     std::vector<bool> vertex_touched(triangulation.n_vertices(), false);
     for (cell = dof_handler.begin_active(); cell != endc; ++cell)
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         if (vertex_touched[cell->vertex_index(vertex_no)] == false)
           {
             Point<dim> &   v = cell->vertex(vertex_no);

--- a/tests/mappings/mapping_q_mixed_manifolds_02.cc
+++ b/tests/mappings/mapping_q_mixed_manifolds_02.cc
@@ -94,7 +94,7 @@ void create_triangulation(Triangulation<2> &tria)
        cell != middle.end();
        ++cell)
     {
-      for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<2>::vertex_indices())
         {
           Point<2> &vertex = cell->vertex(v);
           if (std::abs(vertex[0] - X_2) < 1e-10 &&

--- a/tests/matrix_free/matrix_vector_faces_25.cc
+++ b/tests/matrix_free/matrix_vector_faces_25.cc
@@ -66,7 +66,7 @@ void generate_grid(Triangulation<3> &triangulation, int orientation)
     {10, 11, 8, 9, 6, 7, 4, 5},
     {11, 9, 10, 8, 7, 5, 6, 4}};
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];

--- a/tests/meshworker/step-50-mesh_loop.cc
+++ b/tests/meshworker/step-50-mesh_loop.cc
@@ -503,7 +503,7 @@ namespace Step50
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(v)[0] <= 0.5 && cell->vertex(v)[1] <= 0.5)
           cell->set_refine_flag();
     triangulation.execute_coarsening_and_refinement();

--- a/tests/mpi/communicate_moved_vertices_03.cc
+++ b/tests/mpi/communicate_moved_vertices_03.cc
@@ -49,9 +49,7 @@ test()
   std::map<unsigned int, Point<dim>> non_artificial_vertices_old;
   for (cell = triangulation.begin_active(); cell != endc; ++cell)
     if (!cell->is_artificial())
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         non_artificial_vertices_old[cell->vertex_index(vertex_no)] =
           cell->vertex(vertex_no);
 
@@ -60,9 +58,7 @@ test()
     GridTools::get_locally_owned_vertices(triangulation);
   for (cell = triangulation.begin_active(); cell != endc; ++cell)
     if (cell->is_locally_owned())
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         {
           const unsigned global_vertex_no = cell->vertex_index(vertex_no);
           if (!vertex_moved[global_vertex_no] &&
@@ -78,9 +74,7 @@ test()
   std::map<unsigned int, Point<dim>> non_artificial_vertices_new;
   for (cell = triangulation.begin_active(); cell != endc; ++cell)
     if (!cell->is_artificial())
-      for (unsigned int vertex_no = 0;
-           vertex_no < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex_no)
+      for (const unsigned int vertex_no : GeometryInfo<dim>::vertex_indices())
         {
           Point<dim> point = cell->vertex(vertex_no);
           point(0) -= 1.e-1;

--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -41,7 +41,7 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
       const unsigned int nsubp = nsub + 1;
 
       patch.n_subdivisions = nsub;
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         for (unsigned int d = 0; d < spacedim; ++d)
           patch.vertices[v](d) =
             p + cell_coordinates[d][v] + ((d >= dim) ? v : 0);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -102,7 +102,7 @@ void generate_grid(parallel::distributed::Triangulation<2> &triangulation,
     {7, 6, 5, 4},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<2>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];
@@ -155,7 +155,7 @@ void generate_grid(parallel::distributed::Triangulation<3> &triangulation,
     {15, 13, 14, 12, 11, 9, 10, 8},
   };
 
-  for (unsigned int j = 0; j < GeometryInfo<3>::vertices_per_cell; ++j)
+  for (const unsigned int j : GeometryInfo<3>::vertex_indices())
     {
       cells[0].vertices[j] = cell_vertices_0[j];
       cells[1].vertices[j] = cell_vertices_1[orientation][j];

--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -426,7 +426,7 @@ namespace Step27
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       }

--- a/tests/mpi/tria_copy_triangulation.cc
+++ b/tests/mpi/tria_copy_triangulation.cc
@@ -85,9 +85,7 @@ test()
           Assert(cell1->subdomain_id() == cell2->subdomain_id(),
                  ExcInternalError());
 
-          for (unsigned int vertex = 0;
-               vertex < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex)
+          for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
             {
               Assert(cell1->vertex(vertex).distance(cell2->vertex(vertex)) <
                        1.e-14,

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -428,7 +428,7 @@ namespace Step27
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       }

--- a/tests/multigrid/dof_01.cc
+++ b/tests/multigrid/dof_01.cc
@@ -57,7 +57,7 @@ dofs(const DoFHandler<dim> &dof)
       cell->get_mg_dof_indices(indices);
 
       deallog << "Level " << cell->level();
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << " v" << cell->vertex(i);
       deallog << " dofs ";
       for (unsigned int i = 0; i < indices.size(); ++i)

--- a/tests/multigrid/interface_matrix_entry_01.cc
+++ b/tests/multigrid/interface_matrix_entry_01.cc
@@ -63,7 +63,7 @@ test()
          cell = tria.begin_active();
        cell != tria.end();
        ++cell)
-    for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
       {
         if (dim == 2)
           if (cell->vertex(v)[0] < 0.5 && cell->vertex(v)[1] < 0.5)

--- a/tests/multigrid/max_level_for_coarse_mesh.cc
+++ b/tests/multigrid/max_level_for_coarse_mesh.cc
@@ -51,7 +51,7 @@ test()
              dim>::active_cell_iterator cell = tria.begin_active();
            cell != tria.end();
            ++cell)
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (dim == 2)
               if (cell->vertex(v)[0] < 0.25 && cell->vertex(v)[1] < 0.25)

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -73,9 +73,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -73,9 +73,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -444,9 +444,7 @@ LaplaceProblem<dim>::refine_local()
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -330,9 +330,7 @@ LaplaceProblem<dim>::refine_local()
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -401,9 +401,7 @@ LaplaceProblem<dim>::refine_local()
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -527,9 +527,7 @@ LaplaceProblem<dim>::refine_grid(const std::string &reftype)
              triangulation.begin_active();
            cell != triangulation.end();
            ++cell)
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
           {
             {
               const Point<dim> p = cell->vertex(vertex);

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -546,9 +546,7 @@ LaplaceProblem<dim>::refine_grid(const std::string &reftype)
              triangulation.begin_active();
            cell != triangulation.end();
            ++cell)
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex)
+        for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
           {
             {
               const Point<dim> p = cell->vertex(vertex);

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -517,7 +517,7 @@ namespace Step50
            triangulation.begin_active();
          cell != triangulation.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (cell->vertex(v)[0] <= 0.5 && cell->vertex(v)[1] <= 0.5)
           cell->set_refine_flag();
     triangulation.execute_coarsening_and_refinement();

--- a/tests/multigrid/transfer_03.cc
+++ b/tests/multigrid/transfer_03.cc
@@ -71,9 +71,7 @@ refine_mesh(Triangulation<dim> &triangulation)
        cell != triangulation.end();
        ++cell)
     {
-      for (unsigned int vertex = 0;
-           vertex < GeometryInfo<dim>::vertices_per_cell;
-           ++vertex)
+      for (const unsigned int vertex : GeometryInfo<dim>::vertex_indices())
         {
           const Point<dim> p = cell->vertex(vertex);
           const Point<dim> origin =

--- a/tests/numerics/kelly_crash_02.cc
+++ b/tests/numerics/kelly_crash_02.cc
@@ -195,7 +195,7 @@ test()
   std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
   for (unsigned int i = 0; i < n_cells; ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+      for (const unsigned int j : GeometryInfo<dim>::vertex_indices())
         cells[i].vertices[j] = cell_vertices[i][j];
       cells[i].material_id = 0;
     }

--- a/tests/numerics/project_01.cc
+++ b/tests/numerics/project_01.cc
@@ -82,7 +82,7 @@ test()
   for (typename DoFHandler<dim>::active_cell_iterator cell = dh.begin_active();
        cell != dh.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         // check that the error is
         // somewhat small. it won't

--- a/tests/numerics/project_01_curved_boundary.cc
+++ b/tests/numerics/project_01_curved_boundary.cc
@@ -147,7 +147,7 @@ test()
            dh.begin_active();
          cell != dh.end();
          ++cell)
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << cell->vertex(i) << ' ' << v(cell->vertex_dof_index(i, 0))
                 << std::endl;
   }
@@ -172,7 +172,7 @@ test()
            dh.begin_active();
          cell != dh.end();
          ++cell)
-      for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         deallog << cell->vertex(i) << ' ' << v(cell->vertex_dof_index(i, 0))
                 << std::endl;
   }

--- a/tests/numerics/project_02.cc
+++ b/tests/numerics/project_02.cc
@@ -85,7 +85,7 @@ test()
   for (typename DoFHandler<dim>::active_cell_iterator cell = dh.begin_active();
        cell != dh.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         // check that the error is
         // somewhat small. it won't

--- a/tests/numerics/project_03.cc
+++ b/tests/numerics/project_03.cc
@@ -89,7 +89,7 @@ test()
   for (typename DoFHandler<dim>::active_cell_iterator cell = dh.begin_active();
        cell != dh.end();
        ++cell)
-    for (unsigned int i = 0; i < GeometryInfo<dim>::vertices_per_cell; ++i)
+    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
       {
         deallog << cell->vertex(i) << ' ' << v(cell->vertex_dof_index(i, 0))
                 << std::endl;

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -854,8 +854,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/physics/elasticity-kinematics_01.cc
+++ b/tests/physics/elasticity-kinematics_01.cc
@@ -65,7 +65,7 @@ test_kinematic_tensors()
        cell != dof_handler.end();
        ++cell)
     {
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (std::abs(cell->vertex(v)[0] - 1.0) < 1e-9)
           soln_t[cell->vertex_dof_index(v, 0)] = 1.0;
     }

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -615,8 +615,7 @@ namespace Step18
             cell = dof_handler.begin_active(),
             endc = dof_handler.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6)
                 {
                   monitored_vertex_first_dof = cell->vertex_dof_index(v, 0);
@@ -694,7 +693,7 @@ namespace Step18
            dof_handler.begin_active();
          cell != dof_handler.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (vertex_touched[cell->vertex_index(v)] == false)
           {
             vertex_touched[cell->vertex_index(v)] = true;

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -631,8 +631,7 @@ namespace Step18
             cell = dof_handler.begin_active(),
             endc = dof_handler.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6)
                 {
                   monitored_vertex_first_dof = cell->vertex_dof_index(v, 0);
@@ -710,7 +709,7 @@ namespace Step18
            dof_handler.begin_active();
          cell != dof_handler.end();
          ++cell)
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         if (vertex_touched[cell->vertex_index(v)] == false)
           {
             vertex_touched[cell->vertex_index(v)] = true;

--- a/tests/physics/step-44-standard_tensors-material_push_forward.cc
+++ b/tests/physics/step-44-standard_tensors-material_push_forward.cc
@@ -1025,8 +1025,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/physics/step-44-standard_tensors-spatial.cc
+++ b/tests/physics/step-44-standard_tensors-spatial.cc
@@ -825,8 +825,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/physics/step-44.cc
+++ b/tests/physics/step-44.cc
@@ -838,8 +838,7 @@ namespace Step44
             cell = dof_handler_ref.begin_active(),
             endc = dof_handler_ref.end();
           for (; cell != endc; ++cell)
-            for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell;
-                 ++v)
+            for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
               if (cell->vertex(v).distance(soln_pt) < 1e-6 * parameters.scale)
                 {
                   Tensor<1, dim> soln;

--- a/tests/serialization/cell_data_1.cc
+++ b/tests/serialization/cell_data_1.cc
@@ -29,7 +29,7 @@ test()
 {
   dealii::CellData<structdim> t1;
 
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; i++)
+  for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
     t1.vertices[i] = i;
   t1.material_id = 0;
   t1.boundary_id = 1;
@@ -41,7 +41,7 @@ test()
   }
 
   // test vertices
-  for (unsigned int i = 0; i < GeometryInfo<structdim>::vertices_per_cell; i++)
+  for (const unsigned int i : GeometryInfo<structdim>::vertex_indices())
     {
       dealii::CellData<structdim> t2 = t1;
       t2.vertices[i]++;

--- a/tests/serialization/dof_handler_01.cc
+++ b/tests/serialization/dof_handler_01.cc
@@ -43,7 +43,7 @@ namespace dealii
                                                       c2 = t2.begin();
     for (; (c1 != t1.end()) && (c2 != t2.end()); ++c1, ++c2)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (c1->vertex(v) != c2->vertex(v))
               return false;

--- a/tests/serialization/hp_dof_handler_01.cc
+++ b/tests/serialization/hp_dof_handler_01.cc
@@ -44,7 +44,7 @@ namespace dealii
                                                           c2 = t2.begin();
     for (; (c1 != t1.end()) && (c2 != t2.end()); ++c1, ++c2)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (c1->vertex(v) != c2->vertex(v))
               return false;

--- a/tests/serialization/triangulation_01.cc
+++ b/tests/serialization/triangulation_01.cc
@@ -45,7 +45,7 @@ namespace dealii
                                                          c2 = t2.begin();
     for (; (c1 != t1.end()) && (c2 != t2.end()); ++c1, ++c2)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (c1->vertex(v) != c2->vertex(v))
               return false;

--- a/tests/serialization/triangulation_02.cc
+++ b/tests/serialization/triangulation_02.cc
@@ -47,7 +47,7 @@ namespace dealii
                                                          c2 = t2.begin();
     for (; (c1 != t1.end()) && (c2 != t2.end()); ++c1, ++c2)
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
           {
             if (c1->vertex(v) != c2->vertex(v))
               return false;


### PR DESCRIPTION
This addresses parts of #9620. The first commit introduces `GeometryInfo::vertex_indices()`, the remaining commits make use of it in the include/source directories and in tests/. These are mechanical and were done using the same approach as in previous commits: expand line length, then apply
```
perl -pi -e 's/unsigned int ([a-z_]+) = 0; \1 < GeometryInfo<([a-zA-Z_:1-9]+)>::vertices_per_cell; (\+\+\1|\1\+\+)\)/const unsigned int \1 : GeometryInfo<\2>::vertex_indices())/g;' `find include source tests | egrep '\.(cc|h|cu)$'`
```
then shrink line length again.

/rebuild