### PR TITLE
Enable std::max_element for VectorizedArray

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -101,9 +101,21 @@ public:
    * @param lane A pointer to the current lane.
    */
   VectorizedArrayIterator(T &data, const unsigned int lane)
-    : data(data)
+    : data(&data)
     , lane(lane)
   {}
+
+  /**
+   * Compare for equality.
+   */
+  bool
+  operator==(const VectorizedArrayIterator<T> &other) const
+  {
+    Assert(this->data == other.data,
+           ExcMessage(
+             "You are trying to compare iterators into different arrays."));
+    return this->lane == other.lane;
+  }
 
   /**
    * Compare for inequality.
@@ -111,8 +123,17 @@ public:
   bool
   operator!=(const VectorizedArrayIterator<T> &other) const
   {
+    Assert(this->data == other.data,
+           ExcMessage(
+             "You are trying to compare iterators into different arrays."));
     return this->lane != other.lane;
   }
+
+  /**
+   * Copy assignment.
+   */
+  VectorizedArrayIterator<T> &
+  operator=(const VectorizedArrayIterator<T> &other) = default;
 
   /**
    * Dereferencing operator (const version): returns the value of the current
@@ -120,7 +141,7 @@ public:
    */
   const typename T::value_type &operator*() const
   {
-    return data[lane];
+    return (*data)[lane];
   }
 
 
@@ -133,7 +154,7 @@ public:
                           typename T::value_type>::type &
   operator*()
   {
-    return data[lane];
+    return (*data)[lane];
   }
 
   /**
@@ -150,9 +171,9 @@ public:
 
 private:
   /**
-   * Reference to the actual VectorizedArray.
+   * Pointer to the actual VectorizedArray.
    */
-  T &data;
+  T *data;
 
   /**
    * Pointer to the current lane.

--- a/tests/base/vectorization_iterator_02.cc
+++ b/tests/base/vectorization_iterator_02.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test for std::max_element on VectorizedArray
+
+#include <deal.II/base/vectorization.h>
+
+#include "../tests.h"
+
+
+template <typename Number>
+void
+test_const(const VectorizedArray<Number> &vector)
+{
+  AssertDimension(*std::max_element(vector.begin(), vector.end()),
+                  VectorizedArray<Number>::n_array_elements - 1);
+}
+
+template <typename Number>
+void
+test_nonconst(VectorizedArray<Number> &vector)
+{
+  AssertDimension(*std::max_element(vector.begin(), vector.end()),
+                  VectorizedArray<Number>::n_array_elements - 1);
+}
+
+template <typename Number>
+void
+test()
+{
+  VectorizedArray<Number> vector;
+
+  for (unsigned int v = 0; v < VectorizedArray<Number>::size(); ++v)
+    vector[v] = v;
+
+  test_const(vector);
+  test_nonconst(vector);
+}
+
+
+int
+main()
+{
+  initlog();
+
+  deallog.push("float");
+  test<float>();
+  deallog << "OK" << std::endl;
+  deallog.pop();
+
+  deallog.push("double");
+  test<double>();
+  deallog << "OK" << std::endl;
+  deallog.pop();
+}

--- a/tests/base/vectorization_iterator_02.output
+++ b/tests/base/vectorization_iterator_02.output
@@ -1,0 +1,3 @@
+
+DEAL:float::OK
+DEAL:double::OK


### PR DESCRIPTION
...to be able to write `*std::max_element(vector.begin(), vector.end()` with `vector` being of type `VectorizedArray`.

ping @kronbichler @masterleinad 

FYI @DavidSCN 