### PR TITLE
Do not verify MPI_HAVE_MPI_SEEK_SET during cross compiling

### DIFF
--- a/cmake/configure/configure_1_mpi.cmake
+++ b/cmake/configure/configure_1_mpi.cmake
@@ -30,7 +30,8 @@ MACRO(FEATURE_MPI_FIND_EXTERNAL var)
   IF(MPI_FOUND)
     SET(${var} TRUE)
 
-    IF(NOT MPI_HAVE_MPI_SEEK_SET)
+    # MPI_HAVE_MPI_SEEK_SET can not be verified during cross compiling
+    IF((NOT MPI_HAVE_MPI_SEEK_SET) AND (NOT CMAKE_CROSSCOMPILING))
       MESSAGE(STATUS
         "Could not find a sufficient MPI version: "
         "Your MPI implementation must define MPI_SEEK_SET.")


### PR DESCRIPTION
This is a follow-up to #9778. I find it convenient to cross-compile deal.II in my machine and then upload it to the cluster. It works quite well, but I have to remove the requirement `MPI_HAVE_MPI_SEEK_SET`.

The property `MPI_HAVE_MPI_SEEK_SET` can not be verified during cross-compiling. I guess that CMake has to compile a program and then execute it to verify `MPI_HAVE_MPI_SEEK_SET`. During cross-compiling that is not always possible.