### PR TITLE
Fix three tests

### DIFF
--- a/tests/data_out/data_out_base_vtu_04.with_zlib=on.output.fma
+++ b/tests/data_out/data_out_base_vtu_04.with_zlib=on.output.fma
@@ -1,0 +1,33 @@
+
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="384" NumberOfCells="24" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+AQAAAAASAAAAEgAARQUAAA==eNqdV02IlWUUvmolUhA4o6DNYrC5QwWRYkIK870a9gO5Uu6qMtwU5UZcuFFi0EANRohw58KJmc2dRUi6KPrOGZggCmKSmAJjFmG2GBiQFoEV4jnvd877Pve9q3vdvOeb7zA+zzfPc97ztFrToWX/TjxzLtxZ3lNp/fWVU+HW2Jex/u2rd7Un9i10P0r9O3Z8EC4+3BV7Vs6/E/775Hqsdx94Kyx012Ld6XRS/+3tR8O+F0fjz++feTO8uv5ZrC8vvhI6nZWq6TqY+i+PToW7bz8ef/7kyZfDpc6FWP/x+qT0LPZhW9p5OGyemYi1nvpsvypYXw+2vUt7w7Vft8ef66nPDce1SvtKbF+cfDbsHt/S/B459bnhuFJpX4lt6+hI+PSXf2Ktpz43cBarpm9wvgvdF1L/oa3PhV3b1qe0nnxvPFw7+2HsOfDTiHDs2vfflvofPD0SPj69HPsPHXsqPH/kSOz5/NgG4Xi18m+V9fB/dWf5xlSjh/vVrbGX7JuvyjldDcMXsZ3/dmO4+f7vsdZTnxuO3Ur7Smx3f/izWn3AsdZTnxuOVyvtK7Et7fyu2jwzVzV6mKv0ucEzXTV9vdpQvavutVYfqB8Mf7tlPkFtqN5V91qrD9QPWq89bE26T1AbqnfVvdbqA/WD1t/c+6udfZK/lf79VQeRu+hC9dH0/NzOusnYBDM5ZuFCzkX+sXNEbIKZHLNwIeciHMk5IjbBTI5ZuJBzEY7kHBGbYCbHLFzIuQhmyvofjC9qQ/WuutdafaB+0Hrkx5tt9wlqQ/WuutdafaB+0Hp29Wg7+yRrQ/Wuum++7Y0p9YN5tp19MhhfxCaYa8csXMi5CEdyjohNMNeOWbiQcxGO5BwRm2CuHbNwIeciHAn0n7QhM5N9ZsrJPkvlPef5n7UhM5N9ZsrJPkvlPef5n7UhM5N9ZsrJPkvlPef5n7+VzBDyGSIn+2yR9wzzP2ETvbPfWeID9rtM+GpPu8Qmeme/s8QH7HeZ+CP1IzbRO/udJT5gv8vEH6kfscnfn32Giy7YZ7v8jVL/oHxRGzIzyWemnOyzVN5znv9ZGzIzyWemnOSzVN5znv9ZGzIzyWemnOSzVN4TzP+B+CI20Tv7nSU+YL/LxB/87+zfEyU20Tv7nSU+YL/LxB/8xPGZiRKb6J38zhIfkN9lqnnpmSi1YZoh0BKBxrjUhmmGQEsEGqNSG6YZAi0RaIzKb2XfkODbEnzzPmzmWQYvM3icS2zmWQYvM3icS2zmWQYvM3icS2ymYQJtM2ieh+GL2jDN1KAlAo1RqQ3TTA1aItAYldowzdSgJQKN0TB8EZt5lsDLDB7nEpt5lsDLBB7nEpt5lsDLBB6nUhu2MzDsEq6fefNJjzZsZ2DYJWJ9euyNefNJjzZsZ2DYJVK/+aTnW9kdynC3Ap6DVo8nbLazMexyDDterGfrwwmb7WwMuxzDjhfrLeuvJWy2szHscgw7Xh8222EYdhuGnWcovqgN2xkYdolY3z6+cV59UmrDdgaGXcK+yWPz6pNSG7YzEOwSrp85nzmD8h37fkPCZjsbwy7HsOPFev+VTQmb7WwMuxzDjmf/1/WEzXY2gl2OYMejUhuWGRmyJEPG7NOGZUaGLMmQManUhmVGhizJkDGp/FaWoRiyFUHmohKbZXaCLO98U6ZDbJbZCbI8lRkfsVlmJ8jyVGZ8xGYZliDbUpl5B+WL2rDMyJAlCTImldqwzEiQJQkyZp82LDMSZEmCjEnD8EVsltkJsnxdZnzEZpmdIMvXZcZHbJbZCbJ8XWb8R4PK+tc=
+    </DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+AQAAAAAGAAAABgAARwIAAA==eNol02O7HgQAANB3xp1tm3e272zbtm3VbNRWs70aa0bNZs22VeN5nn04P+EEAoFAGKIThVCEJgJBRCUaYYlIOMITicjEIDbJSUJMYhGfxCQlGXFIQFzikZBEpCA12clCSlKRnsxkJRtpyEBa0pGRTASTi2IUJgc5yUchilCU3OQnD3kpQEGKU4qqVKIEJSlLRSpThRDKUZoylKcC1ahJUxpRnRrUpSGNaUIt6lGbOtSnAc1oSVc60ZwWtKUjnelCK9rRmja0pwPd6MlQBtGdHvRlIIMZQi/60Zs+9GcAwxjJZCYwnBH8yHgmMolRjGE0PzCWcUxhOvP5halMYzZz+ZV5zOAnZjKLn5nDAhaznjUsZBHLWc1a1rGEFSxlGStZxQZ+Zzc72MhvbOVPdrKLTWxjM1vYzh/sYT8nOcZe9vE3RznOCQ5wiIP8xWGOcIqzXOcKpznDRf7lKtc4xyXOc4HL/MMNbvOcJ9zkFvd5zFOecYcH3OUeD3nEC17zlU+85BXv+chnvvCGD7zlHf/xf+B7+DBEJwqhCE0EgohKNMISkXCEJxKRiUFskpOEmMQiPolJSjLikIC4xCMhiUhBarKThZSkIj2ZyUo20pCBtKQjI5kIJhfFKEwOcpKPQhShKLnJTx7yUoCCFKcUValECUpSlopUpgohlKM0ZShPBapRk6Y0ojo1qEtDGtOEWtSjNnWoTwOa0ZKudKI5LWhLRzrThVa0ozVtaE8HutGToQyiOz3oy0AGM4Re9KM3fejPAL4BA4CfwQ==
+    </DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+AQAAAGAAAABgAAAAQQAAAA==eNoNw4EUgDAABcCfwRCGMIQhDGEIIQwhhBBCCCGEEELo7r0rSarN7nC6uzw8vbx9fP3MlhSrze5wurv8AdcaCco=
+    </DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+AQAAABgAAAAYAAAACwAAAA==eNpzc8MOAFIgBpE=
+    </DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="square_function" format="binary">
+AQAAAAAGAAAABgAAPgAAAA==eNpjYGiwZ0DCRTLhKFjmuCEKZmAQQMOU6kfFln2P7ZDxE4t1KBhoBxqmVP+o/0f9P+r/Uf+PTP8DAOyZmHA=    </DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>

--- a/tests/grid/grid_out_svg_02.output.fma
+++ b/tests/grid/grid_out_svg_02.output.fma
@@ -1,0 +1,3257 @@
+
+<svg width="2482" height="1205" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+
+<!-- internal style sheet -->
+<style type="text/css"><![CDATA[
+ rect.background{fill:none}
+ rect{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ text{font-family:Helvetica; text-anchor:middle; fill:rgb(25,25,25)}
+ line{stroke:rgb(25,25,25); stroke-width:4}
+ path{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ circle{fill:white; stroke:black; stroke-width:2}
+
+ path.p0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps0{fill:rgb(0,77,191); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.p1{fill:rgb(0,255,178); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps1{fill:rgb(0,191,134); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r1{fill:rgb(0,255,178); stroke:rgb(25,25,25); stroke-width:2}
+ path.p2{fill:rgb(51,255,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps2{fill:rgb(38,191,0); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r2{fill:rgb(51,255,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.p3{fill:rgb(255,229,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps3{fill:rgb(191,172,0); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r3{fill:rgb(255,229,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.p4{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps4{fill:rgb(191,0,0); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r4{fill:rgb(255,0,0); stroke:rgb(25,25,25); stroke-width:2}
+]]></style>
+
+ <rect class="background" width="2000" height="1205"/>
+  <!-- cells -->
+  <path class="ps0" d="M 1616 716 L 1506 462 L 1202 614 L 1308 716 L 1616 716"/>
+  <text x="1410" y="638" style="font-size:40px">0.0,0,X,0</text>
+  <line x1="1616" y1="716" x2="1506" y2="462"/>
+  <line x1="1308" y1="716" x2="1202" y2="614"/>
+  <path class="ps0" d="M 1506 462 L 1000 462 L 1000 577 L 1202 614 L 1506 462"/>
+  <text x="1181" y="542" style="font-size:33px">0.1,0,X,0</text>
+  <line x1="1506" y1="462" x2="1000" y2="462"/>
+  <line x1="1202" y1="614" x2="1000" y2="577"/>
+  <path class="ps0" d="M 1000 462 L 494 462 L 798 614 L 1000 577 L 1000 462"/>
+  <text x="819" y="542" style="font-size:33px">0.2,0,X,0</text>
+  <line x1="1000" y1="462" x2="494" y2="462"/>
+  <line x1="1000" y1="577" x2="798" y2="614"/>
+  <path class="ps0" d="M 494 462 L 384 716 L 692 716 L 798 614 L 494 462"/>
+  <text x="590" y="638" style="font-size:40px">0.3,0,X,0</text>
+  <line x1="494" y1="462" x2="384" y2="716"/>
+  <line x1="798" y1="614" x2="692" y2="716"/>
+  <path class="ps0" d="M 384 716 L 214 1109 L 764 833 L 692 716 L 384 716"/>
+  <text x="526" y="856" style="font-size:57px">0.4,0,X,0</text>
+  <line x1="384" y1="716" x2="214" y2="1109"/>
+  <line x1="692" y1="716" x2="764" y2="833"/>
+  <path class="ps0" d="M 214 1109 L 1000 1109 L 1000 888 L 764 833 L 214 1109"/>
+  <text x="753" y="1010" style="font-size:70px">0.5,0,X,0</text>
+  <line x1="214" y1="1109" x2="1000" y2="1109"/>
+  <line x1="764" y1="833" x2="1000" y2="888"/>
+  <path class="ps0" d="M 1000 1109 L 1786 1109 L 1236 833 L 1000 888 L 1000 1109"/>
+  <text x="1247" y="1010" style="font-size:70px">0.6,0,X,0</text>
+  <line x1="1000" y1="1109" x2="1786" y2="1109"/>
+  <line x1="1000" y1="888" x2="1236" y2="833"/>
+  <path class="ps0" d="M 1786 1109 L 1616 716 L 1308 716 L 1236 833 L 1786 1109"/>
+  <text x="1474" y="856" style="font-size:57px">0.7,0,X,0</text>
+  <line x1="1786" y1="1109" x2="1616" y2="716"/>
+  <line x1="1236" y1="833" x2="1308" y2="716"/>
+  <path class="ps1" d="M 1632 606 L 1569 475 L 1429 512 L 1474 606 L 1632 606"/>
+  <text x="1525" y="558" style="font-size:22px">1.0,0,X,0</text>
+  <line x1="1632" y1="606" x2="1569" y2="475"/>
+  <path class="ps1" d="M 1569 475 L 1517 367 L 1372 435 L 1429 512 L 1569 475"/>
+  <text x="1472" y="454" style="font-size:18px">1.1,0,X,0</text>
+  <line x1="1569" y1="475" x2="1517" y2="367"/>
+  <path class="ps1" d="M 1474 606 L 1429 512 L 1280 553 L 1316 606 L 1474 606"/>
+  <text x="1375" y="580" style="font-size:24px">1.2,0,X,0</text>
+  <line x1="1316" y1="606" x2="1280" y2="553"/>
+  <path class="ps1" d="M 1429 512 L 1372 435 L 1207 511 L 1280 553 L 1429 512"/>
+  <text x="1323" y="511" style="font-size:21px">1.3,0,X,0</text>
+  <line x1="1280" y1="553" x2="1207" y2="511"/>
+  <path class="ps1" d="M 1517 367 L 1259 367 L 1188 423 L 1372 435 L 1517 367"/>
+  <text x="1335" y="405" style="font-size:16px">1.4,0,X,0</text>
+  <line x1="1517" y1="367" x2="1259" y2="367"/>
+  <path class="ps1" d="M 1259 367 L 1000 367 L 1000 419 L 1188 423 L 1259 367"/>
+  <text x="1112" y="401" style="font-size:16px">1.5,0,X,0</text>
+  <line x1="1259" y1="367" x2="1000" y2="367"/>
+  <path class="ps1" d="M 1372 435 L 1188 423 L 1110 484 L 1207 511 L 1372 435"/>
+  <text x="1220" y="471" style="font-size:19px">1.6,0,X,0</text>
+  <line x1="1207" y1="511" x2="1110" y2="484"/>
+  <path class="ps1" d="M 1188 423 L 1000 419 L 1000 475 L 1110 484 L 1188 423"/>
+  <text x="1075" y="459" style="font-size:19px">1.7,0,X,0</text>
+  <line x1="1110" y1="484" x2="1000" y2="475"/>
+  <path class="ps1" d="M 1000 367 L 741 367 L 812 423 L 1000 419 L 1000 367"/>
+  <text x="888" y="401" style="font-size:16px">1.8,0,X,0</text>
+  <line x1="1000" y1="367" x2="741" y2="367"/>
+  <path class="ps1" d="M 741 367 L 483 367 L 628 435 L 812 423 L 741 367"/>
+  <text x="665" y="405" style="font-size:16px">1.9,0,X,0</text>
+  <line x1="741" y1="367" x2="483" y2="367"/>
+  <path class="ps1" d="M 1000 419 L 812 423 L 890 484 L 1000 475 L 1000 419"/>
+  <text x="925" y="459" style="font-size:19px">1.10,0,X,0</text>
+  <line x1="1000" y1="475" x2="890" y2="484"/>
+  <path class="ps1" d="M 812 423 L 628 435 L 793 511 L 890 484 L 812 423"/>
+  <text x="780" y="471" style="font-size:19px">1.11,0,X,0</text>
+  <line x1="890" y1="484" x2="793" y2="511"/>
+  <path class="ps1" d="M 483 367 L 431 475 L 571 512 L 628 435 L 483 367"/>
+  <text x="528" y="454" style="font-size:18px">1.12,0,X,0</text>
+  <line x1="483" y1="367" x2="431" y2="475"/>
+  <path class="ps1" d="M 431 475 L 368 606 L 526 606 L 571 512 L 431 475"/>
+  <text x="475" y="558" style="font-size:22px">1.13,0,X,0</text>
+  <line x1="431" y1="475" x2="368" y2="606"/>
+  <path class="ps1" d="M 628 435 L 571 512 L 720 553 L 793 511 L 628 435"/>
+  <text x="677" y="511" style="font-size:21px">1.14,0,X,0</text>
+  <line x1="793" y1="511" x2="720" y2="553"/>
+  <path class="ps1" d="M 571 512 L 526 606 L 684 606 L 720 553 L 571 512"/>
+  <text x="625" y="580" style="font-size:24px">1.15,0,X,0</text>
+  <line x1="720" y1="553" x2="684" y2="606"/>
+  <path class="ps1" d="M 368 606 L 289 770 L 500 715 L 526 606 L 368 606"/>
+  <text x="423" y="685" style="font-size:28px">1.16,0,X,0</text>
+  <line x1="368" y1="606" x2="289" y2="770"/>
+  <path class="ps1" d="M 289 770 L 188 981 L 497 838 L 500 715 L 289 770"/>
+  <text x="374" y="837" style="font-size:34px">1.17,0,X,0</text>
+  <line x1="289" y1="770" x2="188" y2="981"/>
+  <path class="ps1" d="M 526 606 L 500 715 L 695 664 L 684 606 L 526 606"/>
+  <text x="602" y="660" style="font-size:27px">1.18,0,X,0</text>
+  <line x1="684" y1="606" x2="695" y2="664"/>
+  <path class="ps1" d="M 500 715 L 497 838 L 758 718 L 695 664 L 500 715"/>
+  <text x="615" y="747" style="font-size:31px">1.19,0,X,0</text>
+  <line x1="695" y1="664" x2="758" y2="718"/>
+  <path class="ps1" d="M 188 981 L 594 981 L 739 861 L 497 838 L 188 981"/>
+  <text x="509" y="932" style="font-size:39px">1.20,0,X,0</text>
+  <line x1="188" y1="981" x2="594" y2="981"/>
+  <path class="ps1" d="M 594 981 L 1000 981 L 1000 868 L 739 861 L 594 981"/>
+  <text x="834" y="941" style="font-size:41px">1.21,0,X,0</text>
+  <line x1="594" y1="981" x2="1000" y2="981"/>
+  <path class="ps1" d="M 497 838 L 739 861 L 865 756 L 758 718 L 497 838"/>
+  <text x="718" y="808" style="font-size:35px">1.22,0,X,0</text>
+  <line x1="758" y1="718" x2="865" y2="756"/>
+  <path class="ps1" d="M 739 861 L 1000 868 L 1000 770 L 865 756 L 739 861"/>
+  <text x="902" y="830" style="font-size:36px">1.23,0,X,0</text>
+  <line x1="865" y1="756" x2="1000" y2="770"/>
+  <path class="ps1" d="M 1000 981 L 1406 981 L 1261 861 L 1000 868 L 1000 981"/>
+  <text x="1166" y="941" style="font-size:41px">1.24,0,X,0</text>
+  <line x1="1000" y1="981" x2="1406" y2="981"/>
+  <path class="ps1" d="M 1406 981 L 1812 981 L 1503 838 L 1261 861 L 1406 981"/>
+  <text x="1491" y="932" style="font-size:39px">1.25,0,X,0</text>
+  <line x1="1406" y1="981" x2="1812" y2="981"/>
+  <path class="ps1" d="M 1000 868 L 1261 861 L 1135 756 L 1000 770 L 1000 868"/>
+  <text x="1098" y="830" style="font-size:36px">1.26,0,X,0</text>
+  <line x1="1000" y1="770" x2="1135" y2="756"/>
+  <path class="ps1" d="M 1261 861 L 1503 838 L 1242 718 L 1135 756 L 1261 861"/>
+  <text x="1282" y="808" style="font-size:35px">1.27,0,X,0</text>
+  <line x1="1135" y1="756" x2="1242" y2="718"/>
+  <path class="ps1" d="M 1812 981 L 1711 770 L 1500 715 L 1503 838 L 1812 981"/>
+  <text x="1626" y="837" style="font-size:34px">1.28,0,X,0</text>
+  <line x1="1812" y1="981" x2="1711" y2="770"/>
+  <path class="ps1" d="M 1711 770 L 1632 606 L 1474 606 L 1500 715 L 1711 770"/>
+  <text x="1577" y="685" style="font-size:28px">1.29,0,X,0</text>
+  <line x1="1711" y1="770" x2="1632" y2="606"/>
+  <path class="ps1" d="M 1503 838 L 1500 715 L 1305 664 L 1242 718 L 1503 838"/>
+  <text x="1385" y="747" style="font-size:31px">1.30,0,X,0</text>
+  <line x1="1242" y1="718" x2="1305" y2="664"/>
+  <path class="ps1" d="M 1500 715 L 1474 606 L 1316 606 L 1305 664 L 1500 715"/>
+  <text x="1398" y="660" style="font-size:27px">1.31,0,X,0</text>
+  <line x1="1305" y1="664" x2="1316" y2="606"/>
+  <path class="ps2" d="M 1486 491 L 1462 446 L 1387 455 L 1405 491 L 1486 491"/>
+  <text x="1435" y="477" style="font-size:13px">2.0,0,X,0</text>
+  <path class="ps2" d="M 1462 446 L 1439 403 L 1365 422 L 1387 455 L 1462 446"/>
+  <text x="1413" y="437" style="font-size:12px">2.1,0,X,0</text>
+  <path class="ps2" d="M 1405 491 L 1387 455 L 1311 465 L 1324 491 L 1405 491"/>
+  <text x="1357" y="482" style="font-size:13px">2.2,0,X,0</text>
+  <line x1="1324" y1="491" x2="1311" y2="465"/>
+  <path class="ps2" d="M 1387 455 L 1365 422 L 1287 441 L 1311 465 L 1387 455"/>
+  <text x="1338" y="451" style="font-size:12px">2.3,0,X,0</text>
+  <line x1="1311" y1="465" x2="1287" y2="441"/>
+  <path class="ps2" d="M 1439 403 L 1409 366 L 1333 392 L 1365 422 L 1439 403"/>
+  <text x="1387" y="401" style="font-size:11px">2.4,0,X,0</text>
+  <path class="ps2" d="M 1409 366 L 1380 331 L 1299 365 L 1333 392 L 1409 366"/>
+  <text x="1356" y="368" style="font-size:10px">2.5,0,X,0</text>
+  <path class="ps2" d="M 1365 422 L 1333 392 L 1254 420 L 1287 441 L 1365 422"/>
+  <text x="1310" y="424" style="font-size:12px">2.6,0,X,0</text>
+  <line x1="1287" y1="441" x2="1254" y2="420"/>
+  <path class="ps2" d="M 1333 392 L 1299 365 L 1212 402 L 1254 420 L 1333 392"/>
+  <text x="1275" y="400" style="font-size:11px">2.7,0,X,0</text>
+  <line x1="1254" y1="420" x2="1212" y2="402"/>
+  <path class="ps2" d="M 1380 331 L 1286 325 L 1227 355 L 1299 365 L 1380 331"/>
+  <text x="1298" y="349" style="font-size:10px">2.8,0,X,0</text>
+  <path class="ps2" d="M 1286 325 L 1192 320 L 1153 348 L 1227 355 L 1286 325"/>
+  <text x="1215" y="342" style="font-size:10px">2.9,0,X,0</text>
+  <path class="ps2" d="M 1299 365 L 1227 355 L 1165 387 L 1212 402 L 1299 365"/>
+  <text x="1226" y="383" style="font-size:11px">2.10,0,X,0</text>
+  <line x1="1212" y1="402" x2="1165" y2="387"/>
+  <path class="ps2" d="M 1227 355 L 1153 348 L 1112 377 L 1165 387 L 1227 355"/>
+  <text x="1165" y="372" style="font-size:10px">2.11,0,X,0</text>
+  <line x1="1165" y1="387" x2="1112" y2="377"/>
+  <path class="ps2" d="M 1192 320 L 1096 318 L 1077 344 L 1153 348 L 1192 320"/>
+  <text x="1130" y="337" style="font-size:9px">2.12,0,X,0</text>
+  <path class="ps2" d="M 1096 318 L 1000 316 L 1000 342 L 1077 344 L 1096 318"/>
+  <text x="1043" y="334" style="font-size:9px">2.13,0,X,0</text>
+  <path class="ps2" d="M 1153 348 L 1077 344 L 1057 370 L 1112 377 L 1153 348"/>
+  <text x="1100" y="364" style="font-size:10px">2.14,0,X,0</text>
+  <line x1="1112" y1="377" x2="1057" y2="370"/>
+  <path class="ps2" d="M 1077 344 L 1000 342 L 1000 368 L 1057 370 L 1077 344"/>
+  <text x="1033" y="361" style="font-size:10px">2.15,0,X,0</text>
+  <line x1="1057" y1="370" x2="1000" y2="368"/>
+  <path class="ps2" d="M 1000 316 L 904 318 L 923 344 L 1000 342 L 1000 316"/>
+  <text x="957" y="334" style="font-size:9px">2.16,0,X,0</text>
+  <path class="ps2" d="M 904 318 L 808 320 L 847 348 L 923 344 L 904 318"/>
+  <text x="870" y="337" style="font-size:9px">2.17,0,X,0</text>
+  <path class="ps2" d="M 1000 342 L 923 344 L 943 370 L 1000 368 L 1000 342"/>
+  <text x="967" y="361" style="font-size:10px">2.18,0,X,0</text>
+  <line x1="1000" y1="368" x2="943" y2="370"/>
+  <path class="ps2" d="M 923 344 L 847 348 L 888 377 L 943 370 L 923 344"/>
+  <text x="900" y="364" style="font-size:10px">2.19,0,X,0</text>
+  <line x1="943" y1="370" x2="888" y2="377"/>
+  <path class="ps2" d="M 808 320 L 714 325 L 773 355 L 847 348 L 808 320"/>
+  <text x="785" y="342" style="font-size:10px">2.20,0,X,0</text>
+  <path class="ps2" d="M 714 325 L 620 331 L 701 365 L 773 355 L 714 325"/>
+  <text x="702" y="349" style="font-size:10px">2.21,0,X,0</text>
+  <path class="ps2" d="M 847 348 L 773 355 L 835 387 L 888 377 L 847 348"/>
+  <text x="835" y="372" style="font-size:10px">2.22,0,X,0</text>
+  <line x1="888" y1="377" x2="835" y2="387"/>
+  <path class="ps2" d="M 773 355 L 701 365 L 788 402 L 835 387 L 773 355"/>
+  <text x="774" y="383" style="font-size:11px">2.23,0,X,0</text>
+  <line x1="835" y1="387" x2="788" y2="402"/>
+  <path class="ps2" d="M 620 331 L 591 366 L 667 392 L 701 365 L 620 331"/>
+  <text x="644" y="368" style="font-size:10px">2.24,0,X,0</text>
+  <path class="ps2" d="M 591 366 L 561 403 L 635 422 L 667 392 L 591 366"/>
+  <text x="613" y="401" style="font-size:11px">2.25,0,X,0</text>
+  <path class="ps2" d="M 701 365 L 667 392 L 746 420 L 788 402 L 701 365"/>
+  <text x="725" y="400" style="font-size:11px">2.26,0,X,0</text>
+  <line x1="788" y1="402" x2="746" y2="420"/>
+  <path class="ps2" d="M 667 392 L 635 422 L 713 441 L 746 420 L 667 392"/>
+  <text x="690" y="424" style="font-size:12px">2.27,0,X,0</text>
+  <line x1="746" y1="420" x2="713" y2="441"/>
+  <path class="ps2" d="M 561 403 L 538 446 L 613 455 L 635 422 L 561 403"/>
+  <text x="587" y="437" style="font-size:12px">2.28,0,X,0</text>
+  <path class="ps2" d="M 538 446 L 514 491 L 595 491 L 613 455 L 538 446"/>
+  <text x="565" y="477" style="font-size:13px">2.29,0,X,0</text>
+  <path class="ps2" d="M 635 422 L 613 455 L 689 465 L 713 441 L 635 422"/>
+  <text x="662" y="451" style="font-size:12px">2.30,0,X,0</text>
+  <line x1="713" y1="441" x2="689" y2="465"/>
+  <path class="ps2" d="M 613 455 L 595 491 L 676 491 L 689 465 L 613 455"/>
+  <text x="643" y="482" style="font-size:13px">2.31,0,X,0</text>
+  <line x1="689" y1="465" x2="676" y2="491"/>
+  <path class="ps2" d="M 514 491 L 500 540 L 588 529 L 595 491 L 514 491"/>
+  <text x="549" y="519" style="font-size:14px">2.32,0,X,0</text>
+  <path class="ps2" d="M 500 540 L 485 593 L 588 569 L 588 529 L 500 540"/>
+  <text x="541" y="565" style="font-size:15px">2.33,0,X,0</text>
+  <path class="ps2" d="M 595 491 L 588 529 L 675 518 L 676 491 L 595 491"/>
+  <text x="633" y="514" style="font-size:14px">2.34,0,X,0</text>
+  <line x1="676" y1="491" x2="675" y2="518"/>
+  <path class="ps2" d="M 588 529 L 588 569 L 687 546 L 675 518 L 588 529"/>
+  <text x="635" y="548" style="font-size:15px">2.35,0,X,0</text>
+  <line x1="675" y1="518" x2="687" y2="546"/>
+  <path class="ps2" d="M 485 593 L 483 649 L 601 609 L 588 569 L 485 593"/>
+  <text x="540" y="612" style="font-size:16px">2.36,0,X,0</text>
+  <path class="ps2" d="M 483 649 L 481 709 L 621 650 L 601 609 L 483 649"/>
+  <text x="548" y="663" style="font-size:18px">2.37,0,X,0</text>
+  <path class="ps2" d="M 588 569 L 601 609 L 712 572 L 687 546 L 588 569"/>
+  <text x="647" y="582" style="font-size:16px">2.38,0,X,0</text>
+  <line x1="687" y1="546" x2="712" y2="572"/>
+  <path class="ps2" d="M 601 609 L 621 650 L 751 596 L 712 572 L 601 609"/>
+  <text x="672" y="615" style="font-size:17px">2.39,0,X,0</text>
+  <line x1="712" y1="572" x2="751" y2="596"/>
+  <path class="ps2" d="M 481 709 L 605 720 L 707 666 L 621 650 L 481 709"/>
+  <text x="605" y="695" style="font-size:19px">2.40,0,X,0</text>
+  <path class="ps2" d="M 605 720 L 731 730 L 798 679 L 707 666 L 605 720"/>
+  <text x="711" y="708" style="font-size:19px">2.41,0,X,0</text>
+  <path class="ps2" d="M 621 650 L 707 666 L 801 616 L 751 596 L 621 650"/>
+  <text x="721" y="641" style="font-size:18px">2.42,0,X,0</text>
+  <line x1="751" y1="596" x2="801" y2="616"/>
+  <path class="ps2" d="M 707 666 L 798 679 L 861 632 L 801 616 L 707 666"/>
+  <text x="792" y="657" style="font-size:18px">2.43,0,X,0</text>
+  <line x1="801" y1="616" x2="861" y2="632"/>
+  <path class="ps2" d="M 731 730 L 865 734 L 898 686 L 798 679 L 731 730"/>
+  <text x="823" y="717" style="font-size:20px">2.44,0,X,0</text>
+  <path class="ps2" d="M 865 734 L 1000 738 L 1000 690 L 898 686 L 865 734"/>
+  <text x="941" y="722" style="font-size:20px">2.45,0,X,0</text>
+  <path class="ps2" d="M 798 679 L 898 686 L 929 642 L 861 632 L 798 679"/>
+  <text x="872" y="669" style="font-size:19px">2.46,0,X,0</text>
+  <line x1="861" y1="632" x2="929" y2="642"/>
+  <path class="ps2" d="M 898 686 L 1000 690 L 1000 645 L 929 642 L 898 686"/>
+  <text x="957" y="675" style="font-size:19px">2.47,0,X,0</text>
+  <line x1="929" y1="642" x2="1000" y2="645"/>
+  <path class="ps2" d="M 1000 738 L 1135 734 L 1102 686 L 1000 690 L 1000 738"/>
+  <text x="1059" y="722" style="font-size:20px">2.48,0,X,0</text>
+  <path class="ps2" d="M 1135 734 L 1269 730 L 1202 679 L 1102 686 L 1135 734"/>
+  <text x="1177" y="717" style="font-size:20px">2.49,0,X,0</text>
+  <path class="ps2" d="M 1000 690 L 1102 686 L 1071 642 L 1000 645 L 1000 690"/>
+  <text x="1043" y="675" style="font-size:19px">2.50,0,X,0</text>
+  <line x1="1000" y1="645" x2="1071" y2="642"/>
+  <path class="ps2" d="M 1102 686 L 1202 679 L 1139 632 L 1071 642 L 1102 686"/>
+  <text x="1128" y="669" style="font-size:19px">2.51,0,X,0</text>
+  <line x1="1071" y1="642" x2="1139" y2="632"/>
+  <path class="ps2" d="M 1269 730 L 1395 720 L 1293 666 L 1202 679 L 1269 730"/>
+  <text x="1289" y="708" style="font-size:19px">2.52,0,X,0</text>
+  <path class="ps2" d="M 1395 720 L 1519 709 L 1379 650 L 1293 666 L 1395 720"/>
+  <text x="1395" y="695" style="font-size:19px">2.53,0,X,0</text>
+  <path class="ps2" d="M 1202 679 L 1293 666 L 1199 616 L 1139 632 L 1202 679"/>
+  <text x="1208" y="657" style="font-size:18px">2.54,0,X,0</text>
+  <line x1="1139" y1="632" x2="1199" y2="616"/>
+  <path class="ps2" d="M 1293 666 L 1379 650 L 1249 596 L 1199 616 L 1293 666"/>
+  <text x="1279" y="641" style="font-size:18px">2.55,0,X,0</text>
+  <line x1="1199" y1="616" x2="1249" y2="596"/>
+  <path class="ps2" d="M 1519 709 L 1517 649 L 1399 609 L 1379 650 L 1519 709"/>
+  <text x="1452" y="663" style="font-size:18px">2.56,0,X,0</text>
+  <path class="ps2" d="M 1517 649 L 1515 593 L 1412 569 L 1399 609 L 1517 649"/>
+  <text x="1460" y="612" style="font-size:16px">2.57,0,X,0</text>
+  <path class="ps2" d="M 1379 650 L 1399 609 L 1288 572 L 1249 596 L 1379 650"/>
+  <text x="1328" y="615" style="font-size:17px">2.58,0,X,0</text>
+  <line x1="1249" y1="596" x2="1288" y2="572"/>
+  <path class="ps2" d="M 1399 609 L 1412 569 L 1313 546 L 1288 572 L 1399 609"/>
+  <text x="1353" y="582" style="font-size:16px">2.59,0,X,0</text>
+  <line x1="1288" y1="572" x2="1313" y2="546"/>
+  <path class="ps2" d="M 1515 593 L 1500 540 L 1412 529 L 1412 569 L 1515 593"/>
+  <text x="1459" y="565" style="font-size:15px">2.60,0,X,0</text>
+  <path class="ps2" d="M 1500 540 L 1486 491 L 1405 491 L 1412 529 L 1500 540"/>
+  <text x="1451" y="519" style="font-size:14px">2.61,0,X,0</text>
+  <path class="ps2" d="M 1412 569 L 1412 529 L 1325 518 L 1313 546 L 1412 569"/>
+  <text x="1365" y="548" style="font-size:15px">2.62,0,X,0</text>
+  <line x1="1313" y1="546" x2="1325" y2="518"/>
+  <path class="ps2" d="M 1412 529 L 1405 491 L 1324 491 L 1325 518 L 1412 529"/>
+  <text x="1367" y="514" style="font-size:14px">2.63,0,X,0</text>
+  <line x1="1325" y1="518" x2="1324" y2="491"/>
+  <path class="p2" d="M 1649 491 L 1614 426 L 1538 436 L 1567 491 L 1649 491"/>
+  <text x="1592" y="466" style="font-size:12px">2.64,0,0,0</text>
+  <line x1="1649" y1="491" x2="1614" y2="426"/>
+  <path class="p2" d="M 1614 426 L 1582 368 L 1512 386 L 1538 436 L 1614 426"/>
+  <text x="1561" y="409" style="font-size:11px">2.65,0,0,0</text>
+  <line x1="1614" y1="426" x2="1582" y2="368"/>
+  <path class="ps2" d="M 1567 491 L 1538 436 L 1462 446 L 1486 491 L 1567 491"/>
+  <text x="1513" y="471" style="font-size:12px">2.66,0,X,0</text>
+  <path class="ps2" d="M 1538 436 L 1512 386 L 1439 403 L 1462 446 L 1538 436"/>
+  <text x="1488" y="423" style="font-size:11px">2.67,0,X,0</text>
+  <path class="p2" d="M 1582 368 L 1554 316 L 1483 340 L 1512 386 L 1582 368"/>
+  <text x="1533" y="356" style="font-size:9px">2.68,0,0,0</text>
+  <line x1="1582" y1="368" x2="1554" y2="316"/>
+  <path class="p2" d="M 1554 316 L 1528 269 L 1457 299 L 1483 340 L 1554 316"/>
+  <text x="1506" y="309" style="font-size:8px">2.69,0,0,0</text>
+  <line x1="1554" y1="316" x2="1528" y2="269"/>
+  <path class="ps2" d="M 1512 386 L 1483 340 L 1409 366 L 1439 403 L 1512 386"/>
+  <text x="1461" y="378" style="font-size:10px">2.70,0,X,0</text>
+  <path class="p2" d="M 1483 340 L 1457 299 L 1380 331 L 1409 366 L 1483 340"/>
+  <text x="1432" y="338" style="font-size:9px">2.71,0,0,0</text>
+  <path class="p2" d="M 1528 269 L 1396 269 L 1342 296 L 1457 299 L 1528 269"/>
+  <text x="1431" y="287" style="font-size:8px">2.72,0,0,0</text>
+  <line x1="1528" y1="269" x2="1396" y2="269"/>
+  <path class="p2" d="M 1396 269 L 1264 269 L 1229 294 L 1342 296 L 1396 269"/>
+  <text x="1308" y="286" style="font-size:8px">2.73,0,0,0</text>
+  <line x1="1396" y1="269" x2="1264" y2="269"/>
+  <path class="p2" d="M 1457 299 L 1342 296 L 1286 325 L 1380 331 L 1457 299"/>
+  <text x="1367" y="317" style="font-size:9px">2.74,0,0,0</text>
+  <path class="ps2" d="M 1342 296 L 1229 294 L 1192 320 L 1286 325 L 1342 296"/>
+  <text x="1263" y="313" style="font-size:9px">2.75,0,X,0</text>
+  <path class="p2" d="M 1264 269 L 1132 269 L 1114 293 L 1229 294 L 1264 269"/>
+  <text x="1185" y="285" style="font-size:8px">2.76,0,0,0</text>
+  <line x1="1264" y1="269" x2="1132" y2="269"/>
+  <path class="p2" d="M 1132 269 L 1000 269 L 1000 292 L 1114 293 L 1132 269"/>
+  <text x="1062" y="284" style="font-size:8px">2.77,0,0,0</text>
+  <line x1="1132" y1="269" x2="1000" y2="269"/>
+  <path class="ps2" d="M 1229 294 L 1114 293 L 1096 318 L 1192 320 L 1229 294"/>
+  <text x="1158" y="310" style="font-size:9px">2.78,0,X,0</text>
+  <path class="ps2" d="M 1114 293 L 1000 292 L 1000 316 L 1096 318 L 1114 293"/>
+  <text x="1053" y="309" style="font-size:9px">2.79,0,X,0</text>
+  <path class="p2" d="M 1000 269 L 868 269 L 886 293 L 1000 292 L 1000 269"/>
+  <text x="938" y="284" style="font-size:8px">2.80,0,0,0</text>
+  <line x1="1000" y1="269" x2="868" y2="269"/>
+  <path class="p2" d="M 868 269 L 736 269 L 771 294 L 886 293 L 868 269"/>
+  <text x="815" y="285" style="font-size:8px">2.81,0,0,0</text>
+  <line x1="868" y1="269" x2="736" y2="269"/>
+  <path class="ps2" d="M 1000 292 L 886 293 L 904 318 L 1000 316 L 1000 292"/>
+  <text x="947" y="309" style="font-size:9px">2.82,0,X,0</text>
+  <path class="ps2" d="M 886 293 L 771 294 L 808 320 L 904 318 L 886 293"/>
+  <text x="842" y="310" style="font-size:9px">2.83,0,X,0</text>
+  <path class="p2" d="M 736 269 L 604 269 L 658 296 L 771 294 L 736 269"/>
+  <text x="692" y="286" style="font-size:8px">2.84,0,0,0</text>
+  <line x1="736" y1="269" x2="604" y2="269"/>
+  <path class="p2" d="M 604 269 L 472 269 L 543 299 L 658 296 L 604 269"/>
+  <text x="569" y="287" style="font-size:8px">2.85,0,0,0</text>
+  <line x1="604" y1="269" x2="472" y2="269"/>
+  <path class="ps2" d="M 771 294 L 658 296 L 714 325 L 808 320 L 771 294"/>
+  <text x="737" y="313" style="font-size:9px">2.86,0,X,0</text>
+  <path class="p2" d="M 658 296 L 543 299 L 620 331 L 714 325 L 658 296"/>
+  <text x="633" y="317" style="font-size:9px">2.87,0,0,0</text>
+  <path class="p2" d="M 472 269 L 446 316 L 517 340 L 543 299 L 472 269"/>
+  <text x="494" y="309" style="font-size:8px">2.88,0,0,0</text>
+  <line x1="472" y1="269" x2="446" y2="316"/>
+  <path class="p2" d="M 446 316 L 418 368 L 488 386 L 517 340 L 446 316"/>
+  <text x="467" y="356" style="font-size:9px">2.89,0,0,0</text>
+  <line x1="446" y1="316" x2="418" y2="368"/>
+  <path class="p2" d="M 543 299 L 517 340 L 591 366 L 620 331 L 543 299"/>
+  <text x="568" y="338" style="font-size:9px">2.90,0,0,0</text>
+  <path class="ps2" d="M 517 340 L 488 386 L 561 403 L 591 366 L 517 340"/>
+  <text x="539" y="378" style="font-size:10px">2.91,0,X,0</text>
+  <path class="p2" d="M 418 368 L 386 426 L 462 436 L 488 386 L 418 368"/>
+  <text x="439" y="409" style="font-size:11px">2.92,0,0,0</text>
+  <line x1="418" y1="368" x2="386" y2="426"/>
+  <path class="p2" d="M 386 426 L 351 491 L 433 491 L 462 436 L 386 426"/>
+  <text x="408" y="466" style="font-size:12px">2.93,0,0,0</text>
+  <line x1="386" y1="426" x2="351" y2="491"/>
+  <path class="ps2" d="M 488 386 L 462 436 L 538 446 L 561 403 L 488 386"/>
+  <text x="512" y="423" style="font-size:11px">2.94,0,X,0</text>
+  <path class="ps2" d="M 462 436 L 433 491 L 514 491 L 538 446 L 462 436"/>
+  <text x="487" y="471" style="font-size:12px">2.95,0,X,0</text>
+  <path class="p2" d="M 351 491 L 312 563 L 407 552 L 433 491 L 351 491"/>
+  <text x="376" y="530" style="font-size:14px">2.96,0,0,0</text>
+  <line x1="351" y1="491" x2="312" y2="563"/>
+  <path class="p2" d="M 312 563 L 268 645 L 379 619 L 407 552 L 312 563"/>
+  <text x="342" y="601" style="font-size:16px">2.97,0,0,0</text>
+  <line x1="312" y1="563" x2="268" y2="645"/>
+  <path class="ps2" d="M 433 491 L 407 552 L 500 540 L 514 491 L 433 491"/>
+  <text x="464" y="525" style="font-size:14px">2.98,0,X,0</text>
+  <path class="ps2" d="M 407 552 L 379 619 L 485 593 L 500 540 L 407 552"/>
+  <text x="443" y="583" style="font-size:15px">2.99,0,X,0</text>
+  <path class="p2" d="M 268 645 L 218 738 L 355 692 L 379 619 L 268 645"/>
+  <text x="306" y="680" style="font-size:17px">2.100,0,0,0</text>
+  <line x1="268" y1="645" x2="218" y2="738"/>
+  <path class="p2" d="M 218 738 L 160 844 L 328 774 L 355 692 L 218 738"/>
+  <text x="267" y="770" style="font-size:20px">2.101,0,0,0</text>
+  <line x1="218" y1="738" x2="160" y2="844"/>
+  <path class="ps2" d="M 379 619 L 355 692 L 483 649 L 485 593 L 379 619"/>
+  <text x="426" y="646" style="font-size:17px">2.102,0,X,0</text>
+  <path class="p2" d="M 355 692 L 328 774 L 481 709 L 483 649 L 355 692"/>
+  <text x="413" y="714" style="font-size:19px">2.103,0,0,0</text>
+  <path class="p2" d="M 160 844 L 370 844 L 492 780 L 328 774 L 160 844"/>
+  <text x="339" y="820" style="font-size:21px">2.104,0,0,0</text>
+  <line x1="160" y1="844" x2="370" y2="844"/>
+  <path class="p2" d="M 370 844 L 580 844 L 658 785 L 492 780 L 370 844"/>
+  <text x="526" y="824" style="font-size:22px">2.105,0,0,0</text>
+  <line x1="370" y1="844" x2="580" y2="844"/>
+  <path class="p2" d="M 328 774 L 492 780 L 605 720 L 481 709 L 328 774"/>
+  <text x="478" y="755" style="font-size:20px">2.106,0,0,0</text>
+  <path class="ps2" d="M 492 780 L 658 785 L 731 730 L 605 720 L 492 780"/>
+  <text x="622" y="764" style="font-size:21px">2.107,0,X,0</text>
+  <path class="p2" d="M 580 844 L 790 844 L 829 787 L 658 785 L 580 844"/>
+  <text x="715" y="826" style="font-size:23px">2.108,0,0,0</text>
+  <line x1="580" y1="844" x2="790" y2="844"/>
+  <path class="p2" d="M 790 844 L 1000 844 L 1000 789 L 829 787 L 790 844"/>
+  <text x="905" y="827" style="font-size:23px">2.109,0,0,0</text>
+  <line x1="790" y1="844" x2="1000" y2="844"/>
+  <path class="ps2" d="M 658 785 L 829 787 L 865 734 L 731 730 L 658 785"/>
+  <text x="771" y="769" style="font-size:21px">2.110,0,X,0</text>
+  <path class="ps2" d="M 829 787 L 1000 789 L 1000 738 L 865 734 L 829 787"/>
+  <text x="924" y="772" style="font-size:21px">2.111,0,X,0</text>
+  <path class="p2" d="M 1000 844 L 1210 844 L 1171 787 L 1000 789 L 1000 844"/>
+  <text x="1095" y="827" style="font-size:23px">2.112,0,0,0</text>
+  <line x1="1000" y1="844" x2="1210" y2="844"/>
+  <path class="p2" d="M 1210 844 L 1420 844 L 1342 785 L 1171 787 L 1210 844"/>
+  <text x="1285" y="826" style="font-size:23px">2.113,0,0,0</text>
+  <line x1="1210" y1="844" x2="1420" y2="844"/>
+  <path class="ps2" d="M 1000 789 L 1171 787 L 1135 734 L 1000 738 L 1000 789"/>
+  <text x="1076" y="772" style="font-size:21px">2.114,0,X,0</text>
+  <path class="ps2" d="M 1171 787 L 1342 785 L 1269 730 L 1135 734 L 1171 787"/>
+  <text x="1229" y="769" style="font-size:21px">2.115,0,X,0</text>
+  <path class="p2" d="M 1420 844 L 1630 844 L 1508 780 L 1342 785 L 1420 844"/>
+  <text x="1474" y="824" style="font-size:22px">2.116,0,0,0</text>
+  <line x1="1420" y1="844" x2="1630" y2="844"/>
+  <path class="p2" d="M 1630 844 L 1840 844 L 1672 774 L 1508 780 L 1630 844"/>
+  <text x="1661" y="820" style="font-size:21px">2.117,0,0,0</text>
+  <line x1="1630" y1="844" x2="1840" y2="844"/>
+  <path class="ps2" d="M 1342 785 L 1508 780 L 1395 720 L 1269 730 L 1342 785"/>
+  <text x="1378" y="764" style="font-size:21px">2.118,0,X,0</text>
+  <path class="p2" d="M 1508 780 L 1672 774 L 1519 709 L 1395 720 L 1508 780"/>
+  <text x="1522" y="755" style="font-size:20px">2.119,0,0,0</text>
+  <path class="p2" d="M 1840 844 L 1782 738 L 1645 692 L 1672 774 L 1840 844"/>
+  <text x="1733" y="770" style="font-size:20px">2.120,0,0,0</text>
+  <line x1="1840" y1="844" x2="1782" y2="738"/>
+  <path class="p2" d="M 1782 738 L 1732 645 L 1621 619 L 1645 692 L 1782 738"/>
+  <text x="1694" y="680" style="font-size:17px">2.121,0,0,0</text>
+  <line x1="1782" y1="738" x2="1732" y2="645"/>
+  <path class="p2" d="M 1672 774 L 1645 692 L 1517 649 L 1519 709 L 1672 774"/>
+  <text x="1587" y="714" style="font-size:19px">2.122,0,0,0</text>
+  <path class="ps2" d="M 1645 692 L 1621 619 L 1515 593 L 1517 649 L 1645 692"/>
+  <text x="1574" y="646" style="font-size:17px">2.123,0,X,0</text>
+  <path class="p2" d="M 1732 645 L 1688 563 L 1593 552 L 1621 619 L 1732 645"/>
+  <text x="1658" y="601" style="font-size:16px">2.124,0,0,0</text>
+  <line x1="1732" y1="645" x2="1688" y2="563"/>
+  <path class="p2" d="M 1688 563 L 1649 491 L 1567 491 L 1593 552 L 1688 563"/>
+  <text x="1624" y="530" style="font-size:14px">2.125,0,0,0</text>
+  <line x1="1688" y1="563" x2="1649" y2="491"/>
+  <path class="ps2" d="M 1621 619 L 1593 552 L 1500 540 L 1515 593 L 1621 619"/>
+  <text x="1557" y="583" style="font-size:15px">2.126,0,X,0</text>
+  <path class="ps2" d="M 1593 552 L 1567 491 L 1486 491 L 1500 540 L 1593 552"/>
+  <text x="1536" y="525" style="font-size:14px">2.127,0,X,0</text>
+  <path class="ps3" d="M 1500 370 L 1487 348 L 1447 350 L 1458 370 L 1500 370"/>
+  <text x="1473" y="363" style="font-size:7px">3.0,0,X,0</text>
+  <path class="ps3" d="M 1487 348 L 1474 328 L 1436 332 L 1447 350 L 1487 348"/>
+  <text x="1461" y="343" style="font-size:7px">3.1,0,X,0</text>
+  <path class="ps3" d="M 1458 370 L 1447 350 L 1407 353 L 1416 370 L 1458 370"/>
+  <text x="1432" y="364" style="font-size:7px">3.2,0,X,0</text>
+  <path class="ps3" d="M 1447 350 L 1436 332 L 1397 336 L 1407 353 L 1447 350"/>
+  <text x="1422" y="346" style="font-size:7px">3.3,0,X,0</text>
+  <path class="ps3" d="M 1474 328 L 1462 308 L 1424 314 L 1436 332 L 1474 328"/>
+  <text x="1449" y="323" style="font-size:6px">3.4,0,X,0</text>
+  <path class="ps3" d="M 1462 308 L 1450 289 L 1412 297 L 1424 314 L 1462 308"/>
+  <text x="1437" y="305" style="font-size:6px">3.5,0,X,0</text>
+  <path class="ps3" d="M 1436 332 L 1424 314 L 1385 321 L 1397 336 L 1436 332"/>
+  <text x="1411" y="329" style="font-size:6px">3.6,0,X,0</text>
+  <path class="ps3" d="M 1424 314 L 1412 297 L 1374 306 L 1385 321 L 1424 314"/>
+  <text x="1399" y="313" style="font-size:6px">3.7,0,X,0</text>
+  <path class="ps3" d="M 1416 370 L 1407 353 L 1367 355 L 1375 370 L 1416 370"/>
+  <text x="1391" y="365" style="font-size:7px">3.8,0,X,0</text>
+  <path class="ps3" d="M 1407 353 L 1397 336 L 1359 341 L 1367 355 L 1407 353"/>
+  <text x="1382" y="350" style="font-size:7px">3.9,0,X,0</text>
+  <path class="ps3" d="M 1375 370 L 1367 355 L 1328 357 L 1333 370 L 1375 370"/>
+  <text x="1351" y="366" style="font-size:7px">3.10,0,X,0</text>
+  <line x1="1333" y1="370" x2="1328" y2="357"/>
+  <path class="ps3" d="M 1367 355 L 1359 341 L 1319 345 L 1328 357 L 1367 355"/>
+  <text x="1343" y="353" style="font-size:7px">3.11,0,X,0</text>
+  <line x1="1328" y1="357" x2="1319" y2="345"/>
+  <path class="ps3" d="M 1397 336 L 1385 321 L 1347 327 L 1359 341 L 1397 336"/>
+  <text x="1372" y="334" style="font-size:6px">3.12,0,X,0</text>
+  <path class="ps3" d="M 1385 321 L 1374 306 L 1334 315 L 1347 327 L 1385 321"/>
+  <text x="1360" y="320" style="font-size:6px">3.13,0,X,0</text>
+  <path class="ps3" d="M 1359 341 L 1347 327 L 1308 334 L 1319 345 L 1359 341"/>
+  <text x="1333" y="340" style="font-size:7px">3.14,0,X,0</text>
+  <line x1="1319" y1="345" x2="1308" y2="334"/>
+  <path class="ps3" d="M 1347 327 L 1334 315 L 1295 323 L 1308 334 L 1347 327"/>
+  <text x="1321" y="328" style="font-size:6px">3.15,0,X,0</text>
+  <line x1="1308" y1="334" x2="1295" y2="323"/>
+  <path class="ps3" d="M 1450 289 L 1434 271 L 1396 282 L 1412 297 L 1450 289"/>
+  <text x="1423" y="288" style="font-size:6px">3.16,0,X,0</text>
+  <path class="p3" d="M 1434 271 L 1419 254 L 1381 266 L 1396 282 L 1434 271"/>
+  <text x="1407" y="271" style="font-size:5px">3.17,0,0,0</text>
+  <path class="ps3" d="M 1412 297 L 1396 282 L 1357 292 L 1374 306 L 1412 297"/>
+  <text x="1385" y="297" style="font-size:6px">3.18,0,X,0</text>
+  <path class="ps3" d="M 1396 282 L 1381 266 L 1341 279 L 1357 292 L 1396 282"/>
+  <text x="1369" y="283" style="font-size:6px">3.19,0,X,0</text>
+  <path class="p3" d="M 1419 254 L 1404 238 L 1364 252 L 1381 266 L 1419 254"/>
+  <text x="1392" y="255" style="font-size:5px">3.20,0,0,0</text>
+  <path class="p3" d="M 1404 238 L 1389 222 L 1348 238 L 1364 252 L 1404 238"/>
+  <text x="1376" y="240" style="font-size:5px">3.21,0,0,0</text>
+  <path class="ps3" d="M 1381 266 L 1364 252 L 1324 266 L 1341 279 L 1381 266"/>
+  <text x="1352" y="268" style="font-size:5px">3.22,0,X,0</text>
+  <path class="ps3" d="M 1364 252 L 1348 238 L 1306 254 L 1324 266 L 1364 252"/>
+  <text x="1336" y="255" style="font-size:5px">3.23,0,X,0</text>
+  <path class="ps3" d="M 1374 306 L 1357 292 L 1318 302 L 1334 315 L 1374 306"/>
+  <text x="1346" y="307" style="font-size:6px">3.24,0,X,0</text>
+  <path class="ps3" d="M 1357 292 L 1341 279 L 1301 291 L 1318 302 L 1357 292"/>
+  <text x="1330" y="294" style="font-size:6px">3.25,0,X,0</text>
+  <path class="ps3" d="M 1334 315 L 1318 302 L 1278 313 L 1295 323 L 1334 315"/>
+  <text x="1306" y="316" style="font-size:6px">3.26,0,X,0</text>
+  <line x1="1295" y1="323" x2="1278" y2="313"/>
+  <path class="ps3" d="M 1318 302 L 1301 291 L 1260 304 L 1278 313 L 1318 302"/>
+  <text x="1290" y="306" style="font-size:6px">3.27,0,X,0</text>
+  <line x1="1278" y1="313" x2="1260" y2="304"/>
+  <path class="ps3" d="M 1341 279 L 1324 266 L 1282 280 L 1301 291 L 1341 279"/>
+  <text x="1312" y="282" style="font-size:6px">3.28,0,X,0</text>
+  <path class="ps3" d="M 1324 266 L 1306 254 L 1263 270 L 1282 280 L 1324 266"/>
+  <text x="1294" y="270" style="font-size:6px">3.29,0,X,0</text>
+  <path class="ps3" d="M 1301 291 L 1282 280 L 1240 295 L 1260 304 L 1301 291"/>
+  <text x="1271" y="295" style="font-size:6px">3.30,0,X,0</text>
+  <line x1="1260" y1="304" x2="1240" y2="295"/>
+  <path class="ps3" d="M 1282 280 L 1263 270 L 1218 287 L 1240 295 L 1282 280"/>
+  <text x="1251" y="286" style="font-size:6px">3.31,0,X,0</text>
+  <line x1="1240" y1="295" x2="1218" y2="287"/>
+  <path class="p3" d="M 1389 222 L 1341 220 L 1305 234 L 1348 238 L 1389 222"/>
+  <text x="1346" y="231" style="font-size:5px">3.32,0,0,0</text>
+  <path class="p3" d="M 1341 220 L 1292 217 L 1263 231 L 1305 234 L 1341 220"/>
+  <text x="1300" y="228" style="font-size:5px">3.33,0,0,0</text>
+  <path class="ps3" d="M 1348 238 L 1305 234 L 1269 249 L 1306 254 L 1348 238"/>
+  <text x="1307" y="246" style="font-size:5px">3.34,0,X,0</text>
+  <path class="ps3" d="M 1305 234 L 1263 231 L 1232 245 L 1269 249 L 1305 234"/>
+  <text x="1267" y="242" style="font-size:5px">3.35,0,X,0</text>
+  <path class="p3" d="M 1292 217 L 1244 215 L 1220 228 L 1263 231 L 1292 217"/>
+  <text x="1255" y="225" style="font-size:5px">3.36,0,0,0</text>
+  <path class="ps3" d="M 1244 215 L 1197 212 L 1177 225 L 1220 228 L 1244 215"/>
+  <text x="1209" y="222" style="font-size:5px">3.37,0,X,0</text>
+  <path class="ps3" d="M 1263 231 L 1220 228 L 1194 241 L 1232 245 L 1263 231"/>
+  <text x="1227" y="239" style="font-size:5px">3.38,0,X,0</text>
+  <path class="ps3" d="M 1220 228 L 1177 225 L 1157 238 L 1194 241 L 1220 228"/>
+  <text x="1187" y="235" style="font-size:5px">3.39,0,X,0</text>
+  <path class="ps3" d="M 1306 254 L 1269 249 L 1232 264 L 1263 270 L 1306 254"/>
+  <text x="1268" y="262" style="font-size:5px">3.40,0,X,0</text>
+  <path class="ps3" d="M 1269 249 L 1232 245 L 1201 259 L 1232 264 L 1269 249"/>
+  <text x="1234" y="257" style="font-size:5px">3.41,0,X,0</text>
+  <path class="ps3" d="M 1263 270 L 1232 264 L 1194 280 L 1218 287 L 1263 270"/>
+  <text x="1227" y="278" style="font-size:6px">3.42,0,X,0</text>
+  <line x1="1218" y1="287" x2="1194" y2="280"/>
+  <path class="ps3" d="M 1232 264 L 1201 259 L 1169 274 L 1194 280 L 1232 264"/>
+  <text x="1199" y="272" style="font-size:6px">3.43,0,X,0</text>
+  <line x1="1194" y1="280" x2="1169" y2="274"/>
+  <path class="ps3" d="M 1232 245 L 1194 241 L 1169 255 L 1201 259 L 1232 245"/>
+  <text x="1199" y="252" style="font-size:5px">3.44,0,X,0</text>
+  <path class="ps3" d="M 1194 241 L 1157 238 L 1136 251 L 1169 255 L 1194 241"/>
+  <text x="1164" y="249" style="font-size:5px">3.45,0,X,0</text>
+  <path class="ps3" d="M 1201 259 L 1169 255 L 1142 269 L 1169 274 L 1201 259"/>
+  <text x="1170" y="267" style="font-size:6px">3.46,0,X,0</text>
+  <line x1="1169" y1="274" x2="1142" y2="269"/>
+  <path class="ps3" d="M 1169 255 L 1136 251 L 1115 264 L 1142 269 L 1169 255"/>
+  <text x="1141" y="262" style="font-size:5px">3.47,0,X,0</text>
+  <line x1="1142" y1="269" x2="1115" y2="264"/>
+  <path class="ps3" d="M 1197 212 L 1147 211 L 1133 223 L 1177 225 L 1197 212"/>
+  <text x="1163" y="220" style="font-size:5px">3.48,0,X,0</text>
+  <path class="ps3" d="M 1147 211 L 1098 210 L 1089 222 L 1133 223 L 1147 211"/>
+  <text x="1117" y="219" style="font-size:5px">3.49,0,X,0</text>
+  <path class="ps3" d="M 1177 225 L 1133 223 L 1118 236 L 1157 238 L 1177 225"/>
+  <text x="1146" y="233" style="font-size:5px">3.50,0,X,0</text>
+  <path class="ps3" d="M 1133 223 L 1089 222 L 1079 234 L 1118 236 L 1133 223"/>
+  <text x="1104" y="231" style="font-size:5px">3.51,0,X,0</text>
+  <path class="ps3" d="M 1098 210 L 1049 210 L 1044 221 L 1089 222 L 1098 210"/>
+  <text x="1070" y="218" style="font-size:5px">3.52,0,X,0</text>
+  <path class="ps3" d="M 1049 210 L 1000 209 L 1000 220 L 1044 221 L 1049 210"/>
+  <text x="1023" y="217" style="font-size:5px">3.53,0,X,0</text>
+  <path class="ps3" d="M 1089 222 L 1044 221 L 1039 233 L 1079 234 L 1089 222"/>
+  <text x="1063" y="230" style="font-size:5px">3.54,0,X,0</text>
+  <path class="ps3" d="M 1044 221 L 1000 220 L 1000 232 L 1039 233 L 1044 221"/>
+  <text x="1021" y="229" style="font-size:5px">3.55,0,X,0</text>
+  <path class="ps3" d="M 1157 238 L 1118 236 L 1103 248 L 1136 251 L 1157 238"/>
+  <text x="1128" y="246" style="font-size:5px">3.56,0,X,0</text>
+  <path class="ps3" d="M 1118 236 L 1079 234 L 1069 246 L 1103 248 L 1118 236"/>
+  <text x="1092" y="244" style="font-size:5px">3.57,0,X,0</text>
+  <path class="ps3" d="M 1136 251 L 1103 248 L 1087 261 L 1115 264 L 1136 251"/>
+  <text x="1110" y="259" style="font-size:5px">3.58,0,X,0</text>
+  <line x1="1115" y1="264" x2="1087" y2="261"/>
+  <path class="ps3" d="M 1103 248 L 1069 246 L 1058 259 L 1087 261 L 1103 248"/>
+  <text x="1079" y="256" style="font-size:5px">3.59,0,X,0</text>
+  <line x1="1087" y1="261" x2="1058" y2="259"/>
+  <path class="ps3" d="M 1079 234 L 1039 233 L 1034 245 L 1069 246 L 1079 234"/>
+  <text x="1055" y="242" style="font-size:5px">3.60,0,X,0</text>
+  <path class="ps3" d="M 1039 233 L 1000 232 L 1000 244 L 1034 245 L 1039 233"/>
+  <text x="1018" y="241" style="font-size:5px">3.61,0,X,0</text>
+  <path class="ps3" d="M 1069 246 L 1034 245 L 1029 257 L 1058 259 L 1069 246"/>
+  <text x="1048" y="254" style="font-size:5px">3.62,0,X,0</text>
+  <line x1="1058" y1="259" x2="1029" y2="257"/>
+  <path class="ps3" d="M 1034 245 L 1000 244 L 1000 257 L 1029 257 L 1034 245"/>
+  <text x="1016" y="253" style="font-size:5px">3.63,0,X,0</text>
+  <line x1="1029" y1="257" x2="1000" y2="257"/>
+  <path class="ps3" d="M 1000 209 L 951 210 L 956 221 L 1000 220 L 1000 209"/>
+  <text x="977" y="217" style="font-size:5px">3.64,0,X,0</text>
+  <path class="ps3" d="M 951 210 L 902 210 L 911 222 L 956 221 L 951 210"/>
+  <text x="930" y="218" style="font-size:5px">3.65,0,X,0</text>
+  <path class="ps3" d="M 1000 220 L 956 221 L 961 233 L 1000 232 L 1000 220"/>
+  <text x="979" y="229" style="font-size:5px">3.66,0,X,0</text>
+  <path class="ps3" d="M 956 221 L 911 222 L 921 234 L 961 233 L 956 221"/>
+  <text x="937" y="230" style="font-size:5px">3.67,0,X,0</text>
+  <path class="ps3" d="M 902 210 L 853 211 L 867 223 L 911 222 L 902 210"/>
+  <text x="883" y="219" style="font-size:5px">3.68,0,X,0</text>
+  <path class="ps3" d="M 853 211 L 803 212 L 823 225 L 867 223 L 853 211"/>
+  <text x="837" y="220" style="font-size:5px">3.69,0,X,0</text>
+  <path class="ps3" d="M 911 222 L 867 223 L 882 236 L 921 234 L 911 222"/>
+  <text x="896" y="231" style="font-size:5px">3.70,0,X,0</text>
+  <path class="ps3" d="M 867 223 L 823 225 L 843 238 L 882 236 L 867 223"/>
+  <text x="854" y="233" style="font-size:5px">3.71,0,X,0</text>
+  <path class="ps3" d="M 1000 232 L 961 233 L 966 245 L 1000 244 L 1000 232"/>
+  <text x="982" y="241" style="font-size:5px">3.72,0,X,0</text>
+  <path class="ps3" d="M 961 233 L 921 234 L 931 246 L 966 245 L 961 233"/>
+  <text x="945" y="242" style="font-size:5px">3.73,0,X,0</text>
+  <path class="ps3" d="M 1000 244 L 966 245 L 971 257 L 1000 257 L 1000 244"/>
+  <text x="984" y="253" style="font-size:5px">3.74,0,X,0</text>
+  <line x1="1000" y1="257" x2="971" y2="257"/>
+  <path class="ps3" d="M 966 245 L 931 246 L 942 259 L 971 257 L 966 245"/>
+  <text x="952" y="254" style="font-size:5px">3.75,0,X,0</text>
+  <line x1="971" y1="257" x2="942" y2="259"/>
+  <path class="ps3" d="M 921 234 L 882 236 L 897 248 L 931 246 L 921 234"/>
+  <text x="908" y="244" style="font-size:5px">3.76,0,X,0</text>
+  <path class="ps3" d="M 882 236 L 843 238 L 864 251 L 897 248 L 882 236"/>
+  <text x="872" y="246" style="font-size:5px">3.77,0,X,0</text>
+  <path class="ps3" d="M 931 246 L 897 248 L 913 261 L 942 259 L 931 246"/>
+  <text x="921" y="256" style="font-size:5px">3.78,0,X,0</text>
+  <line x1="942" y1="259" x2="913" y2="261"/>
+  <path class="ps3" d="M 897 248 L 864 251 L 885 264 L 913 261 L 897 248"/>
+  <text x="890" y="259" style="font-size:5px">3.79,0,X,0</text>
+  <line x1="913" y1="261" x2="885" y2="264"/>
+  <path class="ps3" d="M 803 212 L 756 215 L 780 228 L 823 225 L 803 212"/>
+  <text x="791" y="222" style="font-size:5px">3.80,0,X,0</text>
+  <path class="p3" d="M 756 215 L 708 217 L 737 231 L 780 228 L 756 215"/>
+  <text x="745" y="225" style="font-size:5px">3.81,0,0,0</text>
+  <path class="ps3" d="M 823 225 L 780 228 L 806 241 L 843 238 L 823 225"/>
+  <text x="813" y="235" style="font-size:5px">3.82,0,X,0</text>
+  <path class="ps3" d="M 780 228 L 737 231 L 768 245 L 806 241 L 780 228"/>
+  <text x="773" y="239" style="font-size:5px">3.83,0,X,0</text>
+  <path class="p3" d="M 708 217 L 659 220 L 695 234 L 737 231 L 708 217"/>
+  <text x="700" y="228" style="font-size:5px">3.84,0,0,0</text>
+  <path class="p3" d="M 659 220 L 611 222 L 652 238 L 695 234 L 659 220"/>
+  <text x="654" y="231" style="font-size:5px">3.85,0,0,0</text>
+  <path class="ps3" d="M 737 231 L 695 234 L 731 249 L 768 245 L 737 231"/>
+  <text x="733" y="242" style="font-size:5px">3.86,0,X,0</text>
+  <path class="ps3" d="M 695 234 L 652 238 L 694 254 L 731 249 L 695 234"/>
+  <text x="693" y="246" style="font-size:5px">3.87,0,X,0</text>
+  <path class="ps3" d="M 843 238 L 806 241 L 831 255 L 864 251 L 843 238"/>
+  <text x="836" y="249" style="font-size:5px">3.88,0,X,0</text>
+  <path class="ps3" d="M 806 241 L 768 245 L 799 259 L 831 255 L 806 241"/>
+  <text x="801" y="252" style="font-size:5px">3.89,0,X,0</text>
+  <path class="ps3" d="M 864 251 L 831 255 L 858 269 L 885 264 L 864 251"/>
+  <text x="859" y="262" style="font-size:5px">3.90,0,X,0</text>
+  <line x1="885" y1="264" x2="858" y2="269"/>
+  <path class="ps3" d="M 831 255 L 799 259 L 831 274 L 858 269 L 831 255"/>
+  <text x="830" y="267" style="font-size:6px">3.91,0,X,0</text>
+  <line x1="858" y1="269" x2="831" y2="274"/>
+  <path class="ps3" d="M 768 245 L 731 249 L 768 264 L 799 259 L 768 245"/>
+  <text x="766" y="257" style="font-size:5px">3.92,0,X,0</text>
+  <path class="ps3" d="M 731 249 L 694 254 L 737 270 L 768 264 L 731 249"/>
+  <text x="732" y="262" style="font-size:5px">3.93,0,X,0</text>
+  <path class="ps3" d="M 799 259 L 768 264 L 806 280 L 831 274 L 799 259"/>
+  <text x="801" y="272" style="font-size:6px">3.94,0,X,0</text>
+  <line x1="831" y1="274" x2="806" y2="280"/>
+  <path class="ps3" d="M 768 264 L 737 270 L 782 287 L 806 280 L 768 264"/>
+  <text x="773" y="278" style="font-size:6px">3.95,0,X,0</text>
+  <line x1="806" y1="280" x2="782" y2="287"/>
+  <path class="p3" d="M 611 222 L 596 238 L 636 252 L 652 238 L 611 222"/>
+  <text x="624" y="240" style="font-size:5px">3.96,0,0,0</text>
+  <path class="p3" d="M 596 238 L 581 254 L 619 266 L 636 252 L 596 238"/>
+  <text x="608" y="255" style="font-size:5px">3.97,0,0,0</text>
+  <path class="ps3" d="M 652 238 L 636 252 L 676 266 L 694 254 L 652 238"/>
+  <text x="664" y="255" style="font-size:5px">3.98,0,X,0</text>
+  <path class="ps3" d="M 636 252 L 619 266 L 659 279 L 676 266 L 636 252"/>
+  <text x="648" y="268" style="font-size:5px">3.99,0,X,0</text>
+  <path class="p3" d="M 581 254 L 566 271 L 604 282 L 619 266 L 581 254"/>
+  <text x="593" y="271" style="font-size:5px">3.100,0,0,0</text>
+  <path class="ps3" d="M 566 271 L 550 289 L 588 297 L 604 282 L 566 271"/>
+  <text x="577" y="288" style="font-size:6px">3.101,0,X,0</text>
+  <path class="ps3" d="M 619 266 L 604 282 L 643 292 L 659 279 L 619 266"/>
+  <text x="631" y="283" style="font-size:6px">3.102,0,X,0</text>
+  <path class="ps3" d="M 604 282 L 588 297 L 626 306 L 643 292 L 604 282"/>
+  <text x="615" y="297" style="font-size:6px">3.103,0,X,0</text>
+  <path class="ps3" d="M 694 254 L 676 266 L 718 280 L 737 270 L 694 254"/>
+  <text x="706" y="270" style="font-size:6px">3.104,0,X,0</text>
+  <path class="ps3" d="M 676 266 L 659 279 L 699 291 L 718 280 L 676 266"/>
+  <text x="688" y="282" style="font-size:6px">3.105,0,X,0</text>
+  <path class="ps3" d="M 737 270 L 718 280 L 760 295 L 782 287 L 737 270"/>
+  <text x="749" y="286" style="font-size:6px">3.106,0,X,0</text>
+  <line x1="782" y1="287" x2="760" y2="295"/>
+  <path class="ps3" d="M 718 280 L 699 291 L 740 304 L 760 295 L 718 280"/>
+  <text x="729" y="295" style="font-size:6px">3.107,0,X,0</text>
+  <line x1="760" y1="295" x2="740" y2="304"/>
+  <path class="ps3" d="M 659 279 L 643 292 L 682 302 L 699 291 L 659 279"/>
+  <text x="670" y="294" style="font-size:6px">3.108,0,X,0</text>
+  <path class="ps3" d="M 643 292 L 626 306 L 666 315 L 682 302 L 643 292"/>
+  <text x="654" y="307" style="font-size:6px">3.109,0,X,0</text>
+  <path class="ps3" d="M 699 291 L 682 302 L 722 313 L 740 304 L 699 291"/>
+  <text x="710" y="306" style="font-size:6px">3.110,0,X,0</text>
+  <line x1="740" y1="304" x2="722" y2="313"/>
+  <path class="ps3" d="M 682 302 L 666 315 L 705 323 L 722 313 L 682 302"/>
+  <text x="694" y="316" style="font-size:6px">3.111,0,X,0</text>
+  <line x1="722" y1="313" x2="705" y2="323"/>
+  <path class="ps3" d="M 550 289 L 538 308 L 576 314 L 588 297 L 550 289"/>
+  <text x="563" y="305" style="font-size:6px">3.112,0,X,0</text>
+  <path class="ps3" d="M 538 308 L 526 328 L 564 332 L 576 314 L 538 308"/>
+  <text x="551" y="323" style="font-size:6px">3.113,0,X,0</text>
+  <path class="ps3" d="M 588 297 L 576 314 L 615 321 L 626 306 L 588 297"/>
+  <text x="601" y="313" style="font-size:6px">3.114,0,X,0</text>
+  <path class="ps3" d="M 576 314 L 564 332 L 603 336 L 615 321 L 576 314"/>
+  <text x="589" y="329" style="font-size:6px">3.115,0,X,0</text>
+  <path class="ps3" d="M 526 328 L 513 348 L 553 350 L 564 332 L 526 328"/>
+  <text x="539" y="343" style="font-size:7px">3.116,0,X,0</text>
+  <path class="ps3" d="M 513 348 L 500 370 L 542 370 L 553 350 L 513 348"/>
+  <text x="527" y="363" style="font-size:7px">3.117,0,X,0</text>
+  <path class="ps3" d="M 564 332 L 553 350 L 593 353 L 603 336 L 564 332"/>
+  <text x="578" y="346" style="font-size:7px">3.118,0,X,0</text>
+  <path class="ps3" d="M 553 350 L 542 370 L 584 370 L 593 353 L 553 350"/>
+  <text x="568" y="364" style="font-size:7px">3.119,0,X,0</text>
+  <path class="ps3" d="M 626 306 L 615 321 L 653 327 L 666 315 L 626 306"/>
+  <text x="640" y="320" style="font-size:6px">3.120,0,X,0</text>
+  <path class="ps3" d="M 615 321 L 603 336 L 641 341 L 653 327 L 615 321"/>
+  <text x="628" y="334" style="font-size:6px">3.121,0,X,0</text>
+  <path class="ps3" d="M 666 315 L 653 327 L 692 334 L 705 323 L 666 315"/>
+  <text x="679" y="328" style="font-size:6px">3.122,0,X,0</text>
+  <line x1="705" y1="323" x2="692" y2="334"/>
+  <path class="ps3" d="M 653 327 L 641 341 L 681 345 L 692 334 L 653 327"/>
+  <text x="667" y="340" style="font-size:7px">3.123,0,X,0</text>
+  <line x1="692" y1="334" x2="681" y2="345"/>
+  <path class="ps3" d="M 603 336 L 593 353 L 633 355 L 641 341 L 603 336"/>
+  <text x="618" y="350" style="font-size:7px">3.124,0,X,0</text>
+  <path class="ps3" d="M 593 353 L 584 370 L 625 370 L 633 355 L 593 353"/>
+  <text x="609" y="365" style="font-size:7px">3.125,0,X,0</text>
+  <path class="ps3" d="M 641 341 L 633 355 L 672 357 L 681 345 L 641 341"/>
+  <text x="657" y="353" style="font-size:7px">3.126,0,X,0</text>
+  <line x1="681" y1="345" x2="672" y2="357"/>
+  <path class="ps3" d="M 633 355 L 625 370 L 667 370 L 672 357 L 633 355"/>
+  <text x="649" y="366" style="font-size:7px">3.127,0,X,0</text>
+  <line x1="672" y1="357" x2="667" y2="370"/>
+  <path class="ps3" d="M 500 370 L 493 392 L 537 389 L 542 370 L 500 370"/>
+  <text x="518" y="383" style="font-size:7px">3.128,0,X,0</text>
+  <path class="ps3" d="M 493 392 L 486 415 L 532 410 L 537 389 L 493 392"/>
+  <text x="512" y="405" style="font-size:7px">3.129,0,X,0</text>
+  <path class="ps3" d="M 542 370 L 537 389 L 580 387 L 584 370 L 542 370"/>
+  <text x="561" y="382" style="font-size:7px">3.130,0,X,0</text>
+  <path class="ps3" d="M 537 389 L 532 410 L 577 405 L 580 387 L 537 389"/>
+  <text x="556" y="401" style="font-size:7px">3.131,0,X,0</text>
+  <path class="ps3" d="M 486 415 L 478 439 L 528 431 L 532 410 L 486 415"/>
+  <text x="506" y="428" style="font-size:8px">3.132,0,X,0</text>
+  <path class="ps3" d="M 478 439 L 470 464 L 524 453 L 528 431 L 478 439"/>
+  <text x="500" y="451" style="font-size:8px">3.133,0,X,0</text>
+  <path class="ps3" d="M 532 410 L 528 431 L 576 423 L 577 405 L 532 410"/>
+  <text x="553" y="421" style="font-size:8px">3.134,0,X,0</text>
+  <path class="ps3" d="M 528 431 L 524 453 L 576 442 L 576 423 L 528 431"/>
+  <text x="551" y="441" style="font-size:8px">3.135,0,X,0</text>
+  <path class="ps3" d="M 584 370 L 580 387 L 623 384 L 625 370 L 584 370"/>
+  <text x="603" y="381" style="font-size:7px">3.136,0,X,0</text>
+  <path class="ps3" d="M 580 387 L 577 405 L 621 400 L 623 384 L 580 387"/>
+  <text x="600" y="397" style="font-size:7px">3.137,0,X,0</text>
+  <path class="ps3" d="M 625 370 L 623 384 L 665 382 L 667 370 L 625 370"/>
+  <text x="645" y="380" style="font-size:7px">3.138,0,X,0</text>
+  <line x1="667" y1="370" x2="665" y2="382"/>
+  <path class="ps3" d="M 623 384 L 621 400 L 666 395 L 665 382 L 623 384"/>
+  <text x="644" y="394" style="font-size:7px">3.139,0,X,0</text>
+  <line x1="665" y1="382" x2="666" y2="395"/>
+  <path class="ps3" d="M 577 405 L 576 423 L 624 415 L 621 400 L 577 405"/>
+  <text x="600" y="414" style="font-size:8px">3.140,0,X,0</text>
+  <path class="ps3" d="M 576 423 L 576 442 L 627 431 L 624 415 L 576 423"/>
+  <text x="601" y="432" style="font-size:8px">3.141,0,X,0</text>
+  <path class="ps3" d="M 621 400 L 624 415 L 670 407 L 666 395 L 621 400"/>
+  <text x="645" y="408" style="font-size:8px">3.142,0,X,0</text>
+  <line x1="666" y1="395" x2="670" y2="407"/>
+  <path class="ps3" d="M 624 415 L 627 431 L 678 420 L 670 407 L 624 415"/>
+  <text x="650" y="422" style="font-size:8px">3.143,0,X,0</text>
+  <line x1="670" y1="407" x2="678" y2="420"/>
+  <path class="ps3" d="M 470 464 L 469 489 L 526 475 L 524 453 L 470 464"/>
+  <text x="497" y="475" style="font-size:9px">3.144,0,X,0</text>
+  <path class="p3" d="M 469 489 L 467 516 L 529 497 L 526 475 L 469 489"/>
+  <text x="498" y="499" style="font-size:9px">3.145,0,0,0</text>
+  <path class="ps3" d="M 524 453 L 526 475 L 583 460 L 576 442 L 524 453"/>
+  <text x="552" y="461" style="font-size:8px">3.146,0,X,0</text>
+  <path class="ps3" d="M 526 475 L 529 497 L 589 479 L 583 460 L 526 475"/>
+  <text x="557" y="482" style="font-size:9px">3.147,0,X,0</text>
+  <path class="p3" d="M 467 516 L 466 543 L 534 520 L 529 497 L 467 516"/>
+  <text x="499" y="523" style="font-size:9px">3.148,0,0,0</text>
+  <path class="p3" d="M 466 543 L 464 572 L 539 544 L 534 520 L 466 543"/>
+  <text x="501" y="550" style="font-size:10px">3.149,0,0,0</text>
+  <path class="ps3" d="M 529 497 L 534 520 L 599 498 L 589 479 L 529 497"/>
+  <text x="563" y="503" style="font-size:9px">3.150,0,X,0</text>
+  <path class="ps3" d="M 534 520 L 539 544 L 610 517 L 599 498 L 534 520"/>
+  <text x="571" y="524" style="font-size:9px">3.151,0,X,0</text>
+  <path class="ps3" d="M 576 442 L 583 460 L 636 446 L 627 431 L 576 442"/>
+  <text x="606" y="449" style="font-size:8px">3.152,0,X,0</text>
+  <path class="ps3" d="M 583 460 L 589 479 L 647 461 L 636 446 L 583 460"/>
+  <text x="614" y="466" style="font-size:9px">3.153,0,X,0</text>
+  <path class="ps3" d="M 627 431 L 636 446 L 689 432 L 678 420 L 627 431"/>
+  <text x="658" y="436" style="font-size:8px">3.154,0,X,0</text>
+  <line x1="678" y1="420" x2="689" y2="432"/>
+  <path class="ps3" d="M 636 446 L 647 461 L 704 444 L 689 432 L 636 446"/>
+  <text x="669" y="450" style="font-size:8px">3.155,0,X,0</text>
+  <line x1="689" y1="432" x2="704" y2="444"/>
+  <path class="ps3" d="M 589 479 L 599 498 L 662 476 L 647 461 L 589 479"/>
+  <text x="625" y="483" style="font-size:9px">3.156,0,X,0</text>
+  <path class="ps3" d="M 599 498 L 610 517 L 678 491 L 662 476 L 599 498"/>
+  <text x="637" y="500" style="font-size:9px">3.157,0,X,0</text>
+  <path class="ps3" d="M 647 461 L 662 476 L 722 456 L 704 444 L 647 461"/>
+  <text x="684" y="464" style="font-size:9px">3.158,0,X,0</text>
+  <line x1="704" y1="444" x2="722" y2="456"/>
+  <path class="ps3" d="M 662 476 L 678 491 L 743 467 L 722 456 L 662 476"/>
+  <text x="701" y="477" style="font-size:9px">3.159,0,X,0</text>
+  <line x1="722" y1="456" x2="743" y2="467"/>
+  <path class="p3" d="M 464 572 L 528 577 L 592 550 L 539 544 L 464 572"/>
+  <text x="531" y="566" style="font-size:10px">3.160,0,0,0</text>
+  <path class="p3" d="M 528 577 L 592 582 L 646 556 L 592 550 L 528 577"/>
+  <text x="590" y="571" style="font-size:10px">3.161,0,0,0</text>
+  <path class="ps3" d="M 539 544 L 592 550 L 653 524 L 610 517 L 539 544"/>
+  <text x="599" y="539" style="font-size:10px">3.162,0,X,0</text>
+  <path class="ps3" d="M 592 550 L 646 556 L 698 532 L 653 524 L 592 550"/>
+  <text x="647" y="546" style="font-size:10px">3.163,0,X,0</text>
+  <path class="p3" d="M 592 582 L 657 587 L 702 562 L 646 556 L 592 582"/>
+  <text x="649" y="577" style="font-size:10px">3.164,0,0,0</text>
+  <path class="ps3" d="M 657 587 L 722 592 L 758 567 L 702 562 L 657 587"/>
+  <text x="710" y="582" style="font-size:10px">3.165,0,X,0</text>
+  <path class="ps3" d="M 646 556 L 702 562 L 745 538 L 698 532 L 646 556"/>
+  <text x="698" y="552" style="font-size:10px">3.166,0,X,0</text>
+  <path class="ps3" d="M 702 562 L 758 567 L 792 544 L 745 538 L 702 562"/>
+  <text x="749" y="558" style="font-size:10px">3.167,0,X,0</text>
+  <path class="ps3" d="M 610 517 L 653 524 L 712 500 L 678 491 L 610 517"/>
+  <text x="663" y="513" style="font-size:9px">3.168,0,X,0</text>
+  <path class="ps3" d="M 653 524 L 698 532 L 747 508 L 712 500 L 653 524"/>
+  <text x="703" y="521" style="font-size:10px">3.169,0,X,0</text>
+  <path class="ps3" d="M 678 491 L 712 500 L 768 477 L 743 467 L 678 491"/>
+  <text x="725" y="488" style="font-size:9px">3.170,0,X,0</text>
+  <line x1="743" y1="467" x2="768" y2="477"/>
+  <path class="ps3" d="M 712 500 L 747 508 L 795 486 L 768 477 L 712 500"/>
+  <text x="756" y="497" style="font-size:9px">3.171,0,X,0</text>
+  <line x1="768" y1="477" x2="795" y2="486"/>
+  <path class="ps3" d="M 698 532 L 745 538 L 786 515 L 747 508 L 698 532"/>
+  <text x="744" y="528" style="font-size:10px">3.172,0,X,0</text>
+  <path class="ps3" d="M 745 538 L 792 544 L 825 522 L 786 515 L 745 538"/>
+  <text x="787" y="535" style="font-size:10px">3.173,0,X,0</text>
+  <path class="ps3" d="M 747 508 L 786 515 L 825 493 L 795 486 L 747 508"/>
+  <text x="788" y="505" style="font-size:9px">3.174,0,X,0</text>
+  <line x1="795" y1="486" x2="825" y2="493"/>
+  <path class="ps3" d="M 786 515 L 825 522 L 857 500 L 825 493 L 786 515"/>
+  <text x="823" y="512" style="font-size:9px">3.175,0,X,0</text>
+  <line x1="825" y1="493" x2="857" y2="500"/>
+  <path class="ps3" d="M 722 592 L 791 593 L 818 570 L 758 567 L 722 592"/>
+  <text x="772" y="586" style="font-size:11px">3.176,0,X,0</text>
+  <path class="ps3" d="M 791 593 L 861 595 L 878 573 L 818 570 L 791 593"/>
+  <text x="837" y="588" style="font-size:11px">3.177,0,X,0</text>
+  <path class="ps3" d="M 758 567 L 818 570 L 843 547 L 792 544 L 758 567"/>
+  <text x="803" y="562" style="font-size:10px">3.178,0,X,0</text>
+  <path class="ps3" d="M 818 570 L 878 573 L 895 551 L 843 547 L 818 570"/>
+  <text x="859" y="565" style="font-size:10px">3.179,0,X,0</text>
+  <path class="ps3" d="M 861 595 L 930 597 L 939 574 L 878 573 L 861 595"/>
+  <text x="902" y="590" style="font-size:11px">3.180,0,X,0</text>
+  <path class="ps3" d="M 930 597 L 1000 599 L 1000 576 L 939 574 L 930 597"/>
+  <text x="967" y="592" style="font-size:11px">3.181,0,X,0</text>
+  <path class="ps3" d="M 878 573 L 939 574 L 947 552 L 895 551 L 878 573"/>
+  <text x="915" y="567" style="font-size:10px">3.182,0,X,0</text>
+  <path class="ps3" d="M 939 574 L 1000 576 L 1000 554 L 947 552 L 939 574"/>
+  <text x="972" y="569" style="font-size:10px">3.183,0,X,0</text>
+  <path class="ps3" d="M 792 544 L 843 547 L 868 526 L 825 522 L 792 544"/>
+  <text x="832" y="540" style="font-size:10px">3.184,0,X,0</text>
+  <path class="ps3" d="M 843 547 L 895 551 L 911 530 L 868 526 L 843 547"/>
+  <text x="879" y="543" style="font-size:10px">3.185,0,X,0</text>
+  <path class="ps3" d="M 825 522 L 868 526 L 891 505 L 857 500 L 825 522"/>
+  <text x="860" y="518" style="font-size:10px">3.186,0,X,0</text>
+  <line x1="857" y1="500" x2="891" y2="505"/>
+  <path class="ps3" d="M 868 526 L 911 530 L 927 509 L 891 505 L 868 526"/>
+  <text x="899" y="522" style="font-size:10px">3.187,0,X,0</text>
+  <line x1="891" y1="505" x2="927" y2="509"/>
+  <path class="ps3" d="M 895 551 L 947 552 L 955 532 L 911 530 L 895 551"/>
+  <text x="927" y="546" style="font-size:10px">3.188,0,X,0</text>
+  <path class="ps3" d="M 947 552 L 1000 554 L 1000 533 L 955 532 L 947 552"/>
+  <text x="976" y="548" style="font-size:10px">3.189,0,X,0</text>
+  <path class="ps3" d="M 911 530 L 955 532 L 963 511 L 927 509 L 911 530"/>
+  <text x="939" y="525" style="font-size:10px">3.190,0,X,0</text>
+  <line x1="927" y1="509" x2="963" y2="511"/>
+  <path class="ps3" d="M 955 532 L 1000 533 L 1000 512 L 963 511 L 955 532"/>
+  <text x="980" y="527" style="font-size:10px">3.191,0,X,0</text>
+  <line x1="963" y1="511" x2="1000" y2="512"/>
+  <path class="ps3" d="M 1000 599 L 1070 597 L 1061 574 L 1000 576 L 1000 599"/>
+  <text x="1033" y="592" style="font-size:11px">3.192,0,X,0</text>
+  <path class="ps3" d="M 1070 597 L 1139 595 L 1122 573 L 1061 574 L 1070 597"/>
+  <text x="1098" y="590" style="font-size:11px">3.193,0,X,0</text>
+  <path class="ps3" d="M 1000 576 L 1061 574 L 1053 552 L 1000 554 L 1000 576"/>
+  <text x="1028" y="569" style="font-size:10px">3.194,0,X,0</text>
+  <path class="ps3" d="M 1061 574 L 1122 573 L 1105 551 L 1053 552 L 1061 574"/>
+  <text x="1085" y="567" style="font-size:10px">3.195,0,X,0</text>
+  <path class="ps3" d="M 1139 595 L 1209 593 L 1182 570 L 1122 573 L 1139 595"/>
+  <text x="1163" y="588" style="font-size:11px">3.196,0,X,0</text>
+  <path class="ps3" d="M 1209 593 L 1278 592 L 1242 567 L 1182 570 L 1209 593"/>
+  <text x="1228" y="586" style="font-size:11px">3.197,0,X,0</text>
+  <path class="ps3" d="M 1122 573 L 1182 570 L 1157 547 L 1105 551 L 1122 573"/>
+  <text x="1141" y="565" style="font-size:10px">3.198,0,X,0</text>
+  <path class="ps3" d="M 1182 570 L 1242 567 L 1208 544 L 1157 547 L 1182 570"/>
+  <text x="1197" y="562" style="font-size:10px">3.199,0,X,0</text>
+  <path class="ps3" d="M 1000 554 L 1053 552 L 1045 532 L 1000 533 L 1000 554"/>
+  <text x="1024" y="548" style="font-size:10px">3.200,0,X,0</text>
+  <path class="ps3" d="M 1053 552 L 1105 551 L 1089 530 L 1045 532 L 1053 552"/>
+  <text x="1073" y="546" style="font-size:10px">3.201,0,X,0</text>
+  <path class="ps3" d="M 1000 533 L 1045 532 L 1037 511 L 1000 512 L 1000 533"/>
+  <text x="1020" y="527" style="font-size:10px">3.202,0,X,0</text>
+  <line x1="1000" y1="512" x2="1037" y2="511"/>
+  <path class="ps3" d="M 1045 532 L 1089 530 L 1073 509 L 1037 511 L 1045 532"/>
+  <text x="1061" y="525" style="font-size:10px">3.203,0,X,0</text>
+  <line x1="1037" y1="511" x2="1073" y2="509"/>
+  <path class="ps3" d="M 1105 551 L 1157 547 L 1132 526 L 1089 530 L 1105 551"/>
+  <text x="1121" y="543" style="font-size:10px">3.204,0,X,0</text>
+  <path class="ps3" d="M 1157 547 L 1208 544 L 1175 522 L 1132 526 L 1157 547"/>
+  <text x="1168" y="540" style="font-size:10px">3.205,0,X,0</text>
+  <path class="ps3" d="M 1089 530 L 1132 526 L 1109 505 L 1073 509 L 1089 530"/>
+  <text x="1101" y="522" style="font-size:10px">3.206,0,X,0</text>
+  <line x1="1073" y1="509" x2="1109" y2="505"/>
+  <path class="ps3" d="M 1132 526 L 1175 522 L 1143 500 L 1109 505 L 1132 526"/>
+  <text x="1140" y="518" style="font-size:10px">3.207,0,X,0</text>
+  <line x1="1109" y1="505" x2="1143" y2="500"/>
+  <path class="ps3" d="M 1278 592 L 1343 587 L 1298 562 L 1242 567 L 1278 592"/>
+  <text x="1290" y="582" style="font-size:10px">3.208,0,X,0</text>
+  <path class="p3" d="M 1343 587 L 1408 582 L 1354 556 L 1298 562 L 1343 587"/>
+  <text x="1351" y="577" style="font-size:10px">3.209,0,0,0</text>
+  <path class="ps3" d="M 1242 567 L 1298 562 L 1255 538 L 1208 544 L 1242 567"/>
+  <text x="1251" y="558" style="font-size:10px">3.210,0,X,0</text>
+  <path class="ps3" d="M 1298 562 L 1354 556 L 1302 532 L 1255 538 L 1298 562"/>
+  <text x="1302" y="552" style="font-size:10px">3.211,0,X,0</text>
+  <path class="p3" d="M 1408 582 L 1472 577 L 1408 550 L 1354 556 L 1408 582"/>
+  <text x="1410" y="571" style="font-size:10px">3.212,0,0,0</text>
+  <path class="p3" d="M 1472 577 L 1536 572 L 1461 544 L 1408 550 L 1472 577"/>
+  <text x="1469" y="566" style="font-size:10px">3.213,0,0,0</text>
+  <path class="ps3" d="M 1354 556 L 1408 550 L 1347 524 L 1302 532 L 1354 556"/>
+  <text x="1353" y="546" style="font-size:10px">3.214,0,X,0</text>
+  <path class="ps3" d="M 1408 550 L 1461 544 L 1390 517 L 1347 524 L 1408 550"/>
+  <text x="1401" y="539" style="font-size:10px">3.215,0,X,0</text>
+  <path class="ps3" d="M 1208 544 L 1255 538 L 1214 515 L 1175 522 L 1208 544"/>
+  <text x="1213" y="535" style="font-size:10px">3.216,0,X,0</text>
+  <path class="ps3" d="M 1255 538 L 1302 532 L 1253 508 L 1214 515 L 1255 538"/>
+  <text x="1256" y="528" style="font-size:10px">3.217,0,X,0</text>
+  <path class="ps3" d="M 1175 522 L 1214 515 L 1175 493 L 1143 500 L 1175 522"/>
+  <text x="1177" y="512" style="font-size:9px">3.218,0,X,0</text>
+  <line x1="1143" y1="500" x2="1175" y2="493"/>
+  <path class="ps3" d="M 1214 515 L 1253 508 L 1205 486 L 1175 493 L 1214 515"/>
+  <text x="1212" y="505" style="font-size:9px">3.219,0,X,0</text>
+  <line x1="1175" y1="493" x2="1205" y2="486"/>
+  <path class="ps3" d="M 1302 532 L 1347 524 L 1288 500 L 1253 508 L 1302 532"/>
+  <text x="1297" y="521" style="font-size:10px">3.220,0,X,0</text>
+  <path class="ps3" d="M 1347 524 L 1390 517 L 1322 491 L 1288 500 L 1347 524"/>
+  <text x="1337" y="513" style="font-size:9px">3.221,0,X,0</text>
+  <path class="ps3" d="M 1253 508 L 1288 500 L 1232 477 L 1205 486 L 1253 508"/>
+  <text x="1244" y="497" style="font-size:9px">3.222,0,X,0</text>
+  <line x1="1205" y1="486" x2="1232" y2="477"/>
+  <path class="ps3" d="M 1288 500 L 1322 491 L 1257 467 L 1232 477 L 1288 500"/>
+  <text x="1275" y="488" style="font-size:9px">3.223,0,X,0</text>
+  <line x1="1232" y1="477" x2="1257" y2="467"/>
+  <path class="p3" d="M 1536 572 L 1534 543 L 1466 520 L 1461 544 L 1536 572"/>
+  <text x="1499" y="550" style="font-size:10px">3.224,0,0,0</text>
+  <path class="p3" d="M 1534 543 L 1533 516 L 1471 497 L 1466 520 L 1534 543"/>
+  <text x="1501" y="523" style="font-size:9px">3.225,0,0,0</text>
+  <path class="ps3" d="M 1461 544 L 1466 520 L 1401 498 L 1390 517 L 1461 544"/>
+  <text x="1429" y="524" style="font-size:9px">3.226,0,X,0</text>
+  <path class="ps3" d="M 1466 520 L 1471 497 L 1411 479 L 1401 498 L 1466 520"/>
+  <text x="1437" y="503" style="font-size:9px">3.227,0,X,0</text>
+  <path class="p3" d="M 1533 516 L 1531 489 L 1474 475 L 1471 497 L 1533 516"/>
+  <text x="1502" y="499" style="font-size:9px">3.228,0,0,0</text>
+  <path class="ps3" d="M 1531 489 L 1530 464 L 1476 453 L 1474 475 L 1531 489"/>
+  <text x="1503" y="475" style="font-size:9px">3.229,0,X,0</text>
+  <path class="ps3" d="M 1471 497 L 1474 475 L 1417 460 L 1411 479 L 1471 497"/>
+  <text x="1443" y="482" style="font-size:9px">3.230,0,X,0</text>
+  <path class="ps3" d="M 1474 475 L 1476 453 L 1424 442 L 1417 460 L 1474 475"/>
+  <text x="1448" y="461" style="font-size:8px">3.231,0,X,0</text>
+  <path class="ps3" d="M 1390 517 L 1401 498 L 1338 476 L 1322 491 L 1390 517"/>
+  <text x="1363" y="500" style="font-size:9px">3.232,0,X,0</text>
+  <path class="ps3" d="M 1401 498 L 1411 479 L 1353 461 L 1338 476 L 1401 498"/>
+  <text x="1375" y="483" style="font-size:9px">3.233,0,X,0</text>
+  <path class="ps3" d="M 1322 491 L 1338 476 L 1278 456 L 1257 467 L 1322 491"/>
+  <text x="1299" y="477" style="font-size:9px">3.234,0,X,0</text>
+  <line x1="1257" y1="467" x2="1278" y2="456"/>
+  <path class="ps3" d="M 1338 476 L 1353 461 L 1296 444 L 1278 456 L 1338 476"/>
+  <text x="1316" y="464" style="font-size:9px">3.235,0,X,0</text>
+  <line x1="1278" y1="456" x2="1296" y2="444"/>
+  <path class="ps3" d="M 1411 479 L 1417 460 L 1364 446 L 1353 461 L 1411 479"/>
+  <text x="1386" y="466" style="font-size:9px">3.236,0,X,0</text>
+  <path class="ps3" d="M 1417 460 L 1424 442 L 1373 431 L 1364 446 L 1417 460"/>
+  <text x="1394" y="449" style="font-size:8px">3.237,0,X,0</text>
+  <path class="ps3" d="M 1353 461 L 1364 446 L 1311 432 L 1296 444 L 1353 461"/>
+  <text x="1331" y="450" style="font-size:8px">3.238,0,X,0</text>
+  <line x1="1296" y1="444" x2="1311" y2="432"/>
+  <path class="ps3" d="M 1364 446 L 1373 431 L 1322 420 L 1311 432 L 1364 446"/>
+  <text x="1342" y="436" style="font-size:8px">3.239,0,X,0</text>
+  <line x1="1311" y1="432" x2="1322" y2="420"/>
+  <path class="ps3" d="M 1530 464 L 1522 439 L 1472 431 L 1476 453 L 1530 464"/>
+  <text x="1500" y="451" style="font-size:8px">3.240,0,X,0</text>
+  <path class="ps3" d="M 1522 439 L 1514 415 L 1468 410 L 1472 431 L 1522 439"/>
+  <text x="1494" y="428" style="font-size:8px">3.241,0,X,0</text>
+  <path class="ps3" d="M 1476 453 L 1472 431 L 1424 423 L 1424 442 L 1476 453"/>
+  <text x="1449" y="441" style="font-size:8px">3.242,0,X,0</text>
+  <path class="ps3" d="M 1472 431 L 1468 410 L 1423 405 L 1424 423 L 1472 431"/>
+  <text x="1447" y="421" style="font-size:8px">3.243,0,X,0</text>
+  <path class="ps3" d="M 1514 415 L 1507 392 L 1463 389 L 1468 410 L 1514 415"/>
+  <text x="1488" y="405" style="font-size:7px">3.244,0,X,0</text>
+  <path class="ps3" d="M 1507 392 L 1500 370 L 1458 370 L 1463 389 L 1507 392"/>
+  <text x="1482" y="383" style="font-size:7px">3.245,0,X,0</text>
+  <path class="ps3" d="M 1468 410 L 1463 389 L 1420 387 L 1423 405 L 1468 410"/>
+  <text x="1444" y="401" style="font-size:7px">3.246,0,X,0</text>
+  <path class="ps3" d="M 1463 389 L 1458 370 L 1416 370 L 1420 387 L 1463 389"/>
+  <text x="1439" y="382" style="font-size:7px">3.247,0,X,0</text>
+  <path class="ps3" d="M 1424 442 L 1424 423 L 1376 415 L 1373 431 L 1424 442"/>
+  <text x="1399" y="432" style="font-size:8px">3.248,0,X,0</text>
+  <path class="ps3" d="M 1424 423 L 1423 405 L 1379 400 L 1376 415 L 1424 423"/>
+  <text x="1400" y="414" style="font-size:8px">3.249,0,X,0</text>
+  <path class="ps3" d="M 1373 431 L 1376 415 L 1330 407 L 1322 420 L 1373 431"/>
+  <text x="1350" y="422" style="font-size:8px">3.250,0,X,0</text>
+  <line x1="1322" y1="420" x2="1330" y2="407"/>
+  <path class="ps3" d="M 1376 415 L 1379 400 L 1334 395 L 1330 407 L 1376 415"/>
+  <text x="1355" y="408" style="font-size:8px">3.251,0,X,0</text>
+  <line x1="1330" y1="407" x2="1334" y2="395"/>
+  <path class="ps3" d="M 1423 405 L 1420 387 L 1377 384 L 1379 400 L 1423 405"/>
+  <text x="1400" y="397" style="font-size:7px">3.252,0,X,0</text>
+  <path class="ps3" d="M 1420 387 L 1416 370 L 1375 370 L 1377 384 L 1420 387"/>
+  <text x="1397" y="381" style="font-size:7px">3.253,0,X,0</text>
+  <path class="ps3" d="M 1379 400 L 1377 384 L 1335 382 L 1334 395 L 1379 400"/>
+  <text x="1356" y="394" style="font-size:7px">3.254,0,X,0</text>
+  <line x1="1334" y1="395" x2="1335" y2="382"/>
+  <path class="ps3" d="M 1377 384 L 1375 370 L 1333 370 L 1335 382 L 1377 384"/>
+  <text x="1355" y="380" style="font-size:7px">3.255,0,X,0</text>
+  <line x1="1335" y1="382" x2="1333" y2="370"/>
+  <path class="p3" d="M 1583 370 L 1567 344 L 1527 346 L 1541 370 L 1583 370"/>
+  <text x="1554" y="360" style="font-size:7px">3.256,0,0,0</text>
+  <path class="p3" d="M 1567 344 L 1552 319 L 1513 323 L 1527 346 L 1567 344"/>
+  <text x="1540" y="336" style="font-size:6px">3.257,0,0,0</text>
+  <path class="p3" d="M 1541 370 L 1527 346 L 1487 348 L 1500 370 L 1541 370"/>
+  <text x="1514" y="362" style="font-size:7px">3.258,0,0,0</text>
+  <path class="p3" d="M 1527 346 L 1513 323 L 1474 328 L 1487 348 L 1527 346"/>
+  <text x="1500" y="339" style="font-size:6px">3.259,0,0,0</text>
+  <path class="p3" d="M 1552 319 L 1538 295 L 1500 301 L 1513 323 L 1552 319"/>
+  <text x="1526" y="312" style="font-size:6px">3.260,0,0,0</text>
+  <path class="p3" d="M 1538 295 L 1525 273 L 1488 281 L 1500 301 L 1538 295"/>
+  <text x="1513" y="290" style="font-size:6px">3.261,0,0,0</text>
+  <path class="p3" d="M 1513 323 L 1500 301 L 1462 308 L 1474 328 L 1513 323"/>
+  <text x="1487" y="318" style="font-size:6px">3.262,0,0,0</text>
+  <path class="p3" d="M 1500 301 L 1488 281 L 1450 289 L 1462 308 L 1500 301"/>
+  <text x="1475" y="298" style="font-size:6px">3.263,0,0,0</text>
+  <path class="p3" d="M 1525 273 L 1509 251 L 1472 261 L 1488 281 L 1525 273"/>
+  <text x="1498" y="269" style="font-size:5px">3.264,0,0,0</text>
+  <path class="p3" d="M 1509 251 L 1494 231 L 1457 243 L 1472 261 L 1509 251"/>
+  <text x="1483" y="249" style="font-size:5px">3.265,0,0,0</text>
+  <path class="p3" d="M 1488 281 L 1472 261 L 1434 271 L 1450 289 L 1488 281"/>
+  <text x="1461" y="278" style="font-size:6px">3.266,0,0,0</text>
+  <path class="p3" d="M 1472 261 L 1457 243 L 1419 254 L 1434 271 L 1472 261"/>
+  <text x="1446" y="260" style="font-size:5px">3.267,0,0,0</text>
+  <path class="p3" d="M 1350 191 L 1292 189 L 1269 202 L 1322 204 L 1350 191"/>
+  <text x="1308" y="198" style="font-size:4px">3.268,0,0,0</text>
+  <path class="p3" d="M 1292 189 L 1234 188 L 1216 200 L 1269 202 L 1292 189"/>
+  <text x="1253" y="197" style="font-size:4px">3.269,0,0,0</text>
+  <path class="p3" d="M 1322 204 L 1269 202 L 1244 215 L 1292 217 L 1322 204"/>
+  <text x="1282" y="212" style="font-size:5px">3.270,0,0,0</text>
+  <path class="p3" d="M 1269 202 L 1216 200 L 1197 212 L 1244 215 L 1269 202"/>
+  <text x="1231" y="210" style="font-size:5px">3.271,0,0,0</text>
+  <path class="p3" d="M 1234 188 L 1176 188 L 1162 199 L 1216 200 L 1234 188"/>
+  <text x="1197" y="196" style="font-size:4px">3.272,0,0,0</text>
+  <path class="p3" d="M 1176 188 L 1117 187 L 1108 199 L 1162 199 L 1176 188"/>
+  <text x="1140" y="195" style="font-size:4px">3.273,0,0,0</text>
+  <path class="p3" d="M 1216 200 L 1162 199 L 1147 211 L 1197 212 L 1216 200"/>
+  <text x="1180" y="208" style="font-size:5px">3.274,0,0,0</text>
+  <path class="p3" d="M 1162 199 L 1108 199 L 1098 210 L 1147 211 L 1162 199"/>
+  <text x="1129" y="207" style="font-size:5px">3.275,0,0,0</text>
+  <path class="p3" d="M 1117 187 L 1058 187 L 1054 198 L 1108 199 L 1117 187"/>
+  <text x="1084" y="195" style="font-size:4px">3.276,0,0,0</text>
+  <path class="p3" d="M 1058 187 L 1000 187 L 1000 197 L 1054 198 L 1058 187"/>
+  <text x="1028" y="194" style="font-size:4px">3.277,0,0,0</text>
+  <path class="p3" d="M 1108 199 L 1054 198 L 1049 210 L 1098 210 L 1108 199"/>
+  <text x="1077" y="207" style="font-size:5px">3.278,0,0,0</text>
+  <path class="p3" d="M 1054 198 L 1000 197 L 1000 209 L 1049 210 L 1054 198"/>
+  <text x="1026" y="206" style="font-size:5px">3.279,0,0,0</text>
+  <path class="p3" d="M 1000 187 L 942 187 L 946 198 L 1000 197 L 1000 187"/>
+  <text x="972" y="194" style="font-size:4px">3.280,0,0,0</text>
+  <path class="p3" d="M 942 187 L 883 187 L 892 199 L 946 198 L 942 187"/>
+  <text x="916" y="195" style="font-size:4px">3.281,0,0,0</text>
+  <path class="p3" d="M 1000 197 L 946 198 L 951 210 L 1000 209 L 1000 197"/>
+  <text x="974" y="206" style="font-size:5px">3.282,0,0,0</text>
+  <path class="p3" d="M 946 198 L 892 199 L 902 210 L 951 210 L 946 198"/>
+  <text x="923" y="207" style="font-size:5px">3.283,0,0,0</text>
+  <path class="p3" d="M 883 187 L 824 188 L 838 199 L 892 199 L 883 187"/>
+  <text x="860" y="195" style="font-size:4px">3.284,0,0,0</text>
+  <path class="p3" d="M 824 188 L 766 188 L 784 200 L 838 199 L 824 188"/>
+  <text x="803" y="196" style="font-size:4px">3.285,0,0,0</text>
+  <path class="p3" d="M 892 199 L 838 199 L 853 211 L 902 210 L 892 199"/>
+  <text x="871" y="207" style="font-size:5px">3.286,0,0,0</text>
+  <path class="p3" d="M 838 199 L 784 200 L 803 212 L 853 211 L 838 199"/>
+  <text x="820" y="208" style="font-size:5px">3.287,0,0,0</text>
+  <path class="p3" d="M 766 188 L 708 189 L 731 202 L 784 200 L 766 188"/>
+  <text x="747" y="197" style="font-size:4px">3.288,0,0,0</text>
+  <path class="p3" d="M 708 189 L 650 191 L 678 204 L 731 202 L 708 189"/>
+  <text x="692" y="198" style="font-size:4px">3.289,0,0,0</text>
+  <path class="p3" d="M 784 200 L 731 202 L 756 215 L 803 212 L 784 200"/>
+  <text x="769" y="210" style="font-size:5px">3.290,0,0,0</text>
+  <path class="p3" d="M 731 202 L 678 204 L 708 217 L 756 215 L 731 202"/>
+  <text x="718" y="212" style="font-size:5px">3.291,0,0,0</text>
+  <path class="p3" d="M 506 231 L 491 251 L 528 261 L 543 243 L 506 231"/>
+  <text x="517" y="249" style="font-size:5px">3.292,0,0,0</text>
+  <path class="p3" d="M 491 251 L 475 273 L 512 281 L 528 261 L 491 251"/>
+  <text x="502" y="269" style="font-size:5px">3.293,0,0,0</text>
+  <path class="p3" d="M 543 243 L 528 261 L 566 271 L 581 254 L 543 243"/>
+  <text x="554" y="260" style="font-size:5px">3.294,0,0,0</text>
+  <path class="p3" d="M 528 261 L 512 281 L 550 289 L 566 271 L 528 261"/>
+  <text x="539" y="278" style="font-size:6px">3.295,0,0,0</text>
+  <path class="p3" d="M 475 273 L 462 295 L 500 301 L 512 281 L 475 273"/>
+  <text x="487" y="290" style="font-size:6px">3.296,0,0,0</text>
+  <path class="p3" d="M 462 295 L 448 319 L 487 323 L 500 301 L 462 295"/>
+  <text x="474" y="312" style="font-size:6px">3.297,0,0,0</text>
+  <path class="p3" d="M 512 281 L 500 301 L 538 308 L 550 289 L 512 281"/>
+  <text x="525" y="298" style="font-size:6px">3.298,0,0,0</text>
+  <path class="p3" d="M 500 301 L 487 323 L 526 328 L 538 308 L 500 301"/>
+  <text x="513" y="318" style="font-size:6px">3.299,0,0,0</text>
+  <path class="p3" d="M 448 319 L 433 344 L 473 346 L 487 323 L 448 319"/>
+  <text x="460" y="336" style="font-size:6px">3.300,0,0,0</text>
+  <path class="p3" d="M 433 344 L 417 370 L 459 370 L 473 346 L 433 344"/>
+  <text x="446" y="360" style="font-size:7px">3.301,0,0,0</text>
+  <path class="p3" d="M 487 323 L 473 346 L 513 348 L 526 328 L 487 323"/>
+  <text x="500" y="339" style="font-size:6px">3.302,0,0,0</text>
+  <path class="p3" d="M 473 346 L 459 370 L 500 370 L 513 348 L 473 346"/>
+  <text x="486" y="362" style="font-size:7px">3.303,0,0,0</text>
+  <path class="p3" d="M 417 370 L 404 397 L 449 394 L 459 370 L 417 370"/>
+  <text x="432" y="386" style="font-size:7px">3.304,0,0,0</text>
+  <path class="p3" d="M 404 397 L 390 426 L 438 420 L 449 394 L 404 397"/>
+  <text x="420" y="413" style="font-size:7px">3.305,0,0,0</text>
+  <path class="p3" d="M 459 370 L 449 394 L 493 392 L 500 370 L 459 370"/>
+  <text x="475" y="385" style="font-size:7px">3.306,0,0,0</text>
+  <path class="p3" d="M 449 394 L 438 420 L 486 415 L 493 392 L 449 394"/>
+  <text x="467" y="409" style="font-size:7px">3.307,0,0,0</text>
+  <path class="p3" d="M 390 426 L 376 456 L 427 447 L 438 420 L 390 426"/>
+  <text x="408" y="441" style="font-size:8px">3.308,0,0,0</text>
+  <path class="p3" d="M 376 456 L 360 488 L 416 476 L 427 447 L 376 456"/>
+  <text x="395" y="470" style="font-size:8px">3.309,0,0,0</text>
+  <path class="p3" d="M 438 420 L 427 447 L 478 439 L 486 415 L 438 420"/>
+  <text x="458" y="434" style="font-size:8px">3.310,0,0,0</text>
+  <path class="p3" d="M 427 447 L 416 476 L 470 464 L 478 439 L 427 447"/>
+  <text x="448" y="460" style="font-size:8px">3.311,0,0,0</text>
+  <path class="p3" d="M 360 488 L 348 521 L 409 505 L 416 476 L 360 488"/>
+  <text x="383" y="502" style="font-size:9px">3.312,0,0,0</text>
+  <path class="p3" d="M 348 521 L 334 556 L 402 536 L 409 505 L 348 521"/>
+  <text x="374" y="534" style="font-size:9px">3.313,0,0,0</text>
+  <path class="p3" d="M 416 476 L 409 505 L 469 489 L 470 464 L 416 476"/>
+  <text x="441" y="488" style="font-size:9px">3.314,0,0,0</text>
+  <path class="p3" d="M 409 505 L 402 536 L 467 516 L 469 489 L 409 505"/>
+  <text x="437" y="516" style="font-size:9px">3.315,0,0,0</text>
+  <path class="p3" d="M 475 638 L 561 640 L 610 613 L 535 609 L 475 638"/>
+  <text x="546" y="630" style="font-size:11px">3.316,0,0,0</text>
+  <path class="p3" d="M 561 640 L 647 643 L 685 617 L 610 613 L 561 640"/>
+  <text x="626" y="634" style="font-size:11px">3.317,0,0,0</text>
+  <path class="p3" d="M 535 609 L 610 613 L 657 587 L 592 582 L 535 609"/>
+  <text x="599" y="603" style="font-size:11px">3.318,0,0,0</text>
+  <path class="p3" d="M 610 613 L 685 617 L 722 592 L 657 587 L 610 613"/>
+  <text x="669" y="607" style="font-size:11px">3.319,0,0,0</text>
+  <path class="p3" d="M 647 643 L 735 644 L 764 618 L 685 617 L 647 643"/>
+  <text x="708" y="636" style="font-size:11px">3.320,0,0,0</text>
+  <path class="p3" d="M 735 644 L 823 645 L 842 620 L 764 618 L 735 644"/>
+  <text x="791" y="637" style="font-size:11px">3.321,0,0,0</text>
+  <path class="p3" d="M 685 617 L 764 618 L 791 593 L 722 592 L 685 617"/>
+  <text x="741" y="610" style="font-size:11px">3.322,0,0,0</text>
+  <path class="p3" d="M 764 618 L 842 620 L 861 595 L 791 593 L 764 618"/>
+  <text x="815" y="612" style="font-size:11px">3.323,0,0,0</text>
+  <path class="p3" d="M 823 645 L 912 646 L 921 621 L 842 620 L 823 645"/>
+  <text x="875" y="638" style="font-size:11px">3.324,0,0,0</text>
+  <path class="p3" d="M 912 646 L 1000 647 L 1000 622 L 921 621 L 912 646"/>
+  <text x="958" y="640" style="font-size:12px">3.325,0,0,0</text>
+  <path class="p3" d="M 842 620 L 921 621 L 930 597 L 861 595 L 842 620"/>
+  <text x="889" y="614" style="font-size:11px">3.326,0,0,0</text>
+  <path class="p3" d="M 921 621 L 1000 622 L 1000 599 L 930 597 L 921 621"/>
+  <text x="963" y="615" style="font-size:11px">3.327,0,0,0</text>
+  <path class="p3" d="M 1000 647 L 1088 646 L 1079 621 L 1000 622 L 1000 647"/>
+  <text x="1042" y="640" style="font-size:12px">3.328,0,0,0</text>
+  <path class="p3" d="M 1088 646 L 1177 645 L 1158 620 L 1079 621 L 1088 646"/>
+  <text x="1125" y="638" style="font-size:11px">3.329,0,0,0</text>
+  <path class="p3" d="M 1000 622 L 1079 621 L 1070 597 L 1000 599 L 1000 622"/>
+  <text x="1037" y="615" style="font-size:11px">3.330,0,0,0</text>
+  <path class="p3" d="M 1079 621 L 1158 620 L 1139 595 L 1070 597 L 1079 621"/>
+  <text x="1111" y="614" style="font-size:11px">3.331,0,0,0</text>
+  <path class="p3" d="M 1177 645 L 1265 644 L 1236 618 L 1158 620 L 1177 645"/>
+  <text x="1209" y="637" style="font-size:11px">3.332,0,0,0</text>
+  <path class="p3" d="M 1265 644 L 1353 643 L 1315 617 L 1236 618 L 1265 644"/>
+  <text x="1292" y="636" style="font-size:11px">3.333,0,0,0</text>
+  <path class="p3" d="M 1158 620 L 1236 618 L 1209 593 L 1139 595 L 1158 620"/>
+  <text x="1185" y="612" style="font-size:11px">3.334,0,0,0</text>
+  <path class="p3" d="M 1236 618 L 1315 617 L 1278 592 L 1209 593 L 1236 618"/>
+  <text x="1259" y="610" style="font-size:11px">3.335,0,0,0</text>
+  <path class="p3" d="M 1353 643 L 1439 640 L 1390 613 L 1315 617 L 1353 643"/>
+  <text x="1374" y="634" style="font-size:11px">3.336,0,0,0</text>
+  <path class="p3" d="M 1439 640 L 1525 638 L 1465 609 L 1390 613 L 1439 640"/>
+  <text x="1454" y="630" style="font-size:11px">3.337,0,0,0</text>
+  <path class="p3" d="M 1315 617 L 1390 613 L 1343 587 L 1278 592 L 1315 617"/>
+  <text x="1331" y="607" style="font-size:11px">3.338,0,0,0</text>
+  <path class="p3" d="M 1390 613 L 1465 609 L 1408 582 L 1343 587 L 1390 613"/>
+  <text x="1401" y="603" style="font-size:11px">3.339,0,0,0</text>
+  <path class="p3" d="M 1666 556 L 1652 521 L 1591 505 L 1598 536 L 1666 556"/>
+  <text x="1626" y="534" style="font-size:9px">3.340,0,0,0</text>
+  <path class="p3" d="M 1652 521 L 1640 488 L 1584 476 L 1591 505 L 1652 521"/>
+  <text x="1617" y="502" style="font-size:9px">3.341,0,0,0</text>
+  <path class="p3" d="M 1598 536 L 1591 505 L 1531 489 L 1533 516 L 1598 536"/>
+  <text x="1563" y="516" style="font-size:9px">3.342,0,0,0</text>
+  <path class="p3" d="M 1591 505 L 1584 476 L 1530 464 L 1531 489 L 1591 505"/>
+  <text x="1559" y="488" style="font-size:9px">3.343,0,0,0</text>
+  <path class="p3" d="M 1640 488 L 1624 456 L 1573 447 L 1584 476 L 1640 488"/>
+  <text x="1605" y="470" style="font-size:8px">3.344,0,0,0</text>
+  <path class="p3" d="M 1624 456 L 1610 426 L 1562 420 L 1573 447 L 1624 456"/>
+  <text x="1592" y="441" style="font-size:8px">3.345,0,0,0</text>
+  <path class="p3" d="M 1584 476 L 1573 447 L 1522 439 L 1530 464 L 1584 476"/>
+  <text x="1552" y="460" style="font-size:8px">3.346,0,0,0</text>
+  <path class="p3" d="M 1573 447 L 1562 420 L 1514 415 L 1522 439 L 1573 447"/>
+  <text x="1542" y="434" style="font-size:8px">3.347,0,0,0</text>
+  <path class="p3" d="M 1610 426 L 1596 397 L 1551 394 L 1562 420 L 1610 426"/>
+  <text x="1580" y="413" style="font-size:7px">3.348,0,0,0</text>
+  <path class="p3" d="M 1596 397 L 1583 370 L 1541 370 L 1551 394 L 1596 397"/>
+  <text x="1568" y="386" style="font-size:7px">3.349,0,0,0</text>
+  <path class="p3" d="M 1562 420 L 1551 394 L 1507 392 L 1514 415 L 1562 420"/>
+  <text x="1533" y="409" style="font-size:7px">3.350,0,0,0</text>
+  <path class="p3" d="M 1551 394 L 1541 370 L 1500 370 L 1507 392 L 1551 394"/>
+  <text x="1525" y="385" style="font-size:7px">3.351,0,0,0</text>
+  <path class="p4" d="M 1513 241 L 1507 232 L 1486 232 L 1492 241 L 1513 241"/>
+  <text x="1499" y="239" style="font-size:4px">4.0,0,0,0</text>
+  <path class="p4" d="M 1507 232 L 1500 222 L 1479 223 L 1486 232 L 1507 232"/>
+  <text x="1493" y="229" style="font-size:3px">4.1,0,0,0</text>
+  <path class="p4" d="M 1492 241 L 1486 232 L 1465 233 L 1471 241 L 1492 241"/>
+  <text x="1478" y="239" style="font-size:4px">4.2,0,0,0</text>
+  <path class="p4" d="M 1486 232 L 1479 223 L 1459 224 L 1465 233 L 1486 232"/>
+  <text x="1472" y="230" style="font-size:4px">4.3,0,0,0</text>
+  <path class="p4" d="M 1500 222 L 1493 213 L 1473 214 L 1479 223 L 1500 222"/>
+  <text x="1486" y="219" style="font-size:3px">4.4,0,0,0</text>
+  <path class="p4" d="M 1493 213 L 1487 203 L 1467 205 L 1473 214 L 1493 213"/>
+  <text x="1480" y="210" style="font-size:3px">4.5,0,0,0</text>
+  <path class="p4" d="M 1479 223 L 1473 214 L 1453 216 L 1459 224 L 1479 223"/>
+  <text x="1466" y="221" style="font-size:3px">4.6,0,0,0</text>
+  <path class="p4" d="M 1473 214 L 1467 205 L 1448 207 L 1453 216 L 1473 214"/>
+  <text x="1460" y="212" style="font-size:3px">4.7,0,0,0</text>
+  <path class="p4" d="M 1471 241 L 1465 233 L 1444 233 L 1449 241 L 1471 241"/>
+  <text x="1457" y="239" style="font-size:4px">4.8,0,0,0</text>
+  <path class="p4" d="M 1465 233 L 1459 224 L 1438 225 L 1444 233 L 1465 233"/>
+  <text x="1451" y="231" style="font-size:4px">4.9,0,0,0</text>
+  <path class="p4" d="M 1449 241 L 1444 233 L 1423 234 L 1428 241 L 1449 241"/>
+  <text x="1436" y="239" style="font-size:4px">4.10,0,0,0</text>
+  <path class="p4" d="M 1444 233 L 1438 225 L 1418 226 L 1423 234 L 1444 233"/>
+  <text x="1431" y="232" style="font-size:4px">4.11,0,0,0</text>
+  <path class="p4" d="M 1459 224 L 1453 216 L 1433 217 L 1438 225 L 1459 224"/>
+  <text x="1446" y="222" style="font-size:3px">4.12,0,0,0</text>
+  <path class="p4" d="M 1453 216 L 1448 207 L 1428 209 L 1433 217 L 1453 216"/>
+  <text x="1440" y="214" style="font-size:3px">4.13,0,0,0</text>
+  <path class="p4" d="M 1438 225 L 1433 217 L 1413 219 L 1418 226 L 1438 225"/>
+  <text x="1426" y="223" style="font-size:3px">4.14,0,0,0</text>
+  <path class="p4" d="M 1433 217 L 1428 209 L 1408 211 L 1413 219 L 1433 217"/>
+  <text x="1420" y="216" style="font-size:3px">4.15,0,0,0</text>
+  <path class="p4" d="M 1487 203 L 1480 194 L 1461 197 L 1467 205 L 1487 203"/>
+  <text x="1474" y="202" style="font-size:3px">4.16,0,0,0</text>
+  <path class="p4" d="M 1480 194 L 1474 186 L 1455 189 L 1461 197 L 1480 194"/>
+  <text x="1467" y="193" style="font-size:3px">4.17,0,0,0</text>
+  <path class="p4" d="M 1467 205 L 1461 197 L 1441 199 L 1448 207 L 1467 205"/>
+  <text x="1454" y="204" style="font-size:3px">4.18,0,0,0</text>
+  <path class="p4" d="M 1461 197 L 1455 189 L 1435 192 L 1441 199 L 1461 197"/>
+  <text x="1448" y="196" style="font-size:3px">4.19,0,0,0</text>
+  <path class="p4" d="M 1474 186 L 1468 177 L 1449 180 L 1455 189 L 1474 186"/>
+  <text x="1461" y="184" style="font-size:3px">4.20,0,0,0</text>
+  <path class="p4" d="M 1468 177 L 1462 169 L 1443 172 L 1449 180 L 1468 177"/>
+  <text x="1455" y="176" style="font-size:3px">4.21,0,0,0</text>
+  <path class="p4" d="M 1455 189 L 1449 180 L 1429 184 L 1435 192 L 1455 189"/>
+  <text x="1442" y="188" style="font-size:3px">4.22,0,0,0</text>
+  <path class="p4" d="M 1449 180 L 1443 172 L 1423 176 L 1429 184 L 1449 180"/>
+  <text x="1436" y="180" style="font-size:3px">4.23,0,0,0</text>
+  <path class="p4" d="M 1448 207 L 1441 199 L 1422 202 L 1428 209 L 1448 207"/>
+  <text x="1435" y="206" style="font-size:3px">4.24,0,0,0</text>
+  <path class="p4" d="M 1441 199 L 1435 192 L 1415 194 L 1422 202 L 1441 199"/>
+  <text x="1428" y="198" style="font-size:3px">4.25,0,0,0</text>
+  <path class="p4" d="M 1428 209 L 1422 202 L 1402 204 L 1408 211 L 1428 209"/>
+  <text x="1415" y="208" style="font-size:3px">4.26,0,0,0</text>
+  <path class="p4" d="M 1422 202 L 1415 194 L 1396 197 L 1402 204 L 1422 202"/>
+  <text x="1409" y="201" style="font-size:3px">4.27,0,0,0</text>
+  <path class="p4" d="M 1435 192 L 1429 184 L 1409 187 L 1415 194 L 1435 192"/>
+  <text x="1422" y="191" style="font-size:3px">4.28,0,0,0</text>
+  <path class="p4" d="M 1429 184 L 1423 176 L 1403 180 L 1409 187 L 1429 184"/>
+  <text x="1416" y="183" style="font-size:3px">4.29,0,0,0</text>
+  <path class="p4" d="M 1415 194 L 1409 187 L 1390 191 L 1396 197 L 1415 194"/>
+  <text x="1402" y="194" style="font-size:3px">4.30,0,0,0</text>
+  <path class="p4" d="M 1409 187 L 1403 180 L 1384 184 L 1390 191 L 1409 187"/>
+  <text x="1396" y="187" style="font-size:3px">4.31,0,0,0</text>
+  <path class="p4" d="M 1428 241 L 1423 234 L 1402 234 L 1406 241 L 1428 241"/>
+  <text x="1415" y="240" style="font-size:4px">4.32,0,0,0</text>
+  <path class="p4" d="M 1423 234 L 1418 226 L 1398 227 L 1402 234 L 1423 234"/>
+  <text x="1410" y="232" style="font-size:4px">4.33,0,0,0</text>
+  <path class="p4" d="M 1406 241 L 1402 234 L 1381 235 L 1385 241 L 1406 241"/>
+  <text x="1394" y="240" style="font-size:4px">4.34,0,0,0</text>
+  <path class="p4" d="M 1402 234 L 1398 227 L 1377 228 L 1381 235 L 1402 234"/>
+  <text x="1390" y="233" style="font-size:4px">4.35,0,0,0</text>
+  <path class="p4" d="M 1418 226 L 1413 219 L 1393 220 L 1398 227 L 1418 226"/>
+  <text x="1405" y="225" style="font-size:4px">4.36,0,0,0</text>
+  <path class="p4" d="M 1413 219 L 1408 211 L 1388 213 L 1393 220 L 1413 219"/>
+  <text x="1400" y="217" style="font-size:3px">4.37,0,0,0</text>
+  <path class="p4" d="M 1398 227 L 1393 220 L 1373 222 L 1377 228 L 1398 227"/>
+  <text x="1385" y="226" style="font-size:4px">4.38,0,0,0</text>
+  <path class="p4" d="M 1393 220 L 1388 213 L 1368 216 L 1373 222 L 1393 220"/>
+  <text x="1380" y="219" style="font-size:3px">4.39,0,0,0</text>
+  <path class="p4" d="M 1385 241 L 1381 235 L 1361 235 L 1364 241 L 1385 241"/>
+  <text x="1373" y="240" style="font-size:4px">4.40,0,0,0</text>
+  <path class="p4" d="M 1381 235 L 1377 228 L 1357 229 L 1361 235 L 1381 235"/>
+  <text x="1369" y="234" style="font-size:4px">4.41,0,0,0</text>
+  <path class="p4" d="M 1364 241 L 1361 235 L 1340 236 L 1342 241 L 1364 241"/>
+  <text x="1352" y="240" style="font-size:4px">4.42,0,0,0</text>
+  <line x1="1342" y1="241" x2="1340" y2="236"/>
+  <path class="p4" d="M 1361 235 L 1357 229 L 1337 230 L 1340 236 L 1361 235"/>
+  <text x="1349" y="235" style="font-size:4px">4.43,0,0,0</text>
+  <line x1="1340" y1="236" x2="1337" y2="230"/>
+  <path class="p4" d="M 1377 228 L 1373 222 L 1353 223 L 1357 229 L 1377 228"/>
+  <text x="1365" y="228" style="font-size:4px">4.44,0,0,0</text>
+  <path class="p4" d="M 1373 222 L 1368 216 L 1348 218 L 1353 223 L 1373 222"/>
+  <text x="1360" y="221" style="font-size:3px">4.45,0,0,0</text>
+  <path class="p4" d="M 1357 229 L 1353 223 L 1333 225 L 1337 230 L 1357 229"/>
+  <text x="1345" y="229" style="font-size:4px">4.46,0,0,0</text>
+  <line x1="1337" y1="230" x2="1333" y2="225"/>
+  <path class="p4" d="M 1353 223 L 1348 218 L 1328 220 L 1333 225 L 1353 223"/>
+  <text x="1340" y="223" style="font-size:4px">4.47,0,0,0</text>
+  <line x1="1333" y1="225" x2="1328" y2="220"/>
+  <path class="p4" d="M 1408 211 L 1402 204 L 1382 207 L 1388 213 L 1408 211"/>
+  <text x="1395" y="211" style="font-size:3px">4.48,0,0,0</text>
+  <path class="p4" d="M 1402 204 L 1396 197 L 1376 200 L 1382 207 L 1402 204"/>
+  <text x="1389" y="204" style="font-size:3px">4.49,0,0,0</text>
+  <path class="p4" d="M 1388 213 L 1382 207 L 1362 209 L 1368 216 L 1388 213"/>
+  <text x="1375" y="213" style="font-size:3px">4.50,0,0,0</text>
+  <path class="p4" d="M 1382 207 L 1376 200 L 1356 203 L 1362 209 L 1382 207"/>
+  <text x="1369" y="206" style="font-size:3px">4.51,0,0,0</text>
+  <path class="p4" d="M 1396 197 L 1390 191 L 1370 194 L 1376 200 L 1396 197"/>
+  <text x="1383" y="197" style="font-size:3px">4.52,0,0,0</text>
+  <path class="p4" d="M 1390 191 L 1384 184 L 1364 188 L 1370 194 L 1390 191"/>
+  <text x="1377" y="191" style="font-size:3px">4.53,0,0,0</text>
+  <path class="p4" d="M 1376 200 L 1370 194 L 1350 197 L 1356 203 L 1376 200"/>
+  <text x="1363" y="200" style="font-size:3px">4.54,0,0,0</text>
+  <path class="p4" d="M 1370 194 L 1364 188 L 1343 192 L 1350 197 L 1370 194"/>
+  <text x="1357" y="194" style="font-size:3px">4.55,0,0,0</text>
+  <path class="p4" d="M 1368 216 L 1362 209 L 1342 212 L 1348 218 L 1368 216"/>
+  <text x="1355" y="215" style="font-size:3px">4.56,0,0,0</text>
+  <path class="p4" d="M 1362 209 L 1356 203 L 1336 206 L 1342 212 L 1362 209"/>
+  <text x="1349" y="209" style="font-size:3px">4.57,0,0,0</text>
+  <path class="p4" d="M 1348 218 L 1342 212 L 1323 214 L 1328 220 L 1348 218"/>
+  <text x="1335" y="217" style="font-size:3px">4.58,0,0,0</text>
+  <line x1="1328" y1="220" x2="1323" y2="214"/>
+  <path class="p4" d="M 1342 212 L 1336 206 L 1317 209 L 1323 214 L 1342 212"/>
+  <text x="1330" y="212" style="font-size:3px">4.59,0,0,0</text>
+  <line x1="1323" y1="214" x2="1317" y2="209"/>
+  <path class="p4" d="M 1356 203 L 1350 197 L 1330 201 L 1336 206 L 1356 203"/>
+  <text x="1343" y="204" style="font-size:3px">4.60,0,0,0</text>
+  <path class="p4" d="M 1350 197 L 1343 192 L 1323 196 L 1330 201 L 1350 197"/>
+  <text x="1336" y="198" style="font-size:3px">4.61,0,0,0</text>
+  <path class="p4" d="M 1336 206 L 1330 201 L 1310 204 L 1317 209 L 1336 206"/>
+  <text x="1323" y="207" style="font-size:3px">4.62,0,0,0</text>
+  <line x1="1317" y1="209" x2="1310" y2="204"/>
+  <path class="p4" d="M 1330 201 L 1323 196 L 1302 200 L 1310 204 L 1330 201"/>
+  <text x="1316" y="202" style="font-size:3px">4.63,0,0,0</text>
+  <line x1="1310" y1="204" x2="1302" y2="200"/>
+  <path class="p4" d="M 1462 169 L 1454 161 L 1434 165 L 1443 172 L 1462 169"/>
+  <text x="1448" y="168" style="font-size:3px">4.64,0,0,0</text>
+  <path class="p4" d="M 1454 161 L 1445 153 L 1426 157 L 1434 165 L 1454 161"/>
+  <text x="1440" y="160" style="font-size:3px">4.65,0,0,0</text>
+  <path class="p4" d="M 1443 172 L 1434 165 L 1415 169 L 1423 176 L 1443 172"/>
+  <text x="1429" y="172" style="font-size:3px">4.66,0,0,0</text>
+  <path class="p4" d="M 1434 165 L 1426 157 L 1406 162 L 1415 169 L 1434 165"/>
+  <text x="1420" y="165" style="font-size:3px">4.67,0,0,0</text>
+  <path class="p4" d="M 1423 176 L 1415 169 L 1395 173 L 1403 180 L 1423 176"/>
+  <text x="1409" y="176" style="font-size:3px">4.68,0,0,0</text>
+  <path class="p4" d="M 1415 169 L 1406 162 L 1387 167 L 1395 173 L 1415 169"/>
+  <text x="1401" y="169" style="font-size:3px">4.69,0,0,0</text>
+  <path class="p4" d="M 1403 180 L 1395 173 L 1375 178 L 1384 184 L 1403 180"/>
+  <text x="1389" y="180" style="font-size:3px">4.70,0,0,0</text>
+  <path class="p4" d="M 1395 173 L 1387 167 L 1367 171 L 1375 178 L 1395 173"/>
+  <text x="1381" y="174" style="font-size:3px">4.71,0,0,0</text>
+  <path class="p4" d="M 1406 162 L 1398 155 L 1378 160 L 1387 167 L 1406 162"/>
+  <text x="1392" y="162" style="font-size:3px">4.72,0,0,0</text>
+  <path class="p4" d="M 1398 155 L 1390 148 L 1370 154 L 1378 160 L 1398 155"/>
+  <text x="1384" y="156" style="font-size:3px">4.73,0,0,0</text>
+  <path class="p4" d="M 1387 167 L 1378 160 L 1358 165 L 1367 171 L 1387 167"/>
+  <text x="1372" y="167" style="font-size:3px">4.74,0,0,0</text>
+  <path class="p4" d="M 1378 160 L 1370 154 L 1350 159 L 1358 165 L 1378 160"/>
+  <text x="1364" y="161" style="font-size:3px">4.75,0,0,0</text>
+  <path class="p4" d="M 1390 148 L 1382 142 L 1361 147 L 1370 154 L 1390 148"/>
+  <text x="1376" y="149" style="font-size:3px">4.76,0,0,0</text>
+  <path class="p4" d="M 1382 142 L 1373 135 L 1353 141 L 1361 147 L 1382 142"/>
+  <text x="1367" y="143" style="font-size:3px">4.77,0,0,0</text>
+  <path class="p4" d="M 1370 154 L 1361 147 L 1341 153 L 1350 159 L 1370 154"/>
+  <text x="1356" y="155" style="font-size:3px">4.78,0,0,0</text>
+  <path class="p4" d="M 1361 147 L 1353 141 L 1332 148 L 1341 153 L 1361 147"/>
+  <text x="1347" y="149" style="font-size:3px">4.79,0,0,0</text>
+  <path class="p4" d="M 1373 135 L 1365 129 L 1344 135 L 1353 141 L 1373 135"/>
+  <text x="1359" y="137" style="font-size:3px">4.80,0,0,0</text>
+  <path class="p4" d="M 1365 129 L 1357 122 L 1335 130 L 1344 135 L 1365 129"/>
+  <text x="1350" y="131" style="font-size:3px">4.81,0,0,0</text>
+  <path class="p4" d="M 1353 141 L 1344 135 L 1323 142 L 1332 148 L 1353 141"/>
+  <text x="1338" y="143" style="font-size:3px">4.82,0,0,0</text>
+  <path class="p4" d="M 1344 135 L 1335 130 L 1314 137 L 1323 142 L 1344 135"/>
+  <text x="1329" y="137" style="font-size:3px">4.83,0,0,0</text>
+  <path class="p4" d="M 1384 184 L 1375 178 L 1355 182 L 1364 188 L 1384 184"/>
+  <text x="1369" y="184" style="font-size:3px">4.84,0,0,0</text>
+  <path class="p4" d="M 1375 178 L 1367 171 L 1347 176 L 1355 182 L 1375 178"/>
+  <text x="1361" y="178" style="font-size:3px">4.85,0,0,0</text>
+  <path class="p4" d="M 1364 188 L 1355 182 L 1335 186 L 1343 192 L 1364 188"/>
+  <text x="1349" y="188" style="font-size:3px">4.86,0,0,0</text>
+  <path class="p4" d="M 1355 182 L 1347 176 L 1327 181 L 1335 186 L 1355 182"/>
+  <text x="1341" y="183" style="font-size:3px">4.87,0,0,0</text>
+  <path class="p4" d="M 1367 171 L 1358 165 L 1338 170 L 1347 176 L 1367 171"/>
+  <text x="1352" y="172" style="font-size:3px">4.88,0,0,0</text>
+  <path class="p4" d="M 1358 165 L 1350 159 L 1330 165 L 1338 170 L 1358 165"/>
+  <text x="1344" y="166" style="font-size:3px">4.89,0,0,0</text>
+  <path class="p4" d="M 1347 176 L 1338 170 L 1318 176 L 1327 181 L 1347 176"/>
+  <text x="1332" y="177" style="font-size:3px">4.90,0,0,0</text>
+  <path class="p4" d="M 1338 170 L 1330 165 L 1309 170 L 1318 176 L 1338 170"/>
+  <text x="1324" y="172" style="font-size:3px">4.91,0,0,0</text>
+  <path class="p4" d="M 1343 192 L 1335 186 L 1315 191 L 1323 196 L 1343 192"/>
+  <text x="1329" y="192" style="font-size:3px">4.92,0,0,0</text>
+  <path class="p4" d="M 1335 186 L 1327 181 L 1306 186 L 1315 191 L 1335 186"/>
+  <text x="1321" y="187" style="font-size:3px">4.93,0,0,0</text>
+  <path class="p4" d="M 1323 196 L 1315 191 L 1294 195 L 1302 200 L 1323 196"/>
+  <text x="1309" y="197" style="font-size:3px">4.94,0,0,0</text>
+  <line x1="1302" y1="200" x2="1294" y2="195"/>
+  <path class="p4" d="M 1315 191 L 1306 186 L 1286 190 L 1294 195 L 1315 191"/>
+  <text x="1300" y="192" style="font-size:3px">4.95,0,0,0</text>
+  <line x1="1294" y1="195" x2="1286" y2="190"/>
+  <path class="p4" d="M 1327 181 L 1318 176 L 1297 181 L 1306 186 L 1327 181"/>
+  <text x="1312" y="182" style="font-size:3px">4.96,0,0,0</text>
+  <path class="p4" d="M 1318 176 L 1309 170 L 1288 176 L 1297 181 L 1318 176"/>
+  <text x="1303" y="177" style="font-size:3px">4.97,0,0,0</text>
+  <path class="p4" d="M 1306 186 L 1297 181 L 1277 186 L 1286 190 L 1306 186"/>
+  <text x="1291" y="187" style="font-size:3px">4.98,0,0,0</text>
+  <line x1="1286" y1="190" x2="1277" y2="186"/>
+  <path class="p4" d="M 1297 181 L 1288 176 L 1267 182 L 1277 186 L 1297 181"/>
+  <text x="1282" y="183" style="font-size:3px">4.99,0,0,0</text>
+  <line x1="1277" y1="186" x2="1267" y2="182"/>
+  <path class="p4" d="M 1350 159 L 1341 153 L 1320 159 L 1330 165 L 1350 159"/>
+  <text x="1335" y="161" style="font-size:3px">4.100,0,0,0</text>
+  <path class="p4" d="M 1341 153 L 1332 148 L 1311 154 L 1320 159 L 1341 153"/>
+  <text x="1326" y="155" style="font-size:3px">4.101,0,0,0</text>
+  <path class="p4" d="M 1330 165 L 1320 159 L 1299 166 L 1309 170 L 1330 165"/>
+  <text x="1314" y="167" style="font-size:3px">4.102,0,0,0</text>
+  <path class="p4" d="M 1320 159 L 1311 154 L 1289 161 L 1299 166 L 1320 159"/>
+  <text x="1305" y="161" style="font-size:3px">4.103,0,0,0</text>
+  <path class="p4" d="M 1332 148 L 1323 142 L 1301 149 L 1311 154 L 1332 148"/>
+  <text x="1317" y="150" style="font-size:3px">4.104,0,0,0</text>
+  <path class="p4" d="M 1323 142 L 1314 137 L 1292 144 L 1301 149 L 1323 142"/>
+  <text x="1307" y="145" style="font-size:3px">4.105,0,0,0</text>
+  <path class="p4" d="M 1311 154 L 1301 149 L 1279 156 L 1289 161 L 1311 154"/>
+  <text x="1295" y="157" style="font-size:3px">4.106,0,0,0</text>
+  <path class="p4" d="M 1301 149 L 1292 144 L 1269 152 L 1279 156 L 1301 149"/>
+  <text x="1285" y="152" style="font-size:3px">4.107,0,0,0</text>
+  <path class="p4" d="M 1309 170 L 1299 166 L 1278 172 L 1288 176 L 1309 170"/>
+  <text x="1294" y="172" style="font-size:3px">4.108,0,0,0</text>
+  <path class="p4" d="M 1299 166 L 1289 161 L 1268 167 L 1278 172 L 1299 166"/>
+  <text x="1284" y="168" style="font-size:3px">4.109,0,0,0</text>
+  <path class="p4" d="M 1288 176 L 1278 172 L 1257 178 L 1267 182 L 1288 176"/>
+  <text x="1272" y="178" style="font-size:3px">4.110,0,0,0</text>
+  <line x1="1267" y1="182" x2="1257" y2="178"/>
+  <path class="p4" d="M 1278 172 L 1268 167 L 1246 174 L 1257 178 L 1278 172"/>
+  <text x="1262" y="174" style="font-size:3px">4.111,0,0,0</text>
+  <line x1="1257" y1="178" x2="1246" y2="174"/>
+  <path class="p4" d="M 1289 161 L 1279 156 L 1257 163 L 1268 167 L 1289 161"/>
+  <text x="1273" y="163" style="font-size:3px">4.112,0,0,0</text>
+  <path class="p4" d="M 1279 156 L 1269 152 L 1246 159 L 1257 163 L 1279 156"/>
+  <text x="1263" y="159" style="font-size:3px">4.113,0,0,0</text>
+  <path class="p4" d="M 1268 167 L 1257 163 L 1235 170 L 1246 174 L 1268 167"/>
+  <text x="1251" y="170" style="font-size:3px">4.114,0,0,0</text>
+  <line x1="1246" y1="174" x2="1235" y2="170"/>
+  <path class="p4" d="M 1257 163 L 1246 159 L 1223 167 L 1235 170 L 1257 163"/>
+  <text x="1240" y="166" style="font-size:3px">4.115,0,0,0</text>
+  <line x1="1235" y1="170" x2="1223" y2="167"/>
+  <path class="p4" d="M 1357 122 L 1335 121 L 1315 128 L 1335 130 L 1357 122"/>
+  <text x="1336" y="127" style="font-size:3px">4.116,0,0,0</text>
+  <path class="p4" d="M 1335 121 L 1313 119 L 1294 126 L 1315 128 L 1335 121"/>
+  <text x="1314" y="125" style="font-size:3px">4.117,0,0,0</text>
+  <path class="p4" d="M 1335 130 L 1315 128 L 1295 135 L 1314 137 L 1335 130"/>
+  <text x="1315" y="134" style="font-size:3px">4.118,0,0,0</text>
+  <path class="p4" d="M 1315 128 L 1294 126 L 1276 133 L 1295 135 L 1315 128"/>
+  <text x="1295" y="132" style="font-size:3px">4.119,0,0,0</text>
+  <path class="p4" d="M 1313 119 L 1291 118 L 1274 124 L 1294 126 L 1313 119"/>
+  <text x="1293" y="123" style="font-size:3px">4.120,0,0,0</text>
+  <path class="p4" d="M 1291 118 L 1269 116 L 1254 122 L 1274 124 L 1291 118"/>
+  <text x="1272" y="122" style="font-size:3px">4.121,0,0,0</text>
+  <path class="p4" d="M 1294 126 L 1274 124 L 1257 131 L 1276 133 L 1294 126"/>
+  <text x="1275" y="130" style="font-size:3px">4.122,0,0,0</text>
+  <path class="p4" d="M 1274 124 L 1254 122 L 1238 129 L 1257 131 L 1274 124"/>
+  <text x="1256" y="128" style="font-size:3px">4.123,0,0,0</text>
+  <path class="p4" d="M 1250 102 L 1226 101 L 1214 106 L 1238 108 L 1250 102"/>
+  <text x="1232" y="105" style="font-size:2px">4.124,0,0,0</text>
+  <path class="p4" d="M 1226 101 L 1201 100 L 1191 105 L 1214 106 L 1226 101"/>
+  <text x="1208" y="104" style="font-size:2px">4.125,0,0,0</text>
+  <path class="p4" d="M 1238 108 L 1214 106 L 1203 112 L 1225 113 L 1238 108"/>
+  <text x="1220" y="111" style="font-size:3px">4.126,0,0,0</text>
+  <path class="p4" d="M 1214 106 L 1191 105 L 1181 111 L 1203 112 L 1214 106"/>
+  <text x="1198" y="110" style="font-size:3px">4.127,0,0,0</text>
+  <path class="p4" d="M 1269 116 L 1247 115 L 1233 121 L 1254 122 L 1269 116"/>
+  <text x="1251" y="120" style="font-size:3px">4.128,0,0,0</text>
+  <path class="p4" d="M 1247 115 L 1225 113 L 1212 119 L 1233 121 L 1247 115"/>
+  <text x="1229" y="119" style="font-size:3px">4.129,0,0,0</text>
+  <path class="p4" d="M 1254 122 L 1233 121 L 1219 127 L 1238 129 L 1254 122"/>
+  <text x="1236" y="126" style="font-size:3px">4.130,0,0,0</text>
+  <path class="p4" d="M 1233 121 L 1212 119 L 1199 126 L 1219 127 L 1233 121"/>
+  <text x="1216" y="125" style="font-size:3px">4.131,0,0,0</text>
+  <path class="p4" d="M 1225 113 L 1203 112 L 1192 118 L 1212 119 L 1225 113"/>
+  <text x="1208" y="117" style="font-size:3px">4.132,0,0,0</text>
+  <path class="p4" d="M 1203 112 L 1181 111 L 1171 117 L 1192 118 L 1203 112"/>
+  <text x="1187" y="116" style="font-size:3px">4.133,0,0,0</text>
+  <path class="p4" d="M 1212 119 L 1192 118 L 1180 124 L 1199 126 L 1212 119"/>
+  <text x="1196" y="123" style="font-size:3px">4.134,0,0,0</text>
+  <path class="p4" d="M 1192 118 L 1171 117 L 1161 122 L 1180 124 L 1192 118"/>
+  <text x="1176" y="122" style="font-size:3px">4.135,0,0,0</text>
+  <path class="p4" d="M 1314 137 L 1295 135 L 1274 142 L 1292 144 L 1314 137"/>
+  <text x="1294" y="141" style="font-size:3px">4.136,0,0,0</text>
+  <path class="p4" d="M 1295 135 L 1276 133 L 1257 140 L 1274 142 L 1295 135"/>
+  <text x="1275" y="139" style="font-size:3px">4.137,0,0,0</text>
+  <path class="p4" d="M 1292 144 L 1274 142 L 1253 149 L 1269 152 L 1292 144"/>
+  <text x="1272" y="148" style="font-size:3px">4.138,0,0,0</text>
+  <path class="p4" d="M 1274 142 L 1257 140 L 1238 146 L 1253 149 L 1274 142"/>
+  <text x="1256" y="146" style="font-size:3px">4.139,0,0,0</text>
+  <path class="p4" d="M 1276 133 L 1257 131 L 1239 137 L 1257 140 L 1276 133"/>
+  <text x="1257" y="137" style="font-size:3px">4.140,0,0,0</text>
+  <path class="p4" d="M 1257 131 L 1238 129 L 1222 135 L 1239 137 L 1257 131"/>
+  <text x="1239" y="135" style="font-size:3px">4.141,0,0,0</text>
+  <path class="p4" d="M 1257 140 L 1239 137 L 1222 144 L 1238 146 L 1257 140"/>
+  <text x="1239" y="143" style="font-size:3px">4.142,0,0,0</text>
+  <path class="p4" d="M 1239 137 L 1222 135 L 1206 142 L 1222 144 L 1239 137"/>
+  <text x="1222" y="141" style="font-size:3px">4.143,0,0,0</text>
+  <path class="p4" d="M 1269 152 L 1253 149 L 1232 156 L 1246 159 L 1269 152"/>
+  <text x="1250" y="156" style="font-size:3px">4.144,0,0,0</text>
+  <path class="p4" d="M 1253 149 L 1238 146 L 1218 154 L 1232 156 L 1253 149"/>
+  <text x="1236" y="153" style="font-size:3px">4.145,0,0,0</text>
+  <path class="p4" d="M 1246 159 L 1232 156 L 1211 164 L 1223 167 L 1246 159"/>
+  <text x="1228" y="163" style="font-size:3px">4.146,0,0,0</text>
+  <line x1="1223" y1="167" x2="1211" y2="164"/>
+  <path class="p4" d="M 1232 156 L 1218 154 L 1199 161 L 1211 164 L 1232 156"/>
+  <text x="1215" y="160" style="font-size:3px">4.147,0,0,0</text>
+  <line x1="1211" y1="164" x2="1199" y2="161"/>
+  <path class="p4" d="M 1238 146 L 1222 144 L 1204 151 L 1218 154 L 1238 146"/>
+  <text x="1221" y="150" style="font-size:3px">4.148,0,0,0</text>
+  <path class="p4" d="M 1222 144 L 1206 142 L 1190 148 L 1204 151 L 1222 144"/>
+  <text x="1205" y="148" style="font-size:3px">4.149,0,0,0</text>
+  <path class="p4" d="M 1218 154 L 1204 151 L 1186 158 L 1199 161 L 1218 154"/>
+  <text x="1202" y="157" style="font-size:3px">4.150,0,0,0</text>
+  <line x1="1199" y1="161" x2="1186" y2="158"/>
+  <path class="p4" d="M 1204 151 L 1190 148 L 1173 155 L 1186 158 L 1204 151"/>
+  <text x="1188" y="155" style="font-size:3px">4.151,0,0,0</text>
+  <line x1="1186" y1="158" x2="1173" y2="155"/>
+  <path class="p4" d="M 1238 129 L 1219 127 L 1204 133 L 1222 135 L 1238 129"/>
+  <text x="1221" y="133" style="font-size:3px">4.152,0,0,0</text>
+  <path class="p4" d="M 1219 127 L 1199 126 L 1186 132 L 1204 133 L 1219 127"/>
+  <text x="1202" y="131" style="font-size:3px">4.153,0,0,0</text>
+  <path class="p4" d="M 1222 135 L 1204 133 L 1189 140 L 1206 142 L 1222 135"/>
+  <text x="1205" y="139" style="font-size:3px">4.154,0,0,0</text>
+  <path class="p4" d="M 1204 133 L 1186 132 L 1173 138 L 1189 140 L 1204 133"/>
+  <text x="1188" y="137" style="font-size:3px">4.155,0,0,0</text>
+  <path class="p4" d="M 1199 126 L 1180 124 L 1168 130 L 1186 132 L 1199 126"/>
+  <text x="1183" y="129" style="font-size:3px">4.156,0,0,0</text>
+  <path class="p4" d="M 1180 124 L 1161 122 L 1150 128 L 1168 130 L 1180 124"/>
+  <text x="1165" y="128" style="font-size:3px">4.157,0,0,0</text>
+  <path class="p4" d="M 1186 132 L 1168 130 L 1156 136 L 1173 138 L 1186 132"/>
+  <text x="1171" y="135" style="font-size:3px">4.158,0,0,0</text>
+  <path class="p4" d="M 1168 130 L 1150 128 L 1140 134 L 1156 136 L 1168 130"/>
+  <text x="1154" y="134" style="font-size:3px">4.159,0,0,0</text>
+  <path class="p4" d="M 1206 142 L 1189 140 L 1175 146 L 1190 148 L 1206 142"/>
+  <text x="1190" y="146" style="font-size:3px">4.160,0,0,0</text>
+  <path class="p4" d="M 1189 140 L 1173 138 L 1160 144 L 1175 146 L 1189 140"/>
+  <text x="1174" y="143" style="font-size:3px">4.161,0,0,0</text>
+  <path class="p4" d="M 1190 148 L 1175 146 L 1160 153 L 1173 155 L 1190 148"/>
+  <text x="1174" y="152" style="font-size:3px">4.162,0,0,0</text>
+  <line x1="1173" y1="155" x2="1160" y2="153"/>
+  <path class="p4" d="M 1175 146 L 1160 144 L 1146 150 L 1160 153 L 1175 146"/>
+  <text x="1160" y="150" style="font-size:3px">4.163,0,0,0</text>
+  <line x1="1160" y1="153" x2="1146" y2="150"/>
+  <path class="p4" d="M 1173 138 L 1156 136 L 1144 142 L 1160 144 L 1173 138"/>
+  <text x="1158" y="141" style="font-size:3px">4.164,0,0,0</text>
+  <path class="p4" d="M 1156 136 L 1140 134 L 1129 140 L 1144 142 L 1156 136"/>
+  <text x="1142" y="140" style="font-size:3px">4.165,0,0,0</text>
+  <path class="p4" d="M 1160 144 L 1144 142 L 1132 148 L 1146 150 L 1160 144"/>
+  <text x="1145" y="148" style="font-size:3px">4.166,0,0,0</text>
+  <line x1="1146" y1="150" x2="1132" y2="148"/>
+  <path class="p4" d="M 1144 142 L 1129 140 L 1118 147 L 1132 148 L 1144 142"/>
+  <text x="1131" y="146" style="font-size:3px">4.167,0,0,0</text>
+  <line x1="1132" y1="148" x2="1118" y2="147"/>
+  <path class="p4" d="M 1201 100 L 1176 99 L 1167 105 L 1191 105 L 1201 100"/>
+  <text x="1184" y="103" style="font-size:2px">4.168,0,0,0</text>
+  <path class="p4" d="M 1176 99 L 1151 99 L 1143 104 L 1167 105 L 1176 99"/>
+  <text x="1159" y="103" style="font-size:2px">4.169,0,0,0</text>
+  <path class="p4" d="M 1191 105 L 1167 105 L 1159 110 L 1181 111 L 1191 105"/>
+  <text x="1175" y="109" style="font-size:3px">4.170,0,0,0</text>
+  <path class="p4" d="M 1167 105 L 1143 104 L 1136 110 L 1159 110 L 1167 105"/>
+  <text x="1151" y="109" style="font-size:3px">4.171,0,0,0</text>
+  <path class="p4" d="M 1151 99 L 1126 98 L 1119 104 L 1143 104 L 1151 99"/>
+  <text x="1135" y="102" style="font-size:2px">4.172,0,0,0</text>
+  <path class="p4" d="M 1126 98 L 1100 98 L 1096 103 L 1119 104 L 1126 98"/>
+  <text x="1110" y="102" style="font-size:2px">4.173,0,0,0</text>
+  <path class="p4" d="M 1143 104 L 1119 104 L 1113 109 L 1136 110 L 1143 104"/>
+  <text x="1128" y="108" style="font-size:3px">4.174,0,0,0</text>
+  <path class="p4" d="M 1119 104 L 1096 103 L 1091 108 L 1113 109 L 1119 104"/>
+  <text x="1105" y="108" style="font-size:3px">4.175,0,0,0</text>
+  <path class="p4" d="M 1181 111 L 1159 110 L 1150 116 L 1171 117 L 1181 111"/>
+  <text x="1165" y="115" style="font-size:3px">4.176,0,0,0</text>
+  <path class="p4" d="M 1159 110 L 1136 110 L 1128 115 L 1150 116 L 1159 110"/>
+  <text x="1143" y="114" style="font-size:3px">4.177,0,0,0</text>
+  <path class="p4" d="M 1171 117 L 1150 116 L 1141 122 L 1161 122 L 1171 117"/>
+  <text x="1156" y="121" style="font-size:3px">4.178,0,0,0</text>
+  <path class="p4" d="M 1150 116 L 1128 115 L 1121 121 L 1141 122 L 1150 116"/>
+  <text x="1135" y="120" style="font-size:3px">4.179,0,0,0</text>
+  <path class="p4" d="M 1136 110 L 1113 109 L 1107 114 L 1128 115 L 1136 110"/>
+  <text x="1121" y="113" style="font-size:3px">4.180,0,0,0</text>
+  <path class="p4" d="M 1113 109 L 1091 108 L 1086 114 L 1107 114 L 1113 109"/>
+  <text x="1099" y="113" style="font-size:3px">4.181,0,0,0</text>
+  <path class="p4" d="M 1128 115 L 1107 114 L 1101 120 L 1121 121 L 1128 115"/>
+  <text x="1114" y="119" style="font-size:3px">4.182,0,0,0</text>
+  <path class="p4" d="M 1107 114 L 1086 114 L 1081 119 L 1101 120 L 1107 114"/>
+  <text x="1093" y="118" style="font-size:3px">4.183,0,0,0</text>
+  <path class="p4" d="M 1100 98 L 1075 98 L 1072 103 L 1096 103 L 1100 98"/>
+  <text x="1086" y="101" style="font-size:2px">4.184,0,0,0</text>
+  <path class="p4" d="M 1075 98 L 1050 97 L 1048 102 L 1072 103 L 1075 98"/>
+  <text x="1061" y="101" style="font-size:2px">4.185,0,0,0</text>
+  <path class="p4" d="M 1096 103 L 1072 103 L 1068 108 L 1091 108 L 1096 103"/>
+  <text x="1081" y="107" style="font-size:3px">4.186,0,0,0</text>
+  <path class="p4" d="M 1072 103 L 1048 102 L 1045 108 L 1068 108 L 1072 103"/>
+  <text x="1058" y="107" style="font-size:3px">4.187,0,0,0</text>
+  <path class="p4" d="M 1050 97 L 1025 97 L 1024 102 L 1048 102 L 1050 97"/>
+  <text x="1037" y="101" style="font-size:2px">4.188,0,0,0</text>
+  <path class="p4" d="M 1025 97 L 1000 96 L 1000 102 L 1024 102 L 1025 97"/>
+  <text x="1012" y="100" style="font-size:2px">4.189,0,0,0</text>
+  <path class="p4" d="M 1048 102 L 1024 102 L 1023 107 L 1045 108 L 1048 102"/>
+  <text x="1035" y="106" style="font-size:3px">4.190,0,0,0</text>
+  <path class="p4" d="M 1024 102 L 1000 102 L 1000 107 L 1023 107 L 1024 102"/>
+  <text x="1012" y="106" style="font-size:3px">4.191,0,0,0</text>
+  <path class="p4" d="M 1091 108 L 1068 108 L 1064 113 L 1086 114 L 1091 108"/>
+  <text x="1077" y="112" style="font-size:3px">4.192,0,0,0</text>
+  <path class="p4" d="M 1068 108 L 1045 108 L 1043 113 L 1064 113 L 1068 108"/>
+  <text x="1055" y="112" style="font-size:3px">4.193,0,0,0</text>
+  <path class="p4" d="M 1086 114 L 1064 113 L 1060 119 L 1081 119 L 1086 114"/>
+  <text x="1073" y="118" style="font-size:3px">4.194,0,0,0</text>
+  <path class="p4" d="M 1064 113 L 1043 113 L 1040 118 L 1060 119 L 1064 113"/>
+  <text x="1052" y="117" style="font-size:3px">4.195,0,0,0</text>
+  <path class="p4" d="M 1045 108 L 1023 107 L 1021 112 L 1043 113 L 1045 108"/>
+  <text x="1033" y="112" style="font-size:3px">4.196,0,0,0</text>
+  <path class="p4" d="M 1023 107 L 1000 107 L 1000 112 L 1021 112 L 1023 107"/>
+  <text x="1011" y="111" style="font-size:3px">4.197,0,0,0</text>
+  <path class="p4" d="M 1043 113 L 1021 112 L 1020 118 L 1040 118 L 1043 113"/>
+  <text x="1031" y="117" style="font-size:3px">4.198,0,0,0</text>
+  <path class="p4" d="M 1021 112 L 1000 112 L 1000 117 L 1020 118 L 1021 112"/>
+  <text x="1010" y="116" style="font-size:3px">4.199,0,0,0</text>
+  <path class="p4" d="M 1161 122 L 1141 122 L 1132 127 L 1150 128 L 1161 122"/>
+  <text x="1146" y="126" style="font-size:3px">4.200,0,0,0</text>
+  <path class="p4" d="M 1141 122 L 1121 121 L 1113 126 L 1132 127 L 1141 122"/>
+  <text x="1126" y="125" style="font-size:3px">4.201,0,0,0</text>
+  <path class="p4" d="M 1150 128 L 1132 127 L 1122 133 L 1140 134 L 1150 128"/>
+  <text x="1136" y="132" style="font-size:3px">4.202,0,0,0</text>
+  <path class="p4" d="M 1132 127 L 1113 126 L 1105 132 L 1122 133 L 1132 127"/>
+  <text x="1118" y="131" style="font-size:3px">4.203,0,0,0</text>
+  <path class="p4" d="M 1121 121 L 1101 120 L 1094 125 L 1113 126 L 1121 121"/>
+  <text x="1107" y="125" style="font-size:3px">4.204,0,0,0</text>
+  <path class="p4" d="M 1101 120 L 1081 119 L 1075 124 L 1094 125 L 1101 120"/>
+  <text x="1088" y="124" style="font-size:3px">4.205,0,0,0</text>
+  <path class="p4" d="M 1113 126 L 1094 125 L 1088 131 L 1105 132 L 1113 126"/>
+  <text x="1100" y="130" style="font-size:3px">4.206,0,0,0</text>
+  <path class="p4" d="M 1094 125 L 1075 124 L 1070 130 L 1088 131 L 1094 125"/>
+  <text x="1082" y="129" style="font-size:3px">4.207,0,0,0</text>
+  <path class="p4" d="M 1140 134 L 1122 133 L 1113 139 L 1129 140 L 1140 134"/>
+  <text x="1126" y="138" style="font-size:3px">4.208,0,0,0</text>
+  <path class="p4" d="M 1122 133 L 1105 132 L 1097 138 L 1113 139 L 1122 133"/>
+  <text x="1109" y="137" style="font-size:3px">4.209,0,0,0</text>
+  <path class="p4" d="M 1129 140 L 1113 139 L 1104 145 L 1118 147 L 1129 140"/>
+  <text x="1116" y="144" style="font-size:3px">4.210,0,0,0</text>
+  <line x1="1118" y1="147" x2="1104" y2="145"/>
+  <path class="p4" d="M 1113 139 L 1097 138 L 1089 143 L 1104 145 L 1113 139"/>
+  <text x="1101" y="143" style="font-size:3px">4.211,0,0,0</text>
+  <line x1="1104" y1="145" x2="1089" y2="143"/>
+  <path class="p4" d="M 1105 132 L 1088 131 L 1081 137 L 1097 138 L 1105 132"/>
+  <text x="1093" y="136" style="font-size:3px">4.212,0,0,0</text>
+  <path class="p4" d="M 1088 131 L 1070 130 L 1065 136 L 1081 137 L 1088 131"/>
+  <text x="1076" y="135" style="font-size:3px">4.213,0,0,0</text>
+  <path class="p4" d="M 1097 138 L 1081 137 L 1074 142 L 1089 143 L 1097 138"/>
+  <text x="1085" y="141" style="font-size:3px">4.214,0,0,0</text>
+  <line x1="1089" y1="143" x2="1074" y2="142"/>
+  <path class="p4" d="M 1081 137 L 1065 136 L 1060 141 L 1074 142 L 1081 137"/>
+  <text x="1070" y="140" style="font-size:3px">4.215,0,0,0</text>
+  <line x1="1074" y1="142" x2="1060" y2="141"/>
+  <path class="p4" d="M 1081 119 L 1060 119 L 1057 124 L 1075 124 L 1081 119"/>
+  <text x="1068" y="123" style="font-size:3px">4.216,0,0,0</text>
+  <path class="p4" d="M 1060 119 L 1040 118 L 1038 124 L 1057 124 L 1060 119"/>
+  <text x="1049" y="123" style="font-size:3px">4.217,0,0,0</text>
+  <path class="p4" d="M 1075 124 L 1057 124 L 1053 129 L 1070 130 L 1075 124"/>
+  <text x="1064" y="128" style="font-size:3px">4.218,0,0,0</text>
+  <path class="p4" d="M 1057 124 L 1038 124 L 1035 129 L 1053 129 L 1057 124"/>
+  <text x="1046" y="128" style="font-size:3px">4.219,0,0,0</text>
+  <path class="p4" d="M 1040 118 L 1020 118 L 1019 123 L 1038 124 L 1040 118"/>
+  <text x="1029" y="122" style="font-size:3px">4.220,0,0,0</text>
+  <path class="p4" d="M 1020 118 L 1000 117 L 1000 123 L 1019 123 L 1020 118"/>
+  <text x="1010" y="122" style="font-size:3px">4.221,0,0,0</text>
+  <path class="p4" d="M 1038 124 L 1019 123 L 1018 129 L 1035 129 L 1038 124"/>
+  <text x="1027" y="128" style="font-size:3px">4.222,0,0,0</text>
+  <path class="p4" d="M 1019 123 L 1000 123 L 1000 128 L 1018 129 L 1019 123"/>
+  <text x="1009" y="127" style="font-size:3px">4.223,0,0,0</text>
+  <path class="p4" d="M 1070 130 L 1053 129 L 1049 135 L 1065 136 L 1070 130"/>
+  <text x="1059" y="134" style="font-size:3px">4.224,0,0,0</text>
+  <path class="p4" d="M 1053 129 L 1035 129 L 1033 134 L 1049 135 L 1053 129"/>
+  <text x="1042" y="133" style="font-size:3px">4.225,0,0,0</text>
+  <path class="p4" d="M 1065 136 L 1049 135 L 1045 141 L 1060 141 L 1065 136"/>
+  <text x="1055" y="140" style="font-size:3px">4.226,0,0,0</text>
+  <line x1="1060" y1="141" x2="1045" y2="141"/>
+  <path class="p4" d="M 1049 135 L 1033 134 L 1030 140 L 1045 141 L 1049 135"/>
+  <text x="1039" y="139" style="font-size:3px">4.227,0,0,0</text>
+  <line x1="1045" y1="141" x2="1030" y2="140"/>
+  <path class="p4" d="M 1035 129 L 1018 129 L 1016 134 L 1033 134 L 1035 129"/>
+  <text x="1025" y="133" style="font-size:3px">4.228,0,0,0</text>
+  <path class="p4" d="M 1018 129 L 1000 128 L 1000 134 L 1016 134 L 1018 129"/>
+  <text x="1008" y="133" style="font-size:3px">4.229,0,0,0</text>
+  <path class="p4" d="M 1033 134 L 1016 134 L 1015 140 L 1030 140 L 1033 134"/>
+  <text x="1023" y="139" style="font-size:3px">4.230,0,0,0</text>
+  <line x1="1030" y1="140" x2="1015" y2="140"/>
+  <path class="p4" d="M 1016 134 L 1000 134 L 1000 140 L 1015 140 L 1016 134"/>
+  <text x="1008" y="138" style="font-size:3px">4.231,0,0,0</text>
+  <line x1="1015" y1="140" x2="1000" y2="140"/>
+  <path class="p4" d="M 1000 96 L 975 97 L 976 102 L 1000 102 L 1000 96"/>
+  <text x="988" y="100" style="font-size:2px">4.232,0,0,0</text>
+  <path class="p4" d="M 975 97 L 950 97 L 952 102 L 976 102 L 975 97"/>
+  <text x="963" y="101" style="font-size:2px">4.233,0,0,0</text>
+  <path class="p4" d="M 1000 102 L 976 102 L 977 107 L 1000 107 L 1000 102"/>
+  <text x="988" y="106" style="font-size:3px">4.234,0,0,0</text>
+  <path class="p4" d="M 976 102 L 952 102 L 955 108 L 977 107 L 976 102"/>
+  <text x="965" y="106" style="font-size:3px">4.235,0,0,0</text>
+  <path class="p4" d="M 950 97 L 925 98 L 928 103 L 952 102 L 950 97"/>
+  <text x="939" y="101" style="font-size:2px">4.236,0,0,0</text>
+  <path class="p4" d="M 925 98 L 900 98 L 904 103 L 928 103 L 925 98"/>
+  <text x="914" y="101" style="font-size:2px">4.237,0,0,0</text>
+  <path class="p4" d="M 952 102 L 928 103 L 932 108 L 955 108 L 952 102"/>
+  <text x="942" y="107" style="font-size:3px">4.238,0,0,0</text>
+  <path class="p4" d="M 928 103 L 904 103 L 909 108 L 932 108 L 928 103"/>
+  <text x="919" y="107" style="font-size:3px">4.239,0,0,0</text>
+  <path class="p4" d="M 1000 107 L 977 107 L 979 112 L 1000 112 L 1000 107"/>
+  <text x="989" y="111" style="font-size:3px">4.240,0,0,0</text>
+  <path class="p4" d="M 977 107 L 955 108 L 957 113 L 979 112 L 977 107"/>
+  <text x="967" y="112" style="font-size:3px">4.241,0,0,0</text>
+  <path class="p4" d="M 1000 112 L 979 112 L 980 118 L 1000 117 L 1000 112"/>
+  <text x="990" y="116" style="font-size:3px">4.242,0,0,0</text>
+  <path class="p4" d="M 979 112 L 957 113 L 960 118 L 980 118 L 979 112"/>
+  <text x="969" y="117" style="font-size:3px">4.243,0,0,0</text>
+  <path class="p4" d="M 955 108 L 932 108 L 936 113 L 957 113 L 955 108"/>
+  <text x="945" y="112" style="font-size:3px">4.244,0,0,0</text>
+  <path class="p4" d="M 932 108 L 909 108 L 914 114 L 936 113 L 932 108"/>
+  <text x="923" y="112" style="font-size:3px">4.245,0,0,0</text>
+  <path class="p4" d="M 957 113 L 936 113 L 940 119 L 960 118 L 957 113"/>
+  <text x="948" y="117" style="font-size:3px">4.246,0,0,0</text>
+  <path class="p4" d="M 936 113 L 914 114 L 919 119 L 940 119 L 936 113"/>
+  <text x="927" y="118" style="font-size:3px">4.247,0,0,0</text>
+  <path class="p4" d="M 900 98 L 874 98 L 881 104 L 904 103 L 900 98"/>
+  <text x="890" y="102" style="font-size:2px">4.248,0,0,0</text>
+  <path class="p4" d="M 874 98 L 849 99 L 857 104 L 881 104 L 874 98"/>
+  <text x="865" y="102" style="font-size:2px">4.249,0,0,0</text>
+  <path class="p4" d="M 904 103 L 881 104 L 887 109 L 909 108 L 904 103"/>
+  <text x="895" y="108" style="font-size:3px">4.250,0,0,0</text>
+  <path class="p4" d="M 881 104 L 857 104 L 864 110 L 887 109 L 881 104"/>
+  <text x="872" y="108" style="font-size:3px">4.251,0,0,0</text>
+  <path class="p4" d="M 849 99 L 824 99 L 833 105 L 857 104 L 849 99"/>
+  <text x="841" y="103" style="font-size:2px">4.252,0,0,0</text>
+  <path class="p4" d="M 824 99 L 799 100 L 809 105 L 833 105 L 824 99"/>
+  <text x="816" y="103" style="font-size:2px">4.253,0,0,0</text>
+  <path class="p4" d="M 857 104 L 833 105 L 841 110 L 864 110 L 857 104"/>
+  <text x="849" y="109" style="font-size:3px">4.254,0,0,0</text>
+  <path class="p4" d="M 833 105 L 809 105 L 819 111 L 841 110 L 833 105"/>
+  <text x="825" y="109" style="font-size:3px">4.255,0,0,0</text>
+  <path class="p4" d="M 909 108 L 887 109 L 893 114 L 914 114 L 909 108"/>
+  <text x="901" y="113" style="font-size:3px">4.256,0,0,0</text>
+  <path class="p4" d="M 887 109 L 864 110 L 872 115 L 893 114 L 887 109"/>
+  <text x="879" y="113" style="font-size:3px">4.257,0,0,0</text>
+  <path class="p4" d="M 914 114 L 893 114 L 899 120 L 919 119 L 914 114"/>
+  <text x="907" y="118" style="font-size:3px">4.258,0,0,0</text>
+  <path class="p4" d="M 893 114 L 872 115 L 879 121 L 899 120 L 893 114"/>
+  <text x="886" y="119" style="font-size:3px">4.259,0,0,0</text>
+  <path class="p4" d="M 864 110 L 841 110 L 850 116 L 872 115 L 864 110"/>
+  <text x="857" y="114" style="font-size:3px">4.260,0,0,0</text>
+  <path class="p4" d="M 841 110 L 819 111 L 829 117 L 850 116 L 841 110"/>
+  <text x="835" y="115" style="font-size:3px">4.261,0,0,0</text>
+  <path class="p4" d="M 872 115 L 850 116 L 859 122 L 879 121 L 872 115"/>
+  <text x="865" y="120" style="font-size:3px">4.262,0,0,0</text>
+  <path class="p4" d="M 850 116 L 829 117 L 839 122 L 859 122 L 850 116"/>
+  <text x="844" y="121" style="font-size:3px">4.263,0,0,0</text>
+  <path class="p4" d="M 1000 117 L 980 118 L 981 123 L 1000 123 L 1000 117"/>
+  <text x="990" y="122" style="font-size:3px">4.264,0,0,0</text>
+  <path class="p4" d="M 980 118 L 960 118 L 962 124 L 981 123 L 980 118"/>
+  <text x="971" y="122" style="font-size:3px">4.265,0,0,0</text>
+  <path class="p4" d="M 1000 123 L 981 123 L 982 129 L 1000 128 L 1000 123"/>
+  <text x="991" y="127" style="font-size:3px">4.266,0,0,0</text>
+  <path class="p4" d="M 981 123 L 962 124 L 965 129 L 982 129 L 981 123"/>
+  <text x="973" y="128" style="font-size:3px">4.267,0,0,0</text>
+  <path class="p4" d="M 960 118 L 940 119 L 943 124 L 962 124 L 960 118"/>
+  <text x="951" y="123" style="font-size:3px">4.268,0,0,0</text>
+  <path class="p4" d="M 940 119 L 919 119 L 925 124 L 943 124 L 940 119"/>
+  <text x="932" y="123" style="font-size:3px">4.269,0,0,0</text>
+  <path class="p4" d="M 962 124 L 943 124 L 947 129 L 965 129 L 962 124"/>
+  <text x="954" y="128" style="font-size:3px">4.270,0,0,0</text>
+  <path class="p4" d="M 943 124 L 925 124 L 930 130 L 947 129 L 943 124"/>
+  <text x="936" y="128" style="font-size:3px">4.271,0,0,0</text>
+  <path class="p4" d="M 1000 128 L 982 129 L 984 134 L 1000 134 L 1000 128"/>
+  <text x="992" y="133" style="font-size:3px">4.272,0,0,0</text>
+  <path class="p4" d="M 982 129 L 965 129 L 967 134 L 984 134 L 982 129"/>
+  <text x="975" y="133" style="font-size:3px">4.273,0,0,0</text>
+  <path class="p4" d="M 1000 134 L 984 134 L 985 140 L 1000 140 L 1000 134"/>
+  <text x="992" y="138" style="font-size:3px">4.274,0,0,0</text>
+  <line x1="1000" y1="140" x2="985" y2="140"/>
+  <path class="p4" d="M 984 134 L 967 134 L 970 140 L 985 140 L 984 134"/>
+  <text x="977" y="139" style="font-size:3px">4.275,0,0,0</text>
+  <line x1="985" y1="140" x2="970" y2="140"/>
+  <path class="p4" d="M 965 129 L 947 129 L 951 135 L 967 134 L 965 129"/>
+  <text x="958" y="133" style="font-size:3px">4.276,0,0,0</text>
+  <path class="p4" d="M 947 129 L 930 130 L 935 136 L 951 135 L 947 129"/>
+  <text x="941" y="134" style="font-size:3px">4.277,0,0,0</text>
+  <path class="p4" d="M 967 134 L 951 135 L 955 141 L 970 140 L 967 134"/>
+  <text x="961" y="139" style="font-size:3px">4.278,0,0,0</text>
+  <line x1="970" y1="140" x2="955" y2="141"/>
+  <path class="p4" d="M 951 135 L 935 136 L 940 141 L 955 141 L 951 135"/>
+  <text x="945" y="140" style="font-size:3px">4.279,0,0,0</text>
+  <line x1="955" y1="141" x2="940" y2="141"/>
+  <path class="p4" d="M 919 119 L 899 120 L 906 125 L 925 124 L 919 119"/>
+  <text x="912" y="124" style="font-size:3px">4.280,0,0,0</text>
+  <path class="p4" d="M 899 120 L 879 121 L 887 126 L 906 125 L 899 120"/>
+  <text x="893" y="125" style="font-size:3px">4.281,0,0,0</text>
+  <path class="p4" d="M 925 124 L 906 125 L 912 131 L 930 130 L 925 124"/>
+  <text x="918" y="129" style="font-size:3px">4.282,0,0,0</text>
+  <path class="p4" d="M 906 125 L 887 126 L 895 132 L 912 131 L 906 125"/>
+  <text x="900" y="130" style="font-size:3px">4.283,0,0,0</text>
+  <path class="p4" d="M 879 121 L 859 122 L 868 127 L 887 126 L 879 121"/>
+  <text x="874" y="125" style="font-size:3px">4.284,0,0,0</text>
+  <path class="p4" d="M 859 122 L 839 122 L 850 128 L 868 127 L 859 122"/>
+  <text x="854" y="126" style="font-size:3px">4.285,0,0,0</text>
+  <path class="p4" d="M 887 126 L 868 127 L 878 133 L 895 132 L 887 126"/>
+  <text x="882" y="131" style="font-size:3px">4.286,0,0,0</text>
+  <path class="p4" d="M 868 127 L 850 128 L 860 134 L 878 133 L 868 127"/>
+  <text x="864" y="132" style="font-size:3px">4.287,0,0,0</text>
+  <path class="p4" d="M 930 130 L 912 131 L 919 137 L 935 136 L 930 130"/>
+  <text x="924" y="135" style="font-size:3px">4.288,0,0,0</text>
+  <path class="p4" d="M 912 131 L 895 132 L 903 138 L 919 137 L 912 131"/>
+  <text x="907" y="136" style="font-size:3px">4.289,0,0,0</text>
+  <path class="p4" d="M 935 136 L 919 137 L 926 142 L 940 141 L 935 136"/>
+  <text x="930" y="140" style="font-size:3px">4.290,0,0,0</text>
+  <line x1="940" y1="141" x2="926" y2="142"/>
+  <path class="p4" d="M 919 137 L 903 138 L 911 143 L 926 142 L 919 137"/>
+  <text x="915" y="141" style="font-size:3px">4.291,0,0,0</text>
+  <line x1="926" y1="142" x2="911" y2="143"/>
+  <path class="p4" d="M 895 132 L 878 133 L 887 139 L 903 138 L 895 132"/>
+  <text x="891" y="137" style="font-size:3px">4.292,0,0,0</text>
+  <path class="p4" d="M 878 133 L 860 134 L 871 140 L 887 139 L 878 133"/>
+  <text x="874" y="138" style="font-size:3px">4.293,0,0,0</text>
+  <path class="p4" d="M 903 138 L 887 139 L 896 145 L 911 143 L 903 138"/>
+  <text x="899" y="143" style="font-size:3px">4.294,0,0,0</text>
+  <line x1="911" y1="143" x2="896" y2="145"/>
+  <path class="p4" d="M 887 139 L 871 140 L 882 147 L 896 145 L 887 139"/>
+  <text x="884" y="144" style="font-size:3px">4.295,0,0,0</text>
+  <line x1="896" y1="145" x2="882" y2="147"/>
+  <path class="p4" d="M 799 100 L 774 101 L 786 106 L 809 105 L 799 100"/>
+  <text x="792" y="104" style="font-size:2px">4.296,0,0,0</text>
+  <path class="p4" d="M 774 101 L 750 102 L 762 108 L 786 106 L 774 101"/>
+  <text x="768" y="105" style="font-size:2px">4.297,0,0,0</text>
+  <path class="p4" d="M 809 105 L 786 106 L 797 112 L 819 111 L 809 105"/>
+  <text x="802" y="110" style="font-size:3px">4.298,0,0,0</text>
+  <path class="p4" d="M 786 106 L 762 108 L 775 113 L 797 112 L 786 106"/>
+  <text x="780" y="111" style="font-size:3px">4.299,0,0,0</text>
+  <path class="p4" d="M 819 111 L 797 112 L 808 118 L 829 117 L 819 111"/>
+  <text x="813" y="116" style="font-size:3px">4.300,0,0,0</text>
+  <path class="p4" d="M 797 112 L 775 113 L 788 119 L 808 118 L 797 112"/>
+  <text x="792" y="117" style="font-size:3px">4.301,0,0,0</text>
+  <path class="p4" d="M 829 117 L 808 118 L 820 124 L 839 122 L 829 117"/>
+  <text x="824" y="122" style="font-size:3px">4.302,0,0,0</text>
+  <path class="p4" d="M 808 118 L 788 119 L 801 126 L 820 124 L 808 118"/>
+  <text x="804" y="123" style="font-size:3px">4.303,0,0,0</text>
+  <path class="p4" d="M 775 113 L 753 115 L 767 121 L 788 119 L 775 113"/>
+  <text x="771" y="119" style="font-size:3px">4.304,0,0,0</text>
+  <path class="p4" d="M 753 115 L 731 116 L 746 122 L 767 121 L 753 115"/>
+  <text x="749" y="120" style="font-size:3px">4.305,0,0,0</text>
+  <path class="p4" d="M 788 119 L 767 121 L 781 127 L 801 126 L 788 119"/>
+  <text x="784" y="125" style="font-size:3px">4.306,0,0,0</text>
+  <path class="p4" d="M 767 121 L 746 122 L 762 129 L 781 127 L 767 121"/>
+  <text x="764" y="126" style="font-size:3px">4.307,0,0,0</text>
+  <path class="p4" d="M 731 116 L 709 118 L 726 124 L 746 122 L 731 116"/>
+  <text x="728" y="122" style="font-size:3px">4.308,0,0,0</text>
+  <path class="p4" d="M 709 118 L 687 119 L 706 126 L 726 124 L 709 118"/>
+  <text x="707" y="123" style="font-size:3px">4.309,0,0,0</text>
+  <path class="p4" d="M 746 122 L 726 124 L 743 131 L 762 129 L 746 122"/>
+  <text x="744" y="128" style="font-size:3px">4.310,0,0,0</text>
+  <path class="p4" d="M 726 124 L 706 126 L 724 133 L 743 131 L 726 124"/>
+  <text x="725" y="130" style="font-size:3px">4.311,0,0,0</text>
+  <path class="p4" d="M 687 119 L 665 121 L 685 128 L 706 126 L 687 119"/>
+  <text x="686" y="125" style="font-size:3px">4.312,0,0,0</text>
+  <path class="p4" d="M 665 121 L 643 122 L 665 130 L 685 128 L 665 121"/>
+  <text x="664" y="127" style="font-size:3px">4.313,0,0,0</text>
+  <path class="p4" d="M 706 126 L 685 128 L 705 135 L 724 133 L 706 126"/>
+  <text x="705" y="132" style="font-size:3px">4.314,0,0,0</text>
+  <path class="p4" d="M 685 128 L 665 130 L 686 137 L 705 135 L 685 128"/>
+  <text x="685" y="134" style="font-size:3px">4.315,0,0,0</text>
+  <path class="p4" d="M 839 122 L 820 124 L 832 130 L 850 128 L 839 122"/>
+  <text x="835" y="128" style="font-size:3px">4.316,0,0,0</text>
+  <path class="p4" d="M 820 124 L 801 126 L 814 132 L 832 130 L 820 124"/>
+  <text x="817" y="129" style="font-size:3px">4.317,0,0,0</text>
+  <path class="p4" d="M 850 128 L 832 130 L 844 136 L 860 134 L 850 128"/>
+  <text x="846" y="134" style="font-size:3px">4.318,0,0,0</text>
+  <path class="p4" d="M 832 130 L 814 132 L 827 138 L 844 136 L 832 130"/>
+  <text x="829" y="135" style="font-size:3px">4.319,0,0,0</text>
+  <path class="p4" d="M 801 126 L 781 127 L 796 133 L 814 132 L 801 126"/>
+  <text x="798" y="131" style="font-size:3px">4.320,0,0,0</text>
+  <path class="p4" d="M 781 127 L 762 129 L 778 135 L 796 133 L 781 127"/>
+  <text x="779" y="133" style="font-size:3px">4.321,0,0,0</text>
+  <path class="p4" d="M 814 132 L 796 133 L 811 140 L 827 138 L 814 132"/>
+  <text x="812" y="137" style="font-size:3px">4.322,0,0,0</text>
+  <path class="p4" d="M 796 133 L 778 135 L 794 142 L 811 140 L 796 133"/>
+  <text x="795" y="139" style="font-size:3px">4.323,0,0,0</text>
+  <path class="p4" d="M 860 134 L 844 136 L 856 142 L 871 140 L 860 134"/>
+  <text x="858" y="140" style="font-size:3px">4.324,0,0,0</text>
+  <path class="p4" d="M 844 136 L 827 138 L 840 144 L 856 142 L 844 136"/>
+  <text x="842" y="141" style="font-size:3px">4.325,0,0,0</text>
+  <path class="p4" d="M 871 140 L 856 142 L 868 148 L 882 147 L 871 140"/>
+  <text x="869" y="146" style="font-size:3px">4.326,0,0,0</text>
+  <line x1="882" y1="147" x2="868" y2="148"/>
+  <path class="p4" d="M 856 142 L 840 144 L 854 150 L 868 148 L 856 142"/>
+  <text x="855" y="148" style="font-size:3px">4.327,0,0,0</text>
+  <line x1="868" y1="148" x2="854" y2="150"/>
+  <path class="p4" d="M 827 138 L 811 140 L 825 146 L 840 144 L 827 138"/>
+  <text x="826" y="143" style="font-size:3px">4.328,0,0,0</text>
+  <path class="p4" d="M 811 140 L 794 142 L 810 148 L 825 146 L 811 140"/>
+  <text x="810" y="146" style="font-size:3px">4.329,0,0,0</text>
+  <path class="p4" d="M 840 144 L 825 146 L 840 153 L 854 150 L 840 144"/>
+  <text x="840" y="150" style="font-size:3px">4.330,0,0,0</text>
+  <line x1="854" y1="150" x2="840" y2="153"/>
+  <path class="p4" d="M 825 146 L 810 148 L 827 155 L 840 153 L 825 146"/>
+  <text x="826" y="152" style="font-size:3px">4.331,0,0,0</text>
+  <line x1="840" y1="153" x2="827" y2="155"/>
+  <path class="p4" d="M 762 129 L 743 131 L 761 137 L 778 135 L 762 129"/>
+  <text x="761" y="135" style="font-size:3px">4.332,0,0,0</text>
+  <path class="p4" d="M 743 131 L 724 133 L 743 140 L 761 137 L 743 131"/>
+  <text x="743" y="137" style="font-size:3px">4.333,0,0,0</text>
+  <path class="p4" d="M 778 135 L 761 137 L 778 144 L 794 142 L 778 135"/>
+  <text x="778" y="141" style="font-size:3px">4.334,0,0,0</text>
+  <path class="p4" d="M 761 137 L 743 140 L 762 146 L 778 144 L 761 137"/>
+  <text x="761" y="143" style="font-size:3px">4.335,0,0,0</text>
+  <path class="p4" d="M 724 133 L 705 135 L 726 142 L 743 140 L 724 133"/>
+  <text x="725" y="139" style="font-size:3px">4.336,0,0,0</text>
+  <path class="p4" d="M 705 135 L 686 137 L 708 144 L 726 142 L 705 135"/>
+  <text x="706" y="141" style="font-size:3px">4.337,0,0,0</text>
+  <path class="p4" d="M 743 140 L 726 142 L 747 149 L 762 146 L 743 140"/>
+  <text x="744" y="146" style="font-size:3px">4.338,0,0,0</text>
+  <path class="p4" d="M 726 142 L 708 144 L 731 152 L 747 149 L 726 142"/>
+  <text x="728" y="148" style="font-size:3px">4.339,0,0,0</text>
+  <path class="p4" d="M 794 142 L 778 144 L 796 151 L 810 148 L 794 142"/>
+  <text x="795" y="148" style="font-size:3px">4.340,0,0,0</text>
+  <path class="p4" d="M 778 144 L 762 146 L 782 154 L 796 151 L 778 144"/>
+  <text x="779" y="150" style="font-size:3px">4.341,0,0,0</text>
+  <path class="p4" d="M 810 148 L 796 151 L 814 158 L 827 155 L 810 148"/>
+  <text x="812" y="155" style="font-size:3px">4.342,0,0,0</text>
+  <line x1="827" y1="155" x2="814" y2="158"/>
+  <path class="p4" d="M 796 151 L 782 154 L 801 161 L 814 158 L 796 151"/>
+  <text x="798" y="157" style="font-size:3px">4.343,0,0,0</text>
+  <line x1="814" y1="158" x2="801" y2="161"/>
+  <path class="p4" d="M 762 146 L 747 149 L 768 156 L 782 154 L 762 146"/>
+  <text x="764" y="153" style="font-size:3px">4.344,0,0,0</text>
+  <path class="p4" d="M 747 149 L 731 152 L 754 159 L 768 156 L 747 149"/>
+  <text x="750" y="156" style="font-size:3px">4.345,0,0,0</text>
+  <path class="p4" d="M 782 154 L 768 156 L 789 164 L 801 161 L 782 154"/>
+  <text x="785" y="160" style="font-size:3px">4.346,0,0,0</text>
+  <line x1="801" y1="161" x2="789" y2="164"/>
+  <path class="p4" d="M 768 156 L 754 159 L 777 167 L 789 164 L 768 156"/>
+  <text x="772" y="163" style="font-size:3px">4.347,0,0,0</text>
+  <line x1="789" y1="164" x2="777" y2="167"/>
+  <path class="p4" d="M 643 122 L 635 129 L 656 135 L 665 130 L 643 122"/>
+  <text x="650" y="131" style="font-size:3px">4.348,0,0,0</text>
+  <path class="p4" d="M 635 129 L 627 135 L 647 141 L 656 135 L 635 129"/>
+  <text x="641" y="137" style="font-size:3px">4.349,0,0,0</text>
+  <path class="p4" d="M 665 130 L 656 135 L 677 142 L 686 137 L 665 130"/>
+  <text x="671" y="137" style="font-size:3px">4.350,0,0,0</text>
+  <path class="p4" d="M 656 135 L 647 141 L 668 148 L 677 142 L 656 135"/>
+  <text x="662" y="143" style="font-size:3px">4.351,0,0,0</text>
+  <path class="p4" d="M 627 135 L 618 142 L 639 147 L 647 141 L 627 135"/>
+  <text x="633" y="143" style="font-size:3px">4.352,0,0,0</text>
+  <path class="p4" d="M 618 142 L 610 148 L 630 154 L 639 147 L 618 142"/>
+  <text x="624" y="149" style="font-size:3px">4.353,0,0,0</text>
+  <path class="p4" d="M 647 141 L 639 147 L 659 153 L 668 148 L 647 141"/>
+  <text x="653" y="149" style="font-size:3px">4.354,0,0,0</text>
+  <path class="p4" d="M 639 147 L 630 154 L 650 159 L 659 153 L 639 147"/>
+  <text x="644" y="155" style="font-size:3px">4.355,0,0,0</text>
+  <path class="p4" d="M 555 153 L 546 161 L 566 165 L 574 157 L 555 153"/>
+  <text x="560" y="160" style="font-size:3px">4.356,0,0,0</text>
+  <path class="p4" d="M 546 161 L 538 169 L 557 172 L 566 165 L 546 161"/>
+  <text x="552" y="168" style="font-size:3px">4.357,0,0,0</text>
+  <path class="p4" d="M 574 157 L 566 165 L 585 169 L 594 162 L 574 157"/>
+  <text x="580" y="165" style="font-size:3px">4.358,0,0,0</text>
+  <path class="p4" d="M 566 165 L 557 172 L 577 176 L 585 169 L 566 165"/>
+  <text x="571" y="172" style="font-size:3px">4.359,0,0,0</text>
+  <path class="p4" d="M 610 148 L 602 155 L 622 160 L 630 154 L 610 148"/>
+  <text x="616" y="156" style="font-size:3px">4.360,0,0,0</text>
+  <path class="p4" d="M 602 155 L 594 162 L 613 167 L 622 160 L 602 155"/>
+  <text x="608" y="162" style="font-size:3px">4.361,0,0,0</text>
+  <path class="p4" d="M 630 154 L 622 160 L 642 165 L 650 159 L 630 154"/>
+  <text x="636" y="161" style="font-size:3px">4.362,0,0,0</text>
+  <path class="p4" d="M 622 160 L 613 167 L 633 171 L 642 165 L 622 160"/>
+  <text x="628" y="167" style="font-size:3px">4.363,0,0,0</text>
+  <path class="p4" d="M 594 162 L 585 169 L 605 173 L 613 167 L 594 162"/>
+  <text x="599" y="169" style="font-size:3px">4.364,0,0,0</text>
+  <path class="p4" d="M 585 169 L 577 176 L 597 180 L 605 173 L 585 169"/>
+  <text x="591" y="176" style="font-size:3px">4.365,0,0,0</text>
+  <path class="p4" d="M 613 167 L 605 173 L 625 178 L 633 171 L 613 167"/>
+  <text x="619" y="174" style="font-size:3px">4.366,0,0,0</text>
+  <path class="p4" d="M 605 173 L 597 180 L 616 184 L 625 178 L 605 173"/>
+  <text x="611" y="180" style="font-size:3px">4.367,0,0,0</text>
+  <path class="p4" d="M 686 137 L 677 142 L 699 149 L 708 144 L 686 137"/>
+  <text x="693" y="145" style="font-size:3px">4.368,0,0,0</text>
+  <path class="p4" d="M 677 142 L 668 148 L 689 154 L 699 149 L 677 142"/>
+  <text x="683" y="150" style="font-size:3px">4.369,0,0,0</text>
+  <path class="p4" d="M 708 144 L 699 149 L 721 156 L 731 152 L 708 144"/>
+  <text x="715" y="152" style="font-size:3px">4.370,0,0,0</text>
+  <path class="p4" d="M 699 149 L 689 154 L 711 161 L 721 156 L 699 149"/>
+  <text x="705" y="157" style="font-size:3px">4.371,0,0,0</text>
+  <path class="p4" d="M 668 148 L 659 153 L 680 159 L 689 154 L 668 148"/>
+  <text x="674" y="155" style="font-size:3px">4.372,0,0,0</text>
+  <path class="p4" d="M 659 153 L 650 159 L 670 165 L 680 159 L 659 153"/>
+  <text x="665" y="161" style="font-size:3px">4.373,0,0,0</text>
+  <path class="p4" d="M 689 154 L 680 159 L 701 166 L 711 161 L 689 154"/>
+  <text x="695" y="161" style="font-size:3px">4.374,0,0,0</text>
+  <path class="p4" d="M 680 159 L 670 165 L 691 170 L 701 166 L 680 159"/>
+  <text x="686" y="167" style="font-size:3px">4.375,0,0,0</text>
+  <path class="p4" d="M 731 152 L 721 156 L 743 163 L 754 159 L 731 152"/>
+  <text x="737" y="159" style="font-size:3px">4.376,0,0,0</text>
+  <path class="p4" d="M 721 156 L 711 161 L 732 167 L 743 163 L 721 156"/>
+  <text x="727" y="163" style="font-size:3px">4.377,0,0,0</text>
+  <path class="p4" d="M 754 159 L 743 163 L 765 170 L 777 167 L 754 159"/>
+  <text x="760" y="166" style="font-size:3px">4.378,0,0,0</text>
+  <line x1="777" y1="167" x2="765" y2="170"/>
+  <path class="p4" d="M 743 163 L 732 167 L 754 174 L 765 170 L 743 163"/>
+  <text x="749" y="170" style="font-size:3px">4.379,0,0,0</text>
+  <line x1="765" y1="170" x2="754" y2="174"/>
+  <path class="p4" d="M 711 161 L 701 166 L 722 172 L 732 167 L 711 161"/>
+  <text x="716" y="168" style="font-size:3px">4.380,0,0,0</text>
+  <path class="p4" d="M 701 166 L 691 170 L 712 176 L 722 172 L 701 166"/>
+  <text x="706" y="172" style="font-size:3px">4.381,0,0,0</text>
+  <path class="p4" d="M 732 167 L 722 172 L 743 178 L 754 174 L 732 167"/>
+  <text x="738" y="174" style="font-size:3px">4.382,0,0,0</text>
+  <line x1="754" y1="174" x2="743" y2="178"/>
+  <path class="p4" d="M 722 172 L 712 176 L 733 182 L 743 178 L 722 172"/>
+  <text x="728" y="178" style="font-size:3px">4.383,0,0,0</text>
+  <line x1="743" y1="178" x2="733" y2="182"/>
+  <path class="p4" d="M 650 159 L 642 165 L 662 170 L 670 165 L 650 159"/>
+  <text x="656" y="166" style="font-size:3px">4.384,0,0,0</text>
+  <path class="p4" d="M 642 165 L 633 171 L 653 176 L 662 170 L 642 165"/>
+  <text x="648" y="172" style="font-size:3px">4.385,0,0,0</text>
+  <path class="p4" d="M 670 165 L 662 170 L 682 176 L 691 170 L 670 165"/>
+  <text x="676" y="172" style="font-size:3px">4.386,0,0,0</text>
+  <path class="p4" d="M 662 170 L 653 176 L 673 181 L 682 176 L 662 170"/>
+  <text x="668" y="177" style="font-size:3px">4.387,0,0,0</text>
+  <path class="p4" d="M 633 171 L 625 178 L 645 182 L 653 176 L 633 171"/>
+  <text x="639" y="178" style="font-size:3px">4.388,0,0,0</text>
+  <path class="p4" d="M 625 178 L 616 184 L 636 188 L 645 182 L 625 178"/>
+  <text x="631" y="184" style="font-size:3px">4.389,0,0,0</text>
+  <path class="p4" d="M 653 176 L 645 182 L 665 186 L 673 181 L 653 176"/>
+  <text x="659" y="183" style="font-size:3px">4.390,0,0,0</text>
+  <path class="p4" d="M 645 182 L 636 188 L 657 192 L 665 186 L 645 182"/>
+  <text x="651" y="188" style="font-size:3px">4.391,0,0,0</text>
+  <path class="p4" d="M 691 170 L 682 176 L 703 181 L 712 176 L 691 170"/>
+  <text x="697" y="177" style="font-size:3px">4.392,0,0,0</text>
+  <path class="p4" d="M 682 176 L 673 181 L 694 186 L 703 181 L 682 176"/>
+  <text x="688" y="182" style="font-size:3px">4.393,0,0,0</text>
+  <path class="p4" d="M 712 176 L 703 181 L 723 186 L 733 182 L 712 176"/>
+  <text x="718" y="183" style="font-size:3px">4.394,0,0,0</text>
+  <line x1="733" y1="182" x2="723" y2="186"/>
+  <path class="p4" d="M 703 181 L 694 186 L 714 190 L 723 186 L 703 181"/>
+  <text x="709" y="187" style="font-size:3px">4.395,0,0,0</text>
+  <line x1="723" y1="186" x2="714" y2="190"/>
+  <path class="p4" d="M 673 181 L 665 186 L 685 191 L 694 186 L 673 181"/>
+  <text x="679" y="187" style="font-size:3px">4.396,0,0,0</text>
+  <path class="p4" d="M 665 186 L 657 192 L 677 196 L 685 191 L 665 186"/>
+  <text x="671" y="192" style="font-size:3px">4.397,0,0,0</text>
+  <path class="p4" d="M 694 186 L 685 191 L 706 195 L 714 190 L 694 186"/>
+  <text x="700" y="192" style="font-size:3px">4.398,0,0,0</text>
+  <line x1="714" y1="190" x2="706" y2="195"/>
+  <path class="p4" d="M 685 191 L 677 196 L 698 200 L 706 195 L 685 191"/>
+  <text x="691" y="197" style="font-size:3px">4.399,0,0,0</text>
+  <line x1="706" y1="195" x2="698" y2="200"/>
+  <path class="p4" d="M 538 169 L 532 177 L 551 180 L 557 172 L 538 169"/>
+  <text x="545" y="176" style="font-size:3px">4.400,0,0,0</text>
+  <path class="p4" d="M 532 177 L 526 186 L 545 189 L 551 180 L 532 177"/>
+  <text x="539" y="184" style="font-size:3px">4.401,0,0,0</text>
+  <path class="p4" d="M 557 172 L 551 180 L 571 184 L 577 176 L 557 172"/>
+  <text x="564" y="180" style="font-size:3px">4.402,0,0,0</text>
+  <path class="p4" d="M 551 180 L 545 189 L 565 192 L 571 184 L 551 180"/>
+  <text x="558" y="188" style="font-size:3px">4.403,0,0,0</text>
+  <path class="p4" d="M 526 186 L 520 194 L 539 197 L 545 189 L 526 186"/>
+  <text x="533" y="193" style="font-size:3px">4.404,0,0,0</text>
+  <path class="p4" d="M 520 194 L 513 203 L 533 205 L 539 197 L 520 194"/>
+  <text x="526" y="202" style="font-size:3px">4.405,0,0,0</text>
+  <path class="p4" d="M 545 189 L 539 197 L 559 199 L 565 192 L 545 189"/>
+  <text x="552" y="196" style="font-size:3px">4.406,0,0,0</text>
+  <path class="p4" d="M 539 197 L 533 205 L 552 207 L 559 199 L 539 197"/>
+  <text x="546" y="204" style="font-size:3px">4.407,0,0,0</text>
+  <path class="p4" d="M 577 176 L 571 184 L 591 187 L 597 180 L 577 176"/>
+  <text x="584" y="183" style="font-size:3px">4.408,0,0,0</text>
+  <path class="p4" d="M 571 184 L 565 192 L 585 194 L 591 187 L 571 184"/>
+  <text x="578" y="191" style="font-size:3px">4.409,0,0,0</text>
+  <path class="p4" d="M 597 180 L 591 187 L 610 191 L 616 184 L 597 180"/>
+  <text x="604" y="187" style="font-size:3px">4.410,0,0,0</text>
+  <path class="p4" d="M 591 187 L 585 194 L 604 197 L 610 191 L 591 187"/>
+  <text x="598" y="194" style="font-size:3px">4.411,0,0,0</text>
+  <path class="p4" d="M 565 192 L 559 199 L 578 202 L 585 194 L 565 192"/>
+  <text x="572" y="198" style="font-size:3px">4.412,0,0,0</text>
+  <path class="p4" d="M 559 199 L 552 207 L 572 209 L 578 202 L 559 199"/>
+  <text x="565" y="206" style="font-size:3px">4.413,0,0,0</text>
+  <path class="p4" d="M 585 194 L 578 202 L 598 204 L 604 197 L 585 194"/>
+  <text x="591" y="201" style="font-size:3px">4.414,0,0,0</text>
+  <path class="p4" d="M 578 202 L 572 209 L 592 211 L 598 204 L 578 202"/>
+  <text x="585" y="208" style="font-size:3px">4.415,0,0,0</text>
+  <path class="p4" d="M 513 203 L 507 213 L 527 214 L 533 205 L 513 203"/>
+  <text x="520" y="210" style="font-size:3px">4.416,0,0,0</text>
+  <path class="p4" d="M 507 213 L 500 222 L 521 223 L 527 214 L 507 213"/>
+  <text x="514" y="219" style="font-size:3px">4.417,0,0,0</text>
+  <path class="p4" d="M 533 205 L 527 214 L 547 216 L 552 207 L 533 205"/>
+  <text x="540" y="212" style="font-size:3px">4.418,0,0,0</text>
+  <path class="p4" d="M 527 214 L 521 223 L 541 224 L 547 216 L 527 214"/>
+  <text x="534" y="221" style="font-size:3px">4.419,0,0,0</text>
+  <path class="p4" d="M 500 222 L 493 232 L 514 232 L 521 223 L 500 222"/>
+  <text x="507" y="229" style="font-size:3px">4.420,0,0,0</text>
+  <path class="p4" d="M 493 232 L 487 241 L 508 241 L 514 232 L 493 232"/>
+  <text x="501" y="239" style="font-size:4px">4.421,0,0,0</text>
+  <path class="p4" d="M 521 223 L 514 232 L 535 233 L 541 224 L 521 223"/>
+  <text x="528" y="230" style="font-size:4px">4.422,0,0,0</text>
+  <path class="p4" d="M 514 232 L 508 241 L 529 241 L 535 233 L 514 232"/>
+  <text x="522" y="239" style="font-size:4px">4.423,0,0,0</text>
+  <path class="p4" d="M 552 207 L 547 216 L 567 217 L 572 209 L 552 207"/>
+  <text x="560" y="214" style="font-size:3px">4.424,0,0,0</text>
+  <path class="p4" d="M 547 216 L 541 224 L 562 225 L 567 217 L 547 216"/>
+  <text x="554" y="222" style="font-size:3px">4.425,0,0,0</text>
+  <path class="p4" d="M 572 209 L 567 217 L 587 219 L 592 211 L 572 209"/>
+  <text x="580" y="216" style="font-size:3px">4.426,0,0,0</text>
+  <path class="p4" d="M 567 217 L 562 225 L 582 226 L 587 219 L 567 217"/>
+  <text x="574" y="223" style="font-size:3px">4.427,0,0,0</text>
+  <path class="p4" d="M 541 224 L 535 233 L 556 233 L 562 225 L 541 224"/>
+  <text x="549" y="231" style="font-size:4px">4.428,0,0,0</text>
+  <path class="p4" d="M 535 233 L 529 241 L 551 241 L 556 233 L 535 233"/>
+  <text x="543" y="239" style="font-size:4px">4.429,0,0,0</text>
+  <path class="p4" d="M 562 225 L 556 233 L 577 234 L 582 226 L 562 225"/>
+  <text x="569" y="232" style="font-size:4px">4.430,0,0,0</text>
+  <path class="p4" d="M 556 233 L 551 241 L 572 241 L 577 234 L 556 233"/>
+  <text x="564" y="239" style="font-size:4px">4.431,0,0,0</text>
+  <path class="p4" d="M 616 184 L 610 191 L 630 194 L 636 188 L 616 184"/>
+  <text x="623" y="191" style="font-size:3px">4.432,0,0,0</text>
+  <path class="p4" d="M 610 191 L 604 197 L 624 200 L 630 194 L 610 191"/>
+  <text x="617" y="197" style="font-size:3px">4.433,0,0,0</text>
+  <path class="p4" d="M 636 188 L 630 194 L 650 197 L 657 192 L 636 188"/>
+  <text x="643" y="194" style="font-size:3px">4.434,0,0,0</text>
+  <path class="p4" d="M 630 194 L 624 200 L 644 203 L 650 197 L 630 194"/>
+  <text x="637" y="200" style="font-size:3px">4.435,0,0,0</text>
+  <path class="p4" d="M 604 197 L 598 204 L 618 207 L 624 200 L 604 197"/>
+  <text x="611" y="204" style="font-size:3px">4.436,0,0,0</text>
+  <path class="p4" d="M 598 204 L 592 211 L 612 213 L 618 207 L 598 204"/>
+  <text x="605" y="211" style="font-size:3px">4.437,0,0,0</text>
+  <path class="p4" d="M 624 200 L 618 207 L 638 209 L 644 203 L 624 200"/>
+  <text x="631" y="206" style="font-size:3px">4.438,0,0,0</text>
+  <path class="p4" d="M 618 207 L 612 213 L 632 216 L 638 209 L 618 207"/>
+  <text x="625" y="213" style="font-size:3px">4.439,0,0,0</text>
+  <path class="p4" d="M 657 192 L 650 197 L 670 201 L 677 196 L 657 192"/>
+  <text x="664" y="198" style="font-size:3px">4.440,0,0,0</text>
+  <path class="p4" d="M 650 197 L 644 203 L 664 206 L 670 201 L 650 197"/>
+  <text x="657" y="204" style="font-size:3px">4.441,0,0,0</text>
+  <path class="p4" d="M 677 196 L 670 201 L 690 204 L 698 200 L 677 196"/>
+  <text x="684" y="202" style="font-size:3px">4.442,0,0,0</text>
+  <line x1="698" y1="200" x2="690" y2="204"/>
+  <path class="p4" d="M 670 201 L 664 206 L 683 209 L 690 204 L 670 201"/>
+  <text x="677" y="207" style="font-size:3px">4.443,0,0,0</text>
+  <line x1="690" y1="204" x2="683" y2="209"/>
+  <path class="p4" d="M 644 203 L 638 209 L 658 212 L 664 206 L 644 203"/>
+  <text x="651" y="209" style="font-size:3px">4.444,0,0,0</text>
+  <path class="p4" d="M 638 209 L 632 216 L 652 218 L 658 212 L 638 209"/>
+  <text x="645" y="215" style="font-size:3px">4.445,0,0,0</text>
+  <path class="p4" d="M 664 206 L 658 212 L 677 214 L 683 209 L 664 206"/>
+  <text x="670" y="212" style="font-size:3px">4.446,0,0,0</text>
+  <line x1="683" y1="209" x2="677" y2="214"/>
+  <path class="p4" d="M 658 212 L 652 218 L 672 220 L 677 214 L 658 212"/>
+  <text x="665" y="217" style="font-size:3px">4.447,0,0,0</text>
+  <line x1="677" y1="214" x2="672" y2="220"/>
+  <path class="p4" d="M 592 211 L 587 219 L 607 220 L 612 213 L 592 211"/>
+  <text x="600" y="217" style="font-size:3px">4.448,0,0,0</text>
+  <path class="p4" d="M 587 219 L 582 226 L 602 227 L 607 220 L 587 219"/>
+  <text x="595" y="225" style="font-size:4px">4.449,0,0,0</text>
+  <path class="p4" d="M 612 213 L 607 220 L 627 222 L 632 216 L 612 213"/>
+  <text x="620" y="219" style="font-size:3px">4.450,0,0,0</text>
+  <path class="p4" d="M 607 220 L 602 227 L 623 228 L 627 222 L 607 220"/>
+  <text x="615" y="226" style="font-size:4px">4.451,0,0,0</text>
+  <path class="p4" d="M 582 226 L 577 234 L 598 234 L 602 227 L 582 226"/>
+  <text x="590" y="232" style="font-size:4px">4.452,0,0,0</text>
+  <path class="p4" d="M 577 234 L 572 241 L 594 241 L 598 234 L 577 234"/>
+  <text x="585" y="240" style="font-size:4px">4.453,0,0,0</text>
+  <path class="p4" d="M 602 227 L 598 234 L 619 235 L 623 228 L 602 227"/>
+  <text x="610" y="233" style="font-size:4px">4.454,0,0,0</text>
+  <path class="p4" d="M 598 234 L 594 241 L 615 241 L 619 235 L 598 234"/>
+  <text x="606" y="240" style="font-size:4px">4.455,0,0,0</text>
+  <path class="p4" d="M 632 216 L 627 222 L 647 223 L 652 218 L 632 216"/>
+  <text x="640" y="221" style="font-size:3px">4.456,0,0,0</text>
+  <path class="p4" d="M 627 222 L 623 228 L 643 229 L 647 223 L 627 222"/>
+  <text x="635" y="228" style="font-size:4px">4.457,0,0,0</text>
+  <path class="p4" d="M 652 218 L 647 223 L 667 225 L 672 220 L 652 218"/>
+  <text x="660" y="223" style="font-size:4px">4.458,0,0,0</text>
+  <line x1="672" y1="220" x2="667" y2="225"/>
+  <path class="p4" d="M 647 223 L 643 229 L 663 230 L 667 225 L 647 223"/>
+  <text x="655" y="229" style="font-size:4px">4.459,0,0,0</text>
+  <line x1="667" y1="225" x2="663" y2="230"/>
+  <path class="p4" d="M 623 228 L 619 235 L 639 235 L 643 229 L 623 228"/>
+  <text x="631" y="234" style="font-size:4px">4.460,0,0,0</text>
+  <path class="p4" d="M 619 235 L 615 241 L 636 241 L 639 235 L 619 235"/>
+  <text x="627" y="240" style="font-size:4px">4.461,0,0,0</text>
+  <path class="p4" d="M 643 229 L 639 235 L 660 236 L 663 230 L 643 229"/>
+  <text x="651" y="235" style="font-size:4px">4.462,0,0,0</text>
+  <line x1="663" y1="230" x2="660" y2="236"/>
+  <path class="p4" d="M 639 235 L 636 241 L 658 241 L 660 236 L 639 235"/>
+  <text x="648" y="240" style="font-size:4px">4.463,0,0,0</text>
+  <line x1="660" y1="236" x2="658" y2="241"/>
+  <path class="p4" d="M 487 241 L 483 251 L 505 251 L 508 241 L 487 241"/>
+  <text x="496" y="248" style="font-size:4px">4.464,0,0,0</text>
+  <path class="p4" d="M 483 251 L 479 261 L 501 260 L 505 251 L 483 251"/>
+  <text x="492" y="258" style="font-size:4px">4.465,0,0,0</text>
+  <path class="p4" d="M 508 241 L 505 251 L 527 250 L 529 241 L 508 241"/>
+  <text x="517" y="248" style="font-size:4px">4.466,0,0,0</text>
+  <path class="p4" d="M 505 251 L 501 260 L 524 259 L 527 250 L 505 251"/>
+  <text x="514" y="257" style="font-size:4px">4.467,0,0,0</text>
+  <path class="p4" d="M 479 261 L 475 272 L 498 270 L 501 260 L 479 261"/>
+  <text x="488" y="268" style="font-size:4px">4.468,0,0,0</text>
+  <path class="p4" d="M 475 272 L 471 282 L 495 280 L 498 270 L 475 272"/>
+  <text x="485" y="278" style="font-size:4px">4.469,0,0,0</text>
+  <path class="p4" d="M 501 260 L 498 270 L 521 268 L 524 259 L 501 260"/>
+  <text x="511" y="267" style="font-size:4px">4.470,0,0,0</text>
+  <path class="p4" d="M 498 270 L 495 280 L 518 278 L 521 268 L 498 270"/>
+  <text x="508" y="276" style="font-size:4px">4.471,0,0,0</text>
+  <path class="p4" d="M 529 241 L 527 250 L 548 250 L 551 241 L 529 241"/>
+  <text x="539" y="248" style="font-size:4px">4.472,0,0,0</text>
+  <path class="p4" d="M 527 250 L 524 259 L 546 258 L 548 250 L 527 250"/>
+  <text x="536" y="256" style="font-size:4px">4.473,0,0,0</text>
+  <path class="p4" d="M 551 241 L 548 250 L 570 249 L 572 241 L 551 241"/>
+  <text x="560" y="247" style="font-size:4px">4.474,0,0,0</text>
+  <path class="p4" d="M 548 250 L 546 258 L 568 257 L 570 249 L 548 250"/>
+  <text x="558" y="255" style="font-size:4px">4.475,0,0,0</text>
+  <path class="p4" d="M 524 259 L 521 268 L 544 267 L 546 258 L 524 259"/>
+  <text x="534" y="265" style="font-size:4px">4.476,0,0,0</text>
+  <path class="p4" d="M 521 268 L 518 278 L 541 276 L 544 267 L 521 268"/>
+  <text x="531" y="274" style="font-size:4px">4.477,0,0,0</text>
+  <path class="p4" d="M 546 258 L 544 267 L 566 265 L 568 257 L 546 258"/>
+  <text x="556" y="264" style="font-size:4px">4.478,0,0,0</text>
+  <path class="p4" d="M 544 267 L 541 276 L 565 273 L 566 265 L 544 267"/>
+  <text x="554" y="272" style="font-size:4px">4.479,0,0,0</text>
+  <path class="p4" d="M 471 282 L 467 293 L 492 290 L 495 280 L 471 282"/>
+  <text x="481" y="289" style="font-size:4px">4.480,0,0,0</text>
+  <path class="p4" d="M 467 293 L 463 304 L 488 301 L 492 290 L 467 293"/>
+  <text x="477" y="299" style="font-size:4px">4.481,0,0,0</text>
+  <path class="p4" d="M 495 280 L 492 290 L 516 287 L 518 278 L 495 280"/>
+  <text x="505" y="286" style="font-size:4px">4.482,0,0,0</text>
+  <path class="p4" d="M 492 290 L 488 301 L 514 297 L 516 287 L 492 290"/>
+  <text x="502" y="296" style="font-size:4px">4.483,0,0,0</text>
+  <path class="p4" d="M 463 304 L 459 316 L 485 311 L 488 301 L 463 304"/>
+  <text x="474" y="310" style="font-size:4px">4.484,0,0,0</text>
+  <path class="p4" d="M 459 316 L 454 327 L 482 322 L 485 311 L 459 316"/>
+  <text x="470" y="321" style="font-size:4px">4.485,0,0,0</text>
+  <path class="p4" d="M 488 301 L 485 311 L 512 307 L 514 297 L 488 301"/>
+  <text x="500" y="306" style="font-size:4px">4.486,0,0,0</text>
+  <path class="p4" d="M 485 311 L 482 322 L 509 317 L 512 307 L 485 311"/>
+  <text x="497" y="316" style="font-size:4px">4.487,0,0,0</text>
+  <path class="p4" d="M 518 278 L 516 287 L 540 284 L 541 276 L 518 278"/>
+  <text x="529" y="283" style="font-size:4px">4.488,0,0,0</text>
+  <path class="p4" d="M 516 287 L 514 297 L 539 293 L 540 284 L 516 287"/>
+  <text x="527" y="293" style="font-size:4px">4.489,0,0,0</text>
+  <path class="p4" d="M 541 276 L 540 284 L 564 281 L 565 273 L 541 276"/>
+  <text x="553" y="281" style="font-size:4px">4.490,0,0,0</text>
+  <path class="p4" d="M 540 284 L 539 293 L 564 290 L 564 281 L 540 284"/>
+  <text x="552" y="289" style="font-size:4px">4.491,0,0,0</text>
+  <path class="p4" d="M 514 297 L 512 307 L 538 303 L 539 293 L 514 297"/>
+  <text x="526" y="302" style="font-size:4px">4.492,0,0,0</text>
+  <path class="p4" d="M 512 307 L 509 317 L 537 312 L 538 303 L 512 307"/>
+  <text x="524" y="312" style="font-size:4px">4.493,0,0,0</text>
+  <path class="p4" d="M 539 293 L 538 303 L 564 298 L 564 290 L 539 293"/>
+  <text x="551" y="298" style="font-size:4px">4.494,0,0,0</text>
+  <path class="p4" d="M 538 303 L 537 312 L 563 307 L 564 298 L 538 303"/>
+  <text x="550" y="307" style="font-size:4px">4.495,0,0,0</text>
+  <path class="p4" d="M 572 241 L 570 249 L 592 249 L 594 241 L 572 241"/>
+  <text x="582" y="247" style="font-size:4px">4.496,0,0,0</text>
+  <path class="p4" d="M 570 249 L 568 257 L 590 256 L 592 249 L 570 249"/>
+  <text x="580" y="255" style="font-size:4px">4.497,0,0,0</text>
+  <path class="p4" d="M 594 241 L 592 249 L 613 248 L 615 241 L 594 241"/>
+  <text x="603" y="247" style="font-size:4px">4.498,0,0,0</text>
+  <path class="p4" d="M 592 249 L 590 256 L 612 255 L 613 248 L 592 249"/>
+  <text x="602" y="254" style="font-size:4px">4.499,0,0,0</text>
+  <path class="p4" d="M 568 257 L 566 265 L 589 263 L 590 256 L 568 257"/>
+  <text x="578" y="262" style="font-size:4px">4.500,0,0,0</text>
+  <path class="p4" d="M 566 265 L 565 273 L 588 271 L 589 263 L 566 265"/>
+  <text x="577" y="270" style="font-size:4px">4.501,0,0,0</text>
+  <path class="p4" d="M 590 256 L 589 263 L 611 262 L 612 255 L 590 256"/>
+  <text x="601" y="261" style="font-size:4px">4.502,0,0,0</text>
+  <path class="p4" d="M 589 263 L 588 271 L 611 269 L 611 262 L 589 263"/>
+  <text x="600" y="268" style="font-size:4px">4.503,0,0,0</text>
+  <path class="p4" d="M 615 241 L 613 248 L 635 248 L 636 241 L 615 241"/>
+  <text x="625" y="247" style="font-size:4px">4.504,0,0,0</text>
+  <path class="p4" d="M 613 248 L 612 255 L 634 254 L 635 248 L 613 248"/>
+  <text x="623" y="253" style="font-size:4px">4.505,0,0,0</text>
+  <path class="p4" d="M 636 241 L 635 248 L 656 247 L 658 241 L 636 241"/>
+  <text x="646" y="246" style="font-size:4px">4.506,0,0,0</text>
+  <line x1="658" y1="241" x2="656" y2="247"/>
+  <path class="p4" d="M 635 248 L 634 254 L 655 253 L 656 247 L 635 248"/>
+  <text x="645" y="252" style="font-size:4px">4.507,0,0,0</text>
+  <line x1="656" y1="247" x2="655" y2="253"/>
+  <path class="p4" d="M 612 255 L 611 262 L 633 260 L 634 254 L 612 255"/>
+  <text x="623" y="260" style="font-size:4px">4.508,0,0,0</text>
+  <path class="p4" d="M 611 262 L 611 269 L 633 266 L 633 260 L 611 262"/>
+  <text x="622" y="266" style="font-size:4px">4.509,0,0,0</text>
+  <path class="p4" d="M 634 254 L 633 260 L 655 258 L 655 253 L 634 254"/>
+  <text x="644" y="258" style="font-size:4px">4.510,0,0,0</text>
+  <line x1="655" y1="253" x2="655" y2="258"/>
+  <path class="p4" d="M 633 260 L 633 266 L 656 264 L 655 258 L 633 260"/>
+  <text x="645" y="264" style="font-size:4px">4.511,0,0,0</text>
+  <line x1="655" y1="258" x2="656" y2="264"/>
+  <path class="p4" d="M 565 273 L 564 281 L 588 279 L 588 271 L 565 273"/>
+  <text x="576" y="278" style="font-size:4px">4.512,0,0,0</text>
+  <path class="p4" d="M 564 281 L 564 290 L 588 286 L 588 279 L 564 281"/>
+  <text x="576" y="286" style="font-size:4px">4.513,0,0,0</text>
+  <path class="p4" d="M 588 271 L 588 279 L 612 276 L 611 269 L 588 271"/>
+  <text x="599" y="275" style="font-size:4px">4.514,0,0,0</text>
+  <path class="p4" d="M 588 279 L 588 286 L 613 283 L 612 276 L 588 279"/>
+  <text x="600" y="283" style="font-size:4px">4.515,0,0,0</text>
+  <path class="p4" d="M 564 290 L 564 298 L 589 294 L 588 286 L 564 290"/>
+  <text x="576" y="294" style="font-size:4px">4.516,0,0,0</text>
+  <path class="p4" d="M 564 298 L 563 307 L 590 302 L 589 294 L 564 298"/>
+  <text x="577" y="302" style="font-size:4px">4.517,0,0,0</text>
+  <path class="p4" d="M 588 286 L 589 294 L 615 290 L 613 283 L 588 286"/>
+  <text x="601" y="290" style="font-size:4px">4.518,0,0,0</text>
+  <path class="p4" d="M 589 294 L 590 302 L 617 297 L 615 290 L 589 294"/>
+  <text x="603" y="298" style="font-size:4px">4.519,0,0,0</text>
+  <path class="p4" d="M 611 269 L 612 276 L 635 273 L 633 266 L 611 269"/>
+  <text x="623" y="273" style="font-size:4px">4.520,0,0,0</text>
+  <path class="p4" d="M 612 276 L 613 283 L 637 279 L 635 273 L 612 276"/>
+  <text x="624" y="280" style="font-size:4px">4.521,0,0,0</text>
+  <path class="p4" d="M 633 266 L 635 273 L 658 270 L 656 264 L 633 266"/>
+  <text x="646" y="270" style="font-size:4px">4.522,0,0,0</text>
+  <line x1="656" y1="264" x2="658" y2="270"/>
+  <path class="p4" d="M 635 273 L 637 279 L 661 276 L 658 270 L 635 273"/>
+  <text x="648" y="276" style="font-size:4px">4.523,0,0,0</text>
+  <line x1="658" y1="270" x2="661" y2="276"/>
+  <path class="p4" d="M 613 283 L 615 290 L 639 286 L 637 279 L 613 283"/>
+  <text x="626" y="286" style="font-size:4px">4.524,0,0,0</text>
+  <path class="p4" d="M 615 290 L 617 297 L 643 292 L 639 286 L 615 290"/>
+  <text x="628" y="293" style="font-size:4px">4.525,0,0,0</text>
+  <path class="p4" d="M 637 279 L 639 286 L 664 281 L 661 276 L 637 279"/>
+  <text x="650" y="282" style="font-size:4px">4.526,0,0,0</text>
+  <line x1="661" y1="276" x2="664" y2="281"/>
+  <path class="p4" d="M 639 286 L 643 292 L 668 287 L 664 281 L 639 286"/>
+  <text x="654" y="288" style="font-size:4px">4.527,0,0,0</text>
+  <line x1="664" y1="281" x2="668" y2="287"/>
+  <path class="p4" d="M 454 327 L 453 339 L 482 333 L 482 322 L 454 327"/>
+  <text x="468" y="332" style="font-size:4px">4.528,0,0,0</text>
+  <path class="p4" d="M 453 339 L 452 350 L 482 343 L 482 333 L 453 339"/>
+  <text x="468" y="344" style="font-size:5px">4.529,0,0,0</text>
+  <path class="p4" d="M 482 322 L 482 333 L 511 327 L 509 317 L 482 322"/>
+  <text x="496" y="327" style="font-size:4px">4.530,0,0,0</text>
+  <path class="p4" d="M 482 333 L 482 343 L 512 337 L 511 327 L 482 333"/>
+  <text x="497" y="337" style="font-size:4px">4.531,0,0,0</text>
+  <path class="p4" d="M 509 317 L 511 327 L 539 321 L 537 312 L 509 317"/>
+  <text x="524" y="321" style="font-size:4px">4.532,0,0,0</text>
+  <path class="p4" d="M 511 327 L 512 337 L 541 330 L 539 321 L 511 327"/>
+  <text x="526" y="331" style="font-size:4px">4.533,0,0,0</text>
+  <path class="p4" d="M 537 312 L 539 321 L 567 315 L 563 307 L 537 312"/>
+  <text x="551" y="316" style="font-size:4px">4.534,0,0,0</text>
+  <path class="p4" d="M 539 321 L 541 330 L 570 324 L 567 315 L 539 321"/>
+  <text x="554" y="324" style="font-size:4px">4.535,0,0,0</text>
+  <path class="p4" d="M 512 337 L 513 347 L 543 339 L 541 330 L 512 337"/>
+  <text x="527" y="341" style="font-size:5px">4.536,0,0,0</text>
+  <path class="p4" d="M 513 347 L 515 357 L 546 349 L 543 339 L 513 347"/>
+  <text x="529" y="351" style="font-size:5px">4.537,0,0,0</text>
+  <path class="p4" d="M 541 330 L 543 339 L 573 332 L 570 324 L 541 330"/>
+  <text x="557" y="334" style="font-size:5px">4.538,0,0,0</text>
+  <path class="p4" d="M 543 339 L 546 349 L 577 341 L 573 332 L 543 339"/>
+  <text x="560" y="343" style="font-size:5px">4.539,0,0,0</text>
+  <path class="p4" d="M 515 357 L 517 368 L 550 358 L 546 349 L 515 357"/>
+  <text x="532" y="361" style="font-size:5px">4.540,0,0,0</text>
+  <path class="p4" d="M 517 368 L 519 378 L 553 368 L 550 358 L 517 368"/>
+  <text x="535" y="371" style="font-size:5px">4.541,0,0,0</text>
+  <path class="p4" d="M 546 349 L 550 358 L 582 349 L 577 341 L 546 349"/>
+  <text x="563" y="352" style="font-size:5px">4.542,0,0,0</text>
+  <path class="p4" d="M 550 358 L 553 368 L 587 358 L 582 349 L 550 358"/>
+  <text x="568" y="361" style="font-size:5px">4.543,0,0,0</text>
+  <path class="p4" d="M 519 378 L 521 389 L 557 378 L 553 368 L 519 378"/>
+  <text x="538" y="381" style="font-size:5px">4.544,0,0,0</text>
+  <path class="p4" d="M 521 389 L 524 400 L 561 388 L 557 378 L 521 389"/>
+  <text x="541" y="391" style="font-size:5px">4.545,0,0,0</text>
+  <path class="p4" d="M 553 368 L 557 378 L 592 367 L 587 358 L 553 368"/>
+  <text x="572" y="370" style="font-size:5px">4.546,0,0,0</text>
+  <path class="p4" d="M 557 378 L 561 388 L 597 375 L 592 367 L 557 378"/>
+  <text x="577" y="379" style="font-size:5px">4.547,0,0,0</text>
+  <path class="p4" d="M 563 307 L 567 315 L 594 309 L 590 302 L 563 307"/>
+  <text x="579" y="310" style="font-size:4px">4.548,0,0,0</text>
+  <path class="p4" d="M 567 315 L 570 324 L 598 317 L 594 309 L 567 315"/>
+  <text x="582" y="318" style="font-size:4px">4.549,0,0,0</text>
+  <path class="p4" d="M 590 302 L 594 309 L 621 304 L 617 297 L 590 302"/>
+  <text x="605" y="305" style="font-size:4px">4.550,0,0,0</text>
+  <path class="p4" d="M 594 309 L 598 317 L 626 311 L 621 304 L 594 309"/>
+  <text x="610" y="312" style="font-size:4px">4.551,0,0,0</text>
+  <path class="p4" d="M 570 324 L 573 332 L 602 325 L 598 317 L 570 324"/>
+  <text x="586" y="326" style="font-size:4px">4.552,0,0,0</text>
+  <path class="p4" d="M 573 332 L 577 341 L 607 333 L 602 325 L 573 332"/>
+  <text x="590" y="335" style="font-size:5px">4.553,0,0,0</text>
+  <path class="p4" d="M 598 317 L 602 325 L 631 318 L 626 311 L 598 317"/>
+  <text x="614" y="320" style="font-size:4px">4.554,0,0,0</text>
+  <path class="p4" d="M 602 325 L 607 333 L 637 325 L 631 318 L 602 325"/>
+  <text x="619" y="327" style="font-size:4px">4.555,0,0,0</text>
+  <path class="p4" d="M 617 297 L 621 304 L 648 298 L 643 292 L 617 297"/>
+  <text x="632" y="300" style="font-size:4px">4.556,0,0,0</text>
+  <path class="p4" d="M 621 304 L 626 311 L 653 305 L 648 298 L 621 304"/>
+  <text x="637" y="306" style="font-size:4px">4.557,0,0,0</text>
+  <path class="p4" d="M 643 292 L 648 298 L 674 293 L 668 287 L 643 292"/>
+  <text x="658" y="295" style="font-size:4px">4.558,0,0,0</text>
+  <line x1="668" y1="287" x2="674" y2="293"/>
+  <path class="p4" d="M 648 298 L 653 305 L 680 298 L 674 293 L 648 298"/>
+  <text x="664" y="300" style="font-size:4px">4.559,0,0,0</text>
+  <line x1="674" y1="293" x2="680" y2="298"/>
+  <path class="p4" d="M 626 311 L 631 318 L 659 311 L 653 305 L 626 311"/>
+  <text x="642" y="313" style="font-size:4px">4.560,0,0,0</text>
+  <path class="p4" d="M 631 318 L 637 325 L 666 317 L 659 311 L 631 318"/>
+  <text x="648" y="320" style="font-size:4px">4.561,0,0,0</text>
+  <path class="p4" d="M 653 305 L 659 311 L 687 304 L 680 298 L 653 305"/>
+  <text x="670" y="306" style="font-size:4px">4.562,0,0,0</text>
+  <line x1="680" y1="298" x2="687" y2="304"/>
+  <path class="p4" d="M 659 311 L 666 317 L 695 309 L 687 304 L 659 311"/>
+  <text x="677" y="312" style="font-size:4px">4.563,0,0,0</text>
+  <line x1="687" y1="304" x2="695" y2="309"/>
+  <path class="p4" d="M 577 341 L 582 349 L 613 340 L 607 333 L 577 341"/>
+  <text x="595" y="343" style="font-size:5px">4.564,0,0,0</text>
+  <path class="p4" d="M 582 349 L 587 358 L 619 348 L 613 340 L 582 349"/>
+  <text x="600" y="351" style="font-size:5px">4.565,0,0,0</text>
+  <path class="p4" d="M 607 333 L 613 340 L 644 332 L 637 325 L 607 333"/>
+  <text x="625" y="335" style="font-size:5px">4.566,0,0,0</text>
+  <path class="p4" d="M 613 340 L 619 348 L 651 338 L 644 332 L 613 340"/>
+  <text x="632" y="342" style="font-size:5px">4.567,0,0,0</text>
+  <path class="p4" d="M 587 358 L 592 367 L 626 356 L 619 348 L 587 358"/>
+  <text x="606" y="360" style="font-size:5px">4.568,0,0,0</text>
+  <path class="p4" d="M 592 367 L 597 375 L 633 364 L 626 356 L 592 367"/>
+  <text x="612" y="368" style="font-size:5px">4.569,0,0,0</text>
+  <path class="p4" d="M 619 348 L 626 356 L 660 345 L 651 338 L 619 348"/>
+  <text x="639" y="349" style="font-size:5px">4.570,0,0,0</text>
+  <path class="p4" d="M 626 356 L 633 364 L 668 352 L 660 345 L 626 356"/>
+  <text x="647" y="357" style="font-size:5px">4.571,0,0,0</text>
+  <path class="p4" d="M 637 325 L 644 332 L 674 323 L 666 317 L 637 325"/>
+  <text x="655" y="326" style="font-size:4px">4.572,0,0,0</text>
+  <path class="p4" d="M 644 332 L 651 338 L 683 329 L 674 323 L 644 332"/>
+  <text x="663" y="333" style="font-size:5px">4.573,0,0,0</text>
+  <path class="p4" d="M 666 317 L 674 323 L 704 315 L 695 309 L 666 317"/>
+  <text x="685" y="318" style="font-size:4px">4.574,0,0,0</text>
+  <line x1="695" y1="309" x2="704" y2="315"/>
+  <path class="p4" d="M 674 323 L 683 329 L 714 320 L 704 315 L 674 323"/>
+  <text x="694" y="324" style="font-size:4px">4.575,0,0,0</text>
+  <line x1="704" y1="315" x2="714" y2="320"/>
+  <path class="p4" d="M 651 338 L 660 345 L 692 335 L 683 329 L 651 338"/>
+  <text x="672" y="339" style="font-size:5px">4.576,0,0,0</text>
+  <path class="p4" d="M 660 345 L 668 352 L 702 341 L 692 335 L 660 345"/>
+  <text x="681" y="346" style="font-size:5px">4.577,0,0,0</text>
+  <path class="p4" d="M 683 329 L 692 335 L 724 325 L 714 320 L 683 329"/>
+  <text x="703" y="330" style="font-size:5px">4.578,0,0,0</text>
+  <line x1="714" y1="320" x2="724" y2="325"/>
+  <path class="p4" d="M 692 335 L 702 341 L 735 330 L 724 325 L 692 335"/>
+  <text x="714" y="335" style="font-size:5px">4.579,0,0,0</text>
+  <line x1="724" y1="325" x2="735" y2="330"/>
+  <path class="p4" d="M 524 400 L 551 403 L 586 391 L 561 388 L 524 400"/>
+  <text x="556" y="398" style="font-size:5px">4.580,0,0,0</text>
+  <path class="p4" d="M 551 403 L 579 406 L 611 394 L 586 391 L 551 403"/>
+  <text x="582" y="401" style="font-size:5px">4.581,0,0,0</text>
+  <path class="p4" d="M 561 388 L 586 391 L 620 379 L 597 375 L 561 388"/>
+  <text x="591" y="386" style="font-size:5px">4.582,0,0,0</text>
+  <path class="p4" d="M 586 391 L 611 394 L 642 382 L 620 379 L 586 391"/>
+  <text x="615" y="389" style="font-size:5px">4.583,0,0,0</text>
+  <path class="p4" d="M 579 406 L 607 408 L 636 397 L 611 394 L 579 406"/>
+  <text x="608" y="404" style="font-size:5px">4.584,0,0,0</text>
+  <path class="p4" d="M 607 408 L 634 411 L 661 400 L 636 397 L 607 408"/>
+  <text x="635" y="407" style="font-size:5px">4.585,0,0,0</text>
+  <path class="p4" d="M 611 394 L 636 397 L 665 386 L 642 382 L 611 394"/>
+  <text x="639" y="392" style="font-size:5px">4.586,0,0,0</text>
+  <path class="p4" d="M 636 397 L 661 400 L 688 389 L 665 386 L 636 397"/>
+  <text x="663" y="395" style="font-size:5px">4.587,0,0,0</text>
+  <path class="p4" d="M 646 439 L 679 441 L 700 430 L 669 428 L 646 439"/>
+  <text x="673" y="438" style="font-size:6px">4.588,0,0,0</text>
+  <path class="p4" d="M 679 441 L 713 444 L 732 433 L 700 430 L 679 441"/>
+  <text x="706" y="440" style="font-size:6px">4.589,0,0,0</text>
+  <path class="p4" d="M 669 428 L 700 430 L 721 419 L 692 416 L 669 428"/>
+  <text x="695" y="426" style="font-size:5px">4.590,0,0,0</text>
+  <path class="p4" d="M 700 430 L 732 433 L 750 422 L 721 419 L 700 430"/>
+  <text x="726" y="428" style="font-size:5px">4.591,0,0,0</text>
+  <path class="p4" d="M 634 411 L 663 414 L 688 403 L 661 400 L 634 411"/>
+  <text x="662" y="409" style="font-size:5px">4.592,0,0,0</text>
+  <path class="p4" d="M 663 414 L 692 416 L 714 405 L 688 403 L 663 414"/>
+  <text x="689" y="412" style="font-size:5px">4.593,0,0,0</text>
+  <path class="p4" d="M 661 400 L 688 403 L 712 392 L 688 389 L 661 400"/>
+  <text x="687" y="398" style="font-size:5px">4.594,0,0,0</text>
+  <path class="p4" d="M 688 403 L 714 405 L 736 395 L 712 392 L 688 403"/>
+  <text x="713" y="401" style="font-size:5px">4.595,0,0,0</text>
+  <path class="p4" d="M 692 416 L 721 419 L 741 408 L 714 405 L 692 416"/>
+  <text x="717" y="415" style="font-size:5px">4.596,0,0,0</text>
+  <path class="p4" d="M 721 419 L 750 422 L 768 411 L 741 408 L 721 419"/>
+  <text x="745" y="417" style="font-size:5px">4.597,0,0,0</text>
+  <path class="p4" d="M 714 405 L 741 408 L 761 397 L 736 395 L 714 405"/>
+  <text x="738" y="404" style="font-size:5px">4.598,0,0,0</text>
+  <path class="p4" d="M 741 408 L 768 411 L 785 400 L 761 397 L 741 408"/>
+  <text x="764" y="407" style="font-size:5px">4.599,0,0,0</text>
+  <path class="p4" d="M 597 375 L 620 379 L 653 367 L 633 364 L 597 375"/>
+  <text x="626" y="374" style="font-size:5px">4.600,0,0,0</text>
+  <path class="p4" d="M 620 379 L 642 382 L 673 371 L 653 367 L 620 379"/>
+  <text x="647" y="377" style="font-size:5px">4.601,0,0,0</text>
+  <path class="p4" d="M 633 364 L 653 367 L 685 356 L 668 352 L 633 364"/>
+  <text x="660" y="362" style="font-size:5px">4.602,0,0,0</text>
+  <path class="p4" d="M 653 367 L 673 371 L 703 360 L 685 356 L 653 367"/>
+  <text x="678" y="366" style="font-size:5px">4.603,0,0,0</text>
+  <path class="p4" d="M 642 382 L 665 386 L 693 374 L 673 371 L 642 382"/>
+  <text x="668" y="381" style="font-size:5px">4.604,0,0,0</text>
+  <path class="p4" d="M 665 386 L 688 389 L 714 378 L 693 374 L 665 386"/>
+  <text x="690" y="384" style="font-size:5px">4.605,0,0,0</text>
+  <path class="p4" d="M 673 371 L 693 374 L 721 364 L 703 360 L 673 371"/>
+  <text x="697" y="370" style="font-size:5px">4.606,0,0,0</text>
+  <path class="p4" d="M 693 374 L 714 378 L 739 367 L 721 364 L 693 374"/>
+  <text x="717" y="373" style="font-size:5px">4.607,0,0,0</text>
+  <path class="p4" d="M 668 352 L 685 356 L 717 345 L 702 341 L 668 352"/>
+  <text x="693" y="351" style="font-size:5px">4.608,0,0,0</text>
+  <path class="p4" d="M 685 356 L 703 360 L 732 349 L 717 345 L 685 356"/>
+  <text x="709" y="355" style="font-size:5px">4.609,0,0,0</text>
+  <path class="p4" d="M 702 341 L 717 345 L 748 334 L 735 330 L 702 341"/>
+  <text x="726" y="340" style="font-size:5px">4.610,0,0,0</text>
+  <line x1="735" y1="330" x2="748" y2="334"/>
+  <path class="p4" d="M 717 345 L 732 349 L 761 339 L 748 334 L 717 345"/>
+  <text x="739" y="344" style="font-size:5px">4.611,0,0,0</text>
+  <line x1="748" y1="334" x2="761" y2="339"/>
+  <path class="p4" d="M 703 360 L 721 364 L 748 353 L 732 349 L 703 360"/>
+  <text x="726" y="359" style="font-size:5px">4.612,0,0,0</text>
+  <path class="p4" d="M 721 364 L 739 367 L 764 357 L 748 353 L 721 364"/>
+  <text x="743" y="363" style="font-size:5px">4.613,0,0,0</text>
+  <path class="p4" d="M 732 349 L 748 353 L 774 343 L 761 339 L 732 349"/>
+  <text x="754" y="348" style="font-size:5px">4.614,0,0,0</text>
+  <line x1="761" y1="339" x2="774" y2="343"/>
+  <path class="p4" d="M 748 353 L 764 357 L 789 347 L 774 343 L 748 353"/>
+  <text x="769" y="352" style="font-size:5px">4.615,0,0,0</text>
+  <line x1="774" y1="343" x2="789" y2="347"/>
+  <path class="p4" d="M 688 389 L 712 392 L 736 381 L 714 378 L 688 389"/>
+  <text x="712" y="387" style="font-size:5px">4.616,0,0,0</text>
+  <path class="p4" d="M 712 392 L 736 395 L 758 384 L 736 381 L 712 392"/>
+  <text x="736" y="390" style="font-size:5px">4.617,0,0,0</text>
+  <path class="p4" d="M 714 378 L 736 381 L 759 371 L 739 367 L 714 378"/>
+  <text x="737" y="377" style="font-size:5px">4.618,0,0,0</text>
+  <path class="p4" d="M 736 381 L 758 384 L 779 374 L 759 371 L 736 381"/>
+  <text x="758" y="380" style="font-size:5px">4.619,0,0,0</text>
+  <path class="p4" d="M 736 395 L 761 397 L 780 387 L 758 384 L 736 395"/>
+  <text x="759" y="393" style="font-size:5px">4.620,0,0,0</text>
+  <path class="p4" d="M 761 397 L 785 400 L 803 390 L 780 387 L 761 397"/>
+  <text x="782" y="396" style="font-size:5px">4.621,0,0,0</text>
+  <path class="p4" d="M 758 384 L 780 387 L 799 377 L 779 374 L 758 384"/>
+  <text x="779" y="383" style="font-size:5px">4.622,0,0,0</text>
+  <path class="p4" d="M 780 387 L 803 390 L 820 380 L 799 377 L 780 387"/>
+  <text x="800" y="386" style="font-size:5px">4.623,0,0,0</text>
+  <path class="p4" d="M 739 367 L 759 371 L 782 360 L 764 357 L 739 367"/>
+  <text x="761" y="366" style="font-size:5px">4.624,0,0,0</text>
+  <path class="p4" d="M 759 371 L 779 374 L 799 364 L 782 360 L 759 371"/>
+  <text x="780" y="370" style="font-size:5px">4.625,0,0,0</text>
+  <path class="p4" d="M 764 357 L 782 360 L 804 350 L 789 347 L 764 357"/>
+  <text x="785" y="356" style="font-size:5px">4.626,0,0,0</text>
+  <line x1="789" y1="347" x2="804" y2="350"/>
+  <path class="p4" d="M 782 360 L 799 364 L 819 354 L 804 350 L 782 360"/>
+  <text x="801" y="360" style="font-size:5px">4.627,0,0,0</text>
+  <line x1="804" y1="350" x2="819" y2="354"/>
+  <path class="p4" d="M 779 374 L 799 377 L 818 367 L 799 364 L 779 374"/>
+  <text x="799" y="373" style="font-size:5px">4.628,0,0,0</text>
+  <path class="p4" d="M 799 377 L 820 380 L 836 370 L 818 367 L 799 377"/>
+  <text x="818" y="376" style="font-size:5px">4.629,0,0,0</text>
+  <path class="p4" d="M 799 364 L 818 367 L 836 357 L 819 354 L 799 364"/>
+  <text x="818" y="363" style="font-size:5px">4.630,0,0,0</text>
+  <line x1="819" y1="354" x2="836" y2="357"/>
+  <path class="p4" d="M 818 367 L 836 370 L 853 360 L 836 357 L 818 367"/>
+  <text x="836" y="366" style="font-size:5px">4.631,0,0,0</text>
+  <line x1="836" y1="357" x2="853" y2="360"/>
+  <path class="p4" d="M 713 444 L 749 444 L 765 433 L 732 433 L 713 444"/>
+  <text x="739" y="442" style="font-size:6px">4.632,0,0,0</text>
+  <path class="p4" d="M 749 444 L 784 445 L 798 434 L 765 433 L 749 444"/>
+  <text x="774" y="442" style="font-size:6px">4.633,0,0,0</text>
+  <path class="p4" d="M 732 433 L 765 433 L 781 423 L 750 422 L 732 433"/>
+  <text x="757" y="431" style="font-size:6px">4.634,0,0,0</text>
+  <path class="p4" d="M 765 433 L 798 434 L 812 424 L 781 423 L 765 433"/>
+  <text x="789" y="432" style="font-size:6px">4.635,0,0,0</text>
+  <path class="p4" d="M 784 445 L 820 446 L 832 435 L 798 434 L 784 445"/>
+  <text x="809" y="443" style="font-size:6px">4.636,0,0,0</text>
+  <path class="p4" d="M 820 446 L 856 447 L 865 436 L 832 435 L 820 446"/>
+  <text x="843" y="444" style="font-size:6px">4.637,0,0,0</text>
+  <path class="p4" d="M 798 434 L 832 435 L 843 425 L 812 424 L 798 434"/>
+  <text x="821" y="433" style="font-size:6px">4.638,0,0,0</text>
+  <path class="p4" d="M 832 435 L 865 436 L 874 426 L 843 425 L 832 435"/>
+  <text x="853" y="434" style="font-size:6px">4.639,0,0,0</text>
+  <path class="p4" d="M 750 422 L 781 423 L 796 412 L 768 411 L 750 422"/>
+  <text x="774" y="419" style="font-size:5px">4.640,0,0,0</text>
+  <path class="p4" d="M 781 423 L 812 424 L 825 413 L 796 412 L 781 423"/>
+  <text x="804" y="420" style="font-size:5px">4.641,0,0,0</text>
+  <path class="p4" d="M 768 411 L 796 412 L 812 402 L 785 400 L 768 411"/>
+  <text x="790" y="409" style="font-size:5px">4.642,0,0,0</text>
+  <path class="p4" d="M 796 412 L 825 413 L 838 403 L 812 402 L 796 412"/>
+  <text x="818" y="410" style="font-size:5px">4.643,0,0,0</text>
+  <path class="p4" d="M 812 424 L 843 425 L 854 415 L 825 413 L 812 424"/>
+  <text x="833" y="422" style="font-size:5px">4.644,0,0,0</text>
+  <path class="p4" d="M 843 425 L 874 426 L 883 416 L 854 415 L 843 425"/>
+  <text x="863" y="423" style="font-size:5px">4.645,0,0,0</text>
+  <path class="p4" d="M 825 413 L 854 415 L 865 405 L 838 403 L 825 413"/>
+  <text x="846" y="411" style="font-size:5px">4.646,0,0,0</text>
+  <path class="p4" d="M 854 415 L 883 416 L 891 406 L 865 405 L 854 415"/>
+  <text x="873" y="413" style="font-size:5px">4.647,0,0,0</text>
+  <path class="p4" d="M 856 447 L 892 448 L 899 437 L 865 436 L 856 447"/>
+  <text x="878" y="445" style="font-size:6px">4.648,0,0,0</text>
+  <path class="p4" d="M 892 448 L 928 449 L 932 438 L 899 437 L 892 448"/>
+  <text x="913" y="446" style="font-size:6px">4.649,0,0,0</text>
+  <path class="p4" d="M 865 436 L 899 437 L 905 427 L 874 426 L 865 436"/>
+  <text x="886" y="435" style="font-size:6px">4.650,0,0,0</text>
+  <path class="p4" d="M 899 437 L 932 438 L 937 428 L 905 427 L 899 437"/>
+  <text x="918" y="435" style="font-size:6px">4.651,0,0,0</text>
+  <path class="p4" d="M 928 449 L 964 449 L 966 439 L 932 438 L 928 449"/>
+  <text x="948" y="447" style="font-size:6px">4.652,0,0,0</text>
+  <path class="p4" d="M 964 449 L 1000 450 L 1000 440 L 966 439 L 964 449"/>
+  <text x="983" y="447" style="font-size:6px">4.653,0,0,0</text>
+  <path class="p4" d="M 932 438 L 966 439 L 968 428 L 937 428 L 932 438"/>
+  <text x="951" y="436" style="font-size:6px">4.654,0,0,0</text>
+  <path class="p4" d="M 966 439 L 1000 440 L 1000 429 L 968 428 L 966 439"/>
+  <text x="984" y="437" style="font-size:6px">4.655,0,0,0</text>
+  <path class="p4" d="M 874 426 L 905 427 L 912 417 L 883 416 L 874 426"/>
+  <text x="894" y="424" style="font-size:6px">4.656,0,0,0</text>
+  <path class="p4" d="M 905 427 L 937 428 L 941 418 L 912 417 L 905 427"/>
+  <text x="924" y="425" style="font-size:6px">4.657,0,0,0</text>
+  <path class="p4" d="M 883 416 L 912 417 L 918 407 L 891 406 L 883 416"/>
+  <text x="901" y="414" style="font-size:5px">4.658,0,0,0</text>
+  <path class="p4" d="M 912 417 L 941 418 L 946 408 L 918 407 L 912 417"/>
+  <text x="929" y="415" style="font-size:5px">4.659,0,0,0</text>
+  <path class="p4" d="M 937 428 L 968 428 L 971 418 L 941 418 L 937 428"/>
+  <text x="954" y="426" style="font-size:6px">4.660,0,0,0</text>
+  <path class="p4" d="M 968 428 L 1000 429 L 1000 419 L 971 418 L 968 428"/>
+  <text x="985" y="427" style="font-size:6px">4.661,0,0,0</text>
+  <path class="p4" d="M 941 418 L 971 418 L 973 408 L 946 408 L 941 418"/>
+  <text x="958" y="415" style="font-size:5px">4.662,0,0,0</text>
+  <path class="p4" d="M 971 418 L 1000 419 L 1000 409 L 973 408 L 971 418"/>
+  <text x="986" y="416" style="font-size:5px">4.663,0,0,0</text>
+  <path class="p4" d="M 785 400 L 812 402 L 827 392 L 803 390 L 785 400"/>
+  <text x="807" y="398" style="font-size:5px">4.664,0,0,0</text>
+  <path class="p4" d="M 812 402 L 838 403 L 851 393 L 827 392 L 812 402"/>
+  <text x="832" y="400" style="font-size:5px">4.665,0,0,0</text>
+  <path class="p4" d="M 803 390 L 827 392 L 841 382 L 820 380 L 803 390"/>
+  <text x="823" y="388" style="font-size:5px">4.666,0,0,0</text>
+  <path class="p4" d="M 827 392 L 851 393 L 863 384 L 841 382 L 827 392"/>
+  <text x="846" y="390" style="font-size:5px">4.667,0,0,0</text>
+  <path class="p4" d="M 838 403 L 865 405 L 875 395 L 851 393 L 838 403"/>
+  <text x="857" y="401" style="font-size:5px">4.668,0,0,0</text>
+  <path class="p4" d="M 865 405 L 891 406 L 900 396 L 875 395 L 865 405"/>
+  <text x="883" y="403" style="font-size:5px">4.669,0,0,0</text>
+  <path class="p4" d="M 851 393 L 875 395 L 886 385 L 863 384 L 851 393"/>
+  <text x="869" y="392" style="font-size:5px">4.670,0,0,0</text>
+  <path class="p4" d="M 875 395 L 900 396 L 908 387 L 886 385 L 875 395"/>
+  <text x="892" y="393" style="font-size:5px">4.671,0,0,0</text>
+  <path class="p4" d="M 820 380 L 841 382 L 856 372 L 836 370 L 820 380"/>
+  <text x="838" y="378" style="font-size:5px">4.672,0,0,0</text>
+  <path class="p4" d="M 841 382 L 863 384 L 876 374 L 856 372 L 841 382"/>
+  <text x="859" y="380" style="font-size:5px">4.673,0,0,0</text>
+  <path class="p4" d="M 836 370 L 856 372 L 870 362 L 853 360 L 836 370"/>
+  <text x="854" y="368" style="font-size:5px">4.674,0,0,0</text>
+  <line x1="853" y1="360" x2="870" y2="362"/>
+  <path class="p4" d="M 856 372 L 876 374 L 888 365 L 870 362 L 856 372"/>
+  <text x="872" y="371" style="font-size:5px">4.675,0,0,0</text>
+  <line x1="870" y1="362" x2="888" y2="365"/>
+  <path class="p4" d="M 863 384 L 886 385 L 896 376 L 876 374 L 863 384"/>
+  <text x="880" y="382" style="font-size:5px">4.676,0,0,0</text>
+  <path class="p4" d="M 886 385 L 908 387 L 916 377 L 896 376 L 886 385"/>
+  <text x="902" y="384" style="font-size:5px">4.677,0,0,0</text>
+  <path class="p4" d="M 876 374 L 896 376 L 906 367 L 888 365 L 876 374"/>
+  <text x="891" y="373" style="font-size:5px">4.678,0,0,0</text>
+  <line x1="888" y1="365" x2="906" y2="367"/>
+  <path class="p4" d="M 896 376 L 916 377 L 924 368 L 906 367 L 896 376"/>
+  <text x="911" y="374" style="font-size:5px">4.679,0,0,0</text>
+  <line x1="906" y1="367" x2="924" y2="368"/>
+  <path class="p4" d="M 891 406 L 918 407 L 925 397 L 900 396 L 891 406"/>
+  <text x="909" y="404" style="font-size:5px">4.680,0,0,0</text>
+  <path class="p4" d="M 918 407 L 946 408 L 950 398 L 925 397 L 918 407"/>
+  <text x="935" y="405" style="font-size:5px">4.681,0,0,0</text>
+  <path class="p4" d="M 900 396 L 925 397 L 931 388 L 908 387 L 900 396"/>
+  <text x="916" y="395" style="font-size:5px">4.682,0,0,0</text>
+  <path class="p4" d="M 925 397 L 950 398 L 954 389 L 931 388 L 925 397"/>
+  <text x="940" y="395" style="font-size:5px">4.683,0,0,0</text>
+  <path class="p4" d="M 946 408 L 973 408 L 975 399 L 950 398 L 946 408"/>
+  <text x="961" y="406" style="font-size:5px">4.684,0,0,0</text>
+  <path class="p4" d="M 973 408 L 1000 409 L 1000 399 L 975 399 L 973 408"/>
+  <text x="987" y="406" style="font-size:5px">4.685,0,0,0</text>
+  <path class="p4" d="M 950 398 L 975 399 L 977 389 L 954 389 L 950 398"/>
+  <text x="964" y="396" style="font-size:5px">4.686,0,0,0</text>
+  <path class="p4" d="M 975 399 L 1000 399 L 1000 390 L 977 389 L 975 399"/>
+  <text x="988" y="397" style="font-size:5px">4.687,0,0,0</text>
+  <path class="p4" d="M 908 387 L 931 388 L 937 379 L 916 377 L 908 387"/>
+  <text x="923" y="385" style="font-size:5px">4.688,0,0,0</text>
+  <path class="p4" d="M 931 388 L 954 389 L 958 379 L 937 379 L 931 388"/>
+  <text x="945" y="386" style="font-size:5px">4.689,0,0,0</text>
+  <path class="p4" d="M 916 377 L 937 379 L 943 369 L 924 368 L 916 377"/>
+  <text x="930" y="376" style="font-size:5px">4.690,0,0,0</text>
+  <line x1="924" y1="368" x2="943" y2="369"/>
+  <path class="p4" d="M 937 379 L 958 379 L 962 370 L 943 369 L 937 379"/>
+  <text x="950" y="377" style="font-size:5px">4.691,0,0,0</text>
+  <line x1="943" y1="369" x2="962" y2="370"/>
+  <path class="p4" d="M 954 389 L 977 389 L 979 380 L 958 379 L 954 389"/>
+  <text x="967" y="387" style="font-size:5px">4.692,0,0,0</text>
+  <path class="p4" d="M 977 389 L 1000 390 L 1000 380 L 979 380 L 977 389"/>
+  <text x="989" y="387" style="font-size:5px">4.693,0,0,0</text>
+  <path class="p4" d="M 958 379 L 979 380 L 981 371 L 962 370 L 958 379"/>
+  <text x="970" y="378" style="font-size:5px">4.694,0,0,0</text>
+  <line x1="962" y1="370" x2="981" y2="371"/>
+  <path class="p4" d="M 979 380 L 1000 380 L 1000 371 L 981 371 L 979 380"/>
+  <text x="990" y="378" style="font-size:5px">4.695,0,0,0</text>
+  <line x1="981" y1="371" x2="1000" y2="371"/>
+  <path class="p4" d="M 1000 450 L 1036 449 L 1034 439 L 1000 440 L 1000 450"/>
+  <text x="1017" y="447" style="font-size:6px">4.696,0,0,0</text>
+  <path class="p4" d="M 1036 449 L 1072 449 L 1068 438 L 1034 439 L 1036 449"/>
+  <text x="1052" y="447" style="font-size:6px">4.697,0,0,0</text>
+  <path class="p4" d="M 1000 440 L 1034 439 L 1032 428 L 1000 429 L 1000 440"/>
+  <text x="1016" y="437" style="font-size:6px">4.698,0,0,0</text>
+  <path class="p4" d="M 1034 439 L 1068 438 L 1063 428 L 1032 428 L 1034 439"/>
+  <text x="1049" y="436" style="font-size:6px">4.699,0,0,0</text>
+  <path class="p4" d="M 1072 449 L 1108 448 L 1101 437 L 1068 438 L 1072 449"/>
+  <text x="1087" y="446" style="font-size:6px">4.700,0,0,0</text>
+  <path class="p4" d="M 1108 448 L 1144 447 L 1135 436 L 1101 437 L 1108 448"/>
+  <text x="1122" y="445" style="font-size:6px">4.701,0,0,0</text>
+  <path class="p4" d="M 1068 438 L 1101 437 L 1095 427 L 1063 428 L 1068 438"/>
+  <text x="1082" y="435" style="font-size:6px">4.702,0,0,0</text>
+  <path class="p4" d="M 1101 437 L 1135 436 L 1126 426 L 1095 427 L 1101 437"/>
+  <text x="1114" y="435" style="font-size:6px">4.703,0,0,0</text>
+  <path class="p4" d="M 1000 429 L 1032 428 L 1029 418 L 1000 419 L 1000 429"/>
+  <text x="1015" y="427" style="font-size:6px">4.704,0,0,0</text>
+  <path class="p4" d="M 1032 428 L 1063 428 L 1059 418 L 1029 418 L 1032 428"/>
+  <text x="1046" y="426" style="font-size:6px">4.705,0,0,0</text>
+  <path class="p4" d="M 1000 419 L 1029 418 L 1027 408 L 1000 409 L 1000 419"/>
+  <text x="1014" y="416" style="font-size:5px">4.706,0,0,0</text>
+  <path class="p4" d="M 1029 418 L 1059 418 L 1054 408 L 1027 408 L 1029 418"/>
+  <text x="1042" y="415" style="font-size:5px">4.707,0,0,0</text>
+  <path class="p4" d="M 1063 428 L 1095 427 L 1088 417 L 1059 418 L 1063 428"/>
+  <text x="1076" y="425" style="font-size:6px">4.708,0,0,0</text>
+  <path class="p4" d="M 1095 427 L 1126 426 L 1117 416 L 1088 417 L 1095 427"/>
+  <text x="1106" y="424" style="font-size:6px">4.709,0,0,0</text>
+  <path class="p4" d="M 1059 418 L 1088 417 L 1082 407 L 1054 408 L 1059 418"/>
+  <text x="1071" y="415" style="font-size:5px">4.710,0,0,0</text>
+  <path class="p4" d="M 1088 417 L 1117 416 L 1109 406 L 1082 407 L 1088 417"/>
+  <text x="1099" y="414" style="font-size:5px">4.711,0,0,0</text>
+  <path class="p4" d="M 1144 447 L 1180 446 L 1168 435 L 1135 436 L 1144 447"/>
+  <text x="1157" y="444" style="font-size:6px">4.712,0,0,0</text>
+  <path class="p4" d="M 1180 446 L 1216 445 L 1202 434 L 1168 435 L 1180 446"/>
+  <text x="1191" y="443" style="font-size:6px">4.713,0,0,0</text>
+  <path class="p4" d="M 1135 436 L 1168 435 L 1157 425 L 1126 426 L 1135 436"/>
+  <text x="1147" y="434" style="font-size:6px">4.714,0,0,0</text>
+  <path class="p4" d="M 1168 435 L 1202 434 L 1188 424 L 1157 425 L 1168 435"/>
+  <text x="1179" y="433" style="font-size:6px">4.715,0,0,0</text>
+  <path class="p4" d="M 1216 445 L 1251 444 L 1235 433 L 1202 434 L 1216 445"/>
+  <text x="1226" y="442" style="font-size:6px">4.716,0,0,0</text>
+  <path class="p4" d="M 1251 444 L 1287 444 L 1268 433 L 1235 433 L 1251 444"/>
+  <text x="1261" y="442" style="font-size:6px">4.717,0,0,0</text>
+  <path class="p4" d="M 1202 434 L 1235 433 L 1219 423 L 1188 424 L 1202 434"/>
+  <text x="1211" y="432" style="font-size:6px">4.718,0,0,0</text>
+  <path class="p4" d="M 1235 433 L 1268 433 L 1250 422 L 1219 423 L 1235 433"/>
+  <text x="1243" y="431" style="font-size:6px">4.719,0,0,0</text>
+  <path class="p4" d="M 1126 426 L 1157 425 L 1146 415 L 1117 416 L 1126 426"/>
+  <text x="1137" y="423" style="font-size:5px">4.720,0,0,0</text>
+  <path class="p4" d="M 1157 425 L 1188 424 L 1175 413 L 1146 415 L 1157 425"/>
+  <text x="1167" y="422" style="font-size:5px">4.721,0,0,0</text>
+  <path class="p4" d="M 1117 416 L 1146 415 L 1135 405 L 1109 406 L 1117 416"/>
+  <text x="1127" y="413" style="font-size:5px">4.722,0,0,0</text>
+  <path class="p4" d="M 1146 415 L 1175 413 L 1162 403 L 1135 405 L 1146 415"/>
+  <text x="1154" y="411" style="font-size:5px">4.723,0,0,0</text>
+  <path class="p4" d="M 1188 424 L 1219 423 L 1204 412 L 1175 413 L 1188 424"/>
+  <text x="1196" y="420" style="font-size:5px">4.724,0,0,0</text>
+  <path class="p4" d="M 1219 423 L 1250 422 L 1232 411 L 1204 412 L 1219 423"/>
+  <text x="1226" y="419" style="font-size:5px">4.725,0,0,0</text>
+  <path class="p4" d="M 1175 413 L 1204 412 L 1188 402 L 1162 403 L 1175 413"/>
+  <text x="1182" y="410" style="font-size:5px">4.726,0,0,0</text>
+  <path class="p4" d="M 1204 412 L 1232 411 L 1215 400 L 1188 402 L 1204 412"/>
+  <text x="1210" y="409" style="font-size:5px">4.727,0,0,0</text>
+  <path class="p4" d="M 1000 409 L 1027 408 L 1025 399 L 1000 399 L 1000 409"/>
+  <text x="1013" y="406" style="font-size:5px">4.728,0,0,0</text>
+  <path class="p4" d="M 1027 408 L 1054 408 L 1050 398 L 1025 399 L 1027 408"/>
+  <text x="1039" y="406" style="font-size:5px">4.729,0,0,0</text>
+  <path class="p4" d="M 1000 399 L 1025 399 L 1023 389 L 1000 390 L 1000 399"/>
+  <text x="1012" y="397" style="font-size:5px">4.730,0,0,0</text>
+  <path class="p4" d="M 1025 399 L 1050 398 L 1046 389 L 1023 389 L 1025 399"/>
+  <text x="1036" y="396" style="font-size:5px">4.731,0,0,0</text>
+  <path class="p4" d="M 1054 408 L 1082 407 L 1075 397 L 1050 398 L 1054 408"/>
+  <text x="1065" y="405" style="font-size:5px">4.732,0,0,0</text>
+  <path class="p4" d="M 1082 407 L 1109 406 L 1100 396 L 1075 397 L 1082 407"/>
+  <text x="1091" y="404" style="font-size:5px">4.733,0,0,0</text>
+  <path class="p4" d="M 1050 398 L 1075 397 L 1069 388 L 1046 389 L 1050 398"/>
+  <text x="1060" y="395" style="font-size:5px">4.734,0,0,0</text>
+  <path class="p4" d="M 1075 397 L 1100 396 L 1092 387 L 1069 388 L 1075 397"/>
+  <text x="1084" y="395" style="font-size:5px">4.735,0,0,0</text>
+  <path class="p4" d="M 1000 390 L 1023 389 L 1021 380 L 1000 380 L 1000 390"/>
+  <text x="1011" y="387" style="font-size:5px">4.736,0,0,0</text>
+  <path class="p4" d="M 1023 389 L 1046 389 L 1042 379 L 1021 380 L 1023 389"/>
+  <text x="1033" y="387" style="font-size:5px">4.737,0,0,0</text>
+  <path class="p4" d="M 1000 380 L 1021 380 L 1019 371 L 1000 371 L 1000 380"/>
+  <text x="1010" y="378" style="font-size:5px">4.738,0,0,0</text>
+  <line x1="1000" y1="371" x2="1019" y2="371"/>
+  <path class="p4" d="M 1021 380 L 1042 379 L 1038 370 L 1019 371 L 1021 380"/>
+  <text x="1030" y="378" style="font-size:5px">4.739,0,0,0</text>
+  <line x1="1019" y1="371" x2="1038" y2="370"/>
+  <path class="p4" d="M 1046 389 L 1069 388 L 1063 379 L 1042 379 L 1046 389"/>
+  <text x="1055" y="386" style="font-size:5px">4.740,0,0,0</text>
+  <path class="p4" d="M 1069 388 L 1092 387 L 1084 377 L 1063 379 L 1069 388"/>
+  <text x="1077" y="385" style="font-size:5px">4.741,0,0,0</text>
+  <path class="p4" d="M 1042 379 L 1063 379 L 1057 369 L 1038 370 L 1042 379"/>
+  <text x="1050" y="377" style="font-size:5px">4.742,0,0,0</text>
+  <line x1="1038" y1="370" x2="1057" y2="369"/>
+  <path class="p4" d="M 1063 379 L 1084 377 L 1076 368 L 1057 369 L 1063 379"/>
+  <text x="1070" y="376" style="font-size:5px">4.743,0,0,0</text>
+  <line x1="1057" y1="369" x2="1076" y2="368"/>
+  <path class="p4" d="M 1109 406 L 1135 405 L 1125 395 L 1100 396 L 1109 406"/>
+  <text x="1117" y="403" style="font-size:5px">4.744,0,0,0</text>
+  <path class="p4" d="M 1135 405 L 1162 403 L 1149 393 L 1125 395 L 1135 405"/>
+  <text x="1143" y="401" style="font-size:5px">4.745,0,0,0</text>
+  <path class="p4" d="M 1100 396 L 1125 395 L 1114 385 L 1092 387 L 1100 396"/>
+  <text x="1108" y="393" style="font-size:5px">4.746,0,0,0</text>
+  <path class="p4" d="M 1125 395 L 1149 393 L 1137 384 L 1114 385 L 1125 395"/>
+  <text x="1131" y="392" style="font-size:5px">4.747,0,0,0</text>
+  <path class="p4" d="M 1162 403 L 1188 402 L 1173 392 L 1149 393 L 1162 403"/>
+  <text x="1168" y="400" style="font-size:5px">4.748,0,0,0</text>
+  <path class="p4" d="M 1188 402 L 1215 400 L 1197 390 L 1173 392 L 1188 402"/>
+  <text x="1193" y="398" style="font-size:5px">4.749,0,0,0</text>
+  <path class="p4" d="M 1149 393 L 1173 392 L 1159 382 L 1137 384 L 1149 393"/>
+  <text x="1154" y="390" style="font-size:5px">4.750,0,0,0</text>
+  <path class="p4" d="M 1173 392 L 1197 390 L 1180 380 L 1159 382 L 1173 392"/>
+  <text x="1177" y="388" style="font-size:5px">4.751,0,0,0</text>
+  <path class="p4" d="M 1092 387 L 1114 385 L 1104 376 L 1084 377 L 1092 387"/>
+  <text x="1098" y="384" style="font-size:5px">4.752,0,0,0</text>
+  <path class="p4" d="M 1114 385 L 1137 384 L 1124 374 L 1104 376 L 1114 385"/>
+  <text x="1120" y="382" style="font-size:5px">4.753,0,0,0</text>
+  <path class="p4" d="M 1084 377 L 1104 376 L 1094 367 L 1076 368 L 1084 377"/>
+  <text x="1089" y="374" style="font-size:5px">4.754,0,0,0</text>
+  <line x1="1076" y1="368" x2="1094" y2="367"/>
+  <path class="p4" d="M 1104 376 L 1124 374 L 1112 365 L 1094 367 L 1104 376"/>
+  <text x="1109" y="373" style="font-size:5px">4.755,0,0,0</text>
+  <line x1="1094" y1="367" x2="1112" y2="365"/>
+  <path class="p4" d="M 1137 384 L 1159 382 L 1144 372 L 1124 374 L 1137 384"/>
+  <text x="1141" y="380" style="font-size:5px">4.756,0,0,0</text>
+  <path class="p4" d="M 1159 382 L 1180 380 L 1164 370 L 1144 372 L 1159 382"/>
+  <text x="1162" y="378" style="font-size:5px">4.757,0,0,0</text>
+  <path class="p4" d="M 1124 374 L 1144 372 L 1130 362 L 1112 365 L 1124 374"/>
+  <text x="1128" y="371" style="font-size:5px">4.758,0,0,0</text>
+  <line x1="1112" y1="365" x2="1130" y2="362"/>
+  <path class="p4" d="M 1144 372 L 1164 370 L 1147 360 L 1130 362 L 1144 372"/>
+  <text x="1146" y="368" style="font-size:5px">4.759,0,0,0</text>
+  <line x1="1130" y1="362" x2="1147" y2="360"/>
+  <path class="p4" d="M 1287 444 L 1321 441 L 1300 430 L 1268 433 L 1287 444"/>
+  <text x="1294" y="440" style="font-size:6px">4.760,0,0,0</text>
+  <path class="p4" d="M 1321 441 L 1354 439 L 1331 428 L 1300 430 L 1321 441"/>
+  <text x="1327" y="438" style="font-size:6px">4.761,0,0,0</text>
+  <path class="p4" d="M 1268 433 L 1300 430 L 1279 419 L 1250 422 L 1268 433"/>
+  <text x="1274" y="428" style="font-size:5px">4.762,0,0,0</text>
+  <path class="p4" d="M 1300 430 L 1331 428 L 1308 416 L 1279 419 L 1300 430"/>
+  <text x="1305" y="426" style="font-size:5px">4.763,0,0,0</text>
+  <path class="p4" d="M 1250 422 L 1279 419 L 1259 408 L 1232 411 L 1250 422"/>
+  <text x="1255" y="417" style="font-size:5px">4.764,0,0,0</text>
+  <path class="p4" d="M 1279 419 L 1308 416 L 1286 405 L 1259 408 L 1279 419"/>
+  <text x="1283" y="415" style="font-size:5px">4.765,0,0,0</text>
+  <path class="p4" d="M 1232 411 L 1259 408 L 1239 397 L 1215 400 L 1232 411"/>
+  <text x="1236" y="407" style="font-size:5px">4.766,0,0,0</text>
+  <path class="p4" d="M 1259 408 L 1286 405 L 1264 395 L 1239 397 L 1259 408"/>
+  <text x="1262" y="404" style="font-size:5px">4.767,0,0,0</text>
+  <path class="p4" d="M 1308 416 L 1337 414 L 1312 403 L 1286 405 L 1308 416"/>
+  <text x="1311" y="412" style="font-size:5px">4.768,0,0,0</text>
+  <path class="p4" d="M 1337 414 L 1366 411 L 1339 400 L 1312 403 L 1337 414"/>
+  <text x="1338" y="409" style="font-size:5px">4.769,0,0,0</text>
+  <path class="p4" d="M 1286 405 L 1312 403 L 1288 392 L 1264 395 L 1286 405"/>
+  <text x="1287" y="401" style="font-size:5px">4.770,0,0,0</text>
+  <path class="p4" d="M 1312 403 L 1339 400 L 1312 389 L 1288 392 L 1312 403"/>
+  <text x="1313" y="398" style="font-size:5px">4.771,0,0,0</text>
+  <path class="p4" d="M 1366 411 L 1393 408 L 1364 397 L 1339 400 L 1366 411"/>
+  <text x="1365" y="407" style="font-size:5px">4.772,0,0,0</text>
+  <path class="p4" d="M 1393 408 L 1421 406 L 1389 394 L 1364 397 L 1393 408"/>
+  <text x="1392" y="404" style="font-size:5px">4.773,0,0,0</text>
+  <path class="p4" d="M 1339 400 L 1364 397 L 1335 386 L 1312 389 L 1339 400"/>
+  <text x="1337" y="395" style="font-size:5px">4.774,0,0,0</text>
+  <path class="p4" d="M 1364 397 L 1389 394 L 1358 382 L 1335 386 L 1364 397"/>
+  <text x="1361" y="392" style="font-size:5px">4.775,0,0,0</text>
+  <path class="p4" d="M 1421 406 L 1449 403 L 1414 391 L 1389 394 L 1421 406"/>
+  <text x="1418" y="401" style="font-size:5px">4.776,0,0,0</text>
+  <path class="p4" d="M 1449 403 L 1476 400 L 1439 388 L 1414 391 L 1449 403"/>
+  <text x="1444" y="398" style="font-size:5px">4.777,0,0,0</text>
+  <path class="p4" d="M 1389 394 L 1414 391 L 1380 379 L 1358 382 L 1389 394"/>
+  <text x="1385" y="389" style="font-size:5px">4.778,0,0,0</text>
+  <path class="p4" d="M 1414 391 L 1439 388 L 1403 375 L 1380 379 L 1414 391"/>
+  <text x="1409" y="386" style="font-size:5px">4.779,0,0,0</text>
+  <path class="p4" d="M 1215 400 L 1239 397 L 1220 387 L 1197 390 L 1215 400"/>
+  <text x="1218" y="396" style="font-size:5px">4.780,0,0,0</text>
+  <path class="p4" d="M 1239 397 L 1264 395 L 1242 384 L 1220 387 L 1239 397"/>
+  <text x="1241" y="393" style="font-size:5px">4.781,0,0,0</text>
+  <path class="p4" d="M 1197 390 L 1220 387 L 1201 377 L 1180 380 L 1197 390"/>
+  <text x="1200" y="386" style="font-size:5px">4.782,0,0,0</text>
+  <path class="p4" d="M 1220 387 L 1242 384 L 1221 374 L 1201 377 L 1220 387"/>
+  <text x="1221" y="383" style="font-size:5px">4.783,0,0,0</text>
+  <path class="p4" d="M 1264 395 L 1288 392 L 1264 381 L 1242 384 L 1264 395"/>
+  <text x="1264" y="390" style="font-size:5px">4.784,0,0,0</text>
+  <path class="p4" d="M 1288 392 L 1312 389 L 1286 378 L 1264 381 L 1288 392"/>
+  <text x="1288" y="387" style="font-size:5px">4.785,0,0,0</text>
+  <path class="p4" d="M 1242 384 L 1264 381 L 1241 371 L 1221 374 L 1242 384"/>
+  <text x="1242" y="380" style="font-size:5px">4.786,0,0,0</text>
+  <path class="p4" d="M 1264 381 L 1286 378 L 1261 367 L 1241 371 L 1264 381"/>
+  <text x="1263" y="377" style="font-size:5px">4.787,0,0,0</text>
+  <path class="p4" d="M 1180 380 L 1201 377 L 1182 367 L 1164 370 L 1180 380"/>
+  <text x="1182" y="376" style="font-size:5px">4.788,0,0,0</text>
+  <path class="p4" d="M 1201 377 L 1221 374 L 1201 364 L 1182 367 L 1201 377"/>
+  <text x="1201" y="373" style="font-size:5px">4.789,0,0,0</text>
+  <path class="p4" d="M 1164 370 L 1182 367 L 1164 357 L 1147 360 L 1164 370"/>
+  <text x="1164" y="366" style="font-size:5px">4.790,0,0,0</text>
+  <line x1="1147" y1="360" x2="1164" y2="357"/>
+  <path class="p4" d="M 1182 367 L 1201 364 L 1181 354 L 1164 357 L 1182 367"/>
+  <text x="1182" y="363" style="font-size:5px">4.791,0,0,0</text>
+  <line x1="1164" y1="357" x2="1181" y2="354"/>
+  <path class="p4" d="M 1221 374 L 1241 371 L 1218 360 L 1201 364 L 1221 374"/>
+  <text x="1220" y="370" style="font-size:5px">4.792,0,0,0</text>
+  <path class="p4" d="M 1241 371 L 1261 367 L 1236 357 L 1218 360 L 1241 371"/>
+  <text x="1239" y="366" style="font-size:5px">4.793,0,0,0</text>
+  <path class="p4" d="M 1201 364 L 1218 360 L 1196 350 L 1181 354 L 1201 364"/>
+  <text x="1199" y="360" style="font-size:5px">4.794,0,0,0</text>
+  <line x1="1181" y1="354" x2="1196" y2="350"/>
+  <path class="p4" d="M 1218 360 L 1236 357 L 1211 347 L 1196 350 L 1218 360"/>
+  <text x="1215" y="356" style="font-size:5px">4.795,0,0,0</text>
+  <line x1="1196" y1="350" x2="1211" y2="347"/>
+  <path class="p4" d="M 1312 389 L 1335 386 L 1307 374 L 1286 378 L 1312 389"/>
+  <text x="1310" y="384" style="font-size:5px">4.796,0,0,0</text>
+  <path class="p4" d="M 1335 386 L 1358 382 L 1327 371 L 1307 374 L 1335 386"/>
+  <text x="1332" y="381" style="font-size:5px">4.797,0,0,0</text>
+  <path class="p4" d="M 1286 378 L 1307 374 L 1279 364 L 1261 367 L 1286 378"/>
+  <text x="1283" y="373" style="font-size:5px">4.798,0,0,0</text>
+  <path class="p4" d="M 1307 374 L 1327 371 L 1297 360 L 1279 364 L 1307 374"/>
+  <text x="1303" y="370" style="font-size:5px">4.799,0,0,0</text>
+  <path class="p4" d="M 1358 382 L 1380 379 L 1347 367 L 1327 371 L 1358 382"/>
+  <text x="1353" y="377" style="font-size:5px">4.800,0,0,0</text>
+  <path class="p4" d="M 1380 379 L 1403 375 L 1367 364 L 1347 367 L 1380 379"/>
+  <text x="1374" y="374" style="font-size:5px">4.801,0,0,0</text>
+  <path class="p4" d="M 1327 371 L 1347 367 L 1315 356 L 1297 360 L 1327 371"/>
+  <text x="1322" y="366" style="font-size:5px">4.802,0,0,0</text>
+  <path class="p4" d="M 1347 367 L 1367 364 L 1332 352 L 1315 356 L 1347 367"/>
+  <text x="1340" y="362" style="font-size:5px">4.803,0,0,0</text>
+  <path class="p4" d="M 1261 367 L 1279 364 L 1252 353 L 1236 357 L 1261 367"/>
+  <text x="1257" y="363" style="font-size:5px">4.804,0,0,0</text>
+  <path class="p4" d="M 1279 364 L 1297 360 L 1268 349 L 1252 353 L 1279 364"/>
+  <text x="1274" y="359" style="font-size:5px">4.805,0,0,0</text>
+  <path class="p4" d="M 1236 357 L 1252 353 L 1226 343 L 1211 347 L 1236 357"/>
+  <text x="1231" y="352" style="font-size:5px">4.806,0,0,0</text>
+  <line x1="1211" y1="347" x2="1226" y2="343"/>
+  <path class="p4" d="M 1252 353 L 1268 349 L 1239 339 L 1226 343 L 1252 353"/>
+  <text x="1246" y="348" style="font-size:5px">4.807,0,0,0</text>
+  <line x1="1226" y1="343" x2="1239" y2="339"/>
+  <path class="p4" d="M 1297 360 L 1315 356 L 1283 345 L 1268 349 L 1297 360"/>
+  <text x="1291" y="355" style="font-size:5px">4.808,0,0,0</text>
+  <path class="p4" d="M 1315 356 L 1332 352 L 1298 341 L 1283 345 L 1315 356"/>
+  <text x="1307" y="351" style="font-size:5px">4.809,0,0,0</text>
+  <path class="p4" d="M 1268 349 L 1283 345 L 1252 334 L 1239 339 L 1268 349"/>
+  <text x="1261" y="344" style="font-size:5px">4.810,0,0,0</text>
+  <line x1="1239" y1="339" x2="1252" y2="334"/>
+  <path class="p4" d="M 1283 345 L 1298 341 L 1265 330 L 1252 334 L 1283 345"/>
+  <text x="1274" y="340" style="font-size:5px">4.811,0,0,0</text>
+  <line x1="1252" y1="334" x2="1265" y2="330"/>
+  <path class="p4" d="M 1476 400 L 1479 389 L 1443 378 L 1439 388 L 1476 400"/>
+  <text x="1459" y="391" style="font-size:5px">4.812,0,0,0</text>
+  <path class="p4" d="M 1479 389 L 1481 378 L 1447 368 L 1443 378 L 1479 389"/>
+  <text x="1462" y="381" style="font-size:5px">4.813,0,0,0</text>
+  <path class="p4" d="M 1439 388 L 1443 378 L 1408 367 L 1403 375 L 1439 388"/>
+  <text x="1423" y="379" style="font-size:5px">4.814,0,0,0</text>
+  <path class="p4" d="M 1443 378 L 1447 368 L 1413 358 L 1408 367 L 1443 378"/>
+  <text x="1428" y="370" style="font-size:5px">4.815,0,0,0</text>
+  <path class="p4" d="M 1481 378 L 1483 368 L 1450 358 L 1447 368 L 1481 378"/>
+  <text x="1465" y="371" style="font-size:5px">4.816,0,0,0</text>
+  <path class="p4" d="M 1483 368 L 1485 357 L 1454 349 L 1450 358 L 1483 368"/>
+  <text x="1468" y="361" style="font-size:5px">4.817,0,0,0</text>
+  <path class="p4" d="M 1447 368 L 1450 358 L 1418 349 L 1413 358 L 1447 368"/>
+  <text x="1432" y="361" style="font-size:5px">4.818,0,0,0</text>
+  <path class="p4" d="M 1450 358 L 1454 349 L 1423 341 L 1418 349 L 1450 358"/>
+  <text x="1437" y="352" style="font-size:5px">4.819,0,0,0</text>
+  <path class="p4" d="M 1548 350 L 1547 339 L 1518 333 L 1518 343 L 1548 350"/>
+  <text x="1532" y="344" style="font-size:5px">4.820,0,0,0</text>
+  <path class="p4" d="M 1547 339 L 1546 327 L 1518 322 L 1518 333 L 1547 339"/>
+  <text x="1532" y="332" style="font-size:4px">4.821,0,0,0</text>
+  <path class="p4" d="M 1518 343 L 1518 333 L 1489 327 L 1488 337 L 1518 343"/>
+  <text x="1503" y="337" style="font-size:4px">4.822,0,0,0</text>
+  <path class="p4" d="M 1518 333 L 1518 322 L 1491 317 L 1489 327 L 1518 333"/>
+  <text x="1504" y="327" style="font-size:4px">4.823,0,0,0</text>
+  <path class="p4" d="M 1485 357 L 1487 347 L 1457 339 L 1454 349 L 1485 357"/>
+  <text x="1471" y="351" style="font-size:5px">4.824,0,0,0</text>
+  <path class="p4" d="M 1487 347 L 1488 337 L 1459 330 L 1457 339 L 1487 347"/>
+  <text x="1473" y="341" style="font-size:5px">4.825,0,0,0</text>
+  <path class="p4" d="M 1454 349 L 1457 339 L 1427 332 L 1423 341 L 1454 349"/>
+  <text x="1440" y="343" style="font-size:5px">4.826,0,0,0</text>
+  <path class="p4" d="M 1457 339 L 1459 330 L 1430 324 L 1427 332 L 1457 339"/>
+  <text x="1443" y="334" style="font-size:5px">4.827,0,0,0</text>
+  <path class="p4" d="M 1488 337 L 1489 327 L 1461 321 L 1459 330 L 1488 337"/>
+  <text x="1474" y="331" style="font-size:4px">4.828,0,0,0</text>
+  <path class="p4" d="M 1489 327 L 1491 317 L 1463 312 L 1461 321 L 1489 327"/>
+  <text x="1476" y="321" style="font-size:4px">4.829,0,0,0</text>
+  <path class="p4" d="M 1459 330 L 1461 321 L 1433 315 L 1430 324 L 1459 330"/>
+  <text x="1446" y="324" style="font-size:4px">4.830,0,0,0</text>
+  <path class="p4" d="M 1461 321 L 1463 312 L 1437 307 L 1433 315 L 1461 321"/>
+  <text x="1449" y="316" style="font-size:4px">4.831,0,0,0</text>
+  <path class="p4" d="M 1403 375 L 1408 367 L 1374 356 L 1367 364 L 1403 375"/>
+  <text x="1388" y="368" style="font-size:5px">4.832,0,0,0</text>
+  <path class="p4" d="M 1408 367 L 1413 358 L 1381 348 L 1374 356 L 1408 367"/>
+  <text x="1394" y="360" style="font-size:5px">4.833,0,0,0</text>
+  <path class="p4" d="M 1367 364 L 1374 356 L 1340 345 L 1332 352 L 1367 364"/>
+  <text x="1353" y="357" style="font-size:5px">4.834,0,0,0</text>
+  <path class="p4" d="M 1374 356 L 1381 348 L 1349 338 L 1340 345 L 1374 356"/>
+  <text x="1361" y="349" style="font-size:5px">4.835,0,0,0</text>
+  <path class="p4" d="M 1413 358 L 1418 349 L 1387 340 L 1381 348 L 1413 358"/>
+  <text x="1400" y="351" style="font-size:5px">4.836,0,0,0</text>
+  <path class="p4" d="M 1418 349 L 1423 341 L 1393 333 L 1387 340 L 1418 349"/>
+  <text x="1405" y="343" style="font-size:5px">4.837,0,0,0</text>
+  <path class="p4" d="M 1381 348 L 1387 340 L 1356 332 L 1349 338 L 1381 348"/>
+  <text x="1368" y="342" style="font-size:5px">4.838,0,0,0</text>
+  <path class="p4" d="M 1387 340 L 1393 333 L 1363 325 L 1356 332 L 1387 340"/>
+  <text x="1375" y="335" style="font-size:5px">4.839,0,0,0</text>
+  <path class="p4" d="M 1332 352 L 1340 345 L 1308 335 L 1298 341 L 1332 352"/>
+  <text x="1319" y="346" style="font-size:5px">4.840,0,0,0</text>
+  <path class="p4" d="M 1340 345 L 1349 338 L 1317 329 L 1308 335 L 1340 345"/>
+  <text x="1328" y="339" style="font-size:5px">4.841,0,0,0</text>
+  <path class="p4" d="M 1298 341 L 1308 335 L 1276 325 L 1265 330 L 1298 341"/>
+  <text x="1286" y="335" style="font-size:5px">4.842,0,0,0</text>
+  <line x1="1265" y1="330" x2="1276" y2="325"/>
+  <path class="p4" d="M 1308 335 L 1317 329 L 1286 320 L 1276 325 L 1308 335"/>
+  <text x="1297" y="330" style="font-size:5px">4.843,0,0,0</text>
+  <line x1="1276" y1="325" x2="1286" y2="320"/>
+  <path class="p4" d="M 1349 338 L 1356 332 L 1326 323 L 1317 329 L 1349 338"/>
+  <text x="1337" y="333" style="font-size:5px">4.844,0,0,0</text>
+  <path class="p4" d="M 1356 332 L 1363 325 L 1334 317 L 1326 323 L 1356 332"/>
+  <text x="1345" y="326" style="font-size:4px">4.845,0,0,0</text>
+  <path class="p4" d="M 1317 329 L 1326 323 L 1296 315 L 1286 320 L 1317 329"/>
+  <text x="1306" y="324" style="font-size:4px">4.846,0,0,0</text>
+  <line x1="1286" y1="320" x2="1296" y2="315"/>
+  <path class="p4" d="M 1326 323 L 1334 317 L 1305 309 L 1296 315 L 1326 323"/>
+  <text x="1315" y="318" style="font-size:4px">4.847,0,0,0</text>
+  <line x1="1296" y1="315" x2="1305" y2="309"/>
+  <path class="p4" d="M 1423 341 L 1427 332 L 1398 325 L 1393 333 L 1423 341"/>
+  <text x="1410" y="335" style="font-size:5px">4.848,0,0,0</text>
+  <path class="p4" d="M 1427 332 L 1430 324 L 1402 317 L 1398 325 L 1427 332"/>
+  <text x="1414" y="326" style="font-size:4px">4.849,0,0,0</text>
+  <path class="p4" d="M 1393 333 L 1398 325 L 1369 318 L 1363 325 L 1393 333"/>
+  <text x="1381" y="327" style="font-size:4px">4.850,0,0,0</text>
+  <path class="p4" d="M 1398 325 L 1402 317 L 1374 311 L 1369 318 L 1398 325"/>
+  <text x="1386" y="320" style="font-size:4px">4.851,0,0,0</text>
+  <path class="p4" d="M 1430 324 L 1433 315 L 1406 309 L 1402 317 L 1430 324"/>
+  <text x="1418" y="318" style="font-size:4px">4.852,0,0,0</text>
+  <path class="p4" d="M 1433 315 L 1437 307 L 1410 302 L 1406 309 L 1433 315"/>
+  <text x="1421" y="310" style="font-size:4px">4.853,0,0,0</text>
+  <path class="p4" d="M 1402 317 L 1406 309 L 1379 304 L 1374 311 L 1402 317"/>
+  <text x="1390" y="312" style="font-size:4px">4.854,0,0,0</text>
+  <path class="p4" d="M 1406 309 L 1410 302 L 1383 297 L 1379 304 L 1406 309"/>
+  <text x="1395" y="305" style="font-size:4px">4.855,0,0,0</text>
+  <path class="p4" d="M 1363 325 L 1369 318 L 1341 311 L 1334 317 L 1363 325"/>
+  <text x="1352" y="320" style="font-size:4px">4.856,0,0,0</text>
+  <path class="p4" d="M 1369 318 L 1374 311 L 1347 305 L 1341 311 L 1369 318"/>
+  <text x="1358" y="313" style="font-size:4px">4.857,0,0,0</text>
+  <path class="p4" d="M 1334 317 L 1341 311 L 1313 304 L 1305 309 L 1334 317"/>
+  <text x="1323" y="312" style="font-size:4px">4.858,0,0,0</text>
+  <line x1="1305" y1="309" x2="1313" y2="304"/>
+  <path class="p4" d="M 1341 311 L 1347 305 L 1320 298 L 1313 304 L 1341 311"/>
+  <text x="1330" y="306" style="font-size:4px">4.859,0,0,0</text>
+  <line x1="1313" y1="304" x2="1320" y2="298"/>
+  <path class="p4" d="M 1374 311 L 1379 304 L 1352 298 L 1347 305 L 1374 311"/>
+  <text x="1363" y="306" style="font-size:4px">4.860,0,0,0</text>
+  <path class="p4" d="M 1379 304 L 1383 297 L 1357 292 L 1352 298 L 1379 304"/>
+  <text x="1368" y="300" style="font-size:4px">4.861,0,0,0</text>
+  <path class="p4" d="M 1347 305 L 1352 298 L 1326 293 L 1320 298 L 1347 305"/>
+  <text x="1336" y="300" style="font-size:4px">4.862,0,0,0</text>
+  <line x1="1320" y1="298" x2="1326" y2="293"/>
+  <path class="p4" d="M 1352 298 L 1357 292 L 1332 287 L 1326 293 L 1352 298"/>
+  <text x="1342" y="295" style="font-size:4px">4.863,0,0,0</text>
+  <line x1="1326" y1="293" x2="1332" y2="287"/>
+  <path class="p4" d="M 1546 327 L 1541 316 L 1515 311 L 1518 322 L 1546 327"/>
+  <text x="1530" y="321" style="font-size:4px">4.864,0,0,0</text>
+  <path class="p4" d="M 1541 316 L 1537 304 L 1512 301 L 1515 311 L 1541 316"/>
+  <text x="1526" y="310" style="font-size:4px">4.865,0,0,0</text>
+  <path class="p4" d="M 1518 322 L 1515 311 L 1488 307 L 1491 317 L 1518 322"/>
+  <text x="1503" y="316" style="font-size:4px">4.866,0,0,0</text>
+  <path class="p4" d="M 1515 311 L 1512 301 L 1486 297 L 1488 307 L 1515 311"/>
+  <text x="1500" y="306" style="font-size:4px">4.867,0,0,0</text>
+  <path class="p4" d="M 1537 304 L 1533 293 L 1508 290 L 1512 301 L 1537 304"/>
+  <text x="1523" y="299" style="font-size:4px">4.868,0,0,0</text>
+  <path class="p4" d="M 1533 293 L 1529 282 L 1505 280 L 1508 290 L 1533 293"/>
+  <text x="1519" y="289" style="font-size:4px">4.869,0,0,0</text>
+  <path class="p4" d="M 1512 301 L 1508 290 L 1484 287 L 1486 297 L 1512 301"/>
+  <text x="1498" y="296" style="font-size:4px">4.870,0,0,0</text>
+  <path class="p4" d="M 1508 290 L 1505 280 L 1482 278 L 1484 287 L 1508 290"/>
+  <text x="1495" y="286" style="font-size:4px">4.871,0,0,0</text>
+  <path class="p4" d="M 1491 317 L 1488 307 L 1462 303 L 1463 312 L 1491 317"/>
+  <text x="1476" y="312" style="font-size:4px">4.872,0,0,0</text>
+  <path class="p4" d="M 1488 307 L 1486 297 L 1461 293 L 1462 303 L 1488 307"/>
+  <text x="1474" y="302" style="font-size:4px">4.873,0,0,0</text>
+  <path class="p4" d="M 1463 312 L 1462 303 L 1436 298 L 1437 307 L 1463 312"/>
+  <text x="1450" y="307" style="font-size:4px">4.874,0,0,0</text>
+  <path class="p4" d="M 1462 303 L 1461 293 L 1436 290 L 1436 298 L 1462 303"/>
+  <text x="1449" y="298" style="font-size:4px">4.875,0,0,0</text>
+  <path class="p4" d="M 1486 297 L 1484 287 L 1460 284 L 1461 293 L 1486 297"/>
+  <text x="1473" y="293" style="font-size:4px">4.876,0,0,0</text>
+  <path class="p4" d="M 1484 287 L 1482 278 L 1459 276 L 1460 284 L 1484 287"/>
+  <text x="1471" y="283" style="font-size:4px">4.877,0,0,0</text>
+  <path class="p4" d="M 1461 293 L 1460 284 L 1436 281 L 1436 290 L 1461 293"/>
+  <text x="1448" y="289" style="font-size:4px">4.878,0,0,0</text>
+  <path class="p4" d="M 1460 284 L 1459 276 L 1435 273 L 1436 281 L 1460 284"/>
+  <text x="1447" y="281" style="font-size:4px">4.879,0,0,0</text>
+  <path class="p4" d="M 1529 282 L 1525 272 L 1502 270 L 1505 280 L 1529 282"/>
+  <text x="1515" y="278" style="font-size:4px">4.880,0,0,0</text>
+  <path class="p4" d="M 1525 272 L 1521 261 L 1499 260 L 1502 270 L 1525 272"/>
+  <text x="1512" y="268" style="font-size:4px">4.881,0,0,0</text>
+  <path class="p4" d="M 1505 280 L 1502 270 L 1479 268 L 1482 278 L 1505 280"/>
+  <text x="1492" y="276" style="font-size:4px">4.882,0,0,0</text>
+  <path class="p4" d="M 1502 270 L 1499 260 L 1476 259 L 1479 268 L 1502 270"/>
+  <text x="1489" y="267" style="font-size:4px">4.883,0,0,0</text>
+  <path class="p4" d="M 1521 261 L 1517 251 L 1495 251 L 1499 260 L 1521 261"/>
+  <text x="1508" y="258" style="font-size:4px">4.884,0,0,0</text>
+  <path class="p4" d="M 1517 251 L 1513 241 L 1492 241 L 1495 251 L 1517 251"/>
+  <text x="1504" y="248" style="font-size:4px">4.885,0,0,0</text>
+  <path class="p4" d="M 1499 260 L 1495 251 L 1473 250 L 1476 259 L 1499 260"/>
+  <text x="1486" y="257" style="font-size:4px">4.886,0,0,0</text>
+  <path class="p4" d="M 1495 251 L 1492 241 L 1471 241 L 1473 250 L 1495 251"/>
+  <text x="1483" y="248" style="font-size:4px">4.887,0,0,0</text>
+  <path class="p4" d="M 1482 278 L 1479 268 L 1456 267 L 1459 276 L 1482 278"/>
+  <text x="1469" y="274" style="font-size:4px">4.888,0,0,0</text>
+  <path class="p4" d="M 1479 268 L 1476 259 L 1454 258 L 1456 267 L 1479 268"/>
+  <text x="1466" y="265" style="font-size:4px">4.889,0,0,0</text>
+  <path class="p4" d="M 1459 276 L 1456 267 L 1434 265 L 1435 273 L 1459 276"/>
+  <text x="1446" y="272" style="font-size:4px">4.890,0,0,0</text>
+  <path class="p4" d="M 1456 267 L 1454 258 L 1432 257 L 1434 265 L 1456 267"/>
+  <text x="1444" y="264" style="font-size:4px">4.891,0,0,0</text>
+  <path class="p4" d="M 1476 259 L 1473 250 L 1452 250 L 1454 258 L 1476 259"/>
+  <text x="1464" y="256" style="font-size:4px">4.892,0,0,0</text>
+  <path class="p4" d="M 1473 250 L 1471 241 L 1449 241 L 1452 250 L 1473 250"/>
+  <text x="1461" y="248" style="font-size:4px">4.893,0,0,0</text>
+  <path class="p4" d="M 1454 258 L 1452 250 L 1430 249 L 1432 257 L 1454 258"/>
+  <text x="1442" y="255" style="font-size:4px">4.894,0,0,0</text>
+  <path class="p4" d="M 1452 250 L 1449 241 L 1428 241 L 1430 249 L 1452 250"/>
+  <text x="1440" y="247" style="font-size:4px">4.895,0,0,0</text>
+  <path class="p4" d="M 1437 307 L 1436 298 L 1411 294 L 1410 302 L 1437 307"/>
+  <text x="1423" y="302" style="font-size:4px">4.896,0,0,0</text>
+  <path class="p4" d="M 1436 298 L 1436 290 L 1412 286 L 1411 294 L 1436 298"/>
+  <text x="1424" y="294" style="font-size:4px">4.897,0,0,0</text>
+  <path class="p4" d="M 1410 302 L 1411 294 L 1385 290 L 1383 297 L 1410 302"/>
+  <text x="1397" y="298" style="font-size:4px">4.898,0,0,0</text>
+  <path class="p4" d="M 1411 294 L 1412 286 L 1387 283 L 1385 290 L 1411 294"/>
+  <text x="1399" y="290" style="font-size:4px">4.899,0,0,0</text>
+  <path class="p4" d="M 1436 290 L 1436 281 L 1412 279 L 1412 286 L 1436 290"/>
+  <text x="1424" y="286" style="font-size:4px">4.900,0,0,0</text>
+  <path class="p4" d="M 1436 281 L 1435 273 L 1412 271 L 1412 279 L 1436 281"/>
+  <text x="1424" y="278" style="font-size:4px">4.901,0,0,0</text>
+  <path class="p4" d="M 1412 286 L 1412 279 L 1388 276 L 1387 283 L 1412 286"/>
+  <text x="1400" y="283" style="font-size:4px">4.902,0,0,0</text>
+  <path class="p4" d="M 1412 279 L 1412 271 L 1389 269 L 1388 276 L 1412 279"/>
+  <text x="1401" y="275" style="font-size:4px">4.903,0,0,0</text>
+  <path class="p4" d="M 1383 297 L 1385 290 L 1361 286 L 1357 292 L 1383 297"/>
+  <text x="1372" y="293" style="font-size:4px">4.904,0,0,0</text>
+  <path class="p4" d="M 1385 290 L 1387 283 L 1363 279 L 1361 286 L 1385 290"/>
+  <text x="1374" y="286" style="font-size:4px">4.905,0,0,0</text>
+  <path class="p4" d="M 1357 292 L 1361 286 L 1336 281 L 1332 287 L 1357 292"/>
+  <text x="1346" y="288" style="font-size:4px">4.906,0,0,0</text>
+  <line x1="1332" y1="287" x2="1336" y2="281"/>
+  <path class="p4" d="M 1361 286 L 1363 279 L 1339 276 L 1336 281 L 1361 286"/>
+  <text x="1350" y="282" style="font-size:4px">4.907,0,0,0</text>
+  <line x1="1336" y1="281" x2="1339" y2="276"/>
+  <path class="p4" d="M 1387 283 L 1388 276 L 1365 273 L 1363 279 L 1387 283"/>
+  <text x="1376" y="280" style="font-size:4px">4.908,0,0,0</text>
+  <path class="p4" d="M 1388 276 L 1389 269 L 1367 266 L 1365 273 L 1388 276"/>
+  <text x="1377" y="273" style="font-size:4px">4.909,0,0,0</text>
+  <path class="p4" d="M 1363 279 L 1365 273 L 1342 270 L 1339 276 L 1363 279"/>
+  <text x="1352" y="276" style="font-size:4px">4.910,0,0,0</text>
+  <line x1="1339" y1="276" x2="1342" y2="270"/>
+  <path class="p4" d="M 1365 273 L 1367 266 L 1344 264 L 1342 270 L 1365 273"/>
+  <text x="1354" y="270" style="font-size:4px">4.911,0,0,0</text>
+  <line x1="1342" y1="270" x2="1344" y2="264"/>
+  <path class="p4" d="M 1435 273 L 1434 265 L 1411 263 L 1412 271 L 1435 273"/>
+  <text x="1423" y="270" style="font-size:4px">4.912,0,0,0</text>
+  <path class="p4" d="M 1434 265 L 1432 257 L 1410 256 L 1411 263 L 1434 265"/>
+  <text x="1422" y="262" style="font-size:4px">4.913,0,0,0</text>
+  <path class="p4" d="M 1412 271 L 1411 263 L 1389 262 L 1389 269 L 1412 271"/>
+  <text x="1400" y="268" style="font-size:4px">4.914,0,0,0</text>
+  <path class="p4" d="M 1411 263 L 1410 256 L 1388 255 L 1389 262 L 1411 263"/>
+  <text x="1399" y="261" style="font-size:4px">4.915,0,0,0</text>
+  <path class="p4" d="M 1432 257 L 1430 249 L 1408 249 L 1410 256 L 1432 257"/>
+  <text x="1420" y="255" style="font-size:4px">4.916,0,0,0</text>
+  <path class="p4" d="M 1430 249 L 1428 241 L 1406 241 L 1408 249 L 1430 249"/>
+  <text x="1418" y="247" style="font-size:4px">4.917,0,0,0</text>
+  <path class="p4" d="M 1410 256 L 1408 249 L 1387 248 L 1388 255 L 1410 256"/>
+  <text x="1398" y="254" style="font-size:4px">4.918,0,0,0</text>
+  <path class="p4" d="M 1408 249 L 1406 241 L 1385 241 L 1387 248 L 1408 249"/>
+  <text x="1397" y="247" style="font-size:4px">4.919,0,0,0</text>
+  <path class="p4" d="M 1389 269 L 1389 262 L 1367 260 L 1367 266 L 1389 269"/>
+  <text x="1378" y="266" style="font-size:4px">4.920,0,0,0</text>
+  <path class="p4" d="M 1389 262 L 1388 255 L 1366 254 L 1367 260 L 1389 262"/>
+  <text x="1377" y="260" style="font-size:4px">4.921,0,0,0</text>
+  <path class="p4" d="M 1367 266 L 1367 260 L 1345 258 L 1344 264 L 1367 266"/>
+  <text x="1355" y="264" style="font-size:4px">4.922,0,0,0</text>
+  <line x1="1344" y1="264" x2="1345" y2="258"/>
+  <path class="p4" d="M 1367 260 L 1366 254 L 1345 253 L 1345 258 L 1367 260"/>
+  <text x="1356" y="258" style="font-size:4px">4.923,0,0,0</text>
+  <line x1="1345" y1="258" x2="1345" y2="253"/>
+  <path class="p4" d="M 1388 255 L 1387 248 L 1365 248 L 1366 254 L 1388 255"/>
+  <text x="1377" y="253" style="font-size:4px">4.924,0,0,0</text>
+  <path class="p4" d="M 1387 248 L 1385 241 L 1364 241 L 1365 248 L 1387 248"/>
+  <text x="1375" y="247" style="font-size:4px">4.925,0,0,0</text>
+  <path class="p4" d="M 1366 254 L 1365 248 L 1344 247 L 1345 253 L 1366 254"/>
+  <text x="1355" y="252" style="font-size:4px">4.926,0,0,0</text>
+  <line x1="1345" y1="253" x2="1344" y2="247"/>
+  <path class="p4" d="M 1365 248 L 1364 241 L 1342 241 L 1344 247 L 1365 248"/>
+  <text x="1354" y="246" style="font-size:4px">4.927,0,0,0</text>
+  <line x1="1344" y1="247" x2="1342" y2="241"/>
+
+ <!-- legend -->
+ <rect x="2000" y="96" width="386" height="259"/>
+ <text x="2015" y="128" style="text-anchor:start; font-weight:bold; font-size:21px">cell label</text>
+  <text x="2024" y="159" style="text-anchor:start; font-style:oblique; font-size:21px">cell_level.</text>
+  <text x="2024" y="191" style="text-anchor:start; font-style:oblique; font-size:21px">cell_index,</text>
+  <text x="2024" y="222" style="text-anchor:start; font-style:oblique; font-size:21px">material_id,</text>
+  <text x= "2024" y="254" style="text-anchor:start; font-style:oblique; font-size:21px">subdomain_id,</text>
+  <text x= "2024" y="285" style="text-anchor:start; font-style:oblique; font-size:21px">level_subdomain_id</text>
+  <text x="2000" y="385" style="text-anchor:start; font-size:21px">azimuth: 0°, polar: 60°</text>
+
+ <!-- colorbar -->
+ <text x="2000" y="429" style="text-anchor:start; font-weight:bold; font-size:21px">level_number</text>
+  <rect class="r0" x="2000" y="974" width="30" height="132"/>
+  <text x="2045.00" y="1047.00" style="text-anchor:start; font-size:21px; font-weight:bold">0 min</text>
+  <rect class="r1" x="2000" y="842" width="30" height="132"/>
+  <text x="2045.00" y="915.000" style="text-anchor:start; font-size:21px">1</text>
+  <rect class="r2" x="2000" y="710" width="30" height="132"/>
+  <text x="2045.00" y="783.000" style="text-anchor:start; font-size:21px">2</text>
+  <rect class="r3" x="2000" y="578" width="30" height="132"/>
+  <text x="2045.00" y="651.000" style="text-anchor:start; font-size:21px">3</text>
+  <rect class="r4" x="2000" y="446" width="30" height="132"/>
+  <text x="2045.00" y="519.000" style="text-anchor:start; font-size:21px; font-weight:bold">4 max</text>
+
+</svg>

--- a/tests/matrix_free/dg_pbc_02.with_mpi=true.with_p4est=true.mpirun=7.output.novec
+++ b/tests/matrix_free/dg_pbc_02.with_mpi=true.with_p4est=true.mpirun=7.output.novec
@@ -8,16 +8,16 @@ DEAL:0:2d::Interior faces: 1 0 0 0
 DEAL:0:2d::Exterior faces: 0 1 0 0 
 DEAL:0:2d::Boundary faces: 0 0 2 0 
 DEAL:0:2d::Level: 2
-DEAL:0:2d::Interior faces: 2 1 1 3 
-DEAL:0:2d::Exterior faces: 1 2 3 1 
+DEAL:0:2d::Interior faces: 2 1 2 2 
+DEAL:0:2d::Exterior faces: 1 2 2 2 
 DEAL:0:2d::Boundary faces: 0 0 3 0 
 DEAL:0:2d::Level: 3
-DEAL:0:2d::Interior faces: 10 7 7 8 
-DEAL:0:2d::Exterior faces: 7 10 8 7 
+DEAL:0:2d::Interior faces: 15 2 10 5 
+DEAL:0:2d::Exterior faces: 2 15 5 10 
 DEAL:0:2d::Boundary faces: 0 0 6 0 
 DEAL:0:2d::Level: 4
-DEAL:0:2d::Interior faces: 56 16 47 19 
-DEAL:0:2d::Exterior faces: 16 56 19 47 
+DEAL:0:2d::Interior faces: 62 10 53 13 
+DEAL:0:2d::Exterior faces: 10 62 13 53 
 DEAL:0:2d::Boundary faces: 0 0 12 0 
 DEAL:0:3d::Level: 0
 DEAL:0:3d::Interior faces: 0 0 0 0 0 1 
@@ -45,12 +45,12 @@ DEAL:1:2d::Interior faces: 2 4 1 2
 DEAL:1:2d::Exterior faces: 4 2 2 1 
 DEAL:1:2d::Boundary faces: 0 0 1 0 
 DEAL:1:2d::Level: 3
-DEAL:1:2d::Interior faces: 13 5 11 7 
-DEAL:1:2d::Exterior faces: 5 13 7 11 
+DEAL:1:2d::Interior faces: 14 4 11 7 
+DEAL:1:2d::Exterior faces: 4 14 7 11 
 DEAL:1:2d::Boundary faces: 0 0 2 0 
 DEAL:1:2d::Level: 4
-DEAL:1:2d::Interior faces: 57 18 49 26 
-DEAL:1:2d::Exterior faces: 18 57 26 49 
+DEAL:1:2d::Interior faces: 62 13 56 19 
+DEAL:1:2d::Exterior faces: 13 62 19 56 
 DEAL:1:2d::Boundary faces: 0 0 4 0 
 DEAL:1:3d::Level: 0
 DEAL:1:3d::Interior faces: 0 0 0 0 0 0 
@@ -79,12 +79,12 @@ DEAL:2:2d::Interior faces: 2 1 3 1
 DEAL:2:2d::Exterior faces: 1 2 1 3 
 DEAL:2:2d::Boundary faces: 0 0 0 2 
 DEAL:2:2d::Level: 3
-DEAL:2:2d::Interior faces: 11 8 10 6 
-DEAL:2:2d::Exterior faces: 8 11 6 10 
+DEAL:2:2d::Interior faces: 13 6 8 8 
+DEAL:2:2d::Exterior faces: 6 13 8 8 
 DEAL:2:2d::Boundary faces: 0 0 0 4 
 DEAL:2:2d::Level: 4
-DEAL:2:2d::Interior faces: 56 19 48 17 
-DEAL:2:2d::Exterior faces: 19 56 17 48 
+DEAL:2:2d::Interior faces: 59 16 52 13 
+DEAL:2:2d::Exterior faces: 16 59 13 52 
 DEAL:2:2d::Boundary faces: 0 0 0 8 
 DEAL:2:3d::Level: 0
 DEAL:2:3d::Interior faces: 0 0 0 0 0 0 
@@ -113,12 +113,12 @@ DEAL:3:2d::Interior faces: 3 2 1 1
 DEAL:3:2d::Exterior faces: 2 3 1 1 
 DEAL:3:2d::Boundary faces: 0 0 2 2 
 DEAL:3:2d::Level: 3
-DEAL:3:2d::Interior faces: 11 7 9 4 
-DEAL:3:2d::Exterior faces: 7 11 4 9 
+DEAL:3:2d::Interior faces: 12 6 7 6 
+DEAL:3:2d::Exterior faces: 6 12 6 7 
 DEAL:3:2d::Boundary faces: 0 0 4 4 
 DEAL:3:2d::Level: 4
-DEAL:3:2d::Interior faces: 54 16 48 18 
-DEAL:3:2d::Exterior faces: 16 54 18 48 
+DEAL:3:2d::Interior faces: 60 10 49 17 
+DEAL:3:2d::Exterior faces: 10 60 17 49 
 DEAL:3:2d::Boundary faces: 0 0 8 8 
 DEAL:3:3d::Level: 0
 DEAL:3:3d::Interior faces: 1 1 0 0 0 1 
@@ -147,12 +147,12 @@ DEAL:4:2d::Interior faces: 3 2 2 1
 DEAL:4:2d::Exterior faces: 2 3 1 2 
 DEAL:4:2d::Boundary faces: 0 0 2 0 
 DEAL:4:2d::Level: 3
-DEAL:4:2d::Interior faces: 12 6 8 8 
-DEAL:4:2d::Exterior faces: 6 12 8 8 
+DEAL:4:2d::Interior faces: 14 4 8 8 
+DEAL:4:2d::Exterior faces: 4 14 8 8 
 DEAL:4:2d::Boundary faces: 0 0 4 0 
 DEAL:4:2d::Level: 4
-DEAL:4:2d::Interior faces: 55 17 45 23 
-DEAL:4:2d::Exterior faces: 17 55 23 45 
+DEAL:4:2d::Interior faces: 59 13 51 17 
+DEAL:4:2d::Exterior faces: 13 59 17 51 
 DEAL:4:2d::Boundary faces: 0 0 8 0 
 DEAL:4:3d::Level: 0
 DEAL:4:3d::Interior faces: 0 0 0 0 0 0 
@@ -181,12 +181,12 @@ DEAL:5:2d::Interior faces: 3 1 3 2
 DEAL:5:2d::Exterior faces: 1 3 2 3 
 DEAL:5:2d::Boundary faces: 0 0 0 2 
 DEAL:5:2d::Level: 3
-DEAL:5:2d::Interior faces: 14 5 12 7 
-DEAL:5:2d::Exterior faces: 5 14 7 12 
+DEAL:5:2d::Interior faces: 15 4 13 6 
+DEAL:5:2d::Exterior faces: 4 15 6 13 
 DEAL:5:2d::Boundary faces: 0 0 0 2 
 DEAL:5:2d::Level: 4
-DEAL:5:2d::Interior faces: 58 16 58 18 
-DEAL:5:2d::Exterior faces: 16 58 18 58 
+DEAL:5:2d::Interior faces: 65 9 59 17 
+DEAL:5:2d::Exterior faces: 9 65 17 59 
 DEAL:5:2d::Boundary faces: 0 0 0 4 
 DEAL:5:3d::Level: 0
 DEAL:5:3d::Interior faces: 0 0 0 0 0 0 
@@ -215,12 +215,12 @@ DEAL:6:2d::Interior faces: 4 2 3 0
 DEAL:6:2d::Exterior faces: 2 4 0 3 
 DEAL:6:2d::Boundary faces: 0 0 0 2 
 DEAL:6:2d::Level: 3
-DEAL:6:2d::Interior faces: 12 7 14 1 
-DEAL:6:2d::Exterior faces: 7 12 1 14 
+DEAL:6:2d::Interior faces: 14 5 14 1 
+DEAL:6:2d::Exterior faces: 5 14 1 14 
 DEAL:6:2d::Boundary faces: 0 0 0 6 
 DEAL:6:2d::Level: 4
-DEAL:6:2d::Interior faces: 58 16 59 5 
-DEAL:6:2d::Exterior faces: 16 58 5 59 
+DEAL:6:2d::Interior faces: 62 12 59 5 
+DEAL:6:2d::Exterior faces: 12 62 5 59 
 DEAL:6:2d::Boundary faces: 0 0 0 12 
 DEAL:6:3d::Level: 0
 DEAL:6:3d::Interior faces: 0 0 0 0 0 0 


### PR DESCRIPTION
This PR fixes three unrelated tests:
- `data_out/data_out_base_vtu_04`: Here machines with `-march=somethingnew` produce other output than the regular machines. I've traced that down to the use of fused multiply-add, so I add that variant. Note that we already have two variants for this test. See the run here:
https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=5552
- `grid/grid_out_svg_02`: Same here, we have a few variants pre-existing already, and again I see the present output on FMA-enabled machines.
- `matrix_free/dg_pbc_02`: Here I simply missed to produce the correct output for the case without any vectorization in #9683. The affected problem is here:
https://cdash.43-1.org/testDetails.php?test=39531352&build=5560