### PR TITLE
Change type of template argument width of VectorizedArray to std::size_t

### DIFF
--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -128,7 +128,7 @@ namespace MemoryConsumption
    * Determine the amount of memory in bytes consumed by a
    * <tt>VectorizedArray</tt> variable.
    */
-  template <typename T, int width>
+  template <typename T, std::size_t width>
   inline std::size_t
   memory_consumption(const VectorizedArray<T, width> &);
 
@@ -296,7 +296,7 @@ namespace MemoryConsumption
 
 
 
-  template <typename T, int width>
+  template <typename T, std::size_t width>
   inline std::size_t
   memory_consumption(const VectorizedArray<T, width> &)
   {

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -128,7 +128,7 @@ namespace internal
 // forward declarations to support abs or sqrt operations on VectorizedArray
 #ifndef DOXYGEN
 template <typename Number,
-          int width =
+          std::size_t width =
             internal::VectorizedArrayWidthSpecifier<Number>::max_width>
 class VectorizedArray;
 template <typename T>
@@ -154,36 +154,36 @@ DEAL_II_NAMESPACE_CLOSE
 
 namespace std
 {
-  template <typename Number, int width>
+  template <typename Number, std::size_t width>
   DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
   sqrt(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, std::size_t width>
   DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
   abs(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, std::size_t width>
   DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
   max(const ::dealii::VectorizedArray<Number, width> &,
       const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, std::size_t width>
   DEAL_II_ALWAYS_INLINE ::dealii::VectorizedArray<Number, width>
   min(const ::dealii::VectorizedArray<Number, width> &,
       const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   pow(const ::dealii::VectorizedArray<Number, width> &, const Number p);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   sin(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   cos(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   tan(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   exp(const ::dealii::VectorizedArray<Number, width> &);
-  template <typename Number, int width>
+  template <typename Number, size_t width>
   ::dealii::VectorizedArray<Number, width>
   log(const ::dealii::VectorizedArray<Number, width> &);
 } // namespace std

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -51,7 +51,7 @@ namespace internal
       return a;
     }
 
-    template <typename Number, int width>
+    template <typename Number, std::size_t width>
     Number
     get_first_array_element(const VectorizedArray<Number, width> a)
     {


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/9556#issuecomment-589526815.

This enables me to remove annoying workarounds.

In a follow-up PR, we should deprecate `n_array_elements` and replace its usage by `size()`. At the moment there is still a chaos since both are or can be used and they have different types. Any interest that this is done before the next release?

related to #9680 