### PR TITLE
Make parallel::shared::Triangulation::update_number_cache private

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -341,7 +341,7 @@ namespace parallel
       bool
       with_artificial_cells() const;
 
-    protected:
+    private:
       /**
        * Override the function to update the number cache so we can fill data
        * like @p level_ghost_owners.
@@ -349,7 +349,6 @@ namespace parallel
       virtual void
       update_number_cache() override;
 
-    private:
       /**
        * Settings
        */


### PR DESCRIPTION
This function is private in `p:d:t` and `p:f:t`, however, it is protected in `p:s:t`. I would propose to make all private so that they are consistent.