### PR TITLE
Deprecate VectorizedArray::n_array_elements

### DIFF
--- a/doc/news/changes/incompatibilities/20200320PeterMunch
+++ b/doc/news/changes/incompatibilities/20200320PeterMunch
@@ -1,0 +1,4 @@
+Chaned: VectorizedArray::n_array_elements has been deprecated. 
+Please use the method VectorizedArray::size() to access the same information.
+<br>
+(Peter Munch, 2020/03/20)

--- a/include/deal.II/lac/tensor_product_matrix.h
+++ b/include/deal.II/lac/tensor_product_matrix.h
@@ -799,7 +799,7 @@ TensorProductMatrixSymmetricSum<dim, VectorizedArray<Number>, n_rows_1d>::
   this->mass_matrix        = mass_matrix;
   this->derivative_matrix  = derivative_matrix;
 
-  constexpr unsigned int macro_size = VectorizedArray<Number>::n_array_elements;
+  constexpr unsigned int macro_size = VectorizedArray<Number>::size();
   std::size_t            n_rows_max = (n_rows_1d > 0) ? n_rows_1d : 0;
   if (n_rows_1d == -1)
     for (unsigned int d = 0; d < dim; ++d)

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -381,7 +381,7 @@ namespace internal
        * cells batched together. As opposed to the other classes which are
        * templated on the number type, this class as a pure index container is
        * not templated, so we need to keep the information otherwise contained
-       * in VectorizedArrayType::n_array_elements.
+       * in VectorizedArrayType::size().
        */
       unsigned int vectorization_length;
 

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1739,7 +1739,7 @@ namespace internal
   void
   do_vectorized_read(const Number2 *src_ptr, VectorizedArrayType &dst)
   {
-    for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
       dst[v] = src_ptr[v];
   }
 
@@ -1763,7 +1763,7 @@ namespace internal
                        const unsigned int * indices,
                        VectorizedArrayType &dst)
   {
-    for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
       dst[v] = src_ptr[indices[v]];
   }
 
@@ -1787,7 +1787,7 @@ namespace internal
   void
   do_vectorized_add(const VectorizedArrayType src, Number2 *dst_ptr)
   {
-    for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
       dst_ptr[v] += src[v];
   }
 
@@ -1813,7 +1813,7 @@ namespace internal
                             const unsigned int *      indices,
                             Number2 *                 dst_ptr)
   {
-    for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
       dst_ptr[indices[v]] += src[v];
   }
 
@@ -2089,13 +2089,14 @@ namespace internal
         {
           AssertDimension(
             dof_info.n_vectorization_lanes_filled[dof_access_index][cell],
-            VectorizedArrayType::n_array_elements);
+            VectorizedArrayType::size());
           const unsigned int dof_index =
-            dof_info.dof_indices_contiguous
-              [dof_access_index][cell * VectorizedArrayType::n_array_elements] +
+            dof_info
+              .dof_indices_contiguous[dof_access_index]
+                                     [cell * VectorizedArrayType::size()] +
             dof_info.component_dof_indices_offset[active_fe_index]
                                                  [first_selected_component] *
-              VectorizedArrayType::n_array_elements;
+              VectorizedArrayType::size();
 
           if (fe_degree > 1 && evaluate_gradients == true)
             {
@@ -2116,15 +2117,15 @@ namespace internal
                   AssertIndexRange(ind2, data.dofs_per_component_on_cell);
                   for (unsigned int comp = 0; comp < n_components; ++comp)
                     {
-                      do_vectorized_read(
-                        src_ptr + dof_index +
-                          (ind1 + comp * static_dofs_per_component) *
-                            VectorizedArrayType::n_array_elements,
-                        temp1[i + 2 * comp * dofs_per_face]);
+                      do_vectorized_read(src_ptr + dof_index +
+                                           (ind1 +
+                                            comp * static_dofs_per_component) *
+                                             VectorizedArrayType::size(),
+                                         temp1[i + 2 * comp * dofs_per_face]);
                       do_vectorized_read(
                         src_ptr + dof_index +
                           (ind2 + comp * static_dofs_per_component) *
-                            VectorizedArrayType::n_array_elements,
+                            VectorizedArrayType::size(),
                         temp1[dofs_per_face + i + 2 * comp * dofs_per_face]);
                       temp1[i + dofs_per_face + 2 * comp * dofs_per_face] =
                         grad_weight *
@@ -2143,11 +2144,11 @@ namespace internal
                 {
                   const unsigned int ind = index_array[i];
                   for (unsigned int comp = 0; comp < n_components; ++comp)
-                    do_vectorized_read(
-                      src_ptr + dof_index +
-                        (ind + comp * static_dofs_per_component) *
-                          VectorizedArrayType::n_array_elements,
-                      temp1[i + 2 * comp * dofs_per_face]);
+                    do_vectorized_read(src_ptr + dof_index +
+                                         (ind +
+                                          comp * static_dofs_per_component) *
+                                           VectorizedArrayType::size(),
+                                       temp1[i + 2 * comp * dofs_per_face]);
                 }
             }
         }
@@ -2164,10 +2165,11 @@ namespace internal
         {
           AssertDimension(
             dof_info.n_vectorization_lanes_filled[dof_access_index][cell],
-            VectorizedArrayType::n_array_elements);
+            VectorizedArrayType::size());
           const unsigned int *indices =
-            &dof_info.dof_indices_contiguous
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
+            &dof_info
+               .dof_indices_contiguous[dof_access_index]
+                                      [cell * VectorizedArrayType::size()];
           if (fe_degree > 1 && evaluate_gradients == true)
             {
               // we know that the gradient weights for the Hermite case on the
@@ -2183,29 +2185,28 @@ namespace internal
               for (unsigned int i = 0; i < dofs_per_face; ++i)
                 {
                   const unsigned int ind1 =
-                    index_array[2 * i] * VectorizedArrayType::n_array_elements;
+                    index_array[2 * i] * VectorizedArrayType::size();
                   const unsigned int ind2 =
-                    index_array[2 * i + 1] *
-                    VectorizedArrayType::n_array_elements;
+                    index_array[2 * i + 1] * VectorizedArrayType::size();
                   for (unsigned int comp = 0; comp < n_components; ++comp)
                     {
                       do_vectorized_gather(
                         src_ptr + ind1 +
                           comp * static_dofs_per_component *
-                            VectorizedArrayType::n_array_elements +
+                            VectorizedArrayType::size() +
                           dof_info.component_dof_indices_offset
                               [active_fe_index][first_selected_component] *
-                            VectorizedArrayType::n_array_elements,
+                            VectorizedArrayType::size(),
                         indices,
                         temp1[i + 2 * comp * dofs_per_face]);
                       VectorizedArrayType grad;
                       do_vectorized_gather(
                         src_ptr + ind2 +
                           comp * static_dofs_per_component *
-                            VectorizedArrayType::n_array_elements +
+                            VectorizedArrayType::size() +
                           dof_info.component_dof_indices_offset
                               [active_fe_index][first_selected_component] *
-                            VectorizedArrayType::n_array_elements,
+                            VectorizedArrayType::size(),
                         indices,
                         grad);
                       temp1[i + dofs_per_face + 2 * comp * dofs_per_face] =
@@ -2223,15 +2224,15 @@ namespace internal
               for (unsigned int i = 0; i < dofs_per_face; ++i)
                 {
                   const unsigned int ind =
-                    index_array[i] * VectorizedArrayType::n_array_elements;
+                    index_array[i] * VectorizedArrayType::size();
                   for (unsigned int comp = 0; comp < n_components; ++comp)
                     do_vectorized_gather(
                       src_ptr + ind +
                         comp * static_dofs_per_component *
-                          VectorizedArrayType::n_array_elements +
+                          VectorizedArrayType::size() +
                         dof_info.component_dof_indices_offset
                             [active_fe_index][first_selected_component] *
-                          VectorizedArrayType::n_array_elements,
+                          VectorizedArrayType::size(),
                       indices,
                       temp1[i + 2 * comp * dofs_per_face]);
                 }
@@ -2250,14 +2251,12 @@ namespace internal
         {
           const unsigned int *strides =
             &dof_info.dof_indices_interleave_strides
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
-          unsigned int indices[VectorizedArrayType::n_array_elements];
-          for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements;
-               ++v)
+               [dof_access_index][cell * VectorizedArrayType::size()];
+          unsigned int indices[VectorizedArrayType::size()];
+          for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
             indices[v] =
               dof_info.dof_indices_contiguous
-                [dof_access_index]
-                [cell * VectorizedArrayType::n_array_elements + v] +
+                [dof_access_index][cell * VectorizedArrayType::size() + v] +
               dof_info.component_dof_indices_offset[active_fe_index]
                                                    [first_selected_component] *
                 strides[v];
@@ -2276,23 +2275,21 @@ namespace internal
 
               const unsigned int *index_array =
                 &data.face_to_cell_index_hermite(face_no, 0);
-              if (nvec == VectorizedArrayType::n_array_elements)
+              if (nvec == VectorizedArrayType::size())
                 for (unsigned int comp = 0; comp < n_components; ++comp)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
                     {
-                      unsigned int ind1[VectorizedArrayType::n_array_elements];
+                      unsigned int ind1[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind1[v] =
                           indices[v] + (comp * static_dofs_per_component +
                                         index_array[2 * i]) *
                                          strides[v];
-                      unsigned int ind2[VectorizedArrayType::n_array_elements];
+                      unsigned int ind2[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind2[v] =
                           indices[v] + (comp * static_dofs_per_component +
@@ -2340,14 +2337,13 @@ namespace internal
                               dofs_per_face);
               const unsigned int *index_array =
                 &data.face_to_cell_index_nodal(face_no, 0);
-              if (nvec == VectorizedArrayType::n_array_elements)
+              if (nvec == VectorizedArrayType::size())
                 for (unsigned int comp = 0; comp < n_components; ++comp)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
                     {
-                      unsigned int ind[VectorizedArrayType::n_array_elements];
+                      unsigned int ind[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind[v] =
                           indices[v] +
@@ -2387,11 +2383,12 @@ namespace internal
                  MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
                    contiguous &&
                dof_info.n_vectorization_lanes_filled[dof_access_index][cell] ==
-                 VectorizedArrayType::n_array_elements)
+                 VectorizedArrayType::size())
         {
           const unsigned int *indices =
-            &dof_info.dof_indices_contiguous
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
+            &dof_info
+               .dof_indices_contiguous[dof_access_index]
+                                      [cell * VectorizedArrayType::size()];
           if (evaluate_gradients == true &&
               data.element_type ==
                 MatrixFreeFunctions::tensor_symmetric_hermite)
@@ -2607,13 +2604,14 @@ namespace internal
         {
           AssertDimension(
             dof_info.n_vectorization_lanes_filled[dof_access_index][cell],
-            VectorizedArrayType::n_array_elements);
+            VectorizedArrayType::size());
           const unsigned int dof_index =
-            dof_info.dof_indices_contiguous
-              [dof_access_index][cell * VectorizedArrayType::n_array_elements] +
+            dof_info
+              .dof_indices_contiguous[dof_access_index]
+                                     [cell * VectorizedArrayType::size()] +
             dof_info.component_dof_indices_offset[active_fe_index]
                                                  [first_selected_component] *
-              VectorizedArrayType::n_array_elements;
+              VectorizedArrayType::size();
 
           if (fe_degree > 1 && integrate_gradients == true)
             {
@@ -2641,16 +2639,16 @@ namespace internal
                       VectorizedArrayType grad =
                         grad_weight *
                         temp1[i + dofs_per_face + 2 * comp * dofs_per_face];
-                      do_vectorized_add(
-                        val,
-                        dst_ptr + dof_index +
-                          (ind1 + comp * static_dofs_per_component) *
-                            VectorizedArrayType::n_array_elements);
-                      do_vectorized_add(
-                        grad,
-                        dst_ptr + dof_index +
-                          (ind2 + comp * static_dofs_per_component) *
-                            VectorizedArrayType::n_array_elements);
+                      do_vectorized_add(val,
+                                        dst_ptr + dof_index +
+                                          (ind1 +
+                                           comp * static_dofs_per_component) *
+                                            VectorizedArrayType::size());
+                      do_vectorized_add(grad,
+                                        dst_ptr + dof_index +
+                                          (ind2 +
+                                           comp * static_dofs_per_component) *
+                                            VectorizedArrayType::size());
                     }
                 }
             }
@@ -2664,11 +2662,11 @@ namespace internal
                 {
                   const unsigned int ind = index_array[i];
                   for (unsigned int comp = 0; comp < n_components; ++comp)
-                    do_vectorized_add(
-                      temp1[i + 2 * comp * dofs_per_face],
-                      dst_ptr + dof_index +
-                        (ind + comp * static_dofs_per_component) *
-                          VectorizedArrayType::n_array_elements);
+                    do_vectorized_add(temp1[i + 2 * comp * dofs_per_face],
+                                      dst_ptr + dof_index +
+                                        (ind +
+                                         comp * static_dofs_per_component) *
+                                          VectorizedArrayType::size());
                 }
             }
         }
@@ -2685,10 +2683,11 @@ namespace internal
         {
           AssertDimension(
             dof_info.n_vectorization_lanes_filled[dof_access_index][cell],
-            VectorizedArrayType::n_array_elements);
+            VectorizedArrayType::size());
           const unsigned int *indices =
-            &dof_info.dof_indices_contiguous
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
+            &dof_info
+               .dof_indices_contiguous[dof_access_index]
+                                      [cell * VectorizedArrayType::size()];
           if (fe_degree > 1 && integrate_gradients == true)
             {
               // we know that the gradient weights for the Hermite case on the
@@ -2704,10 +2703,9 @@ namespace internal
               for (unsigned int i = 0; i < dofs_per_face; ++i)
                 {
                   const unsigned int ind1 =
-                    index_array[2 * i] * VectorizedArrayType::n_array_elements;
+                    index_array[2 * i] * VectorizedArrayType::size();
                   const unsigned int ind2 =
-                    index_array[2 * i + 1] *
-                    VectorizedArrayType::n_array_elements;
+                    index_array[2 * i + 1] * VectorizedArrayType::size();
                   for (unsigned int comp = 0; comp < n_components; ++comp)
                     {
                       VectorizedArrayType val =
@@ -2722,19 +2720,19 @@ namespace internal
                         indices,
                         dst_ptr + ind1 +
                           comp * static_dofs_per_component *
-                            VectorizedArrayType::n_array_elements +
+                            VectorizedArrayType::size() +
                           dof_info.component_dof_indices_offset
                               [active_fe_index][first_selected_component] *
-                            VectorizedArrayType::n_array_elements);
+                            VectorizedArrayType::size());
                       do_vectorized_scatter_add(
                         grad,
                         indices,
                         dst_ptr + ind2 +
                           comp * static_dofs_per_component *
-                            VectorizedArrayType::n_array_elements +
+                            VectorizedArrayType::size() +
                           dof_info.component_dof_indices_offset
                               [active_fe_index][first_selected_component] *
-                            VectorizedArrayType::n_array_elements);
+                            VectorizedArrayType::size());
                     }
                 }
             }
