### PR TITLE
Fix compilation with Tpetra vector

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -442,6 +442,22 @@ namespace internal
 
 
 
+#if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
+    template <typename Number>
+    inline void
+    VectorHelper<LinearAlgebra::TpetraWrappers::Vector<Number>>::extract(
+      const LinearAlgebra::TpetraWrappers::Vector<Number> & /*vector*/,
+      const std::vector<types::global_dof_index> & /*indices*/,
+      const ComponentExtractor /*extract_component*/,
+      std::vector<double> & /*values*/)
+    {
+      // TODO: we don't have element access
+      Assert(false, ExcNotImplemented());
+    }
+#endif
+
+
+
     template <typename DoFHandlerType>
     DataEntryBase<DoFHandlerType>::DataEntryBase(
       const DoFHandlerType *          dofs,


### PR DESCRIPTION
This attempts to fix the build failure on configurations with Tpetra like most of our testers:
https://cdash.43-1.org/viewBuildError.php?buildid=5046
I do not have the Tpetra compatible on my system so it would be good if someone who has it could check, but I believe that this is the right thing to do.

This is due to #9100.