### PR TITLE
Fix portability issue

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -15,24 +15,25 @@
 
  */
 
+// clang-format off
 // @sect3{Include files}
 
 // The most fundamental class in the library is the Triangulation class, which
 // is declared here:
-#include <deal.II/grid/tria.h>
+%:include <deal.II/grid/tria.h>
 // We need the following two includes for loops over cells and/or faces:
-#include <deal.II/grid/tria_accessor.h>
-#include <deal.II/grid/tria_iterator.h>
+%:include <deal.II/grid/tria_accessor.h>
+%:include <deal.II/grid/tria_iterator.h>
 // Here are some functions to generate standard grids:
-#include <deal.II/grid/grid_generator.h>
+%:include <deal.II/grid/grid_generator.h>
 // Output of grids in various graphics formats:
-#include <deal.II/grid/grid_out.h>
+%:include <deal.II/grid/grid_out.h>
 
 // This is needed for C++ output:
-#include <iostream>
-#include <fstream>
+%:include <iostream>
+%:include <fstream>
 // And this for the declarations of the `sqrt` and `fabs` functions:
-#include <cmath>
+%:include <cmath>
 
 // The final step in importing deal.II is this: All deal.II functions and
 // classes are in a namespace <code>dealii</code>, to make sure they don't
@@ -48,7 +49,7 @@ using namespace dealii;
 // In the following, first function, we simply use the unit square as domain
 // and produce a globally refined grid from it.
 void first_grid()
-{
+<%
   // The first thing to do is to define an object for a triangulation of a
   // two-dimensional domain:
   Triangulation<2> triangulation;
@@ -74,7 +75,7 @@ void first_grid()
   GridOut       grid_out;
   grid_out.write_svg(triangulation, out);
   std::cout << "Grid written to grid-1.svg" << std::endl;
-}
+%>
 
 
 
@@ -83,7 +84,7 @@ void first_grid()
 // The grid in the following, second function is slightly more complicated in
 // that we use a ring domain and refine the result once globally.
 void second_grid()
-{
+<%
   // We start again by defining an object for a triangulation of a
   // two-dimensional domain:
   Triangulation<2> triangulation;
@@ -142,7 +143,7 @@ void second_grid()
   // In order to demonstrate how to write a loop over all cells, we will
   // refine the grid in five steps towards the inner circle of the domain:
   for (unsigned int step = 0; step < 5; ++step)
-    {
+    <%
       // Next, we need to loop over the active cells of the triangulation. You
       // can think of a triangulation as a collection of cells. If it were an
       // array, you would just get a pointer that you increment from one
@@ -193,8 +194,8 @@ void second_grid()
       // <a href="http://en.cppreference.com/w/cpp/language/range-for">range-
       // based for loops</a>, which wrap up all of the syntax shown above into a
       // much shorter form:
-      for (auto &cell : triangulation.active_cell_iterators())
-        {
+      for (auto bitand cell : triangulation.active_cell_iterators())
+        <%
           // @note See @ref Iterators for more information about the iterator
           // classes used in deal.II, and @ref CPP11 for more information about
           // range-based for loops and the `auto` keyword.
@@ -210,7 +211,7 @@ void second_grid()
           // have to audit our code for the hidden appearance of magic numbers
           // like a 4 that needs to be replaced by an 8:
           for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
-            {
+            <%
               // If this cell is at the inner boundary, then at least one of its
               // vertices must sit on the inner ring and therefore have a radial
               // distance from the center of exactly 0.5, up to floating point
@@ -222,12 +223,12 @@ void second_grid()
                 center.distance(cell->vertex(v));
 
               if (std::fabs(distance_from_center - inner_radius) < 1e-10)
-                {
+                <%
                   cell->set_refine_flag();
                   break;
-                }
-            }
-        }
+                %>
+            %>
+        %>
 
       // Now that we have marked all the cells that we want refined, we let
       // the triangulation actually do this refinement. The function that does
@@ -235,7 +236,7 @@ void second_grid()
       // coarsening, and the function does coarsening and refinement all at
       // once:
       triangulation.execute_coarsening_and_refinement();
-    }
+    %>
 
 
   // Finally, after these five iterations of refinement, we want to again
@@ -246,7 +247,7 @@ void second_grid()
   grid_out.write_svg(triangulation, out);
 
   std::cout << "Grid written to grid-2.svg" << std::endl;
-}
+%>
 
 
 
