### PR TITLE
GridTools/GridGenerator: add some functions to support dim-independent programming

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1756,6 +1756,22 @@ namespace GridGenerator
     const std::vector<types::manifold_id> &manifold_priorities = {});
 
   /**
+   * Overload of extrude_triangulation() to allow dimension independent
+   * code to compile. This function throws an error when called, as
+   * extrude_triangulation() is only implemented to extrude a dim=2 to a dim=3
+   * Triangulation.
+   */
+  void
+  extrude_triangulation(
+    const Triangulation<2, 2> &            input,
+    const unsigned int                     n_slices,
+    const double                           height,
+    Triangulation<2, 2> &                  result,
+    const bool                             copy_manifold_ids   = false,
+    const std::vector<types::manifold_id> &manifold_priorities = {});
+
+
+  /**
    * Overload of the previous function. Take a 2d Triangulation that is being
    * extruded. Differing from the previous function taking height and number of
    * slices for uniform extrusion, this function takes z-axis values
@@ -1782,6 +1798,21 @@ namespace GridGenerator
     Triangulation<3, 3> &                  result,
     const bool                             copy_manifold_ids   = false,
     const std::vector<types::manifold_id> &manifold_priorities = {});
+
+  /**
+   * Overload of extrude_triangulation() to allow dimension independent
+   * code to compile. This function throws an error when called, as
+   * extrude_triangulation() is only implemented to extrude a dim=2 to a dim=3
+   * Triangulation.
+   */
+  void
+  extrude_triangulation(
+    const Triangulation<2, 2> &            input,
+    const std::vector<double> &            slice_coordinates,
+    Triangulation<2, 2> &                  result,
+    const bool                             copy_manifold_ids   = false,
+    const std::vector<types::manifold_id> &manifold_priorities = {});
+
 
 
   /**

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -453,9 +453,12 @@ namespace GridTools
    * given angle (given in radians, rather than degrees). This function uses
    * the transform() function above, so the requirements on the triangulation
    * stated there hold for this function as well.
+   *
+   * @note This function is only supported for dim=2.
    */
+  template <int dim>
   void
-  rotate(const double angle, Triangulation<2> &triangulation);
+  rotate(const double angle, Triangulation<dim> &triangulation);
 
   /**
    * Rotate all vertices of the given @p triangulation in counter-clockwise

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -6199,6 +6199,30 @@ namespace GridGenerator
   void
   extrude_triangulation(
     const Triangulation<2, 2> &            input,
+    const unsigned int                     n_slices,
+    const double                           height,
+    Triangulation<2, 2> &                  result,
+    const bool                             copy_manifold_ids,
+    const std::vector<types::manifold_id> &manifold_priorities)
+  {
+    (void)input;
+    (void)n_slices;
+    (void)height;
+    (void)result;
+    (void)copy_manifold_ids;
+    (void)manifold_priorities;
+
+    AssertThrow(false,
+                ExcMessage(
+                  "GridTools::extrude_triangulation() is only available "
+                  "for Triangulation<3, 3> as output triangulation."));
+  }
+
+
+
+  void
+  extrude_triangulation(
+    const Triangulation<2, 2> &            input,
     const std::vector<double> &            slice_coordinates,
     Triangulation<3, 3> &                  result,
     const bool                             copy_manifold_ids,
@@ -6423,6 +6447,29 @@ namespace GridGenerator
                ++line_n)
             face->line(line_n)->set_manifold_id(*manifold_id_it);
   }
+
+
+
+  void
+  extrude_triangulation(
+    const Triangulation<2, 2> &            input,
+    const std::vector<double> &            slice_coordinates,
+    Triangulation<2, 2> &                  result,
+    const bool                             copy_manifold_ids,
+    const std::vector<types::manifold_id> &manifold_priorities)
+  {
+    (void)input;
+    (void)slice_coordinates;
+    (void)result;
+    (void)copy_manifold_ids;
+    (void)manifold_priorities;
+
+    AssertThrow(false,
+                ExcMessage(
+                  "GridTools::extrude_triangulation() is only available "
+                  "for Triangulation<3, 3> as output triangulation."));
+  }
+
 
 
   template <>

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1068,12 +1068,24 @@ namespace GridTools
   }
 
 
-
+  template <>
   void
   rotate(const double angle, Triangulation<2> &triangulation)
   {
     transform(Rotate2d(angle), triangulation);
   }
+
+  template <>
+  void
+  rotate(const double angle, Triangulation<3> &triangulation)
+  {
+    (void)angle;
+    (void)triangulation;
+
+    AssertThrow(
+      false, ExcMessage("GridTools::rotate() is not available for dim = 3."));
+  }
+
 
   template <int dim>
   void


### PR DESCRIPTION
The functions ``rotate()`` and ``extrude_triangulation()`` are currently only implemented for dim=2 or 3. This PR allows to write code that can be compiled for dim=2,3.