### PR TITLE
Cache the vertex_to_cells and vertex_to_cell_centers structure in the particle_handler

### DIFF
--- a/doc/news/changes/minor/20200312BrunoBlais
+++ b/doc/news/changes/minor/20200312BrunoBlais
@@ -1,0 +1,3 @@
+Improved: ParticleHandler to have a GridTools::Cache to ensure better efficiency
+<br>
+(Bruno Blais, 2020/03/12)

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -700,7 +700,7 @@ namespace Particles
 
     /** The GridTools::Cache is used to store the information about the
      * vertex_to_cells set and the vertex_to_cell_centers vectors to prevent
-     * recomputing them every time we sort_into_subdomain_and_cells()
+     * recomputing them every time we sort_into_subdomain_and_cells().
      * This cache is automatically updated when the triangulation has
      * changed. This cache is stored within a unique pointer because the
      * particle handler has a constructor that enables it to be constructed

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -698,7 +698,8 @@ namespace Particles
      */
     unsigned int handle;
 
-    /** The GridTools::Cache is used to store the information about the
+    /**
+     * The GridTools::Cache is used to store the information about the
      * vertex_to_cells set and the vertex_to_cell_centers vectors to prevent
      * recomputing them every time we sort_into_subdomain_and_cells().
      * This cache is automatically updated when the triangulation has

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -86,7 +86,10 @@ namespace Particles
     /**
      * Destructor.
      */
-    virtual ~ParticleHandler() override = default;
+    virtual ~ParticleHandler() override
+    {
+      connection.disconnect();
+    }
 
     /**
      * Initialize the particle handler. This function does not clear the
@@ -595,6 +598,16 @@ namespace Particles
     void
     serialize(Archive &ar, const unsigned int version);
 
+    /**
+     * Updates the structures that were generated to search in which cells the
+     * particles belong to. The call to this function updates the
+     * vertex_to_cells and the vertex_to_cell_centers data structure. This
+     * function is called every time the triangulation is altered.
+     *
+     */
+    void
+    update_triangulation_cache();
+
   private:
     /**
      * Address of the triangulation to work on.
@@ -695,6 +708,31 @@ namespace Particles
      * triangulation object.
      */
     unsigned int handle;
+
+    /**
+     * A connection to the corresponding any_changes signal of the Triangulation
+     * which is attached to the particle_handler
+     */
+    boost::signals2::connection connection;
+
+    /** This variable stores a set from vertices to adjacent cells. It is used
+     * to locate the cells in which the particle reside. This structured is kept
+     * in memory to prevent its recalculation every time we
+     * sort_into_subdomain_and_cells(). This structure is updated everytime
+     * we call update_triangulation_cache.
+     */
+    std::vector<
+      std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>>
+      vertex_to_cells;
+
+
+    /** This variable stores a vector of vectors to cell centers. It is used
+     * to locate the cells in which the particle reside. This structured is kept
+     * in memory to prevent its recalculation every time we
+     * sort_into_subdomain_and_cells(). This structure is updated everytime
+     * we call update_triangulation_cache.
+     */
+    std::vector<std::vector<Tensor<1, spacedim>>> vertex_to_cell_centers;
 
 #ifdef DEAL_II_WITH_MPI
     /**


### PR DESCRIPTION
Added two cached variables (vertex_to_cells, vertex_to_cell_centers ) to the particle handler that stores the required information of the triangulation that is used to identify in which cells or subdomain the particle lies. This function is directly connected to the triangulation which enforces a reconstruction of the cached variable if the triangulation is changed in any way
This change greatly boosts execution speed in the case where the number of cells and the number of particles is comparable. In our case it leads to a performance boost of up to 70% for diluted particle cases (which is significant...)

This pull request fixes issue #9626 
As always, I am looking forward to your constructive comments and I am more than willing to make any required changes :)!. 

@gassmoeller this is a direct application (I think, I had not used signals before so maybe my usage is clumsy) of your suggestions :)!