### PR TITLE
Improve calculating boolean values

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1459,23 +1459,18 @@ namespace FETools
                                       fe2.dofs_per_cell,
                                       fe1.dofs_per_cell));
 
-    // first try the easy way: maybe
-    // the FE wants to implement things
-    // itself:
-    bool fe_implements_interpolation = true;
+    // first try the easy way: maybe the FE wants to implement things itself:
     try
       {
         internal::FEToolsGetInterpolationMatrixHelper::gim_forwarder(
           fe1, fe2, interpolation_matrix);
+        return;
       }
     catch (
       typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented &)
       {
         // too bad....
-        fe_implements_interpolation = false;
       }
-    if (fe_implements_interpolation == true)
-      return;
 
     // uh, so this was not the
     // case. hm. then do it the hard

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -1006,13 +1006,12 @@ namespace hp
   FECollection<dim, spacedim>::hp_constraints_are_implemented() const
   {
     Assert(finite_elements.size() > 0, ExcNoFiniteElements());
-
-    bool hp_constraints = true;
-    for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      hp_constraints =
-        hp_constraints && finite_elements[i]->hp_constraints_are_implemented();
-
-    return hp_constraints;
+    return std::all_of(
+      finite_elements.cbegin(),
+      finite_elements.cend(),
+      [](const std::shared_ptr<const FiniteElement<dim, spacedim>> &fe) {
+        return fe->hp_constraints_are_implemented();
+      });
   }
 
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -4013,23 +4013,21 @@ AffineConstraints<number>::add_entries_local_to_global(
   Assert(sparsity_pattern.n_rows() == sparsity_pattern.n_cols(),
          ExcNotQuadratic());
 
-  const size_type n_local_dofs       = local_dof_indices.size();
-  bool            dof_mask_is_active = false;
-  if (dof_mask.n_rows() == n_local_dofs)
-    {
-      dof_mask_is_active = true;
-      AssertDimension(dof_mask.n_cols(), n_local_dofs);
-    }
-
+  const size_type n_local_dofs = local_dof_indices.size();
   typename internals::AffineConstraintsData<number>::ScratchDataAccessor
     scratch_data;
 
-  // if the dof mask is not active, all we have to do is to add some indices
-  // in a matrix format. To do this, we first create an array of all the
-  // indices that are to be added. these indices are the local dof indices
-  // plus some indices that come from constraints.
-  if (dof_mask_is_active == false)
+  const bool dof_mask_is_active = (dof_mask.n_rows() == n_local_dofs);
+  if (dof_mask_is_active == true)
     {
+      AssertDimension(dof_mask.n_cols(), n_local_dofs);
+    }
+  else
+    {
+      // if the dof mask is not active, all we have to do is to add some indices
+      // in a matrix format. To do this, we first create an array of all the
+      // indices that are to be added. these indices are the local dof indices
+      // plus some indices that come from constraints.
       std::vector<size_type> &actual_dof_indices = scratch_data->columns;
       actual_dof_indices.resize(n_local_dofs);
       make_sorted_row_list(local_dof_indices, actual_dof_indices);
@@ -4107,11 +4105,8 @@ AffineConstraints<number>::add_entries_local_to_global(
   const bool                    keep_constrained_entries,
   const Table<2, bool> &        dof_mask) const
 {
-  const size_type n_local_rows       = row_indices.size();
-  const size_type n_local_cols       = col_indices.size();
-  bool            dof_mask_is_active = false;
-  if (dof_mask.n_rows() == n_local_rows && dof_mask.n_cols() == n_local_cols)
-    dof_mask_is_active = true;
+  const size_type n_local_rows = row_indices.size();
+  const size_type n_local_cols = col_indices.size();
 
   // if constrained entries should be kept, need to add rows and columns of
   // those to the sparsity pattern
@@ -4131,6 +4126,8 @@ AffineConstraints<number>::add_entries_local_to_global(
   // in a matrix format. To do this, we first create an array of all the
   // indices that are to be added. these indices are the local dof indices
   // plus some indices that come from constraints.
+  const bool dof_mask_is_active =
+    dof_mask.n_rows() == n_local_rows && dof_mask.n_cols() == n_local_cols;
   if (dof_mask_is_active == false)
     {
       std::vector<size_type> actual_row_indices(n_local_rows);
@@ -4176,14 +4173,12 @@ AffineConstraints<number>::add_entries_local_to_global(
   typename internals::AffineConstraintsData<number>::ScratchDataAccessor
     scratch_data;
 
-  bool dof_mask_is_active = false;
-  if (dof_mask.n_rows() == n_local_dofs)
+  const bool dof_mask_is_active = (dof_mask.n_rows() == n_local_dofs);
+  if (dof_mask_is_active == true)
     {
-      dof_mask_is_active = true;
       AssertDimension(dof_mask.n_cols(), n_local_dofs);
     }
-
-  if (dof_mask_is_active == false)
+  else
     {
       std::vector<size_type> &actual_dof_indices = scratch_data->columns;
       actual_dof_indices.resize(n_local_dofs);

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -227,15 +227,12 @@ namespace internal
     {
       for (unsigned int dataset = 0; dataset < dof_data.size(); ++dataset)
         {
-          bool duplicate = false;
-          for (unsigned int j = 0; j < dataset; ++j)
-            if (finite_elements[dataset].get() == finite_elements[j].get())
-              {
-                duplicate = true;
-                break;
-              }
-
-          if (duplicate == false)
+          const bool is_duplicate = std::any_of(
+            finite_elements.cbegin(),
+            finite_elements.cbegin() + dataset,
+            [&](const std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>
+                  &fe) { return finite_elements[dataset].get() == fe.get(); });
+          if (is_duplicate == false)
             {
               if (cell->active())
                 {

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1440,15 +1440,13 @@ ParameterHandler::recursively_print_parameters(
 
       // if there are any parameters in this section then print them
       // as an itemized list
-      bool parameters_exist_here = false;
-      for (const auto &p : current_section)
-        if ((is_parameter_node(p.second) == true) ||
-            (is_alias_node(p.second) == true))
-          {
-            parameters_exist_here = true;
-            break;
-          }
-
+      const bool parameters_exist_here =
+        std::any_of(current_section.begin(),
+                    current_section.end(),
+                    [](const boost::property_tree::ptree::value_type &p) {
+                      return is_parameter_node(p.second) ||
+                             is_alias_node(p.second);
+                    });
       if (parameters_exist_here)
         {
           out << "\\begin{itemize}" << '\n';

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -1536,15 +1536,14 @@ namespace internal
       bool
       uses_both_endpoints(const Quadrature<1> &base_quadrature)
       {
-        bool at_left = false, at_right = false;
-        for (unsigned int i = 0; i < base_quadrature.size(); ++i)
-          {
-            if (base_quadrature.point(i) == Point<1>(0.0))
-              at_left = true;
-            if (base_quadrature.point(i) == Point<1>(1.0))
-              at_right = true;
-          }
-
+        const bool at_left =
+          std::any_of(base_quadrature.get_points().cbegin(),
+                      base_quadrature.get_points().cend(),
+                      [](const Point<1> &p) { return p == Point<1>{0.}; });
+        const bool at_right =
+          std::any_of(base_quadrature.get_points().cbegin(),
+                      base_quadrature.get_points().cend(),
+                      [](const Point<1> &p) { return p == Point<1>{1.}; });
         return (at_left && at_right);
       }
     } // namespace

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -608,21 +608,22 @@ template <>
 unsigned int
 QGaussOneOverR<2>::quad_size(const Point<2> singularity, const unsigned int n)
 {
-  double eps       = 1e-8;
-  bool   on_edge   = false;
-  bool   on_vertex = false;
-  for (unsigned int i = 0; i < 2; ++i)
-    if ((std::abs(singularity[i]) < eps) ||
-        (std::abs(singularity[i] - 1) < eps))
-      on_edge = true;
-  if (on_edge &&
-      (std::abs((singularity - Point<2>(.5, .5)).norm_square() - .5) < eps))
-    on_vertex = true;
+  const double eps = 1e-8;
+  const bool   on_edge =
+    std::any_of(singularity.begin_raw(),
+                singularity.end_raw(),
+                [eps](double coord) {
+                  return std::abs(coord) < eps || std::abs(coord - 1.) < eps;
+                });
+  const bool on_vertex =
+    on_edge &&
+    std::abs((singularity - Point<2>(.5, .5)).norm_square() - .5) < eps;
   if (on_vertex)
-    return (2 * n * n);
-  if (on_edge)
-    return (4 * n * n);
-  return (8 * n * n);
+    return 2 * n * n;
+  else if (on_edge)
+    return 4 * n * n;
+  else
+    return 8 * n * n;
 }
 
 template <>

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4909,13 +4909,13 @@ namespace internal
         // ranks changed. In that case, we can apply the renumbering with some
         // local renumbering only (this is similar to the renumber_mg_dofs()
         // function below)
-        bool locally_owned_set_changes = false;
-        for (types::global_dof_index i : new_numbers)
-          if (dof_handler->locally_owned_dofs().is_element(i) == false)
-            {
-              locally_owned_set_changes = true;
-              break;
-            }
+        const bool locally_owned_set_changes =
+          std::any_of(new_numbers.cbegin(),
+                      new_numbers.cend(),
+                      [this](const types::global_dof_index i) {
+                        return dof_handler->locally_owned_dofs().is_element(
+                                 i) == false;
+                      });
 
         if (Utilities::MPI::sum(static_cast<unsigned int>(
                                   locally_owned_set_changes),

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1729,26 +1729,14 @@ namespace DoFTools
                                 dof_handler.get_fe(0).n_components()));
     std::fill(n_dofs_on_subdomain.begin(), n_dofs_on_subdomain.end(), 0);
 
-    // in debug mode, make sure that there are some cells at least with
-    // this subdomain id
-#ifdef DEBUG
-    {
-      bool found = false;
-      for (typename Triangulation<
-             DoFHandlerType::dimension,
-             DoFHandlerType::space_dimension>::active_cell_iterator cell =
-             dof_handler.get_triangulation().begin_active();
-           cell != dof_handler.get_triangulation().end();
-           ++cell)
-        if (cell->subdomain_id() == subdomain)
-          {
-            found = true;
-            break;
-          }
-      Assert(found == true,
-             ExcMessage("There are no cells for the given subdomain!"));
-    }
-#endif
+    // Make sure there are at least some cells with this subdomain id
+    Assert(std::any_of(
+             dof_handler.begin_active(),
+             typename DoFHandlerType::active_cell_iterator{dof_handler.end()},
+             [subdomain](const typename DoFHandlerType::cell_accessor &cell) {
+               return cell.subdomain_id() == subdomain;
+             }),
+           ExcMessage("There are no cells for the given subdomain!"));
 
     std::vector<types::subdomain_id> subdomain_association(
       dof_handler.n_dofs());

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -648,8 +648,7 @@ namespace TrilinosWrappers
       // check whether the relevant rows correspond to exactly the same map as
       // the owned rows. In that case, do not create the nonlocal graph and
       // fill the columns by demand
-      bool have_ghost_rows = false;
-      {
+      const bool have_ghost_rows = [&]() {
         std::vector<dealii::types::global_dof_index> indices;
         relevant_rows.fill_index_vector(indices);
         Epetra_Map relevant_map(
@@ -661,11 +660,8 @@ namespace TrilinosWrappers
                indices.data())),
           0,
           row_space_map.Comm());
-        if (relevant_map.SameAs(row_space_map))
-          have_ghost_rows = false;
-        else
-          have_ghost_rows = true;
-      }
+        return !relevant_map.SameAs(row_space_map);
+      }();
 
       const unsigned int n_rows = relevant_rows.n_elements();
       std::vector<TrilinosWrappers::types::int_type> ghost_rows;

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -764,16 +764,15 @@ namespace internal
               if (!cell->has_children())
                 continue;
 
-              bool consider_cell = false;
-              if (tria.locally_owned_subdomain() ==
-                    numbers::invalid_subdomain_id ||
-                  cell->level_subdomain_id() == tria.locally_owned_subdomain())
-                consider_cell = true;
+              bool consider_cell =
+                (tria.locally_owned_subdomain() ==
+                   numbers::invalid_subdomain_id ||
+                 cell->level_subdomain_id() == tria.locally_owned_subdomain());
 
               // due to the particular way we store DoF indices (via children),
               // we also need to add the DoF indices for coarse cells where we
               // own at least one child
-              bool cell_is_remote = !consider_cell;
+              const bool cell_is_remote = !consider_cell;
               for (unsigned int c = 0;
                    c < GeometryInfo<dim>::max_children_per_cell;
                    ++c)


### PR DESCRIPTION
I attempted to improve the way some of the Boolean variables are assigned in the code. The goal is to:
* Simplify code flow.
* Make bool variables const.
* Make use of standard algorithms.
* Prevent mistakes.
* Improve performance (in some limited cases).
* Improve readability, although this is subjective.

Some of the standard algorithms, even though they are very expressive and efficient, might become too long because we can't use `auto` parameters in lambdas (with c++11), and we have to write a lot of `begin()` and `end()`. I still preferred them in many cases over `for` loops with `break` statements.