### PR TITLE
remove boost/geometry.hpp from Point

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -23,6 +23,11 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/geometry/algorithms/envelope.hpp>
+#include <boost/geometry/geometries/multi_point.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
+
 DEAL_II_NAMESPACE_OPEN
 
 /**

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -23,7 +23,8 @@
 #include <deal.II/base/tensor.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <boost/geometry.hpp>
+#include <boost/geometry/core/cs.hpp>
+#include <boost/geometry/geometries/point.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <cmath>

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -30,6 +30,7 @@
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/iostreams/copy.hpp>
+#include <boost/lexical_cast.hpp>
 #include <boost/random.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 


### PR DESCRIPTION
We are including point.h in large parts of deal.II and the
boost/geometry.hpp header is a shortcut to include all of boost geometry.
Instead, only selectively include the parts we actually need. This
should speed up compilation of deal.II.

Note: this might break users that include point.h and expect all of boost geometry to be available. I hope this is not enough of an issue to reject this PR.

part of #9790

FYI: @masterleinad @luca-heltai 