### PR TITLE
Split up matrix-free compilation into more files

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -30,6 +30,7 @@
 #include <deal.II/lac/dynamic_sparsity_pattern.h>
 
 #include <deal.II/matrix_free/face_info.h>
+#include <deal.II/matrix_free/mapping_info.h>
 #include <deal.II/matrix_free/task_info.h>
 
 #include <array>
@@ -42,11 +43,38 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
-    // Forward declaration
-#ifndef DOXYGEN
+    /**
+     * A struct that takes entries describing a constraint and puts them into
+     * a sorted list where duplicates are filtered out
+     */
     template <typename Number>
-    struct ConstraintValues;
-#endif
+    struct ConstraintValues
+    {
+      ConstraintValues();
+
+      /**
+       * This function inserts some constrained entries to the collection of
+       * all values. It stores the (reordered) numbering of the dofs
+       * (according to the ordering that matches with the function) in
+       * new_indices, and returns the storage position the double array for
+       * access later on.
+       */
+      template <typename number2>
+      unsigned short
+      insert_entries(
+        const std::vector<std::pair<types::global_dof_index, number2>>
+          &entries);
+
+      std::vector<std::pair<types::global_dof_index, double>>
+                                           constraint_entries;
+      std::vector<types::global_dof_index> constraint_indices;
+
+      std::pair<std::vector<Number>, types::global_dof_index> next_constraint;
+      std::map<std::vector<Number>,
+               types::global_dof_index,
+               FPArrayComparator<Number>>
+        constraints;
+    };
 
     /**
      * The class that stores the indices of the degrees of freedom for all the

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -1010,7 +1010,7 @@ namespace internal
      * face number, subface index and orientation are the same. This is used
      * to batch similar faces together for vectorization.
      */
-    bool
+    inline bool
     compare_faces_for_vectorization(const FaceToCellTopology<1> &face1,
                                     const FaceToCellTopology<1> &face2)
     {

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -29,15 +29,16 @@
 
 #include <deal.II/dofs/dof_accessor.h>
 
+#include <deal.II/fe/fe_dgp.h>
+#include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_poly.h>
+#include <deal.II/fe/fe_q_dg0.h>
 
 #include <deal.II/hp/q_collection.h>
 
-#include <deal.II/matrix_free/dof_info.templates.h>
 #include <deal.II/matrix_free/face_info.h>
 #include <deal.II/matrix_free/face_setup_internal.h>
 #include <deal.II/matrix_free/matrix_free.h>
-#include <deal.II/matrix_free/shape_info.templates.h>
 
 #ifdef DEAL_II_WITH_THREADS
 #  include <deal.II/base/parallel.h>
@@ -1248,19 +1249,14 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
   }
 
   // set constraint pool from the std::map and reorder the indices
-  typename std::map<std::vector<double>,
-                    types::global_dof_index,
-                    internal::MatrixFreeFunctions::FPArrayComparator<double>>::
-    iterator it  = constraint_values.constraints.begin(),
-             end = constraint_values.constraints.end();
   std::vector<const std::vector<double> *> constraints(
     constraint_values.constraints.size());
   unsigned int length = 0;
-  for (; it != end; ++it)
+  for (const auto &it : constraint_values.constraints)
     {
-      AssertIndexRange(it->second, constraints.size());
-      constraints[it->second] = &it->first;
-      length += it->first.size();
+      AssertIndexRange(it.second, constraints.size());
+      constraints[it.second] = &it.first;
+      length += it.first.size();
     }
   constraint_pool_data.clear();
   constraint_pool_data.reserve(length);
@@ -1813,7 +1809,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::clear()
 
 namespace internal
 {
-  void
+  inline void
   fill_index_subrange(
     const unsigned int                                        begin,
     const unsigned int                                        end,
@@ -1832,7 +1828,7 @@ namespace internal
   }
 
   template <int dim>
-  void
+  inline void
   fill_connectivity_subrange(
     const unsigned int                                        begin,
     const unsigned int                                        end,
@@ -1875,7 +1871,7 @@ namespace internal
       }
   }
 
