### PR TITLE
Allow vector_adaptor to work on ghosted vectors.

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1007,6 +1007,14 @@ public:
    */
   std::size_t
   memory_consumption() const;
+
+  /**
+   * This function exists for compatibility with the @p
+   * parallel vector classes (e.g., LinearAlgebra::distributed::Vector class).
+   * Always returns false since this implementation is serial.
+   */
+  bool
+  has_ghost_elements() const;
   //@}
 
 private:
@@ -1311,6 +1319,12 @@ inline void Vector<Number>::compress(::dealii::VectorOperation::values) const
 {}
 
 
+template <typename Number>
+inline bool
+Vector<Number>::has_ghost_elements() const
+{
+  return false;
+}
 
 template <typename Number>
 inline void

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -396,7 +396,14 @@ namespace Rol
     if (vector_ptr->locally_owned_elements().is_element(i))
       vec_ptr->operator[](i) = 1.;
 
-    vec_ptr->compress(VectorOperation::insert);
+    if (vec_ptr->has_ghost_elements())
+      {
+        vec_ptr->update_ghost_values();
+      }
+    else
+      {
+        vec_ptr->compress(VectorOperation::insert);
+      }
 
     Teuchos::RCP<VectorAdaptor> e = Teuchos::rcp(new VectorAdaptor(vec_ptr));
 
@@ -417,7 +424,14 @@ namespace Rol
          iterator++)
       *iterator = f.apply(*iterator);
 
-    vector_ptr->compress(VectorOperation::insert);
+    if (vector_ptr->has_ghost_elements())
+      {
+        vector_ptr->update_ghost_values();
+      }
+    else
+      {
+        vector_ptr->compress(VectorOperation::insert);
+      }
   }
 
 
@@ -445,7 +459,14 @@ namespace Rol
          l_iterator++, r_iterator++)
       *l_iterator = f.apply(*l_iterator, *r_iterator);
 
-    vector_ptr->compress(VectorOperation::insert);
+    if (vector_ptr->has_ghost_elements())
+      {
+        vector_ptr->update_ghost_values();
+      }
+    else
+      {
+        vector_ptr->compress(VectorOperation::insert);
+      }
   }
 
 

--- a/tests/rol/vector_adaptor_with_ghost_01.cc
+++ b/tests/rol/vector_adaptor_with_ghost_01.cc
@@ -92,9 +92,17 @@ test()
   b.compress(VectorOperation::insert);
   c.compress(VectorOperation::insert);
 
+  a.update_ghost_values();
+  b.update_ghost_values();
+  c.update_ghost_values();
+
   Teuchos::RCP<VectorType> a_rcp(new VectorType(a));
   Teuchos::RCP<VectorType> b_rcp(new VectorType(b));
   Teuchos::RCP<VectorType> c_rcp(new VectorType(c));
+
+  a_rcp->update_ghost_values();
+  b_rcp->update_ghost_values();
+  c_rcp->update_ghost_values();
 
   // --- Testing the constructor
   Rol::VectorAdaptor<VectorType> a_rol(a_rcp);


### PR DESCRIPTION
Previous implementation did not work on ghosted vectors since it used
compress().

The test on ghosted vectors did not truly test for ghosted vectors
since it used the copy constructor of LA::distributed::Vector,
which does not fill the ghosted entries.