### PR TITLE
Remove debug output in step-52.

### DIFF
--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -467,7 +467,6 @@ namespace Step52
     static std::string pvd_filename;
     if (method_name_prev != method_name)
       {
-        std::cout << "Starting a new time-stepping scheme ..." << std::endl;
         times_and_names.clear();
         method_name_prev = method_name;
         pvd_filename     = "solution_" + method_name + ".pvd";


### PR DESCRIPTION
The line of output printed here doesn't make reading the output any easier,
and it doesn't actually print what is happening at this place: We start a new
sequence of output files, but we don't start a new method (that has happened
before, when we actually started using the new method).

For reference, the current output looks like this:
```
Explicit methods:
Starting a new time-stepping scheme ...
Forward Euler:            error=1.00883
Starting a new time-stepping scheme ...
Third order Runge-Kutta:  error=0.000227982
Starting a new time-stepping scheme ...
Fourth order Runge-Kutta: error=1.90541e-06
```

Related to #9833 . 
@krishnakumarg1984 -- FYI.

/rebuild