### PR TITLE
clang-tidy: fix performance-no-automatic-move

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -129,10 +129,7 @@ AffineConstraints<number>::is_consistent_in_parallel(
     const size_type line_index = calculate_line_index(line_n);
     if (line_index >= lines_cache.size() ||
         lines_cache[line_index] == numbers::invalid_size_type)
-      {
-        const ConstraintLine empty = {line_n, {}, 0.0};
-        return empty;
-      }
+      return ConstraintLine{line_n, {}, 0.0};
     else
       return lines[lines_cache[line_index]];
   };

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7072,6 +7072,7 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
       this->write_pvtu_record(master_output, filename_vector);
     }
 
+  // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
   return filename_master;
 }
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3799,6 +3799,7 @@ namespace internal
           for (unsigned int index = 0; cell != endc; cell++, index++)
             cell->set_subdomain_id(current_subdomain_ids[index]);
 
+        // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
         return number_cache;
 #endif
       }

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -871,6 +871,7 @@ namespace GridTools
     Assert(contains_artificial_cells<MeshType>(active_halo_layer) == false,
            ExcMessage("Halo layer contains artificial cells"));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return active_halo_layer;
   }
 
@@ -1053,6 +1054,7 @@ namespace GridTools
         "is probably called while using parallel::distributed::Triangulation. "
         "In such case please refer to the description of this function."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return ghost_cell_layer_within_distance;
   }
 

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -371,6 +371,7 @@ namespace hp
     for (unsigned int c = 1; c < size(); ++c)
       Assert(mask == (*this)[c].component_mask(scalar), ExcInternalError());
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -391,6 +392,7 @@ namespace hp
     for (unsigned int c = 1; c < size(); ++c)
       Assert(mask == (*this)[c].component_mask(vector), ExcInternalError());
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -411,6 +413,7 @@ namespace hp
     for (unsigned int c = 1; c < size(); ++c)
       Assert(mask == (*this)[c].component_mask(sym_tensor), ExcInternalError());
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -432,6 +435,7 @@ namespace hp
              ExcMessage("Not all elements of this collection agree on what "
                         "the appropriate mask should be."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -454,6 +458,7 @@ namespace hp
              ExcMessage("Not all elements of this collection agree on what "
                         "the appropriate mask should be."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -476,6 +481,7 @@ namespace hp
              ExcMessage("Not all elements of this collection agree on what "
                         "the appropriate mask should be."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -498,6 +504,7 @@ namespace hp
              ExcMessage("Not all elements of this collection agree on what "
                         "the appropriate mask should be."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 
@@ -521,6 +528,7 @@ namespace hp
              ExcMessage("Not all elements of this collection agree on what "
                         "the appropriate mask should be."));
 
+    // NOLINTNEXTLINE(performance-no-automatic-move) for clang-tidy
     return mask;
   }
 


### PR DESCRIPTION
fix clang-tidy check:
error: constness of 'xyz' prevents automatic move

see https://clang.llvm.org/extra/clang-tidy/checks/performance-no-automatic-move.html

part of #9928 