### PR TITLE
Add additional cell options for 3D hyper shell

### DIFF
--- a/doc/news/changes/minor/20200407MartinKronbichler
+++ b/doc/news/changes/minor/20200407MartinKronbichler
@@ -1,0 +1,9 @@
+Improved: GridGenerator::hyper_shell() in 3d now supports more `n_cells`
+options. While previously only 6, 12, or 96 cells were possible, the function
+now supports any number of the kind $6 \times 2^m$ with $m$ a non-negative
+integer. The new cases $m=2,3$ and $m\geq 5$ correspond to refinement in the
+azimuthal direction of the 6 or 12 cell case with a single mesh layer in
+radial direction, and are intended for shells that are thin and should be
+given more resolution in azimuthal direction.
+<br>
+(Martin Kronbichler, 2020/04/07)

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1050,25 +1050,32 @@ namespace GridGenerator
    * is zero (as is the default), then it is computed adaptively such that the
    * resulting elements have the least aspect ratio.
    *
-   * In 3d, only certain numbers are allowed
+   * In 3d, only certain numbers are allowed:
    * <ul>
    * <li> 6 (or the default 0) for a surface based on a hexahedron (i.e. 6
    *      panels on the inner sphere extruded in radial direction to form 6
    *      cells),
    * <li> 12 for the rhombic dodecahedron,
-   * <li> 24 for the hexahedron-based surface refined once in the spherical
+   * <li> 24 for the hexahedron-based surface refined once in the azimuthal
    *      directions but not in the radial direction,
-   * <li> 48 for the rhombic dodecahedron refined once in the spherical
+   * <li> 48 for the rhombic dodecahedron refined once in the azimuthal
    *      directions but not in the radial direction,
    * <li> 96 for the rhombic dodecahedron refined once. This choice dates from
    *      an older version of deal.II before the Manifold classes were
    *      implemented: today this choce is equivalent to the rhombic
    *      dodecahedron after performing one global refinement.
+   * <li> Numbers of the kind $192\times 2^m$ with $m\geq 0$ integer. This
+   *      choice is similar to the 24 and 48 cell cases, but provides
+   *      additional refinements in azimuthal direction combined with a single
+   *      layer in radial direction. The base mesh is either the 6 or 12 cell
+   *      version, depending on whether $m$ in the power is odd or even,
+   *      respectively.
    * </ul>
-   * The versions with 24 and 48 cells are useful if the shell is thin and the
-   * radial lengths should be made more similar to the circumferential lengths.
+   * The versions with 24, 48, and $2^m 192$ cells are useful if the shell is
+   * thin and the radial lengths should be made more similar to the
+   * circumferential lengths.
    *
-   * The grids with 12 and 96 cells are plotted below:
+   * The 3d grids with 12 and 96 cells are plotted below:
    *
    * @image html hypershell3d-12.png
    * @image html hypershell3d-96.png

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1050,12 +1050,23 @@ namespace GridGenerator
    * is zero (as is the default), then it is computed adaptively such that the
    * resulting elements have the least aspect ratio.
    *
-   * In 3d, only certain numbers are allowed, 6 (or the default 0) for a
-   * surface based on a hexahedron (i.e. 6 panels on the inner sphere extruded
-   * in radial direction to form 6 cells), 12 for the rhombic dodecahedron,
-   * and 96. This choice dates from an older version of deal.II before the
-   * Manifold classes were implemented: today all three choices are roughly
-   * equivalent (after performing global refinement, of course).
+   * In 3d, only certain numbers are allowed
+   * <ul>
+   * <li> 6 (or the default 0) for a surface based on a hexahedron (i.e. 6
+   *      panels on the inner sphere extruded in radial direction to form 6
+   *      cells),
+   * <li> 12 for the rhombic dodecahedron,
+   * <li> 24 for the hexahedron-based surface refined once in the spherical
+   *      directions but not in the radial direction,
+   * <li> 48 for the rhombic dodecahedron refined once in the spherical
+   *      directions but not in the radial direction,
+   * <li> 96 for the rhombic dodecahedron refined once. This choice dates from
+   *      an older version of deal.II before the Manifold classes were
+   *      implemented: today this choce is equivalent to the rhombic
+   *      dodecahedron after performing one global refinement.
+   * </ul>
+   * The versions with 24 and 48 cells are useful if the shell is thin and the
+   * radial lengths should be made more similar to the circumferential lengths.
    *
    * The grids with 12 and 96 cells are plotted below:
    *

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -5361,111 +5361,123 @@ namespace GridGenerator
                                                         {-1, +1, +1}, //
                                                         {+1, +1, +1}}};
 
