### PR TITLE
Introduce and use new ExcNeedsMPI

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1087,6 +1087,14 @@ namespace StandardExceptions
     "find a valid LAPACK library.");
 
   /**
+   * This function requires support for the MPI library.
+   */
+  DeclExceptionMsg(
+    ExcNeedsMPI,
+    "You are attempting to use functionality that is only available "
+    "if deal.II was configured to use MPI.");
+
+  /**
    * This function requires support for the NetCDF library.
    *
    * @deprecated Support for NetCDF in deal.II is deprecated.

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -52,9 +52,7 @@ namespace parallel
     , n_subdomains(Utilities::MPI::n_mpi_processes(this->mpi_communicator))
   {
 #ifndef DEAL_II_WITH_MPI
-    Assert(false,
-           ExcMessage("You compiled deal.II without MPI support, for "
-                      "which parallel::TriangulationBase is not available."));
+    Assert(false, ExcNeedsMPI());
 #endif
   }
 
@@ -67,9 +65,7 @@ namespace parallel
   {
 #ifndef DEAL_II_WITH_MPI
     (void)other_tria;
-    Assert(false,
-           ExcMessage("You compiled deal.II without MPI support, for "
-                      "which parallel::TriangulationBase is not available."));
+    Assert(false, ExcNeedsMPI());
 #else
     dealii::Triangulation<dim, spacedim>::copy_triangulation(other_tria);
 


### PR DESCRIPTION
Related to PR #9387.

I would like to assert here that deal.II was compiled with or without MPI:

https://github.com/dealii/dealii/blob/e78560b2099e1900a9cec668491c6ce8535f4873/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h#L236-L239

https://github.com/dealii/dealii/blob/e78560b2099e1900a9cec668491c6ce8535f4873/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h#L290-L292

However, I did not find an appropriate exception. For example, in `tria_base.cc` a long text is written two times. But I guess there are lot of places where it is checked if deal.II is compiled with or without MPI.

Now we can write `Assert(false, ExcNeedsMPI());`.