### PR TITLE
using namespace dealii is removed from tests that include ../tests.h

### DIFF
--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_01.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_02.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_02.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_03.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_04.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_04.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_05.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_05.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_06.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_06.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_07.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_07.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_2_components_08.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_2_components_08.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_3_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_3_components_01.h
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_3_components_01_tapeless_only.h
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
+++ b/tests/ad_common_tests/helper_scalar_coupled_4_components_01.h
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_scalar_single_component_01.h
+++ b/tests/ad_common_tests/helper_scalar_single_component_01.h
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/ad_common_tests/helper_scalar_single_component_02.h
+++ b/tests/ad_common_tests/helper_scalar_single_component_02.h
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/ad_common_tests/helper_scalar_single_component_03.h
+++ b/tests/ad_common_tests/helper_scalar_single_component_03.h
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/ad_common_tests/helper_scalar_single_component_04.h
+++ b/tests/ad_common_tests/helper_scalar_single_component_04.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_1_indep_1_dep_vars_01.h
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_1_indep_2_dep_vars_01.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_2_indep_1_dep_vars_01.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h
+++ b/tests/ad_common_tests/helper_vector_2_indep_2_dep_vars_01.h
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/ad_common_tests/physics_functions_01.h
+++ b/tests/ad_common_tests/physics_functions_01.h
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/ad_common_tests/physics_functions_02.h
+++ b/tests/ad_common_tests/physics_functions_02.h
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/ad_common_tests/physics_functions_03.h
+++ b/tests/ad_common_tests/physics_functions_03.h
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/ad_common_tests/step-44-helper_res_lin_01.h
+++ b/tests/ad_common_tests/step-44-helper_res_lin_01.h
@@ -65,7 +65,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   namespace Parameters
   {

--- a/tests/ad_common_tests/step-44-helper_scalar_01.h
+++ b/tests/ad_common_tests/step-44-helper_scalar_01.h
@@ -66,7 +66,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   namespace Parameters
   {

--- a/tests/ad_common_tests/step-44-helper_var_form_01.h
+++ b/tests/ad_common_tests/step-44-helper_var_form_01.h
@@ -65,7 +65,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   namespace Parameters
   {

--- a/tests/ad_common_tests/step-44-helper_vector_01.h
+++ b/tests/ad_common_tests/step-44-helper_vector_01.h
@@ -66,7 +66,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   namespace Parameters
   {

--- a/tests/ad_common_tests/symmetric_tensor_functions_01.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_01.h
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/ad_common_tests/symmetric_tensor_functions_02.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_02.h
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/ad_common_tests/symmetric_tensor_functions_03.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_03.h
@@ -30,7 +30,6 @@
 
 #include <iostream>
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 double

--- a/tests/ad_common_tests/symmetric_tensor_functions_04.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_04.h
@@ -30,7 +30,6 @@
 
 #include <iostream>
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 double

--- a/tests/ad_common_tests/tensor_functions_01.h
+++ b/tests/ad_common_tests/tensor_functions_01.h
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/ad_common_tests/tensor_functions_02.h
+++ b/tests/ad_common_tests/tensor_functions_02.h
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename NumberType>

--- a/tests/adolc/ad_number_traits_01.cc
+++ b/tests/adolc/ad_number_traits_01.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 int

--- a/tests/adolc/ad_number_traits_02a.cc
+++ b/tests/adolc/ad_number_traits_02a.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/adolc/ad_number_traits_02b.cc
+++ b/tests/adolc/ad_number_traits_02b.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/adolc/ad_number_traits_03.cc
+++ b/tests/adolc/ad_number_traits_03.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename ADNumber>

--- a/tests/adolc/helper_retaping_01.cc
+++ b/tests/adolc/helper_retaping_01.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/adolc/helper_retaping_02.cc
+++ b/tests/adolc/helper_retaping_02.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/adolc/helper_retaping_03.cc
+++ b/tests/adolc/helper_retaping_03.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/adolc/helper_scalar_failure_01.cc
+++ b/tests/adolc/helper_scalar_failure_01.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/adolc/helper_scalar_failure_02.cc
+++ b/tests/adolc/helper_scalar_failure_02.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/adolc/helper_scalar_failure_03.cc
+++ b/tests/adolc/helper_scalar_failure_03.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/adolc/helper_scalar_failure_04.cc
+++ b/tests/adolc/helper_scalar_failure_04.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/adolc/helper_scalar_failure_05.cc
+++ b/tests/adolc/helper_scalar_failure_05.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 template <int dim, typename number_t, enum AD::NumberTypes ad_type_code>

--- a/tests/adolc/helper_tape_index_01.cc
+++ b/tests/adolc/helper_tape_index_01.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = dealii::Differentiation::AD;
 
 // Function and its derivatives

--- a/tests/adolc/step-44-helper_res_lin_01_1.cc
+++ b/tests/adolc/step-44-helper_res_lin_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44-helper_res_lin_01_2.cc
+++ b/tests/adolc/step-44-helper_res_lin_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44-helper_scalar_01_1.cc
+++ b/tests/adolc/step-44-helper_scalar_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44-helper_var_form_01_1.cc
+++ b/tests/adolc/step-44-helper_var_form_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44-helper_vector_01_1.cc
+++ b/tests/adolc/step-44-helper_vector_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44-helper_vector_01_2.cc
+++ b/tests/adolc/step-44-helper_vector_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/adolc/step-44.cc
+++ b/tests/adolc/step-44.cc
@@ -63,7 +63,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace Parameters
   {
     struct FESystem
@@ -2076,7 +2075,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/adolc/tensor_ops_01.cc
+++ b/tests/adolc/tensor_ops_01.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename number_t,

--- a/tests/adolc/tensor_ops_02.cc
+++ b/tests/adolc/tensor_ops_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename number_t,

--- a/tests/algorithms/newton_01.cc
+++ b/tests/algorithms/newton_01.cc
@@ -24,7 +24,6 @@
 
 // test computing square root of 2 with newton's method
 
-using namespace dealii;
 
 class SquareRoot : public Subscriptor
 {

--- a/tests/algorithms/newton_02.cc
+++ b/tests/algorithms/newton_02.cc
@@ -26,7 +26,6 @@
 
 // verify that all debug vectors have the correct size
 
-using namespace dealii;
 using namespace Algorithms;
 
 template <typename VectorType, int dim>

--- a/tests/algorithms/theta_01.cc
+++ b/tests/algorithms/theta_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Algorithms;
 
 

--- a/tests/aniso/anisotropic_crash.cc
+++ b/tests/aniso/anisotropic_crash.cc
@@ -32,7 +32,6 @@
 
 /// to generate random numbers
 
-using namespace dealii;
 
 int
 main()

--- a/tests/arpack/arpack_advection_diffusion.cc
+++ b/tests/arpack/arpack_advection_diffusion.cc
@@ -70,7 +70,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>
@@ -319,8 +318,6 @@ main(int argc, char **argv)
 {
   try
     {
-      using namespace dealii;
-
       initlog();
 
 

--- a/tests/arpack/parpack_advection_diffusion_trilinos.cc
+++ b/tests/arpack/parpack_advection_diffusion_trilinos.cc
@@ -55,7 +55,6 @@
 
 const unsigned int dim = 2; // run in 2d to save time
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/arpack/step-36_ar.cc
+++ b/tests/arpack/step-36_ar.cc
@@ -62,9 +62,6 @@
 
 namespace Step36
 {
-  using namespace dealii;
-
-
   template <int dim>
   class EigenvalueProblem
   {
@@ -330,7 +327,6 @@ main(int argc, char **argv)
 {
   try
     {
-      using namespace dealii;
       using namespace Step36;
 
       initlog();

--- a/tests/arpack/step-36_ar_shift.cc
+++ b/tests/arpack/step-36_ar_shift.cc
@@ -55,9 +55,6 @@
 
 namespace Step36
 {
-  using namespace dealii;
-
-
   template <int dim>
   class EigenvalueProblem
   {
@@ -333,7 +330,6 @@ main(int argc, char **argv)
 {
   try
     {
-      using namespace dealii;
       using namespace Step36;
 
       initlog();

--- a/tests/arpack/step-36_ar_with_iterations.cc
+++ b/tests/arpack/step-36_ar_with_iterations.cc
@@ -62,9 +62,6 @@
 
 namespace Step36
 {
-  using namespace dealii;
-
-
   template <int dim>
   class EigenvalueProblem
   {
@@ -332,7 +329,6 @@ main(int argc, char **argv)
 {
   try
     {
-      using namespace dealii;
       using namespace Step36;
 
       initlog();

--- a/tests/arpack/step-36_parpack_mf.cc
+++ b/tests/arpack/step-36_parpack_mf.cc
@@ -57,7 +57,6 @@
 
 const unsigned int dim = 2;
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/arpack/step-36_parpack_mf_02.cc
+++ b/tests/arpack/step-36_parpack_mf_02.cc
@@ -56,7 +56,6 @@
 
 const unsigned int dim = 2;
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/arpack/step-36_parpack_mf_03.cc
+++ b/tests/arpack/step-36_parpack_mf_03.cc
@@ -57,7 +57,6 @@
 
 const unsigned int dim = 2;
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/arpack/step-36_parpack_trilinos.cc
+++ b/tests/arpack/step-36_parpack_trilinos.cc
@@ -58,7 +58,6 @@
 
 const unsigned int dim = 2; // run in 2d to save time
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/base/bounding_box_5.cc
+++ b/tests/base/bounding_box_5.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/base/cell_data_storage_01.cc
+++ b/tests/base/cell_data_storage_01.cc
@@ -37,7 +37,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public Function<dim>

--- a/tests/base/cell_data_storage_02.cc
+++ b/tests/base/cell_data_storage_02.cc
@@ -34,7 +34,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public Function<dim>

--- a/tests/base/consensus_algorithm_01.cc
+++ b/tests/base/consensus_algorithm_01.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const MPI_Comm &comm)

--- a/tests/base/geometric_utilities_01.cc
+++ b/tests/base/geometric_utilities_01.cc
@@ -23,7 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::GeometricUtilities::Coordinates;
 
 template <unsigned int dim, typename T>

--- a/tests/base/geometry_info_8.cc
+++ b/tests/base/geometry_info_8.cc
@@ -19,7 +19,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 //
 // Test GeometryInfo<dim>::face_to_cell_vertices

--- a/tests/base/mpi_noncontiguous_partitioner_01.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const MPI_Comm comm)

--- a/tests/base/mpi_noncontiguous_partitioner_02.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_02.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/base/mpi_noncontiguous_partitioner_03.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_03.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const MPI_Comm                       comm,

--- a/tests/base/polynomial_minus_equals.cc
+++ b/tests/base/polynomial_minus_equals.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 int

--- a/tests/base/quadrature_chebyshev.cc
+++ b/tests/base/quadrature_chebyshev.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <typename quadrature_type, unsigned short startn>

--- a/tests/base/quadrature_point_data.cc
+++ b/tests/base/quadrature_point_data.cc
@@ -39,7 +39,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public Function<dim>

--- a/tests/base/quadrature_point_data_02.cc
+++ b/tests/base/quadrature_point_data_02.cc
@@ -40,7 +40,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public Function<dim>

--- a/tests/base/quadrature_point_data_03.cc
+++ b/tests/base/quadrature_point_data_03.cc
@@ -37,7 +37,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public Function<dim>

--- a/tests/base/quadrature_point_data_04.cc
+++ b/tests/base/quadrature_point_data_04.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 using MaterialBase = TransferableQuadraturePointData;
 using QuadratureStorage =

--- a/tests/base/utilities_04.cc
+++ b/tests/base/utilities_04.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 std::vector<std::string>
 split_string(const std::string &text, const char delim = '|')

--- a/tests/base/utilities_05.cc
+++ b/tests/base/utilities_05.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 void

--- a/tests/base/utilities_06.cc
+++ b/tests/base/utilities_06.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 void

--- a/tests/base/utilities_07.cc
+++ b/tests/base/utilities_07.cc
@@ -22,8 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 void

--- a/tests/base/utilities_pack_unpack_05.cc
+++ b/tests/base/utilities_pack_unpack_05.cc
@@ -25,8 +25,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int N, int dim>
 void

--- a/tests/base/utilities_pack_unpack_06.cc
+++ b/tests/base/utilities_pack_unpack_06.cc
@@ -25,8 +25,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int N, int dim>
 void

--- a/tests/base/utilities_pack_unpack_07.cc
+++ b/tests/base/utilities_pack_unpack_07.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int N>

--- a/tests/base/utilities_trim.cc
+++ b/tests/base/utilities_trim.cc
@@ -22,7 +22,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 void
 check(const std::string &input, const std::string &expected)

--- a/tests/bits/find_cell_10.cc
+++ b/tests/bits/find_cell_10.cc
@@ -83,7 +83,6 @@ argv=0x7fffffffdf48) at find_cell_10.cc:103
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void create_coarse_grid(Triangulation<2> &coarse_grid)

--- a/tests/bits/find_cell_11.cc
+++ b/tests/bits/find_cell_11.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/bits/joa_1.cc
+++ b/tests/bits/joa_1.cc
@@ -108,7 +108,6 @@
 
 // Finally, this is as in previous
 // programs:
-using namespace dealii;
 
 
 // @sect3{The <code>LaplaceProblem</code> class template}

--- a/tests/bits/periodicity_05.cc
+++ b/tests/bits/periodicity_05.cc
@@ -62,7 +62,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 class Deal2PeriodicBug
 {

--- a/tests/bits/periodicity_06.cc
+++ b/tests/bits/periodicity_06.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 AffineConstraints<double>
 make_constraint_matrix(const DoFHandler<2> &dof_handler, int version)

--- a/tests/bits/periodicity_07.cc
+++ b/tests/bits/periodicity_07.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 AffineConstraints<double>
 make_constraint_matrix(const DoFHandler<3> &dof_handler, int version)

--- a/tests/bits/step-51.cc
+++ b/tests/bits/step-51.cc
@@ -58,8 +58,6 @@ std::ofstream logfile("output");
 
 namespace Step51
 {
-  using namespace dealii;
-
   template <int dim>
   class SolutionBase
   {

--- a/tests/bits/step-51p.cc
+++ b/tests/bits/step-51p.cc
@@ -58,8 +58,6 @@ std::ofstream logfile("output");
 
 namespace Step51
 {
-  using namespace dealii;
-
   template <int dim>
   class SolutionBase
   {

--- a/tests/codim_one/extract_boundary_mesh_07.cc
+++ b/tests/codim_one/extract_boundary_mesh_07.cc
@@ -45,8 +45,6 @@
 
 namespace Step38
 {
-  using namespace dealii;
-
   template <int spacedim>
   class Extract_Mesh_Test
   {
@@ -117,7 +115,6 @@ main()
   initlog();
 
   {
-    using namespace dealii;
     using namespace Step38;
 
     Extract_Mesh_Test<2> Test;

--- a/tests/codim_one/extract_boundary_mesh_15.cc
+++ b/tests/codim_one/extract_boundary_mesh_15.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int spacedim>
 void

--- a/tests/codim_one/fe_dgq_prolongation_01.cc
+++ b/tests/codim_one/fe_dgq_prolongation_01.cc
@@ -23,9 +23,6 @@
 
 
 
-using namespace dealii;
-
-
 int
 main()
 {

--- a/tests/codim_one/integrate_one_over_r_telles.cc
+++ b/tests/codim_one/integrate_one_over_r_telles.cc
@@ -30,7 +30,6 @@
 #include "../base/simplex.h"
 
 using namespace std;
-using namespace dealii;
 
 int
 main()

--- a/tests/codim_one/integrate_one_over_r_telles_middle.cc
+++ b/tests/codim_one/integrate_one_over_r_telles_middle.cc
@@ -30,7 +30,6 @@
 #include "../base/simplex.h"
 
 using namespace std;
-using namespace dealii;
 
 // We test the integration of singular kernels with a singularity of kind 1/R
 // We multiply this function with a polynomial up to degree 6.

--- a/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
+++ b/tests/codim_one/interpolate_boundary_values_1d_closed_ring.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void

--- a/tests/codim_one/solution_transfer_01.cc
+++ b/tests/codim_one/solution_transfer_01.cc
@@ -45,8 +45,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 int
 main()

--- a/tests/data_out/data_out_curved_cells.cc
+++ b/tests/data_out/data_out_curved_cells.cc
@@ -54,7 +54,6 @@
 #include <vector>
 
 #include "../tests.h"
-using namespace dealii;
 
 
 // this is copied from GridGenerator

--- a/tests/data_out/data_out_postprocessor_tensor_01.cc
+++ b/tests/data_out/data_out_postprocessor_tensor_01.cc
@@ -57,9 +57,6 @@
 
 namespace Step8
 {
-  using namespace dealii;
-
-
   template <int dim>
   class ElasticProblem
   {

--- a/tests/data_out/data_out_postprocessor_vector_03.cc
+++ b/tests/data_out/data_out_postprocessor_vector_03.cc
@@ -56,8 +56,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 template <int dim>

--- a/tests/distributed_grids/2d_refinement_10.cc
+++ b/tests/distributed_grids/2d_refinement_10.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Purpose of this test:
 // Demonstrate that mesh smoothing option limit_level_difference_at_vertices

--- a/tests/distributed_grids/3d_refinement_12.cc
+++ b/tests/distributed_grids/3d_refinement_12.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Purpose of this test:
 // Demonstrate that mesh smoothing option limit_level_difference_at_vertices

--- a/tests/dofs/block_list.h
+++ b/tests/dofs/block_list.h
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -34,7 +34,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 //
 // Test

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -47,8 +47,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
-
 
 
 /*

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -81,8 +81,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
-
 
 
 /*

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -45,8 +45,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
-
 
 
 /*

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -34,7 +34,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 //
 // Test

--- a/tests/dofs/dof_tools_24.cc
+++ b/tests/dofs/dof_tools_24.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /*
  * Call the version of make_flux_sparsity_pattern that takes both cell and face

--- a/tests/dofs/locally_owned_dofs_per_subdomain_01.cc
+++ b/tests/dofs/locally_owned_dofs_per_subdomain_01.cc
@@ -37,7 +37,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/dofs/range_based_for_step-6.cc
+++ b/tests/dofs/range_based_for_step-6.cc
@@ -53,8 +53,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 template <int dim>

--- a/tests/epetraext/sparse_matrix_mmult_01.cc
+++ b/tests/epetraext/sparse_matrix_mmult_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <typename MATRIX>

--- a/tests/epetraext/sparse_matrix_mmult_02.cc
+++ b/tests/epetraext/sparse_matrix_mmult_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 value_rank_0(TrilinosWrappers::SparseMatrix &a)

--- a/tests/examples/step-56.cc
+++ b/tests/examples/step-56.cc
@@ -76,8 +76,6 @@
 
 namespace Step56
 {
-  using namespace dealii;
-
   // In order to make it easy to switch between the different solvers that are
   // being used, we declare an enum that can be passed as an argument to the
   // constructor of the main class.
@@ -1128,7 +1126,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step56;
 
       const int degree = 1;

--- a/tests/fail/circular_01.cc
+++ b/tests/fail/circular_01.cc
@@ -61,7 +61,6 @@ char logname[] = "output";
 
 // Finally, this is as in previous
 // programs:
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/fe/curl_curl_01.cc
+++ b/tests/fe/curl_curl_01.cc
@@ -69,7 +69,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 template <int dim>
 class MaxwellProblem
 {

--- a/tests/fe/fe_compute_point_locations_01.cc
+++ b/tests/fe/fe_compute_point_locations_01.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_enriched_01.cc
+++ b/tests/fe/fe_enriched_01.cc
@@ -45,7 +45,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class EnrichmentFunction : public Function<dim>

--- a/tests/fe/fe_enriched_02.cc
+++ b/tests/fe/fe_enriched_02.cc
@@ -49,7 +49,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_03.cc
+++ b/tests/fe/fe_enriched_03.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class EnrichmentFunction : public Function<dim>

--- a/tests/fe/fe_enriched_04.cc
+++ b/tests/fe/fe_enriched_04.cc
@@ -49,7 +49,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_05.cc
+++ b/tests/fe/fe_enriched_05.cc
@@ -49,7 +49,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_06.cc
+++ b/tests/fe/fe_enriched_06.cc
@@ -50,7 +50,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_07.cc
+++ b/tests/fe/fe_enriched_07.cc
@@ -49,7 +49,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_08.cc
+++ b/tests/fe/fe_enriched_08.cc
@@ -50,7 +50,6 @@ const double eps = 1e-10;
 // argument for build_patches()
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 // uncomment when debugging
 // #define DATA_OUT_FE_ENRICHED

--- a/tests/fe/fe_enriched_08a.cc
+++ b/tests/fe/fe_enriched_08a.cc
@@ -46,7 +46,6 @@
 
 const double eps = 1e-10;
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_enriched_color_01.cc
+++ b/tests/fe/fe_enriched_color_01.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /*
  * Construct a class template which finds if a cell

--- a/tests/fe/fe_enriched_compare_to_fe_system.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system.cc
@@ -57,7 +57,6 @@ const double eps = 1e-10;
 // in the same way for FE_System and FEEnriched.
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 template <int dim>
 class EnrichmentFunction : public Function<dim>

--- a/tests/fe/fe_enriched_compare_to_fe_system_2.cc
+++ b/tests/fe/fe_enriched_compare_to_fe_system_2.cc
@@ -59,7 +59,6 @@ const double eps = 1e-10;
 // functions.
 const unsigned int patches = 10;
 
-using namespace dealii;
 
 template <int dim>
 class EnrichmentFunction : public Function<dim>

--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -56,7 +56,6 @@
 
 const unsigned int dim = 3;
 
-using namespace dealii;
 
 /**
  * Coulomb potential

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -60,7 +60,6 @@
 
 const unsigned int dim = 3;
 
-using namespace dealii;
 
 /**
  * Coulomb potential

--- a/tests/fe/fe_faceq_interpolate.cc
+++ b/tests/fe/fe_faceq_interpolate.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_nedelec_singularity_01.cc
+++ b/tests/fe/fe_nedelec_singularity_01.cc
@@ -89,7 +89,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 namespace nedelec_singularity
 {

--- a/tests/fe/fe_nedelec_singularity_02.cc
+++ b/tests/fe/fe_nedelec_singularity_02.cc
@@ -87,7 +87,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 namespace nedelec_singularity
 {

--- a/tests/fe/fe_nedelec_sz_face_values.cc
+++ b/tests/fe/fe_nedelec_sz_face_values.cc
@@ -31,7 +31,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_nedelec_sz_non_rect_2d.cc
+++ b/tests/fe/fe_nedelec_sz_non_rect_2d.cc
@@ -71,7 +71,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 namespace polytest
 {

--- a/tests/fe/fe_nedelec_sz_non_rect_face.cc
+++ b/tests/fe/fe_nedelec_sz_non_rect_face.cc
@@ -77,8 +77,6 @@
 
 namespace Maxwell
 {
-  using namespace dealii;
-
   // Dirichlet BCs / exact solution:.
   template <int dim>
   class ExactSolution : public Function<dim>

--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -52,7 +52,6 @@
  * Alexander Grayver
  */
 
-using namespace dealii;
 
 static const Point<2> vertices_nonaffine[] = {
   Point<2>(-1., -1.),

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -51,7 +51,6 @@
  * Alexander Grayver, Maien Hamed
  */
 
-using namespace dealii;
 
 static const Point<3> vertices_affine[] = {
   Point<3>(-1., -1., -1.), Point<3>(0., -1., -1.),  Point<3>(1., -1., -1.),

--- a/tests/fe/fe_q_bubbles.cc
+++ b/tests/fe/fe_q_bubbles.cc
@@ -51,7 +51,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class BubbleFunction : public Function<dim>

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -61,8 +61,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
-
   template <int dim>
   struct InnerPreconditioner;
 
@@ -958,7 +956,6 @@ namespace Step22
 int
 main()
 {
-  using namespace dealii;
   using namespace Step22;
 
   initlog();

--- a/tests/fe/fe_series_01.cc
+++ b/tests/fe/fe_series_01.cc
@@ -38,7 +38,6 @@ plot2d([f,fs(0),fs(1),fs(2),fs(3)],[x,0,1]);
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test_1d()

--- a/tests/fe/fe_series_02.cc
+++ b/tests/fe/fe_series_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /**
  * A 1D function given by input legendre coefficients

--- a/tests/fe/fe_series_03.cc
+++ b/tests/fe/fe_series_03.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 std::pair<bool, unsigned int>
 pred_ind(const TableIndices<2> &ind)

--- a/tests/fe/fe_series_04.cc
+++ b/tests/fe/fe_series_04.cc
@@ -55,7 +55,6 @@ bfloat(C(3)), nouns;
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LegendreFunction : public Function<dim>

--- a/tests/fe/fe_series_05.cc
+++ b/tests/fe/fe_series_05.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LegendreFunction : public Function<dim>

--- a/tests/fe/fe_series_06.cc
+++ b/tests/fe/fe_series_06.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test_2d()

--- a/tests/fe/fe_series_07.cc
+++ b/tests/fe/fe_series_07.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 std::pair<bool, unsigned int>
 pred_ind(const TableIndices<2> &ind)

--- a/tests/fe/fe_series_08.cc
+++ b/tests/fe/fe_series_08.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void

--- a/tests/fe/fe_system_generalized_support_points.cc
+++ b/tests/fe/fe_system_generalized_support_points.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_traceq_interpolate.cc
+++ b/tests/fe/fe_traceq_interpolate.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/fe_values_function_manifold.cc
+++ b/tests/fe/fe_values_function_manifold.cc
@@ -60,7 +60,6 @@
 // error causes the Laplace solver to converge at order 2 instead of order 5,
 // resulting in much higher L2 errors when the grid is refined.
 
-using namespace dealii;
 
 static const unsigned int               fe_order          = 4;
 static const dealii::types::boundary_id boundary_id       = 0;

--- a/tests/fe/fe_values_view_21.cc
+++ b/tests/fe/fe_values_view_21.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class MixedElastoPlasticity

--- a/tests/fe/fe_values_view_21_nonsymmetric.cc
+++ b/tests/fe/fe_values_view_21_nonsymmetric.cc
@@ -50,7 +50,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class MixedElastoPlasticity

--- a/tests/fe/fe_values_view_22.cc
+++ b/tests/fe/fe_values_view_22.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/fe/fe_values_view_tensor_01.cc
+++ b/tests/fe/fe_values_view_tensor_01.cc
@@ -47,7 +47,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class MixedElastoPlasticity

--- a/tests/fe/memory_consumption_01.cc
+++ b/tests/fe/memory_consumption_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/multiple_redistribute_dofs_01.cc
+++ b/tests/fe/multiple_redistribute_dofs_01.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/fe/multiple_redistribute_dofs_02.cc
+++ b/tests/fe/multiple_redistribute_dofs_02.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/fe/nedelec_face_interpolation.cc
+++ b/tests/fe/nedelec_face_interpolation.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/fe/nedelec_non_rect_2d.cc
+++ b/tests/fe/nedelec_non_rect_2d.cc
@@ -69,7 +69,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 namespace polytest
 {

--- a/tests/fe/nedelec_non_rect_face.cc
+++ b/tests/fe/nedelec_non_rect_face.cc
@@ -78,8 +78,6 @@
 
 namespace Maxwell
 {
-  using namespace dealii;
-
   // Dirichlet BCs / exact solution:.
   template <int dim>
   class ExactSolution : public Function<dim>

--- a/tests/fe/restrict_prolongation_01.cc
+++ b/tests/fe/restrict_prolongation_01.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/feinterface/step-12.cc
+++ b/tests/feinterface/step-12.cc
@@ -58,10 +58,6 @@
 
 namespace Step12
 {
-  using namespace dealii;
-
-
-
   template <int dim>
   struct ScratchData
   {

--- a/tests/full_matrix/full_matrix_determinant_01.cc
+++ b/tests/full_matrix/full_matrix_determinant_01.cc
@@ -24,8 +24,6 @@
 #include "full_matrix_common.h"
 
 
-using namespace dealii;
-
 
 template <typename number>
 void

--- a/tests/full_matrix/full_matrix_invert_01.cc
+++ b/tests/full_matrix/full_matrix_invert_01.cc
@@ -23,8 +23,6 @@
 #include "full_matrix_common.h"
 
 
-using namespace dealii;
-
 
 template <typename number>
 void

--- a/tests/fullydistributed_grids/tests.h
+++ b/tests/fullydistributed_grids/tests.h
@@ -18,7 +18,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/grid/accessor_01.cc
+++ b/tests/grid/accessor_01.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/grid/accessor_02.cc
+++ b/tests/grid/accessor_02.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/grid/build_global_description_tree.cc
+++ b/tests/grid/build_global_description_tree.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;

--- a/tests/grid/cell_id_04.cc
+++ b/tests/grid/cell_id_04.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/compute_point_locations_01.cc
+++ b/tests/grid/compute_point_locations_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/compute_point_locations_02.cc
+++ b/tests/grid/compute_point_locations_02.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/compute_point_locations_try_all_01.cc
+++ b/tests/grid/compute_point_locations_try_all_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/distributed_compute_point_locations_03.cc
+++ b/tests/grid/distributed_compute_point_locations_03.cc
@@ -36,9 +36,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
-
 
 template <int dim>
 void

--- a/tests/grid/get_dof_to_support_patch_map_01.cc
+++ b/tests/grid/get_dof_to_support_patch_map_01.cc
@@ -38,15 +38,12 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>
 void
 test()
 {
-  using namespace dealii;
-
   Triangulation<dim> triangulation(
     Triangulation<dim>::limit_level_difference_at_vertices);
 
@@ -176,8 +173,6 @@ test()
 int
 main()
 {
-  using namespace dealii;
-
   initlog();
 
   deallog.push("1d");

--- a/tests/grid/grid_generator_open_torus.cc
+++ b/tests/grid/grid_generator_open_torus.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/grid/grid_out_svg_01.cc
+++ b/tests/grid/grid_out_svg_01.cc
@@ -23,7 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 Triangulation<2, 2>
 create_grid()

--- a/tests/grid/grid_out_svg_02.cc
+++ b/tests/grid/grid_out_svg_02.cc
@@ -24,7 +24,6 @@
 
 // Check SVG output with a GridGenerator function.
 
-using namespace dealii;
 
 Triangulation<2, 2>
 create_grid()

--- a/tests/grid/grid_out_svg_03.cc
+++ b/tests/grid/grid_out_svg_03.cc
@@ -23,7 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 Triangulation<2, 2>
 create_grid()

--- a/tests/grid/grid_tools_aspect_ratio.cc
+++ b/tests/grid/grid_tools_aspect_ratio.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 /*
  * The parameters left, right, refinements follow the hyper-rectangle

--- a/tests/grid/grid_tools_cache_04.cc
+++ b/tests/grid/grid_tools_cache_04.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 namespace bg  = boost::geometry;
 namespace bgi = boost::geometry::index;

--- a/tests/grid/grid_tools_cache_05.cc
+++ b/tests/grid/grid_tools_cache_05.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/grid/merge_triangulations_04.cc
+++ b/tests/grid/merge_triangulations_04.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/grid/merge_triangulations_07.cc
+++ b/tests/grid/merge_triangulations_07.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/grid/mesh_3d_22.cc
+++ b/tests/grid/mesh_3d_22.cc
@@ -48,7 +48,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace std;
 
 template <int dim>

--- a/tests/grid/mesh_3d_25.cc
+++ b/tests/grid/mesh_3d_25.cc
@@ -45,7 +45,6 @@
 
 #include "../grid/mesh_3d.h"
 
-using namespace dealii;
 using namespace std;
 
 template <int dim>

--- a/tests/grid/mesh_3d_26.cc
+++ b/tests/grid/mesh_3d_26.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace std;
 
 template <int dim>

--- a/tests/grid/mesh_smoothing_02.cc
+++ b/tests/grid/mesh_smoothing_02.cc
@@ -50,9 +50,6 @@ char logname[] = "output";
 #include "../tests.h"
 
 
-using namespace dealii;
-
-
 
 template <int dim>
 bool

--- a/tests/grid/mesh_smoothing_03.cc
+++ b/tests/grid/mesh_smoothing_03.cc
@@ -38,9 +38,6 @@ char logname[] = "output";
 #include "../tests.h"
 
 
-using namespace dealii;
-
-
 
 void
 test()

--- a/tests/grid/n_faces_01.cc
+++ b/tests/grid/n_faces_01.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 void

--- a/tests/grid/partition_triangulation_zorder_01.cc
+++ b/tests/grid/partition_triangulation_zorder_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/grid/project_to_object_01.cc
+++ b/tests/grid/project_to_object_01.cc
@@ -32,7 +32,6 @@
 int
 main()
 {
-  using namespace dealii;
   initlog();
 
   // test the internal cross derivative function: the stencil should be order 2.

--- a/tests/grid/refine_and_coarsen_fixed_fraction_02.cc
+++ b/tests/grid/refine_and_coarsen_fixed_fraction_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, const char *argv[])

--- a/tests/grid/refine_and_coarsen_fixed_number.cc
+++ b/tests/grid/refine_and_coarsen_fixed_number.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, const char *argv[])

--- a/tests/grid/refine_and_coarsen_fixed_number_02.cc
+++ b/tests/grid/refine_and_coarsen_fixed_number_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, const char *argv[])

--- a/tests/hp/accessor_0.cc
+++ b/tests/hp/accessor_0.cc
@@ -32,7 +32,6 @@ main()
   initlog();
   deallog << std::boolalpha;
 
-  using namespace dealii;
 
   Triangulation<1> triangulation;
   GridGenerator::hyper_cube(triangulation);

--- a/tests/hp/copy_tria_bug.cc
+++ b/tests/hp/copy_tria_bug.cc
@@ -30,9 +30,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
-
 
 template <int dim>
 void

--- a/tests/hp/crash_17.cc
+++ b/tests/hp/crash_17.cc
@@ -58,7 +58,6 @@
 
 // Finally, this is as in previous
 // programs:
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/hp/crash_18.cc
+++ b/tests/hp/crash_18.cc
@@ -64,7 +64,6 @@ char logname[] = "output";
 
 // Finally, this is as in previous
 // programs:
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/hp/crash_21.cc
+++ b/tests/hp/crash_21.cc
@@ -52,8 +52,6 @@
 
 namespace Step
 {
-  using namespace dealii;
-
   template <int dim>
   class Problem : public Subscriptor
   {
@@ -141,7 +139,6 @@ template <int dim>
 void
 test()
 {
-  using namespace dealii;
   using namespace Step;
 
   Problem<dim> problem;

--- a/tests/hp/distribute_dofs_linear_time.cc
+++ b/tests/hp/distribute_dofs_linear_time.cc
@@ -45,7 +45,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 static const types::manifold_id circular_manifold_id = 1;
 static const types::manifold_id straight_manifold_id = 3;

--- a/tests/hp/do_function_derivatives_01.cc
+++ b/tests/hp/do_function_derivatives_01.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/do_function_hessians_01.cc
+++ b/tests/hp/do_function_hessians_01.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/do_function_laplacians_01.cc
+++ b/tests/hp/do_function_laplacians_01.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/hp_constraints_neither_dominate_01.cc
+++ b/tests/hp/hp_constraints_neither_dominate_01.cc
@@ -69,7 +69,6 @@ unsigned int counter = 0;
 
 const double eps = 1e-10;
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/hp/hp_constraints_neither_dominate_02.cc
+++ b/tests/hp/hp_constraints_neither_dominate_02.cc
@@ -69,7 +69,6 @@ unsigned int counter = 0;
 
 const double eps = 1e-10;
 
-using namespace dealii;
 
 template <int dim>
 struct less_than_key

--- a/tests/hp/hp_q_hierarchical_constraints.cc
+++ b/tests/hp/hp_q_hierarchical_constraints.cc
@@ -44,7 +44,6 @@
 
 //#define FEQH_DEBUG_OUTPUT
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/hp/q_vs_dgq.cc
+++ b/tests/hp/q_vs_dgq.cc
@@ -33,8 +33,6 @@
 
 namespace Step27
 {
-  using namespace dealii;
-
   template <int dim>
   class MixedFECollection
   {

--- a/tests/hp/solution_transfer_04.cc
+++ b/tests/hp/solution_transfer_04.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/solution_transfer_05.cc
+++ b/tests/hp/solution_transfer_05.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/solution_transfer_06.cc
+++ b/tests/hp/solution_transfer_06.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/hp/solution_transfer_07.cc
+++ b/tests/hp/solution_transfer_07.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/hp/solution_transfer_08.cc
+++ b/tests/hp/solution_transfer_08.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/hp/solution_transfer_09.cc
+++ b/tests/hp/solution_transfer_09.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/hp/solution_transfer_10.cc
+++ b/tests/hp/solution_transfer_10.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/solution_transfer_13.cc
+++ b/tests/hp/solution_transfer_13.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/hp/solution_transfer_16.cc
+++ b/tests/hp/solution_transfer_16.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/integrators/assembler_simple_matrix_01.cc
+++ b/tests/integrators/assembler_simple_matrix_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <class DOFINFO, typename MatrixType>
 void

--- a/tests/integrators/assembler_simple_matrix_01m.cc
+++ b/tests/integrators/assembler_simple_matrix_01m.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <class DOFINFO, typename MatrixType>
 void

--- a/tests/integrators/assembler_simple_matrix_02.cc
+++ b/tests/integrators/assembler_simple_matrix_02.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/integrators/assembler_simple_matrix_02m.cc
+++ b/tests/integrators/assembler_simple_matrix_02m.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/integrators/assembler_simple_matrix_03.cc
+++ b/tests/integrators/assembler_simple_matrix_03.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename number>
 void

--- a/tests/integrators/assembler_simple_matrix_03m.cc
+++ b/tests/integrators/assembler_simple_matrix_03m.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename number>
 void

--- a/tests/integrators/assembler_simple_matrix_03tri.cc
+++ b/tests/integrators/assembler_simple_matrix_03tri.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename number>
 void

--- a/tests/integrators/assembler_simple_matrix_04.cc
+++ b/tests/integrators/assembler_simple_matrix_04.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename number>
 void

--- a/tests/integrators/assembler_simple_mgmatrix_01.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <class DOFINFO, typename MatrixType>
 void

--- a/tests/integrators/assembler_simple_mgmatrix_02.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_02.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/integrators/assembler_simple_mgmatrix_03.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_03.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename number>
 void

--- a/tests/integrators/assembler_simple_mgmatrix_04.cc
+++ b/tests/integrators/assembler_simple_mgmatrix_04.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace LocalIntegrators;
 
 

--- a/tests/integrators/assembler_simple_system_inhom_01.cc
+++ b/tests/integrators/assembler_simple_system_inhom_01.cc
@@ -68,8 +68,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 /*
  * Right hand side

--- a/tests/integrators/cells_and_faces_01.cc
+++ b/tests/integrators/cells_and_faces_01.cc
@@ -33,7 +33,6 @@
 
 #include "empty_info.h"
 
-using namespace dealii;
 
 
 // Define a class that fills all available entries in the info objects

--- a/tests/integrators/functional_01.cc
+++ b/tests/integrators/functional_01.cc
@@ -31,7 +31,6 @@
 
 #include "empty_info.h"
 
-using namespace dealii;
 
 
 // Define a class that fills all available entries in the info objects

--- a/tests/integrators/maxwell_curl.cc
+++ b/tests/integrators/maxwell_curl.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace LocalIntegrators::Maxwell;
 
 template <int dim>

--- a/tests/integrators/mesh_worker_01.cc
+++ b/tests/integrators/mesh_worker_01.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // Define a class that fills all available entries in the info objects

--- a/tests/integrators/mesh_worker_02.cc
+++ b/tests/integrators/mesh_worker_02.cc
@@ -36,8 +36,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 // Use local matrices for Laplacian / interior penalty DG
 template <int dim>

--- a/tests/integrators/mesh_worker_03.cc
+++ b/tests/integrators/mesh_worker_03.cc
@@ -37,7 +37,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 // Local integrators fill every matrix entry with 10*block_row + block_col
 template <int dim>

--- a/tests/integrators/mesh_worker_1d_dg.cc
+++ b/tests/integrators/mesh_worker_1d_dg.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 //! Solve the advection equation:  \dot{u} + \div{\mathbf{c} u} = 0.0,
@@ -52,8 +51,6 @@ using namespace dealii;
 
 namespace Advection
 {
-  using namespace dealii;
-
   /********************************************
    * ADVECTION PROBLEM
    ********************************************/

--- a/tests/integrators/mesh_worker_matrix_01.cc
+++ b/tests/integrators/mesh_worker_matrix_01.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // Define a class that fills all available entries in the info objects

--- a/tests/lac/block_linear_operator_01.cc
+++ b/tests/lac/block_linear_operator_01.cc
@@ -38,7 +38,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/block_linear_operator_02.cc
+++ b/tests/lac/block_linear_operator_02.cc
@@ -38,7 +38,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/block_linear_operator_03.cc
+++ b/tests/lac/block_linear_operator_03.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/block_linear_operator_04.cc
+++ b/tests/lac/block_linear_operator_04.cc
@@ -30,7 +30,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/block_linear_operator_05.cc
+++ b/tests/lac/block_linear_operator_05.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/block_linear_operator_06.cc
+++ b/tests/lac/block_linear_operator_06.cc
@@ -38,7 +38,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/constrained_linear_operator_01.cc
+++ b/tests/lac/constrained_linear_operator_01.cc
@@ -53,7 +53,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class Step6

--- a/tests/lac/constraint_matrix_distribute_complex.cc
+++ b/tests/lac/constraint_matrix_distribute_complex.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/constraint_matrix_distribute_local_global.cc
+++ b/tests/lac/constraint_matrix_distribute_local_global.cc
@@ -31,7 +31,6 @@
 // (2) the case that all entries of the local matrix
 //     are zero while a dof is constrained.
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/constraints_c1.cc
+++ b/tests/lac/constraints_c1.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/lac/constraints_c1_02.cc
+++ b/tests/lac/constraints_c1_02.cc
@@ -28,8 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
-
 
 
 void

--- a/tests/lac/constraints_shift_01.cc
+++ b/tests/lac/constraints_shift_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -59,7 +59,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/lac/inhomogeneous_constraints_02.cc
+++ b/tests/lac/inhomogeneous_constraints_02.cc
@@ -56,7 +56,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 void
 test(bool use_inhomogeneity_for_rhs)

--- a/tests/lac/inhomogeneous_constraints_03.cc
+++ b/tests/lac/inhomogeneous_constraints_03.cc
@@ -60,7 +60,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 void
 test(bool use_inhomogeneity_for_rhs)

--- a/tests/lac/inhomogeneous_constraints_04.cc
+++ b/tests/lac/inhomogeneous_constraints_04.cc
@@ -57,7 +57,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 void
 test(bool use_constraint_matrix)

--- a/tests/lac/inhomogeneous_constraints_block.cc
+++ b/tests/lac/inhomogeneous_constraints_block.cc
@@ -51,7 +51,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 template <int dim>
 class AdvectionProblem

--- a/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
+++ b/tests/lac/inhomogeneous_constraints_nonsymmetric.cc
@@ -50,7 +50,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 template <int dim>
 class AdvectionProblem

--- a/tests/lac/inhomogeneous_constraints_vector.cc
+++ b/tests/lac/inhomogeneous_constraints_vector.cc
@@ -55,7 +55,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/lac/linear_operator_01.cc
+++ b/tests/lac/linear_operator_01.cc
@@ -22,7 +22,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 // Dummy vectors with different, non convertible types:
 

--- a/tests/lac/linear_operator_01a.cc
+++ b/tests/lac/linear_operator_01a.cc
@@ -25,7 +25,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 // Dummy vectors with different, non convertible types:
 

--- a/tests/lac/linear_operator_01b.cc
+++ b/tests/lac/linear_operator_01b.cc
@@ -28,7 +28,6 @@
 #define PRINTME(name, var) \
   deallog << "Solution vector: " << name << ": " << var;
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_01c.cc
+++ b/tests/lac/linear_operator_01c.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_01d.cc
+++ b/tests/lac/linear_operator_01d.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_02.cc
+++ b/tests/lac/linear_operator_02.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_02a.cc
+++ b/tests/lac/linear_operator_02a.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_03.cc
+++ b/tests/lac/linear_operator_03.cc
@@ -48,7 +48,6 @@
           << var.block(1) << std::endl;
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_04.cc
+++ b/tests/lac/linear_operator_04.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/linear_operator_04a.cc
+++ b/tests/lac/linear_operator_04a.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/linear_operator_05.cc
+++ b/tests/lac/linear_operator_05.cc
@@ -252,7 +252,6 @@ public:
   }
 };
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_06.cc
+++ b/tests/lac/linear_operator_06.cc
@@ -30,7 +30,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_07.cc
+++ b/tests/lac/linear_operator_07.cc
@@ -30,7 +30,6 @@
     deallog << "[block " << i << " ]  " << var.block(i);
 
 
-using namespace dealii;
 
 int
 main()

--- a/tests/lac/linear_operator_08.cc
+++ b/tests/lac/linear_operator_08.cc
@@ -44,7 +44,6 @@
 #  include <deal.II/lac/sparse_direct.h>
 #endif
 
-using namespace dealii;
 
 
 template <class PRECONDITIONER,

--- a/tests/lac/linear_operator_09.cc
+++ b/tests/lac/linear_operator_09.cc
@@ -30,7 +30,6 @@
 #include <deal.II/lac/petsc_block_vector.h>
 
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/linear_operator_10.cc
+++ b/tests/lac/linear_operator_10.cc
@@ -28,7 +28,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <typename VECTOR>
 void

--- a/tests/lac/linear_operator_10a.cc
+++ b/tests/lac/linear_operator_10a.cc
@@ -33,7 +33,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <typename VECTOR>
 void

--- a/tests/lac/linear_operator_12.cc
+++ b/tests/lac/linear_operator_12.cc
@@ -48,7 +48,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/lac/linear_operator_12a.cc
+++ b/tests/lac/linear_operator_12a.cc
@@ -49,7 +49,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/lac/linear_operator_13.cc
+++ b/tests/lac/linear_operator_13.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/lac/linear_operator_14.cc
+++ b/tests/lac/linear_operator_14.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/lac/linear_operator_15.cc
+++ b/tests/lac/linear_operator_15.cc
@@ -28,7 +28,6 @@
 
 #include "../testmatrix.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/linear_operator_16.cc
+++ b/tests/lac/linear_operator_16.cc
@@ -28,7 +28,6 @@
 
 #include "../testmatrix.h"
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/lac/linear_operator_17.cc
+++ b/tests/lac/linear_operator_17.cc
@@ -22,8 +22,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 int
 main()

--- a/tests/lac/linear_operator_17a.cc
+++ b/tests/lac/linear_operator_17a.cc
@@ -23,8 +23,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 int
 main()

--- a/tests/lac/packaged_operation_01.cc
+++ b/tests/lac/packaged_operation_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void

--- a/tests/lac/packaged_operation_01a.cc
+++ b/tests/lac/packaged_operation_01a.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 void

--- a/tests/lac/packaged_operation_02.cc
+++ b/tests/lac/packaged_operation_02.cc
@@ -41,7 +41,6 @@
 
 #include <deal.II/numerics/matrix_tools.h>
 
-using namespace dealii;
 
 
 void

--- a/tests/lac/schur_complement_01.cc
+++ b/tests/lac/schur_complement_01.cc
@@ -31,7 +31,6 @@
 #define PRINTME(name, var) \
   deallog << "Solution vector: " << name << ": " << var;
 
-using namespace dealii;
 
 
 int

--- a/tests/lac/schur_complement_02.cc
+++ b/tests/lac/schur_complement_02.cc
@@ -30,7 +30,6 @@
 
 #define PRINTME(name, var) deallog << "RHS vector: " << name << ": " << var;
 
-using namespace dealii;
 
 
 int

--- a/tests/lac/schur_complement_03.cc
+++ b/tests/lac/schur_complement_03.cc
@@ -59,7 +59,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
   template <int dim>
   class StokesProblem
   {

--- a/tests/lac/schur_complement_04.cc
+++ b/tests/lac/schur_complement_04.cc
@@ -48,7 +48,6 @@
     deallog << "RHS vector: " << name << ": " << str << std::endl; \
   }
 
-using namespace dealii;
 
 
 int

--- a/tests/lac/utilities_02.cc
+++ b/tests/lac/utilities_02.cc
@@ -69,7 +69,6 @@
 
 const unsigned int dim = 2;
 
-using namespace dealii;
 
 const double eps = 1e-10;
 

--- a/tests/lac/vector_memory.cc
+++ b/tests/lac/vector_memory.cc
@@ -22,7 +22,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <typename VectorType>
 void

--- a/tests/manifold/spherical_manifold_02.cc
+++ b/tests/manifold/spherical_manifold_02.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 struct MappingEnum
 {
@@ -63,8 +62,6 @@ struct MappingEnum
 void
 test(MappingEnum::type mapping_name, unsigned int refinements = 1)
 {
-  using namespace dealii;
-
   deallog.depth_console(0);
 
   const unsigned int degree = 2; // Degree of shape functions

--- a/tests/manifold/spherical_manifold_04.cc
+++ b/tests/manifold/spherical_manifold_04.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test(const double R)
@@ -88,7 +87,6 @@ test(const double R)
 }
 
 
-using namespace dealii;
 
 int
 main(int argc, char *argv[])

--- a/tests/manifold/spherical_manifold_07.cc
+++ b/tests/manifold/spherical_manifold_07.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/manifold/spherical_manifold_08.cc
+++ b/tests/manifold/spherical_manifold_08.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/manifold/spherical_manifold_09.cc
+++ b/tests/manifold/spherical_manifold_09.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/manifold/spherical_manifold_10.cc
+++ b/tests/manifold/spherical_manifold_10.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/manifold/spherical_manifold_12.cc
+++ b/tests/manifold/spherical_manifold_12.cc
@@ -29,7 +29,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/manifold/tria_boundary_id_01.cc
+++ b/tests/manifold/tria_boundary_id_01.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename Stream, int dim>
 void

--- a/tests/mappings/mapping_fe_field_02.cc
+++ b/tests/mappings/mapping_fe_field_02.cc
@@ -63,7 +63,6 @@ test()
           << std::endl;
 }
 
-using namespace dealii;
 int
 main()
 {

--- a/tests/mappings/mapping_fe_field_03.cc
+++ b/tests/mappings/mapping_fe_field_03.cc
@@ -78,7 +78,6 @@ test()
           << "Linfty=" << map_vector.linfty_norm() << std::endl;
 }
 
-using namespace dealii;
 int
 main(int argc, char *argv[])
 {

--- a/tests/mappings/mapping_fe_field_04.cc
+++ b/tests/mappings/mapping_fe_field_04.cc
@@ -102,7 +102,6 @@ test()
   deallog << "OK" << std::endl;
 }
 
-using namespace dealii;
 int
 main()
 {

--- a/tests/mappings/mapping_fe_field_05.cc
+++ b/tests/mappings/mapping_fe_field_05.cc
@@ -104,7 +104,6 @@ test()
   deallog << "OK" << std::endl;
 }
 
-using namespace dealii;
 int
 main()
 {

--- a/tests/mappings/mapping_fe_field_06.cc
+++ b/tests/mappings/mapping_fe_field_06.cc
@@ -159,7 +159,6 @@ test()
   deallog << "OK" << std::endl;
 }
 
-using namespace dealii;
 int
 main(int argc, char **argv)
 {

--- a/tests/mappings/mapping_fe_field_real_to_unit_b1.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b1.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_b2_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b2_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_b2_mask.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b2_mask.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_b3_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b3_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_b4_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b4_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_b5_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_b5_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q1.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q1.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q2_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q2_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q2_mask.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q2_mask.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q3_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q3_curved.cc
@@ -44,7 +44,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q4_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q4_curved.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_fe_field_real_to_unit_q5_curved.cc
+++ b/tests/mappings/mapping_fe_field_real_to_unit_q5_curved.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, int spacedim>

--- a/tests/mappings/mapping_project_01.cc
+++ b/tests/mappings/mapping_project_01.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 void
 dim2_grid()
 {

--- a/tests/mappings/mapping_q1_cartesian_grid.cc
+++ b/tests/mappings/mapping_q1_cartesian_grid.cc
@@ -33,7 +33,6 @@
 // transform_unit_to_real_cell, we lost nearly all digits of precision due to
 // roundoff.
 
-using namespace dealii;
 
 class RefineTest
 {

--- a/tests/mappings/mapping_q1_eulerian_01.cc
+++ b/tests/mappings/mapping_q1_eulerian_01.cc
@@ -58,7 +58,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_convergence.cc
+++ b/tests/mappings/mapping_q_convergence.cc
@@ -49,7 +49,6 @@
 // In addition to checking the L2 errors of a projection, this test also
 // verifies that there is no loss in convergence order.
 
-using namespace dealii;
 // Like FESeries::linear_regression. Included here so that this test can also
 // be run with older versions of deal.II.
 double

--- a/tests/mappings/mapping_q_eulerian_01.cc
+++ b/tests/mappings/mapping_q_eulerian_01.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_eulerian_02.cc
+++ b/tests/mappings/mapping_q_eulerian_02.cc
@@ -58,7 +58,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_eulerian_03.cc
+++ b/tests/mappings/mapping_q_eulerian_03.cc
@@ -59,7 +59,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_eulerian_07.cc
+++ b/tests/mappings/mapping_q_eulerian_07.cc
@@ -62,9 +62,6 @@
 
 
 
-using namespace dealii;
-
-
 template <int dim>
 class Displacement : public Function<dim>
 {

--- a/tests/mappings/mapping_q_eulerian_08.cc
+++ b/tests/mappings/mapping_q_eulerian_08.cc
@@ -69,9 +69,6 @@
 
 
 
-using namespace dealii;
-
-
 template <int dim>
 class Displacement : public Function<dim>
 {

--- a/tests/mappings/mapping_q_eulerian_10.cc
+++ b/tests/mappings/mapping_q_eulerian_10.cc
@@ -65,7 +65,6 @@ test()
           << std::endl;
 }
 
-using namespace dealii;
 int
 main()
 {

--- a/tests/mappings/mapping_q_eulerian_11.cc
+++ b/tests/mappings/mapping_q_eulerian_11.cc
@@ -60,8 +60,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class Displacement : public Function<dim>

--- a/tests/mappings/mapping_q_eulerian_12.cc
+++ b/tests/mappings/mapping_q_eulerian_12.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_eulerian_13.cc
+++ b/tests/mappings/mapping_q_eulerian_13.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/mappings/mapping_q_generic_cell_cache.cc
+++ b/tests/mappings/mapping_q_generic_cell_cache.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 int

--- a/tests/mappings/mapping_q_manifold_01.cc
+++ b/tests/mappings/mapping_q_manifold_01.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 double
 zvalue(const double x, const double y)

--- a/tests/mappings/mapping_q_manifold_02.cc
+++ b/tests/mappings/mapping_q_manifold_02.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 double
 f_x(double x_m)

--- a/tests/matrix_free/face_setup_01.cc
+++ b/tests/matrix_free/face_setup_01.cc
@@ -37,8 +37,6 @@
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
   MPILogInitAll                    log;
 

--- a/tests/matrix_free/interpolate_to_mg.cc
+++ b/tests/matrix_free/interpolate_to_mg.cc
@@ -67,9 +67,6 @@
 
 
 
-using namespace dealii;
-
-
 template <int dim>
 class SimpleField : public Function<dim>
 {

--- a/tests/matrix_free/iterators.cc
+++ b/tests/matrix_free/iterators.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename Number              = double,

--- a/tests/matrix_free/matrix_vector_stokes_base.cc
+++ b/tests/matrix_free/matrix_vector_stokes_base.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim, int degree_p, typename BlockVectorType>
 class MatrixFreeTest : public MatrixFreeOperators::Base<dim, BlockVectorType>

--- a/tests/matrix_free/partitioner_01.cc
+++ b/tests/matrix_free/partitioner_01.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename Number              = double,

--- a/tests/matrix_free/read_cell_data_01.cc
+++ b/tests/matrix_free/read_cell_data_01.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename Number              = double,

--- a/tests/matrix_free/read_cell_data_02.cc
+++ b/tests/matrix_free/read_cell_data_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim,
           typename Number              = double,

--- a/tests/matrix_free/step-37-inhomogeneous-1.cc
+++ b/tests/matrix_free/step-37-inhomogeneous-1.cc
@@ -58,8 +58,6 @@
 
 namespace Step37
 {
-  using namespace dealii;
-
   const unsigned int degree_finite_element = 2;
 
   template <int dim>

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -53,8 +53,6 @@
 
 namespace Step37
 {
-  using namespace dealii;
-
   const unsigned int degree_finite_element = 2;
 
 

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -51,8 +51,6 @@
 
 namespace Step48
 {
-  using namespace dealii;
-
   const unsigned int dimension = 2;
   const unsigned int fe_degree = 4;
 

--- a/tests/matrix_free/step-48b.cc
+++ b/tests/matrix_free/step-48b.cc
@@ -46,8 +46,6 @@
 
 namespace Step48
 {
-  using namespace dealii;
-
   const unsigned int fe_degree = 4;
 
 

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -51,8 +51,6 @@
 
 namespace Step48
 {
-  using namespace dealii;
-
   const unsigned int dimension = 2;
   const unsigned int fe_degree = 4;
 

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -76,7 +76,6 @@ double pressure_scaling = 1.0;
 
 namespace StokesClass
 {
-  using namespace dealii;
   class QuietException
   {};
 

--- a/tests/meshworker/codim_01.cc
+++ b/tests/meshworker/codim_01.cc
@@ -36,7 +36,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim, int spacedim>
 class TestIntegrator : public MeshWorker::LocalIntegrator<dim, spacedim>

--- a/tests/meshworker/step-11-mesh_loop.cc
+++ b/tests/meshworker/step-11-mesh_loop.cc
@@ -64,8 +64,6 @@
 // The last step is as in all previous programs:
 namespace Step11
 {
-  using namespace dealii;
-
   // Then we declare a class which represents the solution of a Laplace
   // problem. As this example program is based on step-5, the class looks
   // rather the same, with the sole structural difference that the functions

--- a/tests/meshworker/step-50-mesh_loop.cc
+++ b/tests/meshworker/step-50-mesh_loop.cc
@@ -82,9 +82,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
-
   template <int dim>
   struct ScratchData
   {
@@ -556,7 +553,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/mpi/cuthill_mckee_01.cc
+++ b/tests/mpi/cuthill_mckee_01.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 template <int dim>
 void
 test()

--- a/tests/mpi/data_out_faces_01.cc
+++ b/tests/mpi/data_out_faces_01.cc
@@ -44,8 +44,6 @@
 
 namespace pdd
 {
-  using namespace dealii;
-
   // @sect3{The <code>PDDProblem</code> class template}
 
   template <int dim>

--- a/tests/mpi/distribute_flux_sparsity_pattern.cc
+++ b/tests/mpi/distribute_flux_sparsity_pattern.cc
@@ -48,8 +48,6 @@
 
 namespace LinearAdvectionTest
 {
-  using namespace dealii;
-
   template <int dim>
   class AdvectionProblem
   {
@@ -338,7 +336,6 @@ namespace LinearAdvectionTest
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   initlog();
 
   Utilities::MPI::MPI_InitFinalize         mpi_initialization(argc, argv, 1);

--- a/tests/mpi/flux_edge_01.cc
+++ b/tests/mpi/flux_edge_01.cc
@@ -62,8 +62,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   template <int dim>
   class InteriorPenaltyProblem
   {
@@ -210,7 +208,6 @@ namespace Step39
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   using namespace Step39;
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(

--- a/tests/mpi/has_hanging_nodes.cc
+++ b/tests/mpi/has_hanging_nodes.cc
@@ -60,7 +60,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 //#define DISTRIBUTED
 

--- a/tests/mpi/hp_step-4.cc
+++ b/tests/mpi/hp_step-4.cc
@@ -59,8 +59,6 @@
 
 namespace Step4
 {
-  using namespace dealii;
-
   template <int dim>
   class Step4
   {

--- a/tests/mpi/hp_step-40.cc
+++ b/tests/mpi/hp_step-40.cc
@@ -64,9 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -361,7 +358,6 @@ test_mpi()
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/hp_step-40_variable_01.cc
+++ b/tests/mpi/hp_step-40_variable_01.cc
@@ -64,9 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -364,7 +361,6 @@ test_mpi()
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/interpolate_to_different_mesh_01.cc
+++ b/tests/mpi/interpolate_to_different_mesh_01.cc
@@ -40,7 +40,6 @@
 
 // test VectorTools::interpolate_to_different_mesh in parallel
 
-using namespace dealii;
 
 namespace LA
 {

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -52,7 +52,6 @@
 // this is a slightly modified version from the example by Sam Cox from the
 // mailing
 
-using namespace dealii;
 
 namespace LA
 {

--- a/tests/mpi/mesh_worker_01.cc
+++ b/tests/mpi/mesh_worker_01.cc
@@ -29,8 +29,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class myIntegrator : public dealii::MeshWorker::LocalIntegrator<dim>

--- a/tests/mpi/mesh_worker_02.cc
+++ b/tests/mpi/mesh_worker_02.cc
@@ -29,8 +29,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class myIntegrator : public dealii::MeshWorker::LocalIntegrator<dim>

--- a/tests/mpi/mesh_worker_03.cc
+++ b/tests/mpi/mesh_worker_03.cc
@@ -29,8 +29,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class myIntegrator : public dealii::MeshWorker::LocalIntegrator<dim>

--- a/tests/mpi/mesh_worker_04.cc
+++ b/tests/mpi/mesh_worker_04.cc
@@ -30,8 +30,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class myIntegrator : public dealii::MeshWorker::LocalIntegrator<dim>

--- a/tests/mpi/mesh_worker_05.cc
+++ b/tests/mpi/mesh_worker_05.cc
@@ -30,8 +30,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class myIntegrator : public dealii::MeshWorker::LocalIntegrator<dim>

--- a/tests/mpi/mesh_worker_matrix_01.cc
+++ b/tests/mpi/mesh_worker_matrix_01.cc
@@ -42,7 +42,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // Define a class that fills all available entries in the info objects

--- a/tests/mpi/mg_ghost_dofs_periodic_01.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_01.cc
@@ -104,8 +104,6 @@ test()
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;

--- a/tests/mpi/mg_ghost_dofs_periodic_02.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_02.cc
@@ -85,8 +85,6 @@ test()
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;

--- a/tests/mpi/mg_ghost_dofs_periodic_03.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_03.cc
@@ -99,8 +99,6 @@ test()
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;

--- a/tests/mpi/mg_ghost_dofs_periodic_04.cc
+++ b/tests/mpi/mg_ghost_dofs_periodic_04.cc
@@ -112,8 +112,6 @@ test()
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;

--- a/tests/mpi/muelu_periodicity.cc
+++ b/tests/mpi/muelu_periodicity.cc
@@ -51,8 +51,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
-
   template <int dim>
   class StokesProblem
   {
@@ -799,7 +797,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step22;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -66,8 +66,6 @@
 
 namespace Step50
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -527,7 +525,6 @@ namespace Step50
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   using namespace Step50;
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -66,8 +66,6 @@
 
 namespace Step50
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -509,7 +507,6 @@ namespace Step50
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   using namespace Step50;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());

--- a/tests/mpi/parallel_partitioner_08.cc
+++ b/tests/mpi/parallel_partitioner_08.cc
@@ -161,8 +161,6 @@ test()
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   MPILogInitAll log;

--- a/tests/mpi/parallel_partitioner_09.cc
+++ b/tests/mpi/parallel_partitioner_09.cc
@@ -24,8 +24,6 @@
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize init(argc, argv, 1);
 
   MPILogInitAll log;

--- a/tests/mpi/periodic_neighbor_01.cc
+++ b/tests/mpi/periodic_neighbor_01.cc
@@ -104,7 +104,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 struct periodicity_tests

--- a/tests/mpi/periodicity_01.cc
+++ b/tests/mpi/periodicity_01.cc
@@ -65,8 +65,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -569,7 +567,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/mpi/periodicity_02.cc
+++ b/tests/mpi/periodicity_02.cc
@@ -53,8 +53,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
-
   template <int dim>
   class StokesProblem
   {
@@ -819,7 +817,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step22;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/mpi/periodicity_03.cc
+++ b/tests/mpi/periodicity_03.cc
@@ -55,8 +55,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
-
   template <int dim>
   class StokesProblem
   {
@@ -882,7 +880,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step22;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void
@@ -317,8 +316,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
-
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
       MPILogInitAll log;

--- a/tests/mpi/petsc_step-27.cc
+++ b/tests/mpi/petsc_step-27.cc
@@ -70,9 +70,6 @@ namespace LA
 
 namespace Step27
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -535,7 +532,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step27;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/mpi/project_bv_div_conf.cc
+++ b/tests/mpi/project_bv_div_conf.cc
@@ -45,9 +45,6 @@
 
 namespace ResFlow
 {
-  using namespace dealii;
-
-
   template <int dim>
   class FluxBoundaryValues : public Function<dim>
   {
@@ -241,7 +238,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace ResFlow;
 
       Assert(dim == 2 || dim == 3, ExcNotImplemented());

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -62,8 +62,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -817,7 +815,6 @@ namespace Step39
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   using namespace Step39;
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -63,8 +63,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -787,7 +785,6 @@ namespace Step39
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   using namespace Step39;
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(

--- a/tests/mpi/step-40.cc
+++ b/tests/mpi/step-40.cc
@@ -58,9 +58,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -346,7 +343,6 @@ test_mpi()
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/step-40_cuthill_mckee.cc
+++ b/tests/mpi/step-40_cuthill_mckee.cc
@@ -63,9 +63,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -408,7 +405,6 @@ test_mpi()
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
+++ b/tests/mpi/step-40_cuthill_mckee_MPI-subset.cc
@@ -64,9 +64,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -411,7 +408,6 @@ test_mpi(MPI_Comm comm)
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -58,9 +58,6 @@
 
 namespace Step40
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -324,7 +321,6 @@ test_mpi()
 {
   try
     {
-      using namespace dealii;
       using namespace Step40;
 
 

--- a/tests/mpi/torus.cc
+++ b/tests/mpi/torus.cc
@@ -71,7 +71,6 @@ DeclException1(ExcMissingCell,
 int
 main(int argc, char *argv[])
 {
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
   MPILogInitAll log;

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -70,9 +70,6 @@ namespace LA
 
 namespace Step27
 {
-  using namespace dealii;
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -537,7 +534,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step27;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/multigrid/distribute_bug_01.cc
+++ b/tests/multigrid/distribute_bug_01.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -73,8 +73,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -572,7 +570,6 @@ main(int argc, char *argv[])
     {
       deallog.depth_console(5);
 
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(3 /*degree*/);

--- a/tests/multigrid/interface_matrix_entry_01.cc
+++ b/tests/multigrid/interface_matrix_entry_01.cc
@@ -47,7 +47,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -73,8 +73,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -656,7 +654,6 @@ main(int argc, char *argv[])
     {
       deallog.depth_console(5);
 
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(3 /*degree*/);

--- a/tests/multigrid/mg_data_out_01.cc
+++ b/tests/multigrid/mg_data_out_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_data_out_02.cc
+++ b/tests/multigrid/mg_data_out_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_data_out_03.cc
+++ b/tests/multigrid/mg_data_out_03.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_data_out_04.cc
+++ b/tests/multigrid/mg_data_out_04.cc
@@ -32,7 +32,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_data_out_05.cc
+++ b/tests/multigrid/mg_data_out_05.cc
@@ -37,7 +37,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -58,7 +58,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, typename number, int spacedim>

--- a/tests/multigrid/mg_renumbered_02.cc
+++ b/tests/multigrid/mg_renumbered_02.cc
@@ -63,7 +63,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, typename number, int spacedim>

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -63,7 +63,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim, typename number, int spacedim>

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -63,7 +63,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace LocalIntegrators;
 
 template <int dim>

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -79,10 +79,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -578,7 +574,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -79,10 +79,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -567,7 +563,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -79,10 +79,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -564,7 +560,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -57,7 +57,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -64,7 +64,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace LocalIntegrators;
 
 template <int dim>

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 class LaplaceProblem

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -58,8 +58,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -800,7 +798,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step39;
       initlog(__FILE__);
 

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -60,8 +60,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -807,7 +805,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step39;
       initlog(__FILE__);
 

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -64,8 +64,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -808,7 +806,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step39;
       initlog(__FILE__);
 

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -59,8 +59,6 @@
 
 namespace Step39
 {
-  using namespace dealii;
-
   Functions::SlitSingularityFunction<2> exact_solution;
 
 
@@ -788,7 +786,6 @@ main()
 {
   try
     {
-      using namespace dealii;
       using namespace Step39;
       initlog(__FILE__);
 

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -75,8 +75,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
   template <int dim>
   class LaplaceProblem
   {
@@ -611,7 +609,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -79,10 +79,6 @@ namespace LA
 
 namespace Step50
 {
-  using namespace dealii;
-
-
-
   template <int dim>
   class LaplaceProblem
   {
@@ -572,7 +568,6 @@ main(int argc, char *argv[])
 
   try
     {
-      using namespace dealii;
       using namespace Step50;
 
       LaplaceProblem<2> laplace_problem(1 /*degree*/);

--- a/tests/non_matching/coupling_01.cc
+++ b/tests/non_matching/coupling_01.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension and
 // immersed dimension, and check that constants are projected correctly.

--- a/tests/non_matching/coupling_02.cc
+++ b/tests/non_matching/coupling_02.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension and
 // immersed dimension, with a non trivial component selection in the space_dh,

--- a/tests/non_matching/coupling_03.cc
+++ b/tests/non_matching/coupling_03.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension
 // and immersed dimension, with a non trivial component selection in both

--- a/tests/non_matching/coupling_04.cc
+++ b/tests/non_matching/coupling_04.cc
@@ -36,7 +36,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension
 // and immersed dimension, and check that quadratic functions are correctly

--- a/tests/non_matching/coupling_05.cc
+++ b/tests/non_matching/coupling_05.cc
@@ -45,7 +45,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension
 // and immersed dimension, and check that quadratic functions are correctly

--- a/tests/non_matching/coupling_06.cc
+++ b/tests/non_matching/coupling_06.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension
 // and immersed dimension, and check that quadratic functions are correctly

--- a/tests/non_matching/coupling_07.cc
+++ b/tests/non_matching/coupling_07.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension and
 // immersed dimension, and check that constants are projected correctly.

--- a/tests/non_matching/coupling_08.cc
+++ b/tests/non_matching/coupling_08.cc
@@ -35,7 +35,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that a coupling matrix can be constructed for each pair of dimension and
 // immersed dimension, and check that constants are projected correctly

--- a/tests/non_matching/immersed_surface_quadrature.cc
+++ b/tests/non_matching/immersed_surface_quadrature.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test that an ImmersedSurfaceQuadrature can be constructed for each dimension
 // and that quadrature points can be added to it.

--- a/tests/numerics/assemble_matrix_parallel_01.cc
+++ b/tests/numerics/assemble_matrix_parallel_01.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/numerics/assemble_matrix_parallel_02.cc
+++ b/tests/numerics/assemble_matrix_parallel_02.cc
@@ -56,7 +56,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/numerics/assemble_matrix_parallel_03.cc
+++ b/tests/numerics/assemble_matrix_parallel_03.cc
@@ -54,7 +54,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/numerics/assemble_matrix_parallel_04.cc
+++ b/tests/numerics/assemble_matrix_parallel_04.cc
@@ -55,7 +55,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/numerics/error_estimator_02.cc
+++ b/tests/numerics/error_estimator_02.cc
@@ -100,7 +100,6 @@
 // c++
 #include <iostream>
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public dealii::Function<dim>

--- a/tests/numerics/error_estimator_02_complex.cc
+++ b/tests/numerics/error_estimator_02_complex.cc
@@ -45,7 +45,6 @@
 // c++
 #include <iostream>
 
-using namespace dealii;
 
 template <int dim>
 class MyFunction : public dealii::Function<dim, std::complex<double>>

--- a/tests/numerics/interpolate_to_different_mesh_01.cc
+++ b/tests/numerics/interpolate_to_different_mesh_01.cc
@@ -32,7 +32,6 @@
 #include "../tests.h"
 
 using namespace std;
-using namespace dealii;
 
 template <int spacedim>
 class F1 : public Function<spacedim>

--- a/tests/numerics/interpolate_to_different_mesh_02.cc
+++ b/tests/numerics/interpolate_to_different_mesh_02.cc
@@ -33,7 +33,6 @@
 #include "../tests.h"
 
 using namespace std;
-using namespace dealii;
 
 template <int spacedim>
 class F1 : public Function<spacedim>

--- a/tests/numerics/interpolate_to_different_mesh_03.cc
+++ b/tests/numerics/interpolate_to_different_mesh_03.cc
@@ -36,7 +36,6 @@
 #include "../tests.h"
 
 using namespace std;
-using namespace dealii;
 
 template <unsigned int spacedim>
 void

--- a/tests/numerics/interpolate_to_different_mesh_04.cc
+++ b/tests/numerics/interpolate_to_different_mesh_04.cc
@@ -37,7 +37,6 @@
 #include "../tests.h"
 
 using namespace std;
-using namespace dealii;
 
 template <unsigned int spacedim>
 void

--- a/tests/numerics/no_flux_13.cc
+++ b/tests/numerics/no_flux_13.cc
@@ -33,7 +33,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/numerics/point_value_history_01.cc
+++ b/tests/numerics/point_value_history_01.cc
@@ -46,9 +46,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
-
 
 template <int dim>
 class TestPointValueHistory

--- a/tests/numerics/point_value_history_02.cc
+++ b/tests/numerics/point_value_history_02.cc
@@ -49,8 +49,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class Postprocess : public DataPostprocessor<dim>

--- a/tests/numerics/point_value_history_03.cc
+++ b/tests/numerics/point_value_history_03.cc
@@ -49,8 +49,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 template <int dim>
 class Postprocess : public DataPostprocessor<dim>

--- a/tests/numerics/project_bv_curl_conf_03.cc
+++ b/tests/numerics/project_bv_curl_conf_03.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char **argv)

--- a/tests/optimization/cubic_fit.cc
+++ b/tests/optimization/cubic_fit.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/optimization/cubic_fit_three_points.cc
+++ b/tests/optimization/cubic_fit_three_points.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/optimization/line_minimization.cc
+++ b/tests/optimization/line_minimization.cc
@@ -23,7 +23,6 @@
 #include <iostream>
 
 #include "../tests.h"
-using namespace dealii;
 
 /*
  * MWE in Maxima

--- a/tests/optimization/line_minimization_02.cc
+++ b/tests/optimization/line_minimization_02.cc
@@ -25,7 +25,6 @@
 #include <iostream>
 
 #include "../tests.h"
-using namespace dealii;
 
 /*
  * MWE in Maxima

--- a/tests/optimization/line_minimization_03.cc
+++ b/tests/optimization/line_minimization_03.cc
@@ -25,7 +25,6 @@
 #include <iostream>
 
 #include "../tests.h"
-using namespace dealii;
 
 /*
  * MWE in Maxima

--- a/tests/optimization/line_minimization_03b.cc
+++ b/tests/optimization/line_minimization_03b.cc
@@ -23,7 +23,6 @@
 #include <iostream>
 
 #include "../tests.h"
-using namespace dealii;
 
 /*
  * MWE in Maxima

--- a/tests/optimization/quadratic_fit.cc
+++ b/tests/optimization/quadratic_fit.cc
@@ -23,7 +23,6 @@
 #include <iostream>
 
 #include "../tests.h"
-using namespace dealii;
 
 
 void

--- a/tests/optimization/step-44-with_line_search.cc
+++ b/tests/optimization/step-44-with_line_search.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/optimization/step-44-with_line_search_ptrb.cc
+++ b/tests/optimization/step-44-with_line_search_ptrb.cc
@@ -31,7 +31,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/optimization/step-44-without_line_search.cc
+++ b/tests/optimization/step-44-without_line_search.cc
@@ -29,7 +29,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/parameter_handler/parameter_handler_dos_endings.cc
+++ b/tests/parameter_handler/parameter_handler_dos_endings.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/parameter_handler/pattern_tools_01.cc
+++ b/tests/parameter_handler/pattern_tools_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on elementary types

--- a/tests/parameter_handler/pattern_tools_02.cc
+++ b/tests/parameter_handler/pattern_tools_02.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on non elementary types

--- a/tests/parameter_handler/pattern_tools_03.cc
+++ b/tests/parameter_handler/pattern_tools_03.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on container types

--- a/tests/parameter_handler/pattern_tools_04.cc
+++ b/tests/parameter_handler/pattern_tools_04.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on map types

--- a/tests/parameter_handler/pattern_tools_05.cc
+++ b/tests/parameter_handler/pattern_tools_05.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on complex map types

--- a/tests/parameter_handler/pattern_tools_06.cc
+++ b/tests/parameter_handler/pattern_tools_06.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on complex map types

--- a/tests/parameter_handler/pattern_tools_07.cc
+++ b/tests/parameter_handler/pattern_tools_07.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on arbitrary container types

--- a/tests/parameter_handler/patterns_05.cc
+++ b/tests/parameter_handler/patterns_05.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 // Try conversion on elementary types

--- a/tests/parameter_handler/patterns_06.cc
+++ b/tests/parameter_handler/patterns_06.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main()

--- a/tests/parameter_handler/patterns_07.cc
+++ b/tests/parameter_handler/patterns_07.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 using namespace Patterns::Tools;
 
 int

--- a/tests/petsc/copy_parallel_vector.cc
+++ b/tests/petsc/copy_parallel_vector.cc
@@ -28,8 +28,6 @@
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
-
   Utilities::MPI::MPI_InitFinalize mpi_context(argc, argv, 1);
   MPILogInitAll                    mpi_log;
 

--- a/tests/petsc/different_matrix_preconditioner.cc
+++ b/tests/petsc/different_matrix_preconditioner.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 int
 main(int argc, char **argv)

--- a/tests/petsc/update_ghosts.cc
+++ b/tests/petsc/update_ghosts.cc
@@ -23,7 +23,6 @@
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   initlog();

--- a/tests/petsc_complex/fe_get_function_values.cc
+++ b/tests/petsc_complex/fe_get_function_values.cc
@@ -48,7 +48,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 static const unsigned int dim = 2;
 

--- a/tests/petsc_complex/parallel_sparse_matrix_01.cc
+++ b/tests/petsc_complex/parallel_sparse_matrix_01.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/physics/elasticity-kinematics_01.cc
+++ b/tests/physics/elasticity-kinematics_01.cc
@@ -42,7 +42,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 using namespace dealii::Physics::Elasticity;
 

--- a/tests/physics/elasticity-kinematics_02.cc
+++ b/tests/physics/elasticity-kinematics_02.cc
@@ -25,7 +25,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 using namespace dealii::Physics::Elasticity;
 

--- a/tests/physics/notation-kelvin_01.cc
+++ b/tests/physics/notation-kelvin_01.cc
@@ -27,7 +27,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 
 template <int dim, typename Number>

--- a/tests/physics/notation-kelvin_02.cc
+++ b/tests/physics/notation-kelvin_02.cc
@@ -30,7 +30,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 
 template <int dim, typename Number>

--- a/tests/physics/notation-kelvin_03.cc
+++ b/tests/physics/notation-kelvin_03.cc
@@ -28,7 +28,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 
 template <int dim, typename Number>

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -67,7 +67,6 @@
 #include "../tests.h"
 namespace Step18
 {
-  using namespace dealii;
   template <int dim>
   struct PointHistory
   {
@@ -785,7 +784,6 @@ main(int argc, char **argv)
 
   try
     {
-      using namespace dealii;
       using namespace Step18;
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       TopLevel<3>                      elastic_problem;

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -66,7 +66,6 @@
 #include "../tests.h"
 namespace Step18
 {
-  using namespace dealii;
   template <int dim>
   struct PointHistory
   {
@@ -801,7 +800,6 @@ main(int argc, char **argv)
 
   try
     {
-      using namespace dealii;
       using namespace Step18;
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
       TopLevel<3>                      elastic_problem;

--- a/tests/physics/step-44-standard_tensors-material_push_forward.cc
+++ b/tests/physics/step-44-standard_tensors-material_push_forward.cc
@@ -69,7 +69,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace Parameters
   {
     struct FESystem
@@ -2274,7 +2273,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/physics/step-44-standard_tensors-spatial.cc
+++ b/tests/physics/step-44-standard_tensors-spatial.cc
@@ -67,7 +67,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace Parameters
   {
     struct FESystem
@@ -2073,7 +2072,6 @@ main(int argc, char **argv)
 
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/physics/step-44.cc
+++ b/tests/physics/step-44.cc
@@ -63,7 +63,6 @@
 #include "../tests.h"
 namespace Step44
 {
-  using namespace dealii;
   namespace Parameters
   {
     struct FESystem
@@ -2085,7 +2084,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   using namespace Step44;
   try
     {

--- a/tests/physics/transformations-push_forward_01.cc
+++ b/tests/physics/transformations-push_forward_01.cc
@@ -26,7 +26,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/physics/transformations-rotations_01.cc
+++ b/tests/physics/transformations-rotations_01.cc
@@ -26,7 +26,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 using namespace dealii::Physics;
 
 

--- a/tests/quick_tests/arpack.cc
+++ b/tests/quick_tests/arpack.cc
@@ -43,7 +43,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/quick_tests/umfpack.cc
+++ b/tests/quick_tests/umfpack.cc
@@ -41,7 +41,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/rol/vector_adaptor_01.cc
+++ b/tests/rol/vector_adaptor_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <typename VectorType>
 void

--- a/tests/rol/vector_adaptor_apply_binary_01.cc
+++ b/tests/rol/vector_adaptor_apply_binary_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Taken from deal.II's test: parallel_vector_07
 template <typename VectorType>

--- a/tests/rol/vector_adaptor_no_ghost_01.cc
+++ b/tests/rol/vector_adaptor_no_ghost_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Taken from deal.II's test: parallel_vector_07
 template <typename VectorType>

--- a/tests/rol/vector_adaptor_with_ghost_01.cc
+++ b/tests/rol/vector_adaptor_with_ghost_01.cc
@@ -22,7 +22,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Vectors are prepared similar to deal.II's test: parallel_vector_07
 template <typename VectorType>

--- a/tests/sacado/ad_number_traits_01.cc
+++ b/tests/sacado/ad_number_traits_01.cc
@@ -27,7 +27,6 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 int

--- a/tests/sacado/ad_number_traits_02_none.cc
+++ b/tests/sacado/ad_number_traits_02_none.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/sacado/ad_number_traits_02a.cc
+++ b/tests/sacado/ad_number_traits_02a.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/sacado/ad_number_traits_02b.cc
+++ b/tests/sacado/ad_number_traits_02b.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/sacado/ad_number_traits_02c.cc
+++ b/tests/sacado/ad_number_traits_02c.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/sacado/ad_number_traits_02d.cc
+++ b/tests/sacado/ad_number_traits_02d.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename NumberTraitsType>

--- a/tests/sacado/ad_number_traits_03.cc
+++ b/tests/sacado/ad_number_traits_03.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace AD = Differentiation::AD;
 
 template <typename Number>

--- a/tests/sacado/step-44-helper_res_lin_01_1.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_res_lin_01_2.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_res_lin_01_3.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_3.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_res_lin_01_4.cc
+++ b/tests/sacado/step-44-helper_res_lin_01_4.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_scalar_01_1.cc
+++ b/tests/sacado/step-44-helper_scalar_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_scalar_01_2.cc
+++ b/tests/sacado/step-44-helper_scalar_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_var_form_01_1.cc
+++ b/tests/sacado/step-44-helper_var_form_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_var_form_01_2.cc
+++ b/tests/sacado/step-44-helper_var_form_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_vector_01_1.cc
+++ b/tests/sacado/step-44-helper_vector_01_1.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_vector_01_2.cc
+++ b/tests/sacado/step-44-helper_vector_01_2.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_vector_01_3.cc
+++ b/tests/sacado/step-44-helper_vector_01_3.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/sacado/step-44-helper_vector_01_4.cc
+++ b/tests/sacado/step-44-helper_vector_01_4.cc
@@ -30,7 +30,6 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, testing_max_num_threads());
 
-  using namespace dealii;
   namespace AD = dealii::Differentiation::AD;
   using namespace Step44;
   try

--- a/tests/symengine/basic_01.cc
+++ b/tests/symengine/basic_01.cc
@@ -36,7 +36,6 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 SE::RCP<const SE::Number>

--- a/tests/symengine/basic_02.cc
+++ b/tests/symengine/basic_02.cc
@@ -43,7 +43,6 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 SE::RCP<const SE::Number>

--- a/tests/symengine/basic_03.cc
+++ b/tests/symengine/basic_03.cc
@@ -46,7 +46,6 @@
 #include <fstream>
 #include <iomanip>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 SE::RCP<const SE::Number>

--- a/tests/symengine/basic_04.cc
+++ b/tests/symengine/basic_04.cc
@@ -43,7 +43,6 @@
 #include <iostream>
 #include <vector>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/basic_05.cc
+++ b/tests/symengine/basic_05.cc
@@ -43,7 +43,6 @@
 #include <iostream>
 #include <vector>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/basic_06.cc
+++ b/tests/symengine/basic_06.cc
@@ -39,7 +39,6 @@
 #include <iostream>
 #include <vector>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/basic_07.cc
+++ b/tests/symengine/basic_07.cc
@@ -39,7 +39,6 @@
 #include <iostream>
 #include <vector>
 
-using namespace dealii;
 namespace SE = SymEngine;
 
 int

--- a/tests/symengine/substitution_maps_cyclic_dependencies_01.cc
+++ b/tests/symengine/substitution_maps_cyclic_dependencies_01.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 int

--- a/tests/symengine/substitution_maps_cyclic_dependencies_02.cc
+++ b/tests/symengine/substitution_maps_cyclic_dependencies_02.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 int

--- a/tests/symengine/substitution_maps_scalar_01.cc
+++ b/tests/symengine/substitution_maps_scalar_01.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_scalar_02.cc
+++ b/tests/symengine/substitution_maps_scalar_02.cc
@@ -24,7 +24,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_scalar_03.cc
+++ b/tests/symengine/substitution_maps_scalar_03.cc
@@ -28,7 +28,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_scalar_04.cc
+++ b/tests/symengine/substitution_maps_scalar_04.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_scalar_05.cc
+++ b/tests/symengine/substitution_maps_scalar_05.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_tensor_01.cc
+++ b/tests/symengine/substitution_maps_tensor_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_tensor_02.cc
+++ b/tests/symengine/substitution_maps_tensor_02.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_tensor_03.cc
+++ b/tests/symengine/substitution_maps_tensor_03.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/substitution_maps_tensor_04.cc
+++ b/tests/symengine/substitution_maps_tensor_04.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/symengine_number_type_01.cc
+++ b/tests/symengine/symengine_number_type_01.cc
@@ -36,7 +36,6 @@
 
 #include "../serialization/serialization.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = ::SymEngine;
 

--- a/tests/symengine/symengine_number_type_02.cc
+++ b/tests/symengine/symengine_number_type_02.cc
@@ -27,7 +27,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 namespace SE = SymEngine;
 

--- a/tests/symengine/symengine_number_type_03.cc
+++ b/tests/symengine/symengine_number_type_03.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 int

--- a/tests/symengine/symengine_scalar_operations_01.cc
+++ b/tests/symengine/symengine_scalar_operations_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 

--- a/tests/symengine/symengine_scalar_operations_02.cc
+++ b/tests/symengine/symengine_scalar_operations_02.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 

--- a/tests/symengine/symengine_scalar_operations_03.cc
+++ b/tests/symengine/symengine_scalar_operations_03.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 

--- a/tests/symengine/symengine_scalar_operations_04.cc
+++ b/tests/symengine/symengine_scalar_operations_04.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <typename Number1, typename Number2>

--- a/tests/symengine/symengine_tensor_operations_01.cc
+++ b/tests/symengine/symengine_tensor_operations_01.cc
@@ -21,7 +21,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 

--- a/tests/symengine/symengine_tensor_operations_02.cc
+++ b/tests/symengine/symengine_tensor_operations_02.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 template <int dim, typename NumberType>

--- a/tests/symengine/symengine_tensor_operations_03.cc
+++ b/tests/symengine/symengine_tensor_operations_03.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 // Function and its derivatives

--- a/tests/symengine/symengine_tensor_operations_04.cc
+++ b/tests/symengine/symengine_tensor_operations_04.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 using SD_number_t = SD::Expression;

--- a/tests/symengine/symengine_utilities_01.cc
+++ b/tests/symengine/symengine_utilities_01.cc
@@ -20,7 +20,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 namespace SD = Differentiation::SD;
 
 

--- a/tests/tensors/symmetric_tensor_30.cc
+++ b/tests/tensors/symmetric_tensor_30.cc
@@ -26,7 +26,6 @@ template <int dim>
 void
 check_2()
 {
-  using namespace dealii;
   Testing::rand(true, 42);
 
   SymmetricTensor<2, dim> change_with_brackets;
@@ -61,7 +60,6 @@ template <int dim>
 void
 check_4()
 {
-  using namespace dealii;
   Testing::rand(true, 42);
 
   SymmetricTensor<4, dim> change_with_brackets;

--- a/tests/tensors/tensor_28.cc
+++ b/tests/tensors/tensor_28.cc
@@ -30,7 +30,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/tensors/tensor_30.cc
+++ b/tests/tensors/tensor_30.cc
@@ -25,7 +25,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/trilinos/assemble_matrix_parallel_01.cc
+++ b/tests/trilinos/assemble_matrix_parallel_01.cc
@@ -54,7 +54,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_02.cc
+++ b/tests/trilinos/assemble_matrix_parallel_02.cc
@@ -57,7 +57,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_03.cc
+++ b/tests/trilinos/assemble_matrix_parallel_03.cc
@@ -58,7 +58,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_04.cc
+++ b/tests/trilinos/assemble_matrix_parallel_04.cc
@@ -59,7 +59,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_05.cc
+++ b/tests/trilinos/assemble_matrix_parallel_05.cc
@@ -59,7 +59,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_06.cc
+++ b/tests/trilinos/assemble_matrix_parallel_06.cc
@@ -61,7 +61,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/assemble_matrix_parallel_07.cc
+++ b/tests/trilinos/assemble_matrix_parallel_07.cc
@@ -58,7 +58,6 @@
 
 std::ofstream logfile("output");
 
-using namespace dealii;
 
 
 namespace Assembly

--- a/tests/trilinos/direct_solver_2.cc
+++ b/tests/trilinos/direct_solver_2.cc
@@ -46,7 +46,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -48,7 +48,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 template <int dim>
 class Step4

--- a/tests/trilinos/elide_zeros.cc
+++ b/tests/trilinos/elide_zeros.cc
@@ -89,8 +89,6 @@
 
 namespace LinearAdvectionTest
 {
-  using namespace dealii;
-
   template <int dim>
   class AdvectionProblem
   {
@@ -326,7 +324,6 @@ namespace LinearAdvectionTest
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   initlog();
 
   Utilities::MPI::MPI_InitFinalize         mpi_initialization(argc, argv, 1);

--- a/tests/trilinos/renumbering_01.cc
+++ b/tests/trilinos/renumbering_01.cc
@@ -46,7 +46,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 class Test
 {

--- a/tests/trilinos/solver_control_06.cc
+++ b/tests/trilinos/solver_control_06.cc
@@ -56,7 +56,6 @@
 
 namespace LA = dealii::LinearAlgebraTrilinos;
 
-using namespace dealii;
 
 class Test_Solver_Output
 {

--- a/tests/trilinos/trilinos_sparsity_pattern_02.cc
+++ b/tests/trilinos/trilinos_sparsity_pattern_02.cc
@@ -36,8 +36,6 @@
 
 namespace Step22
 {
-  using namespace dealii;
-
   template <int dim>
   class StokesProblem
   {
@@ -156,7 +154,6 @@ main(int argc, char *argv[])
 {
   try
     {
-      using namespace dealii;
       using namespace Step22;
 
       Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

--- a/tests/trilinos/update_ghosts.cc
+++ b/tests/trilinos/update_ghosts.cc
@@ -23,7 +23,6 @@
 int
 main(int argc, char **argv)
 {
-  using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   initlog();

--- a/tests/trilinos/vector_reinit.cc
+++ b/tests/trilinos/vector_reinit.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 static const unsigned int dim = 2;
 

--- a/tests/trilinos/vector_reinit_to_linear_map.cc
+++ b/tests/trilinos/vector_reinit_to_linear_map.cc
@@ -34,7 +34,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 void
 test()

--- a/tests/vector_tools/integrate_difference_01.cc
+++ b/tests/vector_tools/integrate_difference_01.cc
@@ -37,8 +37,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
-
 
 // x+y(+z), x^2+y^2 (, z+xy)
 // div = 1+2y (+1)

--- a/tests/vector_tools/integrate_difference_01_complex_01.cc
+++ b/tests/vector_tools/integrate_difference_01_complex_01.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y(+z), x^2+y^2 (, z+xy)

--- a/tests/vector_tools/integrate_difference_01_complex_02.cc
+++ b/tests/vector_tools/integrate_difference_01_complex_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y(+z), x^2+y^2 (, z+xy) times i

--- a/tests/vector_tools/integrate_difference_01_complex_03.cc
+++ b/tests/vector_tools/integrate_difference_01_complex_03.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y(+z), x^2+y^2 (, z+xy) times (1+i)/sqrt(2)

--- a/tests/vector_tools/integrate_difference_01_complex_04.cc
+++ b/tests/vector_tools/integrate_difference_01_complex_04.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y(+z), x^2+y^2 (, z+xy) times (1+i)/sqrt(2)

--- a/tests/vector_tools/integrate_difference_02.cc
+++ b/tests/vector_tools/integrate_difference_02.cc
@@ -38,7 +38,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y+z, x^2+y^2, z+xy

--- a/tests/vector_tools/integrate_difference_02_nan.cc
+++ b/tests/vector_tools/integrate_difference_02_nan.cc
@@ -62,7 +62,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 template <int dim>

--- a/tests/vector_tools/integrate_difference_03.cc
+++ b/tests/vector_tools/integrate_difference_03.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y+z, x^2+y^2, z+xy

--- a/tests/vector_tools/integrate_difference_04.cc
+++ b/tests/vector_tools/integrate_difference_04.cc
@@ -39,7 +39,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y+z, x^2+y^2, z+xy

--- a/tests/vector_tools/integrate_difference_04_hp.cc
+++ b/tests/vector_tools/integrate_difference_04_hp.cc
@@ -45,7 +45,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y+z, x^2+y^2, z+xy

--- a/tests/vector_tools/integrate_difference_04_hp_02.cc
+++ b/tests/vector_tools/integrate_difference_04_hp_02.cc
@@ -49,7 +49,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 
 // x+y+z, x^2+y^2, z+xy

--- a/tests/vector_tools/integrate_difference_05.cc
+++ b/tests/vector_tools/integrate_difference_05.cc
@@ -39,7 +39,6 @@
 #include "../tests.h"
 
 
-using namespace dealii;
 
 // First dim components:
 // f_x = x^2+y(+z), f_y = x^2+y^2, f_z = z+xy

--- a/tests/vector_tools/interpolate_with_material_id_01.cc
+++ b/tests/vector_tools/interpolate_with_material_id_01.cc
@@ -55,8 +55,6 @@
 
 namespace PhaseField
 {
-  using namespace dealii;
-
   typedef Vector<double> vectorType;
 
 

--- a/tests/vector_tools/interpolate_with_material_id_02.cc
+++ b/tests/vector_tools/interpolate_with_material_id_02.cc
@@ -40,7 +40,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 template <int dim>
 void

--- a/tests/zoltan/tria_zoltan_01.cc
+++ b/tests/zoltan/tria_zoltan_01.cc
@@ -23,7 +23,6 @@
 
 #include "../tests.h"
 
-using namespace dealii;
 
 // Test to check whether Zoltan PHG throws warning because
 // PHG_EDGE_SIZE_THRESHOLD value is low.


### PR DESCRIPTION
`tests/tests.h` already contains the line `using namespace dealii;`

I removed this namespace statement from all test files that internally include `../tests.h`.

I used a shell command with a combination of `sed` and `grep`.

I double checked that all of my modified files indeed have `#include "../tests.h"` in them.

I did not run the test suite but I assume there should not be an error anywhere.