### PR TITLE
Revisited binary search for parallel::distributed::GridRefinement.

### DIFF
--- a/tests/grid/refine_and_coarsen_fixed_number_03.cc
+++ b/tests/grid/refine_and_coarsen_fixed_number_03.cc
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// verify the binary search algorithm in different compositions of
+// criteria and refinement and coarsening fractions for
+// GridRefinement::refine_and_coarsen_fixed_number().
+
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+verify(Triangulation<dim> & tr,
+       const Vector<float> &criteria,
+       const float          refinement_fraction,
+       const float          coarsening_fraction)
+{
+  GridRefinement::refine_and_coarsen_fixed_number(tr,
+                                                  criteria,
+                                                  refinement_fraction,
+                                                  coarsening_fraction);
+
+  unsigned int n_refine_flags = 0, n_coarsen_flags = 0;
+  for (const auto &cell : tr.active_cell_iterators())
+    {
+      if (cell->refine_flag_set())
+        {
+          ++n_refine_flags;
+          cell->clear_refine_flag();
+        }
+      if (cell->coarsen_flag_set())
+        {
+          ++n_coarsen_flags;
+          cell->clear_coarsen_flag();
+        }
+    }
+
+  deallog << "  refinement_fraction:" << refinement_fraction
+          << " coarsening_fraction:" << coarsening_fraction << std::endl
+          << "    n_refine_flags:" << n_refine_flags
+          << " n_coarsen_flags:" << n_coarsen_flags << std::endl;
+}
+
+
+template <int dim>
+void
+test()
+{
+  const unsigned int n_cells             = 100;
+  const float        refinement_fraction = 0.1, coarsening_fraction = 0.1;
+
+  Triangulation<dim>        tr;
+  std::vector<unsigned int> rep(dim, 1);
+  rep[0] = n_cells;
+  Point<dim> p1, p2;
+  for (unsigned int d = 0; d < dim; ++d)
+    {
+      p1[d] = 0;
+      p2[d] = (d == 0) ? n_cells : 1;
+    }
+  GridGenerator::subdivided_hyper_rectangle(tr, rep, p1, p2);
+
+  deallog << "n_cells:" << n_cells << std::endl;
+  Vector<float> criteria(n_cells);
+  {
+    deallog << "criteria:[b>0,e>0]" << std::endl;
+
+    std::iota(criteria.begin(), criteria.end(), 1);
+    Assert(criteria(0) > 0. && criteria(n_cells - 1) > 0., ExcInternalError());
+
+    verify<dim>(tr, criteria, refinement_fraction, coarsening_fraction);
+    verify<dim>(tr, criteria, refinement_fraction, 0.);
+    verify<dim>(tr, criteria, 0., coarsening_fraction);
+  }
+
+  {
+    deallog << "criteria:[b=0,e>0]" << std::endl;
+
+    std::iota(criteria.begin(), criteria.end(), 0);
+    Assert(criteria(0) == 0. && criteria(n_cells - 1) > 0., ExcInternalError());
+
+    verify<dim>(tr, criteria, refinement_fraction, coarsening_fraction);
+    verify<dim>(tr, criteria, refinement_fraction, 0.);
+    verify<dim>(tr, criteria, 0., coarsening_fraction);
+  }
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+  deallog << std::setprecision(1);
+
+  test<2>();
+}

