### PR TITLE
Fix gcc warning in TBB

### DIFF
--- a/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h
+++ b/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h
@@ -1200,7 +1200,7 @@ private:
     // Initialize the hash and keep the first bucket open
     void internal_init() {
         // Initialize the array of segment pointers
-        memset(my_buckets, 0, sizeof(my_buckets));
+        memset((void*)my_buckets, 0, sizeof(my_buckets));
 
         // Initialize bucket 0
         raw_iterator dummy_node = my_solist.raw_begin();


### PR DESCRIPTION
In analogy to #6731, this silences a warning about using `std::memset` for `std::pair`. More precisely, I am seeing
```
In file included from dealii/bundled/tbb-2018_U2/include/tbb/concurrent_unordered_map.h:27,
                 from dealii/include/deal.II/matrix_free/matrix_free.templates.h:46,
                 from dealii/source/matrix_free/matrix_free.cc:21:
dealii/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h: In instantiation of ‘void tbb::interface5::internal::concurrent_unordered_base<Traits>::internal_init() [with Traits = tbb::interface5::concurrent_unordered_map_traits<std::pair<unsigned int, unsigned int>, unsigned int, tbb::interface5::internal::hash_compare<std::pair<unsigned int, unsigned int>, tbb::tbb_hash<std::pair<unsigned int, unsigned int> >, std::equal_to<std::pair<unsigned int, unsigned int> > >, tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >, false>]’: 
dealii/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h:710:9:   required from ‘tbb::interface5::internal::concurrent_unordered_base<Traits>::concurrent_unordered_base(tbb::interface5::internal::concurrent_unordered_base<Traits>::size_type, const hash_compare&, const allocator_type&) [with Traits = tbb::interface5::concurrent_unordered_map_traits<std::pair<unsigned int, unsigned int>, unsigned int, tbb::interface5::internal::hash_compare<std::pair<unsigned int, unsigned int>, tbb::tbb_hash<std::pair<unsigned int, unsigned int> >, std::equal_to<std::pair<unsigned int, unsigned int> > >, tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >, false>; tbb::interface5::internal::concurrent_unordered_base<Traits>::size_type = long unsigned int; tbb::interface5::internal::concurrent_unordered_base<Traits>::hash_compare = tbb::interface5::internal::hash_compare<std::pair<unsigned int, unsigned int>, tbb::tbb_hash<std::pair<unsigned int, unsigned int> >, std::equal_to<std::pair<unsigned int, unsigned int> > >; tbb::interface5::internal::concurrent_unordered_base<Traits>::allocator_type = tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >]’
dealii/bundled/tbb-2018_U2/include/tbb/concurrent_unordered_map.h:101:73:   required from ‘tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::concurrent_unordered_map(tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::size_type, const hasher&, const key_equal&, const allocator_type&) [with Key = std::pair<unsigned int, unsigned int>; T = unsigned int; Hasher = tbb::tbb_hash<std::pair<unsigned int, unsigned int> >; Key_equality = std::equal_to<std::pair<unsigned int, unsigned int> >; Allocator = tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >; tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::size_type = long unsigned int; tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::hasher = tbb::tbb_hash<std::pair<unsigned int, unsigned int> >; tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::key_equal = std::equal_to<std::pair<unsigned int, unsigned int> >; tbb::interface5::concurrent_unordered_map<Key, T, Hasher, Key_equality, Allocator>::allocator_type = tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >]’
dealii/include/deal.II/matrix_free/matrix_free.templates.h:2083:5:   required from ‘void dealii::MatrixFree<dim, Number, VectorizedArrayType>::make_connectivity_graph_faces(dealii::DynamicSparsityPattern&) [with int dim = 1; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 1>]’
dealii/build_gcc_10/source/matrix_free/matrix_free.inst:58:16:   required from here 
dealii/bundled/tbb-2018_U2/include/tbb/internal/_concurrent_unordered_impl.h:1203:15: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct tbb::atomic<tbb::interface5::internal::flist_iterator<tbb::interface5::internal::split_ordered_list<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int>, tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> > >, std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >*>’ with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
 1203 |         memset(my_buckets, 0, sizeof(my_buckets));
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from dealii/bundled/tbb-2018_U2/include/tbb/tbb_profiling.h:128,
                 from dealii/bundled/tbb-2018_U2/include/tbb/task.h:26,
                 from dealii/include/deal.II/base/thread_management.h:42,
                 from dealii/include/deal.II/base/parallel.h:25,
                 from dealii/include/deal.II/base/aligned_vector.h:24,
                 from dealii/include/deal.II/base/table.h:21,
                 from dealii/include/deal.II/lac/lapack_full_matrix.h:23,
                 from dealii/include/deal.II/base/tensor.h:29,
                 from dealii/include/deal.II/base/symmetric_tensor.h:25,
                 from dealii/include/deal.II/base/array_view.h:23,
                 from dealii/include/deal.II/base/mpi.h:21,
                 from dealii/include/deal.II/matrix_free/matrix_free.templates.h:23,
                 from dealii/source/matrix_free/matrix_free.cc:21:
dealii/bundled/tbb-2018_U2/include/tbb/atomic.h:485:29: note: ‘struct tbb::atomic<tbb::interface5::internal::flist_iterator<tbb::interface5::internal::split_ordered_list<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int>, tbb::tbb_allocator<std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> > >, std::pair<const std::pair<unsigned int, unsigned int>, unsigned int> >*>’ declared here
  485 | template<typename T> struct atomic<T*>: internal::atomic_impl_with_arithmetic<T*,ptrdiff_t,T> {
      |                             ^~~~~~~~~~
^Csource/matrix_free/CMakeFiles/obj_matrix_free_debug.dir/build.make:158: recipe for target 'source/matrix_free/CMakeFiles/obj_matrix_free_debug.dir/matrix_free.cc.o' failed
make[2]: *** [source/matrix_free/CMakeFiles/obj_matrix_free_debug.dir/matrix_free.cc.o] Interrupt
CMakeFiles/Makefile2:3105: recipe for target 'source/matrix_free/CMakeFiles/obj_matrix_free_debug.dir/all' failed
make[1]: *** [source/matrix_free/CMakeFiles/obj_matrix_free_debug.dir/all] Interrupt
Makefile:129: recipe for target 'all' failed
make: *** [all] Interrupt
```
with a recent gcc version.