### PR TITLE
Remove deprecated Multigrid related constructors and functions

### DIFF
--- a/doc/news/changes/incompatibilities/20200327DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20200327DanielArndt-1
@@ -1,0 +1,6 @@
+Removed: The deprecated functions DoFHandler::distribute_mg_dofs() and
+MGTransferPrebuilt::initialize_constraints() and deprecated constructors for
+MGSmootherBlock, MGTransferPrebuilt, MGTransferBlockBase and
+MGTransferBlockSelect have been removed.
+<br>
+(Daniel Arndt, 2020/03/27)

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -536,18 +536,6 @@ public:
   /**
    * Distribute level degrees of freedom on each level for geometric
    * multigrid. The active DoFs need to be distributed using distribute_dofs()
-   * before calling this function and the @p fe needs to be identical to the
-   * finite element passed to distribute_dofs().
-   *
-   * @deprecated Use the version without parameter instead.
-   */
-  DEAL_II_DEPRECATED
-  virtual void
-  distribute_mg_dofs(const FiniteElement<dim, spacedim> &fe);
-
-  /**
-   * Distribute level degrees of freedom on each level for geometric
-   * multigrid. The active DoFs need to be distributed using distribute_dofs()
    * before calling this function.
    */
   virtual void

--- a/include/deal.II/multigrid/mg_block_smoother.h
+++ b/include/deal.II/multigrid/mg_block_smoother.h
@@ -52,20 +52,6 @@ class MGSmootherBlock : public MGSmoother<BlockVector<number>>
 {
 public:
   /**
-   * @deprecated Since GrowingVectorMemory now uses a joint memory pool, it is
-   * recommended to use the constructor without the memory object.
-   *
-   * Constructor. Sets memory and smoothing parameters.
-   */
-  DEAL_II_DEPRECATED
-  MGSmootherBlock(VectorMemory<BlockVector<number>> &mem,
-                  const unsigned int                 steps     = 1,
-                  const bool                         variable  = false,
-                  const bool                         symmetric = false,
-                  const bool                         transpose = false,
-                  const bool                         reverse   = false);
-
-  /**
    * Constructor.
    */
   MGSmootherBlock(const unsigned int steps     = 1,
@@ -148,19 +134,6 @@ private:
 //---------------------------------------------------------------------------
 
 #ifndef DOXYGEN
-
-template <typename MatrixType, class RelaxationType, typename number>
-inline MGSmootherBlock<MatrixType, RelaxationType, number>::MGSmootherBlock(
-  VectorMemory<BlockVector<number>> &mem,
-  const unsigned int                 steps,
-  const bool                         variable,
-  const bool                         symmetric,
-  const bool                         transpose,
-  const bool                         reverse)
-  : MGSmoother<BlockVector<number>>(steps, variable, symmetric, transpose)
-  , reverse(reverse)
-  , mem(&mem)
-{}
 
 template <typename MatrixType, class RelaxationType, typename number>
 inline MGSmootherBlock<MatrixType, RelaxationType, number>::MGSmootherBlock(

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -684,16 +684,6 @@ public:
   MGTransferPrebuilt(const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
-   * Constructor with constraints. Equivalent to the default constructor
-   * followed by initialize_constraints().
-   *
-   * @deprecated @p constraints is unused.
-   */
-  DEAL_II_DEPRECATED
-  MGTransferPrebuilt(const AffineConstraints<double> &constraints,
-                     const MGConstrainedDoFs &        mg_constrained_dofs);
-
-  /**
    * Destructor.
    */
   virtual ~MGTransferPrebuilt() override = default;
@@ -703,16 +693,6 @@ public:
    */
   void
   initialize_constraints(const MGConstrainedDoFs &mg_constrained_dofs);
-
-  /**
-   * Initialize the constraints to be used in build().
-   *
-   * @deprecated @p constraints is unused.
-   */
-  DEAL_II_DEPRECATED
-  void
-  initialize_constraints(const AffineConstraints<double> &constraints,
-                         const MGConstrainedDoFs &        mg_constrained_dofs);
 
   /**
    * Reset the object to the state it had right after the default constructor.

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -75,15 +75,6 @@ public:
   MGTransferBlockBase(const MGConstrainedDoFs &mg_constrained_dofs);
 
   /**
-   * Constructor with constraint matrices as well as mg_constrained_dofs.
-   *
-   * @deprecated @p constraints is unused.
-   */
-  DEAL_II_DEPRECATED
-  MGTransferBlockBase(const AffineConstraints<double> &constraints,
-                      const MGConstrainedDoFs &        mg_constrained_dofs);
-
-  /**
    * Memory used by this object.
    */
   std::size_t
@@ -351,15 +342,6 @@ public:
    * Constructor with constraint matrices as well as mg_constrained_dofs.
    */
   MGTransferBlockSelect(const MGConstrainedDoFs &mg_constrained_dofs);
-
-  /**
-   * Constructor with constraint matrices as well as mg_constrained_dofs.
-   *
-   * @deprecated @p constraints is unused.
-   */
-  DEAL_II_DEPRECATED
-  MGTransferBlockSelect(const AffineConstraints<double> &constraints,
-                        const MGConstrainedDoFs &        mg_constrained_dofs);
 
   /**
    * Destructor.

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -154,35 +154,6 @@ public:
   using const_vector_type = const VectorType;
 
   /**
-   * Constructor. The DoFHandler is used to check whether the provided
-   * minlevel and maxlevel are in the range of valid levels.
-   * If maxlevel is set to the default value, the highest valid
-   * level is used.
-   * <tt>transfer</tt> is an object performing prolongation and
-   * restriction.
-   *
-   * This function already initializes the vectors which will be used later in
-   * the course of the computations. You should therefore create objects of
-   * this type as late as possible.
-   *
-   * @deprecated Use the other constructor instead.
-   * The DoFHandler is actually not needed.
-   */
-  template <int dim>
-#ifndef _MSC_VER
-  DEAL_II_DEPRECATED
-#endif
-  Multigrid(const DoFHandler<dim> &             dof_handler,
-            const MGMatrixBase<VectorType> &    matrix,
-            const MGCoarseGridBase<VectorType> &coarse,
-            const MGTransferBase<VectorType> &  transfer,
-            const MGSmootherBase<VectorType> &  pre_smooth,
-            const MGSmootherBase<VectorType> &  post_smooth,
-            const unsigned int                  minlevel = 0,
-            const unsigned int maxlevel = numbers::invalid_unsigned_int,
-            Cycle              cycle    = v_cycle);
-
-  /**
    * Constructor. <tt>transfer</tt> is an object performing prolongation and
    * restriction. For levels in [minlevel, maxlevel] matrix has to contain
    * valid matrices. By default the maxlevel is set to the maximal valid level.
@@ -634,40 +605,6 @@ private:
 
 #ifndef DOXYGEN
 /* --------------------------- inline functions --------------------- */
-
-
-template <typename VectorType>
-template <int dim>
-Multigrid<VectorType>::Multigrid(const DoFHandler<dim> &         dof_handler,
-                                 const MGMatrixBase<VectorType> &matrix,
-                                 const MGCoarseGridBase<VectorType> &coarse,
-                                 const MGTransferBase<VectorType> &  transfer,
-                                 const MGSmootherBase<VectorType> &  pre_smooth,
-                                 const MGSmootherBase<VectorType> &post_smooth,
-                                 const unsigned int                min_level,
-                                 const unsigned int                max_level,
-                                 Cycle                             cycle)
-  : cycle_type(cycle)
-  , minlevel(min_level)
-  , matrix(&matrix, typeid(*this).name())
-  , coarse(&coarse, typeid(*this).name())
-  , transfer(&transfer, typeid(*this).name())
-  , pre_smooth(&pre_smooth, typeid(*this).name())
-  , post_smooth(&post_smooth, typeid(*this).name())
-  , edge_down(nullptr, typeid(*this).name())
-  , edge_up(nullptr, typeid(*this).name())
-  , debug(0)
-{
-  const unsigned int dof_handler_max_level =
-    dof_handler.get_triangulation().n_global_levels() - 1;
-  if (max_level == numbers::invalid_unsigned_int)
-    maxlevel = dof_handler_max_level;
-  else
-    maxlevel = max_level;
-
-  reinit(minlevel, maxlevel);
-}
-
 
 
 template <typename VectorType>

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1296,16 +1296,6 @@ DoFHandler<dim, spacedim>::distribute_dofs(
 
 template <int dim, int spacedim>
 void
-DoFHandler<dim, spacedim>::distribute_mg_dofs(
-  const FiniteElement<dim, spacedim> &)
-{
-  this->distribute_mg_dofs();
-}
-
-
-
-template <int dim, int spacedim>
-void
 DoFHandler<dim, spacedim>::distribute_mg_dofs()
 {
   Assert(

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -55,32 +55,11 @@ MGTransferPrebuilt<VectorType>::MGTransferPrebuilt(
 
 
 template <typename VectorType>
-MGTransferPrebuilt<VectorType>::MGTransferPrebuilt(
-  const AffineConstraints<double> & /*c*/,
-  const MGConstrainedDoFs &mg_c)
-{
-  this->mg_constrained_dofs = &mg_c;
-}
-
-
-
-template <typename VectorType>
 void
 MGTransferPrebuilt<VectorType>::initialize_constraints(
   const MGConstrainedDoFs &mg_c)
 {
   this->mg_constrained_dofs = &mg_c;
-}
-
-
-
-template <typename VectorType>
-void
-MGTransferPrebuilt<VectorType>::initialize_constraints(
-  const AffineConstraints<double> & /*c*/,
-  const MGConstrainedDoFs &mg_c)
-{
-  initialize_constraints(mg_c);
 }
 
 

--- a/source/multigrid/multigrid.cc
+++ b/source/multigrid/multigrid.cc
@@ -49,14 +49,6 @@ MGTransferBlockBase::MGTransferBlockBase(const MGConstrainedDoFs &mg_c)
 
 
 
-MGTransferBlockBase::MGTransferBlockBase(
-  const AffineConstraints<double> & /*c*/,
-  const MGConstrainedDoFs &mg_c)
-  : n_mg_blocks(0)
-  , mg_constrained_dofs(&mg_c)
-{}
-
-
 template <typename number>
 MGTransferBlock<number>::MGTransferBlock()
   : memory(nullptr, typeid(*this).name())
@@ -262,16 +254,6 @@ MGTransferBlockSelect<number>::MGTransferBlockSelect()
 
 template <typename number>
 MGTransferBlockSelect<number>::MGTransferBlockSelect(
-  const MGConstrainedDoFs &mg_c)
-  : MGTransferBlockBase(mg_c)
-  , selected_block(0)
-{}
-
-
-
-template <typename number>
-MGTransferBlockSelect<number>::MGTransferBlockSelect(
-  const AffineConstraints<double> & /*c*/,
   const MGConstrainedDoFs &mg_c)
   : MGTransferBlockBase(mg_c)
   , selected_block(0)

--- a/tests/bits/step-16.cc
+++ b/tests/bits/step-16.cc
@@ -273,12 +273,8 @@ LaplaceProblem<dim>::solve()
   mg_smoother.set_symmetric(true);
 
   mg::Matrix<Vector<double>> mg_matrix(mg_matrices);
-  Multigrid<Vector<double>>  mg(mg_dof_handler,
-                               mg_matrix,
-                               mg_coarse,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>>  mg(
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>
     preconditioner(mg_dof_handler, mg, mg_transfer);
 

--- a/tests/matrix_free/cell_level_and_index.cc
+++ b/tests/matrix_free/cell_level_and_index.cc
@@ -97,7 +97,7 @@ test(const bool adaptive_ref = true)
   FE_Q<dim>       fe(fe_degree);
   DoFHandler<dim> dof(tria);
   dof.distribute_dofs(fe);
-  dof.distribute_mg_dofs(fe);
+  dof.distribute_mg_dofs();
 
   AffineConstraints<double> constraints;
   constraints.close();

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -584,7 +584,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<LevelMatrixType>>

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -601,7 +601,7 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<dim, LevelMatrixType>>

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -509,7 +509,7 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,
                  MGTransferMF<dim, LevelMatrixType>>

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -408,7 +408,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,
                  MGTransferPrebuiltMF<LevelMatrixType>>

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -221,7 +221,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<double>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,
                  MGTransferMatrixFree<dim, double>>

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -593,7 +593,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -282,7 +282,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -604,7 +604,7 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -280,7 +280,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -601,7 +601,7 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -269,7 +269,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<double>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<double>,

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -353,7 +353,7 @@ do_test(const DoFHandler<dim> &dof)
     mg_interface_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface, mg_interface);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -420,7 +420,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<number>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,
                  MGTransferPrebuiltMF<dim, LevelMatrixType>>

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -416,7 +416,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<number>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,
                  MGTransferPrebuiltMF<dim, LevelMatrixType>>

--- a/tests/matrix_free/parallel_multigrid_mf_02.cc
+++ b/tests/matrix_free/parallel_multigrid_mf_02.cc
@@ -218,7 +218,7 @@ do_test(const DoFHandler<dim> &dof)
   mg::Matrix<LinearAlgebra::distributed::Vector<number>> mg_matrix(mg_matrices);
 
   Multigrid<LinearAlgebra::distributed::Vector<number>> mg(
-    dof, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
   PreconditionMG<dim,
                  LinearAlgebra::distributed::Vector<number>,
                  MGTransferMatrixFree<dim, number>>

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -591,7 +591,7 @@ namespace Step37
     mg::Matrix<Vector<double>> mg_matrix(mg_matrices);
 
     Multigrid<Vector<double>> mg(
-      dof_handler, mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+      mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
     PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>
       preconditioner(dof_handler, mg, mg_transfer);
 

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -423,13 +423,8 @@ namespace Step50
     // Now, we are ready to set up the
     // V-cycle operator and the
     // multilevel preconditioner.
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
-    mg.set_debug(2);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
     PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -410,13 +410,8 @@ namespace Step50
     // Now, we are ready to set up the
     // V-cycle operator and the
     // multilevel preconditioner.
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
-    mg.set_debug(2);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
     PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/mpi/step-39-block.cc
+++ b/tests/mpi/step-39-block.cc
@@ -682,12 +682,8 @@ namespace Step39
     mg::Matrix<TrilinosWrappers::MPI::Vector> mgdown(mg_matrix_dg_down);
     mg::Matrix<TrilinosWrappers::MPI::Vector> mgup(mg_matrix_dg_up);
 
-    Multigrid<TrilinosWrappers::MPI::Vector> mg(dof_handler,
-                                                mgmatrix,
-                                                coarse_grid_solver,
-                                                mg_transfer,
-                                                mg_smoother,
-                                                mg_smoother);
+    Multigrid<TrilinosWrappers::MPI::Vector> mg(
+      mgmatrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
 
     PreconditionMG<dim,

--- a/tests/mpi/step-39.cc
+++ b/tests/mpi/step-39.cc
@@ -652,12 +652,8 @@ namespace Step39
     mg::Matrix<TrilinosWrappers::MPI::Vector> mgdown(mg_matrix_dg_down);
     mg::Matrix<TrilinosWrappers::MPI::Vector> mgup(mg_matrix_dg_up);
 
-    Multigrid<TrilinosWrappers::MPI::Vector> mg(dof_handler,
-                                                mgmatrix,
-                                                coarse_grid_solver,
-                                                mg_transfer,
-                                                mg_smoother,
-                                                mg_smoother);
+    Multigrid<TrilinosWrappers::MPI::Vector> mg(
+      mgmatrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
 
     PreconditionMG<dim,

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -398,12 +398,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
 
     auto print_transfer_to_mg = [](const bool start) {
       deallog << "transfer_to_mg " << (start ? "started" : "finished")

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -469,12 +469,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
 
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 

--- a/tests/multigrid/mg_data_out_03.cc
+++ b/tests/multigrid/mg_data_out_03.cc
@@ -51,7 +51,7 @@ do_test()
 
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   Vector<double> global_dof_vector(dof_handler.n_dofs());
   VectorTools::interpolate(dof_handler,

--- a/tests/multigrid/mg_data_out_04.cc
+++ b/tests/multigrid/mg_data_out_04.cc
@@ -50,7 +50,7 @@ do_test()
   FE_Q<dim>       fe(1);
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   // Make FE vector
   IndexSet locally_relevant_dofs;

--- a/tests/multigrid/mg_data_out_05.cc
+++ b/tests/multigrid/mg_data_out_05.cc
@@ -56,7 +56,7 @@ do_test()
 
   DoFHandler<dim> dof_handler(triangulation);
   dof_handler.distribute_dofs(fe);
-  dof_handler.distribute_mg_dofs(fe);
+  dof_handler.distribute_mg_dofs();
 
   // Make FE vector
   IndexSet locally_relevant_dofs;

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -391,15 +391,10 @@ LaplaceProblem<dim>::test()
 
   mg::Matrix<Vector<double>> mg_matrix_renumbered(mg_matrices_renumbered);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
-                               mg_coarse,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>> mg(
+    mg_matrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
 
-  Multigrid<Vector<double>> mg_renumbered(mg_dof_handler_renumbered,
-                                          mg_matrix_renumbered,
+  Multigrid<Vector<double>> mg_renumbered(mg_matrix_renumbered,
                                           mg_coarse_renumbered,
                                           mg_transfer_renumbered,
                                           mg_smoother_renumbered,

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -491,12 +491,8 @@ LaplaceProblem<dim>::solve()
   mg::Matrix<> mg_interface_up(mg_interface_in);
   mg::Matrix<> mg_interface_down(mg_interface_in);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
-                               coarse_grid_solver,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>> mg(
+    mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -385,8 +385,7 @@ LaplaceProblem<dim>::solve()
   mg::Matrix<> mg_interface_up(mg_interface_matrices);
   mg::Matrix<> mg_interface_down(mg_interface_matrices);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
+  Multigrid<Vector<double>> mg(mg_matrix,
                                coarse_grid_solver,
                                mg_transfer,
                                mg_smoother,

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -374,7 +374,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> mg_transfer(
-    hanging_node_constraints, mg_constrained_dofs);
+    mg_constrained_dofs);
   mg_transfer.build(mg_dof_handler);
 
   SolverControl coarse_solver_control(1000, 1e-10, false, false);

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -374,7 +374,7 @@ void
 LaplaceProblem<dim>::solve()
 {
   MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>> mg_transfer(
-    hanging_node_constraints, mg_constrained_dofs);
+    mg_constrained_dofs);
   mg_transfer.build(mg_dof_handler);
 
   SolverControl coarse_solver_control(1000, 1e-10, false, false);

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -465,12 +465,8 @@ LaplaceProblem<dim>::solve()
   mg::Matrix<> mg_interface_up(mg_interface_matrices);
   mg::Matrix<> mg_interface_down(mg_interface_matrices);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
-                               coarse_grid_solver,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>> mg(
+    mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -454,12 +454,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
     PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -457,12 +457,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
     PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -454,12 +454,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
     PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -387,12 +387,8 @@ LaplaceProblem<dim>::solve()
   mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
   mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-  Multigrid<vector_t> mg(mg_dof_handler,
-                         mg_matrix,
-                         coarse_grid_solver,
-                         mg_transfer,
-                         mg_smoother,
-                         mg_smoother);
+  Multigrid<vector_t> mg(
+    mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, vector_t, MGTransferPrebuilt<vector_t>> preconditioner(

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -510,12 +510,8 @@ LaplaceProblem<dim>::solve(bool use_mw)
   // if (use_mw)
   // mg_interface_down.initialize(mg_interface_out);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
-                               coarse_grid_solver,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>> mg(
+    mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -466,12 +466,8 @@ LaplaceProblem<dim>::solve()
   mg::Matrix<> mg_interface_up(mg_interface_matrices);
   mg::Matrix<> mg_interface_down(mg_interface_matrices);
 
-  Multigrid<Vector<double>> mg(mg_dof_handler,
-                               mg_matrix,
-                               coarse_grid_solver,
-                               mg_transfer,
-                               mg_smoother,
-                               mg_smoother);
+  Multigrid<Vector<double>> mg(
+    mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
   mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 
   PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>

--- a/tests/multigrid/step-39-02.cc
+++ b/tests/multigrid/step-39-02.cc
@@ -612,7 +612,7 @@ namespace Step39
     mg::Matrix<Vector<double>> mgedge(mg_matrix_in_out);
 
     Multigrid<Vector<double>> mg(
-      dof_handler, mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+      mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
     mg.set_edge_matrices(mgedge, mgedge);
 

--- a/tests/multigrid/step-39-02a.cc
+++ b/tests/multigrid/step-39-02a.cc
@@ -619,7 +619,7 @@ namespace Step39
     mg::Matrix<Vector<double>> mgedge(mg_matrix_in_out);
 
     Multigrid<Vector<double>> mg(
-      dof_handler, mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+      mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
     mg.set_edge_matrices(mgedge, mgedge);
 

--- a/tests/multigrid/step-39-03.cc
+++ b/tests/multigrid/step-39-03.cc
@@ -618,7 +618,7 @@ namespace Step39
     mg::Matrix<Vector<double>> mgedge(mg_matrix_in_out);
 
     Multigrid<Vector<double>> mg(
-      dof_handler, mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+      mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
     mg.set_edge_matrices(mgedge, mgedge);
 

--- a/tests/multigrid/step-39.cc
+++ b/tests/multigrid/step-39.cc
@@ -601,7 +601,7 @@ namespace Step39
     mg::Matrix<Vector<double>> mgup(mg_matrix_dg_up);
 
     Multigrid<Vector<double>> mg(
-      dof_handler, mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
+      mgmatrix, mg_coarse, mg_transfer, mg_smoother, mg_smoother);
     mg.set_edge_flux_matrices(mgdown, mgup);
 
     PreconditionMG<dim, Vector<double>, MGTransferPrebuilt<Vector<double>>>

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -454,12 +454,8 @@ namespace Step50
     mg::Matrix<vector_t> mg_interface_up(mg_interface_matrices);
     mg::Matrix<vector_t> mg_interface_down(mg_interface_matrices);
 
-    Multigrid<vector_t> mg(mg_dof_handler,
-                           mg_matrix,
-                           coarse_grid_solver,
-                           mg_transfer,
-                           mg_smoother,
-                           mg_smoother);
+    Multigrid<vector_t> mg(
+      mg_matrix, coarse_grid_solver, mg_transfer, mg_smoother, mg_smoother);
 
     mg.set_edge_matrices(mg_interface_down, mg_interface_up);
 


### PR DESCRIPTION
Deprecated in #4908, #3139 and #3150.