### PR TITLE
SparsityTools::distribute_sparsity_pattern with compute_index_owner

### DIFF
--- a/doc/news/changes/incompatibilities/20200322MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20200322MartinKronbichler
@@ -1,0 +1,6 @@
+Deprecated: SparsityTools::distribute_sparsity_pattern() and
+SparsityTools::gather_sparsity_pattern() taking the locally owned index sets
+of all processes as second arguments have been deprecated. Use the respective
+functions only providing the locally owned dofs of the calling process.
+<br>
+(Martin Kronbichler, 2020/03/22)

--- a/doc/news/changes/minor/20200322MartinKronbichler
+++ b/doc/news/changes/minor/20200322MartinKronbichler
@@ -1,0 +1,9 @@
+New: Variants of SparsityTools::distribute_sparsity_pattern() and
+SparsityTools::gather_sparsity_pattern() taking only the locally owned index
+set of the calling MPI process have been added. They avoid the previously
+necessary MPI all-to-all communication to compute the owned dofs on all
+processes and instead go through Utilities::MPI::compute_index_owned with
+sparse communication. On more than around 1,000 MPI ranks, the new functions
+should be considerably faster.
+<br>
+(Martin Kronbichler, 2020/03/22)

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -314,11 +314,10 @@ namespace Step40
     DynamicSparsityPattern dsp(locally_relevant_dofs);
 
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               dof_handler.locally_owned_dofs(),
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -429,7 +429,7 @@ namespace Step55
 
       SparsityTools::distribute_sparsity_pattern(
         dsp,
-        dof_handler.compute_locally_owned_dofs_per_processor(),
+        dof_handler.locally_owned_dofs(),
         mpi_communicator,
         locally_relevant_dofs);
 

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -764,11 +764,10 @@ namespace step62
     DynamicSparsityPattern dsp(locally_relevant_dofs);
 
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/include/deal.II/lac/sparsity_tools.h
+++ b/include/deal.II/lac/sparsity_tools.h
@@ -246,26 +246,41 @@ namespace SparsityTools
   /**
    * Communicate rows in a dynamic sparsity pattern over MPI.
    *
-   * @param dsp A dynamic sparsity pattern that has been built locally and for
-   * which we need to exchange entries with other processors to make sure that
-   * each processor knows all the elements of the rows of a matrix it stores
-   * and that may eventually be written to. This sparsity pattern will be
-   * changed as a result of this function: All entries in rows that belong to
-   * a different processor are sent to them and added there.
+   * @param[in,out] dsp A dynamic sparsity pattern that has been built locally
+   * and for which we need to exchange entries with other processors to make
+   * sure that each processor knows all the elements of the rows of a matrix
+   * it stores and that may eventually be written to. This sparsity pattern
+   * will be changed as a result of this function: All entries in rows that
+   * belong to a different processor are sent to them and added there.
    *
-   * @param rows_per_cpu A vector containing the number of of rows per CPU for
-   * determining ownership. This is typically the value returned by
-   * DoFHandler::n_locally_owned_dofs_per_processor.
+   * @param locally_owned_rows An IndexSet describing the rows owned by the
+   * calling MPI process. The index set shall be one-to-one among the
+   * processors in the communicator.
    *
    * @param mpi_comm The MPI communicator shared between the processors that
    * participate in this operation.
    *
-   * @param myrange The range of elements stored locally. This should be the
-   * one used in the constructor of the DynamicSparsityPattern, and should
-   * also be the locally relevant set. Only rows contained in myrange are
-   * checked in dsp for transfer. This function needs to be used with
-   * PETScWrappers::MPI::SparseMatrix for it to work correctly in a parallel
-   * computation.
+   * @param locally_relevant_rows The range of elements stored on the local
+   * MPI process. This should be the one used in the constructor of the
+   * DynamicSparsityPattern, and should also be the locally relevant set. Only
+   * rows contained in this set are checked in dsp for transfer. This function
+   * needs to be used with PETScWrappers::MPI::SparseMatrix for it to work
+   * correctly in a parallel computation.
+   */
+  void
+  distribute_sparsity_pattern(DynamicSparsityPattern &dsp,
+                              const IndexSet &        locally_owned_rows,
+                              const MPI_Comm &        mpi_comm,
+                              const IndexSet &        locally_relevant_rows);
+
+  /**
+   * Communicate rows in a dynamic sparsity pattern over MPI, similar to the
+   * one above but using a vector `rows_per_cpu` containing the number of of
+   * rows per CPU for determining ownership. This is typically the value
+   * returned by DoFHandler::n_locally_owned_dofs_per_processor -- given that
+   * the construction of the input to this function involves all-to-all
+   * communication, it is typically slower than the function above for more
+   * than a thousand of processes (and quick enough also for small sizes).
    */
   void
   distribute_sparsity_pattern(
@@ -279,12 +294,24 @@ namespace SparsityTools
    * instead.
    *
    * @param[in,out] dsp The locally built sparsity pattern to be modified.
-   * @param owned_set_per_cpu Typically the value given by
-   * DoFHandler::locally_owned_dofs_per_processor.
+   *
+   * @param locally_owned_rows An IndexSet describing the rows owned by the
+   * calling MPI process. The index set shall be one-to-one among the
+   * processors in the communicator.
    *
    * @param mpi_comm The MPI communicator to use.
    *
-   * @param myrange Typically the locally relevant DoFs.
+   * @param locally_relevant_rows Typically the locally relevant DoFs.
+   */
+  void
+  distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
+                              const IndexSet &             locally_owned_rows,
+                              const MPI_Comm &             mpi_comm,
+                              const IndexSet &locally_relevant_rows);
+
+  /**
+   * @deprecated Use the distribute_sparsity_pattern() with a single index set
+   * for the present MPI process only.
    */
   void
   distribute_sparsity_pattern(BlockDynamicSparsityPattern &dsp,
@@ -304,17 +331,28 @@ namespace SparsityTools
    * we need to extend according to the sparsity of rows stored on other MPI
    * processes.
    *
-   * @param owned_rows_per_processor A vector containing owned rows for each
-   * process in the MPI communicator. This input should be the same on all MPI
-   * processes.
+   * @param locally_owned_rows An IndexSet describing the rows owned by the
+   * calling MPI process. The index set shall be one-to-one among the
+   * processors in the communicator.
    *
    * @param mpi_comm The MPI communicator shared between the processors that
    * participate in this operation.
    *
-   * @param ghost_range The range of rows this MPI process needs to gather.
-   * Only a part which is not included in the locally owned rows will be used.
+   * @param locally_relevant_range The range of rows this MPI process needs to
+   * gather. Only the part which is not included in the locally owned rows will
+   * be used.
    */
   void
+  gather_sparsity_pattern(DynamicSparsityPattern &dsp,
+                          const IndexSet &        locally_owned_rows,
+                          const MPI_Comm &        mpi_comm,
+                          const IndexSet &        locally_relevant_rows);
+
+  /**
+   * @deprecated Use the gather_sparsity_pattern() method with the index set
+   * for the present processor only.
+   */
+  DEAL_II_DEPRECATED void
   gather_sparsity_pattern(DynamicSparsityPattern &     dsp,
                           const std::vector<IndexSet> &owned_rows_per_processor,
                           const MPI_Comm &             mpi_comm,

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -270,27 +270,10 @@ MGTransferPrebuilt<VectorType>::build(
                                     dist_tria->get_communicator() :
                                     MPI_COMM_SELF;
 
-          // Compute # of locally owned MG dofs / processor for distribution
-          const std::vector<::dealii::IndexSet>
-            locally_owned_mg_dofs_per_processor =
-              dof_handler.compute_locally_owned_mg_dofs_per_processor(level +
-                                                                      1);
-          std::vector<::dealii::types::global_dof_index>
-            n_locally_owned_mg_dofs_per_processor(
-              locally_owned_mg_dofs_per_processor.size(), 0);
-
-          for (std::size_t index = 0;
-               index < n_locally_owned_mg_dofs_per_processor.size();
-               ++index)
-            {
-              n_locally_owned_mg_dofs_per_processor[index] =
-                locally_owned_mg_dofs_per_processor[index].n_elements();
-            }
-
           // Distribute sparsity pattern
           ::dealii::SparsityTools::distribute_sparsity_pattern(
             dsp,
-            n_locally_owned_mg_dofs_per_processor,
+            dof_handler.locally_owned_mg_dofs(level + 1),
             communicator,
             dsp.row_index_set());
         }

--- a/tests/dofs/dof_tools_22a.cc
+++ b/tests/dofs/dof_tools_22a.cc
@@ -112,11 +112,10 @@ test()
                                        flux_coupling,
                                        Utilities::MPI::this_mpi_process(
                                          MPI_COMM_WORLD));
-  SparsityTools::distribute_sparsity_pattern(
-    sp,
-    dh.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    relevant_partitioning);
+  SparsityTools::distribute_sparsity_pattern(sp,
+                                             dh.locally_owned_dofs(),
+                                             MPI_COMM_WORLD,
+                                             relevant_partitioning);
 
   // Output
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tests/dofs/sparsity_pattern_06.cc
+++ b/tests/dofs/sparsity_pattern_06.cc
@@ -138,7 +138,7 @@ main(int argc, char **argv)
   dynamic_sparsity_pattern.print(deallog.get_file_stream());
   SparsityTools::distribute_sparsity_pattern(
     dynamic_sparsity_pattern,
-    dof_handler_0.compute_n_locally_owned_dofs_per_processor(),
+    dof_handler_0.locally_owned_dofs(),
     MPI_COMM_WORLD,
     dof_handler_0.locally_owned_dofs());
   dynamic_sparsity_pattern.print(deallog.get_file_stream());

--- a/tests/dofs/sparsity_pattern_07.cc
+++ b/tests/dofs/sparsity_pattern_07.cc
@@ -155,7 +155,7 @@ main(int argc, char **argv)
   dynamic_sparsity_pattern.print(deallog.get_file_stream());
   SparsityTools::distribute_sparsity_pattern(
     dynamic_sparsity_pattern,
-    dof_handler_0.compute_n_locally_owned_dofs_per_processor(),
+    dof_handler_0.locally_owned_dofs(),
     MPI_COMM_WORLD,
     dof_handler_0.locally_owned_dofs());
   dynamic_sparsity_pattern.print(deallog.get_file_stream());

--- a/tests/fe/fe_nedelec_singularity_01.cc
+++ b/tests/fe/fe_nedelec_singularity_01.cc
@@ -400,11 +400,10 @@ namespace nedelec_singularity
     DynamicSparsityPattern dsp(locally_relevant_dofs);
 
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/fe/fe_nedelec_singularity_02.cc
+++ b/tests/fe/fe_nedelec_singularity_02.cc
@@ -390,11 +390,10 @@ namespace nedelec_singularity
     DynamicSparsityPattern dsp(locally_relevant_dofs);
 
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/gla/block_mat_02.cc
+++ b/tests/gla/block_mat_02.cc
@@ -124,7 +124,7 @@ test()
 
   SparsityTools::distribute_sparsity_pattern(
     sp,
-    stokes_dof_handler.compute_locally_owned_dofs_per_processor(),
+    stokes_dof_handler.locally_owned_dofs(),
     MPI_COMM_WORLD,
     stokes_relevant_set);
 

--- a/tests/gla/block_mat_03.cc
+++ b/tests/gla/block_mat_03.cc
@@ -109,11 +109,10 @@ test()
 
   BlockDynamicSparsityPattern bcsp(locally_relevant_partitioning);
   DoFTools::make_sparsity_pattern(dof_handler, bcsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    bcsp,
-    dof_handler.compute_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(bcsp,
+                                             locally_owned_dofs,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant_dofs);
 
   typename LA::MPI::BlockSparseMatrix A;
   A.reinit(locally_owned_partitioning, bcsp, MPI_COMM_WORLD);

--- a/tests/gla/mat_03.cc
+++ b/tests/gla/mat_03.cc
@@ -84,11 +84,10 @@ test()
                                   false,
                                   Utilities::MPI::this_mpi_process(
                                     MPI_COMM_WORLD));
-  SparsityTools::distribute_sparsity_pattern(
-    sp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    relevant);
+  SparsityTools::distribute_sparsity_pattern(sp,
+                                             owned,
+                                             MPI_COMM_WORLD,
+                                             relevant);
   sp.compress();
   matrix.reinit(owned, owned, sp, MPI_COMM_WORLD);
 

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -198,14 +198,12 @@ Step4<dim>::setup_system()
 
   DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
 
-
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant_dofs);
 
   system_matrix.reinit(locally_owned_dofs,
                        locally_owned_dofs,

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -199,14 +199,12 @@ Step4<dim>::setup_system()
 
   DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
 
-
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant_dofs);
 
   system_matrix.reinit(locally_owned_dofs,
                        locally_owned_dofs,

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -130,11 +130,10 @@ namespace LinearAdvectionTest
                                          dynamic_sparsity_pattern,
                                          cell_integral_mask,
                                          flux_integral_mask);
