### PR TITLE
Require gcc 4.9 and clang 4.0.

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -21,10 +21,18 @@
 #
 
 IF( CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8" )
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9" )
   MESSAGE(WARNING "\n"
     "deal.II requires support for features of C++11 that are not present in\n"
-    "versions of GCC prior to 4.8."
+    "versions of GCC prior to 4.9."
+    )
+ENDIF()
+
+IF( CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+    CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.0" )
+  MESSAGE(WARNING "\n"
+    "deal.II requires support for features of C++11 that are not present in\n"
+    "versions of Clang prior to 4.0."
     )
 ENDIF()
 

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -62,8 +62,8 @@
         <acronym>deal.II</acronym> supports at least the following platforms:
     </p>
     <ul>
-        <li>GNU/Linux: GCC version 4.8 or later; Clang version 3.3 or later; ICC versions 15 or later</li>
-        <li>Mac OS X: GCC version 4.8 or later; Clang version 3.3 or later. Please see the <a href="https://github.com/dealii/dealii/wiki/MacOSX" target="_top">deal.II Wiki</a> for installation instructions.</li>
+        <li>GNU/Linux: GCC version 4.9 or later; Clang version 4.0 or later; ICC versions 15 or later</li>
+        <li>Mac OS X: GCC version 4.9 or later; Clang version 4.0 or later. Please see the <a href="https://github.com/dealii/dealii/wiki/MacOSX" target="_top">deal.II Wiki</a> for installation instructions.</li>
         <li>Windows: experimental support for Visual Studio 2017. Please have a look at the
             <a href="https://github.com/dealii/dealii/wiki/Frequently-Asked-Questions#can-i-use-dealii-on-a-windows-platform">
       FAQ</a> and at the <a href="https://github.com/dealii/dealii/wiki/Windows" target="_top">deal.II Wiki</a> for more information and alternative solutions.</li>


### PR DESCRIPTION
This fixes #8184. Strictly speaking, it doesn't actually *require* these compiler versions, but it warns (as it did before) if they are not satisfied, and it documents them as "required".

The cmake file has a bunch of checks further below where we set flags for Clang versions <3.6. If we really *required* Clang 4.0, then these could go away, but I left them in place because we're still only warning about earlier compiler warnings, not error out.