### PR TITLE
Clang tidy 9.0 fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,6 +4,6 @@
 
 # We disable performance-inefficient-string-concatenation because we don't care about "a"+to_string(5)+...
 
-Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation"
+Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation"
 
 WarningsAsErrors: '*'

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -945,12 +945,14 @@ namespace Step69
     // primarily used to write the updated nodal values, stored as
     // <code>Tensor<1,problem_dimension></code>, into the global objects.
 
-    template <std::size_t k>
+    template <std::size_t k, int k2>
     DEAL_II_ALWAYS_INLINE inline void
     scatter(std::array<LinearAlgebra::distributed::Vector<double>, k> &U,
-            const Tensor<1, ((identity<std::size_t>::type)k)> &        tensor,
+            const Tensor<1, k2> &                                      tensor,
             const unsigned int                                         i)
     {
+      static_assert(k == k2,
+                    "The dimensions of the input arguments must agree");
       for (unsigned int j = 0; j < k; ++j)
         U[j].local_element(i) = tensor[j];
     }
@@ -2530,8 +2532,8 @@ namespace Step69
   namespace
   {
     void print_head(ConditionalOStream &pcout,
-                    std::string         header,
-                    std::string         secondary = "")
+                    const std::string & header,
+                    const std::string & secondary = "")
     {
       const auto header_size   = header.size();
       const auto padded_header = std::string((34 - header_size) / 2, ' ') +

--- a/include/deal.II/lac/qr.h
+++ b/include/deal.II/lac/qr.h
@@ -46,7 +46,7 @@ class BaseQR
   /**
    * Number type for R matrix.
    */
-  typedef typename VectorType::value_type Number;
+  using Number = typename VectorType::value_type;
 
 protected:
   /**
@@ -243,7 +243,7 @@ public:
   /**
    * Number type for R matrix.
    */
-  typedef typename VectorType::value_type Number;
+  using Number = typename VectorType::value_type;
 
   /**
    * Default constructor.
@@ -352,7 +352,7 @@ public:
   /**
    * Number type for R matrix.
    */
-  typedef typename VectorType::value_type Number;
+  using Number = typename VectorType::value_type;
 
   /**
    * Default constructor.

--- a/include/deal.II/optimization/solver_bfgs.h
+++ b/include/deal.II/optimization/solver_bfgs.h
@@ -61,7 +61,7 @@ public:
   /**
    * Number type.
    */
-  typedef typename VectorType::value_type Number;
+  using Number = typename VectorType::value_type;
 
 
   /**

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -2007,7 +2007,7 @@ ParameterHandler::get_entries_wrongly_not_set() const
 {
   std::set<std::string> entries_wrongly_not_set;
 
-  for (auto it : entries_set_status)
+  for (const auto &it : entries_set_status)
     if (it.second.first == true && it.second.second == false)
       entries_wrongly_not_set.insert(it.first);
 

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -133,8 +133,8 @@ namespace TrilinosWrappers
     const Epetra_Map &domain_map = matrix.OperatorDomainMap();
 
     const size_type constant_modes_dimension = constant_modes.size();
-    ptr_distributed_constant_modes.reset(new Epetra_MultiVector(
-      domain_map, constant_modes_dimension > 0 ? constant_modes_dimension : 1));
+    ptr_distributed_constant_modes = std_cxx14::make_unique<Epetra_MultiVector>(
+      domain_map, constant_modes_dimension > 0 ? constant_modes_dimension : 1);
     Assert(ptr_distributed_constant_modes, ExcNotInitialized());
     Epetra_MultiVector &distributed_constant_modes =
       *ptr_distributed_constant_modes;

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -301,17 +301,12 @@ namespace OpenCASCADE
     std::vector<TopoDS_Edge>   edges;
     std::vector<TopoDS_Face>   faces;
     OpenCASCADE::extract_geometrical_shapes(shape, faces, edges, vertices);
-    bool mesh_is_present = true;
-    for (unsigned int i = 0; i < faces.size(); ++i)
-      {
+    const bool mesh_is_present =
+      std::none_of(faces.begin(), faces.end(), [&Loc](const TopoDS_Face &face) {
         Handle(Poly_Triangulation) theTriangulation =
-          BRep_Tool::Triangulation(faces[i], Loc);
-        if (theTriangulation.IsNull())
-          {
-            mesh_is_present = false;
-            break;
-          }
-      }
+          BRep_Tool::Triangulation(face, Loc);
+        return theTriangulation.IsNull();
+      });
     TopoDS_Shape shape_to_be_written = shape;
     if (!mesh_is_present)
       {


### PR DESCRIPTION
I used clang-tidy version 9.0 on the library and I found the following:
* There are some new checks that are added to new versions of clang-tidy that produce a ton of warning. These include `modernize-use-trailing-return-type`, `modernize-use-nodiscard`, `modernize-avoid-c-arrays`, `modernize-concat-nested-namespaces`. I explicitly ignored them in the `.clang-tidy` config file. We can fix them later, but they require large effort.
 * New clang-tidy is able to find some code sections and produced warnings that the older clang-tidy (version 6) was not able to find. I fixed those.
 * Some include files are not checked by our clang-tidy CI. Specifically, those header files not included in any source files are not checked by clang-tidy. For example, I found the `typedef` expressions in `optimization/solver_bfgs.h` and `lac/qr.h` but clang-tidy didn't find those.