### PR TITLE
Add functions accepting hp::DoFHandler to BlockInfo

### DIFF
--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -119,12 +119,32 @@ public:
              bool active_only = false);
 
   /**
+   * The same as above but for hp::DoFHandler.
+   *
+   * @note Not implemented.
+   */
+  template <int dim, int spacedim>
+  void
+  initialize(const hp::DoFHandler<dim, spacedim> &,
+             bool levels_only = false,
+             bool active_only = false);
+
+  /**
    * @brief Initialize block structure on cells and compute renumbering
    * between cell dofs and block cell dofs.
    */
   template <int dim, int spacedim>
   void
   initialize_local(const DoFHandler<dim, spacedim> &);
+
+  /**
+   * The same as above but for hp::DoFHandler.
+   *
+   * @note Not implemented.
+   */
+  template <int dim, int spacedim>
+  void
+  initialize_local(const hp::DoFHandler<dim, spacedim> &);
 
   /**
    * Access the BlockIndices structure of the global system.

--- a/source/dofs/block_info.cc
+++ b/source/dofs/block_info.cc
@@ -53,6 +53,21 @@ BlockInfo::initialize(const DoFHandler<dim, spacedim> &dof,
 }
 
 
+
+template <int dim, int spacedim>
+void
+BlockInfo::initialize(const hp::DoFHandler<dim, spacedim> &dof,
+                      bool                                 levels_only,
+                      bool                                 active_only)
+{
+  AssertThrow(false, ExcNotImplemented());
+  (void)dof;
+  (void)levels_only;
+  (void)active_only;
+}
+
+
+
 template <int dim, int spacedim>
 void
 BlockInfo::initialize_local(const DoFHandler<dim, spacedim> &dof)
@@ -70,6 +85,15 @@ BlockInfo::initialize_local(const DoFHandler<dim, spacedim> &dof)
   bi_local.reinit(sizes);
 }
 
+
+
+template <int dim, int spacedim>
+void
+BlockInfo::initialize_local(const hp::DoFHandler<dim, spacedim> &dof)
+{
+  AssertThrow(false, ExcNotImplemented());
+  (void)dof;
+}
 
 // explicit instantiations
 #include "block_info.inst"

--- a/source/dofs/block_info.inst.in
+++ b/source/dofs/block_info.inst.in
@@ -20,16 +20,30 @@ for (deal_II_dimension : DIMENSIONS)
       const DoFHandler<deal_II_dimension, deal_II_dimension> &, bool, bool);
     template void BlockInfo::initialize_local(
       const DoFHandler<deal_II_dimension, deal_II_dimension> &);
+    template void BlockInfo::initialize(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &, bool, bool);
+    template void BlockInfo::initialize_local(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension> &);
 
 #if deal_II_dimension < 3
     template void BlockInfo::initialize(
       const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &, bool, bool);
     template void BlockInfo::initialize_local(
       const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &);
+    template void BlockInfo::initialize(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
+      bool,
+      bool);
+    template void BlockInfo::initialize_local(
+      const hp::DoFHandler<deal_II_dimension, deal_II_dimension + 1> &);
 #endif
 
 #if deal_II_dimension == 3
     template void BlockInfo::initialize(const DoFHandler<1, 3> &, bool, bool);
     template void BlockInfo::initialize_local(const DoFHandler<1, 3> &);
+    template void BlockInfo::initialize(const hp::DoFHandler<1, 3> &,
+                                        bool,
+                                        bool);
+    template void BlockInfo::initialize_local(const hp::DoFHandler<1, 3> &);
 #endif
   }


### PR DESCRIPTION
This PR adds (empty) functions accepting `hp::DoFHandler` to `BlockInfo` to allow `DoFHandler`-independent programming.

Extracted from #9760.