### PR TITLE
GridTools::exchange_cell_data_to_ghosts replace cast

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3898,8 +3898,9 @@ namespace GridTools
 #    else
     constexpr int dim      = MeshType::dimension;
     constexpr int spacedim = MeshType::space_dimension;
-    auto tria = static_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-      &mesh.get_triangulation());
+    auto          tria =
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+        &mesh.get_triangulation());
     Assert(
       tria != nullptr,
       ExcMessage(


### PR DESCRIPTION
Replace `static_cast` by `dynamic_cast` since else the following assert does not work.