### PR TITLE
FETools: Add additional lexicographic_to_hierarchic_numbering functions

### DIFF
--- a/doc/news/changes/incompatibilities/20200407MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20200407MartinKronbichler
@@ -1,0 +1,8 @@
+Changed: The FETools::lexicographic_to_hierarchic_numbering() and
+FETools::hierarchic_to_lexicographic_numbering() functions now take a single
+integer for the degree of the associated FE_Q element and return the
+numbering. The old functions taking the result array as the last argument and
+the ones taking a FiniteElementData as an argument have been deprecated in
+favor of the simpler setup with the degree.
+<br>
+(Martin Kronbichler, 2020/04/07)

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -895,75 +895,72 @@ namespace FETools
    * in y-direction and finally in z-direction. Discontinuous elements of
    * class FE_DGQ() are numbered in this way, for example.
    *
-   * This function constructs a table which lexicographic index each degree of
-   * freedom in the hierarchic numbering would have. It operates on the
-   * continuous finite element given as first argument, and outputs the
-   * lexicographic indices in the second.
-   *
-   * Note that since this function uses specifics of the continuous finite
-   * elements, it can only operate on FiniteElementData<dim> objects inherent
-   * in FE_Q(). However, this function does not take a FE_Q object as it is
-   * also invoked by the FE_Q() constructor.
-   *
-   * It is assumed that the size of the output argument already matches the
-   * correct size, which is equal to the number of degrees of freedom in the
-   * finite element.
-   */
-  template <int dim>
-  void
-  hierarchic_to_lexicographic_numbering(unsigned int               degree,
-                                        std::vector<unsigned int> &h2l);
-
-  /**
-   * Like the previous function but instead of returning its result through
-   * the last argument return it as a value.
+   * This function returns a vector containing information about the
+   * lexicographic index each degree of freedom in the hierarchic numbering
+   * would have to a given degree of a continuous finite element.
    */
   template <int dim>
   std::vector<unsigned int>
   hierarchic_to_lexicographic_numbering(unsigned int degree);
 
   /**
-   * Like the previous functions but using a FiniteElementData instead of the
-   * polynomial degree.
+   * Like the previous function but instead of returning its result as a value
+   * return it through the last argument.
+   *
+   * @deprecated Use the function that returns the renumbering in a vector
+   * instead.
    */
   template <int dim>
-  void
+  DEAL_II_DEPRECATED void
+  hierarchic_to_lexicographic_numbering(unsigned int               degree,
+                                        std::vector<unsigned int> &h2l);
+
+  /**
+   * Like the previous functions but using a FiniteElementData instead of the
+   * polynomial degree.
+   *
+   * @deprecated Use the function that returns the renumbering in a vector and
+   * uses the degree of the basis as an argument instead.
+   */
+  template <int dim>
+  DEAL_II_DEPRECATED void
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data,
                                         std::vector<unsigned int> &   h2l);
 
   /**
-   * Like the previous function but instead of returning its result through
-   * the last argument return it as a value.
+   * @deprecated Use the function that uses the degree of the basis as an
+   * argument instead.
    */
   template <int dim>
-  std::vector<unsigned int>
-  hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data);
+  DEAL_II_DEPRECATED std::vector<unsigned int>
+                     hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data);
 
   /**
    * This is the reverse function to the above one, generating the map from
-   * the lexicographic to the hierarchical numbering. All the remarks made
-   * about the above function are also valid here.
+   * the lexicographic to the hierarchical numbering for a given polynomial
+   * degree of a continuous finite element. All the remarks made about the
+   * above function are also valid here.
    */
   template <int dim>
   std::vector<unsigned int>
   lexicographic_to_hierarchic_numbering(unsigned int degree);
 
   /**
-   * Like the previous functions but using a FiniteElementData instead of the
-   * polynomial degree.
+   * @deprecated Use the function that returns the renumbering in a vector and
+   * uses the degree of the basis as an argument instead.
    */
   template <int dim>
-  void
+  DEAL_II_DEPRECATED void
   lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe_data,
                                         std::vector<unsigned int> &   l2h);
 
   /**
-   * Like the previous function but instead of returning its result through
-   * the last argument return it as a value.
+   * @deprecated Use the function that uses the degree of the basis as an
+   * argument instead.
    */
   template <int dim>
-  std::vector<unsigned int>
-  lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe_data);
+  DEAL_II_DEPRECATED std::vector<unsigned int>
+                     lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe_data);
 
 
   /**

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -909,12 +909,23 @@ namespace FETools
    * correct size, which is equal to the number of degrees of freedom in the
    * finite element.
    */
