### PR TITLE
new free function LinearAlgebra::set_zero_mean_value()

### DIFF
--- a/doc/news/changes/minor/20200306NiklasFehn
+++ b/doc/news/changes/minor/20200306NiklasFehn
@@ -1,0 +1,7 @@
+New: LinearAlgebra::set_zero_mean_value()
+Add free function that allows to shift a vector by a constant value in a
+way that its mean value becomes zero. This function only makes use of the
+pure virtual functions add() and mean_value() of the abstract class
+VectorSpaceVector.
+<br>
+(Niklas Fehn, 2020/03/06)

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -273,6 +273,22 @@ namespace LinearAlgebra
   /*@}*/
 } // namespace LinearAlgebra
 
+// ---------------------------- Free functions --------------------------
+
+namespace LinearAlgebra
+{
+  /**
+   * Shift all entries of the vector by a constant factor so that the mean
+   * value of the vector becomes zero.
+   */
+  template <typename Number>
+  void
+  set_zero_mean_value(VectorSpaceVector<Number> &vector)
+  {
+    vector.add(-vector.mean_value());
+  }
+} // namespace LinearAlgebra
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif


### PR DESCRIPTION
Setting the mean value of a vector to zero is a standard operation, e.g., in incompressible flow solvers. This PR provides a short-cut for this type of operation.