### PR TITLE
Remove hp::DoFHandler::get_fe()

### DIFF
--- a/doc/news/changes/incompatibilities/20200326PeterMunch
+++ b/doc/news/changes/incompatibilities/20200326PeterMunch
@@ -1,0 +1,4 @@
+Removed: The deprecated method hp::DoFHandler::get_fe() has been removed. Please use
+hp::DoFHandler::get_fe_collection() instead.
+<br>
+(Peter Munch, 2020/03/26)

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -956,16 +956,6 @@ namespace hp
                              locally_owned_mg_dofs_per_processor(const unsigned int level) const;
 
     /**
-     * Return a constant reference to the set of finite element objects that
-     * are used by this @p DoFHandler.
-     *
-     * @deprecated Use get_fe_collection() instead.
-     */
-    DEAL_II_DEPRECATED
-    const hp::FECollection<dim, spacedim> &
-    get_fe() const;
-
-    /**
      * Return a constant reference to the indexth finite element object that is
      * used by this @p DoFHandler.
      */
@@ -1716,18 +1706,6 @@ namespace hp
     else
       return mg_number_cache[level].get_locally_owned_dofs_per_processor(
         MPI_COMM_SELF);
-  }
-
-
-
-  template <int dim, int spacedim>
-  inline const hp::FECollection<dim, spacedim> &
-  DoFHandler<dim, spacedim>::get_fe() const
-  {
-    Assert(fe_collection.size() > 0,
-           ExcMessage("No finite element collection is associated with "
-                      "this DoFHandler"));
-    return fe_collection;
   }
 
 

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -529,7 +529,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
   {
     unsigned int n_components = 0;
     for (unsigned int no = 0; no < dof_handler.size(); ++no)
-      n_components += dof_handler[no]->get_fe()[0].n_base_elements();
+      n_components += dof_handler[no]->get_fe(0).n_base_elements();
     const unsigned int n_quad             = quad.size();
     unsigned int       n_fe_in_collection = 0;
     for (unsigned int i = 0; i < n_components; ++i)
@@ -587,7 +587,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
             additional_data.store_plain_indices;
           dof_info[no].global_base_element_offset =
             no > 0 ? dof_info[no - 1].global_base_element_offset +
-                       dof_handler[no - 1]->get_fe()[0].n_base_elements() :
+                       dof_handler[no - 1]->get_fe(0).n_base_elements() :
                      0;
         }
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1253,7 +1253,7 @@ namespace internal
       const VectorType *vector = &((*vectors)[dof_cell->level()]);
 
       const unsigned int dofs_per_cell =
-        this->dof_handler->get_fe()[0].dofs_per_cell;
+        this->dof_handler->get_fe(0).dofs_per_cell;
 
       std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
       dof_cell->get_mg_dof_indices(dof_indices);
@@ -1292,7 +1292,7 @@ namespace internal
       const VectorType *vector = &((*vectors)[dof_cell->level()]);
 
       const unsigned int dofs_per_cell =
-        this->dof_handler->get_fe()[0].dofs_per_cell;
+        this->dof_handler->get_fe(0).dofs_per_cell;
 
       std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
       dof_cell->get_mg_dof_indices(dof_indices);

--- a/include/deal.II/numerics/vector_tools.templates.h
+++ b/include/deal.II/numerics/vector_tools.templates.h
@@ -286,7 +286,7 @@ namespace VectorTools
                 const ComponentMask &                component_mask)
     {
       Assert(component_mask.represents_n_components(
-               dof_handler.get_fe().n_components()),
+               dof_handler.get_fe_collection().n_components()),
              ExcMessage(
                "The number of components in the mask has to be either "
                "zero or equal to the number of components in the finite "
@@ -296,7 +296,7 @@ namespace VectorTools
              ExcDimensionMismatch(vec.size(), dof_handler.n_dofs()));
 
       Assert(component_mask.n_selected_components(
-               dof_handler.get_fe().n_components()) > 0,
+               dof_handler.get_fe_collection().n_components()) > 0,
              ComponentMask::ExcNoComponentSelected());
 
       //
@@ -427,9 +427,10 @@ namespace VectorTools
           dof_values.resize(n_dofs);
 
           // Get all function values:
