### PR TITLE
Split instantiations of matrix-free MappingInfo

### DIFF
--- a/source/matrix_free/CMakeLists.txt
+++ b/source/matrix_free/CMakeLists.txt
@@ -18,6 +18,8 @@ INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 SET(_src
   evaluation_selector.cc
   mapping_info.cc
+  mapping_info_inst2.cc
+  mapping_info_inst3.cc
   matrix_free.cc
   task_info.cc
   )

--- a/source/matrix_free/mapping_info.cc
+++ b/source/matrix_free/mapping_info.cc
@@ -23,33 +23,41 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#define SPLIT_INSTANTIATIONS_COUNT 3
+#ifndef SPLIT_INSTANTIATIONS_INDEX
+#  define SPLIT_INSTANTIATIONS_INDEX 0
+#endif
 #include "mapping_info.inst"
+
+#if SPLIT_INSTANTIATIONS_INDEX == 0
 
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<double, VectorizedArray<double, 1>>;
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<float, VectorizedArray<float, 1>>;
 
-#if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
-  (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
+#  if (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__SSE2__)) || \
+    (DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 1 && defined(__ALTIVEC__))
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<double, VectorizedArray<double, 2>>;
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<float, VectorizedArray<float, 4>>;
-#endif
+#  endif
 
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
+#  if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 2 && defined(__AVX__)
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<double, VectorizedArray<double, 4>>;
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<float, VectorizedArray<float, 8>>;
-#endif
+#  endif
 
-#if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
+#  if DEAL_II_COMPILER_VECTORIZATION_LEVEL >= 3 && defined(__AVX512F__)
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<double, VectorizedArray<double, 8>>;
 template struct internal::MatrixFreeFunctions::
   FPArrayComparator<float, VectorizedArray<float, 16>>;
+#  endif
+
 #endif
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/mapping_info_inst2.cc
+++ b/source/matrix_free/mapping_info_inst2.cc
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#define SPLIT_INSTANTIATIONS_INDEX 1
+#include "mapping_info.cc"

--- a/source/matrix_free/mapping_info_inst3.cc
+++ b/source/matrix_free/mapping_info_inst3.cc
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#define SPLIT_INSTANTIATIONS_INDEX 2
+#include "mapping_info.cc"


### PR DESCRIPTION
Now that we instantiate `MatrixFreeFunctions::MappingInfo` for several kinds of vectorized arrays, the compilation has become pretty big and takes quite some memory. This will get even slightly worse with a PR I am currently working on that should provide a much faster initialization method for high-order mappings.

This PR splits the instantiations up into 3 which gives better compile times on parallel systems (though not really the factor 3 I was hoping for because the compiler does keep track of some redundancies when instantiating multiple objects).