-  void
+  inline void
   fill_connectivity_indirect_subrange(
     const unsigned int            begin,
     const unsigned int            end,

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -95,10 +95,6 @@ namespace internal
 
   namespace MatrixFreeFunctions
   {
-    // forward declaration of internal data structure
-    template <typename Number>
-    struct ConstraintValues;
-
     /**
      * A struct that collects all information related to parallelization with
      * threads: The work is subdivided into tasks that can be done

--- a/source/matrix_free/CMakeLists.txt
+++ b/source/matrix_free/CMakeLists.txt
@@ -16,11 +16,15 @@
 INCLUDE_DIRECTORIES(BEFORE ${CMAKE_CURRENT_BINARY_DIR})
 
 SET(_src
+  dof_info.cc
   evaluation_selector.cc
   mapping_info.cc
   mapping_info_inst2.cc
   mapping_info_inst3.cc
   matrix_free.cc
+  matrix_free_inst2.cc
+  matrix_free_inst3.cc
+  shape_info.cc
   task_info.cc
   )
 
@@ -28,6 +32,7 @@ SET(_inst
   evaluation_selector.inst.in
   mapping_info.inst.in
   matrix_free.inst.in
+  shape_info.inst.in
   )
 
 FILE(GLOB _header

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/utilities.h>
+#include <deal.II/base/vectorization.h>
+
+#include <deal.II/matrix_free/dof_info.templates.h>
+
+#include <iostream>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  namespace MatrixFreeFunctions
+  {
+    template struct ConstraintValues<double>;
+    template struct ConstraintValues<float>;
+
+    template void
+    DoFInfo::read_dof_indices<double>(
+      const std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &,
+      const AffineConstraints<double> &,
+      const unsigned int,
+      ConstraintValues<double> &,
+      bool &);
+
+    template void
+    DoFInfo::read_dof_indices<float>(
+      const std::vector<types::global_dof_index> &,
+      const std::vector<unsigned int> &,
+      const AffineConstraints<float> &,
+      const unsigned int,
+      ConstraintValues<double> &,
+      bool &);
+
+    template void
+    DoFInfo::compute_face_index_compression<1>(
+      const std::vector<FaceToCellTopology<1>> &);
+    template void
+    DoFInfo::compute_face_index_compression<2>(
+      const std::vector<FaceToCellTopology<2>> &);
+    template void
+    DoFInfo::compute_face_index_compression<4>(
+      const std::vector<FaceToCellTopology<4>> &);
+    template void
+    DoFInfo::compute_face_index_compression<8>(
+      const std::vector<FaceToCellTopology<8>> &);
+    template void
+    DoFInfo::compute_face_index_compression<16>(
+      const std::vector<FaceToCellTopology<16>> &);
+
+    template void
+    DoFInfo::compute_vector_zero_access_pattern<1>(
+      const TaskInfo &,
+      const std::vector<FaceToCellTopology<1>> &);
+    template void
+    DoFInfo::compute_vector_zero_access_pattern<2>(
+      const TaskInfo &,
+      const std::vector<FaceToCellTopology<2>> &);
+    template void
+    DoFInfo::compute_vector_zero_access_pattern<4>(
+      const TaskInfo &,
+      const std::vector<FaceToCellTopology<4>> &);
+    template void
+    DoFInfo::compute_vector_zero_access_pattern<8>(
+      const TaskInfo &,
+      const std::vector<FaceToCellTopology<8>> &);
+    template void
+    DoFInfo::compute_vector_zero_access_pattern<16>(
+      const TaskInfo &,
+      const std::vector<FaceToCellTopology<16>> &);
+
+    template void
+    DoFInfo::print_memory_consumption<std::ostream>(std::ostream &,
+                                                    const TaskInfo &) const;
+    template void
+    DoFInfo::print_memory_consumption<ConditionalOStream>(
+      ConditionalOStream &,
+      const TaskInfo &) const;
+
+    template void
+    DoFInfo::print<double>(const std::vector<double> &,
+                           const std::vector<unsigned int> &,
+                           std::ostream &) const;
+
+    template void
+    DoFInfo::print<float>(const std::vector<float> &,
+                          const std::vector<unsigned int> &,
+                          std::ostream &) const;
+  } // namespace MatrixFreeFunctions
+} // namespace internal
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -14,17 +14,6 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
-  {
-    template void internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
-      reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
-  }
-
-
-
 for (deal_II_dimension : DIMENSIONS;
      deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
   {
@@ -78,12 +67,6 @@ for (deal_II_dimension : DIMENSIONS;
                   deal_II_scalar_vectorized>::
         get_dof_handler<hp::DoFHandler<deal_II_dimension>>(const unsigned int)
           const;
-
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
   }
 
 
@@ -124,10 +107,4 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS;
       is_supported(
         const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
 #endif
-  }
-
-for (deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
-  {
-    template struct internal::MatrixFreeFunctions::ShapeInfo<
-      deal_II_scalar_vectorized>;
   }

--- a/source/matrix_free/matrix_free_inst2.cc
+++ b/source/matrix_free/matrix_free_inst2.cc
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#define SPLIT_INSTANTIATIONS_INDEX 1
+#include "matrix_free.cc"

--- a/source/matrix_free/matrix_free_inst3.cc
+++ b/source/matrix_free/matrix_free_inst3.cc
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#define SPLIT_INSTANTIATIONS_INDEX 2
+#include "matrix_free.cc"

--- a/source/matrix_free/shape_info.cc
+++ b/source/matrix_free/shape_info.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2011 - 2018 by the deal.II authors
+// Copyright (C) 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -18,23 +18,15 @@
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/vectorization.h>
 
-#include <deal.II/matrix_free/matrix_free.templates.h>
+#include <deal.II/matrix_free/shape_info.templates.h>
 
 #include <iostream>
 
 DEAL_II_NAMESPACE_OPEN
 
-#define SPLIT_INSTANTIATIONS_COUNT 3
-#ifndef SPLIT_INSTANTIATIONS_INDEX
-#  define SPLIT_INSTANTIATIONS_INDEX 0
-#endif
-#include "matrix_free.inst"
-
-#if SPLIT_INSTANTIATIONS_INDEX == 0
+#include "shape_info.inst"
 
 template struct internal::MatrixFreeFunctions::ShapeInfo<double>;
 template struct internal::MatrixFreeFunctions::ShapeInfo<float>;
-
-#endif
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/shape_info.inst.in
+++ b/source/matrix_free/shape_info.inst.in
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
+  {
+    template void internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
+      reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+  }
+
+
+
+for (deal_II_dimension : DIMENSIONS;
+     deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
+  {
+    template void internal::MatrixFreeFunctions::
+      ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
+        const Quadrature<1> &,
+        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+        const unsigned int);
+  }
+
+for (deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
+  {
+    template struct internal::MatrixFreeFunctions::ShapeInfo<
+      deal_II_scalar_vectorized>;
+  }


### PR DESCRIPTION
The file `source/matrix_free/matrix_free.cc` took more than 1:30 minutes to compile for me. So I split that file into 3 instantiations. However, the compile times were still high, and I had duplicate symbols due to `MF::DoFInfo`. As a solution, I moved out the `DoFInfo` field into a separate compilation unit. And while there, I also moved the compilation of `ShapeInfo` into its own file, which should prepare for #9544.

To make all this work, I had to move a few declarations to the header file, and I need to spell out some additional template function instantiations explicitly.

Related to #9790.
