### PR TITLE
Follow-up to step-67: fix tutorial graph

### DIFF
--- a/examples/step-67/doc/builds-on
+++ b/examples/step-67/doc/builds-on
@@ -1,1 +1,1 @@
-step-33, step-48, step-59
+step-33 step-48 step-59


### PR DESCRIPTION
The tutorial graph
https://dealii.org/developer/doxygen/deal.II/Tutorial.html
does not render because step-67 messes up the links. This fixes the graph (tested locally).