### PR TITLE
Fix test mpi/parallel_vector_16

### DIFF
--- a/tests/mpi/parallel_vector_16.cc
+++ b/tests/mpi/parallel_vector_16.cc
@@ -56,8 +56,9 @@ test()
                                                local_relevant,
                                                MPI_COMM_WORLD);
 
-  deallog << "Local range of proc 0: " << v.local_range().first << " "
-          << v.local_range().second << std::endl;
+  deallog << "Local range of proc 0: "
+          << v.get_partitioner()->local_range().first << " "
+          << v.get_partitioner()->local_range().second << std::endl;
 
   // set local values
   for (types::global_dof_index i = min_index + myid * local_size;


### PR DESCRIPTION
This test is only run with 64 bits, so it was missed in #9886. See also the test failure here:
https://cdash.43-1.org/testDetails.php?test=40721185&build=5719