### PR TITLE
qualify internal namespace with dealii::

### DIFF
--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -95,10 +95,11 @@ namespace LinearAlgebra
 
     dealii::internal::VectorOperations::Vector_copy<Number, Number> copier(
       in_vector.values.get(), this->values.get());
-    internal::VectorOperations::parallel_for(copier,
-                                             static_cast<size_type>(0),
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      copier,
+      static_cast<size_type>(0),
+      this->size(),
+      this->thread_loop_partitioner);
 
     return *this;
   }
@@ -116,10 +117,11 @@ namespace LinearAlgebra
 
     dealii::internal::VectorOperations::Vector_copy<Number, Number2> copier(
       in_vector.values.get(), this->values.get());
-    internal::VectorOperations::parallel_for(copier,
-                                             static_cast<size_type>(0),
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      copier,
+      static_cast<size_type>(0),
+      this->size(),
+      this->thread_loop_partitioner);
 
     return *this;
   }
@@ -134,12 +136,10 @@ namespace LinearAlgebra
            ExcMessage("Only 0 can be assigned to a vector."));
     (void)s;
 
-    internal::VectorOperations::Vector_set<Number> setter(Number(),
-                                                          this->values.get());
-    internal::VectorOperations::parallel_for(setter,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vector_set<Number> setter(
+      Number(), this->values.get());
+    dealii::internal::VectorOperations::parallel_for(
+      setter, 0, this->size(), this->thread_loop_partitioner);
 
     return *this;
   }
@@ -152,12 +152,13 @@ namespace LinearAlgebra
   {
     AssertIsFinite(factor);
 
-    internal::VectorOperations::Vectorization_multiply_factor<Number>
+    dealii::internal::VectorOperations::Vectorization_multiply_factor<Number>
       vector_multiply(this->values.get(), factor);
-    internal::VectorOperations::parallel_for(vector_multiply,
-                                             static_cast<size_type>(0),
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_multiply,
+      static_cast<size_type>(0),
+      this->size(),
+      this->thread_loop_partitioner);
 
     return *this;
   }
@@ -191,12 +192,10 @@ namespace LinearAlgebra
            ExcMessage(
              "Cannot add two vectors with different numbers of elements"));
 
-    internal::VectorOperations::Vectorization_add_v<Number> vector_add(
+    dealii::internal::VectorOperations::Vectorization_add_v<Number> vector_add(
       this->values.get(), down_V.values.get());
-    internal::VectorOperations::parallel_for(vector_add,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_add, 0, this->size(), this->thread_loop_partitioner);
 
     return *this;
   }
@@ -216,12 +215,10 @@ namespace LinearAlgebra
     Assert(down_V.size() == this->size(),
            ExcMessage(
              "Cannot subtract two vectors with different numbers of elements"));
-    internal::VectorOperations::Vectorization_subtract_v<Number>
+    dealii::internal::VectorOperations::Vectorization_subtract_v<Number>
       vector_subtract(this->values.get(), down_V.values.get());
-    internal::VectorOperations::parallel_for(vector_subtract,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_subtract, 0, this->size(), this->thread_loop_partitioner);
 
     return *this;
   }
@@ -240,10 +237,10 @@ namespace LinearAlgebra
     Assert(down_V.size() == this->size(),
            ExcMessage("Cannot compute the scalar product "
                       "of two vectors with different numbers of elements"));
