### PR TITLE
new function Triangulation::has_boundary_id()

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1740,6 +1740,19 @@ public:
   get_boundary_ids() const;
 
   /**
+   * Return whether a specified boundary indicator @p bid is assigned
+   * to this triangulation.
+   *
+   * @ingroup boundary
+   *
+   * @see
+   * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
+   */
+  bool
+  has_boundary_id(const types::boundary_id bid) const;
+
+
+  /**
    * Return a vector containing all manifold indicators assigned to the
    * objects of this Triangulation. Note, that each manifold indicator is
    * reported only once. The size of the return vector will represent the

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10416,6 +10416,19 @@ Triangulation<dim, spacedim>::get_boundary_ids() const
 }
 
 
+template <int dim, int spacedim>
+bool
+Triangulation<dim, spacedim>::has_boundary_id(
+  const types::boundary_id bid) const
+{
+  const auto boundary_ids = this->get_boundary_ids();
+  const bool has_id =
+    (std::find(boundary_ids.begin(), boundary_ids.end(), bid) !=
+     boundary_ids.end());
+
+  return has_id;
+}
+
 
 template <int dim, int spacedim>
 std::vector<types::manifold_id>


### PR DESCRIPTION
Aim: ask triangulation if any of the boundary faces has a given boundary id. The function ``get_boundary_ids()`` does something similar. However, the function ``Triangulation::get_boundary_ids()`` has ``std::vector`` as return type, so that it is not possible to simply write ``tria->get_boundary_ids().find(bid)``. It is probably unrealistic to change the return type to ``std::set``.