### PR TITLE
Remove MGLevelObject::clear()

### DIFF
--- a/doc/news/changes/incompatibilities/20200326DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20200326DanielArndt-1
@@ -1,0 +1,4 @@
+Removed: The deprecated function MGLevelObject::clear() has been removed.
+Use MGLevelObject::clear_elements() instead.
+<br>
+(Daniel Arndt, 2020/03/26)

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -115,20 +115,6 @@ public:
    * function will fail with a compiler error if the @p Object
    * template type to this class does not provide a
    * <code>clear()</code> member function.
-   *
-   * @deprecated Use clear_elements () instead
-   */
-  DEAL_II_DEPRECATED
-  void
-  clear();
-
-  /**
-   * Call @p clear on all objects stored by this object. This function
-   * is only implemented for some @p Object classes, e.g., matrix
-   * types or the PreconditionBlockSOR and similar classes. Using this
-   * function will fail with a compiler error if the @p Object
-   * template type to this class does not provide a
-   * <code>clear()</code> member function.
    */
   void
   clear_elements();
@@ -234,15 +220,6 @@ MGLevelObject<Object>::operator=(const double d)
   for (v = objects.begin(); v != objects.end(); ++v)
     **v = d;
   return *this;
-}
-
-
-template <class Object>
-void
-MGLevelObject<Object>::clear() // DEPRECATED
-{
-  // Avoid code duplication in deprecated call by calling replacing function
-  clear_elements();
 }
 
 

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -478,11 +478,11 @@ namespace Step39
 
     const unsigned int n_levels = triangulation.n_global_levels();
     mg_matrix.resize(0, n_levels - 1);
-    mg_matrix.clear();
+    mg_matrix.clear_elements();
     mg_matrix_dg_up.resize(0, n_levels - 1);
-    mg_matrix_dg_up.clear();
+    mg_matrix_dg_up.clear_elements();
     mg_matrix_dg_down.resize(0, n_levels - 1);
-    mg_matrix_dg_down.clear();
+    mg_matrix_dg_down.clear_elements();
 
     for (unsigned int level = mg_matrix.min_level();
          level <= mg_matrix.max_level();


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/2922.