-    // Start with the shell bounded by
-    // two nested cubes
-    if (n == 6)
+    switch (n)
       {
-        for (unsigned int i = 0; i < 8; ++i)
-          vertices.push_back(p + hexahedron[i] * irad);
-        for (unsigned int i = 0; i < 8; ++i)
-          vertices.push_back(p + hexahedron[i] * orad);
-
-        const unsigned int n_cells                   = 6;
-        const int          cell_vertices[n_cells][8] = {
-          {8, 9, 10, 11, 0, 1, 2, 3},    // bottom
-          {9, 11, 1, 3, 13, 15, 5, 7},   // right
-          {12, 13, 4, 5, 14, 15, 6, 7},  // top
-          {8, 0, 10, 2, 12, 4, 14, 6},   // left
-          {8, 9, 0, 1, 12, 13, 4, 5},    // front
-          {10, 2, 11, 3, 14, 6, 15, 7}}; // back
-
-        cells.resize(n_cells, CellData<3>());
-
-        for (unsigned int i = 0; i < n_cells; ++i)
+        case 6:
           {
-            for (const unsigned int j : GeometryInfo<3>::vertex_indices())
-              cells[i].vertices[j] = cell_vertices[i][j];
-            cells[i].material_id = 0;
-          }
+            // Start with the shell bounded by two nested cubes
+            for (unsigned int i = 0; i < 8; ++i)
+              vertices.push_back(p + hexahedron[i] * irad);
+            for (unsigned int i = 0; i < 8; ++i)
+              vertices.push_back(p + hexahedron[i] * orad);
 
-        tria.create_triangulation(vertices, cells, SubCellData());
-      }
-    // A more regular subdivision can
-    // be obtained by two nested
-    // rhombic dodecahedra
+            const unsigned int n_cells                   = 6;
+            const int          cell_vertices[n_cells][8] = {
+              {8, 9, 10, 11, 0, 1, 2, 3},    // bottom
+              {9, 11, 1, 3, 13, 15, 5, 7},   // right
+              {12, 13, 4, 5, 14, 15, 6, 7},  // top
+              {8, 0, 10, 2, 12, 4, 14, 6},   // left
+              {8, 9, 0, 1, 12, 13, 4, 5},    // front
+              {10, 2, 11, 3, 14, 6, 15, 7}}; // back
 
