### PR TITLE
remove bundled muparser gcc 9 warning

### DIFF
--- a/bundled/muparser_v2_2_4/include/muParserCallback.h
+++ b/bundled/muparser_v2_2_4/include/muParserCallback.h
@@ -81,6 +81,9 @@ public:
     ParserCallback(strfun_type3 a_pFun, bool a_bAllowOpti);
     ParserCallback();
     ParserCallback(const ParserCallback &a_Fun);
+
+    // deall.II: added the following line to remove Wdeprecated-copy warnings:
+    constexpr ParserCallback& operator=(const ParserCallback&)=default;
     
     ParserCallback* Clone() const;
 

--- a/bundled/muparser_v2_2_4/include/muParserCallback.h
+++ b/bundled/muparser_v2_2_4/include/muParserCallback.h
@@ -83,7 +83,7 @@ public:
     ParserCallback(const ParserCallback &a_Fun);
 
     // deall.II: added the following line to remove Wdeprecated-copy warnings:
-    constexpr ParserCallback& operator=(const ParserCallback&)=default;
+    ParserCallback& operator=(const ParserCallback&)=default;
     
     ParserCallback* Clone() const;
 


### PR DESCRIPTION
I am not sure I understand if the default assignment operator does the
right thing here, but this avoids the warning and shouldn't change
functionality.