### PR TITLE
Fix oversight in GridGenerator::hyper_ball in 2d

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4220,7 +4220,7 @@ namespace GridGenerator
         for (unsigned int j = 0; j < 4; ++j)
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
-        cells[i].manifold_id = i == 2 ? 1 : numbers::flat_manifold_id;
+        cells[i].manifold_id = i == 2 ? numbers::flat_manifold_id : 1;
       }
 
     tria.create_triangulation(std::vector<Point<2>>(std::begin(vertices),

--- a/tests/grid/get_coarse_mesh_description_01.output
+++ b/tests/grid/get_coarse_mesh_description_01.output
@@ -31,21 +31,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:1d::Triangulation constructed from an unrefined Triangulation:
 # vtk DataFile Version 3.0
@@ -79,21 +79,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:1d::Triangulation constructed from a refined Triangulation:
 # vtk DataFile Version 3.0
@@ -127,21 +127,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:2d::Original Triangulation:
 # vtk DataFile Version 3.0
@@ -175,21 +175,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:2d::Triangulation constructed from an unrefined Triangulation:
 # vtk DataFile Version 3.0
@@ -223,21 +223,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:2d::Triangulation constructed from a refined Triangulation:
 # vtk DataFile Version 3.0
@@ -271,21 +271,21 @@ CELLS 14 52
 2 7 5
 
 CELL_TYPES 14
-9 9 9 9 9
-3 3 3 3 3 3 3 3 3
+9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 
 
 
 CELL_DATA 14
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-540 270 0 450 360
-0 0 -1 42 -1 -1 -1 0 -1
+540 270 0 450 360 
+0 0 -1 42 -1 -1 -1 0 -1 
 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-181 451 1 271 361
-42 0 42 42 42 42 42 42 42
+181 451 -1 271 361 
+42 0 42 42 42 42 42 42 42 
 
 DEAL:3d::Original Triangulation:
 # vtk DataFile Version 3.0
@@ -371,22 +371,22 @@ CELLS 58 254
 2 15 7
 
 CELL_TYPES 58
-12 12 12 12 12 12 12
-9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9
-3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3
+12 12 12 12 12 12 12 
+9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 
 
 CELL_DATA 58
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-360 360 450 360 270 540 360
--1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1
+360 360 450 360 270 540 360 
+-1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1 
+-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-361 361 271 361 451 181 361
-42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42
-42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42
+361 361 271 361 451 181 361 
+42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42 
+42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 
 DEAL:3d::Triangulation constructed from an unrefined Triangulation:
 # vtk DataFile Version 3.0
 Triangulation generated with deal.II
@@ -471,22 +471,22 @@ CELLS 58 254
 2 15 7
 
 CELL_TYPES 58
-12 12 12 12 12 12 12
-9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9
-3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3
+12 12 12 12 12 12 12 
+9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 
 
 CELL_DATA 58
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-360 360 450 360 270 540 360
--1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1
+360 360 450 360 270 540 360 
+-1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1 
+-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-361 361 271 361 451 181 361
-42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42
-42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42
+361 361 271 361 451 181 361 
+42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42 
+42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 
 DEAL:3d::Triangulation constructed from a refined Triangulation:
 # vtk DataFile Version 3.0
 Triangulation generated with deal.II
@@ -571,19 +571,19 @@ CELLS 58 254
 2 15 7
 
 CELL_TYPES 58
-12 12 12 12 12 12 12
-9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9
-3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3
+12 12 12 12 12 12 12 
+9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 9 
+3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 3 
 
 CELL_DATA 58
 SCALARS MaterialID int 1
 LOOKUP_TABLE default
-360 360 450 360 270 540 360
--1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1
--1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1
+360 360 450 360 270 540 360 
+-1 -1 -1 -1 -1 -1 0 0 0 -1 -1 42 -1 -1 0 -1 0 -1 -1 
+-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 0 -1 0 0 -1 0 0 0 0 0 0 -1 -1 0 0 -1 0 -1 
 
 SCALARS ManifoldID int 1
 LOOKUP_TABLE default
-361 361 271 361 451 181 361
-42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42
-42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42
+361 361 271 361 451 181 361 
+42 42 42 42 42 42 42 0 42 42 42 42 42 42 42 42 42 42 42 
+42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 42 


### PR DESCRIPTION
Found while working on #9802.

This is simply an oversight, as the 3D case does the check the other way around (apart from a different cell order):
https://github.com/dealii/dealii/blob/a2518c4284c372151fba97a5ca630151a1a04234/source/grid/grid_generator.cc#L4978