### PR TITLE
Use the same variable name in all output files in step-52.

### DIFF
--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -445,19 +445,19 @@ namespace Step52
             break;
           }
       }
-    const std::string solution_name = "solution_" + method_name;
 
     DataOut<2> data_out;
 
     data_out.attach_dof_handler(dof_handler);
-    data_out.add_data_vector(solution, solution_name);
+    data_out.add_data_vector(solution, "solution");
 
     data_out.build_patches();
 
     data_out.set_flags(DataOutBase::VtkFlags(time, time_step));
 
-    const std::string filename =
-      solution_name + "-" + Utilities::int_to_string(time_step, 3) + ".vtu";
+    const std::string filename = "solution_" + method_name + "-" +
+                                 Utilities::int_to_string(time_step, 3) +
+                                 ".vtu";
     std::ofstream output(filename);
     data_out.write_vtu(output);
 


### PR DESCRIPTION
#9833 appended the method name to the name of the solution variable, but this is awkward because one can then no longer load a different set of file names (the program generates output for a variety of different time integrators): Visit will complain that the variable that was plotted before is no longer in the newly loaded input file and throw away all plots one had previously created.

@krishnakumarg1984 -- FYI.

/rebuild