### PR TITLE
Fix SFINAE detection of LinOp for matrix-free operators

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1824,7 +1824,7 @@ namespace internal
 
         template <typename U>
         static decltype(std::declval<U>().initialize_dof_vector(
-          LinearAlgebra::distributed::Vector<double>()))
+          std::declval<LinearAlgebra::distributed::Vector<Number> &>()))
         detect(const U &);
 
       public:
@@ -1840,7 +1840,7 @@ namespace internal
                   MatrixType>::type * = nullptr>
       static void
       reinit_domain_vector(MatrixType &                                mat,
-                           LinearAlgebra::distributed::Vector<double> &vec,
+                           LinearAlgebra::distributed::Vector<Number> &vec,
                            bool /*omit_zeroing_entries*/)
       {
         vec.reinit(mat.locally_owned_domain_indices(),
@@ -1854,7 +1854,7 @@ namespace internal
                                 MatrixType>::type * = nullptr>
       static void
       reinit_domain_vector(MatrixType &                                mat,
-                           LinearAlgebra::distributed::Vector<double> &vec,
+                           LinearAlgebra::distributed::Vector<Number> &vec,
                            bool omit_zeroing_entries)
       {
         mat.initialize_dof_vector(vec);
@@ -1870,7 +1870,7 @@ namespace internal
                   MatrixType>::type * = nullptr>
       static void
       reinit_range_vector(MatrixType &                                mat,
-                          LinearAlgebra::distributed::Vector<double> &vec,
+                          LinearAlgebra::distributed::Vector<Number> &vec,
                           bool /*omit_zeroing_entries*/)
       {
         vec.reinit(mat.locally_owned_range_indices(),
@@ -1884,7 +1884,7 @@ namespace internal
                                 MatrixType>::type * = nullptr>
       static void
       reinit_range_vector(MatrixType &                                mat,
-                          LinearAlgebra::distributed::Vector<double> &vec,
+                          LinearAlgebra::distributed::Vector<Number> &vec,
                           bool omit_zeroing_entries)
       {
         mat.initialize_dof_vector(vec);


### PR DESCRIPTION
Follow-up to #9951. This fixes the test
https://cdash.43-1.org/testDetails.php?test=42401078&build=5914
The problem was that `initialize_dof_vector` takes a non-const reference of a `LA::dist::Vector`, which means we cannot construct an exemplar in the function, but we must use a variable we can create a reference to.

While there, also fix the oversight that the outer class takes `Vector<Number>`, not just `Vector<double>`.