@@ -2747,17 +2745,17 @@ namespace internal
               for (unsigned int i = 0; i < dofs_per_face; ++i)
                 {
                   const unsigned int ind =
-                    index_array[i] * VectorizedArrayType::n_array_elements;
+                    index_array[i] * VectorizedArrayType::size();
                   for (unsigned int comp = 0; comp < n_components; ++comp)
                     do_vectorized_scatter_add(
                       temp1[i + 2 * comp * dofs_per_face],
                       indices,
                       dst_ptr + ind +
                         comp * static_dofs_per_component *
-                          VectorizedArrayType::n_array_elements +
+                          VectorizedArrayType::size() +
                         dof_info.component_dof_indices_offset
                             [active_fe_index][first_selected_component] *
-                          VectorizedArrayType::n_array_elements);
+                          VectorizedArrayType::size());
                 }
             }
         }
@@ -2774,14 +2772,12 @@ namespace internal
         {
           const unsigned int *strides =
             &dof_info.dof_indices_interleave_strides
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
-          unsigned int indices[VectorizedArrayType::n_array_elements];
-          for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements;
-               ++v)
+               [dof_access_index][cell * VectorizedArrayType::size()];
+          unsigned int indices[VectorizedArrayType::size()];
+          for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
             indices[v] =
               dof_info.dof_indices_contiguous
-                [dof_access_index]
-                [cell * VectorizedArrayType::n_array_elements + v] +
+                [dof_access_index][cell * VectorizedArrayType::size() + v] +
               dof_info.component_dof_indices_offset[active_fe_index]
                                                    [first_selected_component] *
                 strides[v];
@@ -2800,23 +2796,21 @@ namespace internal
 
               const unsigned int *index_array =
                 &data.face_to_cell_index_hermite(face_no, 0);
