### PR TITLE
Fix assertion in CUDA

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1770,6 +1770,37 @@ namespace internal
 #  endif
 
 /**
+ * An assertion that checks that the kernel was launched and executed
+ * successfully.
+ *
+ * @note This and similar macro names are examples of preprocessor definitions
+ * in the deal.II library that are not prefixed by a string that likely makes
+ * them unique to deal.II. As a consequence, it is possible that other
+ * libraries your code interfaces with define the same name, and the result
+ * will be name collisions (see
+ * https://en.wikipedia.org/wiki/Name_collision). One can <code>\#undef</code>
+ * this macro, as well as all other macros defined by deal.II that are not
+ * prefixed with either <code>DEAL</code> or <code>deal</code>, by including
+ * the header <code>deal.II/base/undefine_macros.h</code> after all other
+ * deal.II headers have been included.
+ *
+ * @ingroup Exceptions
+ * @author Bruno Turcksin, 2020
+ */
+#  ifdef DEBUG
+#    define AssertCudaKernel()                                \
+      {                                                       \
+        cudaError_t local_error_code = cudaPeekAtLastError(); \
+        AssertCuda(local_error_code);                         \
+        local_error_code = cudaDeviceSynchronize();           \
+        AssertCuda(local_error_code)                          \
+      }
+#  else
+#    define AssertCudaKernel() \
+      {}
+#  endif
+
+/**
  * An assertion that checks that the error code produced by calling a cuSPARSE
  * routine is equal to CUSPARSE_STATUS_SUCCESS.
  *

--- a/include/deal.II/base/undefine_macros.h
+++ b/include/deal.II/base/undefine_macros.h
@@ -30,6 +30,10 @@
 #  undef AssertCuda
 #endif // #ifdef AssertCuda
 
+#ifdef AssertCudaKernel
+#  undef AssertCudaKernel
+#endif // #ifdef AssertCudaKernel
+
 #ifdef AssertCusolver
 #  undef AssertCusolver
 #endif // #ifdef AssertCusolver

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1924,12 +1924,7 @@ namespace internal
       const int n_blocks = 1 + (n_constraints - 1) / CUDAWrappers::block_size;
       set_zero_kernel<<<n_blocks, CUDAWrappers::block_size>>>(
         constrained_local_dofs_device, n_constraints, vec.get_values());
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
 
       Utilities::CUDA::free(constrained_local_dofs_device);
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1926,7 +1926,7 @@ namespace internal
         constrained_local_dofs_device, n_constraints, vec.get_values());
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2165,13 +2165,7 @@ namespace internal
         1 + (n_local_elements - 1) / CUDAWrappers::block_size;
       set_initial_guess_kernel<<<n_blocks, CUDAWrappers::block_size>>>(
         first_local_range, n_local_elements, vector.get_values());
-
-#    ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#    endif
+      AssertCudaKernel();
 
       const Number mean_value = vector.mean_value();
       vector.add(-mean_value);

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2168,7 +2168,7 @@ namespace internal
 
 #    ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #    endif

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2096,7 +2096,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2121,7 +2121,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2146,7 +2146,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2167,7 +2167,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2193,7 +2193,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2224,7 +2224,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2248,7 +2248,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2273,7 +2273,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2306,7 +2306,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2327,7 +2327,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2351,7 +2351,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2377,7 +2377,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2408,7 +2408,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -2441,7 +2441,7 @@ namespace internal
 
 #  ifdef DEBUG
         // Check that the kernel was launched correctly
-        AssertCuda(cudaGetLastError());
+        AssertCuda(cudaPeekAtLastError());
         // Check that there was no problem during the execution of the kernel
         AssertCuda(cudaDeviceSynchronize());
 #  endif

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -2093,13 +2093,7 @@ namespace internal
         const int n_blocks = 1 + size / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::set<Number>
           <<<n_blocks, block_size>>>(data.values_dev.get(), s, size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2118,13 +2112,7 @@ namespace internal
                                      1.,
                                      v_data.values_dev.get(),
                                      size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2143,13 +2131,7 @@ namespace internal
                                      -1.,
                                      v_data.values_dev.get(),
                                      size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2164,13 +2146,7 @@ namespace internal
         const int n_blocks = 1 + size / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::vec_add<Number>
           <<<n_blocks, block_size>>>(data.values_dev.get(), a, size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2190,13 +2166,7 @@ namespace internal
                                      a,
                                      v_data.values_dev.get(),
                                      size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2221,13 +2191,7 @@ namespace internal
                                                     b,
                                                     w_data.values_dev.get(),
                                                     size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2245,13 +2209,7 @@ namespace internal
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::sadd<Number>
           <<<dim3(n_blocks, 1), dim3(block_size)>>>(
             x, data.values_dev.get(), 1., v_data.values_dev.get(), size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2270,13 +2228,7 @@ namespace internal
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::sadd<Number>
           <<<dim3(n_blocks, 1), dim3(block_size)>>>(
             x, data.values_dev.get(), a, v_data.values_dev.get(), size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2303,13 +2255,7 @@ namespace internal
                                                     b,
                                                     w_data.values_dev.get(),
                                                     size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2324,13 +2270,7 @@ namespace internal
         const int n_blocks = 1 + size / (chunk_size * block_size);
         ::dealii::LinearAlgebra::CUDAWrappers::kernel::vec_scale<Number>
           <<<n_blocks, block_size>>>(data.values_dev.get(), factor, size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2348,13 +2288,7 @@ namespace internal
           <<<dim3(n_blocks, 1), dim3(block_size)>>>(data.values_dev.get(),
                                                     v_data.values_dev.get(),
                                                     size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2374,13 +2308,7 @@ namespace internal
                                                     a,
                                                     v_data.values_dev.get(),
                                                     size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static void
@@ -2405,13 +2333,7 @@ namespace internal
                                                     b,
                                                     w_data.values_dev.get(),
                                                     size);
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
       }
 
       static Number
@@ -2438,13 +2360,7 @@ namespace internal
                                                     v_data.values_dev.get(),
                                                     static_cast<unsigned int>(
                                                       size));
-
-#  ifdef DEBUG
-        // Check that the kernel was launched correctly
-        AssertCuda(cudaPeekAtLastError());
-        // Check that there was no problem during the execution of the kernel
-        AssertCuda(cudaDeviceSynchronize());
-#  endif
+        AssertCudaKernel();
 
         // Copy the result back to the host
         Number result;

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -785,8 +785,11 @@ namespace CUDAWrappers
   MatrixFree<dim, Number>::evaluate_coefficients(Functor func) const
   {
     for (unsigned int i = 0; i < n_colors; ++i)
-      internal::evaluate_coeff<dim, Number, Functor>
-        <<<grid_dim[i], block_dim[i]>>>(func, get_data(i));
+      {
+        internal::evaluate_coeff<dim, Number, Functor>
+          <<<grid_dim[i], block_dim[i]>>>(func, get_data(i));
+        AssertCudaKernel();
+      }
   }
 
 
@@ -1039,11 +1042,14 @@ namespace CUDAWrappers
   {
     // Execute the loop on the cells
     for (unsigned int i = 0; i < n_colors; ++i)
-      internal::apply_kernel_shmem<dim, Number, Functor>
-        <<<grid_dim[i], block_dim[i]>>>(func,
-                                        get_data(i),
-                                        src.get_values(),
-                                        dst.get_values());
+      {
+        internal::apply_kernel_shmem<dim, Number, Functor>
+          <<<grid_dim[i], block_dim[i]>>>(func,
+                                          get_data(i),
+                                          src.get_values(),
+                                          dst.get_values());
+        AssertCudaKernel();
+      }
   }
 
 
@@ -1065,11 +1071,14 @@ namespace CUDAWrappers
 
         // Execute the loop on the cells
         for (unsigned int i = 0; i < n_colors; ++i)
-          internal::apply_kernel_shmem<dim, Number, Functor>
-            <<<grid_dim[i], block_dim[i]>>>(func,
-                                            get_data(i),
-                                            src.get_values(),
-                                            dst.get_values());
+          {
+            internal::apply_kernel_shmem<dim, Number, Functor>
+              <<<grid_dim[i], block_dim[i]>>>(func,
+                                              get_data(i),
+                                              src.get_values(),
+                                              dst.get_values());
+            AssertCudaKernel();
+          }
         dst.compress(VectorOperation::add);
         src.zero_out_ghosts();
       }
@@ -1084,11 +1093,14 @@ namespace CUDAWrappers
 
         // Execute the loop on the cells
         for (unsigned int i = 0; i < n_colors; ++i)
-          internal::apply_kernel_shmem<dim, Number, Functor>
-            <<<grid_dim[i], block_dim[i]>>>(func,
-                                            get_data(i),
-                                            ghosted_src.get_values(),
-                                            ghosted_dst.get_values());
+          {
+            internal::apply_kernel_shmem<dim, Number, Functor>
+              <<<grid_dim[i], block_dim[i]>>>(func,
+                                              get_data(i),
+                                              ghosted_src.get_values(),
+                                              ghosted_dst.get_values());
+            AssertCudaKernel();
+          }
 
         // Add the ghosted values
         ghosted_dst.compress(VectorOperation::add);
@@ -1125,6 +1137,7 @@ namespace CUDAWrappers
                                                       src.size(),
                                                       src.get_values(),
                                                       dst.get_values());
+    AssertCudaKernel();
   }
 
 
@@ -1143,6 +1156,7 @@ namespace CUDAWrappers
                                                       src.local_size(),
                                                       src.get_values(),
                                                       dst.get_values());
+    AssertCudaKernel();
   }
 
 
@@ -1170,6 +1184,7 @@ namespace CUDAWrappers
                                                       dst.size(),
                                                       val,
                                                       dst.get_values());
+    AssertCudaKernel();
   }
 
 
@@ -1186,6 +1201,7 @@ namespace CUDAWrappers
                                                       dst.local_size(),
                                                       val,
                                                       dst.get_values());
+    AssertCudaKernel();
   }
 
 

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -342,13 +342,7 @@ namespace CUDAWrappers
     const int n_blocks = 1 + (nnz - 1) / block_size;
     internal::scale<Number>
       <<<n_blocks, block_size>>>(val_dev.get(), factor, nnz);
-
-#  ifdef DEBUG
-    // Check that the kernel was launched correctly
-    AssertCuda(cudaPeekAtLastError());
-    // Check that there was no problem during the execution of the kernel
-    AssertCuda(cudaDeviceSynchronize());
-#  endif
+    AssertCudaKernel();
 
     return *this;
   }
@@ -364,13 +358,7 @@ namespace CUDAWrappers
     const int n_blocks = 1 + (nnz - 1) / block_size;
     internal::scale<Number>
       <<<n_blocks, block_size>>>(val_dev.get(), 1. / factor, nnz);
-
-#  ifdef DEBUG
-    // Check that the kernel was launched correctly
-    AssertCuda(cudaPeekAtLastError());
-    // Check that there was no problem during the execution of the kernel
-    AssertCuda(cudaDeviceSynchronize());
-#  endif
+    AssertCudaKernel();
 
     return *this;
   }
@@ -519,13 +507,7 @@ namespace CUDAWrappers
                                  column_index_dev.get(),
                                  row_ptr_dev.get(),
                                  column_sums.get_values());
-
-#  ifdef DEBUG
-    // Check that the kernel was launched correctly
-    AssertCuda(cudaPeekAtLastError());
-    // Check that there was no problem during the execution of the kernel
-    AssertCuda(cudaDeviceSynchronize());
-#  endif
+    AssertCudaKernel();
 
     return column_sums.linfty_norm();
   }
@@ -544,13 +526,7 @@ namespace CUDAWrappers
                                  column_index_dev.get(),
                                  row_ptr_dev.get(),
                                  row_sums.get_values());
-
-#  ifdef DEBUG
-    // Check that the kernel was launched correctly
-    AssertCuda(cudaPeekAtLastError());
-    // Check that there was no problem during the execution of the kernel
-    AssertCuda(cudaDeviceSynchronize());
-#  endif
+    AssertCudaKernel();
 
     return row_sums.linfty_norm();
   }

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -345,7 +345,7 @@ namespace CUDAWrappers
 
 #  ifdef DEBUG
     // Check that the kernel was launched correctly
-    AssertCuda(cudaGetLastError());
+    AssertCuda(cudaPeekAtLastError());
     // Check that there was no problem during the execution of the kernel
     AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -367,7 +367,7 @@ namespace CUDAWrappers
 
 #  ifdef DEBUG
     // Check that the kernel was launched correctly
-    AssertCuda(cudaGetLastError());
+    AssertCuda(cudaPeekAtLastError());
     // Check that there was no problem during the execution of the kernel
     AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -522,7 +522,7 @@ namespace CUDAWrappers
 
 #  ifdef DEBUG
     // Check that the kernel was launched correctly
-    AssertCuda(cudaGetLastError());
+    AssertCuda(cudaPeekAtLastError());
     // Check that there was no problem during the execution of the kernel
     AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -547,7 +547,7 @@ namespace CUDAWrappers
 
 #  ifdef DEBUG
     // Check that the kernel was launched correctly
-    AssertCuda(cudaGetLastError());
+    AssertCuda(cudaPeekAtLastError());
     // Check that there was no problem during the execution of the kernel
     AssertCuda(cudaDeviceSynchronize());
 #  endif

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -161,7 +161,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
           // Check that the kernel was launched correctly
-          AssertCuda(cudaGetLastError());
+          AssertCuda(cudaPeekAtLastError());
           // Check that there was no problem during the execution of the kernel
           AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -202,7 +202,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -224,7 +224,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -255,7 +255,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -286,7 +286,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -349,7 +349,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -379,7 +379,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -423,7 +423,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -456,7 +456,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -485,7 +485,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif
@@ -516,7 +516,7 @@ namespace LinearAlgebra
 
 #  ifdef DEBUG
       // Check that the kernel was launched correctly
-      AssertCuda(cudaGetLastError());
+      AssertCuda(cudaPeekAtLastError());
       // Check that there was no problem during the execution of the kernel
       AssertCuda(cudaDeviceSynchronize());
 #  endif

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -158,13 +158,7 @@ namespace LinearAlgebra
 
           kernel::vector_bin_op<Number, kernel::Binop_Addition>
             <<<n_blocks, block_size>>>(val.get(), tmp, n_elements);
-
-#  ifdef DEBUG
-          // Check that the kernel was launched correctly
-          AssertCuda(cudaPeekAtLastError());
-          // Check that there was no problem during the execution of the kernel
-          AssertCuda(cudaDeviceSynchronize());
-#  endif
+          AssertCudaKernel();
 
           // Delete the temporary vector
           Utilities::CUDA::free(tmp);
@@ -199,13 +193,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::vec_scale<Number>
         <<<n_blocks, block_size>>>(val.get(), factor, n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
 
       return *this;
     }
@@ -221,13 +209,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::vec_scale<Number>
         <<<n_blocks, block_size>>>(val.get(), 1. / factor, n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
 
       return *this;
     }
@@ -252,13 +234,7 @@ namespace LinearAlgebra
 
       kernel::vector_bin_op<Number, kernel::Binop_Addition>
         <<<n_blocks, block_size>>>(val.get(), down_V.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
 
       return *this;
     }
@@ -283,13 +259,7 @@ namespace LinearAlgebra
 
       kernel::vector_bin_op<Number, kernel::Binop_Subtraction>
         <<<n_blocks, block_size>>>(val.get(), down_V.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
 
       return *this;
     }
@@ -346,13 +316,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::vec_add<Number>
         <<<n_blocks, block_size>>>(val.get(), a, n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 
@@ -376,13 +340,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::add_aV<Number><<<dim3(n_blocks, 1), dim3(block_size)>>>(
         val.get(), a, down_V.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 
@@ -420,13 +378,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::add_aVbW<Number><<<dim3(n_blocks, 1), dim3(block_size)>>>(
         val.get(), a, down_V.val.get(), b, down_W.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 
@@ -453,13 +405,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::sadd<Number><<<dim3(n_blocks, 1), dim3(block_size)>>>(
         s, val.get(), a, down_V.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 
@@ -482,13 +428,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::scale<Number><<<dim3(n_blocks, 1), dim3(block_size)>>>(
         val.get(), down_scaling_factors.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 
@@ -513,13 +453,7 @@ namespace LinearAlgebra
       const int n_blocks = 1 + (n_elements - 1) / (chunk_size * block_size);
       kernel::equ<Number><<<dim3(n_blocks, 1), dim3(block_size)>>>(
         val.get(), a, down_V.val.get(), n_elements);
-
-#  ifdef DEBUG
-      // Check that the kernel was launched correctly
-      AssertCuda(cudaPeekAtLastError());
-      // Check that there was no problem during the execution of the kernel
-      AssertCuda(cudaDeviceSynchronize());
-#  endif
+      AssertCudaKernel();
     }
 
 

--- a/tests/cuda/cuda_point.cu
+++ b/tests/cuda/cuda_point.cu
@@ -86,7 +86,7 @@ test_gpu()
   // Miscellaneous
   miscellaneous_kernel<dim, Number><<<1, 1>>>(check);
   // Check that the kernel was launched correctly
-  AssertCuda(cudaGetLastError());
+  AssertCuda(cudaPeekAtLastError());
   // Check that there was no problem during the execution of the kernel
   AssertCuda(cudaDeviceSynchronize());
 

--- a/tests/cuda/matrix_free_no_index_initialize.cu
+++ b/tests/cuda/matrix_free_no_index_initialize.cu
@@ -77,7 +77,7 @@ public:
     data.cell_loop(*this, src_dummy, dst_dummy);
 
     // Check that the kernel was launched correctly
-    AssertCuda(cudaGetLastError());
+    AssertCuda(cudaPeekAtLastError());
     // Check that there was no problem during the execution of the kernel
     AssertCuda(cudaDeviceSynchronize());
 


### PR DESCRIPTION
Working on #8882 (PR coming for that one in the next few days), I realized that we didn't assert important kernels and there was a bug in the way we assert most of the kernel launchs. We used `cudaGetLastError`  but it resets the error code to success after being called. Because the function is called multiple times in `AssertCuda`, the error message is wrong.