### PR TITLE
Fix step-40 test: Output n_dofs rather than IndexSet

### DIFF
--- a/tests/mpi/step-40_direct_solver.cc
+++ b/tests/mpi/step-40_direct_solver.cc
@@ -307,7 +307,7 @@ namespace Step40
              i < Utilities::MPI::n_mpi_processes(mpi_communicator);
              ++i)
           pcout << Utilities::MPI::all_gather(
-                     mpi_communicator, dof_handler.locally_owned_dofs())[i]
+                     mpi_communicator, dof_handler.n_locally_owned_dofs())[i]
                 << '+';
         pcout << std::endl;
 


### PR DESCRIPTION
This should fix the test failure
https://cdash.43-1.org/testDetails.php?test=42721613&build=5975
This was an oversight in #9945.