### PR TITLE
Add a missing assertion.

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5070,6 +5070,10 @@ namespace DataOutBase
     std::vector<bool> data_set_written(n_data_sets, false);
     for (const auto &nonscalar_data_range : nonscalar_data_ranges)
       {
+        AssertThrow(std::get<3>(nonscalar_data_range) !=
+                      DataComponentInterpretation::component_is_part_of_tensor,
+                    ExcNotImplemented());
+
         AssertThrow(std::get<1>(nonscalar_data_range) >=
                       std::get<0>(nonscalar_data_range),
                     ExcLowerRange(std::get<1>(nonscalar_data_range),


### PR DESCRIPTION
I ran into this when working on #1894 -- trying to output tensors in VTK format yields a funny error because it is simply not implemented. Assert earlier.

/rebuild