### PR TITLE
refactoring of ParameterAcceptor::initialize()

### DIFF
--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -373,22 +373,18 @@ public:
    * default values, and don't want to read external files to use a class
    * derived from ParameterAcceptor.
    *
-   * If outfilename is not the empty string, then write the content that was
-   * read in to the outfilename. The format of both input and output files are
-   * selected using the extensions of the files themselves. This can be either
-   * `prm` or `xml` for input, and `prm`, `xml`, or `tex/latex` for output. If
-   * the output format is `prm`, then `output_style_for_prm_format` is used to
-   * decide whether we write the full documentation as well, or only the
-   * parameters.
+   * If `output_filename` is not the empty string, then write the content that
+   * was read in to `output_filename`. The format of both input and output files
+   * are selected using the extensions of the files themselves.
    *
    * If the input file does not exist, a default one with the same name is
-   * created for you, and an exception is thrown.
+   * created, and an exception is thrown.
    *
    * @param filename Input file name
    * @param output_filename Output file name
-   * @param output_style_for_prm_format How to write the output file if format
-   * is `prm`
+   * @param output_style_for_output_filename Defines style of output file
    * @param prm The ParameterHandler to use
+   * @param output_style_for_filename Defines style of default input file (if created)
    */
   static void
   initialize(

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -391,11 +391,14 @@ public:
    * @param prm The ParameterHandler to use
    */
   static void
-  initialize(const std::string &                 filename        = "",
-             const std::string &                 output_filename = "",
-             const ParameterHandler::OutputStyle output_style_for_prm_format =
-               ParameterHandler::ShortText,
-             ParameterHandler &prm = ParameterAcceptor::prm);
+  initialize(
+    const std::string &                 filename        = "",
+    const std::string &                 output_filename = "",
+    const ParameterHandler::OutputStyle output_style_for_output_filename =
+      ParameterHandler::DefaultStyle,
+    ParameterHandler &                  prm = ParameterAcceptor::prm,
+    const ParameterHandler::OutputStyle output_style_for_filename =
+      ParameterHandler::DefaultStyle);
 
   /**
    * Call declare_all_parameters(), read the parameters from the `input_stream`

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1081,6 +1081,15 @@ public:
   parse_input_from_json(std::istream &input, const bool skip_undefined = false);
 
   /**
+   * Create a default input file by calling print_parameters() depending on the
+   * type of input file specified (prm, xml, json).
+   */
+  void
+  create_default_input_file(const std::string filename,
+                            const OutputStyle style) const;
+
+
+  /**
    * Clear all contents.
    */
   void

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1085,14 +1085,8 @@ public:
    * type of input file specified (prm, xml, json).
    */
   void
-<<<<<<< 20b4164047452179eab3f55314f2a886428e31a0
   create_default_input_file(const std::string filename,
                             const OutputStyle style) const;
-=======
-  create_default_input_file(const std::string &filename,
-                            const bool         sort_alphabetical = true,
-                            const bool         short_version     = true) const;
->>>>>>> use a reference instead of copy
 
   /**
    * Clear all contents.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1086,7 +1086,8 @@ public:
    */
   void
   create_default_input_file(const std::string &filename,
-                            const OutputStyle  style) const;
+                            const bool         short_version  = true,
+                            const bool keep_declaration_order = true) const;
 
   /**
    * Clear all contents.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1088,13 +1088,11 @@ public:
   create_default_input_file(const std::string filename,
                             const OutputStyle style) const;
 
-
   /**
    * Clear all contents.
    */
   void
   clear();
-
 
   /**
    * Declare a new entry with name <tt>entry</tt>, default and for which any

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1085,8 +1085,14 @@ public:
    * type of input file specified (prm, xml, json).
    */
   void
+<<<<<<< 20b4164047452179eab3f55314f2a886428e31a0
   create_default_input_file(const std::string filename,
                             const OutputStyle style) const;
+=======
+  create_default_input_file(const std::string &filename,
+                            const bool         sort_alphabetical = true,
+                            const bool         short_version     = true) const;
+>>>>>>> use a reference instead of copy
 
   /**
    * Clear all contents.

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -1085,8 +1085,8 @@ public:
    * type of input file specified (prm, xml, json).
    */
   void
