### PR TITLE
Create GridTools::compute_vertices_with_ghost_neighbors()

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -542,18 +542,6 @@ namespace internal
     tree_exists_locally(const typename types<dim>::forest *parallel_forest,
                         const typename types<dim>::topidx  coarse_grid_cell);
 
-
-
-    /**
-     * Compute the ghost neighbors surrounding each vertex by querying p4est
-     */
-    template <int dim, int spacedim>
-    std::map<unsigned int, std::set<dealii::types::subdomain_id>>
-    compute_vertices_with_ghost_neighbors(
-      const dealii::parallel::distributed::Triangulation<dim, spacedim> &tria,
-      typename dealii::internal::p4est::types<dim>::forest *parallel_forest,
-      typename dealii::internal::p4est::types<dim>::ghost * parallel_ghost);
-
   } // namespace p4est
 } // namespace internal
 

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -213,8 +213,13 @@ namespace parallel
     /**
      * Return a map that, for each vertex, lists all the processors whose
      * subdomains are adjacent to that vertex.
+     *
+     * @deprecated Use GridTools::compute_vertices_with_ghost_neighbors()
+     * instead of
+     * parallel::TriangulationBase::compute_vertices_with_ghost_neighbors().
      */
-    virtual std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+    DEAL_II_DEPRECATED virtual std::map<unsigned int,
+                                        std::set<dealii::types::subdomain_id>>
     compute_vertices_with_ghost_neighbors() const;
 
     /**

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2987,6 +2987,17 @@ namespace GridTools
     std::map<unsigned int, unsigned int> &vertex_to_coinciding_vertex_group);
 
   /**
+   * Return a map that, for each vertex, lists all the processes whose
+   * subdomains are adjacent to that vertex.
+   *
+   * @param[in] tria Triangulation.
+   */
+  template <int dim, int spacedim>
+  std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+  compute_vertices_with_ghost_neighbors(
+    const Triangulation<dim, spacedim> &tria);
+
+  /**
    * A structure that allows the transfer of cell data of type @p T from one processor
    * to another. It corresponds to a packed buffer that stores a vector of
    * CellId and a vector of type @p T.
@@ -3927,7 +3938,7 @@ namespace GridTools
 
     std::map<unsigned int, std::set<dealii::types::subdomain_id>>
       vertices_with_ghost_neighbors =
-        tria->compute_vertices_with_ghost_neighbors();
+        GridTools::compute_vertices_with_ghost_neighbors(*tria);
 
     for (const auto &cell : tria->active_cell_iterators())
       if (cell->is_locally_owned())

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -473,58 +473,6 @@ namespace internal
     std::size_t (&functions<2>::connectivity_memory_used)(
       types<2>::connectivity *p4est) = p4est_connectivity_memory_used;
 
-    template <int dim, int spacedim>
-    std::map<unsigned int, std::set<dealii::types::subdomain_id>>
-    compute_vertices_with_ghost_neighbors(
-      const typename dealii::parallel::distributed::Triangulation<dim, spacedim>
-        &                                                   tria,
-      typename dealii::internal::p4est::types<dim>::forest *parallel_forest,
-      typename dealii::internal::p4est::types<dim>::ghost * parallel_ghost)
-    {
-      std::map<unsigned int, std::set<dealii::types::subdomain_id>>
-        vertices_with_ghost_neighbors;
-
-      dealii::internal::p4est::FindGhosts<dim, spacedim> fg;
-      fg.subids        = sc_array_new(sizeof(dealii::types::subdomain_id));
-      fg.triangulation = &tria;
-      fg.vertices_with_ghost_neighbors = &vertices_with_ghost_neighbors;
-
-      switch (dim)
-        {
-          case 2:
-            p4est_iterate(
-              reinterpret_cast<dealii::internal::p4est::types<2>::forest *>(
-                parallel_forest),
-              reinterpret_cast<dealii::internal::p4est::types<2>::ghost *>(
-                parallel_ghost),
-              static_cast<void *>(&fg),
-              nullptr,
-              find_ghosts_face<2, spacedim>,
-              find_ghosts_corner<2, spacedim>);
-            break;
-
-          case 3:
-            p8est_iterate(
-              reinterpret_cast<dealii::internal::p4est::types<3>::forest *>(
-                parallel_forest),
-              reinterpret_cast<dealii::internal::p4est::types<3>::ghost *>(
-                parallel_ghost),
-              static_cast<void *>(&fg),
-              nullptr,
-              find_ghosts_face<3, 3>,
-              find_ghosts_edge<3, 3>,
-              find_ghosts_corner<3, 3>);
-            break;
-
-          default:
-            Assert(false, ExcNotImplemented());
-        }
-
-      sc_array_destroy(fg.subids);
-
-      return vertices_with_ghost_neighbors;
-    }
-
     constexpr unsigned int functions<2>::max_level;
 
     void (&functions<2>::transfer_fixed)(const types<2>::gloidx *dest_gfq,

--- a/source/distributed/p4est_wrappers.inst.in
+++ b/source/distributed/p4est_wrappers.inst.in
@@ -54,30 +54,3 @@ for (deal_II_dimension : DIMENSIONS)
     \}
 #endif  // DEAL_II_WITH_P4EST
   }
-
-
-for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
-  {
-#ifdef DEAL_II_WITH_P4EST
-
-    namespace internal
-    \{
-      namespace p4est
-      \{
-#  if deal_II_dimension > 1
-#    if deal_II_space_dimension >= deal_II_dimension
-        template std::map<unsigned int, std::set<dealii::types::subdomain_id>>
-        compute_vertices_with_ghost_neighbors(
-          const dealii::parallel::distributed::
-            Triangulation<deal_II_dimension, deal_II_space_dimension> &tria,
-          typename dealii::internal::p4est::types<deal_II_dimension>::forest
-            *parallel_forest,
-          typename dealii::internal::p4est::types<deal_II_dimension>::ghost
-            *parallel_ghost);
-
-#    endif
-#  endif
-      \}
-    \}
-#endif  // DEAL_II_WITH_P4EST
-  }

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -4198,7 +4198,7 @@ namespace parallel
       // at that boundary.
       const std::map<unsigned int, std::set<dealii::types::subdomain_id>>
         vertices_with_ghost_neighbors =
-          this->compute_vertices_with_ghost_neighbors();
+          GridTools::compute_vertices_with_ghost_neighbors(*this);
 
       // now collect cells and their vertices
       // for the interested neighbors

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -353,52 +353,7 @@ namespace parallel
   TriangulationBase<dim, spacedim>::compute_vertices_with_ghost_neighbors()
     const
   {
-    // 1) collect for each vertex on periodic faces all vertices it coincides
-    //    with
-    std::map<unsigned int, std::vector<unsigned int>> coinciding_vertex_groups;
-    std::map<unsigned int, unsigned int> vertex_to_coinciding_vertex_group;
-
-    GridTools::collect_coinciding_vertices(*this,
-                                           coinciding_vertex_groups,
-                                           vertex_to_coinciding_vertex_group);
-
-    // 2) collect vertices belonging to local cells
-    std::vector<bool> vertex_of_own_cell(this->n_vertices(), false);
-    for (const auto &cell : this->active_cell_iterators())
-      if (cell->is_locally_owned())
-        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
-          vertex_of_own_cell[cell->vertex_index(v)] = true;
-
-    // 3) for each vertex belonging to a locally owned cell all ghost
-    //    neighbors (including the periodic own)
-    std::map<unsigned int, std::set<types::subdomain_id>> result;
-
-    // loop over all active ghost cells
-    for (const auto &cell : this->active_cell_iterators())
-      if (cell->is_ghost())
-        {
-          const types::subdomain_id owner = cell->subdomain_id();
-
-          // loop over all its vertices
-          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
-            {
-              // set owner if vertex belongs to a local cell
-              if (vertex_of_own_cell[cell->vertex_index(v)])
-                result[cell->vertex_index(v)].insert(owner);
-
-              // mark also nodes coinciding due to periodicity
-              auto coinciding_vertex_group =
-                vertex_to_coinciding_vertex_group.find(cell->vertex_index(v));
-              if (coinciding_vertex_group !=
-                  vertex_to_coinciding_vertex_group.end())
-                for (auto coinciding_vertex :
-                     coinciding_vertex_groups[coinciding_vertex_group->second])
-                  if (vertex_of_own_cell[coinciding_vertex])
-                    result[coinciding_vertex].insert(owner);
-            }
-        }
-
-    return result;
+    return GridTools::compute_vertices_with_ghost_neighbors(*this);
   }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4550,7 +4550,7 @@ namespace internal
           // to exchange DoF indices
           const std::map<unsigned int, std::set<dealii::types::subdomain_id>>
             vertices_with_ghost_neighbors =
-              triangulation->compute_vertices_with_ghost_neighbors();
+              GridTools::compute_vertices_with_ghost_neighbors(*triangulation);
 
           // mark all cells that either have to send data (locally
           // owned cells that are adjacent to ghost neighbors in some
@@ -5102,7 +5102,8 @@ namespace internal
               const std::map<unsigned int,
                              std::set<dealii::types::subdomain_id>>
                 vertices_with_ghost_neighbors =
-                  triangulation->compute_vertices_with_ghost_neighbors();
+                  GridTools::compute_vertices_with_ghost_neighbors(
+                    *triangulation);
 
 
               // Send and receive cells. After this, only the local cells

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5501,6 +5501,66 @@ namespace GridTools
         coinciding_vertex_groups[p.second].push_back(p.first);
     }
   }
+
+
+
+  template <int dim, int spacedim>
+  std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+  compute_vertices_with_ghost_neighbors(
+    const Triangulation<dim, spacedim> &tria)
+  {
+    if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+          &tria) == nullptr) // nothing to do for a serial triangulation
+      return {};
+
+    // 1) collect for each vertex on periodic faces all vertices it coincides
+    //    with
+    std::map<unsigned int, std::vector<unsigned int>> coinciding_vertex_groups;
+    std::map<unsigned int, unsigned int> vertex_to_coinciding_vertex_group;
+
+    GridTools::collect_coinciding_vertices(tria,
+                                           coinciding_vertex_groups,
+                                           vertex_to_coinciding_vertex_group);
+
+    // 2) collect vertices belonging to local cells
+    std::vector<bool> vertex_of_own_cell(tria.n_vertices(), false);
+    for (const auto &cell : tria.active_cell_iterators())
+      if (cell->is_locally_owned())
+        for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
+          vertex_of_own_cell[cell->vertex_index(v)] = true;
+
+    // 3) for each vertex belonging to a locally owned cell all ghost
+    //    neighbors (including the periodic own)
+    std::map<unsigned int, std::set<types::subdomain_id>> result;
+
+    // loop over all active ghost cells
+    for (const auto &cell : tria.active_cell_iterators())
+      if (cell->is_ghost())
+        {
+          const types::subdomain_id owner = cell->subdomain_id();
+
+          // loop over all its vertices
+          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
+            {
+              // set owner if vertex belongs to a local cell
+              if (vertex_of_own_cell[cell->vertex_index(v)])
+                result[cell->vertex_index(v)].insert(owner);
+
+              // mark also nodes coinciding due to periodicity
+              auto coinciding_vertex_group =
+                vertex_to_coinciding_vertex_group.find(cell->vertex_index(v));
+              if (coinciding_vertex_group !=
+                  vertex_to_coinciding_vertex_group.end())
+                for (auto coinciding_vertex :
+                     coinciding_vertex_groups[coinciding_vertex_group->second])
+                  if (vertex_of_own_cell[coinciding_vertex])
+                    result[coinciding_vertex].insert(owner);
+            }
+        }
+
+    return result;
+  }
+
 } /* namespace GridTools */
 
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -410,6 +410,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Triangulation<deal_II_dimension, deal_II_space_dimension> &,
         std::map<unsigned int, std::vector<unsigned int>> &,
         std::map<unsigned int, unsigned int> &);
+
+      template std::map<unsigned int, std::set<dealii::types::subdomain_id>>
+      compute_vertices_with_ghost_neighbors(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension> &);
     \}
 #endif
   }


### PR DESCRIPTION
This PR is a follow-up to #8783.

This PR:
1) removes the unused function `internal::p4est::compute_vertices_with_ghost_neighbors()`
2) depreciates `parallel::TriangulationBase::compute_vertices_with_ghost_neighbors()` and
3)  adds a new function `GridTools::compute_vertices_with_ghost_neighbors()`.

The reason for moving `parallel::TriangulationBase::compute_vertices_with_ghost_neighbors()` to `GridTools::compute_vertices_with_ghost_neighbors()` is that the function is general (independent of the triangulation type) and only needs public methods of the triangulation (like the iterators).

If this change is fine, I would modify my old change-log entry accordingly.