-    else if (n == 12)
-      {
-        // Octahedron inscribed in the cube [-1,1]^3
-        static const std::array<Point<3>, 6> octahedron = {{{-1, 0, 0}, //
-                                                            {1, 0, 0},  //
-                                                            {0, -1, 0}, //
-                                                            {0, 1, 0},  //
-                                                            {0, 0, -1}, //
-                                                            {0, 0, 1}}};
+            cells.resize(n_cells, CellData<3>());
 
-        for (unsigned int i = 0; i < 8; ++i)
-          vertices.push_back(p + hexahedron[i] * irad);
-        for (unsigned int i = 0; i < 6; ++i)
-          vertices.push_back(p + octahedron[i] * inner_radius);
-        for (unsigned int i = 0; i < 8; ++i)
-          vertices.push_back(p + hexahedron[i] * orad);
-        for (unsigned int i = 0; i < 6; ++i)
-          vertices.push_back(p + octahedron[i] * outer_radius);
-
-        const unsigned int n_cells            = 12;
-        const unsigned int rhombi[n_cells][4] = {{10, 4, 0, 8},
-                                                 {4, 13, 8, 6},
-                                                 {10, 5, 4, 13},
-                                                 {1, 9, 10, 5},
-                                                 {9, 7, 5, 13},
-                                                 {7, 11, 13, 6},
-                                                 {9, 3, 7, 11},
-                                                 {1, 12, 9, 3},
-                                                 {12, 2, 3, 11},
-                                                 {2, 8, 11, 6},
-                                                 {12, 0, 2, 8},
-                                                 {1, 10, 12, 0}};
-
-        cells.resize(n_cells, CellData<3>());
-
-        for (unsigned int i = 0; i < n_cells; ++i)
-          {
-            for (unsigned int j = 0; j < 4; ++j)
+            for (unsigned int i = 0; i < n_cells; ++i)
               {
-                cells[i].vertices[j]     = rhombi[i][j];
-                cells[i].vertices[j + 4] = rhombi[i][j] + 14;
+                for (const unsigned int j : GeometryInfo<3>::vertex_indices())
+                  cells[i].vertices[j] = cell_vertices[i][j];
+                cells[i].material_id = 0;
               }
-            cells[i].material_id = 0;
+
+            tria.create_triangulation(vertices, cells, SubCellData());
+            break;
           }
-
-        tria.create_triangulation(vertices, cells, SubCellData());
-      }
-    else if (n == 96)
-      {
-        // create a triangulation based on the 12-cell version. This function
-        // was needed before SphericalManifold was written: it manually
-        // adjusted the interior vertices to lie along concentric
-        // spheres. Nowadays we can just refine globally:
-        Triangulation<3> tmp;
-        hyper_shell(tmp, p, inner_radius, outer_radius, 12);
-        tmp.refine_global(1);
-
-        // now copy the resulting level 1 cells into the new triangulation,
-        cells.resize(tmp.n_active_cells(), CellData<3>());
-        for (const auto &cell : tmp.active_cell_iterators())
+        case 12:
           {
-            const unsigned int cell_index = cell->active_cell_index();
-            for (const unsigned int v : GeometryInfo<3>::vertex_indices())
-              cells[cell_index].vertices[v] = cell->vertex_index(v);
-            cells[cell_index].material_id = 0;
-          }
+            // A more regular subdivision can be obtained by two nested rhombic
+            // dodecahedra
+            //
+            // Octahedron inscribed in the cube [-1,1]^3
+            static const std::array<Point<3>, 6> octahedron = {{{-1, 0, 0}, //
+                                                                {1, 0, 0},  //
+                                                                {0, -1, 0}, //
+                                                                {0, 1, 0},  //
+                                                                {0, 0, -1}, //
+                                                                {0, 0, 1}}};
 
-        tria.create_triangulation(tmp.get_vertices(), cells, SubCellData());
-      }
-    else
-      {
-        Assert(false, ExcMessage("Invalid number of coarse mesh cells."));
+            for (unsigned int i = 0; i < 8; ++i)
+              vertices.push_back(p + hexahedron[i] * irad);
+            for (unsigned int i = 0; i < 6; ++i)
+              vertices.push_back(p + octahedron[i] * inner_radius);
+            for (unsigned int i = 0; i < 8; ++i)
+              vertices.push_back(p + hexahedron[i] * orad);
+            for (unsigned int i = 0; i < 6; ++i)
+              vertices.push_back(p + octahedron[i] * outer_radius);
+
+            const unsigned int n_cells            = 12;
+            const unsigned int rhombi[n_cells][4] = {{10, 4, 0, 8},
+                                                     {4, 13, 8, 6},
+                                                     {10, 5, 4, 13},
+                                                     {1, 9, 10, 5},
+                                                     {9, 7, 5, 13},
+                                                     {7, 11, 13, 6},
+                                                     {9, 3, 7, 11},
+                                                     {1, 12, 9, 3},
+                                                     {12, 2, 3, 11},
+                                                     {2, 8, 11, 6},
+                                                     {12, 0, 2, 8},
+                                                     {1, 10, 12, 0}};
+
+            cells.resize(n_cells, CellData<3>());
+
+            for (unsigned int i = 0; i < n_cells; ++i)
+              {
+                for (unsigned int j = 0; j < 4; ++j)
+                  {
+                    cells[i].vertices[j]     = rhombi[i][j];
+                    cells[i].vertices[j + 4] = rhombi[i][j] + 14;
+                  }
+                cells[i].material_id = 0;
+              }
+
+            tria.create_triangulation(vertices, cells, SubCellData());
+            break;
+          }
+        case 24:
+        case 48:
+          {
+            // These two meshes are created by first creating a mesh of the
+            // 6-cell/12-cell version, refining globally once, and finally
+            // removing the outer half of the cells
+            Triangulation<3> tmp;
+            hyper_shell(
+              tmp, p, inner_radius, 2 * outer_radius - inner_radius, n / 4);
+            tmp.refine_global(1);
+            std::set<Triangulation<3>::active_cell_iterator> cells_to_remove;
+            for (const auto &cell : tmp.active_cell_iterators())
+              if (cell->center(true).norm_square() >
+                  outer_radius * outer_radius)
+                cells_to_remove.insert(cell);
+            AssertDimension(cells_to_remove.size(), n);
+            create_triangulation_with_removed_cells(tmp, cells_to_remove, tria);
+            break;
+          }
+        case 96:
+          {
+            // create a triangulation based on the 12-cell version. This
+            // function was needed before SphericalManifold was written: it
+            // manually adjusted the interior vertices to lie along concentric
+            // spheres. Nowadays we can just refine globally:
+            Triangulation<3> tmp;
+            hyper_shell(tmp, p, inner_radius, outer_radius, 12);
+            tmp.refine_global(1);
+            flatten_triangulation(tmp, tria);
+            break;
+          }
+        default:
+          {
+            Assert(false, ExcMessage("Invalid number of coarse mesh cells."));
+          }
       }
 
     if (colorize)

