### PR TITLE
CI: clang-tidy all headers

### DIFF
--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -60,7 +60,7 @@ cmake --build . --target expand_all_instantiations || (echo "make expand_all_ins
 # generate allheaders.h
 (cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h
 
-# finally run it clang-tidy on deal.II
+# finally run clang-tidy on deal.II
 #
 # pipe away stderr (just contains nonsensical "x warnings generated")
 # pipe output to output.txt

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -67,7 +67,7 @@ cmake --build . --target expand_all_instantiations || (echo "make expand_all_ins
 run-clang-tidy.py -p . -quiet -header-filter "$SRC/include/*" -extra-arg='-DCLANG_TIDY' 2>error.txt >output.txt
 
 # grep interesting errors and make sure we remove duplicates:
-grep -E '(warning|error): ' output.txt output2.txt | sort | uniq >clang-tidy.log
+grep -E '(warning|error): ' output.txt | sort | uniq >clang-tidy.log
 
 # if we have errors, report them and set exit status to failure
 if [ -s clang-tidy.log ]; then

--- a/contrib/utilities/run_clang_tidy.sh
+++ b/contrib/utilities/run_clang_tidy.sh
@@ -57,13 +57,21 @@ CC=clang CXX=clang++ cmake "${ARGS[@]}" "$SRC" || (echo "cmake failed!"; false) 
 
 cmake --build . --target expand_all_instantiations || (echo "make expand_all_instantiations failed!"; false) || exit 3
 
-# finally run it:
+# generate allheaders.h
+(cd include; find . -name '*.h'; cd $SRC/include/; find . -name '*.h') | grep -v allheaders.h | grep -v undefine_macros.h | sed 's|^./|#include <|' | sed 's|$|>|' >include/deal.II/allheaders.h
+
+# finally run it clang-tidy on deal.II
+#
 # pipe away stderr (just contains nonsensical "x warnings generated")
 # pipe output to output.txt
-run-clang-tidy.py -p . -quiet -header-filter="$SRC/include/*" 2>error.txt >output.txt
+run-clang-tidy.py -p . -quiet -header-filter "$SRC/include/*" -extra-arg='-DCLANG_TIDY' 2>error.txt >output.txt
 
-if grep -E -q '(warning|error): ' output.txt; then
-    grep -E '(warning|error): ' output.txt
+# grep interesting errors and make sure we remove duplicates:
+grep -E '(warning|error): ' output.txt output2.txt | sort | uniq >clang-tidy.log
+
+# if we have errors, report them and set exit status to failure
+if [ -s clang-tidy.log ]; then
+    cat clang-tidy.log
     exit 4
 fi
 

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -40,7 +40,7 @@ namespace Utilities
      */
     template <typename Number = double>
     class NoncontiguousPartitioner
-      : public LinearAlgebra::CommunicationPatternBase
+      : public dealii::LinearAlgebra::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -629,7 +629,7 @@ namespace Utilities
                              100000. *
                              std::numeric_limits<typename numbers::NumberTraits<
                                Number>::real_type>::epsilon(),
-                       typename LinearAlgebra::distributed::Vector<
+                       typename dealii::LinearAlgebra::distributed::Vector<
                          Number>::ExcNonMatchingElements(*read_position,
                                                          locally_owned_array[j],
                                                          my_pid));

--- a/source/dummy.cc
+++ b/source/dummy.cc
@@ -26,3 +26,12 @@ use_global_symbol_42()
 {
   (void)global_symbol_42;
 }
+
+/**
+ * If we are running the contrib/utilities/run_clang_tidy.sh script, we
+ * generate a header file allheaders.h that includes all deal.II
+ * headers. Include the file here so that all headers are being checked.
+ */
+#ifdef CLANG_TIDY
+#  include <deal.II/allheaders.h>
+#endif


### PR DESCRIPTION
Hijack the already existing dummy.cc to include a dynamically created
header that includes all deal.II header files. This will run clang-tidy
on all headers.
I tried running clang-tidy on a .cc generated inside the build
directory, but this doesn't work for some reason.

closes #9933