### PR TITLE
Uniquely specify namespace

### DIFF
--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -169,10 +169,11 @@ namespace internal
     template <typename Functor>
     void
     parallel_for(
-      Functor &                                                  functor,
-      const size_type                                            start,
-      const size_type                                            end,
-      const std::shared_ptr<parallel::internal::TBBPartitioner> &partitioner)
+      Functor &       functor,
+      const size_type start,
+      const size_type end,
+      const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+        &partitioner)
     {
 #ifdef DEAL_II_WITH_THREADS
       const size_type vec_size = end - start;
@@ -197,12 +198,12 @@ namespace internal
           // vector entries). The number of chunks here is calculated inside
           // TBBForFunctor. See also GitHub issue #2496 for further discussion
           // of this strategy.
-          parallel::internal::parallel_for(static_cast<size_type>(0),
-                                           static_cast<size_type>(
-                                             generic_functor.n_chunks),
-                                           generic_functor,
-                                           1,
-                                           tbb_partitioner);
+          ::dealii::parallel::internal::parallel_for(
+            static_cast<size_type>(0),
+            static_cast<size_type>(generic_functor.n_chunks),
+            generic_functor,
+            1,
+            tbb_partitioner);
           partitioner->release_one_partitioner(tbb_partitioner);
         }
       else if (vec_size > 0)
@@ -303,7 +304,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -334,7 +335,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -368,7 +369,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -398,7 +399,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -426,7 +427,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -454,7 +455,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -489,7 +490,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -523,7 +524,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -561,7 +562,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -593,7 +594,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -624,7 +625,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -660,7 +661,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -702,7 +703,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -736,7 +737,7 @@ namespace internal
       void
       operator()(const size_type begin, const size_type end) const
       {
-        if (parallel::internal::EnableOpenMPSimdFor<Number>::value)
+        if (::dealii::parallel::internal::EnableOpenMPSimdFor<Number>::value)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (size_type i = begin; i < end; ++i)
@@ -1372,11 +1373,12 @@ namespace internal
     template <typename Operation, typename ResultType>
     void
     parallel_reduce(
-      const Operation &                                          op,
-      const size_type                                            start,
-      const size_type                                            end,
-      ResultType &                                               result,
-      const std::shared_ptr<parallel::internal::TBBPartitioner> &partitioner)
+      const Operation &op,
+      const size_type  start,
+      const size_type  end,
+      ResultType &     result,
+      const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+        &partitioner)
     {
 #ifdef DEAL_II_WITH_THREADS
       const size_type vec_size = end - start;
@@ -1403,12 +1405,12 @@ namespace internal
           // vector entries). The number of chunks here is calculated inside
           // TBBForFunctor. See also GitHub issue #2496 for further discussion
           // of this strategy.
-          parallel::internal::parallel_for(static_cast<size_type>(0),
-                                           static_cast<size_type>(
-                                             generic_functor.n_chunks),
-                                           generic_functor,
-                                           1,
-                                           tbb_partitioner);
+          ::dealii::parallel::internal::parallel_for(
+            static_cast<size_type>(0),
+            static_cast<size_type>(generic_functor.n_chunks),
+            generic_functor,
+            1,
+            tbb_partitioner);
           partitioner->release_one_partitioner(tbb_partitioner);
           result = generic_functor.do_sum();
         }


### PR DESCRIPTION
This PR fixes a bug that only appears when trying to combine and collectively compile deal.II header files (like we do in ASPECT using cotire). Using the namespace `parallel::internal` in  `include/deal.II/lac/vector_operations_internal.h` leads to errors of the form: `namespace dealii::internal::parallel::internal not declared` when including the combined header (tested with gcc 9.2.1). Of course we are really looking for the namespace `dealii::parallel::internal` but the namespace lookup gets confused. I suspect this is because there is a namespace `dealii::internal::parallel` declared in `distributed/cell_data_transfer.templates.h` and we are inside `dealii::internal` when starting this lookup, which is why the compiler ends up in the wrong namespace. This PR removes the compiler errors by fully referencing the namespace. I suspect this problem appeared before, because most other references in this file to this particular namespace already include the leading `::dealii::`.