@@ -255,7 +256,7 @@ void second_grid()
 // Finally, the main function. There isn't much to do here, only to call the
 // two subfunctions, which produce the two grids.
 int main()
-{
+<%
   first_grid();
   second_grid();
-}
+%>

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -18,16 +18,17 @@
  */
 
 
+// clang-format off
 // The first few includes are just like in the previous program, so do not
 // require additional comments:
-#include <deal.II/grid/tria.h>
-#include <deal.II/grid/tria_accessor.h>
-#include <deal.II/grid/tria_iterator.h>
-#include <deal.II/grid/grid_generator.h>
+%:include <deal.II/grid/tria.h>
+%:include <deal.II/grid/tria_accessor.h>
+%:include <deal.II/grid/tria_iterator.h>
+%:include <deal.II/grid/grid_generator.h>
 
 // However, the next file is new. We need this include file for the
 // association of degrees of freedom ("DoF"s) to vertices, lines, and cells:
-#include <deal.II/dofs/dof_handler.h>
+%:include <deal.II/dofs/dof_handler.h>
 
 // The following include contains the description of the bilinear finite
 // element, including the facts that it has one degree of freedom on each
@@ -37,24 +38,24 @@
 // (In fact, the file contains the description of Lagrange elements in
 // general, i.e. also the quadratic, cubic, etc versions, and not only for 2d
 // but also 1d and 3d.)
-#include <deal.II/fe/fe_q.h>
+%:include <deal.II/fe/fe_q.h>
 // In the following file, several tools for manipulating degrees of freedom
 // can be found:
-#include <deal.II/dofs/dof_tools.h>
+%:include <deal.II/dofs/dof_tools.h>
 // We will use a sparse matrix to visualize the pattern of nonzero entries
 // resulting from the distribution of degrees of freedom on the grid. That
 // class can be found here:
-#include <deal.II/lac/sparse_matrix.h>
+%:include <deal.II/lac/sparse_matrix.h>
 // We will also need to use an intermediate sparsity pattern structure, which
 // is found in this file:
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
+%:include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 // We will want to use a special algorithm to renumber degrees of freedom. It
 // is declared here:
-#include <deal.II/dofs/dof_renumbering.h>
+%:include <deal.II/dofs/dof_renumbering.h>
 
 // And this is again needed for C++ output:
-#include <fstream>
+%:include <fstream>
 
 // Finally, as in step-1, we import the deal.II namespace into the global
 // scope:
@@ -65,31 +66,31 @@ using namespace dealii;
 // This is the function that produced the circular grid in the previous step-1
 // example program with fewer refinements steps. The sole difference is that it
 // returns the grid it produces via its argument.
-void make_grid(Triangulation<2> &triangulation)
-{
+void make_grid(Triangulation<2> bitand triangulation)
+<%
   const Point<2> center(1, 0);
   const double   inner_radius = 0.5, outer_radius = 1.0;
   GridGenerator::hyper_shell(
     triangulation, center, inner_radius, outer_radius, 5);
 
   for (unsigned int step = 0; step < 3; ++step)
-    {
-      for (auto &cell : triangulation.active_cell_iterators())
+    <%
+      for (auto bitand cell : triangulation.active_cell_iterators())
         for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
-          {
+          <%
             const double distance_from_center =
               center.distance(cell->vertex(v));
 
             if (std::fabs(distance_from_center - inner_radius) < 1e-10)
-              {
+              <%
                 cell->set_refine_flag();
                 break;
-              }
-          }
+              %>
+          %>
 
       triangulation.execute_coarsening_and_refinement();
-    }
-}
+    %>
+%>
 
 // @sect3{Creation of a DoFHandler}
 
@@ -122,8 +123,8 @@ void make_grid(Triangulation<2> &triangulation)
 // <code>DoFHandler</code> object to allocate storage for the degrees of
 // freedom (in deal.II lingo: we <i>distribute degrees of
 // freedom</i>).
