### PR TITLE
more boost warning guards

### DIFF
--- a/include/deal.II/boost_adaptors/bounding_box.h
+++ b/include/deal.II/boost_adaptors/bounding_box.h
@@ -20,7 +20,9 @@
 
 #include <deal.II/base/bounding_box.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/boost_adaptors/point.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 namespace boost

--- a/include/deal.II/boost_adaptors/segment.h
+++ b/include/deal.II/boost_adaptors/segment.h
@@ -22,7 +22,9 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/geometry/geometries/segment.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -41,6 +41,7 @@
 
 #  include <deal.II/numerics/rtree.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <boost/archive/binary_iarchive.hpp>
 #  include <boost/archive/binary_oarchive.hpp>
 #  include <boost/geometry/index/detail/serialization.hpp>
@@ -54,7 +55,7 @@
 #    include <boost/iostreams/filtering_stream.hpp>
 #    include <boost/iostreams/stream.hpp>
 #  endif
-
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #  include <bitset>
 #  include <list>


### PR DESCRIPTION
These are not strictly needed on my machine, but I suspect that this depends on the boost version and compiler version.
followup to #9798 and #9800