-    Number                                          sum;
-    internal::VectorOperations::Dot<Number, Number> dot(this->values.get(),
-                                                        down_V.values.get());
-    internal::VectorOperations::parallel_reduce(
+    Number                                                  sum;
+    dealii::internal::VectorOperations::Dot<Number, Number> dot(
+      this->values.get(), down_V.values.get());
+    dealii::internal::VectorOperations::parallel_reduce(
       dot, 0, this->size(), sum, this->thread_loop_partitioner);
 
     return sum;
@@ -268,12 +265,10 @@ namespace LinearAlgebra
   {
     AssertIsFinite(a);
 
-    internal::VectorOperations::Vectorization_add_factor<Number> vector_add(
-      this->values.get(), a);
-    internal::VectorOperations::parallel_for(vector_add,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vectorization_add_factor<Number>
+      vector_add(this->values.get(), a);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_add, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -293,12 +288,10 @@ namespace LinearAlgebra
            ExcMessage(
              "Cannot add two vectors with different numbers of elements"));
 
-    internal::VectorOperations::Vectorization_add_av<Number> vector_add_av(
-      this->values.get(), down_V.values.get(), a);
-    internal::VectorOperations::parallel_for(vector_add_av,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vectorization_add_av<Number>
+      vector_add_av(this->values.get(), down_V.values.get(), a);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_add_av, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -330,12 +323,11 @@ namespace LinearAlgebra
            ExcMessage(
              "Cannot add two vectors with different numbers of elements"));
 
-    internal::VectorOperations::Vectorization_add_avpbw<Number> vector_add(
-      this->values.get(), down_V.values.get(), down_W.values.get(), a, b);
-    internal::VectorOperations::parallel_for(vector_add,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vectorization_add_avpbw<Number>
+      vector_add(
+        this->values.get(), down_V.values.get(), down_W.values.get(), a, b);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_add, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -355,12 +347,10 @@ namespace LinearAlgebra
 
     // Downcast V. It fails, throws an exception.
     const Vector<Number> &down_V = dynamic_cast<const Vector<Number> &>(V);
-    internal::VectorOperations::Vectorization_sadd_xav<Number> vector_sadd_xav(
-      this->values.get(), down_V.values.get(), a, s);
-    internal::VectorOperations::parallel_for(vector_sadd_xav,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vectorization_sadd_xav<Number>
+      vector_sadd_xav(this->values.get(), down_V.values.get(), a, s);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_sadd_xav, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -380,12 +370,10 @@ namespace LinearAlgebra
            ExcMessage(
              "Cannot add two vectors with different numbers of elements"));
 
-    internal::VectorOperations::Vectorization_scale<Number> vector_scale(
-      this->values.get(), down_scaling_factors.values.get());
-    internal::VectorOperations::parallel_for(vector_scale,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::Vectorization_scale<Number>
+      vector_scale(this->values.get(), down_scaling_factors.values.get());
+    dealii::internal::VectorOperations::parallel_for(
+      vector_scale, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -402,12 +390,10 @@ namespace LinearAlgebra
 
     // Downcast V. If fails, throws an exception.
     const Vector<Number> &down_V = dynamic_cast<const Vector<Number> &>(V);
-    internal::VectorOperations::Vectorization_equ_au<Number> vector_equ(
+    dealii::internal::VectorOperations::Vectorization_equ_au<Number> vector_equ(
       this->values.get(), down_V.values.get(), a);
-    internal::VectorOperations::parallel_for(vector_equ,
-                                             0,
-                                             this->size(),
-                                             this->thread_loop_partitioner);
+    dealii::internal::VectorOperations::parallel_for(
+      vector_equ, 0, this->size(), this->thread_loop_partitioner);
   }
 
 
@@ -435,10 +421,10 @@ namespace LinearAlgebra
     Assert(this->size(), ExcEmptyObject());
 
     using real_type = typename VectorSpaceVector<Number>::real_type;
-    value_type                                    sum;
-    internal::VectorOperations::MeanValue<Number> mean_value(
+    value_type                                            sum;
+    dealii::internal::VectorOperations::MeanValue<Number> mean_value(
       this->values.get());
-    internal::VectorOperations::parallel_reduce(
+    dealii::internal::VectorOperations::parallel_reduce(
       mean_value, 0, this->size(), sum, this->thread_loop_partitioner);
 
     return sum / static_cast<real_type>(this->size());
@@ -453,10 +439,10 @@ namespace LinearAlgebra
     Assert(this->size(), ExcEmptyObject());
 
     using real_type = typename VectorSpaceVector<Number>::real_type;
-    real_type                                            sum;
-    internal::VectorOperations::Norm1<Number, real_type> norm1(
+    real_type                                                    sum;
+    dealii::internal::VectorOperations::Norm1<Number, real_type> norm1(
       this->values.get());
-    internal::VectorOperations::parallel_reduce(
+    dealii::internal::VectorOperations::parallel_reduce(
       norm1, 0, this->size(), sum, this->thread_loop_partitioner);
 
     return sum;
@@ -476,10 +462,10 @@ namespace LinearAlgebra
     // so working on the vector twice is uncritical and paid off by the extended
     // precision) using the BLAS approach with a weight, see e.g. dnrm2.f.
     using real_type = typename VectorSpaceVector<Number>::real_type;
-    real_type                                            norm_square;
-    internal::VectorOperations::Norm2<Number, real_type> norm2(
+    real_type                                                    norm_square;
+    dealii::internal::VectorOperations::Norm2<Number, real_type> norm2(
       this->values.get());
-    internal::VectorOperations::parallel_reduce(
+    dealii::internal::VectorOperations::parallel_reduce(
       norm2, 0, this->size(), norm_square, this->thread_loop_partitioner);
     if (numbers::is_finite(norm_square) &&
         norm_square >= std::numeric_limits<real_type>::min())
@@ -550,12 +536,10 @@ namespace LinearAlgebra
            ExcMessage(
              "Cannot add two vectors with different numbers of elements"));
 
-    Number                                        sum;
-    internal::VectorOperations::AddAndDot<Number> adder(this->values.get(),
-                                                        down_V.values.get(),
-                                                        down_W.values.get(),
-                                                        a);
-    internal::VectorOperations::parallel_reduce(
+    Number                                                sum;
+    dealii::internal::VectorOperations::AddAndDot<Number> adder(
+      this->values.get(), down_V.values.get(), down_W.values.get(), a);
+    dealii::internal::VectorOperations::parallel_reduce(
       adder, 0, this->size(), sum, this->thread_loop_partitioner);
     AssertIsFinite(sum);
 


### PR DESCRIPTION
Fix errors like:

/src/include/deal.II/lac/la_vector.templates.h:196:5: error: no member
named 'VectorOperations' in namespace 'dealii::LinearAlgebra::internal';
did you mean 'VectorOperation'? [clang-diagnostic-error]

that appear if some other internal namespace is included before
la_vector.templates.h

part of #9933