### PR TITLE
Use #ifdef to guard std::async in step-69

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -2509,7 +2509,11 @@ namespace Step69
                   output_granularity,
                   "time interval for output");
 
+#ifdef DEAL_II_WITH_THREADS
     asynchronous_writeback = true;
+#else
+    asynchronous_writeback = false;
+#endif
     add_parameter("asynchronous writeback",
                   asynchronous_writeback,
                   "Write out solution in a background thread performing IO");
@@ -2865,7 +2869,15 @@ namespace Step69
     // run in the background.
     if (!asynchronous_writeback)
       {
+#ifdef DEAL_II_WITH_THREADS
         background_thread_state = std::async(std::launch::async, output_worker);
+#else
+        AssertThrow(
+          false,
+          ExcMessage(
+            "\"asynchronous_writeback\" was set to true but deal.II was built "
+            "without thread support (\"DEAL_II_WITH_THREADS=false\")."));
+#endif
       }
     else
       {

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -2867,7 +2867,7 @@ namespace Step69
     // At this point we can return from the <code>output()</code> function
     // and resume with the time stepping in the main loop - the thread will
     // run in the background.
-    if (!asynchronous_writeback)
+    if (asynchronous_writeback)
       {
 #ifdef DEAL_II_WITH_THREADS
         background_thread_state = std::async(std::launch::async, output_worker);


### PR DESCRIPTION
@tamiko I think that you need `DEAL_II_WITH_THREADS`  for step-69. In my computer I explicitly disable `DEAL_II_WITH_THREADS` and step-69 does not compile because it needs threads.