--- a/tests/grid/grid_hyper_shell_07.cc
+++ b/tests/grid/grid_hyper_shell_07.cc
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test the various cell variants of GridGenerator::hyper_shell in 3d
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+template <int dim>
+void
+check(double r1, double r2, unsigned int n)
+{
+  Point<dim>         center;
+  Triangulation<dim> tria(Triangulation<dim>::none);
+  GridGenerator::hyper_shell(tria, center, r1, r2, n);
+
+  deallog << "Number of cells: " << tria.n_cells() << std::endl;
+
+  unsigned int n_r1           = 0;
+  unsigned int n_r2           = 0;
+  unsigned int n_other_radius = 0;
+
+  // ensure that all vertices of the mesh are either at r1 or at r2
+  for (const auto v : tria.get_vertices())
+    if (std::abs(v.norm_square() - r1 * r1) < 1e-12)
+      ++n_r1;
+    else if (std::abs(v.norm_square() - r2 * r2) < 1e-12)
+      ++n_r2;
+    else
+      ++n_other_radius;
+
+  deallog << "Number of vertices at inner radius: " << n_r1 << std::endl;
+  deallog << "Number of vertices at outer radius: " << n_r2 << std::endl;
+  deallog << "Number of vertices at other radius: " << n_other_radius
+          << std::endl;
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  check<3>(.8, 1, 6);
+  check<3>(.8, 1, 12);
+  check<3>(.8, 1, 24);
+  check<3>(.8, 1, 48);
+  check<3>(.8, 1, 96);
+  check<3>(.8, 1, 192);
+  check<3>(.8, 1, 384);
+  check<3>(.8, 1, 768);
+  check<3>(.8, 1, 1536);
+  check<3>(.8, 1, 3072);
+  check<3>(.8, 1, 6144);
+}

--- a/tests/grid/grid_hyper_shell_07.output
+++ b/tests/grid/grid_hyper_shell_07.output
@@ -1,0 +1,56 @@
+
+DEAL::Number of cells: 6
+DEAL::Number of vertices at inner radius: 8
+DEAL::Number of vertices at outer radius: 8
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 12
+DEAL::Number of vertices at inner radius: 14
+DEAL::Number of vertices at outer radius: 14
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 24
+DEAL::Number of vertices at inner radius: 26
+DEAL::Number of vertices at outer radius: 26
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 48
+DEAL::Number of vertices at inner radius: 50
+DEAL::Number of vertices at outer radius: 50
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 96
+DEAL::Number of vertices at inner radius: 50
+DEAL::Number of vertices at outer radius: 50
+DEAL::Number of vertices at other radius: 50
+DEAL::
+DEAL::Number of cells: 192
+DEAL::Number of vertices at inner radius: 194
+DEAL::Number of vertices at outer radius: 194
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 384
+DEAL::Number of vertices at inner radius: 386
+DEAL::Number of vertices at outer radius: 386
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 768
+DEAL::Number of vertices at inner radius: 770
+DEAL::Number of vertices at outer radius: 770
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 1536
+DEAL::Number of vertices at inner radius: 1538
+DEAL::Number of vertices at outer radius: 1538
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 3072
+DEAL::Number of vertices at inner radius: 3074
+DEAL::Number of vertices at outer radius: 3074
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 6144
+DEAL::Number of vertices at inner radius: 6146
+DEAL::Number of vertices at outer radius: 6146
+DEAL::Number of vertices at other radius: 0
+DEAL::

