### PR TITLE
Minimize boost/geometry.h includes

### DIFF
--- a/include/deal.II/boost_adaptors/bounding_box.h
+++ b/include/deal.II/boost_adaptors/bounding_box.h
@@ -22,8 +22,6 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/geometries.hpp>
 
 namespace boost
 {

--- a/include/deal.II/boost_adaptors/point.h
+++ b/include/deal.II/boost_adaptors/point.h
@@ -20,9 +20,6 @@
 
 #include <deal.II/base/point.h>
 
-#include <boost/geometry.hpp>
-
-
 namespace boost
 {
   namespace geometry

--- a/include/deal.II/boost_adaptors/segment.h
+++ b/include/deal.II/boost_adaptors/segment.h
@@ -22,7 +22,7 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
-#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/segment.hpp>
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -24,7 +24,10 @@
 #include <deal.II/boost_adaptors/point.h>
 #include <deal.II/boost_adaptors/segment.h>
 
-#include <boost/geometry.hpp>
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <memory>
 

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -20,8 +20,6 @@
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/grid_tools_cache.h>
 
-#include <boost/geometry.hpp>
-
 DEAL_II_NAMESPACE_OPEN
 
 namespace GridTools

--- a/tests/base/point_04.cc
+++ b/tests/base/point_04.cc
@@ -20,8 +20,6 @@
 
 #include <deal.II/lac/vector.h>
 
-#include <boost/geometry.hpp>
-
 #include "../tests.h"
 
 namespace bg = boost::geometry;

--- a/tests/boost/bounding_box_adaptor_01.cc
+++ b/tests/boost/bounding_box_adaptor_01.cc
@@ -17,6 +17,8 @@
 
 #include <deal.II/boost_adaptors/bounding_box.h>
 
+#include <boost/geometry/algorithms/equals.hpp>
+
 #include "../tests.h"
 
 namespace bg = boost::geometry;

--- a/tests/boost/point_adaptor_01.cc
+++ b/tests/boost/point_adaptor_01.cc
@@ -17,6 +17,9 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
+#include <boost/geometry/algorithms/equals.hpp>
+#include <boost/geometry/algorithms/make.hpp>
+
 #include "../tests.h"
 
 namespace bg = boost::geometry;

--- a/tests/boost/rtree_01.cc
+++ b/tests/boost/rtree_01.cc
@@ -19,6 +19,9 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+
 #include <algorithm>
 
 #include "../tests.h"


### PR DESCRIPTION
Alternative/Related to #9798. These are the minimal includes and guards I need to build warning-free passing all `boost` tests.