### PR TITLE
Remove Utilities::MPI::Partitioner::get_communicator()

### DIFF
--- a/doc/news/changes/incompatibilities/20200326DanielArndt-3
+++ b/doc/news/changes/incompatibilities/20200326DanielArndt-3
@@ -1,0 +1,5 @@
+Removed: The deprecated function Utilities::MPI_Partitioner::get_communicator()
+has been removed. Use Utilities::MPI::Partitioner::get_mpi_communicator()
+instead.
+<br>
+(Daniel Arndt, 2020/03/26)

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -440,13 +440,6 @@ namespace Utilities
       /**
        * Return the MPI communicator underlying the partitioner object.
        */
-      DEAL_II_DEPRECATED
-      const MPI_Comm &
-      get_communicator() const;
-
-      /**
-       * Return the MPI communicator underlying the partitioner object.
-       */
       virtual const MPI_Comm &
       get_mpi_communicator() const override;
 
@@ -940,14 +933,6 @@ namespace Utilities
       // class instead of Utilities::MPI::n_mpi_processes() in order to make
       // this query also work when MPI is not initialized.
       return n_procs;
-    }
-
-
-
-    inline const MPI_Comm &
-    Partitioner::get_communicator() const
-    {
-      return communicator;
     }
 
 

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -580,7 +580,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return -Utilities::MPI::max(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }
@@ -606,7 +606,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }
@@ -627,7 +627,8 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
-                 local_result, this->block(0).partitioner->get_communicator()) /
+                 local_result,
+                 this->block(0).partitioner->get_mpi_communicator()) /
                static_cast<real_type>(this->size());
       else
         return local_result / static_cast<real_type>(this->size());
@@ -647,7 +648,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }
@@ -666,7 +667,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }
@@ -693,10 +694,10 @@ namespace LinearAlgebra
         local_result += std::pow(this->block(i).lp_norm_local(p), p);
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
-        return std::pow(
-          Utilities::MPI::sum(local_result,
-                              this->block(0).partitioner->get_communicator()),
-          static_cast<real_type>(1.0 / p));
+        return std::pow(Utilities::MPI::sum(
+                          local_result,
+                          this->block(0).partitioner->get_mpi_communicator()),
+                        static_cast<real_type>(1.0 / p));
       else
         return std::pow(local_result, static_cast<real_type>(1.0 / p));
     }
@@ -716,7 +717,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::max(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }
@@ -750,7 +751,7 @@ namespace LinearAlgebra
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(
-          local_result, this->block(0).partitioner->get_communicator());
+          local_result, this->block(0).partitioner->get_mpi_communicator());
       else
         return local_result;
     }


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/2615.