### PR TITLE
Step-69: Introduce asynchronous IO mechanism

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -2740,8 +2740,8 @@ namespace Step69
 
   // @sect5{Output and checkpointing}
   //
-  // Writing out the final vtk files is a quite IO intensive task that can
-  // stall the main loop quite a bit. In order to avoid this we use an <a
+  // Writing out the final vtk files is quite an IO intensive task that can
+  // stall the main loop for a while. In order to avoid this we use an <a
   // href="https://en.wikipedia.org/wiki/Asynchronous_I/O">asynchronous
   // IO</a> strategy by creating a background thread that will perform IO
   // while the main loop is allowed to continue. In order for this to work
@@ -2766,14 +2766,9 @@ namespace Step69
     // If the asynchronous writeback option is set we launch a background
     // thread performing all the slow IO to disc. In that case we have to
     // make sure that the background thread actually finished running. If
-    // not, we have to wait to for it to finish because we would otherwise
-    // overwrite <code>output_vector</code>, rerun the
-    // <code>schlieren_postprocessor</code> and
-    // DataOut<dim>::build_patches() prematurely before the output of the
-    // previous output cycle has been fully written out to disk.
-    //
-    // We launch said background thread with <a
-    // href="https://en.cppreference.com/w/cpp/thread/async"><code>std::async</code></a>
+    // not, we have to wait to for it to finish. We launch said background
+    // thread with <a
+    // href="https://en.cppreference.com/w/cpp/thread/async"><code>std::async()</code></a>
     // that returns a <a
     // href="https://en.cppreference.com/w/cpp/thread/future"><code>std::future</code></a>
     // object. This <code>std::future</code> object contains the return
@@ -2827,7 +2822,6 @@ namespace Step69
     // the <code>this</code> pointer as well as most of the arguments of
     // the output function by value so that we have access to them inside
     // the lambda function.
-
     const auto output_worker = [this, name, t, cycle, checkpoint, data_out]() {
       if (checkpoint)
         {
@@ -2869,7 +2863,6 @@ namespace Step69
     // At this point we can return from the <code>output()</code> function
     // and resume with the time stepping in the main loop - the thread will
     // run in the background.
-
     if (!asynchronous_writeback)
       {
         background_thread_state = std::async(std::launch::async, output_worker);

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -495,7 +495,8 @@ namespace Step69
     std::string base_name;
     double      t_final;
     double      output_granularity;
-    bool        enable_compute_error;
+
+    bool asynchronous_writeback;
 
     bool resume;
 
@@ -2506,6 +2507,11 @@ namespace Step69
                   output_granularity,
                   "time interval for output");
 
+    asynchronous_writeback = true;
+    add_parameter("asynchronous writeback",
+                  asynchronous_writeback,
+                  "Write out solution in a background thread performing IO");
+
     resume = false;
     add_parameter("resume", resume, "Resume an interrupted computation.");
   }
@@ -2847,7 +2853,14 @@ namespace Step69
     // time stepping in the main loop - the thread will run in the
     // background.
 
-    output_thread = std::move(std::thread(output_worker));
+    if (!asynchronous_writeback)
+      {
+        output_thread = std::move(std::thread(output_worker));
+      }
+    else
+      {
+        output_worker();
+      }
   }
 
 } // namespace Step69

--- a/examples/step-69/step-69.prm
+++ b/examples/step-69/step-69.prm
@@ -1,17 +1,20 @@
 # Listing of Parameters
 # ---------------------
 subsection A - MainLoop
+  # Write out solution in a background thread performing IO
+  set asynchronous writeback = true
+
   # Base name for all output files
-  set basename           = test
+  set basename               = test
 
   # Final time
-  set final time         = 4
+  set final time             = 4
 
   # time interval for output
-  set output granularity = 0.02
+  set output granularity     = 0.02
 
   # Resume an interrupted computation.
-  set resume             = false
+  set resume                 = false
 end
 
 


### PR DESCRIPTION
This PR introduces a simple asynchronous IO mechanism to step-69:

On every MPI rank a (task group independent) background thread is spawned
for handling IO and writing out the solution and other files to disk.

The main advantage of this approach is that the normal computation can
continue and doesn't have to wait for disk IO. As an example, on a recently
computed 2B gridpoint computation the total time for writeback to the
distributed filesystem was about 20% of the total time of the computation
itself.