### PR TITLE
Minor fixes to BoundingBox

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -273,7 +273,7 @@ private:
  */
 template <int dim, typename Number = double>
 BoundingBox<dim, Number>
-create_unit_box();
+create_unit_bounding_box();
 
 
 /**

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -276,51 +276,54 @@ BoundingBox<dim, Number>
 create_unit_bounding_box();
 
 
-/**
- * This function defines a convention for how coordinates in dim
- * dimensions should translate to the coordinates in dim + 1 dimensions,
- * when one of the coordinates in dim + 1 dimensions is locked to a given
- * value.
- *
- * The convention is the following: Starting from the locked coordinate we
- * store the lower dimensional coordinates consecutively and wrapping
- * around when going over the dimension. This relationship can be
- * described by the following tables:
- *
- *                        2D
- * ------------------------------------------------
- * | locked in 2D | 1D coordinate | 2D coordinate |
- * |--------------------------------------------- |
- * |     x0       |      (a)      |   (x0,  a)    |
- * |     x1       |      (a)      |   (a , x1)    |
- * ------------------------------------------------
- *
- *                       3D
- * --------------------------------------------------
- * | locked in 3D | 2D coordinates | 3D coordinates |
- * |----------------------------------------------- |
- * |     x0       |    (a, b)      | (x0,  a,  b)   |
- * |     x1       |    (a, b)      | ( b, x1,  a)   |
- * |     x2       |    (a, b)      | ( a,  b, x2)   |
- * --------------------------------------------------
- *
- * Given a locked coordinate, this function maps a coordinate index in dim
- * dimension to a coordinate index in dim + 1 dimensions.
- *
- * @param locked_coordinate should be in the range [0, dim+1).
- * @param coordiante_in_dim should be in the range [0, dim).
- * @return A coordinate index in the range [0, dim+1)
- */
-template <int dim>
-inline unsigned int
-coordinate_to_one_dim_higher(const unsigned int locked_coordinate,
-                             const unsigned int coordiante_in_dim)
+namespace internal
 {
-  AssertIndexRange(locked_coordinate, dim + 1);
-  AssertIndexRange(coordiante_in_dim, dim);
-  return (locked_coordinate + coordiante_in_dim + 1) % (dim + 1);
-}
+  /**
+   * This function defines a convention for how coordinates in dim
+   * dimensions should translate to the coordinates in dim + 1 dimensions,
+   * when one of the coordinates in dim + 1 dimensions is locked to a given
+   * value.
+   *
+   * The convention is the following: Starting from the locked coordinate we
+   * store the lower dimensional coordinates consecutively and wrapping
+   * around when going over the dimension. This relationship can be
+   * described by the following tables:
+   *
+   *                        2D
+   * ------------------------------------------------
+   * | locked in 2D | 1D coordinate | 2D coordinate |
+   * |--------------------------------------------- |
+   * |     x0       |      (a)      |   (x0,  a)    |
+   * |     x1       |      (a)      |   (a , x1)    |
+   * ------------------------------------------------
+   *
+   *                       3D
+   * --------------------------------------------------
+   * | locked in 3D | 2D coordinates | 3D coordinates |
+   * |----------------------------------------------- |
+   * |     x0       |    (a, b)      | (x0,  a,  b)   |
+   * |     x1       |    (a, b)      | ( b, x1,  a)   |
+   * |     x2       |    (a, b)      | ( a,  b, x2)   |
+   * --------------------------------------------------
+   *
+   * Given a locked coordinate, this function maps a coordinate index in dim
+   * dimension to a coordinate index in dim + 1 dimensions.
+   *
+   * @param locked_coordinate should be in the range [0, dim+1).
+   * @param coordiante_in_dim should be in the range [0, dim).
+   * @return A coordinate index in the range [0, dim+1)
+   */
+  template <int dim>
+  inline unsigned int
+  coordinate_to_one_dim_higher(const unsigned int locked_coordinate,
+                               const unsigned int coordiante_in_dim)
+  {
+    AssertIndexRange(locked_coordinate, dim + 1);
+    AssertIndexRange(coordiante_in_dim, dim);
+    return (locked_coordinate + coordiante_in_dim + 1) % (dim + 1);
+  }
 
+} // namespace internal
 
 /*------------------------ Inline functions: BoundingBox --------------------*/
 

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -237,7 +237,8 @@ public:
   bounds(const unsigned int direction) const;
 
   /**
-   * Returns the indexth vertex of the box.
+   * Returns the indexth vertex of the box. Vertex is meant in the same way as
+   * for a cell, so that @p index $\in [0, 2^{\text{dim}} - 1]$.
    */
   Point<spacedim, Number>
   vertex(const unsigned int index) const;
@@ -269,7 +270,9 @@ private:
 
 
 /**
- * Returns the unit box [0,1]^dim.
+ * Returns the unit box $[0,1]^\text{dim}$.
+ *
+ * @relates BoundingBox
  */
 template <int dim, typename Number = double>
 BoundingBox<dim, Number>
