### PR TITLE
improve robustness and usability of ParameterHandler

### DIFF
--- a/doc/news/changes/minor/20200323NiklasFehn
+++ b/doc/news/changes/minor/20200323NiklasFehn
@@ -1,0 +1,7 @@
+New: ParameterHandler: add functionality ensuring that parameters are 
+indeed set in order to avoid errors that remain unrecognized otherwise.
+By extending the interfaces of declare_entry() and add_parameter(),
+parameters can be declared as mandatory parameters that must be set
+when parsing from an input file or by a set() function.
+<br>
+(Niklas Fehn, 2020/03/23)

--- a/tests/parameter_handler/parameter_handler_25.cc
+++ b/tests/parameter_handler/parameter_handler_25.cc
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/parameter_handler.h>
+
+#include <map>
+
+#include "../tests.h"
+
+void
+success()
+{
+  unsigned int dim       = 2;
+  std::string  precision = "double";
+
+  ParameterHandler prm;
+  prm.enter_subsection("General");
+  // this one does not have to be set
+  prm.add_parameter("dim",
+                    dim,
+                    "Number of space dimensions",
+                    Patterns::Integer(2, 3));
+  // this one has to be set
+  prm.declare_entry("Precision",
+                    precision,
+                    Patterns::Selection("float|double"),
+                    "Floating point precision",
+                    true);
+  prm.leave_subsection();
+
+  // this try-catch simulates parsing from an incomplete/incorrect input file
+  try
+    {
+      prm.enter_subsection("General");
+      prm.set("Precision", "float");
+      prm.leave_subsection();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  // check set status
+  try
+    {
+      prm.assert_that_entries_have_been_set();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  deallog << std::endl << "successful" << std::endl;
+}
+
+void
+fail()
+{
+  unsigned int dim       = 2;
+  std::string  precision = "double";
+
+  ParameterHandler prm;
+  prm.enter_subsection("General");
+  // both parameters have to be set
+  prm.add_parameter(
+    "dim", dim, "Number of space dimensions", Patterns::Integer(2, 3), true);
+  prm.add_parameter("Precision",
+                    precision,
+                    "Floating point precision",
+                    Patterns::Selection("float|double"),
+                    true);
+  prm.leave_subsection();
+
+  // this try-catch simulates parsing from an incomplete/incorrect input file
+  try
+    {
+      prm.enter_subsection("General");
+      prm.set("Precison", "float"); // here is a typo!
+      // dim is not set!
+      prm.leave_subsection();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+
+  // check set status
+  try
+    {
+      prm.assert_that_entries_have_been_set();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+}
+
+
+int
+main()
+{
+  initlog();
+  deallog.get_file_stream().precision(3);
+
+  try
+    {
+      success();
+      fail();
+    }
+  catch (std::exception &exc)
+    {
+      deallog << exc.what() << std::endl;
+    }
+}

--- a/tests/parameter_handler/parameter_handler_25.output
+++ b/tests/parameter_handler/parameter_handler_25.output
@@ -1,0 +1,28 @@
+
+DEAL::
+DEAL::successful
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::set(const string&, const string&)
+The violated condition was:
+    false
+Additional information:
+    You can't ask for entry <Precison> you have not yet declared.
+--------------------------------------------------------
+
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::assert_that_entries_have_been_set() const
+The violated condition was:
+    entries_wrongly_not_set.size() == 0
+Additional information:
+    Not all entries of the parameter handler that were declared with `has_to_be_set = true` have been set. The following parameters
+
+  General.Precision
+  General.dim
+
+ have not been set. A possible reason might be that you did not add these parameter to the input file or that their spelling is not correct.
+--------------------------------------------------------
+


### PR DESCRIPTION
The ``ParameterHandler`` allows partial parsing of input files, which is very useful. However, it seems as if it does not assert that all entries added to the ``ParameterHandler`` object are indeed found in the input file (at least I could not find such a functionality).

For example you might write in the, e.g. .json, input file

``
{
    "General": {
        "Precison": "double"
     }
}
``

but the parameter will be ignored because of the typo in **Precision**. Not being a big issue here as it might "only" affect the run time, this behavior can lead to subtle issues that are difficult to find, and more importantly, one might not even recognize that the simulation has been run for the wrong set of parameters.

This PR suggest a fix to this problem by adding a new function to the ``ParameterHandler`` that makes sure that all entries have been found. It does not change the behavior of the current code but could be incorporated in follow-up PRs, e.g., by extending the current functions by an additional parameter with appropriate default value.

To write application code that does not prescribe the type of input file provided (prm, xml, json), it is useful to have a ``parse_input()`` function in the library that allows filetype-independent programming.
