### PR TITLE
Do not include fe_q.h in mapping_q_generic.h

### DIFF
--- a/doc/news/changes/incompatibilities/20200416MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20200416MartinKronbichler
@@ -1,0 +1,5 @@
+Changed: The header file `deal.II/fe/fe_q.h` is not included implicitly via
+`deal.II/fe/mapping_q_generic.h` any more. Add the header
+`#include <deal.II/fe/fe_q.h>` if necessary.
+<br>
+(Martin Kronbichler, 2020/04/16)

--- a/examples/step-10/step-10.cc
+++ b/examples/step-10/step-10.cc
@@ -333,8 +333,8 @@ namespace Step10
         Triangulation<dim> triangulation;
         GridGenerator::hyper_ball(triangulation);
 
-        const MappingQ<dim> mapping(degree);
-        const FE_Q<dim>     fe(1);
+        const MappingQ<dim>   mapping(degree);
+        const FE_Nothing<dim> fe;
 
         DoFHandler<dim> dof_handler(triangulation);
 

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -41,6 +41,7 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -53,6 +53,7 @@
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping.h>
 #include <deal.II/fe/mapping_q.h>

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -24,7 +24,6 @@
 #include <deal.II/base/table.h>
 #include <deal.II/base/vectorization.h>
 
-#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping.h>
 
 #include <deal.II/grid/tria_iterator.h>

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -13,6 +13,8 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
+
 #include <deal.II/meshworker/scratch_data.h>
 
 DEAL_II_NAMESPACE_OPEN

--- a/tests/algorithms/newton_02.cc
+++ b/tests/algorithms/newton_02.cc
@@ -17,6 +17,8 @@
 #include <deal.II/algorithms/newton.h>
 #include <deal.II/algorithms/operator.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/base/cell_data_storage_01.cc
+++ b/tests/base/cell_data_storage_01.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/base/cell_data_storage_02.cc
+++ b/tests/base/cell_data_storage_02.cc
@@ -22,6 +22,7 @@
 #include <deal.II/base/tensor.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/base/function_cutoff_01.cc
+++ b/tests/base/function_cutoff_01.cc
@@ -19,6 +19,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 

--- a/tests/base/function_cutoff_02.cc
+++ b/tests/base/function_cutoff_02.cc
@@ -19,6 +19,8 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 

--- a/tests/base/quadrature_point_data.cc
+++ b/tests/base/quadrature_point_data.cc
@@ -27,6 +27,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/base/quadrature_point_data_02.cc
+++ b/tests/base/quadrature_point_data_02.cc
@@ -28,6 +28,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/base/quadrature_point_data_03.cc
+++ b/tests/base/quadrature_point_data_03.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/codim_one/extract_boundary_mesh_07.cc
+++ b/tests/codim_one/extract_boundary_mesh_07.cc
@@ -24,6 +24,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_q_eulerian.h>

--- a/tests/fe/fe_subface_values_01.cc
+++ b/tests/fe/fe_subface_values_01.cc
@@ -69,7 +69,7 @@ run(unsigned int degree, unsigned int n_q_points)
   GridOut grid_out;
   grid_out.write_mesh_per_processor_as_vtu(tria, "mesh");
 
-  FE_Q<dim>              fe(degree);                       // dummy
+  FE_DGQ<dim>            fe(degree);                       // dummy
   QGaussLobatto<dim - 1> quad(n_q_points);                 // dummy
   UpdateFlags            flags = update_quadrature_points; // dummy
 

--- a/tests/fe/fe_values_view_28.cc
+++ b/tests/fe/fe_values_view_28.cc
@@ -23,7 +23,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/feinterface/face_orientation_01.cc
+++ b/tests/feinterface/face_orientation_01.cc
@@ -25,8 +25,8 @@
 
 #include <deal.II/base/quadrature_lib.h>
 
-#include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/feinterface/fe_interface_values_06.cc
+++ b/tests/feinterface/fe_interface_values_06.cc
@@ -21,6 +21,7 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/feinterface/fe_interface_values_07.cc
+++ b/tests/feinterface/fe_interface_values_07.cc
@@ -21,6 +21,7 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/feinterface/fe_interface_values_08.cc
+++ b/tests/feinterface/fe_interface_values_08.cc
@@ -20,6 +20,7 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/feinterface/fe_interface_values_09.cc
+++ b/tests/feinterface/fe_interface_values_09.cc
@@ -20,6 +20,7 @@
 
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_interface_values.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/grid/get_dof_to_support_patch_map_01.cc
+++ b/tests/grid/get_dof_to_support_patch_map_01.cc
@@ -28,6 +28,8 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>

--- a/tests/lac/inhomogeneous_constraints_block.cc
+++ b/tests/lac/inhomogeneous_constraints_block.cc
@@ -27,6 +27,7 @@
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 

--- a/tests/manifold/spherical_manifold_02.cc
+++ b/tests/manifold/spherical_manifold_02.cc
@@ -24,7 +24,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_manifold.h>

--- a/tests/mappings/mapping_fe_field_08.cc
+++ b/tests/mappings/mapping_fe_field_08.cc
@@ -19,6 +19,7 @@
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_fe_field.h>
 #include <deal.II/fe/mapping_q.h>

--- a/tests/mappings/mapping_manifold_06.cc
+++ b/tests/mappings/mapping_manifold_06.cc
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_manifold.h>
 #include <deal.II/fe/mapping_q_generic.h>

--- a/tests/mappings/mapping_manifold_07.cc
+++ b/tests/mappings/mapping_manifold_07.cc
@@ -17,6 +17,7 @@
 
 #include <deal.II/base/utilities.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_values.h>
 #include <deal.II/fe/mapping_manifold.h>
 #include <deal.II/fe/mapping_q_generic.h>

