### PR TITLE
Copy pieces of the module graph into some of the modules.

### DIFF
--- a/doc/doxygen/headers/dofs.h
+++ b/doc/doxygen/headers/dofs.h
@@ -60,4 +60,60 @@
  * such a way that the bandwidth of associated matrices is minimized. Finally,
  * the DoFTools namespace offers a variety of algorithms around handling
  * degrees of freedom.
+ *
+ * In the grand scheme of things, the pieces of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs", fillcolor="deepskyblue"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
  */

--- a/doc/doxygen/headers/fe.h
+++ b/doc/doxygen/headers/fe.h
@@ -26,6 +26,62 @@
  * are discussed in their respective sub-modules listed above. In addition,
  * the FETools class provides functions that provide information on finite
  * elements, transformations between elements, etc.
+ *
+ * In the grand scheme of things, the pieces of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall", fillcolor="deepskyblue"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
  */
 
 
@@ -105,6 +161,62 @@
  * complicated because it has to be general yet efficient. The page on
  * @ref UpdateFlags
  * attempts to give an overview of how this works.
+ *
+ * In the grand scheme of things, the pieces of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess", fillcolor="deepskyblue"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
  *
  * @ingroup feall
  */
@@ -204,6 +316,62 @@
  *
  * Finally, the MappingCartesian class is an optimization for elements that
  * are brick-shaped and with edges parallel to the coordinate axes.
+ *
+ * In the grand scheme of things, the pieces of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping", fillcolor="deepskyblue"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
  *
  * @ingroup feall
  */

--- a/doc/doxygen/headers/grid.h
+++ b/doc/doxygen/headers/grid.h
@@ -18,7 +18,7 @@
  * @defgroup grid Grid classes
  *
  * This module groups classes that have to do with the topology and
- * geometry of meshes. A mesh can be thought of a collection of cells;
+ * geometry of meshes. A mesh can be thought of as a collection of cells;
  * if the mesh has been refined (possibly in an adaptive way), then
  * this collection is grouped into a hierarchy of refinement
  * levels. In addition to cells, the geometric objects that make up a
@@ -28,24 +28,82 @@
  * triangulations made up of linear, quadrilateral, and hexahedral
  * cells; triangles and tetrahedra are not supported.
  *
- * This collection of cells is managed by the Triangulation class. It holds
- * the relevant data in memory and offers interfaces to query it. Most things
- * you want to do on cells are performed in loops over all cells. For this
- * purpose, the Triangulation class offers the concept of iterators (see @ref
- * Iterators): although implemented differently, they behave like pointers to
- * cells or faces and can be queried for the geometric properties of cells as
- * well as information like neighboring cells or faces of a cell.
+ * This collection of cells is managed by the Triangulation class and
+ * derived classes such as parallel::distributed::Triangulation and
+ * parallel::shared::Triangulation. It holds the relevant data in
+ * memory and offers interfaces to query it. Most things you want to
+ * do on cells are performed in loops over all cells. For this
+ * purpose, the Triangulation class offers the concept of iterators
+ * (see @ref Iterators): although implemented differently, they behave
+ * like pointers to cells or faces and can be queried for the
+ * geometric properties of cells as well as information like
+ * neighboring cells or faces of a cell.
  *
  * It is worth noting that the Triangulation class only stores geometry
  * (i.e. the location of vertices and cells) and topology of a mesh
  * (i.e. which cells are neighbors of which other cells, etc). It has nothing
  * to do with finite elements or degrees of freedom that might be defined on a
- * mesh. These functions are performed by the DoFHandler class (see the @ref
- * dofs module) that gets a description of the finite element space and the
+ * mesh. These functions are performed by the DoFHandler class (see the
+ * @ref dofs module) that gets a description of the finite element space and the
  * allocates and manages degrees of freedom on vertices, faces, or cells, as
  * described by the finite element class. This separation makes it possible to
  * have multiple DoFHandler classes work on the same mesh at the same time.
  *
+ * In the grand scheme of things, triangulations in deal.II interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid", fillcolor="deepskyblue"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
  *
  * <h3>Grid generation</h3>
  *

--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -41,7 +41,7 @@
         color="black", fillcolor="white", style="filled"];
   edge [color="black", weight=10];
 