--- a/tests/grid/refine_and_coarsen_fixed_number_03.output
+++ b/tests/grid/refine_and_coarsen_fixed_number_03.output
@@ -1,0 +1,16 @@
+
+DEAL::n_cells:100
+DEAL::criteria:[b>0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10
+DEAL::criteria:[b=0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10

--- a/tests/mpi/refine_and_coarsen_fixed_number_08.cc
+++ b/tests/mpi/refine_and_coarsen_fixed_number_08.cc
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// verify the binary search algorithm in different compositions of
+// criteria and refinement and coarsening fractions for
+// parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number().
+
+#include <deal.II/distributed/grid_refinement.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+verify(parallel::distributed::Triangulation<dim> &tr,
+       const Vector<float> &                      criteria,
+       const float                                refinement_fraction,
+       const float                                coarsening_fraction)
+{
+  parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
+    tr, criteria, refinement_fraction, coarsening_fraction);
+
+  unsigned int n_refine_flags = 0, n_coarsen_flags = 0;
+  for (const auto &cell : tr.active_cell_iterators())
+    if (cell->is_locally_owned())
+      {
+        if (cell->refine_flag_set())
+          {
+            ++n_refine_flags;
+            cell->clear_refine_flag();
+          }
+        if (cell->coarsen_flag_set())
+          {
+            ++n_coarsen_flags;
+            cell->clear_coarsen_flag();
+          }
+      }
+
+  const unsigned int n_global_refine_flags =
+                       Utilities::MPI::sum(n_refine_flags, MPI_COMM_WORLD),
+                     n_global_coarsen_flags =
+                       Utilities::MPI::sum(n_coarsen_flags, MPI_COMM_WORLD);
+
+  deallog << "  refinement_fraction:" << refinement_fraction
+          << " coarsening_fraction:" << coarsening_fraction << std::endl
+          << "    n_refine_flags:" << n_global_refine_flags
+          << " n_coarsen_flags:" << n_global_coarsen_flags << std::endl;
+}
+
+
+template <int dim>
+void
+test()
+{
+  const unsigned int n_cells             = 100;
+  const float        refinement_fraction = 0.1, coarsening_fraction = 0.1;
+
+  parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+  std::vector<unsigned int>                 rep(dim, 1);
+  rep[0] = n_cells;
+  Point<dim> p1, p2;
+  for (unsigned int d = 0; d < dim; ++d)
+    {
+      p1[d] = 0;
+      p2[d] = (d == 0) ? n_cells : 1;
+    }
+  GridGenerator::subdivided_hyper_rectangle(tr, rep, p1, p2);
+
+  deallog << "n_cells:" << n_cells << std::endl;
+  Vector<float> criteria(n_cells);
+  {
+    deallog << "criteria:[b>0,e>0]" << std::endl;
+
+    std::iota(criteria.begin(), criteria.end(), 1);
+    Assert(criteria(0) > 0. && criteria(n_cells - 1) > 0., ExcInternalError());
+
+    verify<dim>(tr, criteria, refinement_fraction, coarsening_fraction);
+    verify<dim>(tr, criteria, refinement_fraction, 0.);
+    verify<dim>(tr, criteria, 0., coarsening_fraction);
+  }
+
+  {
+    deallog << "criteria:[b=0,e>0]" << std::endl;
+
+    std::iota(criteria.begin(), criteria.end(), 0);
+    Assert(criteria(0) == 0. && criteria(n_cells - 1) > 0., ExcInternalError());
+
+    verify<dim>(tr, criteria, refinement_fraction, coarsening_fraction);
+    verify<dim>(tr, criteria, refinement_fraction, 0.);
+    verify<dim>(tr, criteria, 0., coarsening_fraction);
+  }
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+      deallog << std::setprecision(1);
+    }
+
+  test<2>();
+}