-void distribute_dofs(DoFHandler<2> &dof_handler)
-{
+void distribute_dofs(DoFHandler<2> bitand dof_handler)
+<%
   const FE_Q<2> finite_element(1);
   dof_handler.distribute_dofs(finite_element);
 
@@ -197,7 +198,7 @@ void distribute_dofs(DoFHandler<2> &dof_handler)
   // coarsest cells and moves on to the finer ones; since they are all
   // distributed symmetrically around the origin, this shows up again in the
   // sparsity pattern.
-}
+%>
 
 
 // @sect3{Renumbering of DoFs}
@@ -227,8 +228,8 @@ void distribute_dofs(DoFHandler<2> &dof_handler)
 // more localized around the diagonal. The only interesting part of the
 // function is the first call to <code>DoFRenumbering::Cuthill_McKee</code>,
 // the rest is essentially as before:
-void renumber_dofs(DoFHandler<2> &dof_handler)
-{
+void renumber_dofs(DoFHandler<2> bitand dof_handler)
+<%
   DoFRenumbering::Cuthill_McKee(dof_handler);
 
   DynamicSparsityPattern dynamic_sparsity_pattern(dof_handler.n_dofs(),
@@ -240,7 +241,7 @@ void renumber_dofs(DoFHandler<2> &dof_handler)
 
   std::ofstream out("sparsity_pattern2.svg");
   sparsity_pattern.print_svg(out);
-}
+%>
 
 // Again, the output is shown below. Note that the nonzero entries are
 // clustered far better around the diagonal than before. This effect is even
@@ -266,7 +267,7 @@ void renumber_dofs(DoFHandler<2> &dof_handler)
 // and associate it to the triangulation, and finally call above two functions
 // on it:
 int main()
-{
+<%
   Triangulation<2> triangulation;
   make_grid(triangulation);
 
@@ -274,4 +275,4 @@ int main()
 
   distribute_dofs(dof_handler);
   renumber_dofs(dof_handler);
-}
+%>

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -19,41 +19,42 @@
  */
 
 
+// clang-format off
 // @sect3{Many new include files}
 
 // These include files are already known to you. They declare the classes
 // which handle triangulations and enumeration of degrees of freedom:
-#include <deal.II/grid/tria.h>
-#include <deal.II/dofs/dof_handler.h>
+%:include <deal.II/grid/tria.h>
+%:include <deal.II/dofs/dof_handler.h>
 // And this is the file in which the functions are declared that create grids:
-#include <deal.II/grid/grid_generator.h>
+%:include <deal.II/grid/grid_generator.h>
 
 // The next three files contain classes which are needed for loops over all
 // cells and to get the information from the cell objects. The first two have
 // been used before to get geometric information from cells; the last one is
 // new and provides information about the degrees of freedom local to a cell:
-#include <deal.II/grid/tria_accessor.h>
-#include <deal.II/grid/tria_iterator.h>
-#include <deal.II/dofs/dof_accessor.h>
+%:include <deal.II/grid/tria_accessor.h>
+%:include <deal.II/grid/tria_iterator.h>
+%:include <deal.II/dofs/dof_accessor.h>
 
 // This file contains the description of the Lagrange interpolation finite
 // element:
-#include <deal.II/fe/fe_q.h>
+%:include <deal.II/fe/fe_q.h>
 
 // And this file is needed for the creation of sparsity patterns of sparse
 // matrices, as shown in previous examples:
-#include <deal.II/dofs/dof_tools.h>
+%:include <deal.II/dofs/dof_tools.h>
 
 // The next two files are needed for assembling the matrix using quadrature on
 // each cell. The classes declared in them will be explained below:
-#include <deal.II/fe/fe_values.h>
-#include <deal.II/base/quadrature_lib.h>
+%:include <deal.II/fe/fe_values.h>
+%:include <deal.II/base/quadrature_lib.h>
 
 // The following three include files we need for the treatment of boundary
 // values:
-#include <deal.II/base/function.h>
-#include <deal.II/numerics/vector_tools.h>
-#include <deal.II/numerics/matrix_tools.h>
+%:include <deal.II/base/function.h>
+%:include <deal.II/numerics/vector_tools.h>
+%:include <deal.II/numerics/matrix_tools.h>
 
 // We're now almost to the end. The second to last group of include files is
 // for the linear algebra which we employ to solve the system of equations
@@ -63,17 +64,17 @@
 // will then use a Conjugate Gradient solver to solve the problem, for which
 // we need a preconditioner (in this program, we use the identity
 // preconditioner which does nothing, but we need to include the file anyway):
-#include <deal.II/lac/vector.h>
-#include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/dynamic_sparsity_pattern.h>
-#include <deal.II/lac/solver_cg.h>
-#include <deal.II/lac/precondition.h>
+%:include <deal.II/lac/vector.h>
+%:include <deal.II/lac/full_matrix.h>
+%:include <deal.II/lac/sparse_matrix.h>
+%:include <deal.II/lac/dynamic_sparsity_pattern.h>
+%:include <deal.II/lac/solver_cg.h>
+%:include <deal.II/lac/precondition.h>
 
 // Finally, this is for output to a file and to the console:
-#include <deal.II/numerics/data_out.h>
-#include <fstream>
-#include <iostream>
+%:include <deal.II/numerics/data_out.h>
+%:include <fstream>
+%:include <iostream>
 
 // ...and this is to import the deal.II namespace into the global scope:
 using namespace dealii;
@@ -92,7 +93,7 @@ using namespace dealii;
 // run in which order. Everything else in the class, i.e. all the functions
 // that actually do anything, are in the private section of the class:
 class Step3
-{
+<%
 public:
   Step3();
 
@@ -127,7 +128,7 @@ private:
   // vectors.
   Vector<double> solution;
   Vector<double> system_rhs;
-};
+%>;
 
 // @sect4{Step3::Step3}
 
@@ -144,7 +145,7 @@ private:
 Step3::Step3()
   : fe(1)
   , dof_handler(triangulation)
-{}
+<%%>
 
 
 // @sect4{Step3::make_grid}
@@ -163,13 +164,13 @@ Step3::Step3()
 // number of cells using the <code>n_active_cells()</code> function on the
 // triangulation.
 void Step3::make_grid()
-{
+<%
   GridGenerator::hyper_cube(triangulation, -1, 1);
   triangulation.refine_global(5);
 
   std::cout << "Number of active cells: " << triangulation.n_active_cells()
             << std::endl;
-}
+%>
 
 // @note We call the Triangulation::n_active_cells() function, rather than
 // Triangulation::n_cells(). Here, <i>active</i> means the cells that aren't
@@ -194,7 +195,7 @@ void Step3::make_grid()
 // with each vertex. While we're at generating output, let us also take a look
 // at how many degrees of freedom are generated:
 void Step3::setup_system()
-{
+<%
   dof_handler.distribute_dofs(fe);
   std::cout << "Number of degrees of freedom: " << dof_handler.n_dofs()
             << std::endl;
@@ -226,7 +227,7 @@ void Step3::setup_system()
   // hand side vector and the solution vector to the right values:
   solution.reinit(dof_handler.n_dofs());
   system_rhs.reinit(dof_handler.n_dofs());
-}
+%>
 
 // @sect4{Step3::assemble_system}
 
@@ -265,7 +266,7 @@ void Step3::setup_system()
 // Using all this, we will assemble the linear system for this problem in the
 // following function:
 void Step3::assemble_system()
-{
+<%
   // Ok, let's start: we need a quadrature formula for the evaluation of the
   // integrals on each cell. Let's take a Gauss formula with two quadrature
   // points in each direction, i.e. a total of four points since we are in
@@ -298,7 +299,8 @@ void Step3::assemble_system()
   // have to list #update_JxW_values as well:
   FEValues<2> fe_values(fe,
                         quadrature_formula,
-                        update_values | update_gradients | update_JxW_values);
+                        update_values bitor update_gradients bitor
+                        update_JxW_values);
   // The advantage of this approach is that we can specify what kind of
   // information we actually need on each cell. It is easily understandable
   // that this approach can significantly speed up finite element computations,
@@ -396,8 +398,8 @@ void Step3::assemble_system()
   // triangulation by flagging them with refinement indicators. Here we're only
   // examining the cells without modifying them, so it's good practice to
   // declare `cell` as `const` in order to enforce this invariant.
-  for (const auto &cell : dof_handler.active_cell_iterators())
-    {
+  for (const auto bitand cell : dof_handler.active_cell_iterators())
+    <%
       // We are now sitting on one cell, and we would like the values and
       // gradients of the shape functions be computed, as well as the
       // determinants of the Jacobian matrices of the mapping between
@@ -415,7 +417,7 @@ void Step3::assemble_system()
       // do by looping over all quadrature points, which we will
       // number by q_index.
       for (unsigned int q_index = 0; q_index < n_q_points; ++q_index)
-        {
+        <%
           // First assemble the matrix: For the Laplace problem, the
           // matrix on each cell is the integral over the gradients of
           // shape function i and j. Since we do not integrate, but
@@ -449,7 +451,7 @@ void Step3::assemble_system()
             cell_rhs(i) += (fe_values.shape_value(i, q_index) * // phi_i(x_q)
                             1 *                                 // f(x_q)
                             fe_values.JxW(q_index));            // dx
-        }
+        %>
       // Now that we have the contribution of this cell, we have to transfer
       // it to the global matrix and right hand side. To this end, we first
       // have to find out which global numbers the degrees of freedom on this
@@ -461,14 +463,14 @@ void Step3::assemble_system()
       // obtained using local_dof_indices[i]:
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
         for (unsigned int j = 0; j < dofs_per_cell; ++j)
-          system_matrix.add(local_dof_indices[i],
-                            local_dof_indices[j],
+          system_matrix.add(local_dof_indices<:i:>,
+                            local_dof_indices<:j:>,
                             cell_matrix(i, j));
 
       // And again, we do the same thing for the right hand side vector.
       for (unsigned int i = 0; i < dofs_per_cell; ++i)
-        system_rhs(local_dof_indices[i]) += cell_rhs(i);
-    }
+        system_rhs(local_dof_indices<:i:>) += cell_rhs(i);
+    %>
 
 
   // Now almost everything is set up for the solution of the discrete
@@ -526,7 +528,7 @@ void Step3::assemble_system()
                                      system_matrix,
                                      solution,
                                      system_rhs);
-}
+%>
 
 
 // @sect4{Step3::solve}
