### PR TITLE
Comment on the use of thread-safe BLAS/LAPACK

### DIFF
--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -647,6 +647,15 @@ namespace Step51
   // manner.  The @p trace_reconstruct input parameter is used to decide
   // whether we are solving for the global skeleton solution (false) or the
   // local solution (true).
+  //
+  // One thing worth noting for the multi-threaded execution of assembly is
+  // the fact that the local computations in `assemble_system_one_cell()` call
+  // into BLAS and LAPACK functions if those are available in deal.II. Thus,
+  // the underlying BLAS/LAPACK library must support calls from multiple
+  // threads at the same time. Most implementations do support this, but some
+  // libraries need to be built in a specific way to avoid problems. For
+  // example, OpenBLAS compiled without multithreading inside the BLAS/LAPACK
+  // calls needs to built with a flag called `USE_LOCKING` set to true.
   template <int dim>
   void HDG<dim>::assemble_system(const bool trace_reconstruct)
   {


### PR DESCRIPTION
Fixes #9009. 

There is no central place in the tutorial where I could add the statement that we need a thread-safe BLAS/LAPACK implementation, so I put the comment where we run the parallel loop, which is the most obvious place a user will look in my opinion.