### PR TITLE
Make the output of step-52 a bit easier to read.

### DIFF
--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -692,21 +692,21 @@ namespace Step52
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Forward Euler:            error=" << solution.l2_norm()
+    std::cout << "   Forward Euler:            error=" << solution.l2_norm()
               << std::endl;
 
     explicit_method(TimeStepping::RK_THIRD_ORDER,
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Third order Runge-Kutta:  error=" << solution.l2_norm()
+    std::cout << "   Third order Runge-Kutta:  error=" << solution.l2_norm()
               << std::endl;
 
     explicit_method(TimeStepping::RK_CLASSIC_FOURTH_ORDER,
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Fourth order Runge-Kutta: error=" << solution.l2_norm()
+    std::cout << "   Fourth order Runge-Kutta: error=" << solution.l2_norm()
               << std::endl;
     std::cout << std::endl;
 
@@ -716,28 +716,28 @@ namespace Step52
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Backward Euler:           error=" << solution.l2_norm()
+    std::cout << "   Backward Euler:           error=" << solution.l2_norm()
               << std::endl;
 
     implicit_method(TimeStepping::IMPLICIT_MIDPOINT,
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Implicit Midpoint:        error=" << solution.l2_norm()
+    std::cout << "   Implicit Midpoint:        error=" << solution.l2_norm()
               << std::endl;
 
     implicit_method(TimeStepping::CRANK_NICOLSON,
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "Crank-Nicolson:           error=" << solution.l2_norm()
+    std::cout << "   Crank-Nicolson:           error=" << solution.l2_norm()
               << std::endl;
 
     implicit_method(TimeStepping::SDIRK_TWO_STAGES,
                     n_time_steps,
                     initial_time,
                     final_time);
-    std::cout << "SDIRK:                    error=" << solution.l2_norm()
+    std::cout << "   SDIRK:                    error=" << solution.l2_norm()
               << std::endl;
     std::cout << std::endl;
 
@@ -747,7 +747,7 @@ namespace Step52
                                        n_time_steps,
                                        initial_time,
                                        final_time);
-    std::cout << "Heun-Euler:               error=" << solution.l2_norm()
+    std::cout << "   Heun-Euler:               error=" << solution.l2_norm()
               << std::endl;
     std::cout << "                steps performed=" << n_steps << std::endl;
 
@@ -755,7 +755,7 @@ namespace Step52
                                        n_time_steps,
                                        initial_time,
                                        final_time);
-    std::cout << "Bogacki-Shampine:         error=" << solution.l2_norm()
+    std::cout << "   Bogacki-Shampine:         error=" << solution.l2_norm()
               << std::endl;
     std::cout << "                steps performed=" << n_steps << std::endl;
 
@@ -763,7 +763,7 @@ namespace Step52
                                        n_time_steps,
                                        initial_time,
                                        final_time);
-    std::cout << "Dopri:                    error=" << solution.l2_norm()
+    std::cout << "   Dopri:                    error=" << solution.l2_norm()
               << std::endl;
     std::cout << "                steps performed=" << n_steps << std::endl;
 
@@ -771,7 +771,7 @@ namespace Step52
                                        n_time_steps,
                                        initial_time,
                                        final_time);
-    std::cout << "Fehlberg:                 error=" << solution.l2_norm()
+    std::cout << "   Fehlberg:                 error=" << solution.l2_norm()
               << std::endl;
     std::cout << "                steps performed=" << n_steps << std::endl;
 
@@ -779,7 +779,7 @@ namespace Step52
                                        n_time_steps,
                                        initial_time,
                                        final_time);
-    std::cout << "Cash-Karp:                error=" << solution.l2_norm()
+    std::cout << "   Cash-Karp:                error=" << solution.l2_norm()
               << std::endl;
     std::cout << "                steps performed=" << n_steps << std::endl;
   }


### PR DESCRIPTION
Just indenting things make it easier. With #9899, we now get this:
```
Explicit methods:
   Forward Euler:            error=1.00883
   Third order Runge-Kutta:  error=0.000227982
   Fourth order Runge-Kutta: error=1.90541e-06

Implicit methods:
   Backward Euler:           error=1.03428
   Implicit Midpoint:        error=0.00862702
   Crank-Nicolson:           error=0.00862675
   SDIRK:                    error=0.0042349

Embedded explicit methods:
   Heun-Euler:               error=0.0073012
                steps performed=284
   Bogacki-Shampine:         error=0.000403281
                steps performed=181
   Dopri:                    error=5.07155e-05
                steps performed=121
   Fehlberg:                 error=0.00401035
                steps performed=106
   Cash-Karp:                error=0.00156445
                steps performed=107
```
That's better than before, though the "steps performed=" part is still distracting. Will get to that some other time.

Related to #9833 .
@krishnakumarg1984 -- FYI.

/rebuild