### PR TITLE
Fix a funny spacing issue.

### DIFF
--- a/tests/fail/fe_nothing_04.cc
+++ b/tests/fail/fe_nothing_04.cc
@@ -48,7 +48,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(4);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_01.cc
+++ b/tests/hp/fe_nothing_01.cc
@@ -44,7 +44,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, 0, 1);
+  GridGenerator::hyper_cube(triangulation, 0, 1);
   triangulation.refine_global(1);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_02.cc
+++ b/tests/hp/fe_nothing_02.cc
@@ -45,7 +45,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(2);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_03.cc
+++ b/tests/hp/fe_nothing_03.cc
@@ -47,7 +47,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(4);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_05.cc
+++ b/tests/hp/fe_nothing_05.cc
@@ -68,7 +68,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(1);
 
   {

--- a/tests/hp/fe_nothing_06.cc
+++ b/tests/hp/fe_nothing_06.cc
@@ -67,7 +67,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(1);
 
   {

--- a/tests/hp/fe_nothing_07.cc
+++ b/tests/hp/fe_nothing_07.cc
@@ -79,7 +79,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(1);
 
   {

--- a/tests/hp/fe_nothing_08.cc
+++ b/tests/hp/fe_nothing_08.cc
@@ -48,7 +48,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -1, 1);
+  GridGenerator::hyper_cube(triangulation, -1, 1);
   triangulation.refine_global(1);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_09.cc
+++ b/tests/hp/fe_nothing_09.cc
@@ -50,7 +50,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -1, 1);
+  GridGenerator::hyper_cube(triangulation, -1, 1);
   triangulation.refine_global(1);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_11.cc
+++ b/tests/hp/fe_nothing_11.cc
@@ -50,7 +50,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -1, 1);
+  GridGenerator::hyper_cube(triangulation, -1, 1);
   triangulation.refine_global(1);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_15.cc
+++ b/tests/hp/fe_nothing_15.cc
@@ -48,7 +48,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
 
   FESystem<dim>   fe(FE_Q<dim>(1), 1, FE_Nothing<dim>(), 1);
   DoFHandler<dim> dof_handler(triangulation);

--- a/tests/hp/fe_nothing_16.cc
+++ b/tests/hp/fe_nothing_16.cc
@@ -55,7 +55,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
 
   FESystem<dim>   fe(FE_Q<dim>(1), 1, FE_Nothing<dim>(), 1);
   DoFHandler<dim> dof_handler(triangulation);

--- a/tests/hp/fe_nothing_20.cc
+++ b/tests/hp/fe_nothing_20.cc
@@ -49,7 +49,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(4);
 
   hp::FECollection<dim> fe_collection;

--- a/tests/hp/fe_nothing_21.cc
+++ b/tests/hp/fe_nothing_21.cc
@@ -47,7 +47,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(4);
 
   FESystem<dim> fe(FE_Nothing<dim>(), 1, FE_Q<dim>(1), 1);

--- a/tests/hp/interpolate_nothing_03.cc
+++ b/tests/hp/interpolate_nothing_03.cc
@@ -49,7 +49,7 @@ void
 test()
 {
   Triangulation<dim> triangulation;
-  GridGenerator ::hyper_cube(triangulation, -0.5, 0.5);
+  GridGenerator::hyper_cube(triangulation, -0.5, 0.5);
   triangulation.refine_global(3);
 
   hp::FECollection<dim> fe_collection;


### PR DESCRIPTION
It's a bit funny that for all of the things clang-format decides to indent in completely unreadable ways, that it would just not care one way or the other about these things here. I just don't understand...