### PR TITLE
Some doxygen fixes

### DIFF
--- a/doc/doxygen/headers/manifold.h
+++ b/doc/doxygen/headers/manifold.h
@@ -76,7 +76,7 @@
  * </ul>
  * Many other examples, as well as much theoretical underpinning for the
  * implementation in deal.II, is provided in the
- * @ref GlossGeometryPaper "geometry paper".
+ * @ref geometry_paper "geometry paper".
  *
  * In deal.II, a Manifold is seen as a collection of points, together
  * with a notion of distance between points (on the manifold). New

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -752,6 +752,7 @@ private:
 };
 
 
+#ifndef DOXYGEN
 namespace internal
 {
   template <int rank, int dim, typename T, typename U>
@@ -864,10 +865,10 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
   DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef __CUDA_ARCH__
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
-#endif
+#  endif
   return value;
 }
 
@@ -877,10 +878,10 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
   DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number>::operator const Number &() const
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef __CUDA_ARCH__
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
-#endif
+#  endif
   return value;
 }
 
@@ -896,7 +897,7 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
 }
 
 
-#ifdef __INTEL_COMPILER
+#  ifdef __INTEL_COMPILER
 template <int dim, typename Number>
 DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
   DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
@@ -905,7 +906,7 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
   value = p.value;
   return *this;
 }
-#endif
+#  endif
 
 
 template <int dim, typename Number>
@@ -924,13 +925,13 @@ template <typename OtherNumber>
 DEAL_II_CONSTEXPR inline bool
 Tensor<0, dim, Number>::operator==(const Tensor<0, dim, OtherNumber> &p) const
 {
-#if defined(DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING)
+#  if defined(DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING)
   Assert(!(std::is_same<Number, adouble>::value ||
            std::is_same<OtherNumber, adouble>::value),
          ExcMessage(
            "The Tensor equality operator for ADOL-C taped numbers has not yet "
            "been extended to support advanced branching."));
-#endif
+#  endif
 
   return numbers::values_are_equal(value, p.value);
 }
@@ -979,7 +980,7 @@ namespace internal
       val *= s;
     }
 
-#ifdef __CUDA_ARCH__
+#  ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV void
                                                    multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
@@ -987,7 +988,7 @@ namespace internal
       printf("This function is not implemented for std::complex<Number>!\n");
       assert(false);
     }
-#endif
+#  endif
   } // namespace ComplexWorkaround
 } // namespace internal
 
@@ -1038,10 +1039,10 @@ DEAL_II_CONSTEXPR DEAL_II_CUDA_HOST_DEV inline DEAL_II_ALWAYS_INLINE
   Tensor<0, dim, Number>::norm_square() const
 {
   // We cannot use Assert inside a CUDA kernel
-#ifndef __CUDA_ARCH__
+#  ifndef __CUDA_ARCH__
   Assert(dim != 0,
          ExcMessage("Cannot access an object of type Tensor<0,0,Number>"));
-#endif
+#  endif
   return numbers::NumberTraits<Number>::abs_square(value);
 }
 
@@ -1143,9 +1144,9 @@ namespace internal
                                       std::integral_constant<int, dim>)
     {
       // We cannot use Assert in a CUDA kernel
-#ifndef __CUDA_ARCH__
+#  ifndef __CUDA_ARCH__
       AssertIndexRange(i, dim);
-#endif
+#  endif
       return values[i];
     }
 
@@ -1171,12 +1172,12 @@ namespace internal
                                       std::integral_constant<int, 0>)
     {
       // We cannot use Assert in a CUDA kernel
-#ifndef __CUDA_ARCH__
+#  ifndef __CUDA_ARCH__
       Assert(
         false,
         ExcMessage(
           "Cannot access elements of an object of type Tensor<rank,0,Number>."));
-#endif
+#  endif
       return Uninitialized<ArrayElementType>::value;
     }
   } // namespace TensorSubscriptor
@@ -1585,6 +1586,7 @@ Tensor<rank_, dim, Number>::serialize(Archive &ar, const unsigned int)
 template <int rank_, int dim, typename Number>
 constexpr unsigned int Tensor<rank_, dim, Number>::n_independent_components;
 
+#endif // DOXYGEN
 
 /* ----------------- Non-member functions operating on tensors. ------------ */
 

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -182,7 +182,14 @@ namespace Threads
     T data;
 #  endif
   };
+} // namespace Threads
+/**
+ * @}
+ */
 