-
   template <int dim>
   void
   hierarchic_to_lexicographic_numbering(unsigned int               degree,
                                         std::vector<unsigned int> &h2l);
 
+  /**
+   * Like the previous function but instead of returning its result through
+   * the last argument return it as a value.
+   */
+  template <int dim>
+  std::vector<unsigned int>
+  hierarchic_to_lexicographic_numbering(unsigned int degree);
+
+  /**
+   * Like the previous functions but using a FiniteElementData instead of the
+   * polynomial degree.
+   */
   template <int dim>
   void
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data,
@@ -932,6 +943,14 @@ namespace FETools
    * This is the reverse function to the above one, generating the map from
    * the lexicographic to the hierarchical numbering. All the remarks made
    * about the above function are also valid here.
+   */
+  template <int dim>
+  std::vector<unsigned int>
+  lexicographic_to_hierarchic_numbering(unsigned int degree);
+
+  /**
+   * Like the previous functions but using a FiniteElementData instead of the
+   * polynomial degree.
    */
   template <int dim>
   void

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -3123,17 +3123,15 @@ namespace FETools
 
 
   template <int dim>
-  void
-  hierarchic_to_lexicographic_numbering(const unsigned int         degree,
-                                        std::vector<unsigned int> &h2l)
+  std::vector<unsigned int>
+  hierarchic_to_lexicographic_numbering(const unsigned int degree)
   {
     // number of support points in each direction
     const unsigned int n = degree + 1;
 
     const unsigned int dofs_per_cell = Utilities::fixed_power<dim>(n);
 
-    // Assert size matches degree
-    AssertDimension(h2l.size(), dofs_per_cell);
+    std::vector<unsigned int> h2l(dofs_per_cell);
 
     // polynomial degree
     const unsigned int dofs_per_line = degree - 1;
@@ -3289,17 +3287,19 @@ namespace FETools
         default:
           Assert(false, ExcNotImplemented());
       }
+
+    return h2l;
   }
 
 
 
   template <int dim>
-  std::vector<unsigned int>
-  hierarchic_to_lexicographic_numbering(const unsigned int degree)
+  void
+  hierarchic_to_lexicographic_numbering(const unsigned int         degree,
+                                        std::vector<unsigned int> &h2l)
   {
-    std::vector<unsigned int> h2l(Utilities::pow(degree + 1, dim));
-    hierarchic_to_lexicographic_numbering<dim>(degree, h2l);
-    return h2l;
+    AssertDimension(h2l.size(), Utilities::fixed_power<dim>(degree + 1));
+    h2l = hierarchic_to_lexicographic_numbering<dim>(degree);
   }
 
 
@@ -3321,9 +3321,7 @@ namespace FETools
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe)
   {
     Assert(fe.n_components() == 1, ExcInvalidFE());
-    std::vector<unsigned int> h2l(fe.dofs_per_cell);
-    hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1, h2l);
-    return h2l;
+    return hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1);
   }
 
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -3146,6 +3146,11 @@ namespace FETools
     // order
     switch (dim)
       {
+        case 0:
+          {
+            h2l[0] = 0;
+            break;
+          }
         case 1:
           {
             h2l[0] = 0;
@@ -3289,6 +3294,17 @@ namespace FETools
 
 
   template <int dim>
+  std::vector<unsigned int>
+  hierarchic_to_lexicographic_numbering(const unsigned int degree)
+  {
+    std::vector<unsigned int> h2l(Utilities::pow(degree + 1, dim));
+    hierarchic_to_lexicographic_numbering<dim>(degree, h2l);
+    return h2l;
+  }
+
+
+
+  template <int dim>
   void
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe,
                                         std::vector<unsigned int> &   h2l)
@@ -3308,6 +3324,16 @@ namespace FETools
     std::vector<unsigned int> h2l(fe.dofs_per_cell);
     hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1, h2l);
     return h2l;
+  }
+
+
+
+  template <int dim>
+  std::vector<unsigned int>
+  lexicographic_to_hierarchic_numbering(const unsigned int degree)
+  {
+    return Utilities::invert_permutation(
+      hierarchic_to_lexicographic_numbering<dim>(degree));
   }
 
 

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -147,7 +147,7 @@ namespace CUDAWrappers
         fe_q.get_subface_interpolation_matrix(fe_q, 0, interpolation_matrix);
 
         std::vector<unsigned int> mapping =
-          FETools::lexicographic_to_hierarchic_numbering<1>(FE_Q<1>(fe_degree));
+          FETools::lexicographic_to_hierarchic_numbering<1>(fe_degree);
 
         FullMatrix<double> mapped_matrix(fe_q.dofs_per_face,
                                          fe_q.dofs_per_face);
