### PR TITLE
Build and check documentation in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,24 @@ cache:
   directories:
     - programs
 
+addons:
+  apt:
+    packages:
+      - doxygen
+
+before_install:
+    - sudo apt-get -y install graphviz perl texlive-bibtex-extra
+
 install:
     - ./contrib/utilities/download_clang_format
 
 script: 
-    - ./contrib/utilities/check_indentation.sh 
+    - ./contrib/utilities/check_indentation.sh
+    - mkdir build
+    - cd build
+    - cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON ..
+    - make -j documentation
+    - cat doxygen.log && ! [ -s doxygen.log ]
 
 branches:
   only:


### PR DESCRIPTION
This pull request makes the `Travis` CI runner also build the documentation and checks that there are no warnings. After #9880, I get https://travis-ci.org/github/masterleinad/dealii/builds/676604234.