--- a/tests/grid/grid_hyper_shell_08.cc
+++ b/tests/grid/grid_hyper_shell_08.cc
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// test the various cell variants of GridGenerator::hyper_shell in 3d with
+// the center not being the origin, otherwise the same is grid_hyper_shell_07
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+template <int dim>
+void
+check(double r1, double r2, unsigned int n)
+{
+  Point<dim> center;
+  center[0] = 1.2;
+  center[1] = 0.3;
+  Triangulation<dim> tria(Triangulation<dim>::none);
+  GridGenerator::hyper_shell(tria, center, r1, r2, n);
+
+  deallog << "Number of cells: " << tria.n_cells() << std::endl;
+
+  unsigned int n_r1           = 0;
+  unsigned int n_r2           = 0;
+  unsigned int n_other_radius = 0;
+
+  // ensure that all vertices of the mesh are either at r1 or at r2
+  for (const auto v : tria.get_vertices())
+    if (std::abs((v - center).norm_square() - r1 * r1) < 1e-12)
+      ++n_r1;
+    else if (std::abs((v - center).norm_square() - r2 * r2) < 1e-12)
+      ++n_r2;
+    else
+      ++n_other_radius;
+
+  deallog << "Number of vertices at inner radius: " << n_r1 << std::endl;
+  deallog << "Number of vertices at outer radius: " << n_r2 << std::endl;
+  deallog << "Number of vertices at other radius: " << n_other_radius
+          << std::endl;
+  deallog << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  check<3>(.8, 1, 6);
+  check<3>(.8, 1, 12);
+  check<3>(.8, 1, 24);
+  check<3>(.8, 1, 48);
+  check<3>(.8, 1, 96);
+  check<3>(.8, 1, 192);
+  check<3>(.8, 1, 384);
+  check<3>(.8, 1, 768);
+  check<3>(.8, 1, 1536);
+  check<3>(.8, 1, 3072);
+  check<3>(.8, 1, 6144);
+}

--- a/tests/grid/grid_hyper_shell_08.output
+++ b/tests/grid/grid_hyper_shell_08.output
@@ -1,0 +1,56 @@
+
+DEAL::Number of cells: 6
+DEAL::Number of vertices at inner radius: 8
+DEAL::Number of vertices at outer radius: 8
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 12
+DEAL::Number of vertices at inner radius: 14
+DEAL::Number of vertices at outer radius: 14
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 24
+DEAL::Number of vertices at inner radius: 26
+DEAL::Number of vertices at outer radius: 26
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 48
+DEAL::Number of vertices at inner radius: 50
+DEAL::Number of vertices at outer radius: 50
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 96
+DEAL::Number of vertices at inner radius: 50
+DEAL::Number of vertices at outer radius: 50
+DEAL::Number of vertices at other radius: 50
+DEAL::
+DEAL::Number of cells: 192
+DEAL::Number of vertices at inner radius: 194
+DEAL::Number of vertices at outer radius: 194
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 384
+DEAL::Number of vertices at inner radius: 386
+DEAL::Number of vertices at outer radius: 386
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 768
+DEAL::Number of vertices at inner radius: 770
+DEAL::Number of vertices at outer radius: 770
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 1536
+DEAL::Number of vertices at inner radius: 1538
+DEAL::Number of vertices at outer radius: 1538
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 3072
+DEAL::Number of vertices at inner radius: 3074
+DEAL::Number of vertices at outer radius: 3074
+DEAL::Number of vertices at other radius: 0
+DEAL::
+DEAL::Number of cells: 6144
+DEAL::Number of vertices at inner radius: 6146
+DEAL::Number of vertices at outer radius: 6146
+DEAL::Number of vertices at other radius: 0
+DEAL::


### PR DESCRIPTION
One thing I often found annoying with the 3D hyper shell is that one cannot control the ratio of cells in the azimuthal versus radial direction. The current interface allows for a nice solution: We can add variants that refine the 6-cell/12-cell mesh once but only keep one mesh layer in the radial direction, so we end up with 24/48 cells in the coarse mesh. This is good for thin shells.

I could extend this further to make the mesh accept all variants with 2^m * 6 cells, m integer, by creating m/2 refinements and a single layer in radial direction. This would more closely reflect the 2d case. We could even make the "0" cell case choose the most appropriate variant in terms of mesh quality like in 2D. However, we have the odd one out with the old 96 cells, which does not fit in here.

How do we want to proceed:
- Use the proposed patch with 24 and 48 cells only.
- Generalize to 2^m * 6 cells except for the 96 cell case that would be the odd one out.
- Make the incompatible change for 96 cells and use 2^m * 6 cells for all given sizes. This is the nicest option, but it does affect users who use this case.

I can add a test and adjust the code to what we like most.