### PR TITLE
Place figures for 2d/3d quarter hyper ball in same line

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -782,13 +782,16 @@ namespace GridGenerator
    * is set to zero, and a SphericalManifold is attached to it.
    *
    * The resulting grid in 2D and 3D looks as follows:
-   * \htmlonly <style>div.image
-   * img[src="quarter_hyper_ball_2d.png"]{width:40%;}</style> \endhtmlonly
-   * @image html quarter_hyper_ball_2d.png
-   * \htmlonly <style>div.image
-   * img[src="quarter_hyper_ball_3d.png"]{width:40%;}</style> \endhtmlonly
-   * @image html quarter_hyper_ball_3d.png
-   *
+   * <table align="center" class="doxtable">
+   *   <tr>
+   *     <td>
+   *       <img src="quarter_hyper_ball_2d.png" alt="" width="50%">
+   *     </td>
+   *     <td>
+   *       <img src="quarter_hyper_ball_3d.png" alt="" width="45%">
+   *     </td>
+   *   </tr>
+   * </table>
    *
    * @pre The triangulation passed as argument needs to be empty when calling
    * this function.


### PR DESCRIPTION
This is a follow-up to #9796 and places the figures for the hyper ball in a table on the same line. I do like to have the figures not take too much space. The different widths (50% for 2d, 45% for 3d) are because I want to approximately balance the height of the two.