### PR TITLE
Add missing include file for step-69

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -82,8 +82,9 @@
 #include <boost/range/irange.hpp>
 #include <boost/range/iterator_range.hpp>
 
-// For std::isnan and std::isinf.
+// For std::isnan, std::isinf, and std::ifstream
 #include <cmath>
+#include <fstream>
 
 // @sect3{Class template declarations}
 //


### PR DESCRIPTION
This is needed with certain combinations of third-party libraries. Communicated by @kkormann.