### PR TITLE
Make the spelling of 'add_parameter()' arguments consistent.

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -540,10 +540,10 @@ namespace Step69
     , computing_timer(computing_timer)
   {
     length = 4.;
-    add_parameter("length", length, "length of computational domain");
+    add_parameter("length", length, "Length of computational domain");
 
     height = 2.;
-    add_parameter("height", height, "height of computational domain");
+    add_parameter("height", height, "Height of computational domain");
 
     disk_position = 0.6;
     add_parameter("object position",
@@ -553,12 +553,12 @@ namespace Step69
     disk_diameter = 0.5;
     add_parameter("object diameter",
                   disk_diameter,
-                  "diameter of immersed disk");
+                  "Diameter of immersed disk");
 
     refinement = 5;
     add_parameter("refinement",
                   refinement,
-                  "number of refinement steps of the geometry");
+                  "Number of refinement steps of the geometry");
   }
 
   // Note that in the previous constructor we only passed the MPI
@@ -1833,7 +1833,7 @@ namespace Step69
     cfl_update = 0.80;
     add_parameter("cfl update",
                   cfl_update,
-                  "relative CFL constant used for update");
+                  "Relative CFL constant used for update");
   }
 
   // In the class member <code>prepare()</code> we initialize the temporary

--- a/examples/step-69/step-69.prm
+++ b/examples/step-69/step-69.prm
@@ -25,10 +25,10 @@ subsection B - Discretization
   # Length of computational domain
   set length          = 4
 
-  # Diameter of immersed disc
+  # Diameter of immersed disk
   set object diameter = 0.5
 
-  # x position of immersed disc center point
+  # x position of immersed disk center point
   set object position = 0.6
 
   # Number of refinement steps of the geometry

--- a/examples/step-69/step-69.prm
+++ b/examples/step-69/step-69.prm
@@ -10,7 +10,7 @@ subsection A - MainLoop
   # Final time
   set final time             = 4
 
-  # time interval for output
+  # Time interval for output
   set output granularity     = 0.02
 
   # Resume an interrupted computation.
@@ -19,19 +19,19 @@ end
 
 
 subsection B - Discretization
-  # height of computational domain
+  # Height of computational domain
   set height          = 2
 
-  # length of computational domain
+  # Length of computational domain
   set length          = 4
 
-  # diameter of immersed disc
+  # Diameter of immersed disc
   set object diameter = 0.5
 
   # x position of immersed disc center point
   set object position = 0.6
 
-  # number of refinement steps of the geometry
+  # Number of refinement steps of the geometry
   set refinement      = 5
 end
 
@@ -50,7 +50,7 @@ end
 
 
 subsection E - TimeStepping
-  # relative CFL constant used for update
+  # Relative CFL constant used for update
   set cfl update = 0.8
 end
 


### PR DESCRIPTION
Specifically, always capitalize the first letter. Right now, it's inconsistent.

/rebuild