### PR TITLE
merge_triangulations(): replace std::initializer_list by std::vector

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1547,11 +1547,10 @@ namespace GridGenerator
   template <int dim, int spacedim>
   void
   merge_triangulations(
-    const std::initializer_list<const Triangulation<dim, spacedim> *const>
-      &                           triangulations,
-    Triangulation<dim, spacedim> &result,
-    const double                  duplicated_vertex_tolerance = 1.0e-12,
-    const bool                    copy_manifold_ids           = false);
+    const std::vector<const Triangulation<dim, spacedim> *> &triangulations,
+    Triangulation<dim, spacedim> &                           result,
+    const double duplicated_vertex_tolerance = 1.0e-12,
+    const bool   copy_manifold_ids           = false);
 
   /**
    * \brief Replicate a given triangulation in multiple coordinate axes

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -5726,11 +5726,10 @@ namespace GridGenerator
   template <int dim, int spacedim>
   void
   merge_triangulations(
-    const std::initializer_list<const Triangulation<dim, spacedim> *const>
-      &                           triangulations,
-    Triangulation<dim, spacedim> &result,
-    const double                  duplicated_vertex_tolerance,
-    const bool                    copy_manifold_ids)
+    const std::vector<const Triangulation<dim, spacedim> *> &triangulations,
+    Triangulation<dim, spacedim> &                           result,
+    const double duplicated_vertex_tolerance,
+    const bool   copy_manifold_ids)
   {
     std::vector<Point<spacedim>> vertices;
     std::vector<CellData<dim>>   cells;

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -80,9 +80,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 
       template void
       merge_triangulations(
-        const std::initializer_list<
-          const Triangulation<deal_II_dimension, deal_II_space_dimension>
-            *const> &,
+        const std::vector<
+          const Triangulation<deal_II_dimension, deal_II_space_dimension> *> &,
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         const double,
         const bool);


### PR DESCRIPTION
The current interface with ``std::initializer_list`` is impractical as it prevents automatization.

This PR suggests to use ``std::vector`` instead. The function can still be called with an initializer list, as a vector can be initialized with such an object. At the same time, the vector improves flexibility.