@@ -282,8 +282,7 @@ namespace CUDAWrappers
       std::vector<types::global_dof_index> neighbor_dofs(dofs_per_face);
 
       const auto lex_face_mapping =
-        FETools::lexicographic_to_hierarchic_numbering<dim - 1>(
-          FE_Q<dim - 1>(fe_degree));
+        FETools::lexicographic_to_hierarchic_numbering<dim - 1>(fe_degree);
 
       for (const unsigned int face : GeometryInfo<dim>::face_indices())
         {

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -367,10 +367,7 @@ FE_Bernstein<dim, spacedim>::renumber_bases(const unsigned int deg)
 {
   TensorProductPolynomials<dim> tpp(
     dealii::generate_complete_bernstein_basis<double>(deg));
-  std::vector<unsigned int>    renumber(Utilities::fixed_power<dim>(deg + 1));
-  const FiniteElementData<dim> fe(this->get_dpo_vector(deg), 1, deg);
-  FETools::hierarchic_to_lexicographic_numbering(fe, renumber);
-  tpp.set_numbering(renumber);
+  tpp.set_numbering(FETools::hierarchic_to_lexicographic_numbering<dim>(deg));
   return tpp;
 }
 

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -21,4 +21,18 @@ DEAL_II_NAMESPACE_OPEN
 /*-------------- Explicit Instantiations -------------------------------*/
 #include "fe_tools.inst"
 
+// these do not fit into the templates of the dimension in the inst file
+namespace FETools
+{
+  template void
+  hierarchic_to_lexicographic_numbering<0>(unsigned int,
+                                           std::vector<unsigned int> &);
+
+  template std::vector<unsigned int>
+  hierarchic_to_lexicographic_numbering<0>(unsigned int);
+
+  template std::vector<unsigned int>
+  lexicographic_to_hierarchic_numbering<0>(unsigned int);
+} // namespace FETools
+
 DEAL_II_NAMESPACE_CLOSE

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -272,6 +272,12 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         std::vector<unsigned int> &);
 
       template std::vector<unsigned int>
+      hierarchic_to_lexicographic_numbering<deal_II_dimension>(unsigned int);
+
+      template std::vector<unsigned int>
+      lexicographic_to_hierarchic_numbering<deal_II_dimension>(unsigned int);
+
+      template std::vector<unsigned int>
       hierarchic_to_lexicographic_numbering<deal_II_dimension>(
         const FiniteElementData<deal_II_dimension> &);
 

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -50,9 +50,8 @@ FE_TraceQ<dim, spacedim>::FE_TraceQ(const unsigned int degree)
   Assert(degree > 0,
          ExcMessage("FE_Trace can only be used for polynomial degrees "
                     "greater than zero"));
-  std::vector<unsigned int> renumber(this->dofs_per_face);
-  FETools::hierarchic_to_lexicographic_numbering<dim - 1>(degree, renumber);
-  this->poly_space.set_numbering(renumber);
+  this->poly_space.set_numbering(
+    FETools::hierarchic_to_lexicographic_numbering<dim - 1>(degree));
 
   // Initialize face support points
   this->unit_face_support_points = fe_q.get_unit_face_support_points();

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -106,15 +106,9 @@ MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerianGeneric::
   const unsigned int       n_q_points = q_iterated.size();
 
   // we then need to define a renumbering vector that allows us to go from a
-  // lexicographic numbering scheme to a hierarchic one.  this fragment is
-  // taking almost verbatim from the MappingQ class.
-  std::vector<unsigned int> renumber(n_q_points);
-  std::vector<unsigned int> dpo(dim + 1, 1U);
-  for (unsigned int i = 1; i < dpo.size(); ++i)
-    dpo[i] = dpo[i - 1] * (map_degree - 1);
-
-  FETools::lexicographic_to_hierarchic_numbering(
-    FiniteElementData<dim>(dpo, 1, map_degree), renumber);
+  // lexicographic numbering scheme to a hierarchic one.
+  const std::vector<unsigned int> renumber =
+    FETools::lexicographic_to_hierarchic_numbering<dim>(map_degree);
 
   // finally we assign the quadrature points in the required order.
   for (unsigned int q = 0; q < n_q_points; ++q)

--- a/tests/bits/fe_tools_01a.cc
+++ b/tests/bits/fe_tools_01a.cc
@@ -33,7 +33,7 @@
 
 
 // check
-//   DoFTools::lexicographic_to_hierarchic_numbering
+//   FETools::lexicographic_to_hierarchic_numbering
 
 
 template <int dim>
