### PR TITLE
do not build release on github actions OSX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         cmake --version
     - name: configure
       run: |
-        cmake -D CMAKE_BUILD_TYPE=DebugRelease -D DEAL_II_CXX_FLAGS='-Werror' .
+        cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_CXX_FLAGS='-Werror' .
     - name: archive
       uses: actions/upload-artifact@v1
       with:
@@ -56,7 +56,7 @@ jobs:
         cmake --version
     - name: configure
       run: |
-        CC=mpicc CXX=mpic++ cmake -D CMAKE_BUILD_TYPE=DebugRelease -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_WITH_MPI=on .
+        CC=mpicc CXX=mpic++ cmake -D CMAKE_BUILD_TYPE=Debug -D DEAL_II_WITH_64BIT_INDICES=ON -D DEAL_II_CXX_FLAGS='-Werror' -D DEAL_II_WITH_MPI=on .
     - name: archive
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
revert #9844

Github only does 5 parallel OSX builds per projectand now each of them
takes close to 2 hours. This is a bit too slow.