### PR TITLE
Fix a bug in mg ghost layer with periodicity and n_levels=1

### DIFF
--- a/doc/news/changes/minor/20200330MartinKronbichler-1
+++ b/doc/news/changes/minor/20200330MartinKronbichler-1
@@ -1,0 +1,3 @@
+Fixed: A bug in the setup of CellAccessor::level_subdomain_id() for multigrid
+levels that manifested itself only on non-refined meshes has been fixed.
+<br> (Martin Kronbichler, 2020/03/30)

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4516,7 +4516,7 @@ namespace parallel
       // to connect to a vertex that is 'dim' hops away from the locally owned
       // cell. Depending on the order of the periodic face map, we might
       // connect to that point by chance or miss it. However, after looping
-      // through all the periodict directions (which are at most as many as
+      // through all the periodic directions (which are at most as many as
       // the number of space dimensions) we can be sure that all connections
       // to vertices have been created.
       for (unsigned int repetition = 0; repetition < dim; ++repetition)
@@ -4591,6 +4591,11 @@ namespace parallel
              ExcMessage("The triangulation is empty!"));
       Assert(this->n_levels() == 1,
              ExcMessage("The triangulation is refined!"));
+
+      // call the base class for storing the periodicity information; we must
+      // do this before going to p4est and rebuilding the triangulation to get
+      // the level subdomain ids correct in the multigrid case
+      dealii::Triangulation<dim, spacedim>::add_periodicity(periodicity_vector);
 
       for (const auto &face_pair : periodicity_vector)
         {
@@ -4721,7 +4726,6 @@ namespace parallel
         /* user_data_constructor = */ nullptr,
         /* user_pointer */ this);
 
-
       try
         {
           copy_local_forest_to_triangulation();
@@ -4732,9 +4736,6 @@ namespace parallel
           // cells
           Assert(false, ExcInternalError());
         }
-
-      // finally call the base class for storing the periodicity information
-      dealii::Triangulation<dim, spacedim>::add_periodicity(periodicity_vector);
 
       // The range of ghost_owners might have changed so update that information
       this->update_number_cache();

