### PR TITLE
Make TpetraWrappers appear in Doxygen

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -207,6 +207,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_SYMENGINE_WITH_LLVM=1 \
                          DEAL_II_WITH_THREADS=1 \
                          DEAL_II_WITH_TRILINOS=1 \
+                         DEAL_II_TRILINOS_WITH_TPETRA=1 \
                          DEAL_II_TRILINOS_WITH_ROL=1 \
                          DEAL_II_WITH_UMFPACK=1 \
                          DEAL_II_WITH_ZLIB=1 \

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -48,6 +48,13 @@ namespace LinearAlgebra
   class ReadWriteVector;
 #  endif
 
+  /**
+   * A namespace for classes that provide wrappers for Trilinos' Tpetra vectors.
+   *
+   * This namespace provides wrappers for the Tpetra::Vector class from the
+   * Tpetra package (https://trilinos.github.io/tpetra.html) that is part of
+   * Trilinos.
+   */
   namespace TpetraWrappers
   {
     /**


### PR DESCRIPTION
I had to also disable the following line:

https://github.com/dealii/dealii/blob/fec0887042e095a5c3dfeae829a5bd626e5f5b6d/include/deal.II/lac/trilinos_tpetra_vector.h#L22

to make it visible, but I guess `DEAL_II_TRILINOS_WITH_TPETRA` is defined for the online documentation?