### PR TITLE
Remove a few VectorizedArray::n_array_elements

### DIFF
--- a/doc/doxygen/headers/matrixfree.h
+++ b/doc/doxygen/headers/matrixfree.h
@@ -220,7 +220,7 @@
  * access is thus not linear. Furthermore, the support for multi-component
  * systems becomes transparent if we provide a <i>start index</i> to every
  * single component separately. Thus, the `row_starts` field is of length
- * `n_cell_batches()*VectorizedArray<Number>::n_array_elements*n_components`.
+ * `n_cell_batches()*VectorizedArray<Number>::size()*n_components`.
  * </li>
  * <li> The translation between components within a system of multiple base
  * elements is controlled by the four variables

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -1152,9 +1152,8 @@ namespace Step37
   void LaplaceProblem<dim>::run()
   {
     {
-      const unsigned int n_vect_doubles =
-        VectorizedArray<double>::n_array_elements;
-      const unsigned int n_vect_bits = 8 * sizeof(double) * n_vect_doubles;
+      const unsigned int n_vect_doubles = VectorizedArray<double>::size();
+      const unsigned int n_vect_bits    = 8 * sizeof(double) * n_vect_doubles;
 
       pcout << "Vectorization over " << n_vect_doubles
             << " doubles = " << n_vect_bits << " bits ("

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -529,9 +529,8 @@ namespace Step48
             << Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD) << std::endl;
       pcout << "Number of threads on each rank: "
             << MultithreadInfo::n_threads() << std::endl;
-      const unsigned int n_vect_doubles =
-        VectorizedArray<double>::n_array_elements;
-      const unsigned int n_vect_bits = 8 * sizeof(double) * n_vect_doubles;
+      const unsigned int n_vect_doubles = VectorizedArray<double>::size();
+      const unsigned int n_vect_bits    = 8 * sizeof(double) * n_vect_doubles;
       pcout << "Vectorization over " << n_vect_doubles
             << " doubles = " << n_vect_bits << " bits ("
             << Utilities::System::get_current_vectorization_level()

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -818,9 +818,7 @@ namespace Step59
         for (unsigned int d = 0; d < dim; ++d)
           for (unsigned int e = 0; e < dim; ++e)
             if (d != e)
-              for (unsigned int v = 0;
-                   v < VectorizedArray<number>::n_array_elements;
-                   ++v)
+              for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
                 AssertThrow(inverse_jacobian[d][e][v] == 0.,
                             ExcNotImplemented());
 
@@ -1084,9 +1082,7 @@ namespace Step59
             VectorizedArray<double> rhs_val = VectorizedArray<double>();
             Point<dim, VectorizedArray<double>> point_batch =
               phi.quadrature_point(q);
-            for (unsigned int v = 0;
-                 v < VectorizedArray<double>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
               {
                 Point<dim> single_point;
                 for (unsigned int d = 0; d < dim; ++d)
@@ -1143,9 +1139,7 @@ namespace Step59
             Point<dim, VectorizedArray<double>> point_batch =
               phi_face.quadrature_point(q);
 
-            for (unsigned int v = 0;
-                 v < VectorizedArray<double>::n_array_elements;
-                 ++v)
+            for (unsigned int v = 0; v < VectorizedArray<double>::size(); ++v)
               {
                 Point<dim> single_point;
                 for (unsigned int d = 0; d < dim; ++d)


### PR DESCRIPTION
Follow-up to #9688 - there were a few `n_array_elements` left in the `examples` and `doc` subfolders.