### PR TITLE
Remove MeshWorker::CopyData::operator=(double)

### DIFF
--- a/doc/news/changes/incompatibilities/20200430Jean-PaulPelteret
+++ b/doc/news/changes/incompatibilities/20200430Jean-PaulPelteret
@@ -1,0 +1,6 @@
+Removed: The function `MeshWorker::CopyData::operator=(const double)` has been
+removed, as resetting the state of the `copier` from within a `boundary_worker`
+or `face_worker` is not permitted and can lead to hard to trace bugs within a
+user's code.
+<br>
+(Jean-Paul Pelteret, 2020/04/30)

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -72,19 +72,6 @@ namespace MeshWorker
       default;
 
     /**
-     * Allow resetting of all elements of the struct to zero, by simply
-     * calling `(*this) = 0;`
-     *
-     * Notice that the only allowed number here is really `0`. Calling this
-     * function with any other number will trigger an assertion.
-     *
-     * The elements of the arrays of local degrees of freedom indices are
-     * all set to numbers::invalid_dof_index.
-     */
-    void
-    operator=(const double number);
-
-    /**
      * An array of local matrices.
      */
     std::array<FullMatrix<double>, n_matrices> matrices;
@@ -134,25 +121,6 @@ namespace MeshWorker
 
     for (unsigned int i = 0; i < n_dof_indices; ++i)
       local_dof_indices[i].resize(dof_indices_sizes[i++]);
-  }
-
-
-
-  template <int n_matrices, int n_vectors, int n_dof_indices>
-  void
-  CopyData<n_matrices, n_vectors, n_dof_indices>::operator=(const double number)
-  {
-    Assert(number == 0.0,
-           ExcMessage("You should only call this method with "
-                      "argument 0.0"));
-
-    for (auto &m : matrices)
-      m = number;
-    for (auto &v : vectors)
-      v = number;
-    for (auto &d : local_dof_indices)
-      for (auto &val : d)
-        val = numbers::invalid_dof_index;
   }
 
 #endif // DOXYGEN

--- a/include/deal.II/meshworker/copy_data.h
+++ b/include/deal.II/meshworker/copy_data.h
@@ -55,12 +55,12 @@ namespace MeshWorker
      * Initialize everything with the same @p size. This is usually the number
      * of local degrees of freedom.
      */
-    CopyData(const unsigned int size);
+    explicit CopyData(const unsigned int size);
 
     /**
      * For every object, specify the size they should have.
      */
