### PR TITLE
Rename NoncontiguousPartitioner::update_values()

### DIFF
--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -130,7 +130,7 @@ namespace Utilities
           partitioner_export_end = partitioner_export_start + 200,
 
           /// NoncontiguousPartitioner::update_values
-          noncontiguous_partitioner_update_values,
+          noncontiguous_partitioner_update_ghost_values,
 
           // Utilities::MPI::compute_union
           compute_union,

--- a/source/base/mpi_noncontiguous_partitioner.inst.in
+++ b/source/base/mpi_noncontiguous_partitioner.inst.in
@@ -21,32 +21,10 @@ for (S : REAL_SCALARS)
     \{
       namespace MPI
       \{
-        template class NoncontiguousPartitioner<S>;
-
         template void
-        NoncontiguousPartitioner<S>::update_values(
-          std::vector<S> &      dst,
-          const std::vector<S> &src) const;
-
-        template void
-        NoncontiguousPartitioner<S>::update_values(
-          AlignedVector<S> &      dst,
-          const AlignedVector<S> &src) const;
-
-        template void
-        NoncontiguousPartitioner<S>::update_values(
-          ArrayView<S> &      dst,
-          const ArrayView<S> &src) const;
-
-        template void
-        NoncontiguousPartitioner<S>::update_values(
-          LinearAlgebra::Vector<S> &      dst,
-          const LinearAlgebra::Vector<S> &src) const;
-
-        template void
-        NoncontiguousPartitioner<S>::update_values(
-          LinearAlgebra::distributed::Vector<S> &      dst,
-          const LinearAlgebra::distributed::Vector<S> &src) const;
+        NoncontiguousPartitioner::export_to_ghosted_array(
+          const ArrayView<const S> &src,
+          const ArrayView<S> &      dst) const;
       \}
     \}
   }

--- a/tests/base/mpi_noncontiguous_partitioner_01.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_01.cc
@@ -40,16 +40,18 @@ test(const MPI_Comm comm)
       index_set_want.add_index(2);
     }
 
-  Utilities::MPI::NoncontiguousPartitioner<double> vector(index_set_has,
-                                                          index_set_want,
-                                                          comm);
+  Utilities::MPI::NoncontiguousPartitioner vector(index_set_has,
+                                                  index_set_want,
+                                                  comm);
 
   AlignedVector<double> src(index_set_has.n_elements());
   AlignedVector<double> dst(index_set_want.n_elements());
 
   src[0] = Utilities::MPI::this_mpi_process(comm) * 100 + 1;
 
-  vector.update_values(dst, src);
+  vector.export_to_ghosted_array(ArrayView<const double>(src.data(),
+                                                         src.size()),
+                                 ArrayView<double>(dst.data(), dst.size()));
 
   for (size_t i = 0; i < src.size(); i++)
     deallog << static_cast<int>(src[i]) << " ";

--- a/tests/base/mpi_noncontiguous_partitioner_02.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_02.cc
@@ -114,9 +114,9 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
   if (do_revert)
     std::reverse(indices_want.begin(), indices_want.end());
 
-  Utilities::MPI::NoncontiguousPartitioner<double> vector(indices_has,
-                                                          indices_want,
-                                                          comm);
+  Utilities::MPI::NoncontiguousPartitioner vector(indices_has,
+                                                  indices_want,
+                                                  comm);
 
   AlignedVector<double> src(indices_has.size());
   for (unsigned int i = 0; i < indices_has.size(); i++)
@@ -125,7 +125,9 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
 
   AlignedVector<double> dst(indices_want.size());
 
-  vector.update_values(dst, src);
+  vector.export_to_ghosted_array(ArrayView<const double>(src.data(),
+                                                         src.size()),
+                                 ArrayView<double>(dst.data(), dst.size()));
 
   for (size_t i = 0; i < src.size(); i++)
     deallog << static_cast<int>(src[i]) << " ";

--- a/tests/base/mpi_noncontiguous_partitioner_03.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_03.cc
@@ -27,7 +27,7 @@ test(const MPI_Comm                       comm,
      std::vector<types::global_dof_index> index_set_has,
      std::vector<types::global_dof_index> index_set_want)
 {
-  Utilities::MPI::NoncontiguousPartitioner<double> vector;
+  Utilities::MPI::NoncontiguousPartitioner vector;
   vector.reinit(index_set_has, index_set_want, comm);
 
   AlignedVector<double> src(index_set_has.size(), 0);
@@ -36,7 +36,9 @@ test(const MPI_Comm                       comm,
   for (unsigned int i = 0; i < index_set_has.size(); i++)
     src[i] = Utilities::MPI::this_mpi_process(comm) * 100 + i;
 
-  vector.update_values(dst, src);
+  vector.export_to_ghosted_array(ArrayView<const double>(src.data(),
+                                                         src.size()),
+                                 ArrayView<double>(dst.data(), dst.size()));
 
   for (size_t i = 0; i < src.size(); i++)
     deallog << static_cast<int>(src[i]) << " ";


### PR DESCRIPTION
Togehter with @kronbichler, we are indending to add a `compression()` function to the class `NoncontiguousPartitioner`. To make this class more consistent with `Partitioner`, this PR renames `NoncontiguousPartitioner::update_values()` to `NoncontiguousPartitioner::update_ghost_values()`.