### PR TITLE
Fix two tests after elimination of logfile

### DIFF
--- a/tests/mpi/torus.cc
+++ b/tests/mpi/torus.cc
@@ -76,11 +76,6 @@ main(int argc, char *argv[])
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;
 
-  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    {
-      static initlog();
-    }
-
   parallel::distributed::Triangulation<2, 3> triangulation(
     MPI_COMM_WORLD,
     typename Triangulation<2, 3>::MeshSmoothing(

--- a/tests/petsc/vector_print.cc
+++ b/tests/petsc/vector_print.cc
@@ -46,10 +46,10 @@ main(int argc, char **argv)
 
         // print with prescribed precision
         deallog << "across=false" << std::endl;
-        v.print(logfile, 10, true, false);
+        v.print(deallog.get_file_stream(), 10, true, false);
 
         deallog << "across=true" << std::endl;
-        v.print(logfile, 10, true, true);
+        v.print(deallog.get_file_stream(), 10, true, true);
 
         // print once more. should be the old precision again
         deallog << numbers::PI << std::endl;


### PR DESCRIPTION
As documented by https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=4942 , we have two test failures as a consequence of #9650. This fixes those tests.