### PR TITLE
Remove update_once/each() functions from FE_NedelecSZ.

### DIFF
--- a/include/deal.II/fe/fe_nedelec_sz.h
+++ b/include/deal.II/fe/fe_nedelec_sz.h
@@ -147,22 +147,6 @@ public:
                             const Point<dim> & p,
                             const unsigned int component) const override;
 
-  /**
-   * Given <tt>flags</tt>, determines the values which must be computed only
-   * for the reference cell. Make sure, that #mapping_kind is set by the
-   * derived class, such that this function can operate correctly.
-   */
-  UpdateFlags
-  update_once(const UpdateFlags flags) const;
-
-  /**
-   * Given <tt>flags</tt>, determines the values which must be computed in
-   * each cell cell. Make sure, that #mapping_kind is set by the derived
-   * class, such that this function can operate correctly.
-   */
-  UpdateFlags
-  update_each(const UpdateFlags flags) const;
-
 protected:
   /**
    * The mapping kind to be used to map shape functions from the reference

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -136,7 +136,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
     typename dealii::FiniteElement<dim, spacedim>::InternalDataBase>
         data_ptr   = std_cxx14::make_unique<InternalData>();
   auto &data       = dynamic_cast<InternalData &>(*data_ptr);
-  data.update_each = update_each(update_flags) | update_once(update_flags);
+  data.update_each = requires_update_flags(update_flags);
 
   // Useful quantities:
   const unsigned int degree(this->degree - 1); // Note: FE holds input degree+1
@@ -2175,30 +2175,6 @@ template <int dim, int spacedim>
 UpdateFlags
 FE_NedelecSZ<dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
-{
-  return update_once(flags) | update_each(flags);
-}
-
-
-
-template <int dim, int spacedim>
-UpdateFlags
-FE_NedelecSZ<dim, spacedim>::update_once(const UpdateFlags flags) const
-{
-  const bool values_once = (mapping_kind == mapping_none);
-
-  UpdateFlags out = update_default;
-  if (values_once && (flags & update_values))
-    out |= update_values;
-
-  return out;
-}
-
-
-
-template <int dim, int spacedim>
-UpdateFlags
-FE_NedelecSZ<dim, spacedim>::update_each(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 


### PR DESCRIPTION
These functions *used* to be part of the public interfaces of FE classes, but haven't
in a long time. They also aren't 'virtual' any more for this class. Furthermore,
all uses of these functions are of the form 'update_once() | update_each()', so
we may as well just call the 'requires_update_flags()' function that is the
current interface.

Related to #2198.

/rebuild