-    SparsityTools::distribute_sparsity_pattern(
-      dynamic_sparsity_pattern,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      MPI_COMM_WORLD,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dynamic_sparsity_pattern,
+                                               locally_owned_dofs,
+                                               MPI_COMM_WORLD,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/mpi/distribute_sp_01.cc
+++ b/tests/mpi/distribute_sp_01.cc
@@ -15,7 +15,8 @@
 
 
 
-// check SparsityTools::distribute_sparsity_pattern
+// check SparsityTools::distribute_sparsity_pattern with the slow part of
+// supplying the number of rows on all processes
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/utilities.h>

--- a/tests/mpi/distribute_sp_02.cc
+++ b/tests/mpi/distribute_sp_02.cc
@@ -39,14 +39,12 @@ test_mpi()
   if (myid == 0)
     deallog << "Running on " << numprocs << " CPU(s)." << std::endl;
 
-  unsigned int          num_local = 10;
-  unsigned int          n         = numprocs * num_local;
-  std::vector<IndexSet> locally_owned_dofs_per_cpu(numprocs, IndexSet(n));
-  for (unsigned int i = 0; i < numprocs; ++i)
-    locally_owned_dofs_per_cpu[i].add_range((i)*num_local, (i + 1) * num_local);
+  unsigned int num_local = 10;
+  unsigned int n         = numprocs * num_local;
+  IndexSet     locally_owned_dofs(n);
+  locally_owned_dofs.add_range(myid * num_local, (myid + 1) * num_local);
 
-  IndexSet locally_rel(n);
-  locally_rel.add_range(myid * num_local, (myid + 1) * num_local);
+  IndexSet locally_rel(locally_owned_dofs);
   if (myid > 0)
     locally_rel.add_range((myid - 1) * num_local, (myid + 0) * num_local);
   if (myid < numprocs - 1)
@@ -68,7 +66,7 @@ test_mpi()
     }
 
   SparsityTools::distribute_sparsity_pattern(csp,
-                                             locally_owned_dofs_per_cpu,
+                                             locally_owned_dofs,
                                              MPI_COMM_WORLD,
                                              locally_rel);
   /*  {
@@ -113,14 +111,8 @@ test_mpi()
   for (unsigned int i = 0; i < n; ++i)
     csp.add(i, myid);
 
-  std::vector<IndexSet> locally_owned_dofs_per_cpu2(numprocs, IndexSet(n));
-  for (unsigned int i = 0; i < numprocs; ++i)
-    locally_owned_dofs_per_cpu2[i].add_range((i)*num_local,
-                                             (i + 1) * num_local);
-
-
   SparsityTools::distribute_sparsity_pattern(csp,
-                                             locally_owned_dofs_per_cpu2,
+                                             locally_owned_dofs,
                                              MPI_COMM_WORLD,
                                              locally_rel);
 

--- a/tests/mpi/hp_step-4.cc
+++ b/tests/mpi/hp_step-4.cc
@@ -218,11 +218,10 @@ namespace Step4
 
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
 
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -158,11 +158,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -164,11 +164,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -150,11 +150,10 @@ SeventhProblem<dim>::setup_system()
   constraints.close();
   DynamicSparsityPattern csp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    csp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    mpi_communicator,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(csp,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
   system_matrix.reinit(locally_owned_dofs,
                        locally_owned_dofs,
                        csp,

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -179,11 +179,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               dof_handler.locally_owned_dofs(),
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -243,11 +243,10 @@ namespace Step27
 
     DynamicSparsityPattern dsp(locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -152,11 +152,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -214,11 +214,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -215,11 +215,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -152,11 +152,10 @@ namespace Step40
                                dof_handler.n_dofs(),
                                locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, csp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      csp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(csp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
     system_matrix.reinit(
       mpi_communicator,
       csp,

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -243,11 +243,10 @@ namespace Step27
 
     DynamicSparsityPattern dsp(locally_relevant_dofs);
     DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-    SparsityTools::distribute_sparsity_pattern(
-      dsp,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      mpi_communicator,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dsp,
+                                               locally_owned_dofs,
+                                               mpi_communicator,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/petsc_complex/parallel_sparse_matrix_01.cc
+++ b/tests/petsc_complex/parallel_sparse_matrix_01.cc
@@ -91,11 +91,10 @@ test(const unsigned int poly_degree = 1)
 
   DynamicSparsityPattern dsp(locally_relevant_dofs);
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    mpi_communicator,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             mpi_communicator,
+                                             locally_relevant_dofs);
 
   mass_matrix.reinit(locally_owned_dofs,
                      locally_owned_dofs,

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -189,10 +189,8 @@ namespace Step18
     const unsigned int                   n_mpi_processes;
     const unsigned int                   this_mpi_process;
     ConditionalOStream                   pcout;
-    std::vector<types::global_dof_index> local_dofs_per_process;
     IndexSet                             locally_owned_dofs;
     IndexSet                             locally_relevant_dofs;
-    unsigned int                         n_local_cells;
     static const SymmetricTensor<4, dim> stress_strain_tensor;
     int                                  monitored_vertex_first_dof;
   };
@@ -355,10 +353,6 @@ namespace Step18
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-    n_local_cells = GridTools::count_cells_with_subdomain_association(
-      triangulation, triangulation.locally_owned_subdomain());
-    local_dofs_per_process =
-      dof_handler.compute_n_locally_owned_dofs_per_processor();
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);
@@ -369,7 +363,7 @@ namespace Step18
                                     hanging_node_constraints,
                                     /*keep constrained dofs*/ false);
     SparsityTools::distribute_sparsity_pattern(sparsity_pattern,
-                                               local_dofs_per_process,
+                                               locally_owned_dofs,
                                                mpi_communicator,
                                                locally_relevant_dofs);
     system_matrix.reinit(locally_owned_dofs,

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -205,10 +205,8 @@ namespace Step18
     const unsigned int                   n_mpi_processes;
     const unsigned int                   this_mpi_process;
     ConditionalOStream                   pcout;
-    std::vector<types::global_dof_index> local_dofs_per_process;
     IndexSet                             locally_owned_dofs;
     IndexSet                             locally_relevant_dofs;
-    unsigned int                         n_local_cells;
     static const SymmetricTensor<4, dim> stress_strain_tensor;
     int                                  monitored_vertex_first_dof;
   };
