### PR TITLE
MPI: silence "avoid a deadlock" error message

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -976,11 +976,7 @@ namespace Utilities
           if (std::uncaught_exception() == true)
 #  endif
             {
-              std::cerr
-                << "ERROR: Uncaught exception in MPI_InitFinalize on proc "
-                << this_mpi_process(MPI_COMM_WORLD)
-                << ". Skipping MPI_Finalize() to avoid a deadlock."
-                << std::endl;
+              // do not try to call MPI_Finalize to avoid a deadlock.
             }
           else
             {


### PR DESCRIPTION
When an exception occurs (solver convergence, out of memory, etc..), we
end up printing an error message from every single MPI rank. I have
never used this information in practice and it produces a lot of
unnecessary noise. Even worse, it produces gigantic, useless log files
when running with 100k+ MPI ranks. Therefore, I proposed removing this
altogether.