### PR TITLE
MF::copy_from: add missing fields

### DIFF
--- a/doc/news/changes/minor/20200316DanielJodlbauer
+++ b/doc/news/changes/minor/20200316DanielJodlbauer
@@ -1,0 +1,3 @@
+Fixed: Add missing fields to MatrixFree::copy_from.
+<br>
+(Daniel Jodlbauer, 2020/03/16)

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -334,17 +334,19 @@ MatrixFree<dim, Number, VectorizedArrayType>::copy_from(
   const MatrixFree<dim, Number, VectorizedArrayType> &v)
 {
   clear();
-  dof_handlers              = v.dof_handlers;
-  dof_info                  = v.dof_info;
-  constraint_pool_data      = v.constraint_pool_data;
-  constraint_pool_row_index = v.constraint_pool_row_index;
-  mapping_info              = v.mapping_info;
-  shape_info                = v.shape_info;
-  cell_level_index          = v.cell_level_index;
-  task_info                 = v.task_info;
-  indices_are_initialized   = v.indices_are_initialized;
-  mapping_is_initialized    = v.mapping_is_initialized;
-  mg_level                  = v.mg_level;
+  dof_handlers               = v.dof_handlers;
+  dof_info                   = v.dof_info;
+  constraint_pool_data       = v.constraint_pool_data;
+  constraint_pool_row_index  = v.constraint_pool_row_index;
+  mapping_info               = v.mapping_info;
+  shape_info                 = v.shape_info;
+  cell_level_index           = v.cell_level_index;
+  cell_level_index_end_local = v.cell_level_index_end_local;
+  task_info                  = v.task_info;
+  face_info                  = v.face_info;
+  indices_are_initialized    = v.indices_are_initialized;
+  mapping_is_initialized     = v.mapping_is_initialized;
+  mg_level                   = v.mg_level;
 }
 
 


### PR DESCRIPTION
The copy constructor / `copy_from` method from `MatrixFree` did not handle `face_info` and `cell_level_index_end_local`.
The crucial one for me was `face_info`, not sure if `cell_level_index_end_local` is necessary.