@@ -371,10 +369,6 @@ namespace Step18
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
     DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-    n_local_cells = GridTools::count_cells_with_subdomain_association(
-      triangulation, triangulation.locally_owned_subdomain());
-    local_dofs_per_process =
-      dof_handler.compute_n_locally_owned_dofs_per_processor();
     hanging_node_constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler,
                                             hanging_node_constraints);
@@ -385,7 +379,7 @@ namespace Step18
                                     hanging_node_constraints,
                                     /*keep constrained dofs*/ false);
     SparsityTools::distribute_sparsity_pattern(sparsity_pattern,
-                                               local_dofs_per_process,
+                                               locally_owned_dofs,
                                                mpi_communicator,
                                                locally_relevant_dofs);
     system_matrix.reinit(locally_owned_dofs,

--- a/tests/sparsity/dynamic_sparsity_pattern_19.cc
+++ b/tests/sparsity/dynamic_sparsity_pattern_19.cc
@@ -37,8 +37,6 @@ test()
   else
     owned.add_range(7, 10);
 
-  const auto rows_per_cpu = Utilities::MPI::all_gather(comm, owned);
-
   IndexSet ghost_range(owned);
   if (myid == 0)
     {
@@ -86,7 +84,7 @@ test()
   deallog << "Before gather_sparsity_pattern:" << std::endl;
   dsp.print(deallog.get_file_stream());
 
-  SparsityTools::gather_sparsity_pattern(dsp, rows_per_cpu, comm, ghost_range);
+  SparsityTools::gather_sparsity_pattern(dsp, owned, comm, ghost_range);
 
   deallog << "After gather_sparsity_pattern:" << std::endl;
   dsp.print(deallog.get_file_stream());

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -200,11 +200,10 @@ Step4<dim>::setup_system()
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant_dofs);
 
   system_matrix.reinit(locally_owned_dofs,
                        locally_owned_dofs,

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -162,11 +162,10 @@ Step4<dim>::setup_system()
 
   DynamicSparsityPattern dsp(dof_handler.n_dofs());
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    MPI_COMM_WORLD,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             MPI_COMM_WORLD,
+                                             locally_relevant_dofs);
 
   system_matrix.reinit(locally_owned_dofs,
                        locally_owned_dofs,

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -169,11 +169,10 @@ namespace LinearAdvectionTest
                                          cell_integral_mask,
                                          flux_integral_mask);
 
-    SparsityTools::distribute_sparsity_pattern(
-      dynamic_sparsity_pattern,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      MPI_COMM_WORLD,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(dynamic_sparsity_pattern,
+                                               locally_owned_dofs,
+                                               MPI_COMM_WORLD,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -124,11 +124,10 @@ private:
                                     sparsity_pattern,
                                     constraints,
                                     /*keep constrained dofs*/ false);
-    SparsityTools::distribute_sparsity_pattern(
-      sparsity_pattern,
-      dof_handler.compute_n_locally_owned_dofs_per_processor(),
-      MPI_COMM_WORLD,
-      locally_relevant_dofs);
+    SparsityTools::distribute_sparsity_pattern(sparsity_pattern,
+                                               locally_owned_dofs,
+                                               MPI_COMM_WORLD,
+                                               locally_relevant_dofs);
 
     system_matrix.reinit(locally_owned_dofs,
                          locally_owned_dofs,

--- a/tests/trilinos/solver_control_06.cc
+++ b/tests/trilinos/solver_control_06.cc
@@ -217,11 +217,10 @@ Test_Solver_Output::setup_system()
 
   DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
 
-  SparsityTools::distribute_sparsity_pattern(
-    dsp,
-    dof_handler.compute_n_locally_owned_dofs_per_processor(),
-    mpi_comm,
-    locally_relevant_dofs);
+  SparsityTools::distribute_sparsity_pattern(dsp,
+                                             locally_owned_dofs,
+                                             mpi_comm,
+                                             locally_relevant_dofs);
 
   system_matrix.reinit(locally_owned_dofs, locally_owned_dofs, dsp, mpi_comm);
 }


### PR DESCRIPTION
This PR adds alternative functions for `SparsityTools::distribute_sparsity_pattern()` and `SparsityTools::gather_sparsity_pattern()` that only take the locally owned index set of the present MPI process, rather than that of all processes. This allows us to simplify the tutorials and a few dozen of test cases, and in particular avoids the expensive call to `MPI_Allgather` discussed in #8298 and #8293, expensive meaning that with more than a few thousands of rank, the new implementation should be considerably faster. I also deprecated two of the three old functions which do not make sense any more; I left the one with the number of dofs per processor because it might be of use in some corner cases.

One of these corner cases are `dealii::Triangulation` cases where the linear system gets split among processes (but not the mesh), which I left as they were - they are mostly based off some variant of step-36.

Fixes #8306 .

This PR also significantly reduces the number of calls to `DoFHandler::compute_{n_}locally_owned_dofs_per_processor()` in the test suite. We can further eliminate a considerable number of them by initializing PETSc sparse matrices from an `IndexSet` of locally owned data rather than *all* sizes - I do not think they belong here. If we believe they are important to switch (personally I am indifferent), we can open an issue to fix those later.