### PR TITLE
Disallow use of Tensor<-1> and Tensor<-2>.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -63,11 +63,17 @@ namespace Differentiation
 // overload resolution of operator* and related contraction variants.
 template <int dim, typename Number>
 class Tensor<-2, dim, Number>
-{};
+{
+public:
+  Tensor() = delete;
+};
 
 template <int dim, typename Number>
 class Tensor<-1, dim, Number>
-{};
+{
+public:
+  Tensor() = delete;
+};
 #endif /* DOXYGEN */
 
 


### PR DESCRIPTION
The discussion in #9490 made me look into `tensor.h` where I realize that we have specializations for `Tensor<-1>` and `Tensor<-2>`. The comments say that we use them in some template instantiations -- though I suspect that what that comment really means is that we only *reference* these types instead of actually creating objects of these types.

In any case, creating objects of these types would likely be a bug. So let's avoid that by making the default constructors `=delete`d and not offering any other constructor either.

/rebuild