--- a/tests/mpi/refine_and_coarsen_fixed_number_08.mpirun=1.with_p4est=true.output
+++ b/tests/mpi/refine_and_coarsen_fixed_number_08.mpirun=1.with_p4est=true.output
@@ -1,0 +1,16 @@
+
+DEAL::n_cells:100
+DEAL::criteria:[b>0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10
+DEAL::criteria:[b=0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10

--- a/tests/mpi/refine_and_coarsen_fixed_number_08.mpirun=4.with_p4est=true.output
+++ b/tests/mpi/refine_and_coarsen_fixed_number_08.mpirun=4.with_p4est=true.output
@@ -1,0 +1,16 @@
+
+DEAL::n_cells:100
+DEAL::criteria:[b>0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10
+DEAL::criteria:[b=0,e>0]
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.1
+DEAL::    n_refine_flags:10 n_coarsen_flags:10
+DEAL::  refinement_fraction:0.1 coarsening_fraction:0.
+DEAL::    n_refine_flags:10 n_coarsen_flags:0
+DEAL::  refinement_fraction:0. coarsening_fraction:0.1
+DEAL::    n_refine_flags:0 n_coarsen_flags:10

--- a/tests/mpi/tria_ghost_owners_01.mpirun=7.with_p4est=true.output
+++ b/tests/mpi/tria_ghost_owners_01.mpirun=7.with_p4est=true.output
@@ -31,7 +31,7 @@ DEAL:0:3d::total active cells = 11702
 DEAL:0:3d::* cycle 3
 DEAL:0:3d::ghost owners: 1 2 
 DEAL:0:3d::level ghost owners: 1 2 
-DEAL:0:3d::total active cells = 37868
+DEAL:0:3d::total active cells = 37833
 DEAL:0:3d::OK
 
 DEAL:1:2d::* cycle 0

--- a/tests/mpi/tria_ghost_owners_02.mpirun=11.with_p4est=true.output
+++ b/tests/mpi/tria_ghost_owners_02.mpirun=11.with_p4est=true.output
@@ -6,15 +6,15 @@ DEAL:0:2d::total active cells = 124
 DEAL:0:2d::* cycle 1
 DEAL:0:2d::ghost owners: 1 2 3 5 6 
 DEAL:0:2d::level ghost owners: 1 2 3 5 6 8 
-DEAL:0:2d::total active cells = 169
+DEAL:0:2d::total active cells = 496
 DEAL:0:2d::* cycle 2
-DEAL:0:2d::ghost owners: 1 2 
-DEAL:0:2d::level ghost owners: 1 2 5 7 
-DEAL:0:2d::total active cells = 190
+DEAL:0:2d::ghost owners: 1 2 3 5 
+DEAL:0:2d::level ghost owners: 1 2 3 5 6 8 
+DEAL:0:2d::total active cells = 733
 DEAL:0:2d::* cycle 3
-DEAL:0:2d::ghost owners: 1 
-DEAL:0:2d::level ghost owners: 1 2 3 6 9 
-DEAL:0:2d::total active cells = 304
+DEAL:0:2d::ghost owners: 1 2 
+DEAL:0:2d::level ghost owners: 1 2 3 5 8 
+DEAL:0:2d::total active cells = 1288
 DEAL:0:2d::OK
 DEAL:0:3d::* cycle 0
 DEAL:0:3d::ghost owners: 2 3 4 6 7 8 10 
@@ -41,11 +41,11 @@ DEAL:1:2d::* cycle 1
 DEAL:1:2d::ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::level ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::* cycle 2
-DEAL:1:2d::ghost owners: 0 2 4 
-DEAL:1:2d::level ghost owners: 0 2 4 5 
+DEAL:1:2d::ghost owners: 0 2 3 5 6 8 
+DEAL:1:2d::level ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::* cycle 3
-DEAL:1:2d::ghost owners: 0 2 3 5 
-DEAL:1:2d::level ghost owners: 0 2 3 5 
+DEAL:1:2d::ghost owners: 0 2 3 
+DEAL:1:2d::level ghost owners: 0 2 3 5 6 
 DEAL:1:2d::OK
 DEAL:1:3d::* cycle 0
 DEAL:1:3d::ghost owners: 
@@ -69,11 +69,11 @@ DEAL:2:2d::* cycle 1
 DEAL:2:2d::ghost owners: 0 1 3 
 DEAL:2:2d::level ghost owners: 0 1 3 5 8 
 DEAL:2:2d::* cycle 2
-DEAL:2:2d::ghost owners: 0 1 3 4 5 7 
-DEAL:2:2d::level ghost owners: 0 1 3 4 5 7 
+DEAL:2:2d::ghost owners: 0 1 3 
+DEAL:2:2d::level ghost owners: 0 1 3 
 DEAL:2:2d::* cycle 3
-DEAL:2:2d::ghost owners: 1 3 6 7 
-DEAL:2:2d::level ghost owners: 0 1 3 5 6 7 9 
+DEAL:2:2d::ghost owners: 0 1 3 4 5 6 8 
+DEAL:2:2d::level ghost owners: 0 1 3 4 5 6 8 
 DEAL:2:2d::OK
 DEAL:2:3d::* cycle 0
 DEAL:2:3d::ghost owners: 0 3 4 6 7 8 10 
@@ -97,11 +97,11 @@ DEAL:3:2d::* cycle 1
 DEAL:3:2d::ghost owners: 0 1 2 4 5 6 8 9 
 DEAL:3:2d::level ghost owners: 0 1 2 4 5 6 8 9 
 DEAL:3:2d::* cycle 2
-DEAL:3:2d::ghost owners: 2 4 
-DEAL:3:2d::level ghost owners: 2 4 
+DEAL:3:2d::ghost owners: 0 1 2 4 6 8 9 
+DEAL:3:2d::level ghost owners: 0 1 2 4 6 8 9 
 DEAL:3:2d::* cycle 3
-DEAL:3:2d::ghost owners: 1 2 4 5 7 9 
-DEAL:3:2d::level ghost owners: 0 1 2 4 5 6 7 9 
+DEAL:3:2d::ghost owners: 1 2 4 5 
+DEAL:3:2d::level ghost owners: 0 1 2 4 5 6 8 9 
 DEAL:3:2d::OK
 DEAL:3:3d::* cycle 0
 DEAL:3:3d::ghost owners: 0 2 4 6 7 8 10 
@@ -125,11 +125,11 @@ DEAL:4:2d::* cycle 1
 DEAL:4:2d::ghost owners: 3 5 8 9 
 DEAL:4:2d::level ghost owners: 3 5 8 9 
 DEAL:4:2d::* cycle 2
-DEAL:4:2d::ghost owners: 1 2 3 5 7 8 
-DEAL:4:2d::level ghost owners: 1 2 3 5 7 8 
+DEAL:4:2d::ghost owners: 3 5 8 9 
+DEAL:4:2d::level ghost owners: 3 5 8 9 
 DEAL:4:2d::* cycle 3
-DEAL:4:2d::ghost owners: 3 5 6 
-DEAL:4:2d::level ghost owners: 3 5 6 
+DEAL:4:2d::ghost owners: 2 3 5 6 8 9 
+DEAL:4:2d::level ghost owners: 2 3 5 6 8 9 
 DEAL:4:2d::OK
 DEAL:4:3d::* cycle 0
 DEAL:4:3d::ghost owners: 0 2 3 6 7 8 10 
@@ -153,11 +153,11 @@ DEAL:5:2d::* cycle 1
 DEAL:5:2d::ghost owners: 0 1 3 4 6 7 9 
 DEAL:5:2d::level ghost owners: 0 1 2 3 4 6 7 8 9 
 DEAL:5:2d::* cycle 2
-DEAL:5:2d::ghost owners: 2 4 6 7 8 
-DEAL:5:2d::level ghost owners: 0 1 2 4 6 7 8 9 
+DEAL:5:2d::ghost owners: 0 1 4 6 7 9 
+DEAL:5:2d::level ghost owners: 0 1 4 6 7 8 9 
 DEAL:5:2d::* cycle 3
-DEAL:5:2d::ghost owners: 1 3 4 6 7 9 
-DEAL:5:2d::level ghost owners: 1 2 3 4 6 7 9 10 
+DEAL:5:2d::ghost owners: 2 3 4 6 8 9 
+DEAL:5:2d::level ghost owners: 0 1 2 3 4 6 7 8 9 
 DEAL:5:2d::OK
 DEAL:5:3d::* cycle 0
 DEAL:5:3d::ghost owners: 
@@ -181,11 +181,11 @@ DEAL:6:2d::* cycle 1
 DEAL:6:2d::ghost owners: 0 1 3 5 7 8 
 DEAL:6:2d::level ghost owners: 0 1 3 5 7 8 10 
 DEAL:6:2d::* cycle 2
-DEAL:6:2d::ghost owners: 5 7 8 9 
-DEAL:6:2d::level ghost owners: 5 7 8 9 
+DEAL:6:2d::ghost owners: 1 3 5 7 8 10 
+DEAL:6:2d::level ghost owners: 0 1 3 5 7 8 10 
 DEAL:6:2d::* cycle 3
-DEAL:6:2d::ghost owners: 2 4 5 7 9 10 
-DEAL:6:2d::level ghost owners: 0 2 3 4 5 7 8 9 10 
+DEAL:6:2d::ghost owners: 2 4 5 7 8 9 
+DEAL:6:2d::level ghost owners: 1 2 3 4 5 7 8 9 
 DEAL:6:2d::OK
 DEAL:6:3d::* cycle 0
 DEAL:6:3d::ghost owners: 0 2 3 4 7 8 10 
@@ -209,11 +209,11 @@ DEAL:7:2d::* cycle 1
 DEAL:7:2d::ghost owners: 5 6 8 10 
 DEAL:7:2d::level ghost owners: 5 6 8 10 
 DEAL:7:2d::* cycle 2
-DEAL:7:2d::ghost owners: 2 4 5 6 8 9 
-DEAL:7:2d::level ghost owners: 0 2 4 5 6 8 9 10 
+DEAL:7:2d::ghost owners: 5 6 8 
+DEAL:7:2d::level ghost owners: 5 6 8 10 
 DEAL:7:2d::* cycle 3
-DEAL:7:2d::ghost owners: 2 3 5 6 8 9 
-DEAL:7:2d::level ghost owners: 2 3 5 6 8 9 10 
+DEAL:7:2d::ghost owners: 6 8 9 
+DEAL:7:2d::level ghost owners: 5 6 8 9 
 DEAL:7:2d::OK
 DEAL:7:3d::* cycle 0
 DEAL:7:3d::ghost owners: 0 2 3 4 6 8 10 
@@ -237,11 +237,11 @@ DEAL:8:2d::* cycle 1
 DEAL:8:2d::ghost owners: 1 3 4 6 7 9 10 
 DEAL:8:2d::level ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:2d::* cycle 2
-DEAL:8:2d::ghost owners: 4 5 6 7 9 10 
-DEAL:8:2d::level ghost owners: 4 5 6 7 9 10 
+DEAL:8:2d::ghost owners: 1 3 4 6 7 9 10 
+DEAL:8:2d::level ghost owners: 0 1 3 4 5 6 7 9 10 
 DEAL:8:2d::* cycle 3
-DEAL:8:2d::ghost owners: 7 9 10 
-DEAL:8:2d::level ghost owners: 6 7 9 10 
+DEAL:8:2d::ghost owners: 2 4 5 6 7 9 10 
+DEAL:8:2d::level ghost owners: 0 2 3 4 5 6 7 9 10 
 DEAL:8:2d::OK
 DEAL:8:3d::* cycle 0
 DEAL:8:3d::ghost owners: 0 2 3 4 6 7 10 
@@ -265,11 +265,11 @@ DEAL:9:2d::* cycle 1
 DEAL:9:2d::ghost owners: 3 4 5 8 10 
 DEAL:9:2d::level ghost owners: 3 4 5 8 10 
 DEAL:9:2d::* cycle 2
-DEAL:9:2d::ghost owners: 6 7 8 10 
-DEAL:9:2d::level ghost owners: 5 6 7 8 10 
+DEAL:9:2d::ghost owners: 3 4 5 8 10 
+DEAL:9:2d::level ghost owners: 3 4 5 8 10 
 DEAL:9:2d::* cycle 3
-DEAL:9:2d::ghost owners: 3 5 6 7 8 10 
-DEAL:9:2d::level ghost owners: 0 2 3 5 6 7 8 10 
+DEAL:9:2d::ghost owners: 4 5 6 7 8 10 
+DEAL:9:2d::level ghost owners: 3 4 5 6 7 8 10 
 DEAL:9:2d::OK
 DEAL:9:3d::* cycle 0
 DEAL:9:3d::ghost owners: 
@@ -293,11 +293,11 @@ DEAL:10:2d::* cycle 1
 DEAL:10:2d::ghost owners: 7 8 9 
 DEAL:10:2d::level ghost owners: 6 7 8 9 
 DEAL:10:2d::* cycle 2
-DEAL:10:2d::ghost owners: 8 9 
-DEAL:10:2d::level ghost owners: 7 8 9 
-DEAL:10:2d::* cycle 3
 DEAL:10:2d::ghost owners: 6 8 9 
-DEAL:10:2d::level ghost owners: 5 6 7 8 9 
+DEAL:10:2d::level ghost owners: 6 7 8 9 
+DEAL:10:2d::* cycle 3
+DEAL:10:2d::ghost owners: 8 9 
+DEAL:10:2d::level ghost owners: 8 9 
 DEAL:10:2d::OK
 DEAL:10:3d::* cycle 0
 DEAL:10:3d::ghost owners: 0 2 3 4 6 7 8 


### PR DESCRIPTION
This patch allows negative indicators for refinement in the `parallel::distributed` context again.

It basically reverts a 6-year old commit https://github.com/dealii/dealii/commit/283a86b27f1a9a06ceb6ce90ac2142cdf47b97ac and I'm pretty sure this is the correct way to deal with the problem its author encountered back then.

I guess the cause of their issue was that the difference between both values in `interesting_range` was too large. Thus the lower value got decreased too much, resulting in a wrong value for the `test_threshold` during the binary search and ultimately yielding the wrong number of cells flagged for refinement.

Right now, I'll run the testsuite on my workstation to provide modified test results. But I doubt that there will be any, since in the current state of the code only positive indicators are possible.

@bangerth @tjhei -- What do you think?