-    CopyData(
+    explicit CopyData(
       const std::array<std::array<unsigned int, 2>, n_matrices> &matrix_sizes,
       const std::array<unsigned int, n_vectors> &                vector_sizes,
       const std::array<unsigned int, n_dof_indices> &dof_indices_sizes);

--- a/tests/meshworker/mesh_loop_04.cc
+++ b/tests/meshworker/mesh_loop_04.cc
@@ -72,7 +72,6 @@ test()
   auto cell_worker = [](const Iterator &cell, ScratchData &s, CopyData &c) {
     const auto &fev = s.reinit(cell);
     const auto &JxW = s.get_JxW_values();
-    c               = 0;
     for (auto w : JxW)
       c.vectors[0][0] += w;
   };

--- a/tests/meshworker/mesh_loop_05.cc
+++ b/tests/meshworker/mesh_loop_05.cc
@@ -77,7 +77,6 @@ test()
   auto cell_worker = [](const Iterator &cell, ScratchData &s, CopyData &c) {
     const auto &fev = s.reinit(cell);
     const auto &JxW = s.get_JxW_values();
-    c               = 0;
     for (auto w : JxW)
       c.vectors[0][0] += w;
   };

--- a/tests/meshworker/mesh_loop_06.cc
+++ b/tests/meshworker/mesh_loop_06.cc
@@ -78,7 +78,6 @@ test(const types::material_id test_id)
   auto cell_worker = [](const Iterator &cell, ScratchData &s, CopyData &c) {
     const auto &fev = s.reinit(cell);
     const auto &JxW = s.get_JxW_values();
-    c               = 0;
     for (auto w : JxW)
       c.vectors[0][0] += w;
   };

--- a/tests/meshworker/mesh_loop_07.cc
+++ b/tests/meshworker/mesh_loop_07.cc
@@ -62,7 +62,6 @@ run()
                           ScratchData &           scratch_data,
                           CopyData &              copy_data) {
       const auto &fe_values = scratch_data.reinit(cell);
-      copy_data             = 0;
 
       for (unsigned int q_point = 0; q_point < fe_values.n_quadrature_points;
            ++q_point)

--- a/tests/meshworker/mesh_loop_07.cc
+++ b/tests/meshworker/mesh_loop_07.cc
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that mesh loop returns the correct values for integral over
+// volumes and boundaries
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/meshworker/copy_data.h>
+#include <deal.II/meshworker/mesh_loop.h>
+#include <deal.II/meshworker/scratch_data.h>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim = dim>
+void
+run()
+{
+  deallog << "Dim: " << dim << std::endl;
+
+  const FE_Q<dim, spacedim> fe(1);
+  const QGauss<dim>         cell_quadrature(fe.degree + 1);
+  const QGauss<dim - 1>     face_quadrature(fe.degree + 1);
+
+  Triangulation<dim, spacedim> triangulation;
+  GridGenerator::subdivided_hyper_cube(triangulation, 4, 0.0, 1.0);
+
+  DoFHandler<dim, spacedim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+
+  using ScratchData      = MeshWorker::ScratchData<dim, spacedim>;
+  using CopyData         = MeshWorker::CopyData<1, 1, 1>;
+  using CellIteratorType = decltype(dof_handler.begin_active());
+
+  // Volume integral
+  {
+    ScratchData scratch(dof_handler.get_fe(),
+                        cell_quadrature,
+                        update_JxW_values);
+    CopyData    copy(1);
+
+    auto cell_worker = [](const CellIteratorType &cell,
+                          ScratchData &           scratch_data,
+                          CopyData &              copy_data) {
+      const auto &fe_values = scratch_data.reinit(cell);
+      copy_data             = 0;
+
+      for (unsigned int q_point = 0; q_point < fe_values.n_quadrature_points;
+           ++q_point)
+        {
+          copy_data.vectors[0][0] += 1.0 * fe_values.JxW(q_point);
+        }
+    };
+
+    double volume = 0.0;
+    auto   copier = [&volume](const CopyData &copy_data) {
+      volume += copy_data.vectors[0][0];
+    };
+
+    MeshWorker::mesh_loop(dof_handler.active_cell_iterators(),
+                          cell_worker,
+                          copier,
+                          scratch,
+                          copy,
+                          MeshWorker::assemble_own_cells);
+    deallog << "Volume: " << volume << std::endl;
+
+    double reference_volume = 0.0;
+    for (auto &cell : dof_handler.active_cell_iterators())
+      reference_volume += cell->measure();
+
+    Assert(std::abs(volume - reference_volume) < 1e-6,
+           ExcMessage("Volumes do not match. Reference value: " +
+                      Utilities::to_string(reference_volume) +
+                      "; Calculated value: " + Utilities::to_string(volume)));
+  }
+
+  // Boundary integral
+  {
+    ScratchData scratch(dof_handler.get_fe(),
+                        cell_quadrature,
+                        update_default,
+                        face_quadrature,
+                        update_JxW_values);
+    CopyData    copy(1);
+
+    std::function<void(const CellIteratorType &, ScratchData &, CopyData &)>
+      empty_cell_worker;
+
+    auto boundary_worker = [](const CellIteratorType &cell,
+                              const unsigned int      face,
+                              ScratchData &           scratch_data,
+                              CopyData &              copy_data) {
+      const auto &fe_face_values = scratch_data.reinit(cell, face);
+
+      for (unsigned int q_point = 0;
+           q_point < fe_face_values.n_quadrature_points;
+           ++q_point)
+        {
+          copy_data.vectors[0][0] += 1.0 * fe_face_values.JxW(q_point);
+        }
+    };
+
+    double area   = 0.0;
+    auto   copier = [&area](const CopyData &copy_data) {
+      // ***
+      // The problem is observed here. For some faces, the copy_data that
+      // is passed in is reset, even though there is always work being
+      // done in the boundary_worker.
+      // ***
+      area += copy_data.vectors[0][0];
+    };
+
+    MeshWorker::mesh_loop(dof_handler.active_cell_iterators(),
+                          empty_cell_worker,
+                          copier,
+                          scratch,
+                          copy,
+                          MeshWorker::assemble_boundary_faces,
+                          boundary_worker);
+    deallog << "Area: " << area << std::endl;
+
+    double reference_area = 0.0;
+    for (auto &cell : dof_handler.active_cell_iterators())
+      for (const unsigned int face : GeometryInfo<dim>::face_indices())
+        if (cell->face(face)->at_boundary())
+          {
+            reference_area += cell->face(face)->measure();
+          }
+
+    Assert(std::abs(area - reference_area) < 1e-6,
+           ExcMessage("Areas do not match. Reference value: " +
+                      Utilities::to_string(reference_area) +
+                      "; Calculated value: " + Utilities::to_string(area)));
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  run<2>();
+  run<3>();
+
+  deallog << "OK" << std::endl;
+}

--- a/tests/meshworker/mesh_loop_07.output
+++ b/tests/meshworker/mesh_loop_07.output
@@ -1,0 +1,10 @@
+
+DEAL::Dim: 2
+DEAL::Volume: 1.00000
+DEAL::Area: 4.00000
+DEAL::OK
+DEAL::Dim: 3
+DEAL::Volume: 1.00000
+DEAL::Area: 6.00000
+DEAL::OK
+DEAL::OK

--- a/tests/meshworker/scratch_data_01.cc
+++ b/tests/meshworker/scratch_data_01.cc
@@ -72,7 +72,6 @@ test()
   auto cell_worker = [](const Iterator &cell, ScratchData &s, CopyData &c) {
     const auto &fev = s.reinit(cell);
     const auto &JxW = s.get_JxW_values();
-    c               = 0;
     for (auto w : JxW)
       c.vectors[0][0] += w;
   };

--- a/tests/meshworker/scratch_data_02.cc
+++ b/tests/meshworker/scratch_data_02.cc
@@ -116,8 +116,6 @@ test()
       const auto &JxW = s.get_JxW_values();
       const auto &p   = s.get_quadrature_points();
 
-      c = 0;
-
       c.local_dof_indices[0] = s.get_local_dof_indices();
 
       for (unsigned int q = 0; q < p.size(); ++q)

--- a/tests/meshworker/scratch_data_03.cc
+++ b/tests/meshworker/scratch_data_03.cc
@@ -116,8 +116,6 @@ test()
       const auto &JxW = s.get_JxW_values();
       const auto &p   = s.get_quadrature_points();
 
-      c = 0;
-
       c.local_dof_indices[0] = s.get_local_dof_indices();
 
       for (unsigned int q = 0; q < p.size(); ++q)

--- a/tests/meshworker/scratch_data_05.cc
+++ b/tests/meshworker/scratch_data_05.cc
@@ -130,8 +130,6 @@ test()
     const auto &u      = s.get_values("solution", scalar, dummy);
     const auto &grad_u = s.get_gradients("solution", scalar, dummy);
 
-    c = 0;
-
     c.local_dof_indices[0] = s.get_local_dof_indices();
 
     for (unsigned int i = 0; i < fev.dofs_per_cell; ++i)

--- a/tests/meshworker/scratch_data_06.cc
+++ b/tests/meshworker/scratch_data_06.cc
@@ -130,8 +130,6 @@ test()
     const auto &u      = s.get_values("solution", scalar, energy);
     const auto &grad_u = s.get_gradients("solution", scalar, energy);
 
-    c = 0;
-
     c.local_dof_indices[0] = s.get_local_dof_indices();
 
     for (unsigned int q = 0; q < p.size(); ++q)

--- a/tests/meshworker/scratch_data_07.cc
+++ b/tests/meshworker/scratch_data_07.cc
@@ -132,8 +132,6 @@ test()
     const auto &u                = s.get_values("solution", scalar, energy);
     const auto &grad_u           = s.get_gradients("solution", scalar, energy);
 
-    c = 0;
-
     c.local_dof_indices[0] = s.get_local_dof_indices();
 
     for (unsigned int q = 0; q < p.size(); ++q)


### PR DESCRIPTION
Also add an example of what not to do with copiers inside of a boundary worker.

Fixes #9971