### PR TITLE
Fix broken documentation.

### DIFF
--- a/include/deal.II/base/graph_coloring.h
+++ b/include/deal.II/base/graph_coloring.h
@@ -199,12 +199,15 @@ namespace GraphColoring
 
     /**
      * This function uses DSATUR (Degree SATURation) to color the elements of
-     * a set. DSATUR works as follows: -# Arrange the vertices by decreasing
-     * order of degrees. -# Color a vertex of maximal degree with color 1. -#
-     * Choose a vertex with a maximal saturation degree. If there is equality,
-     * choose any vertex of maximal degree in the uncolored subgraph. -# Color
-     * the chosen vertex with the least possible (lowest numbered) color. -#
-     * If all the vertices are colored, stop. Otherwise, return to 3.
+     * a set. DSATUR works as follows:
+     * -# Arrange the vertices by decreasing order of degrees.
+     * -# Color a vertex of maximal degree with color 1.
+     * -# Choose a vertex with a maximal saturation degree. If there is
+     *    equality, choose any vertex of maximal degree in the uncolored
+     *    subgraph.
+     * -# Color the chosen vertex with the least possible (lowest numbered)
+     *    color.
+     * -# If all the vertices are colored, stop. Otherwise, return to 3.
      *
      * @param[in] partition The set of iterators that should be colored.
      * @param[in] get_conflict_indices A user defined function object


### PR DESCRIPTION
This was apparently mangled when we ran clang-indent the first time.
/rebuild