+#  ifndef DOXYGEN
+namespace Threads
+{
   // ----------------- inline and template functions --------------------------
 
   template <typename T>
@@ -202,11 +209,11 @@ namespace Threads
   inline T &
   ThreadLocalStorage<T>::get()
   {
-#  ifdef DEAL_II_WITH_THREADS
+#    ifdef DEAL_II_WITH_THREADS
     return data.local();
-#  else
+#    else
     return data;
-#  endif
+#    endif
   }
 
 
@@ -214,12 +221,12 @@ namespace Threads
   inline T &
   ThreadLocalStorage<T>::get(bool &exists)
   {
-#  ifdef DEAL_II_WITH_THREADS
+#    ifdef DEAL_II_WITH_THREADS
     return data.local(exists);
-#  else
+#    else
     exists = true;
     return data;
-#  endif
+#    endif
   }
 
 
@@ -241,11 +248,11 @@ namespace Threads
 
   template <typename T>
   inline
-#  ifdef DEAL_II_WITH_THREADS
+#    ifdef DEAL_II_WITH_THREADS
     tbb::enumerable_thread_specific<T> &
-#  else
+#    else
     T &
-#  endif
+#    endif
     ThreadLocalStorage<T>::get_implementation()
   {
     return data;
@@ -257,18 +264,15 @@ namespace Threads
   inline void
   ThreadLocalStorage<T>::clear()
   {
-#  ifdef DEAL_II_WITH_THREADS
+#    ifdef DEAL_II_WITH_THREADS
     data.clear();
-#  else
+#    else
     data = T{};
-#  endif
+#    endif
   }
 } // namespace Threads
 
-/**
- * @}
- */
-
+#  endif // DOXYGEN
 
 //---------------------------------------------------------------------------
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -235,6 +235,7 @@ std::ostream &
 operator<<(std::ostream &out, const BlockMask &mask);
 
 
+#ifndef DOXYGEN
 // -------------------- inline functions ---------------------
 
 inline BlockMask::BlockMask(const std::vector<bool> &block_mask)
@@ -382,7 +383,7 @@ BlockMask::operator!=(const BlockMask &mask) const
 {
   return block_mask != mask.block_mask;
 }
-
+#endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -256,7 +256,7 @@ private:
 std::ostream &
 operator<<(std::ostream &out, const ComponentMask &mask);
 
-
+#ifndef DOXYGEN
 // -------------------- inline functions ---------------------
 
 inline ComponentMask::ComponentMask(const std::vector<bool> &component_mask)
@@ -413,7 +413,7 @@ ComponentMask::operator!=(const ComponentMask &mask) const
 {
   return component_mask != mask.component_mask;
 }
-
+#endif // DOXYGEN
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/manifold.h
+++ b/include/deal.II/grid/manifold.h
@@ -176,7 +176,7 @@ namespace Manifolds
  * geometry, but their common uses can be easily described simply through
  * examples. An exhaustive discussion of how, where, and why this class
  * is used is provided in the
- * @ref GlossGeometryPaper "geometry paper".
+ * @ref geometry_paper "geometry paper".
  *
  *
  * <h3>Common use case: Creating a new vertex</h3>

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -453,7 +453,7 @@ namespace TriangulationDescription
      * Construct a TriangulationDescription::Description. In contrast
      * to the function above, this function is also responsible for creating
      * a serial triangulation and for its partitioning (by calling the
-     * provided `std::functions' objects). Internally only selected processes (
+     * provided `std::function` objects). Internally only selected processes (
      * every n-th/each root of a group of size group_size) create a serial
      * triangulation and the TriangulationDescription::Description for all
      * processes in its group, which is communicated.

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -234,7 +234,7 @@ namespace LocalIntegrators
      *
      * @param M11 The internal matrix for the first cell obtained as result.
      * @param M12 The external matrix for the first cell obtained as result.
-     * @param M12 The external matrix for the second cell obtained as result.
+     * @param M21 The external matrix for the second cell obtained as result.
      * @param M22 The internal matrix for the second cell obtained as result.
      * @param fe1 The FEValues object describing the local trial function
      * space for the first cell. #update_values and #update_JxW_values must be

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -3461,7 +3461,7 @@ namespace TrilinosWrappers
 // explicit instantiations
 #  include "trilinos_sparse_matrix.inst"
 
-
+#  ifndef DOXYGEN
 // TODO: put these instantiations into generic file
 namespace TrilinosWrappers
 {
@@ -3515,8 +3515,8 @@ namespace TrilinosWrappers
     dealii::LinearAlgebra::distributed::Vector<double> &,
     const dealii::LinearAlgebra::distributed::Vector<double> &) const;
 
-#  ifdef DEAL_II_WITH_MPI
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    ifdef DEAL_II_WITH_MPI
+#      ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template void
   SparseMatrix::vmult(
     dealii::LinearAlgebra::TpetraWrappers::Vector<double> &,
@@ -3526,13 +3526,13 @@ namespace TrilinosWrappers
   SparseMatrix::vmult(
     dealii::LinearAlgebra::TpetraWrappers::Vector<float> &,
     const dealii::LinearAlgebra::TpetraWrappers::Vector<float> &) const;
-#    endif
+#      endif
 
   template void
   SparseMatrix::vmult(
     dealii::LinearAlgebra::EpetraWrappers::Vector &,
     const dealii::LinearAlgebra::EpetraWrappers::Vector &) const;
-#  endif
+#    endif
 
   template void
   SparseMatrix::Tvmult(MPI::Vector &, const MPI::Vector &) const;
@@ -3546,8 +3546,8 @@ namespace TrilinosWrappers
     dealii::LinearAlgebra::distributed::Vector<double> &,
     const dealii::LinearAlgebra::distributed::Vector<double> &) const;
 
-#  ifdef DEAL_II_WITH_MPI
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    ifdef DEAL_II_WITH_MPI
+#      ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template void
   SparseMatrix::Tvmult(
     dealii::LinearAlgebra::TpetraWrappers::Vector<double> &,
@@ -3557,13 +3557,13 @@ namespace TrilinosWrappers
   SparseMatrix::Tvmult(
     dealii::LinearAlgebra::TpetraWrappers::Vector<float> &,
     const dealii::LinearAlgebra::TpetraWrappers::Vector<float> &) const;
-#    endif
+#      endif
 
   template void
   SparseMatrix::Tvmult(
     dealii::LinearAlgebra::EpetraWrappers::Vector &,
     const dealii::LinearAlgebra::EpetraWrappers::Vector &) const;
-#  endif
+#    endif
 
   template void
   SparseMatrix::vmult_add(MPI::Vector &, const MPI::Vector &) const;
@@ -3577,8 +3577,8 @@ namespace TrilinosWrappers
     dealii::LinearAlgebra::distributed::Vector<double> &,
     const dealii::LinearAlgebra::distributed::Vector<double> &) const;
 
-#  ifdef DEAL_II_WITH_MPI
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    ifdef DEAL_II_WITH_MPI
+#      ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template void
   SparseMatrix::vmult_add(
     dealii::LinearAlgebra::TpetraWrappers::Vector<double> &,
@@ -3588,13 +3588,13 @@ namespace TrilinosWrappers
   SparseMatrix::vmult_add(
     dealii::LinearAlgebra::TpetraWrappers::Vector<float> &,
     const dealii::LinearAlgebra::TpetraWrappers::Vector<float> &) const;
-#    endif
+#      endif
 
   template void
   SparseMatrix::vmult_add(
     dealii::LinearAlgebra::EpetraWrappers::Vector &,
     const dealii::LinearAlgebra::EpetraWrappers::Vector &) const;
-#  endif
+#    endif
 
   template void
   SparseMatrix::Tvmult_add(MPI::Vector &, const MPI::Vector &) const;
@@ -3608,8 +3608,8 @@ namespace TrilinosWrappers
     dealii::LinearAlgebra::distributed::Vector<double> &,
     const dealii::LinearAlgebra::distributed::Vector<double> &) const;
 
-#  ifdef DEAL_II_WITH_MPI
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    ifdef DEAL_II_WITH_MPI
+#      ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template void
   SparseMatrix::Tvmult_add(
     dealii::LinearAlgebra::TpetraWrappers::Vector<double> &,
@@ -3619,14 +3619,15 @@ namespace TrilinosWrappers
   SparseMatrix::Tvmult_add(
     dealii::LinearAlgebra::TpetraWrappers::Vector<float> &,
     const dealii::LinearAlgebra::TpetraWrappers::Vector<float> &) const;
-#    endif
+#      endif
 
   template void
   SparseMatrix::Tvmult_add(
     dealii::LinearAlgebra::EpetraWrappers::Vector &,
     const dealii::LinearAlgebra::EpetraWrappers::Vector &) const;
-#  endif
+#    endif
 } // namespace TrilinosWrappers
+#  endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
- don't let `doxygen` see a couple implementations of `inline` functions.
- replace `GlossGeometryPaper` by `geometry_paper`
- some typos