### PR TITLE
Remove more deprecations

### DIFF
--- a/doc/news/changes/incompatibilities/20200408DanielArndt
+++ b/doc/news/changes/incompatibilities/20200408DanielArndt
@@ -1,0 +1,8 @@
+Removed: The deprecated functions Utilities::fixed_int_power(),
+LinearAlgebra::distributed::BlockVector::equ(),
+LinearAlgebra::distributed::BlockVector::sadd()
+and FEEvaluationBase::get_cell_data_number() and the deprecated variable
+DoFHandler::invalid_dof_index and hp::DoFHandler::invalid_dof_index have been
+removed.
+<br>
+(Daniel Arndt, 2020/04/08)

--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -467,49 +467,6 @@ namespace Utilities
   fixed_power(const T t);
 
   /**
-   * Calculate a fixed power of an integer number by a template expression
-   * where both the number <code>a</code> and the power <code>N</code> are
-   * compile-time constants. This computes the result of the power operation
-   * at compile time, enabling its use e.g. in other templates.
-   *
-   * Use this class as in <code>fixed_int_power@<5,2@>::%value</code> to
-   * compute 5<sup>2</sup>.
-   *
-   * @deprecated This template has been deprecated in favor of C++11's support
-   * for <code>constexpr</code> calculations, e.g., use
-   *
-   * @code
-   * constexpr int value = Utilities::pow(2, dim);
-   * @endcode
-   *
-   * instead of
-   *
-   * @code
-   * const int value = Utilities::fixed_int_power<2, dim>::value;
-   * @endcode
-   *
-   * to obtain a constant expression for <code>value</code>.
-   */
-  template <int a, int N>
-  struct DEAL_II_DEPRECATED fixed_int_power
-  {
-    static const int value = a * fixed_int_power<a, N - 1>::value;
-  };
-
-  /**
-   * Base case for the power operation with <code>N=0</code>, which gives the
-   * result 1.
-   *
-   * @deprecated This template is deprecated: see the note in the general
-   * version of this template for more information.
-   */
-  template <int a>
-  struct DEAL_II_DEPRECATED fixed_int_power<a, 0>
-  {
-    static const int value = 1;
-  };
-
-  /**
    * A replacement for <code>std::pow</code> that allows compile-time
    * calculations for constant expression arguments. The @p base must
    * be an integer type and the exponent @p iexp must not be negative.

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -410,21 +410,6 @@ public:
   static const bool is_hp_dof_handler = false;
 
   /**
-   * When the arrays holding the DoF indices are set up, but before they are
-   * filled with actual values, they are set to an invalid value, in order to
-   * monitor possible problems. This invalid value is the constant defined
-   * here.
-   *
-   * Please note that you should not rely on it having a certain value, but
-   * rather take its symbolic name.
-   *
-   * @deprecated Use numbers::invalid_dof_index instead.
-   */
-  DEAL_II_DEPRECATED
-  static const types::global_dof_index invalid_dof_index =
-    numbers::invalid_dof_index;
-
-  /**
    * The default index of the finite element to be used on a given cell. Since
    * the present class only supports the same finite element to be used on all
    * cells, the index of the finite element needs to be the same on all cells

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -361,21 +361,6 @@ namespace hp
     static const bool is_hp_dof_handler = true;
 
     /**
-     * When the arrays holding the DoF indices are set up, but before they are
-     * filled with actual values, they are set to an invalid value, in order
-     * to monitor possible problems. This invalid value is the constant
-     * defined here.
-     *
-     * Please note that you should not rely on it having a certain value, but
-     * rather take its symbolic name.
-     *
-     * @deprecated Use numbers::invalid_dof_index instead.
-     */
-    DEAL_II_DEPRECATED
-    static const types::global_dof_index invalid_dof_index =
-      numbers::invalid_dof_index;
-
-    /**
      * The default index of the finite element to be used on a given cell. For
      * the usual, non-hp dealii::DoFHandler class that only supports the same
      * finite element to be used on all cells, the index of the finite element

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -377,31 +377,6 @@ namespace LinearAlgebra
       sadd(const Number s, const BlockVector<Number> &V);
 
       /**
-       * Assignment <tt>*this = a*u + b*v</tt>.
-       *
-       * This function is deprecated.
-       */
-      DEAL_II_DEPRECATED
-      void
-      equ(const Number               a,
-          const BlockVector<Number> &u,
-          const Number               b,
-          const BlockVector<Number> &v);
-
-      /**
-       * Scaling and multiple addition.
-       *
-       * This function is deprecated.
-       */
-      DEAL_II_DEPRECATED
-      void
-      sadd(const Number               s,
-           const Number               a,
-           const BlockVector<Number> &V,
-           const Number               b,
-           const BlockVector<Number> &W);
-
-      /**
        * Return whether the vector contains only elements with value zero.
        * This function is mainly for internal consistency checks and should
        * seldom be used when not in debug mode since it uses quite some time.

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -391,21 +391,6 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    void
-    BlockVector<Number>::equ(const Number               a,
-                             const BlockVector<Number> &v,
-                             const Number               b,
-                             const BlockVector<Number> &w)
-    {
-      AssertDimension(this->n_blocks(), v.n_blocks());
-      AssertDimension(this->n_blocks(), w.n_blocks());
-      for (unsigned int block = 0; block < this->n_blocks(); ++block)
-        this->block(block).equ(a, v.block(block), b, w.block(block));
-    }
-
-
-
-    template <typename Number>
     BlockVector<Number> &
     BlockVector<Number>::operator+=(const VectorSpaceVector<Number> &vv)
     {
@@ -518,22 +503,6 @@ namespace LinearAlgebra
       AssertDimension(this->n_blocks(), v.n_blocks());
       for (unsigned int block = 0; block < this->n_blocks(); ++block)
         this->block(block).sadd(x, v.block(block));
-    }
-
-
-
-    template <typename Number>
-    void
-    BlockVector<Number>::sadd(const Number               x,
-                              const Number               a,
-                              const BlockVector<Number> &v,
-                              const Number               b,
-                              const BlockVector<Number> &w)
-    {
-      AssertDimension(this->n_blocks(), v.n_blocks());
-      AssertDimension(this->n_blocks(), w.n_blocks());
-      for (unsigned int block = 0; block < this->n_blocks(); ++block)
-        this->block(block).sadd(x, a, v.block(block), b, w.block(block));
     }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -118,13 +118,6 @@ public:
   ~FEEvaluationBase();
 
   /**
-   * @deprecated Use get_mapping_data_index_offset() instead.
-   */
-  DEAL_II_DEPRECATED
-  unsigned int
-  get_cell_data_number() const;
-
-  /**
    * Return the index offset within the geometry fields for the cell the @p
    * reinit() function has been called for. This index can be used to access
    * an index into a field that has the same compression behavior as the
@@ -3404,20 +3397,6 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   scratch_data =
     scratch_data_array->begin() + n_components_ * dofs_per_component +
     (n_components_ * (dim * dim + 2 * dim + 1) * n_quadrature_points);
-}
-
-
-
-template <int dim,
-          int n_components_,
-          typename Number,
-          bool is_face,
-          typename VectorizedArrayType>
-inline unsigned int
-FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
-  get_cell_data_number() const
-{
-  return get_mapping_data_index_offset();
 }
 
 

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -47,9 +47,6 @@ template <int dim, int spacedim>
 const unsigned int DoFHandler<dim, spacedim>::space_dimension;
 
 template <int dim, int spacedim>
-const types::global_dof_index DoFHandler<dim, spacedim>::invalid_dof_index;
-
-template <int dim, int spacedim>
 const unsigned int DoFHandler<dim, spacedim>::default_fe_index;
 
 

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -1260,9 +1260,6 @@ namespace hp
   const unsigned int DoFHandler<dim, spacedim>::dimension;
 
   template <int dim, int spacedim>
-  const types::global_dof_index DoFHandler<dim, spacedim>::invalid_dof_index;
-
-  template <int dim, int spacedim>
   const unsigned int DoFHandler<dim, spacedim>::default_fe_index;
 
 


### PR DESCRIPTION
- `Utilities::fixed_int_power()` was deprecated in https://github.com/dealii/dealii/pull/5919.
- `(hp::)DoFHandler::invalid_dof_index` was deprecated in #4534
- `LinearAlgebra::distributed::BlockVector::equ/sadd()` was deprecated in #2615.
- `FEEvaluationBase::get_cell_data_number()` was deprecated in https://github.com/dealii/dealii/pull/6202.