### PR TITLE
Instantiate AffineConstraints::distribute_local_to_global

### DIFF
--- a/source/lac/affine_constraints.inst.in
+++ b/source/lac/affine_constraints.inst.in
@@ -171,6 +171,24 @@ for (S : REAL_AND_COMPLEX_SCALARS; T : DEAL_II_VEC_TEMPLATES)
             std::integral_constant<bool, false>) const;
   }
 
+// TrilinosWrappers::SparseMatrix:
+
+for (T : DEAL_II_VEC_TEMPLATES)
+  {
+#ifdef DEAL_II_WITH_TRILINOS
+    template void AffineConstraints<double>::distribute_local_to_global<
+      TrilinosWrappers::SparseMatrix,
+      LinearAlgebra::distributed::T<double>>(
+      const FullMatrix<double> &,
+      const Vector<double> &,
+      const std::vector<size_type> &,
+      TrilinosWrappers::SparseMatrix &,
+      LinearAlgebra::distributed::T<double> &,
+      bool,
+      std::integral_constant<bool, false>) const;
+#endif
+  }
+
 // BlockSparseMatrix:
 
 for (S : REAL_AND_COMPLEX_SCALARS)

--- a/tests/trilinos/direct_solver_3.cc
+++ b/tests/trilinos/direct_solver_3.cc
@@ -232,13 +232,10 @@ Step4<dim>::assemble_system()
 
           cell->get_dof_indices(local_dof_indices);
           constraints.distribute_local_to_global(cell_matrix,
+                                                 cell_rhs,
                                                  local_dof_indices,
-                                                 system_matrix);
-
-          constraints.distribute_local_to_global(cell_rhs,
-                                                 local_dof_indices,
-                                                 system_rhs,
-                                                 cell_matrix);
+                                                 system_matrix,
+                                                 system_rhs);
           constraints.distribute_local_to_global(cell_rhs_two,
                                                  local_dof_indices,
                                                  system_rhs_two,


### PR DESCRIPTION
for `TrilinosWrappers::SparseMatrix` and `LinearAlgebra::distributed::Vector`.