### PR TITLE
Added windows build to github-ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,3 +95,42 @@ jobs:
         ./contrib/utilities/check_indentation.sh
         make -j 2
         make -j 2 test #quicktests
+
+  windows-serial:
+    # Serial build on Windows
+    name: Windows Serial
+    runs-on: [windows-latest]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: info
+      run: |
+        cmake --version
+        wmic logicaldisk get size, freespace, caption
+    - name: configure
+      shell: bash
+      run: |
+        mkdir build
+        mkdir c:/project
+        cd build
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project ..
+    - name: archive logs
+      uses: actions/upload-artifact@v1
+      with:
+        name: windows-serial-detailed.log
+        path: build/detailed.log
+    - name: build library
+      shell: bash
+      run: |
+        cmake --build build  --target install -- -m
+        cd c:/project
+        7z a dealii-windows.zip *
+    - name: test library
+      shell: bash
+      run: |
+        cmake --build build  --target test -- -m
+    - name: archive library
+      uses: actions/upload-artifact@v1
+      with:
+        name: dealii-windows.zip
+        path: c:/project/dealii-windows.zip


### PR DESCRIPTION
With this PR, we could remove appveyor from our CI checks, and keep all builds on the same spot.