### PR TITLE
Fix copying hp::FEValues objects.

### DIFF
--- a/doc/news/changes/minor/20200428Bangerth
+++ b/doc/news/changes/minor/20200428Bangerth
@@ -1,0 +1,5 @@
+Fixed: Copying objects of type hp::FEValuesBase and derived classes
+led to unexpected results because both source and destination kept
+pointers to a shared space. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2020/04/28)

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -88,6 +88,18 @@ namespace hp
       const UpdateFlags                                       update_flags);
 
     /**
+     * Copy constructor.
+     */
+    FEValuesBase(const FEValuesBase<dim, q_dim, FEValuesType> &other);
+
+    /**
+     * Copy operator. While objects of this type can be copy-constructed,
+     * they cannot be copied and consequently this operator is disabled.
+     */
+    FEValuesBase &
+    operator=(const FEValuesBase &) = delete;
+
+    /**
      * For timing purposes it may be useful to create all required FE*Values
      * objects in advance, rather than computing them on request via lazy
      * allocation as usual in this class.
@@ -196,7 +208,7 @@ namespace hp
      * Initially, all entries have zero pointers, and we will allocate them
      * lazily as needed in select_fe_values() or precalculate_fe_values().
      */
-    Table<3, std::shared_ptr<FEValuesType>> fe_values_table;
+    Table<3, std::unique_ptr<FEValuesType>> fe_values_table;
 
     /**
      * Set of indices pointing at the fe_values object selected last time

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -13,6 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/std_cxx14/memory.h>
 #include <deal.II/base/thread_management.h>
 
 #include <deal.II/fe/mapping_q1.h>
@@ -65,6 +66,38 @@ namespace hp
 
 
   template <int dim, int q_dim, class FEValuesType>
+  FEValuesBase<dim, q_dim, FEValuesType>::FEValuesBase(
+    const FEValuesBase<dim, q_dim, FEValuesType> &other)
+    : fe_collection(other.fe_collection)
+    , mapping_collection(other.mapping_collection)
+    , q_collection(other.q_collection)
+    , fe_values_table(fe_collection->size(),
+                      mapping_collection->size(),
+                      q_collection.size())
+    , present_fe_values_index(other.present_fe_values_index)
+    , update_flags(other.update_flags)
+  {
+    // We've already resized the `fe_values_table` correctly above, but right
+    // now it just contains nullptrs. Create copies of the objects that
+    // `other.fe_values_table` stores
+    for (unsigned int fe_index = 0; fe_index < fe_collection->size();
+         ++fe_index)
+      for (unsigned int m_index = 0; m_index < mapping_collection->size();
+           ++m_index)
+        for (unsigned int q_index = 0; q_index < q_collection.size(); ++q_index)
+          if (other.fe_values_table[fe_index][m_index][q_index].get() !=
+              nullptr)
+            fe_values_table[fe_index][m_index][q_index] =
+              std_cxx14::make_unique<FEValuesType>(
+                (*mapping_collection)[m_index],
+                (*fe_collection)[fe_index],
+                q_collection[q_index],
+                update_flags);
+  }
+
+
+
+  template <int dim, int q_dim, class FEValuesType>
   FEValuesType &
   FEValuesBase<dim, q_dim, FEValuesType>::select_fe_values(
     const unsigned int fe_index,
@@ -86,10 +119,11 @@ namespace hp
     // of indices
     if (fe_values_table(present_fe_values_index).get() == nullptr)
       fe_values_table(present_fe_values_index) =
-        std::make_shared<FEValuesType>((*mapping_collection)[mapping_index],
-                                       (*fe_collection)[fe_index],
-                                       q_collection[q_index],
-                                       update_flags);
+        std_cxx14::make_unique<FEValuesType>(
+          (*mapping_collection)[mapping_index],
+          (*fe_collection)[fe_index],
+          q_collection[q_index],
+          update_flags);
 
     // now there definitely is one!
     return *fe_values_table(present_fe_values_index);
@@ -121,7 +155,7 @@ namespace hp
         task_group +=
           Threads::new_task([&, fe_index, mapping_index, q_index]() {
             fe_values_table(TableIndices<3>(fe_index, mapping_index, q_index)) =
-              std::make_shared<FEValuesType>(
+              std_cxx14::make_unique<FEValuesType>(
                 (*mapping_collection)[mapping_index],
                 (*fe_collection)[fe_index],
                 q_collection[q_index],

--- a/tests/hp/hp_fe_values_copy.cc
+++ b/tests/hp/hp_fe_values_copy.cc
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// hp::FEValues objects can be copied, but that sometimes led to
+// surprising results because it kept shared pointers underneath (this
+// has been fixed).
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_nothing.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/hp/dof_handler.h>
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/fe_values.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> triangulation;
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global(1);
+
+  hp::FECollection<dim> fe_collection;
+  fe_collection.push_back(FE_Nothing<dim>());
+
+  hp::DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe_collection);
+
+  deallog << "   Number of active cells:       "
+          << triangulation.n_active_cells() << std::endl
+          << "   Number of degrees of freedom: " << dof_handler.n_dofs()
+          << std::endl;
+
+
+  hp::QCollection<dim> quadrature_collection;
+  quadrature_collection.push_back(QMidpoint<dim>());
+
+  // Create one hp::FEValues object, and initialize it for the first
+  // cell. When we later ask for the location of the quadrature point,
+  // it better be the midpoint of that cell
+  const auto        cell1 = dof_handler.begin_active();
+  hp::FEValues<dim> hp_fe_values1(fe_collection,
+                                  quadrature_collection,
+                                  update_quadrature_points);
+  hp_fe_values1.reinit(cell1);
+
+  // Now make a copy of the object and initialize it for the second cell
+  const auto        cell2 = ++dof_handler.begin_active();
+  hp::FEValues<dim> hp_fe_values2(hp_fe_values1);
+  hp_fe_values2.reinit(cell2);
+
+  // Output the quadrature points computed by the two objects. They
+  // ought to correspond to the cell centers of the first and second
+  // cell.
+  deallog << hp_fe_values1.get_present_fe_values().get_quadrature_points()[0]
+          << " should be at " << cell1->center() << std::endl;
+
+  deallog << hp_fe_values2.get_present_fe_values().get_quadrature_points()[0]
+          << " should be at " << cell2->center() << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/hp/hp_fe_values_copy.output
+++ b/tests/hp/hp_fe_values_copy.output
@@ -1,0 +1,13 @@
+
+DEAL::   Number of active cells:       2
+DEAL::   Number of degrees of freedom: 0
+DEAL::0.250000 should be at 0.250000
+DEAL::0.750000 should be at 0.750000
+DEAL::   Number of active cells:       4
+DEAL::   Number of degrees of freedom: 0
+DEAL::0.250000 0.250000 should be at 0.250000 0.250000
+DEAL::0.750000 0.250000 should be at 0.750000 0.250000
+DEAL::   Number of active cells:       8
+DEAL::   Number of degrees of freedom: 0
+DEAL::0.250000 0.250000 0.250000 should be at 0.250000 0.250000 0.250000
+DEAL::0.750000 0.250000 0.250000 should be at 0.750000 0.250000 0.250000


### PR DESCRIPTION
This falls in the category of "How the heck did we never notice this!?!?". While looking at @marcfehling's #9968, I realized that `hp::FEValuesBase` uses `std::shared_ptr` objects to underlying `FEValues` objects. It had no explicit copy constructor or operator, and so source and destination in the automatically generated copy constructor keep pointers to shared space.

Sure enough, it's not very difficult to generate a test where you do this:
```
  const auto        cell1 = dof_handler.begin_active();
  hp::FEValues<dim> hp_fe_values1(fe_collection,
                                  quadrature_collection,
                                  update_quadrature_points);
  hp_fe_values1.reinit(cell1);

  // Now make a copy of the object and initialize it for the second cell
  const auto        cell2 = ++dof_handler.begin_active();
  hp::FEValues<dim> hp_fe_values2(hp_fe_values1);
  hp_fe_values2.reinit(cell2);
```
and now `hp_fe_values1` has the data that corresponds to `cell2`. Not what we wanted. Worse: This is the kind of thing we do all the time in `WorkStream` (where the copies are used on separate threads).

It's unclear to me how we never noticed this issue! Either way, it's easy to fix: Just use `std::unique_ptr` and write an explicit copy constructor.

/rebuild