@@ -312,6 +315,8 @@ namespace internal
    * @param locked_coordinate should be in the range [0, dim+1).
    * @param coordiante_in_dim should be in the range [0, dim).
    * @return A coordinate index in the range [0, dim+1)
+   *
+   * @relates BoundingBox
    */
   template <int dim>
   inline unsigned int

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -301,7 +301,7 @@ BoundingBox<spacedim, Number>::cross_section(const unsigned int direction) const
   for (unsigned int d = 0; d < spacedim - 1; ++d)
     {
       const int index_to_write_from =
-        coordinate_to_one_dim_higher<spacedim - 1>(direction, d);
+        internal::coordinate_to_one_dim_higher<spacedim - 1>(direction, d);
 
       cross_section_lower_upper_corner.first[d] =
         boundary_points.first[index_to_write_from];

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -317,7 +317,7 @@ BoundingBox<spacedim, Number>::cross_section(const unsigned int direction) const
 
 template <int dim, typename Number>
 BoundingBox<dim, Number>
-create_unit_box()
+create_unit_bounding_box()
 {
   std::pair<Point<dim, Number>, Point<dim, Number>> lower_upper_corner;
   for (unsigned int i = 0; i < dim; ++i)

--- a/source/base/bounding_box.inst.in
+++ b/source/base/bounding_box.inst.in
@@ -18,5 +18,5 @@ for (deal_II_dimension : SPACE_DIMENSIONS; number : REAL_SCALARS)
   {
     template class BoundingBox<deal_II_dimension, number>;
 
-    template BoundingBox<deal_II_dimension, number> create_unit_box();
+    template BoundingBox<deal_II_dimension, number> create_unit_bounding_box();
   }

--- a/tests/base/bounding_box_6.cc
+++ b/tests/base/bounding_box_6.cc
@@ -20,7 +20,7 @@
 // child
 // vertex
 // bounds
-// and the non-member but related function create_unit_box
+// and the non-member but related function create_unit_bounding_box
 // Each function is tested in the function named test_{member_function_name}.
 
 #include <deal.II/base/bounding_box.h>
@@ -189,10 +189,10 @@ test_bounds()
 // Test that we can call the create_unit_box function.
 template <int dim>
 void
-test_create_unit_box()
+test_create_unit_bounding_box()
 {
-  deallog << "test_create_unit_box" << std::endl;
-  BoundingBox<dim> box = create_unit_box<dim>();
+  deallog << "test_create_unit_bounding_box" << std::endl;
+  BoundingBox<dim> box = create_unit_bounding_box<dim>();
   print_box(box);
 }
 
@@ -222,7 +222,7 @@ run_test()
   test_bounds<dim>();
   deallog << std::endl;
 
-  test_create_unit_box<dim>();
+  test_create_unit_bounding_box<dim>();
   deallog << std::endl;
 
   deallog << std::endl;

--- a/tests/base/bounding_box_6.output
+++ b/tests/base/bounding_box_6.output
@@ -24,7 +24,7 @@ DEAL::test_bounds
 DEAL::Bounds in direction 0
 DEAL::[-1.00000, 1.00000]
 DEAL::
-DEAL::test_create_unit_box
+DEAL::test_create_unit_bounding_box
 DEAL::[0.00000, 1.00000]
 DEAL::
 DEAL::
@@ -63,7 +63,7 @@ DEAL::[-1.00000, 1.00000]
 DEAL::Bounds in direction 1
 DEAL::[-2.00000, 2.00000]
 DEAL::
-DEAL::test_create_unit_box
+DEAL::test_create_unit_bounding_box
 DEAL::[0.00000, 1.00000]x[0.00000, 1.00000]
 DEAL::
 DEAL::
@@ -118,7 +118,7 @@ DEAL::[-2.00000, 2.00000]
 DEAL::Bounds in direction 2
 DEAL::[-3.00000, 3.00000]
 DEAL::
-DEAL::test_create_unit_box
+DEAL::test_create_unit_bounding_box
 DEAL::[0.00000, 1.00000]x[0.00000, 1.00000]x[0.00000, 1.00000]
 DEAL::
 DEAL::

--- a/tests/base/coordinate_to_one_dim_higher.cc
+++ b/tests/base/coordinate_to_one_dim_higher.cc
@@ -33,7 +33,8 @@ print_what_each_coordinate_maps_to()
       deallog << "locked coordinate = " << locked << std::endl;
       for (unsigned int i = 0; i < dim; ++i)
         {
-          deallog << i << " -> " << coordinate_to_one_dim_higher<dim>(locked, i)
+          deallog << i << " -> "
+                  << internal::coordinate_to_one_dim_higher<dim>(locked, i)
                   << std::endl;
         }
     }


### PR DESCRIPTION
Fix a few comments by @bangerth related to #9831.

- Rename `create_unit_box()` to `create_unit_bounding_box()`.
- Move the function `coordinate_to_one_dim_higher` to an internal namespace.
- Minor documentation fixes.