-          Assert(n_components == function(cell)->n_components,
-                 ExcDimensionMismatch(dof_handler.get_fe().n_components(),
-                                      function(cell)->n_components));
+          Assert(
+            n_components == function(cell)->n_components,
+            ExcDimensionMismatch(dof_handler.get_fe_collection().n_components(),
+                                 function(cell)->n_components));
           function(cell)->vector_value_list(generalized_support_points,
                                             function_values);
 
@@ -553,8 +554,9 @@ namespace VectorTools
     VectorType &                                               vec,
     const ComponentMask &                                      component_mask)
   {
-    Assert(dof_handler.get_fe().n_components() == function.n_components,
-           ExcDimensionMismatch(dof_handler.get_fe().n_components(),
+    Assert(dof_handler.get_fe_collection().n_components() ==
+             function.n_components,
+           ExcDimensionMismatch(dof_handler.get_fe_collection().n_components(),
                                 function.n_components));
 
     // Create a small lambda capture wrapping function and call the

--- a/tests/distributed_grids/hp_2d_dofhandler_01.cc
+++ b/tests/distributed_grids/hp_2d_dofhandler_01.cc
@@ -63,7 +63,7 @@ test()
 
   typename hp::DoFHandler<dim>::active_cell_iterator cell = dofh.begin_active();
 
-  const unsigned int dofs_per_cell = dofh.get_fe()[0].dofs_per_cell;
+  const unsigned int dofs_per_cell = dofh.get_fe(0).dofs_per_cell;
   std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
 

--- a/tests/dofs/dof_tools_12.cc
+++ b/tests/dofs/dof_tools_12.cc
@@ -28,7 +28,7 @@ template <typename DoFHandlerType>
 void
 check_this(const DoFHandlerType &dof_handler)
 {
-  std::vector<bool> mask(dof_handler.get_fe().n_components(), false);
+  std::vector<bool> mask(dof_handler.get_fe(0).n_components(), false);
 
   // only select first component
   mask[0] = true;

--- a/tests/hp/dof_renumbering_04.cc
+++ b/tests/hp/dof_renumbering_04.cc
@@ -64,9 +64,9 @@ template <int dim>
 void
 check_renumbering(hp::DoFHandler<dim> &dof)
 {
-  for (unsigned int i = 0; i < dof.get_fe().size(); ++i)
+  for (unsigned int i = 0; i < dof.get_fe_collection().size(); ++i)
     {
-      const FiniteElement<dim> &element = dof.get_fe()[i];
+      const FiniteElement<dim> &element = dof.get_fe_collection()[i];
       deallog << element.get_name() << std::endl;
     }
 

--- a/tests/hp/dof_renumbering_05.cc
+++ b/tests/hp/dof_renumbering_05.cc
@@ -64,9 +64,9 @@ template <int dim>
 void
 check_renumbering(hp::DoFHandler<dim> &dof)
 {
-  for (unsigned int i = 0; i < dof.get_fe().size(); ++i)
+  for (unsigned int i = 0; i < dof.get_fe_collection().size(); ++i)
     {
-      const FiniteElement<dim> &element = dof.get_fe()[i];
+      const FiniteElement<dim> &element = dof.get_fe_collection()[i];
       deallog << element.get_name() << std::endl;
     }
 

--- a/tests/hp/dof_renumbering_06.cc
+++ b/tests/hp/dof_renumbering_06.cc
@@ -64,9 +64,9 @@ template <int dim>
 void
 check_renumbering(hp::DoFHandler<dim> &dof)
 {
-  for (unsigned int i = 0; i < dof.get_fe().size(); ++i)
+  for (unsigned int i = 0; i < dof.get_fe_collection().size(); ++i)
     {
-      const FiniteElement<dim> &element = dof.get_fe()[i];
+      const FiniteElement<dim> &element = dof.get_fe_collection()[i];
       deallog << element.get_name() << std::endl;
     }
 

--- a/tests/hp/n_active_fe_indices.cc
+++ b/tests/hp/n_active_fe_indices.cc
@@ -47,7 +47,7 @@ check_cells(const hp::DoFHandler<dim> &dof_handler)
       deallog << "cell=" << cell << std::endl;
       deallog << "n=" << cell->n_active_fe_indices() << std::endl;
       deallog << "x=";
-      for (unsigned int i = 0; i < dof_handler.get_fe().size(); ++i)
+      for (unsigned int i = 0; i < dof_handler.get_fe_collection().size(); ++i)
         deallog << cell->fe_index_is_active(i);
       deallog << std::endl;
 
@@ -74,7 +74,8 @@ check_faces(const hp::DoFHandler<dim> &dof_handler)
         deallog << "face=" << cell->face(f) << std::endl;
         deallog << "n=" << cell->face(f)->n_active_fe_indices() << std::endl;
         deallog << "x=";
-        for (unsigned int i = 0; i < dof_handler.get_fe().size(); ++i)
+        for (unsigned int i = 0; i < dof_handler.get_fe_collection().size();
+             ++i)
           deallog << cell->face(f)->fe_index_is_active(i);
         deallog << std::endl;
 
@@ -107,13 +108,14 @@ check_edges(const hp::DoFHandler<dim> &dof_handler)
         deallog << "edge=" << cell->line(e) << std::endl;
         deallog << "n=" << cell->line(e)->n_active_fe_indices() << std::endl;
         deallog << "x=";
-        for (unsigned int i = 0; i < dof_handler.get_fe().size(); ++i)
+        for (unsigned int i = 0; i < dof_handler.get_fe_collection().size();
+             ++i)
           deallog << cell->line(e)->fe_index_is_active(i);
         deallog << std::endl;
 
         Assert(cell->line(e)->n_active_fe_indices() >= 1, ExcInternalError());
         Assert(cell->line(e)->n_active_fe_indices() <=
-                 dof_handler.get_fe().size(),
+                 dof_handler.get_fe_collection().size(),
                ExcInternalError());
       }
 }

--- a/tests/hp/renumber_block_wise_02.cc
+++ b/tests/hp/renumber_block_wise_02.cc
@@ -75,7 +75,7 @@ check_renumbering(hp::DoFHandler<dim> &dof)
   // components so that each
   // component maps to its natural
   // block
-  std::vector<unsigned int> order(dof.get_fe().n_components());
+  std::vector<unsigned int> order(dof.get_fe_collection().n_components());
   order[0] = 0;
   order[1] = 1;
   order[2] = 1;

--- a/tests/hp/renumber_component_wise.cc
+++ b/tests/hp/renumber_component_wise.cc
@@ -69,7 +69,7 @@ check_renumbering(hp::DoFHandler<dim> &dof)
 {
   // Prepare a reordering of
   // components for later use
-  std::vector<unsigned int> order(dof.get_fe().n_components());
+  std::vector<unsigned int> order(dof.get_fe_collection().n_components());
   for (unsigned int i = 0; i < order.size(); ++i)
     order[i] = order.size() - i - 1;
 

--- a/tests/hp/step-12.cc
+++ b/tests/hp/step-12.cc
@@ -484,7 +484,7 @@ template <int dim>
 void
 DGMethod<dim>::assemble_system1()
 {
-  const unsigned int dofs_per_cell = dof_handler.get_fe()[0].dofs_per_cell;
+  const unsigned int dofs_per_cell = dof_handler.get_fe(0).dofs_per_cell;
   std::vector<types::global_dof_index> dofs(dofs_per_cell);
   std::vector<types::global_dof_index> dofs_neighbor(dofs_per_cell);
 
@@ -663,7 +663,7 @@ template <int dim>
 void
 DGMethod<dim>::assemble_system2()
 {
-  const unsigned int dofs_per_cell = dof_handler.get_fe()[0].dofs_per_cell;
+  const unsigned int dofs_per_cell = dof_handler.get_fe(0).dofs_per_cell;
   std::vector<types::global_dof_index> dofs(dofs_per_cell);
   std::vector<types::global_dof_index> dofs_neighbor(dofs_per_cell);
 


### PR DESCRIPTION
This PR removes the deprecated method `hp::DoFHandler::get_fe()`. I guess we can do this since the function has been deprecated more than two years ago.

Do you agree @bangerth and @marcfehling?