### PR TITLE
Avoid global logfile variable for matrix-free tests

### DIFF
--- a/tests/matrix_free/additional_data_copy.cc
+++ b/tests/matrix_free/additional_data_copy.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 template <typename T>
 bool

--- a/tests/matrix_free/advect_1d.cc
+++ b/tests/matrix_free/advect_1d.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/advect_1d_system.cc
+++ b/tests/matrix_free/advect_1d_system.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/advect_1d_vectorization_mask.cc
+++ b/tests/matrix_free/advect_1d_vectorization_mask.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -36,9 +36,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 
 template <int dim, int fe_degree>
 void
@@ -158,7 +155,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -36,8 +36,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 
 const unsigned int degree_p = 1;
 
@@ -215,7 +213,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -39,8 +39,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 
 namespace Assembly
 {
@@ -198,7 +196,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/cell_categorization.cc
+++ b/tests/matrix_free/cell_categorization.cc
@@ -32,7 +32,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
 
 template <int dim>
 void

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -39,7 +39,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
 
 template <int dim>
 void

--- a/tests/matrix_free/compress_constraints.cc
+++ b/tests/matrix_free/compress_constraints.cc
@@ -38,8 +38,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
-
 
 
 template <int dim>
@@ -97,7 +95,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/compress_mapping.cc
+++ b/tests/matrix_free/compress_mapping.cc
@@ -37,8 +37,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
-
 
 
 template <int dim>
@@ -182,7 +180,7 @@ test_parallelogram()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/copy.cc
+++ b/tests/matrix_free/copy.cc
@@ -23,8 +23,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -19,10 +19,6 @@
 // the heap (using AlignedVector) instead of allocating it on the stack. Tests
 // also copy constructors of FEEvaluation.
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/utilities.h>
 
@@ -51,6 +47,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 
 
@@ -336,7 +334,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/dg_pbc_01.cc
+++ b/tests/matrix_free/dg_pbc_01.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 // We want to use the matrix-vector product provided by this function (which

--- a/tests/matrix_free/dg_pbc_02.cc
+++ b/tests/matrix_free/dg_pbc_02.cc
@@ -35,8 +35,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 
 
 template <int dim>

--- a/tests/matrix_free/estimate_condition_number_mass.cc
+++ b/tests/matrix_free/estimate_condition_number_mass.cc
@@ -19,10 +19,6 @@
 // different polynomial degrees. The mesh uses a hypercube mesh with no
 // hanging nodes and no other constraints
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/function_lib.h>
 
 #include <deal.II/fe/fe_dgq.h>
@@ -39,6 +35,8 @@ std::ofstream logfile("output");
 #include <deal.II/matrix_free/matrix_free.h>
 
 #include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
 
 
 void
@@ -156,7 +154,7 @@ test(const FiniteElement<dim> &fe, const unsigned int n_iterations)
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(2);
 

--- a/tests/matrix_free/faces_value_optimization.cc
+++ b/tests/matrix_free/faces_value_optimization.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 template <int dim, int fe_degree, typename number>
 class MatrixFreeTest

--- a/tests/matrix_free/faces_value_optimization_02.cc
+++ b/tests/matrix_free/faces_value_optimization_02.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 template <int dim, int fe_degree, typename number>
 class MatrixFreeTest

--- a/tests/matrix_free/get_functions_cartesian.cc
+++ b/tests/matrix_free/get_functions_cartesian.cc
@@ -23,9 +23,6 @@
 
 #include "../tests.h"
 
-
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_circle.cc
+++ b/tests/matrix_free/get_functions_circle.cc
@@ -23,8 +23,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -274,8 +274,7 @@ do_test(const DoFHandler<dim> &          dof,
 int
 main()
 {
-  deallog.attach(logfile);
-  deallog.depth_console(0);
+  initlog();
 
   deallog << std::setprecision(3);
   {

--- a/tests/matrix_free/get_functions_constraints.cc
+++ b/tests/matrix_free/get_functions_constraints.cc
@@ -21,8 +21,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_faces.cc
+++ b/tests/matrix_free/get_functions_faces.cc
@@ -33,8 +33,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 
 
 template <int dim, int fe_degree, typename number>

--- a/tests/matrix_free/get_functions_float.cc
+++ b/tests/matrix_free/get_functions_float.cc
@@ -25,9 +25,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_gl.cc
+++ b/tests/matrix_free/get_functions_gl.cc
@@ -23,9 +23,6 @@
 
 #include "../tests.h"
 
-
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_mappingq.cc
+++ b/tests/matrix_free/get_functions_mappingq.cc
@@ -23,8 +23,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -44,8 +44,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 
 template <int dim,
           int fe_degree,
@@ -291,11 +289,8 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-  // need to set quite a loose tolerance because
-  // FEValues approximates Hessians with finite
-  // differences, which are not so accurate
-  deallog << std::setprecision(3);
+  initlog();
+  deallog << std::setprecision(7);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -46,8 +46,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
 
 template <int dim,
           int fe_degree,
@@ -342,11 +340,8 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-  // need to set quite a loose tolerance because
-  // FEValues approximates Hessians with finite
-  // differences, which are not so accurate
-  deallog << std::setprecision(3);
+  initlog();
+  deallog << std::setprecision(7);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/get_functions_notempl.cc
+++ b/tests/matrix_free/get_functions_notempl.cc
@@ -24,8 +24,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_q_hierarchical.cc
+++ b/tests/matrix_free/get_functions_q_hierarchical.cc
@@ -30,8 +30,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_rect.cc
+++ b/tests/matrix_free/get_functions_rect.cc
@@ -24,8 +24,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 

--- a/tests/matrix_free/get_functions_variants.cc
+++ b/tests/matrix_free/get_functions_variants.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, typename Number>
@@ -197,7 +196,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/get_functions_variants_gl.cc
+++ b/tests/matrix_free/get_functions_variants_gl.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, typename Number>
@@ -193,7 +192,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/get_values_plain.cc
+++ b/tests/matrix_free/get_values_plain.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,
@@ -193,7 +192,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
   {

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, typename Number>
@@ -230,7 +229,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, typename Number>
@@ -355,7 +354,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -47,7 +47,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree, typename Number>
@@ -345,7 +344,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/jxw_values.cc
+++ b/tests/matrix_free/jxw_values.cc
@@ -34,7 +34,6 @@
 
 #include "create_mesh.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim>
@@ -102,7 +101,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(3);
 
   test<2>();

--- a/tests/matrix_free/matrix_vector_01.cc
+++ b/tests/matrix_free/matrix_vector_01.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_02.cc
+++ b/tests/matrix_free/matrix_vector_02.cc
@@ -24,8 +24,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_03.cc
+++ b/tests/matrix_free/matrix_vector_03.cc
@@ -24,8 +24,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_04.cc
+++ b/tests/matrix_free/matrix_vector_04.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_04b.cc
+++ b/tests/matrix_free/matrix_vector_04b.cc
@@ -20,8 +20,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_05.cc
+++ b/tests/matrix_free/matrix_vector_05.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_06.cc
+++ b/tests/matrix_free/matrix_vector_06.cc
@@ -26,9 +26,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_06_notempl.cc
+++ b/tests/matrix_free/matrix_vector_06_notempl.cc
@@ -24,9 +24,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_07.cc
+++ b/tests/matrix_free/matrix_vector_07.cc
@@ -29,8 +29,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_08.cc
+++ b/tests/matrix_free/matrix_vector_08.cc
@@ -24,9 +24,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_09.cc
+++ b/tests/matrix_free/matrix_vector_09.cc
@@ -24,9 +24,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_14.cc
+++ b/tests/matrix_free/matrix_vector_14.cc
@@ -25,9 +25,6 @@
 
 #include "../tests.h"
 
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_14_notempl.cc
+++ b/tests/matrix_free/matrix_vector_14_notempl.cc
@@ -22,9 +22,6 @@
 
 #include "../tests.h"
 
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_14b.cc
+++ b/tests/matrix_free/matrix_vector_14b.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_15.cc
+++ b/tests/matrix_free/matrix_vector_15.cc
@@ -43,9 +43,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 
 template <int dim,
           int fe_degree,
@@ -235,7 +232,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -43,9 +43,6 @@
 #include "../tests.h"
 
 
-std::ofstream logfile("output");
-
-
 
 template <int dim,
           int fe_degree,
@@ -235,7 +232,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/matrix_vector_17.cc
+++ b/tests/matrix_free/matrix_vector_17.cc
@@ -25,8 +25,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_common.h
+++ b/tests/matrix_free/matrix_vector_common.h
@@ -166,10 +166,7 @@ do_test(const DoFHandler<dim> &          dof,
 int
 main()
 {
-  deallog.attach(logfile);
-  deallog.depth_console(0);
-
-  deallog << std::setprecision(3);
+  initlog();
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/matrix_vector_curl.cc
+++ b/tests/matrix_free/matrix_vector_curl.cc
@@ -21,10 +21,6 @@
 // vector-valued problem (curl-curl operator which does not really make a lot
 // of sense from a problem point of view, though).
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -51,6 +47,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 const double global_coefficient = 0.1;
 
@@ -283,8 +281,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/matrix_vector_div.cc
+++ b/tests/matrix_free/matrix_vector_div.cc
@@ -21,10 +21,6 @@
 // vector-valued problem (div-div operator which does not really make a lot
 // of sense from a problem point of view, though).
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -51,6 +47,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 #include "create_mesh.h"
 
@@ -286,7 +284,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
 

--- a/tests/matrix_free/matrix_vector_faces_01.cc
+++ b/tests/matrix_free/matrix_vector_faces_01.cc
@@ -25,8 +25,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_02.cc
+++ b/tests/matrix_free/matrix_vector_faces_02.cc
@@ -25,8 +25,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_03.cc
+++ b/tests/matrix_free/matrix_vector_faces_03.cc
@@ -28,9 +28,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_04.cc
+++ b/tests/matrix_free/matrix_vector_faces_04.cc
@@ -25,8 +25,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_05.cc
+++ b/tests/matrix_free/matrix_vector_faces_05.cc
@@ -27,8 +27,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_06.cc
+++ b/tests/matrix_free/matrix_vector_faces_06.cc
@@ -27,9 +27,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_07.cc
+++ b/tests/matrix_free/matrix_vector_faces_07.cc
@@ -29,9 +29,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_08.cc
+++ b/tests/matrix_free/matrix_vector_faces_08.cc
@@ -29,9 +29,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_09.cc
+++ b/tests/matrix_free/matrix_vector_faces_09.cc
@@ -28,9 +28,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_10.cc
+++ b/tests/matrix_free/matrix_vector_faces_10.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_11.cc
+++ b/tests/matrix_free/matrix_vector_faces_11.cc
@@ -33,9 +33,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_12.cc
+++ b/tests/matrix_free/matrix_vector_faces_12.cc
@@ -28,9 +28,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_13.cc
+++ b/tests/matrix_free/matrix_vector_faces_13.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_14.cc
+++ b/tests/matrix_free/matrix_vector_faces_14.cc
@@ -32,8 +32,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_15.cc
+++ b/tests/matrix_free/matrix_vector_faces_15.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_16.cc
+++ b/tests/matrix_free/matrix_vector_faces_16.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_17.cc
+++ b/tests/matrix_free/matrix_vector_faces_17.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_18.cc
+++ b/tests/matrix_free/matrix_vector_faces_18.cc
@@ -30,8 +30,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_19.cc
+++ b/tests/matrix_free/matrix_vector_faces_19.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_20.cc
+++ b/tests/matrix_free/matrix_vector_faces_20.cc
@@ -34,8 +34,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_21.cc
+++ b/tests/matrix_free/matrix_vector_faces_21.cc
@@ -35,8 +35,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_22.cc
+++ b/tests/matrix_free/matrix_vector_faces_22.cc
@@ -33,8 +33,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_23.cc
+++ b/tests/matrix_free/matrix_vector_faces_23.cc
@@ -35,8 +35,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_24.cc
+++ b/tests/matrix_free/matrix_vector_faces_24.cc
@@ -33,9 +33,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_25.cc
+++ b/tests/matrix_free/matrix_vector_faces_25.cc
@@ -27,8 +27,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_faces_26.cc
+++ b/tests/matrix_free/matrix_vector_faces_26.cc
@@ -25,8 +25,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_27.cc
+++ b/tests/matrix_free/matrix_vector_faces_27.cc
@@ -27,8 +27,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 template <int dim, int fe_degree>

--- a/tests/matrix_free/matrix_vector_faces_28.cc
+++ b/tests/matrix_free/matrix_vector_faces_28.cc
@@ -32,9 +32,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/matrix_vector_float.cc
+++ b/tests/matrix_free/matrix_vector_float.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 #include "create_mesh.h"
 #include "matrix_vector_common.h"
 

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -20,14 +20,12 @@
 // matrix for hp DoFHandler on a hyperball mesh with hanging nodes and finite
 // elements orders distributed randomly.
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/function.h>
 
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/fe_values.h>
+
+#include "../tests.h"
 
 #include "matrix_vector_common.h"
 

--- a/tests/matrix_free/matrix_vector_large_degree_01.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_01.cc
@@ -22,10 +22,6 @@
 // matrix-based results in this case, this test simply checks that the
 // matrix-vector product runs without error
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -37,6 +33,8 @@ std::ofstream logfile("output");
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
+
+#include "../tests.h"
 
 #include "matrix_vector_mf.h"
 

--- a/tests/matrix_free/matrix_vector_large_degree_03.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_03.cc
@@ -20,10 +20,6 @@
 // have a constant-coefficient Laplacian, we can verify the implementation by
 // comparing to the result with 21 quadrature points.
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -35,6 +31,8 @@ std::ofstream logfile("output");
 
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
+
+#include "../tests.h"
 
 #include "matrix_vector_mf.h"
 

--- a/tests/matrix_free/matrix_vector_mg.cc
+++ b/tests/matrix_free/matrix_vector_mg.cc
@@ -20,14 +20,12 @@
 // matrix for MG DoFHandler on a hyperball mesh with no hanging nodes but
 // homogeneous Dirichlet conditions
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/function.h>
 
 #include <deal.II/multigrid/mg_matrix.h>
 #include <deal.II/multigrid/mg_tools.h>
+
+#include "../tests.h"
 
 #include "matrix_vector_common.h"
 

--- a/tests/matrix_free/matrix_vector_stokes.cc
+++ b/tests/matrix_free/matrix_vector_stokes.cc
@@ -20,10 +20,6 @@
 // matrix. No hanging nodes and no other
 // constraints for a vector-valued problem (stokes equations).
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -50,6 +46,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 #include "create_mesh.h"
 
@@ -317,8 +315,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/matrix_vector_stokes_flux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_flux.cc
@@ -22,10 +22,6 @@
 // the Stokes equations. Like matrix_vector_stokes_onedof except for
 // different constraints
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
 
@@ -55,6 +51,8 @@ std::ofstream logfile("output");
 #include <complex>
 #include <fstream>
 #include <iostream>
+
+#include "../tests.h"
 
 
 

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -21,10 +21,6 @@
 // between the vector components in the form of no-normal flux constraints on
 // the Stokes equations.
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -52,6 +48,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 
 
@@ -331,8 +329,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/matrix_vector_stokes_notempl.cc
+++ b/tests/matrix_free/matrix_vector_stokes_notempl.cc
@@ -18,10 +18,6 @@
 // same as matrix_vector_stokes_noflux but no template parameter on the
 // polynomial degree
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -49,6 +45,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 
 
@@ -327,8 +325,7 @@ test(const unsigned int fe_degree)
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/matrix_vector_stokes_onedof.cc
+++ b/tests/matrix_free/matrix_vector_stokes_onedof.cc
@@ -20,10 +20,6 @@
 // putting all degrees of freedom into a single DoFHandler, where the
 // selection is done through FEEvaluation
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
 
@@ -53,6 +49,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 
 

--- a/tests/matrix_free/matrix_vector_stokes_qdg0.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0.cc
@@ -20,10 +20,6 @@
 // matrix. No hanging nodes and no other
 // constraints for a vector-valued problem (stokes equations).
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -51,6 +47,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 #include "create_mesh.h"
 
@@ -319,8 +317,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
@@ -21,10 +21,6 @@
 // problem (stokes equations). Same as matrix_vector_stokes_qdg0 but now
 // without the template on the degree of the element.
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -52,6 +48,8 @@ std::ofstream logfile("output");
 
 #include <complex>
 #include <iostream>
+
+#include "../tests.h"
 
 #include "create_mesh.h"
 
@@ -316,8 +314,7 @@ test(const unsigned int fe_degree)
 int
 main()
 {
-  deallog.attach(logfile);
-
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -53,7 +53,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -52,7 +52,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -53,7 +53,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -18,11 +18,6 @@
 // check that FEEvaluation can be evaluated without indices initialized (and
 // throws an exception when trying to read/write from/to vectors)
 
-#include "../tests.h"
-
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/utilities.h>
 
 #include <deal.II/dofs/dof_handler.h>
@@ -44,6 +39,8 @@ std::ofstream logfile("output");
 #include <deal.II/numerics/vector_tools.h>
 
 #include <iostream>
+
+#include "../tests.h"
 
 
 // forward declare this function
@@ -173,7 +170,7 @@ int
 main()
 {
   deal_II_exceptions::disable_abort_on_exception();
-  deallog.attach(logfile);
+  initlog();
 
   deallog << std::setprecision(3);
   test<2, 1>();

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,
@@ -456,12 +455,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -49,8 +49,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
-
 
 
 template <typename MatrixType, typename Number>
@@ -276,12 +274,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim,
@@ -654,12 +653,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -50,7 +50,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 
@@ -349,12 +348,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -50,7 +50,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 
@@ -348,11 +347,8 @@ main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
 
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -65,7 +65,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 
@@ -427,12 +426,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -51,7 +51,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 
@@ -336,12 +335,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 
@@ -470,12 +469,8 @@ int
 main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv, 1);
-
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      deallog.attach(logfile);
-      deallog << std::setprecision(4);
-    }
+  mpi_initlog();
+  deallog << std::setprecision(4);
 
   // 2 blocks
   {

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 using namespace dealii::MatrixFreeOperators;
 

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim, int fe_degree>
@@ -116,7 +115,7 @@ test()
 int
 main()
 {
-  deallog.attach(logfile);
+  initlog();
   deallog << std::setprecision(3);
 
   {

--- a/tests/matrix_free/shape_info.cc
+++ b/tests/matrix_free/shape_info.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim>

--- a/tests/matrix_free/shape_info_inverse.cc
+++ b/tests/matrix_free/shape_info_inverse.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-std::ofstream logfile("output");
 
 
 template <int dim>

--- a/tests/matrix_free/thread_correctness.cc
+++ b/tests/matrix_free/thread_correctness.cc
@@ -23,9 +23,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_common.h"
 
 

--- a/tests/matrix_free/thread_correctness_dg.cc
+++ b/tests/matrix_free/thread_correctness_dg.cc
@@ -25,9 +25,6 @@
 #include "../tests.h"
 
 #include "create_mesh.h"
-
-std::ofstream logfile("output");
-
 #include "matrix_vector_faces_common.h"
 
 

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -19,15 +19,13 @@
 // matrix free matrix-vector products for hp elements by comparing to the
 // serial version
 
-#include "../tests.h"
-
-std::ofstream logfile("output");
-
 #include <deal.II/base/function.h>
 #include <deal.II/base/template_constraints.h>
 
 #include <deal.II/hp/dof_handler.h>
 #include <deal.II/hp/fe_values.h>
+
+#include "../tests.h"
 
 #include "create_mesh.h"
 #include "matrix_vector_common.h"

--- a/tests/matrix_free/update_mapping_only.cc
+++ b/tests/matrix_free/update_mapping_only.cc
@@ -23,9 +23,6 @@
 
 #include "../tests.h"
 
-
-std::ofstream logfile("output");
-
 #include "get_functions_common.h"
 
 


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/9565#discussion_r390943577 I ran a script to remove the global `logfile` variable in some tests. Because we used different ways to replace that variable depending on whether we use MPI or not (`mpi_initlog()` vs `initlog()`), I had to do some manual labor so I stopped after the matrix-free folder. But this is already good progress and hopefully avoids some copy-paste issues in those parts of the tests.

Passes `matrix_free` tests locally.