### PR TITLE
Fix a few tests

### DIFF
--- a/include/deal.II/numerics/vector_tools_point_gradient.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.h
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/config.h>
 
+#include <vector>
+
 
 DEAL_II_NAMESPACE_OPEN
 

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <functional>
 #include <memory>
 
 DEAL_II_NAMESPACE_OPEN

--- a/tests/matrix_free/iterators.cc
+++ b/tests/matrix_free/iterators.cc
@@ -85,6 +85,8 @@ public:
         additional_data.mapping_update_flags_inner_faces    = update_values;
         additional_data.mapping_update_flags_boundary_faces = update_values;
         additional_data.mg_level                            = level;
+        additional_data.tasks_parallel_scheme =
+          MatrixFree<dim, Number, VectorizedArrayType>::AdditionalData::none;
 
         MatrixFree<dim, Number, VectorizedArrayType> matrix_free;
         matrix_free.reinit(

--- a/tests/trilinos/subtract_mean_value_04.cc
+++ b/tests/trilinos/subtract_mean_value_04.cc
@@ -17,6 +17,8 @@
 
 // check VectorTools::subtract_mean_value() for Trilinos vectors
 
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/trilinos_epetra_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
 #include <deal.II/lac/trilinos_vector.h>
 


### PR DESCRIPTION
This fixes a few test failures:
- The minimal bundled all-headers failures here (caused by #9929):
https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=5826
- A missing include to the Epetra vector and `ReadWriteVector` here:
https://cdash.43-1.org/testDetails.php?test=41775551&build=5825
- A race condition in `matrix_free/iterators` that only manifested itself in a run with no vectorization (because it needed enough cell batches to actually do something in parallel) - to write into a `set`, we must disable TBB parallelism.