### PR TITLE
Remove two unused headers.

### DIFF
--- a/include/deal.II/optimization/line_minimization.h
+++ b/include/deal.II/optimization/line_minimization.h
@@ -26,9 +26,6 @@
 
 #include <deal.II/numerics/history.h>
 
-#include <errno.h>
-#include <sys/stat.h>
-
 #include <fstream>
 #include <string>
 


### PR DESCRIPTION
Alternative to #9982 - I can still compile the library and run all test that match `minimize|optim` with this patch.

@tjhei can we close #9982 in favor of getting rid of the headers altogether?