### PR TITLE
Include ComponentMask in vector_tools_interpolate.h

### DIFF
--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -18,13 +18,14 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/fe/component_mask.h>
+
 #include <map>
 
 DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 class AffineConstraints;
-class ComponentMask;
 template <int dim, int spacedim>
 class DoFHandler;
 template <typename number>


### PR DESCRIPTION
clang complains rightfully that `ComponentMask` is only forward declared, despite using the default constructor:
https://cdash.43-1.org/testDetails.php?test=41845020&build=5839
Thus, we should include the proper header. Follow-up to #9929.