### PR TITLE
tidy warning: deprecated errno.h header

### DIFF
--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -26,9 +26,9 @@
 
 #include <deal.II/numerics/history.h>
 
-#include <errno.h>
 #include <sys/stat.h>
 
+#include <cerrno>
 #include <fstream>
 #include <string>
 


### PR DESCRIPTION
fix clang-tidy warning:
/src/include/deal.II/optimization/line_minimization.h:29:10: error:
inclusion of deprecated C++ header 'errno.h'; consider using 'cerrno'
instead [modernize-deprecated-headers,-warnings-as-errors]

part of #9930