### PR TITLE
Also use checkout@v2 for Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
     runs-on: [windows-latest]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: info
       run: |
         cmake --version


### PR DESCRIPTION
Motivated by the filing Windows build in https://github.com/dealii/dealii/pull/9910/checks?check_run_id=593400386.