### PR TITLE
Remove most <> from tutorials

### DIFF
--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -388,10 +388,10 @@ namespace Step11
   template <int dim>
   void LaplaceProblem<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -469,8 +469,8 @@ namespace Step12
   template <int dim>
   void AdvectionProblem<dim>::solve()
   {
-    SolverControl      solver_control(1000, 1e-12);
-    SolverRichardson<> solver(solver_control);
+    SolverControl                    solver_control(1000, 1e-12);
+    SolverRichardson<Vector<double>> solver(solver_control);
 
     // Here we create the preconditioner,
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;

--- a/examples/step-12b/step-12b.cc
+++ b/examples/step-12b/step-12b.cc
@@ -508,8 +508,8 @@ namespace Step12
   template <int dim>
   void AdvectionProblem<dim>::solve(Vector<double> &solution)
   {
-    SolverControl      solver_control(1000, 1e-12);
-    SolverRichardson<> solver(solver_control);
+    SolverControl                    solver_control(1000, 1e-12);
+    SolverRichardson<Vector<double>> solver(solver_control);
 
     // Here we create the preconditioner,
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -734,7 +734,7 @@ namespace Step13
     template <int dim>
     void Solver<dim>::assemble_linear_system(LinearSystem &linear_system)
     {
-      Threads::Task<> rhs_task =
+      Threads::Task<void> rhs_task =
         Threads::new_task(&Solver<dim>::assemble_rhs, *this, linear_system.rhs);
 
       auto worker =
@@ -949,7 +949,7 @@ namespace Step13
         &DoFTools::make_hanging_node_constraints;
 
       // Start a side task then continue on the main thread
-      Threads::Task<> side_task =
+      Threads::Task<void> side_task =
         Threads::new_task(mhnc_p, dof_handler, hanging_node_constraints);
 
       DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
@@ -978,10 +978,10 @@ namespace Step13
     template <int dim>
     void Solver<dim>::LinearSystem::solve(Vector<double> &solution) const
     {
-      SolverControl solver_control(1000, 1e-12);
-      SolverCG<>    cg(solver_control);
+      SolverControl            solver_control(1000, 1e-12);
+      SolverCG<Vector<double>> cg(solver_control);
 
-      PreconditionSSOR<> preconditioner;
+      PreconditionSSOR<SparseMatrix<double>> preconditioner;
       preconditioner.initialize(matrix, 1.2);
 
       cg.solve(matrix, solution, rhs, preconditioner);

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -519,7 +519,7 @@ namespace Step14
     template <int dim>
     void Solver<dim>::assemble_linear_system(LinearSystem &linear_system)
     {
-      Threads::Task<> rhs_task =
+      Threads::Task<void> rhs_task =
         Threads::new_task(&Solver<dim>::assemble_rhs, *this, linear_system.rhs);
 
       auto worker =
@@ -658,7 +658,7 @@ namespace Step14
         &DoFTools::make_hanging_node_constraints;
 
       // Start a side task then continue on the main thread
-      Threads::Task<> side_task =
+      Threads::Task<void> side_task =
         Threads::new_task(mhnc_p, dof_handler, hanging_node_constraints);
 
       DynamicSparsityPattern dsp(dof_handler.n_dofs(), dof_handler.n_dofs());
@@ -682,10 +682,10 @@ namespace Step14
     template <int dim>
     void Solver<dim>::LinearSystem::solve(Vector<double> &solution) const
     {
-      SolverControl solver_control(5000, 1e-12);
-      SolverCG<>    cg(solver_control);
+      SolverControl            solver_control(5000, 1e-12);
+      SolverCG<Vector<double>> cg(solver_control);
 
-      PreconditionSSOR<> preconditioner;
+      PreconditionSSOR<SparseMatrix<double>> preconditioner;
       preconditioner.initialize(matrix, 1.2);
 
       cg.solve(matrix, solution, rhs, preconditioner);
@@ -1996,7 +1996,7 @@ namespace Step14
     template <int dim>
     void WeightedResidual<dim>::solve_problem()
     {
-      Threads::TaskGroup<> tasks;
+      Threads::TaskGroup<void> tasks;
       tasks +=
         Threads::new_task(&WeightedResidual<dim>::solve_primal_problem, *this);
       tasks +=

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -343,11 +343,11 @@ namespace Step15
   template <int dim>
   void MinimalSurfaceProblem<dim>::solve()
   {
-    SolverControl solver_control(system_rhs.size(),
+    SolverControl            solver_control(system_rhs.size(),
                                  system_rhs.l2_norm() * 1e-6);
-    SolverCG<>    solver(solver_control);
+    SolverCG<Vector<double>> solver(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     solver.solve(system_matrix, newton_update, system_rhs, preconditioner);

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -424,7 +424,7 @@ namespace Step16
   // us, and thus the difference between this function and the previous lies
   // only in the setup of the assembler and the different iterators in the loop.
   //
-  // We generate an AffineConstraints<> object for each level containing the
+  // We generate an AffineConstraints object for each level containing the
   // boundary and interface dofs as constrained entries. The corresponding
   // object is then used to generate the level matrices.
   template <int dim>
@@ -433,7 +433,7 @@ namespace Step16
     MappingQ1<dim>     mapping;
     const unsigned int n_levels = triangulation.n_levels();
 
-    std::vector<AffineConstraints<>> boundary_constraints(n_levels);
+    std::vector<AffineConstraints<double>> boundary_constraints(n_levels);
     for (unsigned int level = 0; level < n_levels; ++level)
       {
         IndexSet dofset;
@@ -527,7 +527,7 @@ namespace Step16
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);
-    MGCoarseGridHouseholder<> coarse_grid_solver;
+    MGCoarseGridHouseholder<double, Vector<double>> coarse_grid_solver;
     coarse_grid_solver.initialize(coarse_matrix);
 
     // The next component of a multilevel solver or preconditioner is that we
@@ -583,8 +583,8 @@ namespace Step16
 
     // With all this together, we can finally get about solving the linear
     // system in the usual way:
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    solver(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> solver(solver_control);
 
     solution = 0;
 

--- a/examples/step-16b/step-16b.cc
+++ b/examples/step-16b/step-16b.cc
@@ -478,7 +478,7 @@ namespace Step16
 
     FullMatrix<double> coarse_matrix;
     coarse_matrix.copy_from(mg_matrices[0]);
-    MGCoarseGridHouseholder<> coarse_grid_solver;
+    MGCoarseGridHouseholder<double, Vector<double>> coarse_grid_solver;
     coarse_grid_solver.initialize(coarse_matrix);
 
     // The next component of a multilevel solver or preconditioner is that we
@@ -534,8 +534,8 @@ namespace Step16
 
     // With all this together, we can finally get about solving the linear
     // system in the usual way:
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    solver(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> solver(solver_control);
 
     solution = 0;
 

--- a/examples/step-20/doc/intro.dox
+++ b/examples/step-20/doc/intro.dox
@@ -563,11 +563,11 @@ we can write:
 @code
     const auto op_M = linear_operator(M);
 
-    PreconditionJacobi<> preconditioner_M;
+    PreconditionJacobi<SparseMatrix<double>> preconditioner_M;
     preconditioner_M.initialize(M);
 
     ReductionControl reduction_control_M(2000, 1.0e-18, 1.0e-10);
-    SolverCG<>    solver_M(reduction_control_M);
+    SolverCG<Vector<double>>    solver_M(reduction_control_M);
 
     const auto op_M_inv = inverse_operator(op_M, solver_M, preconditioner_M);
 @endcode
@@ -679,7 +679,7 @@ With these prerequisites at hand, solving for $P$ and $U$ is a matter of
 creating another solver and inverse:
 @code
     SolverControl solver_control_S(2000, 1.e-12);
-    SolverCG<>    solver_S(solver_control_S);
+    SolverCG<Vector<double>>    solver_S(solver_control_S);
     PreconditionIdentity preconditioner_S;
 
     const auto op_S_inv = inverse_operator(op_S, solver_S, preconditioner_S);
@@ -751,7 +751,7 @@ using an IterationNumberControl that allows us to fix the number of CG
 iterations that are performed to a fixed small number (in our case 30):
 @code
     IterationNumberControl iteration_number_control_aS(30, 1.e-18);
-    SolverCG<>           solver_aS(iteration_number_control_aS);
+    SolverCG<Vector<double>>           solver_aS(iteration_number_control_aS);
     PreconditionIdentity preconditioner_aS;
     const auto preconditioner_S =
       inverse_operator(op_aS, solver_aS, preconditioner_aS);

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -609,9 +609,9 @@ namespace Step20
     const auto op_M = linear_operator(M);
     const auto op_B = linear_operator(B);
 
-    ReductionControl     reduction_control_M(2000, 1.0e-18, 1.0e-10);
-    SolverCG<>           solver_M(reduction_control_M);
-    PreconditionJacobi<> preconditioner_M;
+    ReductionControl         reduction_control_M(2000, 1.0e-18, 1.0e-10);
+    SolverCG<Vector<double>> solver_M(reduction_control_M);
+    PreconditionJacobi<SparseMatrix<double>> preconditioner_M;
 
     preconditioner_M.initialize(M);
 
@@ -625,8 +625,8 @@ namespace Step20
 
     // We now create a preconditioner out of <code>op_aS</code> that
     // applies a fixed number of 30 (inexpensive) CG iterations:
-    IterationNumberControl iteration_number_control_aS(30, 1.e-18);
-    SolverCG<>             solver_aS(iteration_number_control_aS);
+    IterationNumberControl   iteration_number_control_aS(30, 1.e-18);
+    SolverCG<Vector<double>> solver_aS(iteration_number_control_aS);
 
     const auto preconditioner_S =
       inverse_operator(op_aS, solver_aS, PreconditionIdentity());
@@ -637,8 +637,8 @@ namespace Step20
     // preconditioner we just declared.
     const auto schur_rhs = transpose_operator(op_B) * op_M_inv * F - G;
 
-    SolverControl solver_control_S(2000, 1.e-12);
-    SolverCG<>    solver_S(solver_control_S);
+    SolverControl            solver_control_S(2000, 1.e-12);
+    SolverCG<Vector<double>> solver_S(solver_control_S);
 
     const auto op_S_inv = inverse_operator(op_S, solver_S, preconditioner_S);
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -424,7 +424,7 @@ namespace Step21
     {
       SolverControl solver_control(std::max<unsigned int>(src.size(), 200),
                                    1e-8 * src.l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
 
       dst = 0;
 
@@ -933,9 +933,9 @@ namespace Step21
         approximate_schur_complement);
 
 
-      SolverControl solver_control(solution.block(1).size(),
+      SolverControl            solver_control(solution.block(1).size(),
                                    1e-12 * schur_rhs.l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
 
       cg.solve(schur_complement, solution.block(1), schur_rhs, preconditioner);
 
@@ -972,9 +972,9 @@ namespace Step21
     // onto the physically reasonable range:
     assemble_rhs_S();
     {
-      SolverControl solver_control(system_matrix.block(2, 2).m(),
+      SolverControl            solver_control(system_matrix.block(2, 2).m(),
                                    1e-8 * system_rhs.block(2).l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
       cg.solve(system_matrix.block(2, 2),
                solution.block(2),
                system_rhs.block(2),

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -308,8 +308,8 @@ namespace Step22
     Vector<double> &      dst,
     const Vector<double> &src) const
   {
-    SolverControl solver_control(src.size(), 1e-6 * src.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(src.size(), 1e-6 * src.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
 
     dst = 0;
 
@@ -830,9 +830,9 @@ namespace Step22
         system_matrix, A_inverse);
 
       // The usual control structures for the solver call are created...
-      SolverControl solver_control(solution.block(1).size(),
+      SolverControl            solver_control(solution.block(1).size(),
                                    1e-6 * schur_rhs.l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
 
       // Now to the preconditioner to the Schur complement. As explained in
       // the introduction, the preconditioning is done by a mass matrix in the

--- a/examples/step-23/step-23.cc
+++ b/examples/step-23/step-23.cc
@@ -362,8 +362,8 @@ namespace Step23
   template <int dim>
   void WaveEquation<dim>::solve_u()
   {
-    SolverControl solver_control(1000, 1e-8 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-8 * system_rhs.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
 
     cg.solve(matrix_u, solution_u, system_rhs, PreconditionIdentity());
 
@@ -376,8 +376,8 @@ namespace Step23
   template <int dim>
   void WaveEquation<dim>::solve_v()
   {
-    SolverControl solver_control(1000, 1e-8 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-8 * system_rhs.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
 
     cg.solve(matrix_v, solution_v, system_rhs, PreconditionIdentity());
 

--- a/examples/step-24/step-24.cc
+++ b/examples/step-24/step-24.cc
@@ -393,7 +393,7 @@ namespace Step24
   void TATForwardProblem<dim>::solve_p()
   {
     SolverControl solver_control(1000, 1e-8 * system_rhs_p.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverCG<Vector<double>> cg(solver_control);
 
     cg.solve(system_matrix, solution_p, system_rhs_p, PreconditionIdentity());
 
@@ -407,7 +407,7 @@ namespace Step24
   void TATForwardProblem<dim>::solve_v()
   {
     SolverControl solver_control(1000, 1e-8 * system_rhs_v.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverCG<Vector<double>> cg(solver_control);
 
     cg.solve(mass_matrix, solution_v, system_rhs_v, PreconditionIdentity());
 

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -531,10 +531,10 @@ namespace Step25
   template <int dim>
   unsigned int SineGordonProblem<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-12 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-12 * system_rhs.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution_update, system_rhs, preconditioner);

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -273,10 +273,10 @@ namespace Step26
   template <int dim>
   void HeatEquation<dim>::solve_time_step()
   {
-    SolverControl solver_control(1000, 1e-8 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-8 * system_rhs.l2_norm());
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.0);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -374,11 +374,11 @@ namespace Step27
   template <int dim>
   void LaplaceProblem<dim>::solve()
   {
-    SolverControl solver_control(system_rhs.size(),
+    SolverControl            solver_control(system_rhs.size(),
                                  1e-12 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -1014,11 +1014,11 @@ namespace Step28
                                        solution,
                                        system_rhs);
 
-    SolverControl solver_control(system_matrix.m(),
+    SolverControl            solver_control(system_matrix.m(),
                                  1e-12 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);
@@ -1525,7 +1525,7 @@ namespace Step28
     BlockVector<float> group_error_indicators(n_cells);
 
     {
-      Threads::ThreadGroup<> threads;
+      Threads::ThreadGroup<void> threads;
       for (unsigned int group = 0; group < parameters.n_groups; ++group)
         threads += Threads::new_thread(&EnergyGroup<dim>::estimate_errors,
                                        *energy_groups[group],
@@ -1538,7 +1538,7 @@ namespace Step28
     const float coarsen_threshold = 0.01 * max_error;
 
     {
-      Threads::ThreadGroup<> threads;
+      Threads::ThreadGroup<void> threads;
       for (unsigned int group = 0; group < parameters.n_groups; ++group)
         threads += Threads::new_thread(&EnergyGroup<dim>::refine_grid,
                                        *energy_groups[group],
@@ -1612,7 +1612,7 @@ namespace Step28
         std::cout << std::endl << std::endl;
 
 
-        Threads::ThreadGroup<> threads;
+        Threads::ThreadGroup<void> threads;
         for (unsigned int group = 0; group < parameters.n_groups; ++group)
           threads +=
             Threads::new_thread(&EnergyGroup<dim>::assemble_system_matrix,

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -552,7 +552,7 @@ void Step3::solve()
   // class is the type of the vectors, but the empty angle brackets indicate
   // that we simply take the default argument (which is
   // <code>Vector@<double@></code>):
-  SolverCG<> solver(solver_control);
+  SolverCG<Vector<double>> solver(solver_control);
 
   // Now solve the system of equations. The CG solver takes a preconditioner
   // as its fourth argument. We don't feel ready to delve into this yet, so we

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -641,8 +641,8 @@ namespace Step30
   template <int dim>
   void DGMethod<dim>::solve(Vector<double> &solution)
   {
-    SolverControl      solver_control(1000, 1e-12, false, false);
-    SolverRichardson<> solver(solver_control);
+    SolverControl                    solver_control(1000, 1e-12, false, false);
+    SolverRichardson<Vector<double>> solver(solver_control);
 
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;
 

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1117,8 +1117,9 @@ namespace Step35
   NavierStokesProjection<dim>::diffusion_component_solve(const unsigned int d)
   {
     SolverControl solver_control(vel_max_its, vel_eps * force[d].l2_norm());
-    SolverGMRES<> gmres(solver_control,
-                        SolverGMRES<>::AdditionalData(vel_Krylov_size));
+    SolverGMRES<Vector<double>> gmres(
+      solver_control,
+      SolverGMRES<Vector<double>>::AdditionalData(vel_Krylov_size));
     gmres.solve(vel_it_matrix[d], u_n[d], force[d], prec_velocity[d]);
   }
 
@@ -1236,7 +1237,7 @@ namespace Step35
                                      vel_diag_strength, vel_off_diagonals));
 
     SolverControl solvercontrol(vel_max_its, vel_eps * pres_tmp.l2_norm());
-    SolverCG<>    cg(solvercontrol);
+    SolverCG<Vector<double>> cg(solvercontrol);
     cg.solve(pres_iterative, phi_n, pres_tmp, prec_pres_Laplace);
 
     phi_n *= 1.5 / dt;

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -424,9 +424,9 @@ namespace Step38
   void LaplaceBeltramiProblem<spacedim>::solve()
   {
     SolverControl solver_control(solution.size(), 1e-7 * system_rhs.l2_norm());
-    SolverCG<>    cg(solver_control);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -453,8 +453,8 @@ void Step4<dim>::assemble_system()
 template <int dim>
 void Step4<dim>::solve()
 {
-  SolverControl solver_control(1000, 1e-12);
-  SolverCG<>    solver(solver_control);
+  SolverControl            solver_control(1000, 1e-12);
+  SolverCG<Vector<double>> solver(solver_control);
   solver.solve(system_matrix, solution, system_rhs, PreconditionIdentity());
 
   // We have made one addition, though: since we suppress output from the

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -264,10 +264,10 @@ void Step5<dim>::assemble_system()
 template <int dim>
 void Step5<dim>::solve()
 {
-  SolverControl solver_control(1000, 1e-12);
-  SolverCG<>    solver(solver_control);
+  SolverControl            solver_control(1000, 1e-12);
+  SolverCG<Vector<double>> solver(solver_control);
 
-  PreconditionSSOR<> preconditioner;
+  PreconditionSSOR<SparseMatrix<double>> preconditioner;
   preconditioner.initialize(system_matrix, 1.2);
 
   solver.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -969,9 +969,9 @@ namespace Step51
   template <int dim>
   void HDG<dim>::solve()
   {
-    SolverControl    solver_control(system_matrix.m() * 10,
+    SolverControl                  solver_control(system_matrix.m() * 10,
                                  1e-11 * system_rhs.l2_norm());
-    SolverBicgstab<> solver(solver_control);
+    SolverBicgstab<Vector<double>> solver(solver_control);
     solver.solve(system_matrix, solution, system_rhs, PreconditionIdentity());
 
     std::cout << "   Number of BiCGStab iterations: "

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -361,7 +361,7 @@ namespace Step56
     // First solve with the approximation for S
     {
       SolverControl solver_control(1000, 1e-6 * src.block(1).l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
 
       dst.block(1) = 0.0;
       cg.solve(schur_complement_matrix,
@@ -384,8 +384,8 @@ namespace Step56
     // or just apply one preconditioner sweep
     if (do_solve_A == true)
       {
-        SolverControl solver_control(10000, utmp.l2_norm() * 1e-4);
-        SolverCG<>    cg(solver_control);
+        SolverControl            solver_control(10000, utmp.l2_norm() * 1e-4);
+        SolverCG<Vector<double>> cg(solver_control);
 
         dst.block(0) = 0.0;
         cg.solve(system_matrix.block(0, 0),
@@ -884,7 +884,7 @@ namespace Step56
         // Setup coarse grid solver
         FullMatrix<double> coarse_matrix;
         coarse_matrix.copy_from(mg_matrices[0]);
-        MGCoarseGridHouseholder<> coarse_grid_solver;
+        MGCoarseGridHouseholder<double, Vector<double>> coarse_grid_solver;
         coarse_grid_solver.initialize(coarse_matrix);
 
         using Smoother = PreconditionSOR<SparseMatrix<double>>;

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -235,7 +235,7 @@ namespace Step57
 
     {
       SolverControl solver_control(1000, 1e-6 * src.block(1).l2_norm());
-      SolverCG<>    cg(solver_control);
+      SolverCG<Vector<double>> cg(solver_control);
 
       dst.block(1) = 0.0;
       cg.solve(pressure_mass_matrix,

--- a/examples/step-6/doc/results.dox
+++ b/examples/step-6/doc/results.dox
@@ -128,17 +128,17 @@ up for grabs.
 In deal.II, it is relatively simple to change the preconditioner. For
 example, by changing the existing lines of code
 @code
-  PreconditionSSOR<> preconditioner;
+  PreconditionSSOR<SparseMatrix<double>> preconditioner;
   preconditioner.initialize(system_matrix, 1.2);
 @endcode
 into
 @code
-  PreconditionSSOR<> preconditioner;
+  PreconditionSSOR<SparseMatrix<double>> preconditioner;
   preconditioner.initialize(system_matrix, 1.0);
 @endcode
 we can try out different relaxation parameters for SSOR. By using
 @code
-  PreconditionJacobi<> preconditioner;
+  PreconditionJacobi<SparseMatrix<double>> preconditioner;
   preconditioner.initialize(system_matrix);
 @endcode
 we can use Jacobi as a preconditioner. And by using

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -335,10 +335,10 @@ void Step6<dim>::assemble_system()
 template <int dim>
 void Step6<dim>::solve()
 {
-  SolverControl solver_control(1000, 1e-12);
-  SolverCG<>    solver(solver_control);
+  SolverControl            solver_control(1000, 1e-12);
+  SolverCG<Vector<double>> solver(solver_control);
 
-  PreconditionSSOR<> preconditioner;
+  PreconditionSSOR<SparseMatrix<double>> preconditioner;
   preconditioner.initialize(system_matrix, 1.2);
 
   solver.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -603,8 +603,8 @@ namespace Step61
   template <int dim>
   void WGDarcyEquation<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-8 * system_rhs.l2_norm());
-    SolverCG<>    solver(solver_control);
+    SolverControl            solver_control(1000, 1e-8 * system_rhs.l2_norm());
+    SolverCG<Vector<double>> solver(solver_control);
     solver.solve(system_matrix, solution, system_rhs, PreconditionIdentity());
     constraints.distribute(solution);
   }

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -1083,8 +1083,8 @@ namespace Step63
 
     std::cout << "     Solving with GMRES to tol " << solve_tolerance << "..."
               << std::endl;
-    SolverGMRES<> solver(solver_control,
-                         SolverGMRES<>::AdditionalData(50, true));
+    SolverGMRES<Vector<double>> solver(
+      solver_control, SolverGMRES<Vector<double>>::AdditionalData(50, true));
 
     Timer time;
     time.start();

--- a/examples/step-65/step-65.cc
+++ b/examples/step-65/step-65.cc
@@ -430,10 +430,10 @@ namespace Step65
   {
     TimerOutput::Scope scope(timer, "Solve linear system");
 
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    solver(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> solver(solver_control);
 
-    PreconditionJacobi<> preconditioner;
+    PreconditionJacobi<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix);
 
     solver.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -724,10 +724,10 @@ namespace Step7
   template <int dim>
   void HelmholtzProblem<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -422,10 +422,10 @@ namespace Step8
   template <int dim>
   void ElasticProblem<dim>::solve()
   {
-    SolverControl solver_control(1000, 1e-12);
-    SolverCG<>    cg(solver_control);
+    SolverControl            solver_control(1000, 1e-12);
+    SolverCG<Vector<double>> cg(solver_control);
 
-    PreconditionSSOR<> preconditioner;
+    PreconditionSSOR<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.2);
 
     cg.solve(system_matrix, solution, system_rhs, preconditioner);

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -765,11 +765,11 @@ namespace Step9
   template <int dim>
   void AdvectionProblem<dim>::solve()
   {
-    SolverControl        solver_control(std::max<std::size_t>(1000,
+    SolverControl               solver_control(std::max<std::size_t>(1000,
                                                        system_rhs.size() / 10),
                                  1e-10 * system_rhs.l2_norm());
-    SolverGMRES<>        solver(solver_control);
-    PreconditionJacobi<> preconditioner;
+    SolverGMRES<Vector<double>> solver(solver_control);
+    PreconditionJacobi<SparseMatrix<double>> preconditioner;
     preconditioner.initialize(system_matrix, 1.0);
     solver.solve(system_matrix, solution, system_rhs, preconditioner);
 


### PR DESCRIPTION
Or is there an educational purpose in keeping these?

Currently, there are lot of places where s.th. like this is written:
```cpp
SolverRichardson<> solver(solver_control);
```
For the tutorials, I feel it would have more benefit to be explicit about the type:
```cpp
SolverRichardson<Vector<double>> solver(solver_control);
```
or simply write (as proposed by this PR):
```cpp
SolverRichardson solver(solver_control);
```