### PR TITLE
Avoid deprecated VectorizedArray::n_array_elements

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -466,8 +466,8 @@ namespace internal
       compute_mapping_q(
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
-        const std::vector<
-          FaceToCellTopology<VectorizedArrayType::n_array_elements>> &faces);
+        const std::vector<FaceToCellTopology<VectorizedArrayType::size()>>
+          &faces);
 
       /**
        * Computes the information in the given cells, called within


### PR DESCRIPTION
In #9656 I did think of calling the abbreviation for `n_lanes = VectorizedArray::size()`, but missed the `n_array_elements` that got deprecated in #9688 while the PR was open. It is now fixed.