### PR TITLE
remove empty virtual destructors

### DIFF
--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -85,10 +85,6 @@ public:
              VectorMemory<VectorType> &mem,
              const AdditionalData &    data = AdditionalData());
 
-  /**
-   * Virtual destructor.
-   */
-  virtual ~EigenPower();
 
   /**
    * Power method. @p x is the (not necessarily normalized, but nonzero) start
@@ -176,12 +172,6 @@ public:
                VectorMemory<VectorType> &mem,
                const AdditionalData &    data = AdditionalData());
 
-
-  /**
-   * Virtual destructor.
-   */
-  virtual ~EigenInverse();
-
   /**
    * Inverse method. @p value is the start guess for the eigenvalue and @p x
    * is the (not necessarily normalized, but nonzero) start vector for the
@@ -210,12 +200,6 @@ EigenPower<VectorType>::EigenPower(SolverControl &           cn,
                                    const AdditionalData &    data)
   : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
-{}
-
-
-
-template <class VectorType>
-EigenPower<VectorType>::~EigenPower()
 {}
 
 
@@ -299,12 +283,6 @@ EigenInverse<VectorType>::EigenInverse(SolverControl &           cn,
                                        const AdditionalData &    data)
   : SolverBase<VectorType>(cn, mem)
   , additional_data(data)
-{}
-
-
-
-template <class VectorType>
-EigenInverse<VectorType>::~EigenInverse()
 {}
 
 

--- a/include/deal.II/lac/solver_fire.h
+++ b/include/deal.II/lac/solver_fire.h
@@ -136,11 +136,6 @@ public:
              const AdditionalData &data = AdditionalData());
 
   /**
-   * Virtual destructor.
-   */
-  virtual ~SolverFIRE();
-
-  /**
    * Obtain a set of variables @p x that minimize an objective function
    * described by the polymorphic function wrapper @p compute, with a given
    * preconditioner @p inverse_mass_matrix and initial @p x values.
@@ -225,12 +220,6 @@ SolverFIRE<VectorType>::SolverFIRE(SolverControl &       solver_control,
                                    const AdditionalData &data)
   : SolverBase<VectorType>(solver_control)
   , additional_data(data)
-{}
-
-
-
-template <typename VectorType>
-SolverFIRE<VectorType>::~SolverFIRE()
 {}
 
 

--- a/include/deal.II/lac/solver_relaxation.h
+++ b/include/deal.II/lac/solver_relaxation.h
@@ -73,11 +73,6 @@ public:
                    const AdditionalData &data = AdditionalData());
 
   /**
-   * Virtual destructor.
-   */
-  virtual ~SolverRelaxation();
-
-  /**
    * Solve the system $Ax = b$ using the relaxation method $x_{k+1} =
    * R(x_k,b)$. The matrix <i>A</i> itself is only used to compute the
    * residual.
@@ -98,11 +93,6 @@ SolverRelaxation<VectorType>::SolverRelaxation(SolverControl &cn,
   : SolverBase<VectorType>(cn)
 {}
 
-
-
-template <class VectorType>
-SolverRelaxation<VectorType>::~SolverRelaxation()
-{}
 
 
 template <class VectorType>


### PR DESCRIPTION
reported by clang-tidy. Making them ``=default`` is not needed as ``Subscriptor`` already gives the class a virtual destructor.

part of #9933