### PR TITLE
VectorizedArrayIterator enable std::distance and add operator+

### DIFF
--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -169,6 +169,25 @@ public:
     return *this;
   }
 
+  /**
+   * Create new iterator, which is shifted by @p offset.
+   */
+  VectorizedArrayIterator<T>
+  operator+(const unsigned int &offset) const
+  {
+    return VectorizedArrayIterator<T>(*data, lane + offset);
+  }
+
+  /**
+   * Compute distance between this iterator and iterator @p other.
+   */
+  unsigned int
+  operator-(const VectorizedArrayIterator<T> &other) const
+  {
+    AssertIndexRange(other.lane, lane + 1);
+    return lane - other.lane;
+  }
+
 private:
   /**
    * Pointer to the actual VectorizedArray.
@@ -5438,6 +5457,19 @@ namespace std
   {
     return x.get_min(y);
   }
+
+
+
+  /**
+   * Iterator traits for VectorizedArrayIterator.
+   */
+  template <class T>
+  struct iterator_traits<dealii::VectorizedArrayIterator<T>>
+  {
+    using iterator_category = random_access_iterator_tag;
+    using value_type        = typename T::value_type;
+    using difference_type   = unsigned int;
+  };
 
 } // namespace std
 

--- a/tests/base/vectorization_iterator_02.cc
+++ b/tests/base/vectorization_iterator_02.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// test for std::max_element on VectorizedArray
+// test for std::max_element and std::distance on VectorizedArray
 
 #include <deal.II/base/vectorization.h>
 
@@ -27,6 +27,14 @@ test_const(const VectorizedArray<Number> &vector)
 {
   AssertDimension(*std::max_element(vector.begin(), vector.end()),
                   VectorizedArray<Number>::n_array_elements - 1);
+  AssertDimension(std::distance(vector.begin(),
+                                std::max_element(vector.begin(), vector.end())),
+                  VectorizedArray<Number>::n_array_elements - 1);
+  AssertDimension(std::distance(vector.begin(),
+                                vector.begin() +
+                                  (VectorizedArray<Number>::n_array_elements -
+                                   1)),
+                  VectorizedArray<Number>::n_array_elements - 1);
 }
 
 template <typename Number>
@@ -34,6 +42,14 @@ void
 test_nonconst(VectorizedArray<Number> &vector)
 {
   AssertDimension(*std::max_element(vector.begin(), vector.end()),
+                  VectorizedArray<Number>::n_array_elements - 1);
+  AssertDimension(std::distance(vector.begin(),
+                                std::max_element(vector.begin(), vector.end())),
+                  VectorizedArray<Number>::n_array_elements - 1);
+  AssertDimension(std::distance(vector.begin(),
+                                vector.begin() +
+                                  (VectorizedArray<Number>::n_array_elements -
+                                   1)),
                   VectorizedArray<Number>::n_array_elements - 1);
 }
 


### PR DESCRIPTION
Independent of the issue reported in https://github.com/dealii/dealii/pull/9660#issuecomment-599985295. I was working on enabling:
```cpp
VectorizedArray<Number> vec;
MatrixFree<Number> matrix_free;

std::max_element(vec.begin(), vec.begin() + matrix_free.n_components_filled (cell));
```

This PR should enable to above code and also fix the issue.

FYI @DavidSCN 