-  create_default_input_file(const std::string filename,
-                            const OutputStyle style) const;
+  create_default_input_file(const std::string &filename,
+                            const OutputStyle  style) const;
 
   /**
    * Clear all contents.

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -80,6 +80,7 @@ ParameterAcceptor::initialize(
       prm.parse_input(filename);
     }
 
+  // TODO refactor this part
   if (!output_filename.empty())
     {
       std::ofstream outfile(output_filename.c_str());
@@ -96,15 +97,29 @@ ParameterAcceptor::initialize(
             output_style_for_output_filename == ParameterHandler::Text ||
               output_style_for_output_filename == ParameterHandler::ShortText,
             ExcMessage(
-              "Only Text or ShortText can be specified in output_style_for_prm_format."))
-            prm.print_parameters(outfile, output_style_for_output_filename);
+              "Only Text or ShortText can be specified in output_style_for_output_filename "
+              "in combination with prm filename extension."))
         }
       else if (extension == "xml")
-        prm.print_parameters(outfile, output_style_for_output_filename);
+        {
+          Assert(
+            output_style_for_output_filename == ParameterHandler::XML,
+            ExcMessage(
+              "Only XML can be specified in output_style_for_output_filename "
+              "in combination with xml filename extension."))
+        }
       else if (extension == "latex" || extension == "tex")
-        prm.print_parameters(outfile, output_style_for_output_filename);
+        {
+          Assert(
+            output_style_for_output_filename == ParameterHandler::LaTeX,
+            ExcMessage(
+              "Only LaTeX can be specified in output_style_for_output_filename "
+              "in combination with latex or tex filename extension."))
+        }
       else
         AssertThrow(false, ExcNotImplemented());
+
+      prm.print_parameters(outfile, output_style_for_output_filename);
     }
 
   // Finally do the parsing.

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -67,7 +67,10 @@ ParameterAcceptor::initialize(
       std::ifstream is(filename);
       if (!is)
         {
-          prm.create_default_input_file(filename, output_style_for_filename);
+          std::ofstream out(filename);
+          Assert(out, ExcIO());
+          prm.print_parameters(out, output_style_for_filename);
+          out.close();
           AssertThrow(false,
                       ExcMessage(
                         "You specified <" + filename + "> as input file, " +

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -56,54 +56,25 @@ void
 ParameterAcceptor::initialize(
   const std::string &                 filename,
   const std::string &                 output_filename,
-  const ParameterHandler::OutputStyle output_style_for_prm_format,
-  ParameterHandler &                  prm)
+  const ParameterHandler::OutputStyle output_style_for_output_filename,
+  ParameterHandler &                  prm,
+  const ParameterHandler::OutputStyle output_style_for_filename)
+
 {
   declare_all_parameters(prm);
   if (!filename.empty())
     {
-      // check the extension of input file
-      if (filename.substr(filename.find_last_of('.') + 1) == "prm")
+      std::ifstream is(filename);
+      if (!is)
         {
-          try
-            {
-              prm.parse_input(filename);
-            }
-          catch (const dealii::PathSearch::ExcFileNotFound &)
-            {
-              std::ofstream out(filename);
-              Assert(out, ExcIO());
-              prm.print_parameters(out, ParameterHandler::Text);
-              out.close();
-              AssertThrow(false,
-                          ExcMessage("You specified <" + filename +
-                                     "> as input " +
-                                     "parameter file, but it does not exist. " +
-                                     "We created it for you."));
-            }
+          prm.create_default_input_file(filename, output_style_for_filename);
+          AssertThrow(false,
+                      ExcMessage(
+                        "You specified <" + filename + "> as input file, " +
+                        "but it does not exist. We created it for you."));
         }
-      else if (filename.substr(filename.find_last_of('.') + 1) == "xml")
-        {
-          std::ifstream is(filename);
-          if (!is)
-            {
-              std::ofstream out(filename);
-              Assert(out, ExcIO());
-              prm.print_parameters(out, ParameterHandler::XML);
-              out.close();
-              AssertThrow(false,
-                          ExcMessage("You specified <" + filename +
-                                     "> as input " +
-                                     "parameter file, but it does not exist. " +
-                                     "We created it for you."));
-            }
-          prm.parse_input_from_xml(is);
-        }
-      else
-        AssertThrow(
-          false,
-          ExcMessage(
-            "Invalid extension of parameter file. Please use .prm or .xml"));
+
+      prm.parse_input(filename);
     }
 
   if (!output_filename.empty())
@@ -119,16 +90,16 @@ ParameterAcceptor::initialize(
                   << "# DEAL_II_PACKAGE_VERSION = " << DEAL_II_PACKAGE_VERSION
                   << std::endl;
           Assert(
-            output_style_for_prm_format == ParameterHandler::Text ||
-              output_style_for_prm_format == ParameterHandler::ShortText,
+            output_style_for_output_filename == ParameterHandler::Text ||
+              output_style_for_output_filename == ParameterHandler::ShortText,
             ExcMessage(
               "Only Text or ShortText can be specified in output_style_for_prm_format."))
-            prm.print_parameters(outfile, output_style_for_prm_format);
+            prm.print_parameters(outfile, output_style_for_output_filename);
         }
       else if (extension == "xml")
-        prm.print_parameters(outfile, ParameterHandler::XML);
+        prm.print_parameters(outfile, output_style_for_output_filename);
       else if (extension == "latex" || extension == "tex")
-        prm.print_parameters(outfile, ParameterHandler::LaTeX);
+        prm.print_parameters(outfile, output_style_for_output_filename);
       else
         AssertThrow(false, ExcNotImplemented());
     }

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -802,7 +802,7 @@ ParameterHandler::create_default_input_file(const std::string filename,
                   ExcMessage("OutputStyle does not fit to filename ending."));
       print_parameters(out, style);
     }
- else
+  else
     {
       AssertThrow(
         false,

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -775,6 +775,47 @@ ParameterHandler::parse_input_from_json(std::istream &in,
 
 
 void
+ParameterHandler::create_default_input_file(const std::string filename,
+                                            const OutputStyle style) const
+{
+  std::ofstream out(filename);
+  Assert(out, ExcIO());
+
+  std::string file_ending = filename.substr(filename.find_last_of(".") + 1);
+  boost::algorithm::to_lower(file_ending);
+
+  if (file_ending == "prm")
+    {
+      AssertThrow(style & PRM,
+                  ExcMessage("OutputStyle does not fit to filename ending."));
+      print_parameters(out, style);
+    }
+  else if (file_ending == "xml")
+    {
+      AssertThrow(style & XML,
+                  ExcMessage("OutputStyle does not fit to filename ending."));
+      print_parameters(out, style);
+    }
+  else if (file_ending == "json")
+    {
+      AssertThrow(style & JSON,
+                  ExcMessage("OutputStyle does not fit to filename ending."));
+      print_parameters(out, style);
+    }
+  else
+    {
+      AssertThrow(
+        false,
+        ExcMessage(
+          "Unknown input file. Supported types are .prm, .xml, and .json."));
+    }
+
+  out.close();
+}
+
+
+
+void
 ParameterHandler::clear()
 {
   entries = std_cxx14::make_unique<boost::property_tree::ptree>();

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -775,32 +775,33 @@ ParameterHandler::parse_input_from_json(std::istream &in,
 
 
 void
-ParameterHandler::create_default_input_file(const std::string &filename,
-                                            const OutputStyle  style) const
+ParameterHandler::create_default_input_file(
+  const std::string &filename,
+  const bool         short_version,
+  const bool         keep_declaration_order) const
 {
   std::ofstream out(filename);
   Assert(out, ExcIO());
 
+  const OutputStyle style_short =
+    (short_version ? Short : static_cast<OutputStyle>(0));
+  const OutputStyle style_order =
+    (keep_declaration_order ? KeepDeclarationOrder :
+                              static_cast<OutputStyle>(0));
+
   std::string file_ending = filename.substr(filename.find_last_of('.') + 1);
   boost::algorithm::to_lower(file_ending);
-
   if (file_ending == "prm")
     {
-      AssertThrow(style & PRM,
-                  ExcMessage("OutputStyle does not fit to filename ending."));
-      print_parameters(out, style);
+      print_parameters(out, PRM | style_short | style_order);
     }
   else if (file_ending == "xml")
     {
-      AssertThrow(style & XML,
-                  ExcMessage("OutputStyle does not fit to filename ending."));
-      print_parameters(out, style);
+      print_parameters(out, XML | style_short | style_order);
     }
   else if (file_ending == "json")
     {
-      AssertThrow(style & JSON,
-                  ExcMessage("OutputStyle does not fit to filename ending."));
-      print_parameters(out, style);
+      print_parameters(out, JSON | style_short | style_order);
     }
   else
     {

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -775,13 +775,13 @@ ParameterHandler::parse_input_from_json(std::istream &in,
 
 
 void
-ParameterHandler::create_default_input_file(const std::string filename,
-                                            const OutputStyle style) const
+ParameterHandler::create_default_input_file(const std::string &filename,
+                                            const OutputStyle  style) const
 {
   std::ofstream out(filename);
   Assert(out, ExcIO());
 
-  std::string file_ending = filename.substr(filename.find_last_of(".") + 1);
+  std::string file_ending = filename.substr(filename.find_last_of('.') + 1);
   boost::algorithm::to_lower(file_ending);
 
   if (file_ending == "prm")

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -802,7 +802,7 @@ ParameterHandler::create_default_input_file(const std::string filename,
                   ExcMessage("OutputStyle does not fit to filename ending."));
       print_parameters(out, style);
     }
-  else
+ else
     {
       AssertThrow(
         false,


### PR DESCRIPTION
This PR builds on PR #9741 and shows how ``ParameterAcceptor`` can be simplified by implementing base functionality in ``ParameterHandler`` so that it can be used by application classes. According to single responsibility, switching between different code paths according to the type of input file should be done in the base class ``ParameterHandler`` that cares about this. One will otherwise end up in several implementations, one supporting .prm, another one .prm and .xml, another one .json, etc. with a lot of duplicated code. Making chances to the code will become increasingly complex otherwise since several classes have to be kept up-to-date.