--- a/tests/mpi/mg_ghost_layer_periodic.cc
+++ b/tests/mpi/mg_ghost_layer_periodic.cc
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// test level subdomain ids for periodic boundary conditions
+
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/distributed/grid_refinement.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  parallel::distributed::Triangulation<dim> tria(
+    MPI_COMM_WORLD,
+    Triangulation<dim>::limit_level_difference_at_vertices,
+    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+
+  GridGenerator::subdivided_hyper_cube(tria, 3, 0., 1.);
+
+  for (const auto &cell : tria.cell_iterators())
+    for (unsigned int face_index : GeometryInfo<dim>::face_indices())
+      {
+        if (std::abs(cell->face(face_index)->center()(face_index / 2)) < 1e-12)
+          cell->face(face_index)->set_all_boundary_ids(face_index);
+        if (std::abs(cell->face(face_index)->center()(face_index / 2) - 1.) <
+            1e-12)
+          cell->face(face_index)->set_all_boundary_ids(face_index);
+      }
+
+  std::vector<
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+    periodic_faces;
+  for (unsigned int d = 0; d < dim; ++d)
+    GridTools::collect_periodic_faces(static_cast<Triangulation<dim> &>(tria),
+                                      2 * d,
+                                      2 * d + 1,
+                                      d,
+                                      periodic_faces);
+
+  tria.add_periodicity(periodic_faces);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      for (const auto &cell : tria.cell_iterators())
+        if (cell->level_subdomain_id() == tria.locally_owned_subdomain())
+          {
+            deallog << Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) << " "
+                    << cell->id() << " neighbor subdomain ids: ";
+            for (unsigned int f : GeometryInfo<dim>::face_indices())
+              {
+                deallog << cell->neighbor_or_periodic_neighbor(f)->id() << " ";
+                if (cell->is_active())
+                  deallog
+                    << cell->neighbor_or_periodic_neighbor(f)->subdomain_id()
+                    << " ";
+                deallog << cell->neighbor_or_periodic_neighbor(f)
+                             ->level_subdomain_id()
+                        << "  ";
+              }
+            deallog << std::endl;
+          }
+      tria.refine_global();
+    }
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  try
+    {
+      test<2>();
+      test<3>();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/mpi/mg_ghost_layer_periodic.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/mg_ghost_layer_periodic.with_p4est=true.mpirun=2.output
@@ -1,0 +1,327 @@
+
+DEAL:0::0 0_0: neighbor subdomain ids: 4_0: 1 1  1_0: 0 0  6_0: 1 1  2_0: 0 0  
+DEAL:0::0 1_0: neighbor subdomain ids: 0_0: 0 0  4_0: 1 1  7_0: 1 1  3_0: 0 0  
+DEAL:0::0 2_0: neighbor subdomain ids: 5_0: 1 1  3_0: 0 0  0_0: 0 0  6_0: 1 1  
+DEAL:0::0 3_0: neighbor subdomain ids: 2_0: 0 0  5_0: 1 1  1_0: 0 0  7_0: 1 1  
+DEAL:0::0 0_0: neighbor subdomain ids: 4_0: 0  1_0: 0  6_0: 1  2_0: 0  
+DEAL:0::0 1_0: neighbor subdomain ids: 0_0: 0  4_0: 0  7_0: 1  3_0: 0  
+DEAL:0::0 4_0: neighbor subdomain ids: 1_0: 0  0_0: 0  8_0: 1  5_0: 1  
+DEAL:0::0 2_0: neighbor subdomain ids: 5_0: 1  3_0: 0  0_0: 0  6_0: 1  
+DEAL:0::0 3_0: neighbor subdomain ids: 2_0: 0  5_0: 1  1_0: 0  7_0: 1  
+DEAL:0::0 0_1:0 neighbor subdomain ids: 4_1:1 0 0  0_1:1 0 0  6_1:2 1 1  0_1:2 0 0  
+DEAL:0::0 0_1:1 neighbor subdomain ids: 0_1:0 0 0  1_1:0 0 0  6_1:3 1 1  0_1:3 0 0  
+DEAL:0::0 0_1:2 neighbor subdomain ids: 4_1:3 0 0  0_1:3 0 0  0_1:0 0 0  2_1:0 0 0  
+DEAL:0::0 0_1:3 neighbor subdomain ids: 0_1:2 0 0  1_1:2 0 0  0_1:1 0 0  2_1:1 0 0  
+DEAL:0::0 1_1:0 neighbor subdomain ids: 0_1:1 0 0  1_1:1 0 0  7_1:2 1 1  1_1:2 0 0  
+DEAL:0::0 1_1:1 neighbor subdomain ids: 1_1:0 0 0  4_1:0 0 0  7_1:3 1 1  1_1:3 0 0  
+DEAL:0::0 1_1:2 neighbor subdomain ids: 0_1:3 0 0  1_1:3 0 0  1_1:0 0 0  3_1:0 0 0  
+DEAL:0::0 1_1:3 neighbor subdomain ids: 1_1:2 0 0  4_1:2 0 0  1_1:1 0 0  3_1:1 0 0  
+DEAL:0::0 4_1:0 neighbor subdomain ids: 1_1:1 0 0  4_1:1 0 0  8_1:2 1 1  4_1:2 0 0  
+DEAL:0::0 4_1:1 neighbor subdomain ids: 4_1:0 0 0  0_1:0 0 0  8_1:3 1 1  4_1:3 0 0  
+DEAL:0::0 4_1:2 neighbor subdomain ids: 1_1:3 0 0  4_1:3 0 0  4_1:0 0 0  5_1:0 1 1  
+DEAL:0::0 4_1:3 neighbor subdomain ids: 4_1:2 0 0  0_1:2 0 0  4_1:1 0 0  5_1:1 1 1  
+DEAL:0::0 2_1:0 neighbor subdomain ids: 5_1:1 1 1  2_1:1 0 0  0_1:2 0 0  2_1:2 0 0  
+DEAL:0::0 2_1:1 neighbor subdomain ids: 2_1:0 0 0  3_1:0 0 0  0_1:3 0 0  2_1:3 0 0  
+DEAL:0::0 2_1:2 neighbor subdomain ids: 5_1:3 1 1  2_1:3 0 0  2_1:0 0 0  6_1:0 1 1  
+DEAL:0::0 2_1:3 neighbor subdomain ids: 2_1:2 0 0  3_1:2 0 0  2_1:1 0 0  6_1:1 1 1  
+DEAL:0::0 3_1:0 neighbor subdomain ids: 2_1:1 0 0  3_1:1 0 0  1_1:2 0 0  3_1:2 0 0  
+DEAL:0::0 3_1:1 neighbor subdomain ids: 3_1:0 0 0  5_1:0 1 1  1_1:3 0 0  3_1:3 0 0  
+DEAL:0::0 3_1:2 neighbor subdomain ids: 2_1:3 0 0  3_1:3 0 0  3_1:0 0 0  7_1:0 1 1  
+DEAL:0::0 3_1:3 neighbor subdomain ids: 3_1:2 0 0  5_1:2 1 1  3_1:1 0 0  7_1:1 1 1  
+DEAL:0::0 0_0: neighbor subdomain ids: 8_0: 0 0  1_0: 0 0  12_0: 0 0  2_0: 0 0  18_0: 1 1  4_0: 0 0  
+DEAL:0::0 1_0: neighbor subdomain ids: 0_0: 0 0  8_0: 0 0  13_0: 1 1  3_0: 0 0  19_0: 1 1  5_0: 0 0  
+DEAL:0::0 8_0: neighbor subdomain ids: 1_0: 0 0  0_0: 0 0  16_0: 1 1  9_0: 0 0  22_0: 1 1  10_0: 0 0  
+DEAL:0::0 2_0: neighbor subdomain ids: 9_0: 0 0  3_0: 0 0  0_0: 0 0  12_0: 0 0  20_0: 1 1  6_0: 0 0  
+DEAL:0::0 3_0: neighbor subdomain ids: 2_0: 0 0  9_0: 0 0  1_0: 0 0  13_0: 1 1  21_0: 1 1  7_0: 0 0  
+DEAL:0::0 9_0: neighbor subdomain ids: 3_0: 0 0  2_0: 0 0  8_0: 0 0  16_0: 1 1  23_0: 1 1  11_0: 0 0  
+DEAL:0::0 12_0: neighbor subdomain ids: 16_0: 1 1  13_0: 1 1  2_0: 0 0  0_0: 0 0  24_0: 1 1  14_0: 1 1  
+DEAL:0::0 4_0: neighbor subdomain ids: 10_0: 0 0  5_0: 0 0  14_0: 1 1  6_0: 0 0  0_0: 0 0  18_0: 1 1  
+DEAL:0::0 5_0: neighbor subdomain ids: 4_0: 0 0  10_0: 0 0  15_0: 1 1  7_0: 0 0  1_0: 0 0  19_0: 1 1  
+DEAL:0::0 10_0: neighbor subdomain ids: 5_0: 0 0  4_0: 0 0  17_0: 1 1  11_0: 0 0  8_0: 0 0  22_0: 1 1  
+DEAL:0::0 6_0: neighbor subdomain ids: 11_0: 0 0  7_0: 0 0  4_0: 0 0  14_0: 1 1  2_0: 0 0  20_0: 1 1  
+DEAL:0::0 7_0: neighbor subdomain ids: 6_0: 0 0  11_0: 0 0  5_0: 0 0  15_0: 1 1  3_0: 0 0  21_0: 1 1  
+DEAL:0::0 11_0: neighbor subdomain ids: 7_0: 0 0  6_0: 0 0  10_0: 0 0  17_0: 1 1  9_0: 0 0  23_0: 1 1  
+DEAL:0::0 0_0: neighbor subdomain ids: 8_0: 0  1_0: 0  12_0: 0  2_0: 0  18_0: 1  4_0: 0  
+DEAL:0::0 1_0: neighbor subdomain ids: 0_0: 0  8_0: 0  13_0: 0  3_0: 0  19_0: 1  5_0: 0  
+DEAL:0::0 8_0: neighbor subdomain ids: 1_0: 0  0_0: 0  16_0: 1  9_0: 0  22_0: 1  10_0: 0  
+DEAL:0::0 2_0: neighbor subdomain ids: 9_0: 0  3_0: 0  0_0: 0  12_0: 0  20_0: 1  6_0: 0  
+DEAL:0::0 3_0: neighbor subdomain ids: 2_0: 0  9_0: 0  1_0: 0  13_0: 0  21_0: 1  7_0: 0  
+DEAL:0::0 9_0: neighbor subdomain ids: 3_0: 0  2_0: 0  8_0: 0  16_0: 1  23_0: 1  11_0: 0  
+DEAL:0::0 12_0: neighbor subdomain ids: 16_0: 1  13_0: 0  2_0: 0  0_0: 0  24_0: 1  14_0: 1  
+DEAL:0::0 13_0: neighbor subdomain ids: 12_0: 0  16_0: 1  3_0: 0  1_0: 0  25_0: 1  15_0: 1  
+DEAL:0::0 4_0: neighbor subdomain ids: 10_0: 0  5_0: 0  14_0: 1  6_0: 0  0_0: 0  18_0: 1  
+DEAL:0::0 5_0: neighbor subdomain ids: 4_0: 0  10_0: 0  15_0: 1  7_0: 0  1_0: 0  19_0: 1  
+DEAL:0::0 10_0: neighbor subdomain ids: 5_0: 0  4_0: 0  17_0: 1  11_0: 0  8_0: 0  22_0: 1  
+DEAL:0::0 6_0: neighbor subdomain ids: 11_0: 0  7_0: 0  4_0: 0  14_0: 1  2_0: 0  20_0: 1  
+DEAL:0::0 7_0: neighbor subdomain ids: 6_0: 0  11_0: 0  5_0: 0  15_0: 1  3_0: 0  21_0: 1  
+DEAL:0::0 11_0: neighbor subdomain ids: 7_0: 0  6_0: 0  10_0: 0  17_0: 1  9_0: 0  23_0: 1  
+DEAL:0::0 0_1:0 neighbor subdomain ids: 8_1:1 0 0  0_1:1 0 0  12_1:2 0 0  0_1:2 0 0  18_1:4 1 1  0_1:4 0 0  
+DEAL:0::0 0_1:1 neighbor subdomain ids: 0_1:0 0 0  1_1:0 0 0  12_1:3 0 0  0_1:3 0 0  18_1:5 1 1  0_1:5 0 0  
+DEAL:0::0 0_1:2 neighbor subdomain ids: 8_1:3 0 0  0_1:3 0 0  0_1:0 0 0  2_1:0 0 0  18_1:6 1 1  0_1:6 0 0  
+DEAL:0::0 0_1:3 neighbor subdomain ids: 0_1:2 0 0  1_1:2 0 0  0_1:1 0 0  2_1:1 0 0  18_1:7 1 1  0_1:7 0 0  
+DEAL:0::0 0_1:4 neighbor subdomain ids: 8_1:5 0 0  0_1:5 0 0  12_1:6 0 0  0_1:6 0 0  0_1:0 0 0  4_1:0 0 0  
+DEAL:0::0 0_1:5 neighbor subdomain ids: 0_1:4 0 0  1_1:4 0 0  12_1:7 0 0  0_1:7 0 0  0_1:1 0 0  4_1:1 0 0  
+DEAL:0::0 0_1:6 neighbor subdomain ids: 8_1:7 0 0  0_1:7 0 0  0_1:4 0 0  2_1:4 0 0  0_1:2 0 0  4_1:2 0 0  
+DEAL:0::0 0_1:7 neighbor subdomain ids: 0_1:6 0 0  1_1:6 0 0  0_1:5 0 0  2_1:5 0 0  0_1:3 0 0  4_1:3 0 0  
+DEAL:0::0 1_1:0 neighbor subdomain ids: 0_1:1 0 0  1_1:1 0 0  13_1:2 0 0  1_1:2 0 0  19_1:4 1 1  1_1:4 0 0  
+DEAL:0::0 1_1:1 neighbor subdomain ids: 1_1:0 0 0  8_1:0 0 0  13_1:3 0 0  1_1:3 0 0  19_1:5 1 1  1_1:5 0 0  
+DEAL:0::0 1_1:2 neighbor subdomain ids: 0_1:3 0 0  1_1:3 0 0  1_1:0 0 0  3_1:0 0 0  19_1:6 1 1  1_1:6 0 0  
+DEAL:0::0 1_1:3 neighbor subdomain ids: 1_1:2 0 0  8_1:2 0 0  1_1:1 0 0  3_1:1 0 0  19_1:7 1 1  1_1:7 0 0  
+DEAL:0::0 1_1:4 neighbor subdomain ids: 0_1:5 0 0  1_1:5 0 0  13_1:6 0 0  1_1:6 0 0  1_1:0 0 0  5_1:0 0 0  
+DEAL:0::0 1_1:5 neighbor subdomain ids: 1_1:4 0 0  8_1:4 0 0  13_1:7 0 0  1_1:7 0 0  1_1:1 0 0  5_1:1 0 0  
+DEAL:0::0 1_1:6 neighbor subdomain ids: 0_1:7 0 0  1_1:7 0 0  1_1:4 0 0  3_1:4 0 0  1_1:2 0 0  5_1:2 0 0  
+DEAL:0::0 1_1:7 neighbor subdomain ids: 1_1:6 0 0  8_1:6 0 0  1_1:5 0 0  3_1:5 0 0  1_1:3 0 0  5_1:3 0 0  
+DEAL:0::0 8_1:0 neighbor subdomain ids: 1_1:1 0 0  8_1:1 0 0  16_1:2 1 1  8_1:2 0 0  22_1:4 1 1  8_1:4 0 0  
+DEAL:0::0 8_1:1 neighbor subdomain ids: 8_1:0 0 0  0_1:0 0 0  16_1:3 1 1  8_1:3 0 0  22_1:5 1 1  8_1:5 0 0  
+DEAL:0::0 8_1:2 neighbor subdomain ids: 1_1:3 0 0  8_1:3 0 0  8_1:0 0 0  9_1:0 0 0  22_1:6 1 1  8_1:6 0 0  
+DEAL:0::0 8_1:3 neighbor subdomain ids: 8_1:2 0 0  0_1:2 0 0  8_1:1 0 0  9_1:1 0 0  22_1:7 1 1  8_1:7 0 0  
+DEAL:0::0 8_1:4 neighbor subdomain ids: 1_1:5 0 0  8_1:5 0 0  16_1:6 1 1  8_1:6 0 0  8_1:0 0 0  10_1:0 0 0  
+DEAL:0::0 8_1:5 neighbor subdomain ids: 8_1:4 0 0  0_1:4 0 0  16_1:7 1 1  8_1:7 0 0  8_1:1 0 0  10_1:1 0 0  
+DEAL:0::0 8_1:6 neighbor subdomain ids: 1_1:7 0 0  8_1:7 0 0  8_1:4 0 0  9_1:4 0 0  8_1:2 0 0  10_1:2 0 0  
+DEAL:0::0 8_1:7 neighbor subdomain ids: 8_1:6 0 0  0_1:6 0 0  8_1:5 0 0  9_1:5 0 0  8_1:3 0 0  10_1:3 0 0  
+DEAL:0::0 2_1:0 neighbor subdomain ids: 9_1:1 0 0  2_1:1 0 0  0_1:2 0 0  2_1:2 0 0  20_1:4 1 1  2_1:4 0 0  
+DEAL:0::0 2_1:1 neighbor subdomain ids: 2_1:0 0 0  3_1:0 0 0  0_1:3 0 0  2_1:3 0 0  20_1:5 1 1  2_1:5 0 0  
+DEAL:0::0 2_1:2 neighbor subdomain ids: 9_1:3 0 0  2_1:3 0 0  2_1:0 0 0  12_1:0 0 0  20_1:6 1 1  2_1:6 0 0  
+DEAL:0::0 2_1:3 neighbor subdomain ids: 2_1:2 0 0  3_1:2 0 0  2_1:1 0 0  12_1:1 0 0  20_1:7 1 1  2_1:7 0 0  
+DEAL:0::0 2_1:4 neighbor subdomain ids: 9_1:5 0 0  2_1:5 0 0  0_1:6 0 0  2_1:6 0 0  2_1:0 0 0  6_1:0 0 0  
+DEAL:0::0 2_1:5 neighbor subdomain ids: 2_1:4 0 0  3_1:4 0 0  0_1:7 0 0  2_1:7 0 0  2_1:1 0 0  6_1:1 0 0  
+DEAL:0::0 2_1:6 neighbor subdomain ids: 9_1:7 0 0  2_1:7 0 0  2_1:4 0 0  12_1:4 0 0  2_1:2 0 0  6_1:2 0 0  
+DEAL:0::0 2_1:7 neighbor subdomain ids: 2_1:6 0 0  3_1:6 0 0  2_1:5 0 0  12_1:5 0 0  2_1:3 0 0  6_1:3 0 0  
+DEAL:0::0 3_1:0 neighbor subdomain ids: 2_1:1 0 0  3_1:1 0 0  1_1:2 0 0  3_1:2 0 0  21_1:4 1 1  3_1:4 0 0  
+DEAL:0::0 3_1:1 neighbor subdomain ids: 3_1:0 0 0  9_1:0 0 0  1_1:3 0 0  3_1:3 0 0  21_1:5 1 1  3_1:5 0 0  
+DEAL:0::0 3_1:2 neighbor subdomain ids: 2_1:3 0 0  3_1:3 0 0  3_1:0 0 0  13_1:0 0 0  21_1:6 1 1  3_1:6 0 0  
+DEAL:0::0 3_1:3 neighbor subdomain ids: 3_1:2 0 0  9_1:2 0 0  3_1:1 0 0  13_1:1 0 0  21_1:7 1 1  3_1:7 0 0  
+DEAL:0::0 3_1:4 neighbor subdomain ids: 2_1:5 0 0  3_1:5 0 0  1_1:6 0 0  3_1:6 0 0  3_1:0 0 0  7_1:0 0 0  
+DEAL:0::0 3_1:5 neighbor subdomain ids: 3_1:4 0 0  9_1:4 0 0  1_1:7 0 0  3_1:7 0 0  3_1:1 0 0  7_1:1 0 0  
+DEAL:0::0 3_1:6 neighbor subdomain ids: 2_1:7 0 0  3_1:7 0 0  3_1:4 0 0  13_1:4 0 0  3_1:2 0 0  7_1:2 0 0  
+DEAL:0::0 3_1:7 neighbor subdomain ids: 3_1:6 0 0  9_1:6 0 0  3_1:5 0 0  13_1:5 0 0  3_1:3 0 0  7_1:3 0 0  
+DEAL:0::0 9_1:0 neighbor subdomain ids: 3_1:1 0 0  9_1:1 0 0  8_1:2 0 0  9_1:2 0 0  23_1:4 1 1  9_1:4 0 0  
+DEAL:0::0 9_1:1 neighbor subdomain ids: 9_1:0 0 0  2_1:0 0 0  8_1:3 0 0  9_1:3 0 0  23_1:5 1 1  9_1:5 0 0  
+DEAL:0::0 9_1:2 neighbor subdomain ids: 3_1:3 0 0  9_1:3 0 0  9_1:0 0 0  16_1:0 1 1  23_1:6 1 1  9_1:6 0 0  
+DEAL:0::0 9_1:3 neighbor subdomain ids: 9_1:2 0 0  2_1:2 0 0  9_1:1 0 0  16_1:1 1 1  23_1:7 1 1  9_1:7 0 0  
+DEAL:0::0 9_1:4 neighbor subdomain ids: 3_1:5 0 0  9_1:5 0 0  8_1:6 0 0  9_1:6 0 0  9_1:0 0 0  11_1:0 0 0  
+DEAL:0::0 9_1:5 neighbor subdomain ids: 9_1:4 0 0  2_1:4 0 0  8_1:7 0 0  9_1:7 0 0  9_1:1 0 0  11_1:1 0 0  
+DEAL:0::0 9_1:6 neighbor subdomain ids: 3_1:7 0 0  9_1:7 0 0  9_1:4 0 0  16_1:4 1 1  9_1:2 0 0  11_1:2 0 0  
+DEAL:0::0 9_1:7 neighbor subdomain ids: 9_1:6 0 0  2_1:6 0 0  9_1:5 0 0  16_1:5 1 1  9_1:3 0 0  11_1:3 0 0  
+DEAL:0::0 12_1:0 neighbor subdomain ids: 16_1:1 1 1  12_1:1 0 0  2_1:2 0 0  12_1:2 0 0  24_1:4 1 1  12_1:4 0 0  
+DEAL:0::0 12_1:1 neighbor subdomain ids: 12_1:0 0 0  13_1:0 0 0  2_1:3 0 0  12_1:3 0 0  24_1:5 1 1  12_1:5 0 0  
+DEAL:0::0 12_1:2 neighbor subdomain ids: 16_1:3 1 1  12_1:3 0 0  12_1:0 0 0  0_1:0 0 0  24_1:6 1 1  12_1:6 0 0  
+DEAL:0::0 12_1:3 neighbor subdomain ids: 12_1:2 0 0  13_1:2 0 0  12_1:1 0 0  0_1:1 0 0  24_1:7 1 1  12_1:7 0 0  
+DEAL:0::0 12_1:4 neighbor subdomain ids: 16_1:5 1 1  12_1:5 0 0  2_1:6 0 0  12_1:6 0 0  12_1:0 0 0  14_1:0 1 1  
+DEAL:0::0 12_1:5 neighbor subdomain ids: 12_1:4 0 0  13_1:4 0 0  2_1:7 0 0  12_1:7 0 0  12_1:1 0 0  14_1:1 1 1  
+DEAL:0::0 12_1:6 neighbor subdomain ids: 16_1:7 1 1  12_1:7 0 0  12_1:4 0 0  0_1:4 0 0  12_1:2 0 0  14_1:2 1 1  
+DEAL:0::0 12_1:7 neighbor subdomain ids: 12_1:6 0 0  13_1:6 0 0  12_1:5 0 0  0_1:5 0 0  12_1:3 0 0  14_1:3 1 1  
+DEAL:0::0 13_1:0 neighbor subdomain ids: 12_1:1 0 0  13_1:1 0 0  3_1:2 0 0  13_1:2 0 0  25_1:4 1 1  13_1:4 0 0  
+DEAL:0::0 13_1:1 neighbor subdomain ids: 13_1:0 0 0  16_1:0 1 1  3_1:3 0 0  13_1:3 0 0  25_1:5 1 1  13_1:5 0 0  
+DEAL:0::0 13_1:2 neighbor subdomain ids: 12_1:3 0 0  13_1:3 0 0  13_1:0 0 0  1_1:0 0 0  25_1:6 1 1  13_1:6 0 0  
+DEAL:0::0 13_1:3 neighbor subdomain ids: 13_1:2 0 0  16_1:2 1 1  13_1:1 0 0  1_1:1 0 0  25_1:7 1 1  13_1:7 0 0  
+DEAL:0::0 13_1:4 neighbor subdomain ids: 12_1:5 0 0  13_1:5 0 0  3_1:6 0 0  13_1:6 0 0  13_1:0 0 0  15_1:0 1 1  
+DEAL:0::0 13_1:5 neighbor subdomain ids: 13_1:4 0 0  16_1:4 1 1  3_1:7 0 0  13_1:7 0 0  13_1:1 0 0  15_1:1 1 1  
+DEAL:0::0 13_1:6 neighbor subdomain ids: 12_1:7 0 0  13_1:7 0 0  13_1:4 0 0  1_1:4 0 0  13_1:2 0 0  15_1:2 1 1  
+DEAL:0::0 13_1:7 neighbor subdomain ids: 13_1:6 0 0  16_1:6 1 1  13_1:5 0 0  1_1:5 0 0  13_1:3 0 0  15_1:3 1 1  
+DEAL:0::0 4_1:0 neighbor subdomain ids: 10_1:1 0 0  4_1:1 0 0  14_1:2 1 1  4_1:2 0 0  0_1:4 0 0  4_1:4 0 0  
+DEAL:0::0 4_1:1 neighbor subdomain ids: 4_1:0 0 0  5_1:0 0 0  14_1:3 1 1  4_1:3 0 0  0_1:5 0 0  4_1:5 0 0  
+DEAL:0::0 4_1:2 neighbor subdomain ids: 10_1:3 0 0  4_1:3 0 0  4_1:0 0 0  6_1:0 0 0  0_1:6 0 0  4_1:6 0 0  
+DEAL:0::0 4_1:3 neighbor subdomain ids: 4_1:2 0 0  5_1:2 0 0  4_1:1 0 0  6_1:1 0 0  0_1:7 0 0  4_1:7 0 0  
+DEAL:0::0 4_1:4 neighbor subdomain ids: 10_1:5 0 0  4_1:5 0 0  14_1:6 1 1  4_1:6 0 0  4_1:0 0 0  18_1:0 1 1  
+DEAL:0::0 4_1:5 neighbor subdomain ids: 4_1:4 0 0  5_1:4 0 0  14_1:7 1 1  4_1:7 0 0  4_1:1 0 0  18_1:1 1 1  
+DEAL:0::0 4_1:6 neighbor subdomain ids: 10_1:7 0 0  4_1:7 0 0  4_1:4 0 0  6_1:4 0 0  4_1:2 0 0  18_1:2 1 1  
+DEAL:0::0 4_1:7 neighbor subdomain ids: 4_1:6 0 0  5_1:6 0 0  4_1:5 0 0  6_1:5 0 0  4_1:3 0 0  18_1:3 1 1  
+DEAL:0::0 5_1:0 neighbor subdomain ids: 4_1:1 0 0  5_1:1 0 0  15_1:2 1 1  5_1:2 0 0  1_1:4 0 0  5_1:4 0 0  
+DEAL:0::0 5_1:1 neighbor subdomain ids: 5_1:0 0 0  10_1:0 0 0  15_1:3 1 1  5_1:3 0 0  1_1:5 0 0  5_1:5 0 0  
+DEAL:0::0 5_1:2 neighbor subdomain ids: 4_1:3 0 0  5_1:3 0 0  5_1:0 0 0  7_1:0 0 0  1_1:6 0 0  5_1:6 0 0  
+DEAL:0::0 5_1:3 neighbor subdomain ids: 5_1:2 0 0  10_1:2 0 0  5_1:1 0 0  7_1:1 0 0  1_1:7 0 0  5_1:7 0 0  
+DEAL:0::0 5_1:4 neighbor subdomain ids: 4_1:5 0 0  5_1:5 0 0  15_1:6 1 1  5_1:6 0 0  5_1:0 0 0  19_1:0 1 1  
+DEAL:0::0 5_1:5 neighbor subdomain ids: 5_1:4 0 0  10_1:4 0 0  15_1:7 1 1  5_1:7 0 0  5_1:1 0 0  19_1:1 1 1  
+DEAL:0::0 5_1:6 neighbor subdomain ids: 4_1:7 0 0  5_1:7 0 0  5_1:4 0 0  7_1:4 0 0  5_1:2 0 0  19_1:2 1 1  
+DEAL:0::0 5_1:7 neighbor subdomain ids: 5_1:6 0 0  10_1:6 0 0  5_1:5 0 0  7_1:5 0 0  5_1:3 0 0  19_1:3 1 1  
+DEAL:0::0 10_1:0 neighbor subdomain ids: 5_1:1 0 0  10_1:1 0 0  17_1:2 1 1  10_1:2 0 0  8_1:4 0 0  10_1:4 0 0  
+DEAL:0::0 10_1:1 neighbor subdomain ids: 10_1:0 0 0  4_1:0 0 0  17_1:3 1 1  10_1:3 0 0  8_1:5 0 0  10_1:5 0 0  
+DEAL:0::0 10_1:2 neighbor subdomain ids: 5_1:3 0 0  10_1:3 0 0  10_1:0 0 0  11_1:0 0 0  8_1:6 0 0  10_1:6 0 0  
+DEAL:0::0 10_1:3 neighbor subdomain ids: 10_1:2 0 0  4_1:2 0 0  10_1:1 0 0  11_1:1 0 0  8_1:7 0 0  10_1:7 0 0  
+DEAL:0::0 10_1:4 neighbor subdomain ids: 5_1:5 0 0  10_1:5 0 0  17_1:6 1 1  10_1:6 0 0  10_1:0 0 0  22_1:0 1 1  
+DEAL:0::0 10_1:5 neighbor subdomain ids: 10_1:4 0 0  4_1:4 0 0  17_1:7 1 1  10_1:7 0 0  10_1:1 0 0  22_1:1 1 1  
+DEAL:0::0 10_1:6 neighbor subdomain ids: 5_1:7 0 0  10_1:7 0 0  10_1:4 0 0  11_1:4 0 0  10_1:2 0 0  22_1:2 1 1  
+DEAL:0::0 10_1:7 neighbor subdomain ids: 10_1:6 0 0  4_1:6 0 0  10_1:5 0 0  11_1:5 0 0  10_1:3 0 0  22_1:3 1 1  
+DEAL:0::0 6_1:0 neighbor subdomain ids: 11_1:1 0 0  6_1:1 0 0  4_1:2 0 0  6_1:2 0 0  2_1:4 0 0  6_1:4 0 0  
+DEAL:0::0 6_1:1 neighbor subdomain ids: 6_1:0 0 0  7_1:0 0 0  4_1:3 0 0  6_1:3 0 0  2_1:5 0 0  6_1:5 0 0  
+DEAL:0::0 6_1:2 neighbor subdomain ids: 11_1:3 0 0  6_1:3 0 0  6_1:0 0 0  14_1:0 1 1  2_1:6 0 0  6_1:6 0 0  
+DEAL:0::0 6_1:3 neighbor subdomain ids: 6_1:2 0 0  7_1:2 0 0  6_1:1 0 0  14_1:1 1 1  2_1:7 0 0  6_1:7 0 0  
+DEAL:0::0 6_1:4 neighbor subdomain ids: 11_1:5 0 0  6_1:5 0 0  4_1:6 0 0  6_1:6 0 0  6_1:0 0 0  20_1:0 1 1  
+DEAL:0::0 6_1:5 neighbor subdomain ids: 6_1:4 0 0  7_1:4 0 0  4_1:7 0 0  6_1:7 0 0  6_1:1 0 0  20_1:1 1 1  
+DEAL:0::0 6_1:6 neighbor subdomain ids: 11_1:7 0 0  6_1:7 0 0  6_1:4 0 0  14_1:4 1 1  6_1:2 0 0  20_1:2 1 1  
+DEAL:0::0 6_1:7 neighbor subdomain ids: 6_1:6 0 0  7_1:6 0 0  6_1:5 0 0  14_1:5 1 1  6_1:3 0 0  20_1:3 1 1  
+DEAL:0::0 7_1:0 neighbor subdomain ids: 6_1:1 0 0  7_1:1 0 0  5_1:2 0 0  7_1:2 0 0  3_1:4 0 0  7_1:4 0 0  
+DEAL:0::0 7_1:1 neighbor subdomain ids: 7_1:0 0 0  11_1:0 0 0  5_1:3 0 0  7_1:3 0 0  3_1:5 0 0  7_1:5 0 0  
+DEAL:0::0 7_1:2 neighbor subdomain ids: 6_1:3 0 0  7_1:3 0 0  7_1:0 0 0  15_1:0 1 1  3_1:6 0 0  7_1:6 0 0  
+DEAL:0::0 7_1:3 neighbor subdomain ids: 7_1:2 0 0  11_1:2 0 0  7_1:1 0 0  15_1:1 1 1  3_1:7 0 0  7_1:7 0 0  
+DEAL:0::0 7_1:4 neighbor subdomain ids: 6_1:5 0 0  7_1:5 0 0  5_1:6 0 0  7_1:6 0 0  7_1:0 0 0  21_1:0 1 1  
+DEAL:0::0 7_1:5 neighbor subdomain ids: 7_1:4 0 0  11_1:4 0 0  5_1:7 0 0  7_1:7 0 0  7_1:1 0 0  21_1:1 1 1  
+DEAL:0::0 7_1:6 neighbor subdomain ids: 6_1:7 0 0  7_1:7 0 0  7_1:4 0 0  15_1:4 1 1  7_1:2 0 0  21_1:2 1 1  
+DEAL:0::0 7_1:7 neighbor subdomain ids: 7_1:6 0 0  11_1:6 0 0  7_1:5 0 0  15_1:5 1 1  7_1:3 0 0  21_1:3 1 1  
+DEAL:0::0 11_1:0 neighbor subdomain ids: 7_1:1 0 0  11_1:1 0 0  10_1:2 0 0  11_1:2 0 0  9_1:4 0 0  11_1:4 0 0  
+DEAL:0::0 11_1:1 neighbor subdomain ids: 11_1:0 0 0  6_1:0 0 0  10_1:3 0 0  11_1:3 0 0  9_1:5 0 0  11_1:5 0 0  
+DEAL:0::0 11_1:2 neighbor subdomain ids: 7_1:3 0 0  11_1:3 0 0  11_1:0 0 0  17_1:0 1 1  9_1:6 0 0  11_1:6 0 0  
+DEAL:0::0 11_1:3 neighbor subdomain ids: 11_1:2 0 0  6_1:2 0 0  11_1:1 0 0  17_1:1 1 1  9_1:7 0 0  11_1:7 0 0  
+DEAL:0::0 11_1:4 neighbor subdomain ids: 7_1:5 0 0  11_1:5 0 0  10_1:6 0 0  11_1:6 0 0  11_1:0 0 0  23_1:0 1 1  
+DEAL:0::0 11_1:5 neighbor subdomain ids: 11_1:4 0 0  6_1:4 0 0  10_1:7 0 0  11_1:7 0 0  11_1:1 0 0  23_1:1 1 1  
+DEAL:0::0 11_1:6 neighbor subdomain ids: 7_1:7 0 0  11_1:7 0 0  11_1:4 0 0  17_1:4 1 1  11_1:2 0 0  23_1:2 1 1  
+DEAL:0::0 11_1:7 neighbor subdomain ids: 11_1:6 0 0  6_1:6 0 0  11_1:5 0 0  17_1:5 1 1  11_1:3 0 0  23_1:3 1 1  
+
+DEAL:1::1 4_0: neighbor subdomain ids: 1_0: 0 0  0_0: 0 0  8_0: 1 1  5_0: 1 1  
+DEAL:1::1 5_0: neighbor subdomain ids: 3_0: 0 0  2_0: 0 0  4_0: 1 1  8_0: 1 1  
+DEAL:1::1 6_0: neighbor subdomain ids: 8_0: 1 1  7_0: 1 1  2_0: 0 0  0_0: 0 0  
+DEAL:1::1 7_0: neighbor subdomain ids: 6_0: 1 1  8_0: 1 1  3_0: 0 0  1_0: 0 0  
+DEAL:1::1 8_0: neighbor subdomain ids: 7_0: 1 1  6_0: 1 1  5_0: 1 1  4_0: 1 1  
+DEAL:1::1 5_0: neighbor subdomain ids: 3_0: 0  2_0: 0  4_0: 0  8_0: 1  
+DEAL:1::1 6_0: neighbor subdomain ids: 8_0: 1  7_0: 1  2_0: 0  0_0: 0  
+DEAL:1::1 7_0: neighbor subdomain ids: 6_0: 1  8_0: 1  3_0: 0  1_0: 0  
+DEAL:1::1 8_0: neighbor subdomain ids: 7_0: 1  6_0: 1  5_0: 1  4_0: 0  
+DEAL:1::1 5_1:0 neighbor subdomain ids: 3_1:1 0 0  5_1:1 1 1  4_1:2 0 0  5_1:2 1 1  
+DEAL:1::1 5_1:1 neighbor subdomain ids: 5_1:0 1 1  2_1:0 0 0  4_1:3 0 0  5_1:3 1 1  
+DEAL:1::1 5_1:2 neighbor subdomain ids: 3_1:3 0 0  5_1:3 1 1  5_1:0 1 1  8_1:0 1 1  
+DEAL:1::1 5_1:3 neighbor subdomain ids: 5_1:2 1 1  2_1:2 0 0  5_1:1 1 1  8_1:1 1 1  
+DEAL:1::1 6_1:0 neighbor subdomain ids: 8_1:1 1 1  6_1:1 1 1  2_1:2 0 0  6_1:2 1 1  
+DEAL:1::1 6_1:1 neighbor subdomain ids: 6_1:0 1 1  7_1:0 1 1  2_1:3 0 0  6_1:3 1 1  
+DEAL:1::1 6_1:2 neighbor subdomain ids: 8_1:3 1 1  6_1:3 1 1  6_1:0 1 1  0_1:0 0 0  
+DEAL:1::1 6_1:3 neighbor subdomain ids: 6_1:2 1 1  7_1:2 1 1  6_1:1 1 1  0_1:1 0 0  
+DEAL:1::1 7_1:0 neighbor subdomain ids: 6_1:1 1 1  7_1:1 1 1  3_1:2 0 0  7_1:2 1 1  
+DEAL:1::1 7_1:1 neighbor subdomain ids: 7_1:0 1 1  8_1:0 1 1  3_1:3 0 0  7_1:3 1 1  
+DEAL:1::1 7_1:2 neighbor subdomain ids: 6_1:3 1 1  7_1:3 1 1  7_1:0 1 1  1_1:0 0 0  
+DEAL:1::1 7_1:3 neighbor subdomain ids: 7_1:2 1 1  8_1:2 1 1  7_1:1 1 1  1_1:1 0 0  
+DEAL:1::1 8_1:0 neighbor subdomain ids: 7_1:1 1 1  8_1:1 1 1  5_1:2 1 1  8_1:2 1 1  
+DEAL:1::1 8_1:1 neighbor subdomain ids: 8_1:0 1 1  6_1:0 1 1  5_1:3 1 1  8_1:3 1 1  
+DEAL:1::1 8_1:2 neighbor subdomain ids: 7_1:3 1 1  8_1:3 1 1  8_1:0 1 1  4_1:0 0 0  
+DEAL:1::1 8_1:3 neighbor subdomain ids: 8_1:2 1 1  6_1:2 1 1  8_1:1 1 1  4_1:1 0 0  
+DEAL:1::1 13_0: neighbor subdomain ids: 12_0: 0 0  16_0: 1 1  3_0: 0 0  1_0: 0 0  25_0: 1 1  15_0: 1 1  
+DEAL:1::1 16_0: neighbor subdomain ids: 13_0: 1 1  12_0: 0 0  9_0: 0 0  8_0: 0 0  26_0: 1 1  17_0: 1 1  
+DEAL:1::1 14_0: neighbor subdomain ids: 17_0: 1 1  15_0: 1 1  6_0: 0 0  4_0: 0 0  12_0: 0 0  24_0: 1 1  
+DEAL:1::1 15_0: neighbor subdomain ids: 14_0: 1 1  17_0: 1 1  7_0: 0 0  5_0: 0 0  13_0: 1 1  25_0: 1 1  
+DEAL:1::1 17_0: neighbor subdomain ids: 15_0: 1 1  14_0: 1 1  11_0: 0 0  10_0: 0 0  16_0: 1 1  26_0: 1 1  
+DEAL:1::1 18_0: neighbor subdomain ids: 22_0: 1 1  19_0: 1 1  24_0: 1 1  20_0: 1 1  4_0: 0 0  0_0: 0 0  
+DEAL:1::1 19_0: neighbor subdomain ids: 18_0: 1 1  22_0: 1 1  25_0: 1 1  21_0: 1 1  5_0: 0 0  1_0: 0 0  
+DEAL:1::1 22_0: neighbor subdomain ids: 19_0: 1 1  18_0: 1 1  26_0: 1 1  23_0: 1 1  10_0: 0 0  8_0: 0 0  
+DEAL:1::1 20_0: neighbor subdomain ids: 23_0: 1 1  21_0: 1 1  18_0: 1 1  24_0: 1 1  6_0: 0 0  2_0: 0 0  
+DEAL:1::1 21_0: neighbor subdomain ids: 20_0: 1 1  23_0: 1 1  19_0: 1 1  25_0: 1 1  7_0: 0 0  3_0: 0 0  
+DEAL:1::1 23_0: neighbor subdomain ids: 21_0: 1 1  20_0: 1 1  22_0: 1 1  26_0: 1 1  11_0: 0 0  9_0: 0 0  
+DEAL:1::1 24_0: neighbor subdomain ids: 26_0: 1 1  25_0: 1 1  20_0: 1 1  18_0: 1 1  14_0: 1 1  12_0: 0 0  
+DEAL:1::1 25_0: neighbor subdomain ids: 24_0: 1 1  26_0: 1 1  21_0: 1 1  19_0: 1 1  15_0: 1 1  13_0: 1 1  
+DEAL:1::1 26_0: neighbor subdomain ids: 25_0: 1 1  24_0: 1 1  23_0: 1 1  22_0: 1 1  17_0: 1 1  16_0: 1 1  
+DEAL:1::1 16_0: neighbor subdomain ids: 13_0: 0  12_0: 0  9_0: 0  8_0: 0  26_0: 1  17_0: 1  
+DEAL:1::1 14_0: neighbor subdomain ids: 17_0: 1  15_0: 1  6_0: 0  4_0: 0  12_0: 0  24_0: 1  
+DEAL:1::1 15_0: neighbor subdomain ids: 14_0: 1  17_0: 1  7_0: 0  5_0: 0  13_0: 0  25_0: 1  
+DEAL:1::1 17_0: neighbor subdomain ids: 15_0: 1  14_0: 1  11_0: 0  10_0: 0  16_0: 1  26_0: 1  
+DEAL:1::1 18_0: neighbor subdomain ids: 22_0: 1  19_0: 1  24_0: 1  20_0: 1  4_0: 0  0_0: 0  
+DEAL:1::1 19_0: neighbor subdomain ids: 18_0: 1  22_0: 1  25_0: 1  21_0: 1  5_0: 0  1_0: 0  
+DEAL:1::1 22_0: neighbor subdomain ids: 19_0: 1  18_0: 1  26_0: 1  23_0: 1  10_0: 0  8_0: 0  
+DEAL:1::1 20_0: neighbor subdomain ids: 23_0: 1  21_0: 1  18_0: 1  24_0: 1  6_0: 0  2_0: 0  
+DEAL:1::1 21_0: neighbor subdomain ids: 20_0: 1  23_0: 1  19_0: 1  25_0: 1  7_0: 0  3_0: 0  
+DEAL:1::1 23_0: neighbor subdomain ids: 21_0: 1  20_0: 1  22_0: 1  26_0: 1  11_0: 0  9_0: 0  
+DEAL:1::1 24_0: neighbor subdomain ids: 26_0: 1  25_0: 1  20_0: 1  18_0: 1  14_0: 1  12_0: 0  
+DEAL:1::1 25_0: neighbor subdomain ids: 24_0: 1  26_0: 1  21_0: 1  19_0: 1  15_0: 1  13_0: 0  
+DEAL:1::1 26_0: neighbor subdomain ids: 25_0: 1  24_0: 1  23_0: 1  22_0: 1  17_0: 1  16_0: 1  
+DEAL:1::1 16_1:0 neighbor subdomain ids: 13_1:1 0 0  16_1:1 1 1  9_1:2 0 0  16_1:2 1 1  26_1:4 1 1  16_1:4 1 1  
+DEAL:1::1 16_1:1 neighbor subdomain ids: 16_1:0 1 1  12_1:0 0 0  9_1:3 0 0  16_1:3 1 1  26_1:5 1 1  16_1:5 1 1  
+DEAL:1::1 16_1:2 neighbor subdomain ids: 13_1:3 0 0  16_1:3 1 1  16_1:0 1 1  8_1:0 0 0  26_1:6 1 1  16_1:6 1 1  
+DEAL:1::1 16_1:3 neighbor subdomain ids: 16_1:2 1 1  12_1:2 0 0  16_1:1 1 1  8_1:1 0 0  26_1:7 1 1  16_1:7 1 1  
+DEAL:1::1 16_1:4 neighbor subdomain ids: 13_1:5 0 0  16_1:5 1 1  9_1:6 0 0  16_1:6 1 1  16_1:0 1 1  17_1:0 1 1  
+DEAL:1::1 16_1:5 neighbor subdomain ids: 16_1:4 1 1  12_1:4 0 0  9_1:7 0 0  16_1:7 1 1  16_1:1 1 1  17_1:1 1 1  
+DEAL:1::1 16_1:6 neighbor subdomain ids: 13_1:7 0 0  16_1:7 1 1  16_1:4 1 1  8_1:4 0 0  16_1:2 1 1  17_1:2 1 1  
+DEAL:1::1 16_1:7 neighbor subdomain ids: 16_1:6 1 1  12_1:6 0 0  16_1:5 1 1  8_1:5 0 0  16_1:3 1 1  17_1:3 1 1  
+DEAL:1::1 14_1:0 neighbor subdomain ids: 17_1:1 1 1  14_1:1 1 1  6_1:2 0 0  14_1:2 1 1  12_1:4 0 0  14_1:4 1 1  
+DEAL:1::1 14_1:1 neighbor subdomain ids: 14_1:0 1 1  15_1:0 1 1  6_1:3 0 0  14_1:3 1 1  12_1:5 0 0  14_1:5 1 1  
+DEAL:1::1 14_1:2 neighbor subdomain ids: 17_1:3 1 1  14_1:3 1 1  14_1:0 1 1  4_1:0 0 0  12_1:6 0 0  14_1:6 1 1  
+DEAL:1::1 14_1:3 neighbor subdomain ids: 14_1:2 1 1  15_1:2 1 1  14_1:1 1 1  4_1:1 0 0  12_1:7 0 0  14_1:7 1 1  
+DEAL:1::1 14_1:4 neighbor subdomain ids: 17_1:5 1 1  14_1:5 1 1  6_1:6 0 0  14_1:6 1 1  14_1:0 1 1  24_1:0 1 1  
+DEAL:1::1 14_1:5 neighbor subdomain ids: 14_1:4 1 1  15_1:4 1 1  6_1:7 0 0  14_1:7 1 1  14_1:1 1 1  24_1:1 1 1  
+DEAL:1::1 14_1:6 neighbor subdomain ids: 17_1:7 1 1  14_1:7 1 1  14_1:4 1 1  4_1:4 0 0  14_1:2 1 1  24_1:2 1 1  
+DEAL:1::1 14_1:7 neighbor subdomain ids: 14_1:6 1 1  15_1:6 1 1  14_1:5 1 1  4_1:5 0 0  14_1:3 1 1  24_1:3 1 1  
+DEAL:1::1 15_1:0 neighbor subdomain ids: 14_1:1 1 1  15_1:1 1 1  7_1:2 0 0  15_1:2 1 1  13_1:4 0 0  15_1:4 1 1  
+DEAL:1::1 15_1:1 neighbor subdomain ids: 15_1:0 1 1  17_1:0 1 1  7_1:3 0 0  15_1:3 1 1  13_1:5 0 0  15_1:5 1 1  
+DEAL:1::1 15_1:2 neighbor subdomain ids: 14_1:3 1 1  15_1:3 1 1  15_1:0 1 1  5_1:0 0 0  13_1:6 0 0  15_1:6 1 1  
+DEAL:1::1 15_1:3 neighbor subdomain ids: 15_1:2 1 1  17_1:2 1 1  15_1:1 1 1  5_1:1 0 0  13_1:7 0 0  15_1:7 1 1  
+DEAL:1::1 15_1:4 neighbor subdomain ids: 14_1:5 1 1  15_1:5 1 1  7_1:6 0 0  15_1:6 1 1  15_1:0 1 1  25_1:0 1 1  
+DEAL:1::1 15_1:5 neighbor subdomain ids: 15_1:4 1 1  17_1:4 1 1  7_1:7 0 0  15_1:7 1 1  15_1:1 1 1  25_1:1 1 1  
+DEAL:1::1 15_1:6 neighbor subdomain ids: 14_1:7 1 1  15_1:7 1 1  15_1:4 1 1  5_1:4 0 0  15_1:2 1 1  25_1:2 1 1  
+DEAL:1::1 15_1:7 neighbor subdomain ids: 15_1:6 1 1  17_1:6 1 1  15_1:5 1 1  5_1:5 0 0  15_1:3 1 1  25_1:3 1 1  
+DEAL:1::1 17_1:0 neighbor subdomain ids: 15_1:1 1 1  17_1:1 1 1  11_1:2 0 0  17_1:2 1 1  16_1:4 1 1  17_1:4 1 1  
+DEAL:1::1 17_1:1 neighbor subdomain ids: 17_1:0 1 1  14_1:0 1 1  11_1:3 0 0  17_1:3 1 1  16_1:5 1 1  17_1:5 1 1  
+DEAL:1::1 17_1:2 neighbor subdomain ids: 15_1:3 1 1  17_1:3 1 1  17_1:0 1 1  10_1:0 0 0  16_1:6 1 1  17_1:6 1 1  
+DEAL:1::1 17_1:3 neighbor subdomain ids: 17_1:2 1 1  14_1:2 1 1  17_1:1 1 1  10_1:1 0 0  16_1:7 1 1  17_1:7 1 1  
+DEAL:1::1 17_1:4 neighbor subdomain ids: 15_1:5 1 1  17_1:5 1 1  11_1:6 0 0  17_1:6 1 1  17_1:0 1 1  26_1:0 1 1  
+DEAL:1::1 17_1:5 neighbor subdomain ids: 17_1:4 1 1  14_1:4 1 1  11_1:7 0 0  17_1:7 1 1  17_1:1 1 1  26_1:1 1 1  
+DEAL:1::1 17_1:6 neighbor subdomain ids: 15_1:7 1 1  17_1:7 1 1  17_1:4 1 1  10_1:4 0 0  17_1:2 1 1  26_1:2 1 1  
+DEAL:1::1 17_1:7 neighbor subdomain ids: 17_1:6 1 1  14_1:6 1 1  17_1:5 1 1  10_1:5 0 0  17_1:3 1 1  26_1:3 1 1  
+DEAL:1::1 18_1:0 neighbor subdomain ids: 22_1:1 1 1  18_1:1 1 1  24_1:2 1 1  18_1:2 1 1  4_1:4 0 0  18_1:4 1 1  
+DEAL:1::1 18_1:1 neighbor subdomain ids: 18_1:0 1 1  19_1:0 1 1  24_1:3 1 1  18_1:3 1 1  4_1:5 0 0  18_1:5 1 1  
+DEAL:1::1 18_1:2 neighbor subdomain ids: 22_1:3 1 1  18_1:3 1 1  18_1:0 1 1  20_1:0 1 1  4_1:6 0 0  18_1:6 1 1  
+DEAL:1::1 18_1:3 neighbor subdomain ids: 18_1:2 1 1  19_1:2 1 1  18_1:1 1 1  20_1:1 1 1  4_1:7 0 0  18_1:7 1 1  
+DEAL:1::1 18_1:4 neighbor subdomain ids: 22_1:5 1 1  18_1:5 1 1  24_1:6 1 1  18_1:6 1 1  18_1:0 1 1  0_1:0 0 0  
+DEAL:1::1 18_1:5 neighbor subdomain ids: 18_1:4 1 1  19_1:4 1 1  24_1:7 1 1  18_1:7 1 1  18_1:1 1 1  0_1:1 0 0  
+DEAL:1::1 18_1:6 neighbor subdomain ids: 22_1:7 1 1  18_1:7 1 1  18_1:4 1 1  20_1:4 1 1  18_1:2 1 1  0_1:2 0 0  
+DEAL:1::1 18_1:7 neighbor subdomain ids: 18_1:6 1 1  19_1:6 1 1  18_1:5 1 1  20_1:5 1 1  18_1:3 1 1  0_1:3 0 0  
+DEAL:1::1 19_1:0 neighbor subdomain ids: 18_1:1 1 1  19_1:1 1 1  25_1:2 1 1  19_1:2 1 1  5_1:4 0 0  19_1:4 1 1  
+DEAL:1::1 19_1:1 neighbor subdomain ids: 19_1:0 1 1  22_1:0 1 1  25_1:3 1 1  19_1:3 1 1  5_1:5 0 0  19_1:5 1 1  
+DEAL:1::1 19_1:2 neighbor subdomain ids: 18_1:3 1 1  19_1:3 1 1  19_1:0 1 1  21_1:0 1 1  5_1:6 0 0  19_1:6 1 1  
+DEAL:1::1 19_1:3 neighbor subdomain ids: 19_1:2 1 1  22_1:2 1 1  19_1:1 1 1  21_1:1 1 1  5_1:7 0 0  19_1:7 1 1  
+DEAL:1::1 19_1:4 neighbor subdomain ids: 18_1:5 1 1  19_1:5 1 1  25_1:6 1 1  19_1:6 1 1  19_1:0 1 1  1_1:0 0 0  
+DEAL:1::1 19_1:5 neighbor subdomain ids: 19_1:4 1 1  22_1:4 1 1  25_1:7 1 1  19_1:7 1 1  19_1:1 1 1  1_1:1 0 0  
+DEAL:1::1 19_1:6 neighbor subdomain ids: 18_1:7 1 1  19_1:7 1 1  19_1:4 1 1  21_1:4 1 1  19_1:2 1 1  1_1:2 0 0  
+DEAL:1::1 19_1:7 neighbor subdomain ids: 19_1:6 1 1  22_1:6 1 1  19_1:5 1 1  21_1:5 1 1  19_1:3 1 1  1_1:3 0 0  
+DEAL:1::1 22_1:0 neighbor subdomain ids: 19_1:1 1 1  22_1:1 1 1  26_1:2 1 1  22_1:2 1 1  10_1:4 0 0  22_1:4 1 1  
+DEAL:1::1 22_1:1 neighbor subdomain ids: 22_1:0 1 1  18_1:0 1 1  26_1:3 1 1  22_1:3 1 1  10_1:5 0 0  22_1:5 1 1  
+DEAL:1::1 22_1:2 neighbor subdomain ids: 19_1:3 1 1  22_1:3 1 1  22_1:0 1 1  23_1:0 1 1  10_1:6 0 0  22_1:6 1 1  
+DEAL:1::1 22_1:3 neighbor subdomain ids: 22_1:2 1 1  18_1:2 1 1  22_1:1 1 1  23_1:1 1 1  10_1:7 0 0  22_1:7 1 1  
+DEAL:1::1 22_1:4 neighbor subdomain ids: 19_1:5 1 1  22_1:5 1 1  26_1:6 1 1  22_1:6 1 1  22_1:0 1 1  8_1:0 0 0  
+DEAL:1::1 22_1:5 neighbor subdomain ids: 22_1:4 1 1  18_1:4 1 1  26_1:7 1 1  22_1:7 1 1  22_1:1 1 1  8_1:1 0 0  
+DEAL:1::1 22_1:6 neighbor subdomain ids: 19_1:7 1 1  22_1:7 1 1  22_1:4 1 1  23_1:4 1 1  22_1:2 1 1  8_1:2 0 0  
+DEAL:1::1 22_1:7 neighbor subdomain ids: 22_1:6 1 1  18_1:6 1 1  22_1:5 1 1  23_1:5 1 1  22_1:3 1 1  8_1:3 0 0  
+DEAL:1::1 20_1:0 neighbor subdomain ids: 23_1:1 1 1  20_1:1 1 1  18_1:2 1 1  20_1:2 1 1  6_1:4 0 0  20_1:4 1 1  
+DEAL:1::1 20_1:1 neighbor subdomain ids: 20_1:0 1 1  21_1:0 1 1  18_1:3 1 1  20_1:3 1 1  6_1:5 0 0  20_1:5 1 1  
+DEAL:1::1 20_1:2 neighbor subdomain ids: 23_1:3 1 1  20_1:3 1 1  20_1:0 1 1  24_1:0 1 1  6_1:6 0 0  20_1:6 1 1  
+DEAL:1::1 20_1:3 neighbor subdomain ids: 20_1:2 1 1  21_1:2 1 1  20_1:1 1 1  24_1:1 1 1  6_1:7 0 0  20_1:7 1 1  
+DEAL:1::1 20_1:4 neighbor subdomain ids: 23_1:5 1 1  20_1:5 1 1  18_1:6 1 1  20_1:6 1 1  20_1:0 1 1  2_1:0 0 0  
+DEAL:1::1 20_1:5 neighbor subdomain ids: 20_1:4 1 1  21_1:4 1 1  18_1:7 1 1  20_1:7 1 1  20_1:1 1 1  2_1:1 0 0  
+DEAL:1::1 20_1:6 neighbor subdomain ids: 23_1:7 1 1  20_1:7 1 1  20_1:4 1 1  24_1:4 1 1  20_1:2 1 1  2_1:2 0 0  
+DEAL:1::1 20_1:7 neighbor subdomain ids: 20_1:6 1 1  21_1:6 1 1  20_1:5 1 1  24_1:5 1 1  20_1:3 1 1  2_1:3 0 0  
+DEAL:1::1 21_1:0 neighbor subdomain ids: 20_1:1 1 1  21_1:1 1 1  19_1:2 1 1  21_1:2 1 1  7_1:4 0 0  21_1:4 1 1  
+DEAL:1::1 21_1:1 neighbor subdomain ids: 21_1:0 1 1  23_1:0 1 1  19_1:3 1 1  21_1:3 1 1  7_1:5 0 0  21_1:5 1 1  
+DEAL:1::1 21_1:2 neighbor subdomain ids: 20_1:3 1 1  21_1:3 1 1  21_1:0 1 1  25_1:0 1 1  7_1:6 0 0  21_1:6 1 1  
+DEAL:1::1 21_1:3 neighbor subdomain ids: 21_1:2 1 1  23_1:2 1 1  21_1:1 1 1  25_1:1 1 1  7_1:7 0 0  21_1:7 1 1  
+DEAL:1::1 21_1:4 neighbor subdomain ids: 20_1:5 1 1  21_1:5 1 1  19_1:6 1 1  21_1:6 1 1  21_1:0 1 1  3_1:0 0 0  
+DEAL:1::1 21_1:5 neighbor subdomain ids: 21_1:4 1 1  23_1:4 1 1  19_1:7 1 1  21_1:7 1 1  21_1:1 1 1  3_1:1 0 0  
+DEAL:1::1 21_1:6 neighbor subdomain ids: 20_1:7 1 1  21_1:7 1 1  21_1:4 1 1  25_1:4 1 1  21_1:2 1 1  3_1:2 0 0  
+DEAL:1::1 21_1:7 neighbor subdomain ids: 21_1:6 1 1  23_1:6 1 1  21_1:5 1 1  25_1:5 1 1  21_1:3 1 1  3_1:3 0 0  
+DEAL:1::1 23_1:0 neighbor subdomain ids: 21_1:1 1 1  23_1:1 1 1  22_1:2 1 1  23_1:2 1 1  11_1:4 0 0  23_1:4 1 1  
+DEAL:1::1 23_1:1 neighbor subdomain ids: 23_1:0 1 1  20_1:0 1 1  22_1:3 1 1  23_1:3 1 1  11_1:5 0 0  23_1:5 1 1  
+DEAL:1::1 23_1:2 neighbor subdomain ids: 21_1:3 1 1  23_1:3 1 1  23_1:0 1 1  26_1:0 1 1  11_1:6 0 0  23_1:6 1 1  
+DEAL:1::1 23_1:3 neighbor subdomain ids: 23_1:2 1 1  20_1:2 1 1  23_1:1 1 1  26_1:1 1 1  11_1:7 0 0  23_1:7 1 1  
+DEAL:1::1 23_1:4 neighbor subdomain ids: 21_1:5 1 1  23_1:5 1 1  22_1:6 1 1  23_1:6 1 1  23_1:0 1 1  9_1:0 0 0  
+DEAL:1::1 23_1:5 neighbor subdomain ids: 23_1:4 1 1  20_1:4 1 1  22_1:7 1 1  23_1:7 1 1  23_1:1 1 1  9_1:1 0 0  
+DEAL:1::1 23_1:6 neighbor subdomain ids: 21_1:7 1 1  23_1:7 1 1  23_1:4 1 1  26_1:4 1 1  23_1:2 1 1  9_1:2 0 0  
+DEAL:1::1 23_1:7 neighbor subdomain ids: 23_1:6 1 1  20_1:6 1 1  23_1:5 1 1  26_1:5 1 1  23_1:3 1 1  9_1:3 0 0  
+DEAL:1::1 24_1:0 neighbor subdomain ids: 26_1:1 1 1  24_1:1 1 1  20_1:2 1 1  24_1:2 1 1  14_1:4 1 1  24_1:4 1 1  
+DEAL:1::1 24_1:1 neighbor subdomain ids: 24_1:0 1 1  25_1:0 1 1  20_1:3 1 1  24_1:3 1 1  14_1:5 1 1  24_1:5 1 1  
+DEAL:1::1 24_1:2 neighbor subdomain ids: 26_1:3 1 1  24_1:3 1 1  24_1:0 1 1  18_1:0 1 1  14_1:6 1 1  24_1:6 1 1  
+DEAL:1::1 24_1:3 neighbor subdomain ids: 24_1:2 1 1  25_1:2 1 1  24_1:1 1 1  18_1:1 1 1  14_1:7 1 1  24_1:7 1 1  
+DEAL:1::1 24_1:4 neighbor subdomain ids: 26_1:5 1 1  24_1:5 1 1  20_1:6 1 1  24_1:6 1 1  24_1:0 1 1  12_1:0 0 0  
+DEAL:1::1 24_1:5 neighbor subdomain ids: 24_1:4 1 1  25_1:4 1 1  20_1:7 1 1  24_1:7 1 1  24_1:1 1 1  12_1:1 0 0  
+DEAL:1::1 24_1:6 neighbor subdomain ids: 26_1:7 1 1  24_1:7 1 1  24_1:4 1 1  18_1:4 1 1  24_1:2 1 1  12_1:2 0 0  
+DEAL:1::1 24_1:7 neighbor subdomain ids: 24_1:6 1 1  25_1:6 1 1  24_1:5 1 1  18_1:5 1 1  24_1:3 1 1  12_1:3 0 0  
+DEAL:1::1 25_1:0 neighbor subdomain ids: 24_1:1 1 1  25_1:1 1 1  21_1:2 1 1  25_1:2 1 1  15_1:4 1 1  25_1:4 1 1  
+DEAL:1::1 25_1:1 neighbor subdomain ids: 25_1:0 1 1  26_1:0 1 1  21_1:3 1 1  25_1:3 1 1  15_1:5 1 1  25_1:5 1 1  
+DEAL:1::1 25_1:2 neighbor subdomain ids: 24_1:3 1 1  25_1:3 1 1  25_1:0 1 1  19_1:0 1 1  15_1:6 1 1  25_1:6 1 1  
+DEAL:1::1 25_1:3 neighbor subdomain ids: 25_1:2 1 1  26_1:2 1 1  25_1:1 1 1  19_1:1 1 1  15_1:7 1 1  25_1:7 1 1  
+DEAL:1::1 25_1:4 neighbor subdomain ids: 24_1:5 1 1  25_1:5 1 1  21_1:6 1 1  25_1:6 1 1  25_1:0 1 1  13_1:0 0 0  
+DEAL:1::1 25_1:5 neighbor subdomain ids: 25_1:4 1 1  26_1:4 1 1  21_1:7 1 1  25_1:7 1 1  25_1:1 1 1  13_1:1 0 0  
+DEAL:1::1 25_1:6 neighbor subdomain ids: 24_1:7 1 1  25_1:7 1 1  25_1:4 1 1  19_1:4 1 1  25_1:2 1 1  13_1:2 0 0  
+DEAL:1::1 25_1:7 neighbor subdomain ids: 25_1:6 1 1  26_1:6 1 1  25_1:5 1 1  19_1:5 1 1  25_1:3 1 1  13_1:3 0 0  
+DEAL:1::1 26_1:0 neighbor subdomain ids: 25_1:1 1 1  26_1:1 1 1  23_1:2 1 1  26_1:2 1 1  17_1:4 1 1  26_1:4 1 1  
+DEAL:1::1 26_1:1 neighbor subdomain ids: 26_1:0 1 1  24_1:0 1 1  23_1:3 1 1  26_1:3 1 1  17_1:5 1 1  26_1:5 1 1  
+DEAL:1::1 26_1:2 neighbor subdomain ids: 25_1:3 1 1  26_1:3 1 1  26_1:0 1 1  22_1:0 1 1  17_1:6 1 1  26_1:6 1 1  
+DEAL:1::1 26_1:3 neighbor subdomain ids: 26_1:2 1 1  24_1:2 1 1  26_1:1 1 1  22_1:1 1 1  17_1:7 1 1  26_1:7 1 1  
+DEAL:1::1 26_1:4 neighbor subdomain ids: 25_1:5 1 1  26_1:5 1 1  23_1:6 1 1  26_1:6 1 1  26_1:0 1 1  16_1:0 1 1  
+DEAL:1::1 26_1:5 neighbor subdomain ids: 26_1:4 1 1  24_1:4 1 1  23_1:7 1 1  26_1:7 1 1  26_1:1 1 1  16_1:1 1 1  
+DEAL:1::1 26_1:6 neighbor subdomain ids: 25_1:7 1 1  26_1:7 1 1  26_1:4 1 1  22_1:4 1 1  26_1:2 1 1  16_1:2 1 1  
+DEAL:1::1 26_1:7 neighbor subdomain ids: 26_1:6 1 1  24_1:6 1 1  26_1:5 1 1  22_1:5 1 1  26_1:3 1 1  16_1:3 1 1  
+


### PR DESCRIPTION
This PR fixes a subtle bug in the setup of the level subdomain ids in the ghost layer of the multigrid levels: If we have a mesh with one single level (i.e., not refined, and a case where multigrid may not make much sense), we forgot to identify cells behind periodic boundaries as level ghost cells; this makes downstream multigrid data structures to break down.

The fix is to move the code that sets the periodic data structures before we call
https://github.com/dealii/dealii/blob/a0a79b2d3df7bfd3bb0530dccf557fea1516c680/source/distributed/tria.cc#L4727
Otherwise the code inside this call, namely the one that identifies the appropriate cells and vertices here:
https://github.com/dealii/dealii/blob/a0a79b2d3df7bfd3bb0530dccf557fea1516c680/source/distributed/tria.cc#L3713-L3739
does not include the periodic neighbors for a triangulation immediately after `add_periodicity`.

This was not a problem when we refined the mesh, as then the periodicity has already been set.

FYI @nfehn 