@@ -42,8 +42,8 @@ check(const FE_Q<dim> &fe, const std::string &name)
 {
   deallog << "Checking " << name << " in " << dim << "d:" << std::endl;
 
-  std::vector<unsigned int> n(fe.dofs_per_cell);
-  FETools::lexicographic_to_hierarchic_numbering(fe, n);
+  const std::vector<unsigned int> n =
+    FETools::lexicographic_to_hierarchic_numbering<dim>(fe.degree);
   for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
     deallog << n[i] << " ";
   deallog << std::endl;

--- a/tests/bits/fe_tools_01b.cc
+++ b/tests/bits/fe_tools_01b.cc
@@ -33,7 +33,7 @@
 
 
 // check
-//   DoFTools::hierarchic_to_lexicographic_numbering
+//   FETools::hierarchic_to_lexicographic_numbering
 
 
 template <int dim>
@@ -42,8 +42,8 @@ check(const FE_Q<dim> &fe, const std::string &name)
 {
   deallog << "Checking " << name << " in " << dim << "d:" << std::endl;
 
-  std::vector<unsigned int> n(fe.dofs_per_cell);
-  FETools::hierarchic_to_lexicographic_numbering(fe, n);
+  const std::vector<unsigned int> n =
+    FETools::hierarchic_to_lexicographic_numbering<dim>(fe.degree);
   for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
     deallog << n[i] << " ";
   deallog << std::endl;

--- a/tests/bits/fe_tools_01c.cc
+++ b/tests/bits/fe_tools_01c.cc
@@ -33,9 +33,9 @@
 
 
 // check invertability of the map from
-//   DoFTools::hierarchic_to_lexicographic_numbering
+//   FETools::hierarchic_to_lexicographic_numbering
 // to
-//   DoFTools::lexicographic_to_hierarchic_numbering
+//   FETools::lexicographic_to_hierarchic_numbering
 
 
 template <int dim>
@@ -44,11 +44,11 @@ check(const FE_Q<dim> &fe, const std::string &name)
 {
   deallog << "Checking " << name << " in " << dim << "d:" << std::endl;
 
-  std::vector<unsigned int> n1(fe.dofs_per_cell);
-  FETools::hierarchic_to_lexicographic_numbering(fe, n1);
+  const std::vector<unsigned int> n1 =
+    FETools::hierarchic_to_lexicographic_numbering<dim>(fe.degree);
 
-  std::vector<unsigned int> n2(fe.dofs_per_cell);
-  FETools::lexicographic_to_hierarchic_numbering(fe, n2);
+  const std::vector<unsigned int> n2 =
+    FETools::lexicographic_to_hierarchic_numbering<dim>(fe.degree);
 
   for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
     {

--- a/tests/fe/numbering.cc
+++ b/tests/fe/numbering.cc
@@ -234,8 +234,8 @@ check(const FE_Q<dim> &fe)
   // identity. output the two maps to
   // generate some output for
   // automatic comparison
-  std::vector<unsigned int> l2h(fe.dofs_per_cell);
-  FETools::lexicographic_to_hierarchic_numbering(fe, l2h);
+  const std::vector<unsigned int> l2h =
+    FETools::lexicographic_to_hierarchic_numbering<dim>(fe.degree);
   for (unsigned int i = 0; i < dofs_per_cell; ++i)
     {
       Assert(l2h[hierarchic_to_lexicographic_numbering[i]] == i,
@@ -247,8 +247,8 @@ check(const FE_Q<dim> &fe)
   // finally, we also have the
   // forward map in the lib, so check
   // for equality
-  std::vector<unsigned int> h2l(fe.dofs_per_cell);
-  FETools::hierarchic_to_lexicographic_numbering(fe, h2l);
+  const std::vector<unsigned int> h2l =
+    FETools::hierarchic_to_lexicographic_numbering<dim>(fe.degree);
   AssertThrow(hierarchic_to_lexicographic_numbering == h2l, ExcInternalError());
 }
 


### PR DESCRIPTION
While working on #9826, I realized that `FETools::lexicographic_to_hierarchic_numbering` is a pain to use because we need to provide the result array as argument. This PR adds the functions that return the respective arrays instead, as we have done for a number of other functions in the hierarchic to lexicographic context. Given this new function, I can now also simplify `fe_q_base` and `mapping_q_eulerian` which both used to construct a more complicated data structure to then return things.

I do not yet apply them to `MappingQGeneric` because that is the topic of #9826, but I add that together these functions save around 55 lines of code in already big implementations (`fe_q_base`, `mapping_q_generic`, `mapping_q_eulerian`) by augmenting some tools functions that are well-separated, so I consider this a clear win.