### PR TITLE
Improve CellWeights documentation

### DIFF
--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -197,19 +197,27 @@ namespace parallel
     CellWeights(const hp::DoFHandler<dim, spacedim> &dof_handler);
 
     /**
-     * @copydoc CellWeights::constant_weighting()
+     * Choose a constant weight @p factor on each cell.
+     *
+     * @deprecated Use CellWeights::constant_weighting() instead.
      */
     DEAL_II_DEPRECATED void
     register_constant_weighting(const unsigned int factor = 1000);
 
     /**
-     * @copydoc CellWeights::ndofs_weighting()
+     * Choose a weight for each cell that is proportional to its number of
+     * degrees of freedom with a factor @p factor.
+     *
+     * @deprecated Use CellWeights::ndofs_weighting() instead.
      */
     DEAL_II_DEPRECATED void
     register_ndofs_weighting(const unsigned int factor = 1000);
 
     /**
-     * @copydoc CellWeights::ndofs_squared_weighting()
+     * Choose a weight for each cell that is proportional to its number of
+     * degrees of freedom <i>squared</i> with a factor @p factor.
+     *
+     * @deprecated Use CellWeights::ndofs_weighting() instead.
      */
     DEAL_II_DEPRECATED void
     register_ndofs_squared_weighting(const unsigned int factor = 1000);


### PR DESCRIPTION
Doxygen has troubles finding the to be copied documentation so just restore what we had previously.