-              if (nvec == VectorizedArrayType::n_array_elements)
+              if (nvec == VectorizedArrayType::size())
                 for (unsigned int comp = 0; comp < n_components; ++comp)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
                     {
-                      unsigned int ind1[VectorizedArrayType::n_array_elements];
+                      unsigned int ind1[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind1[v] =
                           indices[v] + (comp * static_dofs_per_component +
                                         index_array[2 * i]) *
                                          strides[v];
-                      unsigned int ind2[VectorizedArrayType::n_array_elements];
+                      unsigned int ind2[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind2[v] =
                           indices[v] + (comp * static_dofs_per_component +
@@ -2864,14 +2858,13 @@ namespace internal
                               dofs_per_face);
               const unsigned int *index_array =
                 &data.face_to_cell_index_nodal(face_no, 0);
-              if (nvec == VectorizedArrayType::n_array_elements)
+              if (nvec == VectorizedArrayType::size())
                 for (unsigned int comp = 0; comp < n_components; ++comp)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
                     {
-                      unsigned int ind[VectorizedArrayType::n_array_elements];
+                      unsigned int ind[VectorizedArrayType::size()];
                       DEAL_II_OPENMP_SIMD_PRAGMA
-                      for (unsigned int v = 0;
-                           v < VectorizedArrayType::n_array_elements;
+                      for (unsigned int v = 0; v < VectorizedArrayType::size();
                            ++v)
                         ind[v] =
                           indices[v] +
@@ -2907,11 +2900,12 @@ namespace internal
                  internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
                    contiguous &&
                dof_info.n_vectorization_lanes_filled[dof_access_index][cell] ==
-                 VectorizedArrayType::n_array_elements)
+                 VectorizedArrayType::size())
         {
           const unsigned int *indices =
-            &dof_info.dof_indices_contiguous
-               [dof_access_index][cell * VectorizedArrayType::n_array_elements];
+            &dof_info
+               .dof_indices_contiguous[dof_access_index]
+                                      [cell * VectorizedArrayType::size()];
 
           if (integrate_gradients == true &&
               data.element_type ==

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -179,7 +179,7 @@ public:
    * on the given cell. This call is slower than the ones done through a
    * MatrixFree object and lead to a structure that does not effectively use
    * vectorization in the evaluate routines based on these values (instead,
-   * VectorizedArray::n_array_elements same copies are worked on).
+   * VectorizedArray::size() same copies are worked on).
    *
    * If the given vector template class is a block vector (determined through
    * the template function 'IsBlockVector<VectorType>::value', which checks
@@ -211,7 +211,7 @@ public:
    * on the given cell. This call is slower than the ones done through a
    * MatrixFree object and lead to a structure that does not effectively use
    * vectorization in the evaluate routines based on these values (instead,
-   * VectorizedArray::n_array_elements same copies are worked on).
+   * VectorizedArray::size() same copies are worked on).
    *
    * If the given vector template class is a block vector (determined through
    * the template function 'IsBlockVector<VectorType>::value', which checks
@@ -246,7 +246,7 @@ public:
    * on the given cell. This call is slower than the ones done through a
    * MatrixFree object and lead to a structure that does not effectively use
    * vectorization in the evaluate routines based on these values (instead,
-   * VectorizedArray::n_array_elements same copies are worked on).
+   * VectorizedArray::size() same copies are worked on).
    *
    * If the given vector template class is a block vector (determined through
    * the template function 'IsBlockVector<VectorType>::value', which checks
@@ -258,10 +258,10 @@ public:
   template <typename VectorType>
   void
   distribute_local_to_global(
-    VectorType &                                              dst,
-    const unsigned int                                        first_index = 0,
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask =
-      std::bitset<VectorizedArrayType::n_array_elements>().flip()) const;
+    VectorType &                                    dst,
+    const unsigned int                              first_index = 0,
+    const std::bitset<VectorizedArrayType::size()> &mask =
+      std::bitset<VectorizedArrayType::size()>().flip()) const;
 
   /**
    * Takes the values stored internally on dof values of the current cell and
@@ -286,7 +286,7 @@ public:
    * on the given cell. This call is slower than the ones done through a
    * MatrixFree object and lead to a structure that does not effectively use
    * vectorization in the evaluate routines based on these values (instead,
-   * VectorizedArray::n_array_elements same copies are worked on).
+   * VectorizedArray::size() same copies are worked on).
    *
    * If the given vector template class is a block vector (determined through
    * the template function 'IsBlockVector<VectorType>::value', which checks
@@ -297,11 +297,10 @@ public:
    */
   template <typename VectorType>
   void
-  set_dof_values(
-    VectorType &                                              dst,
-    const unsigned int                                        first_index = 0,
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask =
-      std::bitset<VectorizedArrayType::n_array_elements>().flip()) const;
+  set_dof_values(VectorType &       dst,
+                 const unsigned int first_index = 0,
+                 const std::bitset<VectorizedArrayType::size()> &mask =
+                   std::bitset<VectorizedArrayType::size()>().flip()) const;
 
   //@}
 
@@ -606,16 +605,15 @@ public:
    * arbitrary data type.
    */
   template <typename T>
-  std::array<T, VectorizedArrayType::n_array_elements>
-  read_cell_data(
-    const AlignedVector<std::array<T, VectorizedArrayType::n_array_elements>>
-      &array) const;
+  std::array<T, VectorizedArrayType::size()>
+  read_cell_data(const AlignedVector<std::array<T, VectorizedArrayType::size()>>
+                   &array) const;
 
   /**
    * Return the id of the cells this FEEvaluation or FEFaceEvaluation is
    * associated with.
    */
-  std::array<unsigned int, VectorizedArrayType::n_array_elements>
+  std::array<unsigned int, VectorizedArrayType::size()>
   get_cell_ids() const;
 
   //@}
@@ -838,11 +836,10 @@ protected:
    */
   template <typename VectorType, typename VectorOperation>
   void
-  read_write_operation(
-    const VectorOperation &                                   operation,
-    VectorType *                                              vectors[],
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask,
-    const bool apply_constraints = true) const;
+  read_write_operation(const VectorOperation &operation,
+                       VectorType *           vectors[],
+                       const std::bitset<VectorizedArrayType::size()> &mask,
+                       const bool apply_constraints = true) const;
 
   /**
    * A unified function to read from and write into vectors based on the given
@@ -854,9 +851,9 @@ protected:
   template <typename VectorType, typename VectorOperation>
   void
   read_write_operation_contiguous(
-    const VectorOperation &                                   operation,
-    VectorType *                                              vectors[],
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask) const;
+    const VectorOperation &                         operation,
+    VectorType *                                    vectors[],
+    const std::bitset<VectorizedArrayType::size()> &mask) const;
 
   /**
    * A unified function to read from and write into vectors based on the given
@@ -1757,9 +1754,7 @@ protected:
  *           phi.quadrature_point(q_index);
  *         // Need to evaluate function for each component in VectorizedArray
  *         VectorizedArray<double> f_value;
- *         for (unsigned int v=0;
- *              v<VectorizedArray<double>::n_array_elements;
- *              ++v)
+ *         for (unsigned int v=0; v<VectorizedArray<double>::size(); ++v)
  *           {
  *             Point<dim> p;
  *             for (unsigned int d=0; d<dim; ++d)
@@ -1848,12 +1843,12 @@ protected:
  *   {
  *     fe_eval.reinit(cell);
  *     for (unsigned int i=0; i<dofs_per_cell;
- *          i += VectorizedArray<double>::n_array_elements)
+ *          i += VectorizedArray<double>::size())
  *       {
  *         const unsigned int n_items =
- *           i+VectorizedArray<double>::n_array_elements > dofs_per_cell ?
+ *           i+VectorizedArray<double>::size() > dofs_per_cell ?
  *           (dofs_per_cell - i) :
- *           VectorizedArray<double>::n_array_elements;
+ *           VectorizedArray<double>::size();
  *
  *         // Set n_items unit vectors
  *         for (unsigned int j=0; j<dofs_per_cell; ++j)
@@ -3056,7 +3051,7 @@ inline FEEvaluationBase<dim,
   set_data_pointers();
   Assert(matrix_info->mapping_initialized() == true, ExcNotInitialized());
   AssertDimension(matrix_info->get_task_info().vectorization_length,
-                  VectorizedArrayType::n_array_elements);
+                  VectorizedArrayType::size());
   AssertDimension((is_face ? data->n_q_points_face : data->n_q_points),
                   n_quadrature_points);
   AssertDimension(n_quadrature_points,
@@ -3564,12 +3559,12 @@ template <int dim,
           typename Number,
           bool is_face,
           typename VectorizedArrayType>
-std::array<unsigned int, VectorizedArrayType::n_array_elements>
+std::array<unsigned int, VectorizedArrayType::size()>
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   get_cell_ids() const
 {
-  const unsigned int v_len = VectorizedArrayType::n_array_elements;
-  std::array<unsigned int, VectorizedArrayType::n_array_elements> cells;
+  const unsigned int              v_len = VectorizedArrayType::size();
+  std::array<unsigned int, v_len> cells;
 
   // initialize array
   for (unsigned int i = 0; i < v_len; ++i)
@@ -3627,7 +3622,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
         is_interior_face ?
           &this->matrix_info->get_face_info(cell).cells_interior[0] :
           &this->matrix_info->get_face_info(cell).cells_exterior[0];
-      for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; ++i)
+      for (unsigned int i = 0; i < VectorizedArrayType::size(); ++i)
         if (cells_[i] != numbers::invalid_unsigned_int)
           cells[i] = cells_[i];
     }
@@ -3655,10 +3650,10 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
 
   // 2) actually gather values
   VectorizedArrayType out = make_vectorized_array<Number>(Number(1.));
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; ++i)
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); ++i)
     if (cells[i] != numbers::invalid_unsigned_int)
-      out[i] = array[cells[i] / VectorizedArrayType::n_array_elements]
-                    [cells[i] % VectorizedArrayType::n_array_elements];
+      out[i] = array[cells[i] / VectorizedArrayType::size()]
+                    [cells[i] % VectorizedArrayType::size()];
   return out;
 }
 
@@ -3670,11 +3665,10 @@ template <int dim,
           bool is_face,
           typename VectorizedArrayType>
 template <typename T>
-inline std::array<T, VectorizedArrayType::n_array_elements>
+inline std::array<T, VectorizedArrayType::size()>
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
-  read_cell_data(
-    const AlignedVector<std::array<T, VectorizedArrayType::n_array_elements>>
-      &array) const
+  read_cell_data(const AlignedVector<std::array<T, VectorizedArrayType::size()>>
+                   &array) const
 {
   Assert(matrix_info != nullptr, ExcNotImplemented());
   AssertDimension(array.size(),
@@ -3684,11 +3678,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   const auto cells = this->get_cell_ids();
 
   // 2) actually gather values
-  std::array<T, VectorizedArrayType::n_array_elements> out;
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; ++i)
+  std::array<T, VectorizedArrayType::size()> out;
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); ++i)
     if (cells[i] != numbers::invalid_unsigned_int)
-      out[i] = array[cells[i] / VectorizedArrayType::n_array_elements]
-                    [cells[i] % VectorizedArrayType::n_array_elements];
+      out[i] = array[cells[i] / VectorizedArrayType::size()]
+                    [cells[i] % VectorizedArrayType::size()];
   return out;
 }
 
@@ -3780,11 +3774,10 @@ template <int dim,
 template <typename VectorType, typename VectorOperation>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
-  read_write_operation(
-    const VectorOperation &                                   operation,
-    VectorType *                                              src[],
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask,
-    const bool apply_constraints) const
+  read_write_operation(const VectorOperation &operation,
+                       VectorType *           src[],
+                       const std::bitset<VectorizedArrayType::size()> &mask,
+                       const bool apply_constraints) const
 {
   // Case 1: No MatrixFree object given, simple case because we do not need to
   // process constraints and need not care about vectorization -> go to
@@ -3831,8 +3824,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
 
   // Case 3: standard operation with one index per degree of freedom -> go on
   // here
-  constexpr unsigned int n_vectorization =
-    VectorizedArrayType::n_array_elements;
+  constexpr unsigned int n_vectorization = VectorizedArrayType::size();
   Assert(mask.count() == n_vectorization,
          ExcNotImplemented("Masking currently not implemented for "
                            "non-contiguous DoF storage"));
@@ -3889,7 +3881,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
       if (dof_access_index ==
           internal::MatrixFreeFunctions::DoFInfo::dof_access_cell)
         for (unsigned int v = 0; v < n_vectorization_actual; ++v)
-          cells_copied[v] = cell * VectorizedArrayType::n_array_elements + v;
+          cells_copied[v] = cell * VectorizedArrayType::size() + v;
       cells = dof_access_index ==
                   internal::MatrixFreeFunctions::DoFInfo::dof_access_cell ?
                 &cells_copied[0] :
@@ -4209,9 +4201,9 @@ template <typename VectorType, typename VectorOperation>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   read_write_operation_contiguous(
-    const VectorOperation &                                   operation,
-    VectorType *                                              src[],
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask) const
+    const VectorOperation &                         operation,
+    VectorType *                                    src[],
+    const std::bitset<VectorizedArrayType::size()> &mask) const
 {
   // This functions processes the functions read_dof_values,
   // distribute_local_to_global, and set_dof_values with the same code for
@@ -4236,13 +4228,13 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   if (dof_info->index_storage_variants[ind][cell] ==
         internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
           interleaved_contiguous &&
-      n_lanes == VectorizedArrayType::n_array_elements)
+      n_lanes == VectorizedArrayType::size())
     {
       const unsigned int dof_index =
-        dof_indices_cont[cell * VectorizedArrayType::n_array_elements] +
+        dof_indices_cont[cell * VectorizedArrayType::size()] +
         dof_info->component_dof_indices_offset[active_fe_index]
                                               [first_selected_component] *
-          VectorizedArrayType::n_array_elements;
+          VectorizedArrayType::size();
       if (n_components == 1 || n_fe_components == 1)
         for (unsigned int comp = 0; comp < n_components; ++comp)
           operation.process_dofs_vectorized(data->dofs_per_component_on_cell,
@@ -4265,24 +4257,24 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   const unsigned int vectorization_populated =
     dof_info->n_vectorization_lanes_filled[ind][this->cell];
 
-  unsigned int dof_indices[VectorizedArrayType::n_array_elements];
+  unsigned int dof_indices[VectorizedArrayType::size()];
   for (unsigned int v = 0; v < vectorization_populated; ++v)
     dof_indices[v] =
-      dof_indices_cont[cell * VectorizedArrayType::n_array_elements + v] +
+      dof_indices_cont[cell * VectorizedArrayType::size() + v] +
       dof_info->component_dof_indices_offset[active_fe_index]
                                             [first_selected_component] *
         dof_info->dof_indices_interleave_strides
-          [ind][cell * VectorizedArrayType::n_array_elements + v];
+          [ind][cell * VectorizedArrayType::size() + v];
 
   for (unsigned int v = vectorization_populated;
-       v < VectorizedArrayType::n_array_elements;
+       v < VectorizedArrayType::size();
        ++v)
     dof_indices[v] = numbers::invalid_unsigned_int;
 
   // In the case with contiguous cell indices, we know that there are no
   // constraints and that the indices within each element are contiguous
-  if (vectorization_populated == VectorizedArrayType::n_array_elements &&
-      n_lanes == VectorizedArrayType::n_array_elements)
+  if (vectorization_populated == VectorizedArrayType::size() &&
+      n_lanes == VectorizedArrayType::size())
     {
       if (dof_info->index_storage_variants[ind][cell] ==
           internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
@@ -4312,12 +4304,11 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
             for (unsigned int i = 0; i < data->dofs_per_component_on_cell; ++i)
               {
                 for (unsigned int comp = 0; comp < n_components; ++comp)
-                  operation.process_dof_gather(
-                    dof_indices,
-                    *src[comp],
-                    i * VectorizedArrayType::n_array_elements,
-                    values_dofs[comp][i],
-                    vector_selector);
+                  operation.process_dof_gather(dof_indices,
+                                               *src[comp],
+                                               i * VectorizedArrayType::size(),
+                                               values_dofs[comp][i],
+                                               vector_selector);
               }
           else
             for (unsigned int comp = 0; comp < n_components; ++comp)
@@ -4328,7 +4319,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                     dof_indices,
                     *src[0],
                     (comp * data->dofs_per_component_on_cell + i) *
-                      VectorizedArrayType::n_array_elements,
+                      VectorizedArrayType::size(),
                     values_dofs[comp][i],
                     vector_selector);
                 }
@@ -4341,7 +4332,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                  ExcNotImplemented());
           const unsigned int *offsets =
             &dof_info->dof_indices_interleave_strides
-               [ind][VectorizedArrayType::n_array_elements * cell];
+               [ind][VectorizedArrayType::size() * cell];
           if (n_components == 1 || n_fe_components == 1)
             for (unsigned int i = 0; i < data->dofs_per_component_on_cell; ++i)
               {
@@ -4352,9 +4343,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                                                values_dofs[comp][i],
                                                vector_selector);
                 DEAL_II_OPENMP_SIMD_PRAGMA
-                for (unsigned int v = 0;
-                     v < VectorizedArrayType::n_array_elements;
-                     ++v)
+                for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
                   dof_indices[v] += offsets[v];
               }
           else
@@ -4368,9 +4357,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
                                                values_dofs[comp][i],
                                                vector_selector);
                   DEAL_II_OPENMP_SIMD_PRAGMA
-                  for (unsigned int v = 0;
-                       v < VectorizedArrayType::n_array_elements;
-                       ++v)
+                  for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
                     dof_indices[v] += offsets[v];
                 }
         }
@@ -4413,10 +4400,9 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
           {
             const unsigned int *offsets =
               &dof_info->dof_indices_interleave_strides
-                 [ind][VectorizedArrayType::n_array_elements * cell];
+                 [ind][VectorizedArrayType::size() * cell];
             for (unsigned int v = 0; v < vectorization_populated; ++v)
-              AssertIndexRange(offsets[v],
-                               VectorizedArrayType::n_array_elements + 1);
+              AssertIndexRange(offsets[v], VectorizedArrayType::size() + 1);
             if (n_components == 1 || n_fe_components == 1)
               for (unsigned int v = 0; v < vectorization_populated; ++v)
                 {
@@ -4470,11 +4456,10 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
         get_vector_component(const_cast<VectorType &>(src), d + first_index);
 
   internal::VectorReader<Number, VectorizedArrayType> reader;
-  read_write_operation(
-    reader,
-    src_data,
-    std::bitset<VectorizedArrayType::n_array_elements>().flip(),
-    true);
+  read_write_operation(reader,
+                       src_data,
+                       std::bitset<VectorizedArrayType::size()>().flip(),
+                       true);
 
 #  ifdef DEBUG
   dof_values_initialized = true;
@@ -4505,11 +4490,10 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
         get_vector_component(const_cast<VectorType &>(src), d + first_index);
 
   internal::VectorReader<Number, VectorizedArrayType> reader;
-  read_write_operation(
-    reader,
-    src_data,
-    std::bitset<VectorizedArrayType::n_array_elements>().flip(),
-    false);
+  read_write_operation(reader,
+                       src_data,
+                       std::bitset<VectorizedArrayType::size()>().flip(),
+                       false);
 
 #  ifdef DEBUG
   dof_values_initialized = true;
@@ -4527,9 +4511,9 @@ template <typename VectorType>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   distribute_local_to_global(
-    VectorType &                                              dst,
-    const unsigned int                                        first_index,
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask) const
+    VectorType &                                    dst,
+    const unsigned int                              first_index,
+    const std::bitset<VectorizedArrayType::size()> &mask) const
 {
 #  ifdef DEBUG
   Assert(dof_values_initialized == true,
@@ -4562,10 +4546,9 @@ template <int dim,
 template <typename VectorType>
 inline void
 FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
-  set_dof_values(
-    VectorType &                                              dst,
-    const unsigned int                                        first_index,
-    const std::bitset<VectorizedArrayType::n_array_elements> &mask) const
+  set_dof_values(VectorType &                                    dst,
+                 const unsigned int                              first_index,
+                 const std::bitset<VectorizedArrayType::size()> &mask) const
 {
 #  ifdef DEBUG
   Assert(dof_values_initialized == true,
@@ -7090,7 +7073,7 @@ FEEvaluation<
         input_vector.begin() +
         this->dof_info->dof_indices_contiguous
           [internal::MatrixFreeFunctions::DoFInfo::dof_access_cell]
-          [this->cell * VectorizedArrayType::n_array_elements]) %
+          [this->cell * VectorizedArrayType::size()]) %
           sizeof(VectorizedArrayType) ==
         0)
     {
@@ -7099,11 +7082,11 @@ FEEvaluation<
           input_vector.begin() +
           this->dof_info->dof_indices_contiguous
             [internal::MatrixFreeFunctions::DoFInfo::dof_access_cell]
-            [this->cell * VectorizedArrayType::n_array_elements] +
+            [this->cell * VectorizedArrayType::size()] +
           this->dof_info
               ->component_dof_indices_offset[this->active_fe_index]
                                             [this->first_selected_component] *
-            VectorizedArrayType::n_array_elements);
+            VectorizedArrayType::size());
 
       evaluate(vec_values,
                evaluate_values,
@@ -7226,7 +7209,7 @@ FEEvaluation<
         destination.begin() +
         this->dof_info->dof_indices_contiguous
           [internal::MatrixFreeFunctions::DoFInfo::dof_access_cell]
-          [this->cell * VectorizedArrayType::n_array_elements]) %
+          [this->cell * VectorizedArrayType::size()]) %
           sizeof(VectorizedArrayType) ==
         0)
     {
@@ -7234,11 +7217,11 @@ FEEvaluation<
         destination.begin() +
         this->dof_info->dof_indices_contiguous
           [internal::MatrixFreeFunctions::DoFInfo::dof_access_cell]
-          [this->cell * VectorizedArrayType::n_array_elements] +
+          [this->cell * VectorizedArrayType::size()] +
         this->dof_info
             ->component_dof_indices_offset[this->active_fe_index]
                                           [this->first_selected_component] *
-          VectorizedArrayType::n_array_elements);
+          VectorizedArrayType::size());
       SelectEvaluator<dim,
                       fe_degree,
                       n_q_points_1d,
@@ -7326,7 +7309,7 @@ FEFaceEvaluation<dim,
       internal::MatrixFreeFunctions::DoFInfo::dof_access_face_interior :
       internal::MatrixFreeFunctions::DoFInfo::dof_access_face_exterior;
   Assert(this->mapping_data != nullptr, ExcNotInitialized());
-  const unsigned int n_vectors = VectorizedArrayType::n_array_elements;
+  const unsigned int n_vectors = VectorizedArrayType::size();
   const internal::MatrixFreeFunctions::FaceToCellTopology<n_vectors> &faces =
     this->matrix_info->get_face_info(face_index);
   if (face_index >=

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -327,7 +327,7 @@ namespace internal
       initialize(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const FaceInfo<VectorizedArrayType::n_array_elements> &   faces,
+        const FaceInfo<VectorizedArrayType::size()> &             faces,
         const std::vector<unsigned int> &              active_fe_index,
         const Mapping<dim> &                           mapping,
         const std::vector<dealii::hp::QCollection<1>> &quad,
@@ -346,7 +346,7 @@ namespace internal
       update_mapping(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const FaceInfo<VectorizedArrayType::n_array_elements> &   faces,
+        const FaceInfo<VectorizedArrayType::size()> &             faces,
         const std::vector<unsigned int> &active_fe_index,
         const Mapping<dim> &             mapping);
 
@@ -460,9 +460,9 @@ namespace internal
       initialize_faces(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const std::vector<
-          FaceToCellTopology<VectorizedArrayType::n_array_elements>> &faces,
-        const Mapping<dim> &                                          mapping);
+        const std::vector<FaceToCellTopology<VectorizedArrayType::size()>>
+          &                 faces,
+        const Mapping<dim> &mapping);
 
       /**
        * Computes the information in the given faces, called within
@@ -545,32 +545,23 @@ namespace internal
 
       bool
       operator()(
-        const Tensor<1, VectorizedArrayType::n_array_elements, Number> &t1,
-        const Tensor<1, VectorizedArrayType::n_array_elements, Number> &t2)
-        const;
+        const Tensor<1, VectorizedArrayType::size(), Number> &t1,
+        const Tensor<1, VectorizedArrayType::size(), Number> &t2) const;
 
       template <int dim>
       bool
       operator()(
-        const Tensor<1,
-                     dim,
-                     Tensor<1, VectorizedArrayType::n_array_elements, Number>>
+        const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>>
           &t1,
-        const Tensor<1,
-                     dim,
-                     Tensor<1, VectorizedArrayType::n_array_elements, Number>>
+        const Tensor<1, dim, Tensor<1, VectorizedArrayType::size(), Number>>
           &t2) const;
 
       template <int dim>
       bool
       operator()(
-        const Tensor<2,
-                     dim,
-                     Tensor<1, VectorizedArrayType::n_array_elements, Number>>
+        const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>>
           &t1,
-        const Tensor<2,
-                     dim,
-                     Tensor<1, VectorizedArrayType::n_array_elements, Number>>
+        const Tensor<2, dim, Tensor<1, VectorizedArrayType::size(), Number>>
           &t2) const;
 
       Number tolerance;

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1570,7 +1570,7 @@ public:
    * general. The cell range in @p cell_loop runs from zero to n_cell_batches()
    * (exclusive), so this is the appropriate size if you want to store arrays
    * of data for all cells to be worked on. This number is approximately
-   * `n_physical_cells()/VectorizedArray::n_array_elements` (depending on how
+   * `n_physical_cells()/VectorizedArray::size()` (depending on how
    * many cell chunks that do not get filled up completely).
    */
   unsigned int
@@ -1582,7 +1582,7 @@ public:
    * general. The cell range in @p cell_loop runs from zero to
    * n_cell_batches() (exclusive), so this is the appropriate size if you want
    * to store arrays of data for all cells to be worked on. This number is
-   * approximately `n_physical_cells()/VectorizedArray::n_array_elements`
+   * approximately `n_physical_cells()/VectorizedArray::size()`
    * (depending on how many cell chunks that do not get filled up completely).
    */
   unsigned int
@@ -1638,7 +1638,7 @@ public:
    * Return the boundary ids for the faces within a cell, using the cells'
    * sorting by lanes in the VectorizedArray.
    */
-  std::array<types::boundary_id, VectorizedArrayType::n_array_elements>
+  std::array<types::boundary_id, VectorizedArrayType::size()>
   get_faces_by_cells_boundary_id(const unsigned int macro_cell,
                                  const unsigned int face_number) const;
 
@@ -1924,7 +1924,7 @@ public:
    * Return the connectivity information of a face.
    */
   const internal::MatrixFreeFunctions::FaceToCellTopology<
-    VectorizedArrayType::n_array_elements> &
+    VectorizedArrayType::size()> &
   get_face_info(const unsigned int face_batch_number) const;
 
 
@@ -2139,7 +2139,7 @@ private:
    * Vector holding face information. Only initialized if
    * build_face_info=true.
    */
-  internal::MatrixFreeFunctions::FaceInfo<VectorizedArrayType::n_array_elements>
+  internal::MatrixFreeFunctions::FaceInfo<VectorizedArrayType::size()>
     face_info;
 
   /**
@@ -2350,7 +2350,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_boundary_id(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
-inline std::array<types::boundary_id, VectorizedArrayType::n_array_elements>
+inline std::array<types::boundary_id, VectorizedArrayType::size()>
 MatrixFree<dim, Number, VectorizedArrayType>::get_faces_by_cells_boundary_id(
   const unsigned int macro_cell,
   const unsigned int face_number) const
@@ -2359,7 +2359,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_faces_by_cells_boundary_id(
   AssertIndexRange(face_number, GeometryInfo<dim>::faces_per_cell);
   Assert(face_info.cell_and_face_boundary_id.size(0) >= n_macro_cells(),
          ExcNotInitialized());
-  std::array<types::boundary_id, VectorizedArrayType::n_array_elements> result;
+  std::array<types::boundary_id, VectorizedArrayType::size()> result;
   result.fill(numbers::invalid_boundary_id);
   for (unsigned int v = 0; v < n_active_entries_per_cell_batch(macro_cell); ++v)
     result[v] = face_info.cell_and_face_boundary_id(macro_cell, face_number, v);
@@ -2461,13 +2461,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::at_irregular_cell(
   const unsigned int macro_cell) const
 {
   AssertIndexRange(macro_cell, task_info.cell_partition_data.back());
-  return VectorizedArrayType::n_array_elements > 1 &&
-         cell_level_index[(macro_cell + 1) *
-                            VectorizedArrayType::n_array_elements -
-                          1] ==
-           cell_level_index[(macro_cell + 1) *
-                              VectorizedArrayType::n_array_elements -
-                            2];
+  return VectorizedArrayType::size() > 1 &&
+         cell_level_index[(macro_cell + 1) * VectorizedArrayType::size() - 1] ==
+           cell_level_index[(macro_cell + 1) * VectorizedArrayType::size() - 2];
 }
 
 
@@ -2488,16 +2484,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::n_active_entries_per_cell_batch(
   const unsigned int cell_batch_number) const
 {
   AssertIndexRange(cell_batch_number, task_info.cell_partition_data.back());
-  unsigned int n_components = VectorizedArrayType::n_array_elements;
-  while (
-    n_components > 1 &&
-    cell_level_index[cell_batch_number * VectorizedArrayType::n_array_elements +
-                     n_components - 1] ==
-      cell_level_index[cell_batch_number *
-                         VectorizedArrayType::n_array_elements +
-                       n_components - 2])
+  unsigned int n_components = VectorizedArrayType::size();
+  while (n_components > 1 &&
+         cell_level_index[cell_batch_number * VectorizedArrayType::size() +
+                          n_components - 1] ==
+           cell_level_index[cell_batch_number * VectorizedArrayType::size() +
+                            n_components - 2])
     --n_components;
-  AssertIndexRange(n_components - 1, VectorizedArrayType::n_array_elements);
+  AssertIndexRange(n_components - 1, VectorizedArrayType::size());
   return n_components;
 }
 
@@ -2509,12 +2503,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::n_active_entries_per_face_batch(
   const unsigned int face_batch_number) const
 {
   AssertIndexRange(face_batch_number, face_info.faces.size());
-  unsigned int n_components = VectorizedArrayType::n_array_elements;
+  unsigned int n_components = VectorizedArrayType::size();
   while (n_components > 1 &&
          face_info.faces[face_batch_number].cells_interior[n_components - 1] ==
            numbers::invalid_unsigned_int)
     --n_components;
-  AssertIndexRange(n_components - 1, VectorizedArrayType::n_array_elements);
+  AssertIndexRange(n_components - 1, VectorizedArrayType::size());
   return n_components;
 }
 
@@ -2613,7 +2607,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_shape_info(
 
 template <int dim, typename Number, typename VectorizedArrayType>
 inline const internal::MatrixFreeFunctions::FaceToCellTopology<
-  VectorizedArrayType::n_array_elements> &
+  VectorizedArrayType::size()> &
 MatrixFree<dim, Number, VectorizedArrayType>::get_face_info(
   const unsigned int macro_face) const
 {
@@ -2686,7 +2680,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_face_category(
     return std::make_pair(0U, 0U);
 
   std::pair<unsigned int, unsigned int> result;
-  for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements &&
+  for (unsigned int v = 0; v < VectorizedArrayType::size() &&
                            face_info.faces[macro_face].cells_interior[v] !=
                              numbers::invalid_unsigned_int;
        ++v)
@@ -2696,7 +2690,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_face_category(
         .cell_active_fe_index[face_info.faces[macro_face].cells_interior[v]]);
   if (face_info.faces[macro_face].cells_exterior[0] !=
       numbers::invalid_unsigned_int)
-    for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements &&
+    for (unsigned int v = 0; v < VectorizedArrayType::size() &&
                              face_info.faces[macro_face].cells_exterior[v] !=
                                numbers::invalid_unsigned_int;
          ++v)

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -199,8 +199,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_cell_iterator(
   const unsigned int vector_number,
   const unsigned int dof_handler_index) const
 {
-  const unsigned int vectorization_length =
-    VectorizedArrayType::n_array_elements;
+  const unsigned int vectorization_length = VectorizedArrayType::size();
   AssertIndexRange(dof_handler_index, dof_handlers.n_dof_handlers);
   AssertIndexRange(macro_cell_number, task_info.cell_partition_data.back());
   AssertIndexRange(vector_number, n_components_filled(macro_cell_number));
@@ -235,8 +234,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_cell_level_and_index(
   const unsigned int macro_cell_number,
   const unsigned int vector_number) const
 {
-  const unsigned int vectorization_length =
-    VectorizedArrayType::n_array_elements;
+  const unsigned int vectorization_length = VectorizedArrayType::size();
   AssertIndexRange(macro_cell_number, task_info.cell_partition_data.back());
   AssertIndexRange(vector_number, n_components_filled(macro_cell_number));
 
@@ -284,7 +282,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_face_iterator(
     }
 
   const internal::MatrixFreeFunctions::FaceToCellTopology<
-    VectorizedArrayType::n_array_elements>
+    VectorizedArrayType::size()>
     face2cell_info = get_face_info(face_batch_number);
 
   const unsigned int cell_index =
@@ -308,8 +306,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_hp_cell_iterator(
   const unsigned int vector_number,
   const unsigned int dof_handler_index) const
 {
-  constexpr unsigned int vectorization_length =
-    VectorizedArrayType::n_array_elements;
+  constexpr unsigned int vectorization_length = VectorizedArrayType::size();
   AssertIndexRange(dof_handler_index, dof_handlers.n_dof_handlers);
   AssertIndexRange(macro_cell_number, task_info.cell_partition_data.back());
   AssertIndexRange(vector_number, n_components_filled(macro_cell_number));
@@ -454,7 +451,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
       std::vector<unsigned char> dummy2;
       task_info.collect_boundary_cells(cell_level_index.size(),
                                        cell_level_index.size(),
-                                       VectorizedArrayType::n_array_elements,
+                                       VectorizedArrayType::size(),
                                        dummy);
       task_info.create_blocks_serial(
         dummy, dummy, 1, dummy, false, dummy, dummy2);
@@ -480,9 +477,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           // if indices are not initialized, the cell_level_index might not be
           // divisible by the vectorization length. But it must be for
           // mapping_info...
-          while (cell_level_index.size() %
-                   VectorizedArrayType::n_array_elements !=
-                 0)
+          while (cell_level_index.size() % VectorizedArrayType::size() != 0)
             cell_level_index.push_back(cell_level_index.back());
         }
     }
@@ -626,7 +621,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
       std::vector<unsigned char> dummy2;
       task_info.collect_boundary_cells(cell_level_index.size(),
                                        cell_level_index.size(),
-                                       VectorizedArrayType::n_array_elements,
+                                       VectorizedArrayType::size(),
                                        dummy);
       task_info.create_blocks_serial(
         dummy, dummy, 1, dummy, false, dummy, dummy2);
@@ -654,9 +649,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           // if indices are not initialized, the cell_level_index might not be
           // divisible by the vectorization length. But it must be for
           // mapping_info...
-          while (cell_level_index.size() %
-                   VectorizedArrayType::n_array_elements !=
-                 0)
+          while (cell_level_index.size() % VectorizedArrayType::size() != 0)
             cell_level_index.push_back(cell_level_index.back());
         }
     }
@@ -781,7 +774,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_dof_handlers(
 
   dof_info.resize(dof_handlers.n_dof_handlers);
   for (unsigned int no = 0; no < dof_handlers.n_dof_handlers; ++no)
-    dof_info[no].vectorization_length = VectorizedArrayType::n_array_elements;
+    dof_info[no].vectorization_length = VectorizedArrayType::size();
 
   // Go through cells on zeroth level and then successively step down into
   // children. This gives a z-ordering of the cells, which is beneficial when
@@ -852,7 +845,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_dof_handlers(
 
   dof_info.resize(dof_handlers.n_dof_handlers);
   for (unsigned int no = 0; no < dof_handlers.n_dof_handlers; ++no)
-    dof_info[no].vectorization_length = VectorizedArrayType::n_array_elements;
+    dof_info[no].vectorization_length = VectorizedArrayType::size();
 
   // go through cells on zeroth level and then successively step down into
   // children. This gives a z-ordering of the cells, which is beneficial when
@@ -1139,8 +1132,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
         subdomain_boundary_cells.push_back(counter);
     }
 
-  const unsigned int vectorization_length =
-    VectorizedArrayType::n_array_elements;
+  const unsigned int vectorization_length = VectorizedArrayType::size();
   task_info.collect_boundary_cells(cell_level_index_end_local,
                                    n_active_cells,
                                    vectorization_length,
@@ -1518,7 +1510,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
 
       cell_level_index.resize(
         cell_level_index.size() +
-        VectorizedArrayType::n_array_elements *
+        VectorizedArrayType::size() *
           (task_info.refinement_edge_face_partition_data[1] -
            task_info.refinement_edge_face_partition_data[0]));
 
@@ -1530,48 +1522,48 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
       face_info.cell_and_face_to_plain_faces.reinit(
         TableIndices<3>(task_info.cell_partition_data.back(),
                         GeometryInfo<dim>::faces_per_cell,
-                        VectorizedArrayType::n_array_elements),
+                        VectorizedArrayType::size()),
         true);
       face_info.cell_and_face_to_plain_faces.fill(
         numbers::invalid_unsigned_int);
       face_info.cell_and_face_boundary_id.reinit(
         TableIndices<3>(task_info.cell_partition_data.back(),
                         GeometryInfo<dim>::faces_per_cell,
-                        VectorizedArrayType::n_array_elements),
+                        VectorizedArrayType::size()),
         true);
       face_info.cell_and_face_boundary_id.fill(numbers::invalid_boundary_id);
 
       for (unsigned int f = 0; f < task_info.ghost_face_partition_data.back();
            ++f)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements &&
+        for (unsigned int v = 0; v < VectorizedArrayType::size() &&
                                  face_info.faces[f].cells_interior[v] !=
                                    numbers::invalid_unsigned_int;
              ++v)
           {
             TableIndices<3> index(face_info.faces[f].cells_interior[v] /
-                                    VectorizedArrayType::n_array_elements,
+                                    VectorizedArrayType::size(),
                                   face_info.faces[f].interior_face_no,
                                   face_info.faces[f].cells_interior[v] %
-                                    VectorizedArrayType::n_array_elements);
+                                    VectorizedArrayType::size());
 
             // Assert(cell_and_face_to_plain_faces(index) ==
             // numbers::invalid_unsigned_int,
             //       ExcInternalError("Should only visit each face once"));
             face_info.cell_and_face_to_plain_faces(index) =
-              f * VectorizedArrayType::n_array_elements + v;
+              f * VectorizedArrayType::size() + v;
             if (face_info.faces[f].cells_exterior[v] !=
                 numbers::invalid_unsigned_int)
               {
                 TableIndices<3> index(face_info.faces[f].cells_exterior[v] /
-                                        VectorizedArrayType::n_array_elements,
+                                        VectorizedArrayType::size(),
                                       face_info.faces[f].exterior_face_no,
                                       face_info.faces[f].cells_exterior[v] %
-                                        VectorizedArrayType::n_array_elements);
+                                        VectorizedArrayType::size());
                 // Assert(cell_and_face_to_plain_faces(index) ==
                 // numbers::invalid_unsigned_int,
                 //       ExcInternalError("Should only visit each face once"));
                 face_info.cell_and_face_to_plain_faces(index) =
-                  f * VectorizedArrayType::n_array_elements + v;
+                  f * VectorizedArrayType::size() + v;
               }
             else
               face_info.cell_and_face_boundary_id(index) =
@@ -1590,8 +1582,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
           std::vector<types::global_dof_index> ghost_indices;
           {
             for (unsigned int cell = 0;
-                 cell <
-                 VectorizedArrayType::n_array_elements * n_macro_cells_before;
+                 cell < VectorizedArrayType::size() * n_macro_cells_before;
                  ++cell)
               if (cell == 0 ||
                   cell_level_index[cell] != cell_level_index[cell - 1])
@@ -1654,15 +1645,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                                          const bool,
                                          const bool)> &fu) {
               for (unsigned int f = 0; f < n_inner_face_batches(); ++f)
-                for (unsigned int v = 0;
-                     v < VectorizedArrayType::n_array_elements &&
-                     face_info.faces[f].cells_interior[v] !=
-                       numbers::invalid_unsigned_int;
+                for (unsigned int v = 0; v < VectorizedArrayType::size() &&
+                                         face_info.faces[f].cells_interior[v] !=
+                                           numbers::invalid_unsigned_int;
                      ++v)
                   {
                     AssertIndexRange(face_info.faces[f].cells_interior[v],
                                      n_macro_cells_before *
-                                       VectorizedArrayType::n_array_elements);
+                                       VectorizedArrayType::size());
                     const unsigned int p = face_info.faces[f].cells_exterior[v];
                     const unsigned int face_no =
                       face_info.faces[f].exterior_face_no;
@@ -1680,17 +1670,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                                          const bool)> &fu) {
               for (unsigned int c = 0; c < n_cell_batches(); ++c)
                 for (const unsigned int d : GeometryInfo<dim>::face_indices())
-                  for (unsigned int v = 0;
-                       v < VectorizedArrayType::n_array_elements;
-                       ++v)
+                  for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
                     {
                       unsigned int f =
                         this->face_info.cell_and_face_to_plain_faces(c, d, v);
                       if (f == numbers::invalid_unsigned_int)
                         continue;
 
-                      const unsigned int v_len =
-                        VectorizedArrayType::n_array_elements;
+                      const unsigned int v_len = VectorizedArrayType::size();
                       const unsigned int cell_this = c * v_len + v;
 
                       const unsigned int cell_m = this->get_face_info(f / v_len)
@@ -1855,14 +1842,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                     // using AssertIndexRange, but that leads to an
                     // internal compiler error with GCC 7.4. Do things
                     // by hand instead.
-                    Assert(
-                      face_info.faces[f].cells_interior[v] <
-                        n_macro_cells_before *
-                          VectorizedArrayType::n_array_elements,
-                      ExcIndexRange(face_info.faces[f].cells_interior[v],
-                                    0,
-                                    n_macro_cells_before *
-                                      VectorizedArrayType::n_array_elements));
+                    Assert(face_info.faces[f].cells_interior[v] <
+                             n_macro_cells_before * VectorizedArrayType::size(),
+                           ExcIndexRange(face_info.faces[f].cells_interior[v],
+                                         0,
+                                         n_macro_cells_before *
+                                           VectorizedArrayType::size()));
                     if (flag ||
                         (di.index_storage_variants
                              [ext ? internal::MatrixFreeFunctions::DoFInfo::

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -2034,7 +2034,7 @@ namespace MatrixFreeOperators
     bool
     non_negative(const VectorizedArrayType &n)
     {
-      for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         if (n[v] < 0.)
           return false;
 

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -237,7 +237,7 @@ namespace internal
     {
       const Number *vec_ptr = vec.begin() + dof_index;
       for (unsigned int i = 0; i < dofs_per_cell;
-           ++i, vec_ptr += VectorizedArrayType::n_array_elements)
+           ++i, vec_ptr += VectorizedArrayType::size())
         dof_values[i].load(vec_ptr);
     }
 
@@ -252,9 +252,9 @@ namespace internal
                             std::integral_constant<bool, false>) const
     {
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
-          dof_values[i][v] = vector_access(
-            vec, dof_index + v + i * VectorizedArrayType::n_array_elements);
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+          dof_values[i][v] =
+            vector_access(vec, dof_index + v + i * VectorizedArrayType::size());
     }
 
 
@@ -284,7 +284,7 @@ namespace internal
                                       std::integral_constant<bool, false>) const
     {
       for (unsigned int d = 0; d < dofs_per_cell; ++d)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
           dof_values[d][v] = vector_access(vec, dof_indices[v] + d);
     }
 
@@ -315,7 +315,7 @@ namespace internal
                        VectorizedArrayType &res,
                        std::integral_constant<bool, false>) const
     {
-      for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         res[v] = vector_access(vec, indices[v] + constant_offset);
     }
 
@@ -393,7 +393,7 @@ namespace internal
     {
       Number *vec_ptr = vec.begin() + dof_index;
       for (unsigned int i = 0; i < dofs_per_cell;
-           ++i, vec_ptr += VectorizedArrayType::n_array_elements)
+           ++i, vec_ptr += VectorizedArrayType::size())
         {
           VectorizedArrayType tmp;
           tmp.load(vec_ptr);
@@ -413,10 +413,9 @@ namespace internal
                             std::integral_constant<bool, false>) const
     {
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
           vector_access_add(vec,
-                            dof_index + v +
-                              i * VectorizedArrayType::n_array_elements,
+                            dof_index + v + i * VectorizedArrayType::size(),
                             dof_values[i][v]);
     }
 
@@ -445,7 +444,7 @@ namespace internal
                                       std::integral_constant<bool, false>) const
     {
       for (unsigned int d = 0; d < dofs_per_cell; ++d)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
           vector_access_add(vec, dof_indices[v] + d, dof_values[d][v]);
     }
 
@@ -462,7 +461,7 @@ namespace internal
                        std::integral_constant<bool, true>) const
     {
 #if DEAL_II_COMPILER_VECTORIZATION_LEVEL < 3
-      for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         vector_access(vec, indices[v] + constant_offset) += res[v];
 #else
       // only use gather in case there is also scatter.
@@ -485,7 +484,7 @@ namespace internal
                        VectorizedArrayType &res,
                        std::integral_constant<bool, false>) const
     {
-      for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         vector_access_add(vec, indices[v] + constant_offset, res[v]);
     }
 
@@ -558,7 +557,7 @@ namespace internal
     {
       Number *vec_ptr = vec.begin() + dof_index;
       for (unsigned int i = 0; i < dofs_per_cell;
-           ++i, vec_ptr += VectorizedArrayType::n_array_elements)
+           ++i, vec_ptr += VectorizedArrayType::size())
         dof_values[i].store(vec_ptr);
     }
 
@@ -573,10 +572,8 @@ namespace internal
                             std::integral_constant<bool, false>) const
     {
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
-          vector_access(vec,
-                        dof_index + v +
-                          i * VectorizedArrayType::n_array_elements) =
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+          vector_access(vec, dof_index + v + i * VectorizedArrayType::size()) =
             dof_values[i][v];
     }
 
@@ -605,7 +602,7 @@ namespace internal
                                       std::integral_constant<bool, false>) const
     {
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
-        for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+        for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
           vector_access(vec, dof_indices[v] + i) = dof_values[i][v];
     }
 
@@ -632,7 +629,7 @@ namespace internal
                        VectorizedArrayType &res,
                        std::integral_constant<bool, false>) const
     {
-      for (unsigned int v = 0; v < VectorizedArrayType::n_array_elements; ++v)
+      for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
         vector_access(vec, indices[v] + constant_offset) = res[v];
     }
 

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -757,7 +757,7 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize(
               const unsigned int max_size =
                 std::max(n_q_points, n_shape_values);
               const unsigned int vec_length =
-                dealii::VectorizedArray<double>::n_array_elements;
+                dealii::VectorizedArray<double>::size();
               const unsigned int n_comp = 1 + (spacedim - 1) / vec_length;
 
               scratch.resize((dim - 1) * max_size);
@@ -824,8 +824,8 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize_face(
       const unsigned int n_shape_values = fe.n_dofs_per_cell();
       const unsigned int n_q_points     = q.size();
       const unsigned int max_size       = std::max(n_q_points, n_shape_values);
-      const unsigned int vec_length = VectorizedArray<double>::n_array_elements;
-      const unsigned int n_comp     = 1 + (spacedim - 1) / vec_length;
+      const unsigned int vec_length     = VectorizedArray<double>::size();
+      const unsigned int n_comp         = 1 + (spacedim - 1) / vec_length;
 
       scratch.resize((dim - 1) * max_size);
       values_dofs.resize(n_comp * n_shape_values);
@@ -1495,10 +1495,9 @@ namespace internal
 
         const unsigned int n_shape_values = data.n_shape_functions;
         const unsigned int n_q_points     = data.shape_info.n_q_points;
-        const unsigned int vec_length =
-          VectorizedArray<double>::n_array_elements;
-        const unsigned int n_comp     = 1 + (spacedim - 1) / vec_length;
-        const unsigned int n_hessians = (dim * (dim + 1)) / 2;
+        const unsigned int vec_length     = VectorizedArray<double>::size();
+        const unsigned int n_comp         = 1 + (spacedim - 1) / vec_length;
+        const unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
         const bool evaluate_values = update_flags & update_quadrature_points;
         const bool evaluate_gradients =

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -149,7 +149,7 @@ MGTransferMatrixFree<dim, Number>::build(
     prolongation_matrix_1d[i] = elem_info.prolongation_matrix_1d[i];
 
   // reshuffle into aligned vector of vectorized arrays
-  const unsigned int vec_size = VectorizedArray<Number>::n_array_elements;
+  const unsigned int vec_size = VectorizedArray<Number>::size();
   const unsigned int n_levels =
     dof_handler.get_triangulation().n_global_levels();
 
@@ -379,8 +379,8 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
   LinearAlgebra::distributed::Vector<Number> &      dst,
   const LinearAlgebra::distributed::Vector<Number> &src) const
 {
-  const unsigned int vec_size    = VectorizedArray<Number>::n_array_elements;
-  const unsigned int degree_size = (degree > -1 ? degree : fe_degree) + 1;
+  const unsigned int vec_size        = VectorizedArray<Number>::size();
+  const unsigned int degree_size     = (degree > -1 ? degree : fe_degree) + 1;
   const unsigned int n_child_dofs_1d = 2 * degree_size - element_is_continuous;
   const unsigned int n_scalar_cell_dofs =
     Utilities::fixed_power<dim>(n_child_dofs_1d);
@@ -518,8 +518,8 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
   LinearAlgebra::distributed::Vector<Number> &      dst,
   const LinearAlgebra::distributed::Vector<Number> &src) const
 {
-  const unsigned int vec_size    = VectorizedArray<Number>::n_array_elements;
-  const unsigned int degree_size = (degree > -1 ? degree : fe_degree) + 1;
+  const unsigned int vec_size        = VectorizedArray<Number>::size();
+  const unsigned int degree_size     = (degree > -1 ? degree : fe_degree) + 1;
   const unsigned int n_child_dofs_1d = 2 * degree_size - element_is_continuous;
   const unsigned int n_scalar_cell_dofs =
     Utilities::fixed_power<dim>(n_child_dofs_1d);

--- a/tests/base/point_03.cc
+++ b/tests/base/point_03.cc
@@ -29,7 +29,7 @@ check()
   VectorizedArray<number>             distance_vec;
   Point<dim, VectorizedArray<number>> p1_vec, p2_vec;
 
-  for (unsigned int v = 0; v < VectorizedArray<number>::n_array_elements; ++v)
+  for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
     {
       Point<dim, number> p1, p2;
       for (unsigned int i = 0; i < dim; ++i)
@@ -48,12 +48,12 @@ check()
   distance_vec -= distance_vec2;
   number diff = 0.;
 
-  for (unsigned int v = 0; v < VectorizedArray<number>::n_array_elements; ++v)
+  for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
     diff += std::abs(distance_vec[v]);
 
   AssertThrow(diff < 2 * std::numeric_limits<number>::epsilon() *
-                       VectorizedArray<number>::n_array_elements *
-                       VectorizedArray<number>::n_array_elements,
+                       VectorizedArray<number>::size() *
+                       VectorizedArray<number>::size(),
               ExcMessage("diff is " + std::to_string(diff)));
 
   deallog << "Ok" << std::endl;

--- a/tests/base/utilities_02b.cc
+++ b/tests/base/utilities_02b.cc
@@ -25,18 +25,18 @@ template <typename VectorizedArrayType>
 void
 do_test(const VectorizedArrayType array)
 {
-  deallog << "  test " << VectorizedArrayType::n_array_elements
-          << " array elements" << std::endl;
+  deallog << "  test " << VectorizedArrayType::size() << " array elements"
+          << std::endl;
 
   auto exponentiated_array = Utilities::fixed_power<3>(array);
 
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); i++)
     deallog << exponentiated_array[i] << " ";
   deallog << std::endl;
 
   exponentiated_array = Utilities::fixed_power<-3>(array);
 
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); i++)
     deallog << exponentiated_array[i] << " ";
   deallog << std::endl;
 }

--- a/tests/base/vectorization_01.cc
+++ b/tests/base/vectorization_01.cc
@@ -30,7 +30,7 @@ test()
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
   VectorizedArray<Number> a, b, c;
-  const unsigned int      n_vectors = VectorizedArray<Number>::n_array_elements;
+  const unsigned int      n_vectors = VectorizedArray<Number>::size();
   a                                 = Number(2.);
   b                                 = Number(-1.);
   for (unsigned int i = 0; i < n_vectors; ++i)

--- a/tests/base/vectorization_02.cc
+++ b/tests/base/vectorization_02.cc
@@ -25,7 +25,7 @@ void
 test()
 {
   typedef VectorizedArray<double> vector_t;
-  const unsigned int n_vectors = VectorizedArray<double>::n_array_elements;
+  const unsigned int              n_vectors = VectorizedArray<double>::size();
   typedef AlignedVector<vector_t> VEC;
   std::vector<double>             a_ref(4), b_ref;
   VEC                             a(4);

--- a/tests/base/vectorization_03.cc
+++ b/tests/base/vectorization_03.cc
@@ -74,7 +74,7 @@ test()
   weight = random_value<double>();
 
   VectorizedArray<double> vec;
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
     vec[v] = random_value<double>();
 
   current.values[0] = vec;
@@ -91,7 +91,7 @@ test()
   vector *= 2. * current.get_value(0)[0];
 
   double error = 0;
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
     error += std::abs(current.get_value(0)[v] / (current.cartesian_weight[v] *
                                                  current.jac_weight[0][0]) -
                       (2. * vec[v] - ol[v] - weight[v] * std::sin(vec[v])));

--- a/tests/base/vectorization_04.cc
+++ b/tests/base/vectorization_04.cc
@@ -25,7 +25,7 @@ template <typename Number>
 void
 test()
 {
-  const unsigned int  n_vectors = VectorizedArray<Number>::n_array_elements;
+  const unsigned int  n_vectors = VectorizedArray<Number>::size();
   std::vector<Number> values(n_vectors * 5);
   for (unsigned int i = 0; i < values.size(); ++i)
     values[i] = i;

--- a/tests/base/vectorization_05.cc
+++ b/tests/base/vectorization_05.cc
@@ -30,7 +30,7 @@ test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int      n_vectors = VectorizedArray<Number>::n_array_elements;
+  const unsigned int      n_vectors = VectorizedArray<Number>::size();
   VectorizedArray<Number> arr[n_numbers];
   Number                  other[n_vectors * n_numbers];
   unsigned int            offsets[n_vectors];

--- a/tests/base/vectorization_06.cc
+++ b/tests/base/vectorization_06.cc
@@ -35,7 +35,7 @@ test()
   for (unsigned int i = 0; i < vec.size(); ++i)
     vec[i] = i + 1;
 
-  const unsigned int n_vectors = VectorizedArray<Number>::n_array_elements;
+  const unsigned int n_vectors = VectorizedArray<Number>::size();
   unsigned int       indices[n_vectors];
   for (unsigned int i = 0; i < n_vectors; ++i)
     indices[i] = i;

--- a/tests/base/vectorization_09.cc
+++ b/tests/base/vectorization_09.cc
@@ -26,7 +26,7 @@ void
 test()
 {
   const unsigned int  n_chunks  = 50000;
-  const unsigned int  n_vectors = VectorizedArray<Number>::n_array_elements;
+  const unsigned int  n_vectors = VectorizedArray<Number>::size();
   std::vector<Number> values(n_vectors * n_chunks);
   for (unsigned int i = 0; i < values.size(); ++i)
     values[i] = i;

--- a/tests/base/vectorization_10.cc
+++ b/tests/base/vectorization_10.cc
@@ -31,8 +31,7 @@ do_test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int n_vectors =
-    VectorizedArray<Number, width>::n_array_elements;
+  const unsigned int n_vectors = VectorizedArray<Number, width>::size();
   VectorizedArray<Number, width> arr[n_numbers];
   Number                         other[n_vectors * n_numbers];
   unsigned int                   offsets[n_vectors];

--- a/tests/base/vectorization_11.cc
+++ b/tests/base/vectorization_11.cc
@@ -29,9 +29,9 @@ void
 do_test(const VectorizedArrayType                      array,
         const typename VectorizedArrayType::value_type number)
 {
-  deallog << "  test " << VectorizedArrayType::n_array_elements
-          << " array elements" << std::endl;
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+  deallog << "  test " << VectorizedArrayType::size() << " array elements"
+          << std::endl;
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); i++)
     if (array[i] != number)
       deallog << "  problem in element " << i << std::endl;
 }

--- a/tests/base/vectorization_12.cc
+++ b/tests/base/vectorization_12.cc
@@ -27,7 +27,7 @@ template <typename Number>
 void
 test()
 {
-  constexpr unsigned int n = VectorizedArray<Number>::n_array_elements;
+  constexpr unsigned int n = VectorizedArray<Number>::size();
 
   VectorizedArray<Number> a;
   std::stringstream       test_stream;

--- a/tests/base/vectorization_13.cc
+++ b/tests/base/vectorization_13.cc
@@ -26,12 +26,12 @@ void
 do_test(const VectorizedArrayType                      array,
         const typename VectorizedArrayType::value_type number)
 {
-  deallog << "  test " << VectorizedArrayType::n_array_elements
-          << " array elements" << std::endl;
+  deallog << "  test " << VectorizedArrayType::size() << " array elements"
+          << std::endl;
 
   auto exponentiated_array = std::pow(array, number);
 
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); i++)
     deallog << exponentiated_array[i] << " ";
   deallog << std::endl;
 }

--- a/tests/base/vectorization_14.cc
+++ b/tests/base/vectorization_14.cc
@@ -25,11 +25,11 @@ template <typename VectorizedArrayType>
 void
 do_test()
 {
-  deallog << "  test " << VectorizedArrayType::n_array_elements
-          << " array elements" << std::endl;
+  deallog << "  test " << VectorizedArrayType::size() << " array elements"
+          << std::endl;
 
   VectorizedArrayType left;
-  for (unsigned int i = 0; i < VectorizedArrayType::n_array_elements; i++)
+  for (unsigned int i = 0; i < VectorizedArrayType::size(); i++)
     left[i] = i + 1.;
 
   VectorizedArrayType right(3.);

--- a/tests/base/vectorization_15.cc
+++ b/tests/base/vectorization_15.cc
@@ -31,8 +31,7 @@ do_test()
 {
   // since the number of array elements is system dependent, it is not a good
   // idea to print them to an output file. Instead, check the values manually
-  const unsigned int n_vectors =
-    VectorizedArray<Number, width>::n_array_elements;
+  const unsigned int n_vectors = VectorizedArray<Number, width>::size();
   VectorizedArray<Number, width> arr[n_numbers];
   Number                         other[n_vectors * n_numbers];
   unsigned int                   offsets[n_vectors];

--- a/tests/base/vectorization_iterator_02.cc
+++ b/tests/base/vectorization_iterator_02.cc
@@ -26,15 +26,14 @@ void
 test_const(const VectorizedArray<Number> &vector)
 {
   AssertDimension(*std::max_element(vector.begin(), vector.end()),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                  VectorizedArray<Number>::size() - 1);
   AssertDimension(std::distance(vector.begin(),
                                 std::max_element(vector.begin(), vector.end())),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                  VectorizedArray<Number>::size() - 1);
   AssertDimension(std::distance(vector.begin(),
                                 vector.begin() +
-                                  (VectorizedArray<Number>::n_array_elements -
-                                   1)),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                                  (VectorizedArray<Number>::size() - 1)),
+                  VectorizedArray<Number>::size() - 1);
 }
 
 template <typename Number>
@@ -42,19 +41,18 @@ void
 test_nonconst(VectorizedArray<Number> &vector)
 {
   AssertDimension(*std::max_element(vector.begin(), vector.end()),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                  VectorizedArray<Number>::size() - 1);
   AssertDimension(std::distance(vector.begin(),
                                 std::max_element(vector.begin(), vector.end())),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                  VectorizedArray<Number>::size() - 1);
   AssertDimension(std::distance(vector.begin(),
                                 vector.begin() +
-                                  (VectorizedArray<Number>::n_array_elements -
-                                   1)),
-                  VectorizedArray<Number>::n_array_elements - 1);
+                                  (VectorizedArray<Number>::size() - 1)),
+                  VectorizedArray<Number>::size() - 1);
 
   auto it = vector.begin();
-  std::advance(it, VectorizedArray<Number>::n_array_elements - 1);
-  AssertDimension(*it, VectorizedArray<Number>::n_array_elements - 1);
+  std::advance(it, VectorizedArray<Number>::size() - 1);
+  AssertDimension(*it, VectorizedArray<Number>::size() - 1);
 }
 
 template <typename Number>

--- a/tests/lac/tensor_product_matrix_vectorized_01.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_01.cc
@@ -77,7 +77,7 @@ do_test(const unsigned int size)
     v3(w1.size());
   convert_to_vectorized(w1, v1);
 
-  constexpr unsigned int macro_size = VectorizedArray<double>::n_array_elements;
+  constexpr unsigned int macro_size = VectorizedArray<double>::size();
   Vector<double>         vec_flat(v1.size() * macro_size);
   std::array<unsigned int, macro_size> offsets;
   for (unsigned int i = 0; i < macro_size; ++i)

--- a/tests/lac/tensor_product_matrix_vectorized_02.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_02.cc
@@ -77,7 +77,7 @@ do_test()
     v3(w1.size());
   convert_to_vectorized(w1, v1);
 
-  constexpr unsigned int macro_size = VectorizedArray<double>::n_array_elements;
+  constexpr unsigned int macro_size = VectorizedArray<double>::size();
   Vector<double>         vec_flat(v1.size() * macro_size);
   std::array<unsigned int, macro_size> offsets;
   for (unsigned int i = 0; i < macro_size; ++i)

--- a/tests/lac/tensor_product_matrix_vectorized_03.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_03.cc
@@ -77,7 +77,7 @@ do_test()
     v3(w1.size());
   convert_to_vectorized(w1, v1);
 
-  constexpr unsigned int macro_size = VectorizedArray<float>::n_array_elements;
+  constexpr unsigned int macro_size = VectorizedArray<float>::size();
   Vector<float>          vec_flat(v1.size() * macro_size);
   std::array<unsigned int, macro_size> offsets;
   for (unsigned int i = 0; i < macro_size; ++i)

--- a/tests/lac/tensor_product_matrix_vectorized_04.cc
+++ b/tests/lac/tensor_product_matrix_vectorized_04.cc
@@ -71,7 +71,7 @@ do_test(const unsigned int size)
     v3(w1.size());
   convert_to_vectorized(w1, v1);
 
-  constexpr unsigned int macro_size = VectorizedArray<double>::n_array_elements;
+  constexpr unsigned int macro_size = VectorizedArray<double>::size();
   Vector<double>         vec_flat(v1.size() * macro_size);
   std::array<unsigned int, macro_size> offsets;
   for (unsigned int i = 0; i < macro_size; ++i)

--- a/tests/mappings/mapping_q_eulerian_08.cc
+++ b/tests/mappings/mapping_q_eulerian_08.cc
@@ -92,8 +92,7 @@ public:
   {
     Tensor<1, dim, VectorizedArray<NumberType>> shift_vec;
     Point<dim>                                  p;
-    for (unsigned int v = 0; v < VectorizedArray<NumberType>::n_array_elements;
-         ++v)
+    for (unsigned int v = 0; v < VectorizedArray<NumberType>::size(); ++v)
       {
         for (unsigned int d = 0; d < dim; ++d)
           p[d] = p_vec[d][v];
@@ -256,8 +255,7 @@ test(const unsigned int n_ref = 0)
               const auto &qp = fe_eval.quadrature_point(q);
               const auto  v2 = qp + displacement_function.shift_value(qp);
               VectorizedArray<NumberType> dist = v1.distance(v2);
-              for (unsigned int v = 0;
-                   v < VectorizedArray<NumberType>::n_array_elements;
+              for (unsigned int v = 0; v < VectorizedArray<NumberType>::size();
                    ++v)
                 AssertThrow(dist[v] < 1e-8,
                             ExcMessage("distance: " + std::to_string(dist[v])));
@@ -336,7 +334,7 @@ test(const unsigned int n_ref = 0)
                 const auto  v2 = qp + displacement_function.shift_value(qp);
                 VectorizedArray<NumberType> dist = v1.distance(v2);
                 for (unsigned int v = 0;
-                     v < VectorizedArray<NumberType>::n_array_elements;
+                     v < VectorizedArray<NumberType>::size();
                      ++v)
                   AssertThrow(dist[v] < 1e-8,
                               ExcMessage(

--- a/tests/matrix_free/advect_1d_vectorization_mask.cc
+++ b/tests/matrix_free/advect_1d_vectorization_mask.cc
@@ -107,7 +107,7 @@ private:
     FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, number> phi(
       data, 0, 0, start_vector_component);
 
-    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+    const unsigned int n_vect = VectorizedArray<number>::size();
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
@@ -143,7 +143,7 @@ private:
                                       n_components,
                                       number>::value_type value_type;
 
-    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+    const unsigned int n_vect = VectorizedArray<number>::size();
 
     for (unsigned int face = face_range.first; face < face_range.second; face++)
       {
@@ -200,7 +200,7 @@ private:
                                       n_components,
                                       number>::value_type value_type;
 
-    const unsigned int n_vect = VectorizedArray<number>::n_array_elements;
+    const unsigned int n_vect = VectorizedArray<number>::size();
 
     for (unsigned int face = face_range.first; face < face_range.second; face++)
       {
@@ -225,7 +225,7 @@ private:
         for (unsigned int v = 0; v < n_vect; ++v)
           {
             std::bitset<n_vect> mask =
-              std::bitset<VectorizedArray<number>::n_array_elements>();
+              std::bitset<VectorizedArray<number>::size()>();
             mask[v] = true;
             fe_eval.distribute_local_to_global(dst, 0, mask);
           }

--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -89,12 +89,12 @@ do_test(const DoFHandler<dim> &dof)
 
         fe_eval.reinit(cell);
         for (unsigned int i = 0; i < dofs_per_cell;
-             i += VectorizedArray<double>::n_array_elements)
+             i += VectorizedArray<double>::size())
           {
             const unsigned int n_items =
-              i + VectorizedArray<double>::n_array_elements > dofs_per_cell ?
+              i + VectorizedArray<double>::size() > dofs_per_cell ?
                 (dofs_per_cell - i) :
-                VectorizedArray<double>::n_array_elements;
+                VectorizedArray<double>::size();
             for (unsigned int j = 0; j < dofs_per_cell; ++j)
               fe_eval.begin_dof_values()[j] = VectorizedArray<double>();
             for (unsigned int v = 0; v < n_items; ++v)

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -112,12 +112,12 @@ do_test(const DoFHandler<dim> &dof)
         const unsigned int dofs_per_cell_u = phi_u.dofs_per_cell;
         const unsigned int dofs_per_cell_p = phi_p.dofs_per_cell;
         for (unsigned int i = 0; i < dofs_per_cell_u;
-             i += VectorizedArray<double>::n_array_elements)
+             i += VectorizedArray<double>::size())
           {
             const unsigned int n_items =
-              i + VectorizedArray<double>::n_array_elements > dofs_per_cell_u ?
+              i + VectorizedArray<double>::size() > dofs_per_cell_u ?
                 (dofs_per_cell_u - i) :
-                VectorizedArray<double>::n_array_elements;
+                VectorizedArray<double>::size();
             for (unsigned int j = 0; j < dofs_per_cell_u; ++j)
               phi_u.begin_dof_values()[j] = VectorizedArray<double>();
             for (unsigned int v = 0; v < n_items; ++v)
@@ -148,12 +148,12 @@ do_test(const DoFHandler<dim> &dof)
           }
 
         for (unsigned int i = 0; i < dofs_per_cell_p;
-             i += VectorizedArray<double>::n_array_elements)
+             i += VectorizedArray<double>::size())
           {
             const unsigned int n_items =
-              i + VectorizedArray<double>::n_array_elements > dofs_per_cell_p ?
+              i + VectorizedArray<double>::size() > dofs_per_cell_p ?
                 (dofs_per_cell_p - i) :
-                VectorizedArray<double>::n_array_elements;
+                VectorizedArray<double>::size();
             for (unsigned int j = 0; j < dofs_per_cell_p; ++j)
               phi_p.begin_dof_values()[j] = VectorizedArray<double>();
             for (unsigned int v = 0; v < n_items; ++v)

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -110,12 +110,12 @@ assemble_on_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
   FEEvaluation<dim, fe_degree> &fe_eval = data.fe_eval[0];
   fe_eval.reinit(cell);
   for (unsigned int i = 0; i < dofs_per_cell;
-       i += VectorizedArray<double>::n_array_elements)
+       i += VectorizedArray<double>::size())
     {
       const unsigned int n_items =
-        i + VectorizedArray<double>::n_array_elements > dofs_per_cell ?
+        i + VectorizedArray<double>::size() > dofs_per_cell ?
           (dofs_per_cell - i) :
-          VectorizedArray<double>::n_array_elements;
+          VectorizedArray<double>::size();
       for (unsigned int j = 0; j < dofs_per_cell; ++j)
         fe_eval.begin_dof_values()[j] = VectorizedArray<double>();
       for (unsigned int v = 0; v < n_items; ++v)

--- a/tests/matrix_free/cell_level_and_index.cc
+++ b/tests/matrix_free/cell_level_and_index.cc
@@ -43,7 +43,7 @@ void
 compare_indices(const MatrixFree<dim, number> *mf_data)
 {
   const unsigned int     n_batches  = mf_data->n_macro_cells();
-  constexpr unsigned int batch_size = VectorizedArray<number>::n_array_elements;
+  constexpr unsigned int batch_size = VectorizedArray<number>::size();
   for (unsigned int batch_no = 0; batch_no < n_batches; ++batch_no)
     {
       const unsigned int n_lanes_filled =

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -278,13 +278,10 @@ private:
                         phif.inverse_jacobian(0))[dim - 1]) *
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
-            std::array<types::boundary_id,
-                       VectorizedArray<number>::n_array_elements>
+            std::array<types::boundary_id, VectorizedArray<number>::size()>
                                     boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
             VectorizedArray<number> factor_boundary;
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               // interior face
               if (boundary_ids[v] == numbers::invalid_boundary_id)
                 factor_boundary[v] = 0.5;

--- a/tests/matrix_free/dg_pbc_02.cc
+++ b/tests/matrix_free/dg_pbc_02.cc
@@ -101,9 +101,7 @@ test()
         n_inner_other_faces(2 * dim), n_boundary_faces(2 * dim);
       for (unsigned int f = 0; f < mf_data.n_inner_face_batches(); ++f)
         {
-          for (unsigned int v = 0;
-               v < VectorizedArray<double>::n_array_elements;
-               ++v)
+          for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
             if (mf_data.get_face_info(f).cells_interior[v] !=
                 numbers::invalid_unsigned_int)
               {
@@ -117,9 +115,7 @@ test()
            mf_data.n_inner_face_batches() + mf_data.n_boundary_face_batches();
            ++f)
         {
-          for (unsigned int v = 0;
-               v < VectorizedArray<double>::n_array_elements;
-               ++v)
+          for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
             if (mf_data.get_face_info(f).cells_interior[v] !=
                 numbers::invalid_unsigned_int)
               {

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -97,10 +97,9 @@ test(const bool adaptive_ref = true)
     mf_data->reinit(dof, constraints, quad, data);
   }
 
-  const unsigned int     n_cells  = mf_data->n_macro_cells();
-  const auto &           dof_info = mf_data->get_dof_info();
-  constexpr unsigned int n_vectorization =
-    VectorizedArray<number>::n_array_elements;
+  const unsigned int     n_cells         = mf_data->n_macro_cells();
+  const auto &           dof_info        = mf_data->get_dof_info();
+  constexpr unsigned int n_vectorization = VectorizedArray<number>::size();
 
   std::vector<unsigned int> my_rows;
   my_rows.reserve(fe.dofs_per_cell * n_vectorization);

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -99,10 +99,9 @@ test(const bool adaptive_ref = true)
     mf_data->reinit(dof, constraints, quad, data);
   }
 
-  const unsigned int     n_cells  = mf_data->n_macro_cells();
-  const auto &           dof_info = mf_data->get_dof_info();
-  constexpr unsigned int n_vectorization =
-    VectorizedArray<number>::n_array_elements;
+  const unsigned int     n_cells         = mf_data->n_macro_cells();
+  const auto &           dof_info        = mf_data->get_dof_info();
+  constexpr unsigned int n_vectorization = VectorizedArray<number>::size();
 
   std::vector<unsigned int> my_rows;
   my_rows.reserve(fe.dofs_per_cell * n_vectorization);

--- a/tests/matrix_free/estimate_condition_number_mass.cc
+++ b/tests/matrix_free/estimate_condition_number_mass.cc
@@ -119,7 +119,7 @@ test(const FiniteElement<dim> &fe, const unsigned int n_iterations)
   {
     const QGauss<1>                                  quad(fe_degree + 1);
     typename MatrixFree<dim, number>::AdditionalData data;
-    data.tasks_block_size = 8 / VectorizedArray<number>::n_array_elements;
+    data.tasks_block_size = 8 / VectorizedArray<number>::size();
     mf_data.reinit(dof, constraints, quad, data);
   }
 

--- a/tests/matrix_free/evaluate_1d_shape_07.cc
+++ b/tests/matrix_free/evaluate_1d_shape_07.cc
@@ -40,7 +40,7 @@ test()
 
   VectorizedArray<double> x[N], x_ref[N], y[M], y_ref[M];
   for (unsigned int i = 0; i < N; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       x[i][v] = random_value<double>();
 
   // compute reference
@@ -71,8 +71,7 @@ test()
   for (unsigned int i = 0; i < M; ++i)
     {
       deallog << y[i][0] - y_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(y[i][v] - y_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }
@@ -80,7 +79,7 @@ test()
 
 
   for (unsigned int i = 0; i < M; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       y[i][v] = random_value<double>();
 
   // compute reference
@@ -104,8 +103,7 @@ test()
   for (unsigned int i = 0; i < N; ++i)
     {
       deallog << x[i][0] - x_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(x[i][v] - x_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }

--- a/tests/matrix_free/evaluate_1d_shape_08.cc
+++ b/tests/matrix_free/evaluate_1d_shape_08.cc
@@ -69,7 +69,7 @@ test()
 
   VectorizedArray<double> x[N], x_ref[N], y[M], y_ref[M];
   for (unsigned int i = 0; i < N; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       x[i][v] = random_value<double>();
 
   // compute reference
@@ -100,15 +100,14 @@ test()
   for (unsigned int i = 0; i < M; ++i)
     {
       deallog << y[i][0] - y_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(y[i][v] - y_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }
   deallog << std::endl;
 
   for (unsigned int i = 0; i < M; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       y[i][v] = random_value<double>();
 
   // compute reference
@@ -132,8 +131,7 @@ test()
   for (unsigned int i = 0; i < N; ++i)
     {
       deallog << x[i][0] - x_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(x[i][v] - x_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }

--- a/tests/matrix_free/evaluate_1d_shape_09.cc
+++ b/tests/matrix_free/evaluate_1d_shape_09.cc
@@ -48,7 +48,7 @@ test()
 
   VectorizedArray<double> x[N], x_ref[N], y[M], y_ref[M];
   for (unsigned int i = 0; i < N; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       x[i][v] = random_value<double>();
 
   // compute reference
@@ -79,8 +79,7 @@ test()
   for (unsigned int i = 0; i < M; ++i)
     {
       deallog << y[i][0] - y_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(y[i][v] - y_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }
@@ -88,7 +87,7 @@ test()
 
 
   for (unsigned int i = 0; i < M; ++i)
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       y[i][v] = random_value<double>();
 
   // compute reference
@@ -112,8 +111,7 @@ test()
   for (unsigned int i = 0; i < N; ++i)
     {
       deallog << x[i][0] - x_ref[i][0] << " ";
-      for (unsigned int v = 1; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 1; v < VectorizedArray<double>::size(); ++v)
         AssertThrow(std::abs(x[i][v] - x_ref[i][v]) < 1e-12,
                     ExcInternalError());
     }

--- a/tests/matrix_free/faces_value_optimization.cc
+++ b/tests/matrix_free/faces_value_optimization.cc
@@ -88,9 +88,7 @@ private:
           {
             VectorizedArray<number> diff =
               (ref.get_value(q) - check.get_value(q));
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {
@@ -138,9 +136,7 @@ private:
           {
             VectorizedArray<number> diff =
               (refr.get_value(q) - checkr.get_value(q));
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {

--- a/tests/matrix_free/faces_value_optimization_02.cc
+++ b/tests/matrix_free/faces_value_optimization_02.cc
@@ -88,9 +88,7 @@ private:
           {
             VectorizedArray<number> diff =
               (ref.get_value(q) - check.get_value(q));
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {
@@ -138,9 +136,7 @@ private:
           {
             VectorizedArray<number> diff =
               (refr.get_value(q) - checkr.get_value(q));
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {

--- a/tests/matrix_free/get_functions_variants.cc
+++ b/tests/matrix_free/get_functions_variants.cc
@@ -132,8 +132,7 @@ operator()(const MatrixFree<dim, Number> &data,
       // FEEvaluations. Those are tested in other
       // functions and seen as reference here
       for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
-        for (unsigned int j = 0; j < VectorizedArray<Number>::n_array_elements;
-             ++j)
+        for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {
             errors[0] +=
               std::fabs(fe_eval.get_value(q)[j] - fe_eval2.get_value(q)[j]);

--- a/tests/matrix_free/get_functions_variants_gl.cc
+++ b/tests/matrix_free/get_functions_variants_gl.cc
@@ -128,8 +128,7 @@ operator()(const MatrixFree<dim, Number> &data,
       // FEEvaluations. Those are tested in other
       // functions and seen as reference here
       for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
-        for (unsigned int j = 0; j < VectorizedArray<Number>::n_array_elements;
-             ++j)
+        for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {
             errors[0] +=
               std::fabs(fe_eval.get_value(q)[j] - fe_eval2.get_value(q)[j]);

--- a/tests/matrix_free/get_values_plain.cc
+++ b/tests/matrix_free/get_values_plain.cc
@@ -75,9 +75,7 @@ public:
         fe_eval_plain.read_dof_values_plain(src);
 
         for (unsigned int i = 0; i < fe_eval.dofs_per_cell; ++i)
-          for (unsigned int j = 0;
-               j < VectorizedArray<Number>::n_array_elements;
-               ++j)
+          for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
             {
               error += std::fabs(fe_eval.get_dof_value(i)[j] -
                                  fe_eval_plain.get_dof_value(i)[j]);

--- a/tests/matrix_free/interpolate_functions_common.h
+++ b/tests/matrix_free/interpolate_functions_common.h
@@ -130,8 +130,7 @@ public:
         fe_evalp.read_dof_values(src);
         fe_evalp.evaluate(true, true);
 
-        for (unsigned int j = 0; j < VectorizedArray<Number>::n_array_elements;
-             ++j)
+        for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {
             // skip empty components in VectorizedArray
             if (data.get_face_info(face).cells_interior[j] ==
@@ -194,8 +193,7 @@ public:
         fe_evalm.read_dof_values(src);
         fe_evalm.evaluate(true, true);
 
-        for (unsigned int j = 0; j < VectorizedArray<Number>::n_array_elements;
-             ++j)
+        for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {
             // skip empty components in VectorizedArray
             if (data.get_face_info(face).cells_interior[j] ==

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -69,7 +69,7 @@ public:
   {
     VectorizedArray<double> res = make_vectorized_array(0.);
     Point<dim>              p;
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       {
         for (unsigned int d = 0; d < dim; d++)
           p[d] = p_vec[d][v];

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -83,8 +83,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -83,8 +83,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_20.cc
+++ b/tests/matrix_free/matrix_vector_20.cc
@@ -95,8 +95,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_21.cc
+++ b/tests/matrix_free/matrix_vector_21.cc
@@ -85,8 +85,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_22.cc
+++ b/tests/matrix_free/matrix_vector_22.cc
@@ -84,8 +84,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_23.cc
+++ b/tests/matrix_free/matrix_vector_23.cc
@@ -96,8 +96,7 @@ class MatrixFreeTest
 {
 public:
   typedef VectorizedArray<Number> vector_t;
-  static const std::size_t        n_vectors =
-    VectorizedArray<Number>::n_array_elements;
+  static const std::size_t        n_vectors = VectorizedArray<Number>::size();
 
   MatrixFreeTest(const MatrixFree<dim, Number> &data_in)
     : data(data_in){};

--- a/tests/matrix_free/matrix_vector_faces_common.h
+++ b/tests/matrix_free/matrix_vector_faces_common.h
@@ -165,17 +165,14 @@ private:
           {
             value_type average_value =
               (fe_eval.get_value(q) - fe_eval_neighbor.get_value(q)) *
-              make_vectorized_array<number,
-                                    VectorizedArrayType::n_array_elements>(0.5);
+              make_vectorized_array<number, VectorizedArrayType::size()>(0.5);
             value_type average_valgrad =
               fe_eval.get_normal_derivative(q) +
               fe_eval_neighbor.get_normal_derivative(q);
             average_valgrad =
               average_value * sigmaF -
               average_valgrad *
-                make_vectorized_array<number,
-                                      VectorizedArrayType::n_array_elements>(
-                  0.5);
+                make_vectorized_array<number, VectorizedArrayType::size()>(0.5);
             fe_eval.submit_normal_derivative(-average_value, q);
             fe_eval_neighbor.submit_normal_derivative(-average_value, q);
             fe_eval.submit_value(average_valgrad, q);
@@ -369,17 +366,14 @@ private:
           {
             value_type average_value =
               (fe_eval.get_value(q) - fe_eval_neighbor.get_value(q)) *
-              make_vectorized_array<number,
-                                    VectorizedArrayType::n_array_elements>(0.5);
+              make_vectorized_array<number, VectorizedArrayType::size()>(0.5);
             value_type average_valgrad =
               fe_eval.get_normal_derivative(q) +
               fe_eval_neighbor.get_normal_derivative(q);
             average_valgrad =
               average_value * sigmaF -
               average_valgrad *
-                make_vectorized_array<number,
-                                      VectorizedArrayType::n_array_elements>(
-                  0.5);
+                make_vectorized_array<number, VectorizedArrayType::size()>(0.5);
             fe_eval.submit_normal_derivative(-average_value, q);
             fe_eval_neighbor.submit_normal_derivative(-average_value, q);
             fe_eval.submit_value(average_valgrad, q);
@@ -592,9 +586,7 @@ private:
             const VectorizedArrayType normal_times_advection =
               advection * phi_m.get_normal_vector(q);
             const value_type flux_times_normal =
-              make_vectorized_array<number,
-                                    VectorizedArrayType::n_array_elements>(
-                0.5) *
+              make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
                std::abs(normal_times_advection) * (u_minus - u_plus));
             phi_m.submit_value(-flux_times_normal, q);
@@ -628,8 +620,7 @@ private:
                                 number,
                                 VectorizedArrayType>::value_type value_type;
     value_type                                                   u_plus;
-    u_plus =
-      make_vectorized_array<number, VectorizedArrayType::n_array_elements>(1.3);
+    u_plus = make_vectorized_array<number, VectorizedArrayType::size()>(1.3);
 
     for (unsigned int face = face_range.first; face < face_range.second; face++)
       {
@@ -642,9 +633,7 @@ private:
             const VectorizedArrayType normal_times_advection =
               advection * fe_eval.get_normal_vector(q);
             const value_type flux_times_normal =
-              make_vectorized_array<number,
-                                    VectorizedArrayType::n_array_elements>(
-                0.5) *
+              make_vectorized_array<number, VectorizedArrayType::size()>(0.5) *
               ((u_minus + u_plus) * normal_times_advection +
                std::abs(normal_times_advection) * (u_minus - u_plus));
             fe_eval.submit_value(-flux_times_normal, q);

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -331,13 +331,10 @@ private:
               std::abs((phif.get_normal_vector(0) *
                         phif.inverse_jacobian(0))[dim - 1]) *
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
-            std::array<types::boundary_id,
-                       VectorizedArray<number>::n_array_elements>
+            std::array<types::boundary_id, VectorizedArray<number>::size()>
                                     boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
             VectorizedArray<number> factor_boundary;
-            for (unsigned int v = 0;
-                 v < VectorizedArray<number>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               // interior face
               if (boundary_ids[v] == numbers::invalid_boundary_id)
                 factor_boundary[v] = 0.5;

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -85,9 +85,7 @@ public:
 
         // values should evaluate to one, derivatives to zero
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
-          for (unsigned int d = 0;
-               d < VectorizedArray<Number>::n_array_elements;
-               ++d)
+          for (unsigned int d = 0; d < VectorizedArray<Number>::size(); ++d)
             {
               Assert(fe_eval.get_value(q)[d] == 1., ExcInternalError());
               for (unsigned int e = 0; e < dim; ++e)

--- a/tests/matrix_free/read_cell_data_01.cc
+++ b/tests/matrix_free/read_cell_data_01.cc
@@ -180,8 +180,7 @@ private:
       }
   }
 
-  AlignedVector<std::array<CellId, VectorizedArrayType::n_array_elements>>
-    cell_ids;
+  AlignedVector<std::array<CellId, VectorizedArrayType::size()>> cell_ids;
 };
 
 

--- a/tests/matrix_free/read_cell_data_02.cc
+++ b/tests/matrix_free/read_cell_data_02.cc
@@ -151,8 +151,7 @@ private:
       }
   }
 
-  AlignedVector<std::array<CellId, VectorizedArrayType::n_array_elements>>
-    cell_ids;
+  AlignedVector<std::array<CellId, VectorizedArrayType::size()>> cell_ids;
 };
 
 

--- a/tests/matrix_free/step-48b.cc
+++ b/tests/matrix_free/step-48b.cc
@@ -154,9 +154,7 @@ namespace Step48
             // components (should be stable irrespective of vectorization
             // width)
             if (q == 0)
-              for (unsigned int v = 0;
-                   v < VectorizedArray<double>::n_array_elements;
-                   ++v)
+              for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
                 deallog << submit_value[v] << " = " << simple_value[v] << " - "
                         << sin_value[v] << std::endl;
           }

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -486,9 +486,7 @@ namespace StokesClass
           {
             VectorizedArray<number> return_value =
               make_vectorized_array<number>(1.);
-            for (unsigned int i = 0;
-                 i < VectorizedArray<number>::n_array_elements;
-                 ++i)
+            for (unsigned int i = 0; i < VectorizedArray<number>::size(); ++i)
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
@@ -623,9 +621,7 @@ namespace StokesClass
           {
             VectorizedArray<number> return_value =
               make_vectorized_array<number>(1.);
-            for (unsigned int i = 0;
-                 i < VectorizedArray<number>::n_array_elements;
-                 ++i)
+            for (unsigned int i = 0; i < VectorizedArray<number>::size(); ++i)
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
@@ -803,9 +799,7 @@ namespace StokesClass
           {
             VectorizedArray<number> return_value =
               make_vectorized_array<number>(1.);
-            for (unsigned int i = 0;
-                 i < VectorizedArray<number>::n_array_elements;
-                 ++i)
+            for (unsigned int i = 0; i < VectorizedArray<number>::size(); ++i)
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)
@@ -1228,9 +1222,7 @@ namespace StokesClass
             for (unsigned int d = 0; d < dim; ++d)
               rhs_u[d] = make_vectorized_array<double>(1.0);
             VectorizedArray<double> rhs_p = make_vectorized_array<double>(1.0);
-            for (unsigned int i = 0;
-                 i < VectorizedArray<double>::n_array_elements;
-                 ++i)
+            for (unsigned int i = 0; i < VectorizedArray<double>::size(); ++i)
               {
                 Point<dim> p;
                 for (unsigned int d = 0; d < dim; ++d)

--- a/tests/numerics/project_parallel_qp_common.h
+++ b/tests/numerics/project_parallel_qp_common.h
@@ -78,7 +78,7 @@ public:
   {
     VectorizedArray<double> res = make_vectorized_array(0.);
     Point<dim>              p;
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       {
         for (unsigned int d = 0; d < dim; d++)
           p[d] = p_vec[d][v];

--- a/tests/numerics/project_parallel_qpmf_common.h
+++ b/tests/numerics/project_parallel_qpmf_common.h
@@ -80,7 +80,7 @@ public:
   {
     VectorizedArray<double> res = make_vectorized_array(0.);
     Point<dim>              p;
-    for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; ++v)
+    for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
       {
         for (unsigned int d = 0; d < dim; d++)
           p[d] = p_vec[d][v];

--- a/tests/physics/elasticity-kinematics_02.cc
+++ b/tests/physics/elasticity-kinematics_02.cc
@@ -55,7 +55,7 @@ main()
 
   // Scale the gradients along the vectorization-index so that each grad_u[v] is
   // unique.
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; v++)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); v++)
     for (unsigned int i = 0; i < dim; i++)
       for (unsigned int j = 0; j < dim; j++)
         grad_u[i][j][v] *= (v + 1);
@@ -69,7 +69,7 @@ main()
 
   // You can't use .norm() on some difference-tensor of the two so we compare
   // element-wise!
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; v++)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); v++)
     for (unsigned int i = 0; i < dim; i++)
       for (unsigned int j = 0; j < dim; j++)
         if (F_solution[i][j][v] - F_test[i][j][v] != 0.0)
@@ -84,7 +84,7 @@ main()
   SymmetricTensor<2, dim, VectorizedArray<double>> E_test =
     Kinematics::E(F_test);
 
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; v++)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); v++)
     for (unsigned int i = 0; i < dim; i++)
       for (unsigned int j = 0; j < dim; j++)
         if (E_test[i][j][v] - E_solution[i][j][v] != 0.0)
@@ -96,7 +96,7 @@ main()
   Tensor<2, dim, VectorizedArray<double>> F_iso_test;
   F_iso_test = Kinematics::F_iso(F_test);
 
-  for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements; v++)
+  for (unsigned int v = 0; v < VectorizedArray<double>::size(); v++)
     for (unsigned int i = 0; i < dim; i++)
       for (unsigned int j = 0; j < dim; j++)
         if (F_iso_test[i][j][v] - F_iso_solution[i][j][v] != 0.0)

--- a/tests/tensors/symmetric_tensor_38.cc
+++ b/tests/tensors/symmetric_tensor_38.cc
@@ -52,8 +52,7 @@ main()
         deallog << r1[i][j][0] << std::endl;
         AssertThrow(std::abs(r1[i][j][0] - factor_float * s1[i][j][0]) < 1.e-10,
                     ExcInternalError());
-        for (unsigned int k = 1; k < VectorizedArray<float>::n_array_elements;
-             ++k)
+        for (unsigned int k = 1; k < VectorizedArray<float>::size(); ++k)
           {
             AssertThrow(std::abs(r1[i][j][k] - r1[i][j][0]) < 1.e-10,
                         ExcInternalError());
@@ -61,8 +60,7 @@ main()
         deallog << r2[i][j][0] << std::endl;
         Assert(std::abs(r2[i][j][0] - factor_double * s2[i][j][0]) < 1.e-10,
                ExcInternalError());
-        for (unsigned int k = 1; k < VectorizedArray<double>::n_array_elements;
-             ++k)
+        for (unsigned int k = 1; k < VectorizedArray<double>::size(); ++k)
           {
             AssertThrow(std::abs(r2[i][j][k] - r2[i][j][0]) < 1.e-10,
                         ExcInternalError());

--- a/tests/tensors/symmetric_tensor_39.cc
+++ b/tests/tensors/symmetric_tensor_39.cc
@@ -32,9 +32,7 @@ void fill_tensor(
   Number counter = 0.0;
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = 0; j < dim; ++j)
-      for (unsigned int v = 0;
-           v < dealii::VectorizedArray<Number>::n_array_elements;
-           v++)
+      for (unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); v++)
         {
           A[i][j][v] = counter;
           counter += 1.0;
@@ -72,8 +70,7 @@ main()
   // like VectorizedArray<double> frob_norm = B.norm() -> Maybe a TODO?
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = 0; j < dim; ++j)
-      for (unsigned int v = 0; v < VectorizedArray<double>::n_array_elements;
-           ++v)
+      for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
         if (B[i][j][v] != 0.0)
           deallog << "Not OK" << std::endl;
 


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/9681#issuecomment-601204517.

For some reason `matrix_free/matrix_vector_faces_28.debug` fails, but that also fails on master.