-  tria       [label="Triangulation",    URL="\ref grid", ];
+  tria       [label="Triangulation",    URL="\ref grid"];
   fe         [label="Finite elements",    URL="\ref feall"];
   mapping    [label="Mapping",          URL="\ref mapping"];
   quadrature [label="Quadrature",       URL="\ref Quadrature"];

--- a/doc/doxygen/headers/manifold.h
+++ b/doc/doxygen/headers/manifold.h
@@ -95,6 +95,63 @@
  * reasonable implementations. More complicated examples can be described
  * using the techniques shown in step-53 and step-54.
  *
+ * In the grand scheme of things, the classes of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold", fillcolor="deepskyblue"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
+ *
+ *
  * <h3>An example</h3>
  *
  * A simple example why dealing with curved geometries is already provided by

--- a/doc/doxygen/headers/matrixfree.h
+++ b/doc/doxygen/headers/matrixfree.h
@@ -32,7 +32,7 @@ digraph G
   edge [color="black", weight=10];
   subgraph base {
     rank="same";
-  tria       [label="Triangulation",    URL="\ref grid", ];
+  tria       [label="Triangulation",    URL="\ref grid"];
   fe         [label="FiniteElement",    URL="\ref feall"];
   mapping    [label="Mapping",          URL="\ref mapping"];
   quadrature [label="Quadrature",       URL="\ref Quadrature"];

--- a/doc/doxygen/headers/quadrature.h
+++ b/doc/doxygen/headers/quadrature.h
@@ -30,6 +30,62 @@
  * coordinate direction than in another) through the QAnisotropic class, as
  * well as the definition of quadrature formulas that are not tensor products.
  *
+ * In the grand scheme of things, the classes of this module interact
+ * with a variety of other parts of the library:
+ * @dot
+ digraph G
+{
+  graph[rankdir="TB",bgcolor="transparent"];
+
+  node [fontname="FreeSans",fontsize=15,
+        shape=record,height=0.2,width=0.4,
+        color="black", fillcolor="white", style="filled"];
+  edge [color="black", weight=10];
+
+  tria       [label="Triangulation",    URL="\ref grid"];
+  fe         [label="Finite elements",    URL="\ref feall"];
+  mapping    [label="Mapping",          URL="\ref mapping"];
+  quadrature [label="Quadrature",       URL="\ref Quadrature", fillcolor="deepskyblue"];
+  dh         [label="DoFHandler",       URL="\ref dofs"];
+  fevalues   [label="FEValues",         URL="\ref feaccess"];
+  systems    [label="Linear systems",   URL="\ref LAC"];
+  solvers    [label="Linear solvers",   URL="\ref Solvers"];
+  output     [label="Graphical output", URL="\ref output"];
+  manifold   [label="Manifold",         URL="\ref manifold"];
+
+  tria -> dh              [color="black",style="solid"];
+  fe -> dh                [color="black",style="solid"];
+  fe -> fevalues          [color="black",style="solid"];
+  mapping -> fevalues     [color="black",style="solid"];
+  quadrature -> fevalues  [color="black",style="solid"];
+  dh -> systems           [color="black",style="solid"];
+  fevalues -> systems     [color="black",style="solid"];
+  systems -> solvers      [color="black",style="solid"];
+  solvers -> output       [color="black",style="solid"];
+  manifold -> tria        [color="black",style="solid"];
+  manifold -> mapping     [color="black",style="solid"];
+
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=record,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  opencascade [label="OpenCASCADE"];
+  opencascade -> manifold [dir="none"];
+
+
+  node [fontname="FreeSans",fontsize=12,
+        shape=ellipse,height=0.2,width=0.4,
+        color="gray55", fontcolor="gray55", fillcolor="white", style="filled"];
+  edge [color="gray55", weight=1];
+
+  gmsh        [label="gmsh", URL="\ref Gmsh"];
+  gmsh -> tria       [dir="none"];
+}
+ * @enddot
+ *
  *
  * <h3>Use</h3>
  *


### PR DESCRIPTION
For some modules, this patch copies a subset of the big module graph into the
module documentation, with the current module highlighted. This makes it
easier to see the connections between modules not just from the documentation
front page, but also from the individual modules.

This is analogous to #9717 and a follow-up to #9687.