--- a/tests/mappings/mapping_q_manifold_01.cc
+++ b/tests/mappings/mapping_q_manifold_01.cc
@@ -22,6 +22,7 @@
 #include <deal.II/dofs/dof_tools.h>
 
 #include <deal.II/fe/fe_nedelec.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -24,7 +24,7 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>

--- a/tests/matrix_free/face_setup_01.cc
+++ b/tests/matrix_free/face_setup_01.cc
@@ -26,6 +26,8 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 
 #include <deal.II/lac/la_parallel_vector.h>

--- a/tests/matrix_free/matrix_vector_large_degree_01.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_01.cc
@@ -27,6 +27,8 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>

--- a/tests/matrix_free/matrix_vector_large_degree_03.cc
+++ b/tests/matrix_free/matrix_vector_large_degree_03.cc
@@ -25,6 +25,8 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/manifold_lib.h>
 #include <deal.II/grid/tria.h>

--- a/tests/meshworker/mesh_loop_04.cc
+++ b/tests/meshworker/mesh_loop_04.cc
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/iterator_range.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/tests/meshworker/mesh_loop_05.cc
+++ b/tests/meshworker/mesh_loop_05.cc
@@ -22,6 +22,8 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/tests/meshworker/mesh_loop_06.cc
+++ b/tests/meshworker/mesh_loop_06.cc
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/iterator_range.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>

--- a/tests/meshworker/scratch_data_01.cc
+++ b/tests/meshworker/scratch_data_01.cc
@@ -16,6 +16,8 @@
 
 // Test ScratchData on simple volume computation
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>

--- a/tests/meshworker/scratch_data_02.cc
+++ b/tests/meshworker/scratch_data_02.cc
@@ -22,7 +22,7 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>

--- a/tests/mpi/interpolate_to_different_mesh_02.cc
+++ b/tests/mpi/interpolate_to_different_mesh_02.cc
@@ -22,7 +22,7 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>

--- a/tests/mpi/periodicity_05.cc
+++ b/tests/mpi/periodicity_05.cc
@@ -21,6 +21,8 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 

--- a/tests/mpi/solution_transfer_05.cc
+++ b/tests/mpi/solution_transfer_05.cc
@@ -56,7 +56,7 @@ test()
   const unsigned int    max_degree = 6 - dim;
   hp::FECollection<dim> fe_dgq;
   for (unsigned int deg = 1; deg <= max_degree; ++deg)
-    fe_dgq.push_back(FE_Q<dim>(deg));
+    fe_dgq.push_back(FE_DGQ<dim>(deg));
 
   hp::DoFHandler<dim> dgq_dof_handler(tria);
 

--- a/tests/multigrid/constrained_dofs_05.cc
+++ b/tests/multigrid/constrained_dofs_05.cc
@@ -17,6 +17,8 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>

--- a/tests/multigrid/mg_data_out_04.cc
+++ b/tests/multigrid/mg_data_out_04.cc
@@ -19,6 +19,8 @@
 
 #include <deal.II/distributed/tria.h>
 
+#include <deal.II/fe/fe_q.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>

--- a/tests/numerics/no_flux_08.cc
+++ b/tests/numerics/no_flux_08.cc
@@ -35,6 +35,7 @@
 // this was fixed with r24044 together with the no_flux_07 test that
 // reduces it to its essence
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_09.cc
+++ b/tests/numerics/no_flux_09.cc
@@ -32,6 +32,7 @@
 //(none)
 
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_10.cc
+++ b/tests/numerics/no_flux_10.cc
@@ -35,6 +35,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_11.cc
+++ b/tests/numerics/no_flux_11.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_12.cc
+++ b/tests/numerics/no_flux_12.cc
@@ -60,6 +60,7 @@ exception was: 5:     ExcNotImplemented()
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_14.cc
+++ b/tests/numerics/no_flux_14.cc
@@ -21,6 +21,7 @@
 // vertices.
 
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/no_flux_15.cc
+++ b/tests/numerics/no_flux_15.cc
@@ -24,6 +24,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_q.h>
 

--- a/tests/numerics/project_bv_div_conf_03.cc
+++ b/tests/numerics/project_bv_div_conf_03.cc
@@ -22,7 +22,7 @@
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
-#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_raviart_thomas.h>
 #include <deal.II/fe/fe_system.h>
 #include <deal.II/fe/mapping_cartesian.h>

--- a/tests/vector_tools/integrate_difference_05.cc
+++ b/tests/vector_tools/integrate_difference_05.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_system.h>
 
 #include <deal.II/grid/grid_generator.h>

--- a/tests/vector_tools/interpolate_with_material_id_02.cc
+++ b/tests/vector_tools/interpolate_with_material_id_02.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/mapping_q.h>
 
 #include <deal.II/grid/filtered_iterator.h>


### PR DESCRIPTION
Given that #9826 removed the `FE_Q` from `MappingQGeneric`, I think it is appropriate to not include `deal.II/fe/fe_q.h` in that file. Since the header `mapping_q_generic.h` is included in a central place (due to the ubiquitous use of the linear variant), this means that some places that used to work before now need to include `fe_q.h` explicitly, see the list of 51 files in the library and testsuite in this patch.

I guess this would deserve a changelog in the *incompatibilities section*. I have not added it yet because I wanted to wait if there is objections here. This is what I would write:
```
Changed: The header file `deal.II/fe/fe_q.h` is not included implicitly via
`deal.II/fe/mapping_q_generic.h` any more. Add the header `#include <deal.II/fe/fe_q.h>`
if necessary.
``` 