### PR TITLE
Change return type of DoFHandler::n_locally_owned_dofs()

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1023,7 +1023,7 @@ public:
    * cells owned by other processors may be theirs, and degrees of freedom on
    * ghost cells are also not necessarily included.
    */
-  unsigned int
+  types::global_dof_index
   n_locally_owned_dofs() const;
 
   /**
@@ -1495,7 +1495,7 @@ DoFHandler<dim, spacedim>::n_dofs(const unsigned int level) const
 
 
 template <int dim, int spacedim>
-unsigned int
+types::global_dof_index
 DoFHandler<dim, spacedim>::n_locally_owned_dofs() const
 {
   return number_cache.n_locally_owned_dofs;


### PR DESCRIPTION
I would like to make the return type of this function consistent with the return type of `hp::DoFHandler::n_locally_owned_dofs()`.