### PR TITLE
TrilinosML constant modes bug fix

### DIFF
--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1265,6 +1265,14 @@ namespace DoFTools
                          const ComponentMask &           component_mask,
                          std::vector<std::vector<bool>> &constant_modes)
   {
+    // If there are no locally owned DoFs, return with an empty
+    // constant_modes object:
+    if (dof_handler.n_locally_owned_dofs() == 0)
+      {
+        constant_modes = std::vector<std::vector<bool>>(0);
+        return;
+      }
+
     const unsigned int n_components = dof_handler.get_fe(0).n_components();
     Assert(component_mask.represents_n_components(n_components),
            ExcDimensionMismatch(n_components, component_mask.size()));


### PR DESCRIPTION
When using the `constant_modes` setting for Trilinos PreconditionAMG, if a rank has no locally owned dofs but the `constant_modes` are stored, Trilinos will throw an error (for version 12-10-1) or a warning (version 12-18-1) during the initialization of the preconditioner. 

Using step-32 with no global or adaptive refinement (12 total active cells) on > 12 cores as an example, the following error/warning gets thrown during `build_stokes_preconditioner()`:

**trilinos-12-10-1:**
_*ML*ERR* : Null space vectors is NULL!
ML::FATAL ERROR:: 1, /hdscratch/shared/libs-candi-9.1.1-r2/tmp/unpack/Trilinos-trilinos-release-12-10-1/packages/ml/src/Utils/ml_MultiLevelPreconditioner_NullSpace.cpp, line 98_

**trilinos-12-18-1:**
_WARNING:  When no nullspace vector is specified, the number
of PDE equations must equal the nullspace dimension._

Fix: I return an empty constant modes vector in the `DoFTools::extract_constant_modes()` call if the dof_handler has no locally owned dofs.  