### PR TITLE
Simplify parallel::TriangulationBase::update_number_cache

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -243,13 +243,6 @@ namespace parallel
 
     private:
       /**
-       * Override the function to update the number cache so we can fill data
-       * like @p level_ghost_owners.
-       */
-      virtual void
-      update_number_cache() override;
-
-      /**
        * store the Settings.
        */
       TriangulationDescription::Settings settings;

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -343,13 +343,6 @@ namespace parallel
 
     private:
       /**
-       * Override the function to update the number cache so we can fill data
-       * like @p level_ghost_owners.
-       */
-      virtual void
-      update_number_cache() override;
-
-      /**
        * Settings
        */
       const Settings settings;

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -862,13 +862,6 @@ namespace parallel
 
     private:
       /**
-       * Override the function to update the number cache so we can fill data
-       * like @p level_ghost_owners.
-       */
-      virtual void
-      update_number_cache() override;
-
-      /**
        * store the Settings.
        */
       Settings settings;

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -301,12 +301,6 @@ namespace parallel
      */
     virtual void
     update_number_cache();
-
-    /**
-     * Store MPI ranks of level ghost owners of this processor on all levels.
-     */
-    void
-    fill_level_ghost_owners();
   };
 
   /**

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -173,7 +173,7 @@ namespace parallel
             }
         }
 
-      update_number_cache();
+      this->update_number_cache();
     }
 
 
@@ -261,19 +261,6 @@ namespace parallel
     {
       this->partitioner = partitioner;
       this->settings    = settings;
-    }
-
-
-
-    template <int dim, int spacedim>
-    void
-    Triangulation<dim, spacedim>::update_number_cache()
-    {
-      parallel::Triangulation<dim, spacedim>::update_number_cache();
-
-      if (settings &
-          TriangulationDescription::Settings::construct_multigrid_hierarchy)
-        parallel::Triangulation<dim, spacedim>::fill_level_ghost_owners();
     }
 
 

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -419,18 +419,6 @@ namespace parallel
       partition();
       this->update_number_cache();
     }
-
-
-
-    template <int dim, int spacedim>
-    void
-    Triangulation<dim, spacedim>::update_number_cache()
-    {
-      parallel::TriangulationBase<dim, spacedim>::update_number_cache();
-
-      if (settings & construct_multigrid_hierarchy)
-        parallel::TriangulationBase<dim, spacedim>::fill_level_ghost_owners();
-    }
   } // namespace shared
 } // namespace parallel
 

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2915,18 +2915,6 @@ namespace parallel
 
 
     template <int dim, int spacedim>
-    void
-    Triangulation<dim, spacedim>::update_number_cache()
-    {
-      parallel::TriangulationBase<dim, spacedim>::update_number_cache();
-
-      if (settings & construct_multigrid_hierarchy)
-        parallel::TriangulationBase<dim, spacedim>::fill_level_ghost_owners();
-    }
-
-
-
-    template <int dim, int spacedim>
     typename dealii::internal::p4est::types<dim>::tree *
     Triangulation<dim, spacedim>::init_tree(
       const int dealii_coarse_cell_index) const

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -215,92 +215,90 @@ namespace parallel
 
     number_cache.n_global_levels =
       Utilities::MPI::max(this->n_levels(), this->mpi_communicator);
-  }
 
+    // Store MPI ranks of level ghost owners of this processor on all levels.
+    if (this->is_multilevel_hierarchy_constructed() == true)
+      {
+        number_cache.level_ghost_owners.clear();
 
+        // if there is nothing to do, then do nothing
+        if (this->n_levels() == 0)
+          return;
 
-  template <int dim, int spacedim>
-  void
-  TriangulationBase<dim, spacedim>::fill_level_ghost_owners()
-  {
-    number_cache.level_ghost_owners.clear();
-
-    // if there is nothing to do, then do nothing
-    if (this->n_levels() == 0)
-      return;
-
-    // find level ghost owners
-    for (typename Triangulation<dim, spacedim>::cell_iterator cell =
-           this->begin();
-         cell != this->end();
-         ++cell)
-      if (cell->level_subdomain_id() != numbers::artificial_subdomain_id &&
-          cell->level_subdomain_id() != this->locally_owned_subdomain())
-        this->number_cache.level_ghost_owners.insert(
-          cell->level_subdomain_id());
+        // find level ghost owners
+        for (typename Triangulation<dim, spacedim>::cell_iterator cell =
+               this->begin();
+             cell != this->end();
+             ++cell)
+          if (cell->level_subdomain_id() != numbers::artificial_subdomain_id &&
+              cell->level_subdomain_id() != this->locally_owned_subdomain())
+            this->number_cache.level_ghost_owners.insert(
+              cell->level_subdomain_id());
 
 #  ifdef DEBUG
-    // Check that level_ghost_owners is symmetric by sending a message to
-    // everyone
-    {
-      int ierr = MPI_Barrier(this->mpi_communicator);
-      AssertThrowMPI(ierr);
-
-      const int mpi_tag = Utilities::MPI::internal::Tags::
-        triangulation_base_fill_level_ghost_owners;
-
-      // important: preallocate to avoid (re)allocation:
-      std::vector<MPI_Request> requests(
-        this->number_cache.level_ghost_owners.size());
-      unsigned int dummy       = 0;
-      unsigned int req_counter = 0;
-
-      for (std::set<types::subdomain_id>::iterator it =
-             this->number_cache.level_ghost_owners.begin();
-           it != this->number_cache.level_ghost_owners.end();
-           ++it, ++req_counter)
+        // Check that level_ghost_owners is symmetric by sending a message to
+        // everyone
         {
-          ierr = MPI_Isend(&dummy,
-                           1,
-                           MPI_UNSIGNED,
-                           *it,
-                           mpi_tag,
-                           this->mpi_communicator,
-                           &requests[req_counter]);
+          int ierr = MPI_Barrier(this->mpi_communicator);
+          AssertThrowMPI(ierr);
+
+          const int mpi_tag = Utilities::MPI::internal::Tags::
+            triangulation_base_fill_level_ghost_owners;
+
+          // important: preallocate to avoid (re)allocation:
+          std::vector<MPI_Request> requests(
+            this->number_cache.level_ghost_owners.size());
+          unsigned int dummy       = 0;
+          unsigned int req_counter = 0;
+
+          for (std::set<types::subdomain_id>::iterator it =
+                 this->number_cache.level_ghost_owners.begin();
+               it != this->number_cache.level_ghost_owners.end();
+               ++it, ++req_counter)
+            {
+              ierr = MPI_Isend(&dummy,
+                               1,
+                               MPI_UNSIGNED,
+                               *it,
+                               mpi_tag,
+                               this->mpi_communicator,
+                               &requests[req_counter]);
+              AssertThrowMPI(ierr);
+            }
+
+          for (std::set<types::subdomain_id>::iterator it =
+                 this->number_cache.level_ghost_owners.begin();
+               it != this->number_cache.level_ghost_owners.end();
+               ++it)
+            {
+              unsigned int dummy;
+              ierr = MPI_Recv(&dummy,
+                              1,
+                              MPI_UNSIGNED,
+                              *it,
+                              mpi_tag,
+                              this->mpi_communicator,
+                              MPI_STATUS_IGNORE);
+              AssertThrowMPI(ierr);
+            }
+
+          if (requests.size() > 0)
+            {
+              ierr = MPI_Waitall(requests.size(),
+                                 requests.data(),
+                                 MPI_STATUSES_IGNORE);
+              AssertThrowMPI(ierr);
+            }
+
+          ierr = MPI_Barrier(this->mpi_communicator);
           AssertThrowMPI(ierr);
         }
-
-      for (std::set<types::subdomain_id>::iterator it =
-             this->number_cache.level_ghost_owners.begin();
-           it != this->number_cache.level_ghost_owners.end();
-           ++it)
-        {
-          unsigned int dummy;
-          ierr = MPI_Recv(&dummy,
-                          1,
-                          MPI_UNSIGNED,
-                          *it,
-                          mpi_tag,
-                          this->mpi_communicator,
-                          MPI_STATUS_IGNORE);
-          AssertThrowMPI(ierr);
-        }
-
-      if (requests.size() > 0)
-        {
-          ierr =
-            MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
-          AssertThrowMPI(ierr);
-        }
-
-      ierr = MPI_Barrier(this->mpi_communicator);
-      AssertThrowMPI(ierr);
-    }
 #  endif
 
-    Assert(this->number_cache.level_ghost_owners.size() <
-             Utilities::MPI::n_mpi_processes(this->mpi_communicator),
-           ExcInternalError());
+        Assert(this->number_cache.level_ghost_owners.size() <
+                 Utilities::MPI::n_mpi_processes(this->mpi_communicator),
+               ExcInternalError());
+      }
   }
 
 #else
@@ -308,13 +306,6 @@ namespace parallel
   template <int dim, int spacedim>
   void
   TriangulationBase<dim, spacedim>::update_number_cache()
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-  template <int dim, int spacedim>
-  void
-  TriangulationBase<dim, spacedim>::fill_level_ghost_owners()
   {
     Assert(false, ExcNotImplemented());
   }


### PR DESCRIPTION
A simplifications enabled by #9915.

This PR extends `parallel::TriangulationBase::update_number_cache()` with multigrid functionalities, which have been added till now in the derived classes.

FYI @tjhei 