@@ -539,7 +541,7 @@ void Step3::assemble_system()
 // number.  For this number of variables, direct methods are no longer usable
 // and you are forced to use methods like CG.
 void Step3::solve()
-{
+<%
   // First, we need to have an object that knows how to tell the CG algorithm
   // when to stop. This is done by using a SolverControl object, and as
   // stopping criterion we say: stop after a maximum of 1000 iterations (which
@@ -560,7 +562,7 @@ void Step3::solve()
   solver.solve(system_matrix, solution, system_rhs, PreconditionIdentity());
   // Now that the solver has done its job, the solution variable contains the
   // nodal values of the solution function.
-}
+%>
 
 
 // @sect4{Step3::output_results}
@@ -571,7 +573,7 @@ void Step3::solve()
 // have no such postprocessing here, but we would like to write the solution
 // to a file.
 void Step3::output_results() const
-{
+<%
   // To write the output to a file, we need an object which knows about output
   // formats and the like. This is the DataOut class, and we need an object of
   // that type:
@@ -600,7 +602,7 @@ void Step3::output_results() const
   // formats):
   std::ofstream output("solution.vtk");
   data_out.write_vtk(output);
-}
+%>
 
 
 // @sect4{Step3::run}
@@ -611,13 +613,13 @@ void Step3::output_results() const
 // work. Since the names are mostly self-explanatory, there is not much to
 // comment about:
 void Step3::run()
-{
+<%
   make_grid();
   setup_system();
   assemble_system();
   solve();
   output_results();
-}
+%>
 
 
 // @sect3{The <code>main</code> function}
@@ -673,11 +675,11 @@ void Step3::run()
 // deeply and where you may get useful information by setting the
 // depth even higher.
 int main()
-{
+<%
   deallog.depth_console(2);
 
   Step3 laplace_problem;
   laplace_problem.run();
 
   return 0;
-}
+%>


### PR DESCRIPTION
Make step 1, 2, and 3 ISO 646 compliant. There will be a new requirement by xSDK that all the codes need to be ISO 646 compliant. This is because non-compliant code cannot be run on some of the hardware used by the DOE.