### PR TITLE
Add output variants for new MF::MappingInfo test

### DIFF
--- a/tests/matrix_free/compress_mapping.output.avx512
+++ b/tests/matrix_free/compress_mapping.output.avx512
@@ -1,0 +1,21 @@
+
+DEAL:2d::General mesh
+DEAL:2d::OK
+DEAL:2d::Hyper cube
+DEAL:2d::OK
+DEAL:2d::Parallelogram
+DEAL:2d::OK
+DEAL:2d::Deformed hyper cube
+DEAL:2d::Number of different Jacobians: 4
+DEAL:2d::Number of different Jacobians: 36
+DEAL:2d::OK
+DEAL:3d::General mesh
+DEAL:3d::OK
+DEAL:3d::Hyper cube
+DEAL:3d::OK
+DEAL:3d::Parallelogram
+DEAL:3d::OK
+DEAL:3d::Deformed hyper cube
+DEAL:3d::Number of different Jacobians: 4
+DEAL:3d::Number of different Jacobians: 108
+DEAL:3d::OK

--- a/tests/matrix_free/compress_mapping.output.novec
+++ b/tests/matrix_free/compress_mapping.output.novec
@@ -1,0 +1,21 @@
+
+DEAL:2d::General mesh
+DEAL:2d::OK
+DEAL:2d::Hyper cube
+DEAL:2d::OK
+DEAL:2d::Parallelogram
+DEAL:2d::OK
+DEAL:2d::Deformed hyper cube
+DEAL:2d::Number of different Jacobians: 8
+DEAL:2d::Number of different Jacobians: 144
+DEAL:2d::OK
+DEAL:3d::General mesh
+DEAL:3d::OK
+DEAL:3d::Hyper cube
+DEAL:3d::OK
+DEAL:3d::Parallelogram
+DEAL:3d::OK
+DEAL:3d::Deformed hyper cube
+DEAL:3d::Number of different Jacobians: 4
+DEAL:3d::Number of different Jacobians: 216
+DEAL:3d::OK


### PR DESCRIPTION
In #9656 I extended a test for the compression of the mapping. While the output file is correct for AVX and SSE2 (2 cells in horizontal direction trigger the compression), it is not on AVX-512 and without vectorization. In the former, we have 4 cells together in horizontal direction for 2D, so only half as much output. Without vectorization and the full mapping, we need twice as many variants as there is only a single cell.