### PR TITLE
step-47 - fix typos

### DIFF
--- a/examples/step-47/doc/intro.dox
+++ b/examples/step-47/doc/intro.dox
@@ -318,7 +318,7 @@ the following terms:
   \average{\frac{\partial^2 v_h}{\partial \mathbf n^2}}
   \jump{\frac{\partial u_h}{\partial \mathbf n}}
 + \sum_{e \in \mathbb{F}}
-  \frac{\sigma}{h_e}\int_e
+  \frac{\gamma}{h_e}\int_e
   \jump{\frac{\partial v_h}{\partial \mathbf n}}
   \jump{\frac{\partial u_h}{\partial \mathbf n}}.
 @f}
@@ -508,7 +508,7 @@ As a consequence, we then need choose as boundary conditions the following:
                 \pi\sin(\pi x) \cos(\pi y)
              \end{pmatrix}\right|_{\partial\Omega} \cdot \mathbf n.
 @f}
-The right hand side is easily computes as
+The right hand side is easily computed as
 @f{align*}{
   f = \Delta^2 u = 4 \pi^4 \sin(\pi x) \sin(\pi y).
 @f}

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -491,7 +491,7 @@ namespace Step47
       // In the formula above, $h_K$ is the size of cell $K$. But this
       // is not quite so straightforward either: If one uses highly
       // stretched cells, then a more involved theory says that $h$
-      // should be replaced be the diameter of cell $K$ normal to the
+      // should be replaced by the diameter of cell $K$ normal to the
       // direction of the edge in question.  It turns out that there
       // is a function in deal.II for that. Secondly, $h_K$ may be
       // different when viewed from the two different sides of a face.
@@ -521,8 +521,8 @@ namespace Step47
       // of the bilinear form were as follows:
       // @f{align*}{
       //  -\sum_{e \in \mathbb{F}} \int_{e}
-      //  \jump{ \frac{\partial^2 v_h}{\partial \mathbf n^2}}
-      //  \average{\frac{\partial u_h}{\partial \mathbf n}} \ ds
+      //  \jump{ \frac{\partial v_h}{\partial \mathbf n}}
+      //  \average{\frac{\partial^2 u_h}{\partial \mathbf n^2}} \ ds
       // -\sum_{e \in \mathbb{F}} \int_{e}
       // \average{\frac{\partial^2 v_h}{\partial \mathbf n^2}}
       // \jump{\frac{\partial u_h}{\partial \mathbf n}} \ ds
@@ -796,7 +796,7 @@ namespace Step47
     // solution $u_h$, but given the Lagrange shape functions we use, $u_h$ of
     // course has kinks at the interfaces between cells, and consequently second
     // derivatives are singular at interfaces. As a consequence, we really only
-    // integrating over the interiors of the cells and ignore the interface
+    // integrate over the interior of cells and ignore the interface
     // contributions. This is *not* an equivalent norm to the energy norm for
     // the problem, but still gives us an idea of how fast the error converges.
     //


### PR DESCRIPTION
I started to work with step-47 and fixed some typos (including equations) while reading the documentation.