### PR TITLE
Implement default initializer for EigenvalueInformation

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1187,6 +1187,15 @@ public:
      * AdditionalData::degree or estimated as described there).
      */
     unsigned int degree;
+    /**
+     * Constructor initializing with invalid values.
+     */
+    EigenvalueInformation()
+      : min_eigenvalue_estimate{std::numeric_limits<double>::max()}
+      , max_eigenvalue_estimate{std::numeric_limits<double>::lowest()}
+      , cg_iterations{0}
+      , degree{0}
+    {}
   };
 
   /**


### PR DESCRIPTION
Fixes most of the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=5357.