### PR TITLE
Don't parse *.cc files with doxygen

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -70,7 +70,7 @@ WARN_IF_DOC_ERROR      = YES
 
 INPUT                  =
 RECURSIVE              = YES
-EXCLUDE_PATTERNS       = *.templates.h
+EXCLUDE_PATTERNS       = *.templates.h @CMAKE_SOURCE_DIR@/source/*.cc
 EXAMPLE_PATH           = @CMAKE_BINARY_DIR@/doc/doxygen/tutorial \
                          @CMAKE_SOURCE_DIR@/examples/doxygen
 EXAMPLE_RECURSIVE      = NO


### PR DESCRIPTION
This cuts down the number of `doxygen` warnings to around 250 lines for me. Admittedly, this, of course, implies that no links these files are generated anymore. On the other hand, most of the warnings come from these files implying that that doesn't work properly anyway.