### PR TITLE
Remove auto from test mpi_noncontiguous_partitioner_02.cc

### DIFF
--- a/tests/base/mpi_noncontiguous_partitioner_02.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_02.cc
@@ -65,7 +65,7 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
 
   std::vector<types::global_dof_index> indices_has, indices_want;
 
-  auto norm_point_to_lex = [&](const auto c) {
+  auto norm_point_to_lex = [&](const Point<dim> &c) {
     // convert normalized point [0, 1] to lex
     if (dim == 2)
       return std::floor(c[0]) + n_cells_1D * std::floor(c[1]);


### PR DESCRIPTION
This should fix the first (auto) warning in https://github.com/dealii/dealii/pull/9387#issuecomment-596101511.

I hope `'n_cells_1D’ was not declared in this scope` will automatically be fixed; the variable is definitely in the scope. 

ping @kronbichler 