### PR TITLE
Introduce std_cxx20::ranges::iota_view

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -1250,16 +1250,6 @@ namespace Step69
     // to carry out (computation and storage of normals, and normalization
     // of the $\mathbf{c}_{ij}$ of entries) threads cannot conflict
     // attempting to write the same entry (we do not need a scheduler).
-    //
-    // We have one more difficulty to overcome: In order to implement the
-    // <code>on_subranges</code> lambda we need to name the iterator type
-    // of the object returned by <code>std_cxx20::ranges::iota_view%<unsigned
-    // int%>()</code>. This is unfortunately a very convoluted name exposing
-    // implementation details about <code>std_cxx20::ranges::iota_view</code>.
-    // For this reason we resort to the <a
-    // href="https://en.cppreference.com/w/cpp/language/decltype"><code>decltype</code></a>
-    // specifier, a C++11 feature that returns the type of an entity, or
-    // expression.
     {
       TimerOutput::Scope scope(computing_timer,
                                "offline_data - compute |c_ij|, and n_ij");

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -2102,8 +2102,8 @@ namespace Step69
                                "time_stepping - 3 perform update");
 
       const auto on_subranges =
-        [&](typename decltype(indices_owned)::iterator       i1,
-            const typename decltype(indices_owned)::iterator i2) {
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
           for (const auto i : boost::make_iterator_range(i1, i2))
             {
               Assert(i < n_locally_owned, ExcInternalError());
@@ -2352,8 +2352,8 @@ namespace Step69
     // global maxima and minima of the gradients.
     {
       const auto on_subranges = //
-        [&](typename decltype(indices)::iterator       i1,
-            const typename decltype(indices)::iterator i2) {
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
           double r_i_max_on_subrange = 0.;
           double r_i_min_on_subrange = std::numeric_limits<double>::infinity();
 
@@ -2437,8 +2437,8 @@ namespace Step69
 
     {
       const auto on_subranges = //
-        [&](typename decltype(indices)::iterator       i1,
-            const typename decltype(indices)::iterator i2) {
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
           for (const auto i : boost::make_iterator_range(i1, i2))
             {
               Assert(i < n_locally_owned, ExcInternalError());

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -78,9 +78,9 @@
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 
-// The last two boost header files are for creating custom iterator ranges
+// The last two header files are for creating custom iterator ranges
 // over integer intervals.
-#include <boost/range/irange.hpp>
+#include <deal.II/base/std_cxx20/iota_view.h>
 #include <boost/range/iterator_range.hpp>
 
 // For std::isnan, std::isinf, std::ifstream, std::async, and std::future
@@ -1225,7 +1225,8 @@ namespace Step69
     // defined by the <code>indices.begin()</code> and
     // <code>indices.end()</code> iterators into subranges (we want to be
     // able to read any entry in those subranges with constant complexity).
-    // In order to provide such iterators we resort to boost::irange.
+    // In order to provide such iterators we resort to
+    // std_cxx20::ranges::iota_view.
     //
     // The bulk of the following piece of code is spent defining
     // the "worker" <code>on_subranges</code>: i.e. the  operation applied at
@@ -1252,10 +1253,10 @@ namespace Step69
     //
     // We have one more difficulty to overcome: In order to implement the
     // <code>on_subranges</code> lambda we need to name the iterator type
-    // of the object returned by <code>boost::irange%<unsigned
+    // of the object returned by <code>std_cxx20::ranges::iota_view%<unsigned
     // int%>()</code>. This is unfortunately a very convoluted name exposing
-    // implementation details about <code>boost::irange</code>. For this
-    // reason we resort to the <a
+    // implementation details about <code>std_cxx20::ranges::iota_view</code>.
+    // For this reason we resort to the <a
     // href="https://en.cppreference.com/w/cpp/language/decltype"><code>decltype</code></a>
     // specifier, a C++11 feature that returns the type of an entity, or
     // expression.
@@ -1263,12 +1264,14 @@ namespace Step69
       TimerOutput::Scope scope(computing_timer,
                                "offline_data - compute |c_ij|, and n_ij");
 
-      const auto indices = boost::irange<unsigned int>(0, n_locally_relevant);
+      const std_cxx20::ranges::iota_view<unsigned int> indices(
+        0, n_locally_relevant);
 
       const auto on_subranges = //
-        [&](typename decltype(indices)::iterator       i1,
-            const typename decltype(indices)::iterator i2) {
-          for (const auto row_index : boost::make_iterator_range(i1, i2))
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+          for (const auto row_index :
+               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
             {
               // First column-loop: we compute and store the entries of the
               // matrix norm_matrix and write normalized entries into the
@@ -1870,9 +1873,10 @@ namespace Step69
     const auto &n_locally_owned    = offline_data->n_locally_owned;
     const auto &n_locally_relevant = offline_data->n_locally_relevant;
 
-    const auto indices_owned = boost::irange<unsigned int>(0, n_locally_owned);
-    const auto indices_relevant =
-      boost::irange<unsigned int>(0, n_locally_relevant);
+    const std_cxx20::ranges::iota_view<unsigned int> indices_owned(
+      0, n_locally_owned);
+    const std_cxx20::ranges::iota_view<unsigned int> indices_relevant(
+      0, n_locally_relevant);
 
     const auto &sparsity = offline_data->sparsity_pattern;
 
@@ -1926,9 +1930,10 @@ namespace Step69
                                "time_stepping - 1 compute d_ij");
 
       const auto on_subranges = //
-        [&](typename decltype(indices_relevant)::iterator       i1,
-            const typename decltype(indices_relevant)::iterator i2) {
-          for (const auto i : boost::make_iterator_range(i1, i2))
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+          for (const auto i :
+               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
             {
               const auto U_i = gather(U, i);
 
@@ -2021,11 +2026,12 @@ namespace Step69
       // locally.
 
       const auto on_subranges = //
-        [&](typename decltype(indices_relevant)::iterator       i1,
-            const typename decltype(indices_relevant)::iterator i2) {
+        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
+            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
           double tau_max_on_subrange = std::numeric_limits<double>::infinity();
 
-          for (const auto i : boost::make_iterator_range(i1, i2))
+          for (const auto i :
+               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
             {
               double d_sum = 0.;
 
@@ -2344,7 +2350,8 @@ namespace Step69
     const auto &boundary_normal_map = offline_data->boundary_normal_map;
     const auto &n_locally_owned     = offline_data->n_locally_owned;
 
-    const auto indices = boost::irange<unsigned int>(0, n_locally_owned);
+    const auto indices =
+      std_cxx20::ranges::iota_view<unsigned int>(0, n_locally_owned);
 
     // We define the r_i_max and r_i_min in the current MPI process as
     // atomic doubles in order to avoid race conditions between threads:

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -1254,14 +1254,17 @@ namespace Step69
       TimerOutput::Scope scope(computing_timer,
                                "offline_data - compute |c_ij|, and n_ij");
 
-      const std_cxx20::ranges::iota_view<unsigned int> indices(
+      const std_cxx20::ranges::iota_view<unsigned int, unsigned int> indices(
         0, n_locally_relevant);
 
       const auto on_subranges = //
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           for (const auto row_index :
-               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
+               std_cxx20::ranges::iota_view<unsigned int, unsigned int>(*i1,
+                                                                        *i2))
             {
               // First column-loop: we compute and store the entries of the
               // matrix norm_matrix and write normalized entries into the
@@ -1863,10 +1866,10 @@ namespace Step69
     const auto &n_locally_owned    = offline_data->n_locally_owned;
     const auto &n_locally_relevant = offline_data->n_locally_relevant;
 
-    const std_cxx20::ranges::iota_view<unsigned int> indices_owned(
-      0, n_locally_owned);
-    const std_cxx20::ranges::iota_view<unsigned int> indices_relevant(
-      0, n_locally_relevant);
+    const std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+      indices_owned(0, n_locally_owned);
+    const std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+      indices_relevant(0, n_locally_relevant);
 
     const auto &sparsity = offline_data->sparsity_pattern;
 
@@ -1920,10 +1923,13 @@ namespace Step69
                                "time_stepping - 1 compute d_ij");
 
       const auto on_subranges = //
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           for (const auto i :
-               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
+               std_cxx20::ranges::iota_view<unsigned int, unsigned int>(*i1,
+                                                                        *i2))
             {
               const auto U_i = gather(U, i);
 
@@ -2016,12 +2022,15 @@ namespace Step69
       // locally.
 
       const auto on_subranges = //
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           double tau_max_on_subrange = std::numeric_limits<double>::infinity();
 
           for (const auto i :
-               std_cxx20::ranges::iota_view<unsigned int>(*i1, *i2))
+               std_cxx20::ranges::iota_view<unsigned int, unsigned int>(*i1,
+                                                                        *i2))
             {
               double d_sum = 0.;
 
@@ -2102,8 +2111,10 @@ namespace Step69
                                "time_stepping - 3 perform update");
 
       const auto on_subranges =
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           for (const auto i : boost::make_iterator_range(i1, i2))
             {
               Assert(i < n_locally_owned, ExcInternalError());
@@ -2341,7 +2352,8 @@ namespace Step69
     const auto &n_locally_owned     = offline_data->n_locally_owned;
 
     const auto indices =
-      std_cxx20::ranges::iota_view<unsigned int>(0, n_locally_owned);
+      std_cxx20::ranges::iota_view<unsigned int, unsigned int>(0,
+                                                               n_locally_owned);
 
     // We define the r_i_max and r_i_min in the current MPI process as
     // atomic doubles in order to avoid race conditions between threads:
@@ -2352,8 +2364,10 @@ namespace Step69
     // global maxima and minima of the gradients.
     {
       const auto on_subranges = //
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           double r_i_max_on_subrange = 0.;
           double r_i_min_on_subrange = std::numeric_limits<double>::infinity();
 
@@ -2437,8 +2451,10 @@ namespace Step69
 
     {
       const auto on_subranges = //
-        [&](std_cxx20::ranges::iota_view<unsigned int>::iterator       i1,
-            const std_cxx20::ranges::iota_view<unsigned int>::iterator i2) {
+        [&](
+          std_cxx20::ranges::iota_view<unsigned int, unsigned int>::iterator i1,
+          const std_cxx20::ranges::iota_view<unsigned int,
+                                             unsigned int>::iterator i2) {
           for (const auto i : boost::make_iterator_range(i1, i2))
             {
               Assert(i < n_locally_owned, ExcInternalError());

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -21,8 +21,7 @@
 
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
-
-#include <boost/range/irange.hpp>
+#include <deal.II/base/std_cxx20/iota_view.h>
 
 #include <array>
 #include <cstdint>
@@ -1947,7 +1946,7 @@ struct GeometryInfo
    * taking on all valid indices for faces (zero and one in 1d, zero
    * through three in 2d, and zero through 5 in 3d).
    */
-  static boost::integer_range<unsigned int>
+  static std_cxx20::ranges::iota_view<unsigned int>
   face_indices();
 
   /**
@@ -1978,7 +1977,7 @@ struct GeometryInfo
    * Here, we are looping over all vertices of all cells, with `vertex_index`
    * taking on all valid indices.
    */
-  static boost::integer_range<unsigned int>
+  static std_cxx20::ranges::iota_view<unsigned int>
   vertex_indices();
 
   /**
@@ -2833,19 +2832,19 @@ GeometryInfo<0>::vertex_indices()
 
 
 template <int dim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int>
 GeometryInfo<dim>::face_indices()
 {
-  return boost::irange(0U, faces_per_cell);
+  return std_cxx20::ranges::iota_view<unsigned int>(0U, faces_per_cell);
 }
 
 
 
 template <int dim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int>
 GeometryInfo<dim>::vertex_indices()
 {
-  return boost::irange(0U, vertices_per_cell);
+  return std_cxx20::ranges::iota_view<unsigned int>(0U, vertices_per_cell);
 }
 
 

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -1946,7 +1946,7 @@ struct GeometryInfo
    * taking on all valid indices for faces (zero and one in 1d, zero
    * through three in 2d, and zero through 5 in 3d).
    */
-  static std_cxx20::ranges::iota_view<unsigned int>
+  static std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   face_indices();
 
   /**
@@ -1977,7 +1977,7 @@ struct GeometryInfo
    * Here, we are looping over all vertices of all cells, with `vertex_index`
    * taking on all valid indices.
    */
-  static std_cxx20::ranges::iota_view<unsigned int>
+  static std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   vertex_indices();
 
   /**
@@ -2832,19 +2832,19 @@ GeometryInfo<0>::vertex_indices()
 
 
 template <int dim>
-inline std_cxx20::ranges::iota_view<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 GeometryInfo<dim>::face_indices()
 {
-  return std_cxx20::ranges::iota_view<unsigned int>(0U, faces_per_cell);
+  return {0U, faces_per_cell};
 }
 
 
 
 template <int dim>
-inline std_cxx20::ranges::iota_view<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 GeometryInfo<dim>::vertex_indices()
 {
-  return std_cxx20::ranges::iota_view<unsigned int>(0U, vertices_per_cell);
+  return {0U, vertices_per_cell};
 }
 
 

--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+#ifndef dealii_cxx20_iota_view_h
+#define dealii_cxx20_iota_view_h
+
+#include <deal.II/base/config.h>
+
+#include <boost/range/irange.hpp>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace std_cxx20
+{
+  namespace ranges
+  {
+    /**
+     * A poor-man's implementation of std::ranges::iota_view using
+     * boost's integer_range class. The two classes are not completely
+     * identical, but close enough so that we can use the boost
+     * class until std::ranges::iota_range becomes available in
+     * compilers.
+     *
+     * The std::ranges::iota_view class represents a range of values
+     * or iterators that one can loop over. A documentation of this
+     * class can be found at
+     * https://en.cppreference.com/w/cpp/ranges/iota_view .
+     */
+    template <typename IncrementableType>
+    using iota_view = boost::integer_range<IncrementableType>;
+  } // namespace ranges
+} // namespace std_cxx20
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -17,8 +17,11 @@
 
 #include <deal.II/base/config.h>
 
-#include <boost/range/irange.hpp>
-
+#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
+#  include <ranges>
+#else
+#  include <boost/range/irange.hpp>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -26,6 +29,10 @@ namespace std_cxx20
 {
   namespace ranges
   {
+#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
+    template <typename IncrementableType, typename BoundType>
+    using iota_view = std::ranges::iota_view<IncrementableType, BoundType>;
+#else
     /**
      * A poor-man's implementation of std::ranges::iota_view using
      * boost's integer_range class. The two classes are not completely
@@ -38,8 +45,9 @@ namespace std_cxx20
      * class can be found at
      * https://en.cppreference.com/w/cpp/ranges/iota_view .
      */
-    template <typename IncrementableType>
+    template <typename IncrementableType, typename /*BoundType*/>
     using iota_view = boost::integer_range<IncrementableType>;
+#endif
   } // namespace ranges
 } // namespace std_cxx20
 

--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -30,8 +30,7 @@ namespace std_cxx20
   namespace ranges
   {
 #if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
-    template <typename IncrementableType, typename BoundType>
-    using iota_view = std::ranges::iota_view<IncrementableType, BoundType>;
+    using std::ranges::iota_view;
 #else
     /**
      * A poor-man's implementation of std::ranges::iota_view using

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -2936,7 +2936,7 @@ public:
    * `i` and `j` taking on all valid indices for cell degrees of freedom, as
    * defined by the finite element passed to `fe_values`.
    */
-  boost::integer_range<unsigned int>
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   dof_indices() const;
 
   /**
@@ -2971,7 +2971,7 @@ public:
    * @note If the @p start_dof_index is equal to the number of DoFs in the cell,
    * then the returned index range is empty.
    */
-  boost::integer_range<unsigned int>
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   dof_indices_starting_at(const unsigned int start_dof_index) const;
 
   /**
@@ -3004,7 +3004,7 @@ public:
    * @note If the @p end_dof_index is equal to zero, then the returned index
    * range is empty.
    */
-  boost::integer_range<unsigned int>
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   dof_indices_ending_at(const unsigned int end_dof_index) const;
 
   //@}
@@ -5528,34 +5528,34 @@ FEValuesBase<dim, spacedim>::get_inverse_jacobians() const
 
 
 template <int dim, int spacedim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::dof_indices() const
 {
-  return boost::irange(0U, dofs_per_cell);
+  return {0U, dofs_per_cell};
 }
 
 
 
 template <int dim, int spacedim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::dof_indices_starting_at(
   const unsigned int start_dof_index) const
 {
   Assert(start_dof_index <= dofs_per_cell,
          ExcIndexRange(start_dof_index, 0, dofs_per_cell + 1));
-  return boost::irange(start_dof_index, dofs_per_cell);
+  return {start_dof_index, dofs_per_cell};
 }
 
 
 
 template <int dim, int spacedim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::dof_indices_ending_at(
   const unsigned int end_dof_index) const
 {
   Assert(end_dof_index < dofs_per_cell,
          ExcIndexRange(end_dof_index, 0, dofs_per_cell));
-  return boost::irange(0U, end_dof_index + 1);
+  return {0U, end_dof_index + 1};
 }
 
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -3030,7 +3030,7 @@ public:
    * `q_point` taking on all valid indices for quadrature points, as defined
    * by the quadrature rule passed to `fe_values`.
    */
-  std_cxx20::ranges::iota_view<unsigned int>
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
   quadrature_point_indices() const;
 
   /**
@@ -5561,10 +5561,10 @@ FEValuesBase<dim, spacedim>::dof_indices_ending_at(
 
 
 template <int dim, int spacedim>
-inline std_cxx20::ranges::iota_view<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 FEValuesBase<dim, spacedim>::quadrature_point_indices() const
 {
-  return std_cxx20::ranges::iota_view<unsigned int>(0U, n_quadrature_points);
+  return {0U, n_quadrature_points};
 }
 
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -23,6 +23,7 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/quadrature.h>
+#include <deal.II/base/std_cxx20/iota_view.h>
 #include <deal.II/base/subscriptor.h>
 #include <deal.II/base/symmetric_tensor.h>
 
@@ -38,8 +39,6 @@
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/hp/dof_handler.h>
-
-#include <boost/range/irange.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -3031,7 +3030,7 @@ public:
    * `q_point` taking on all valid indices for quadrature points, as defined
    * by the quadrature rule passed to `fe_values`.
    */
-  boost::integer_range<unsigned int>
+  std_cxx20::ranges::iota_view<unsigned int>
   quadrature_point_indices() const;
 
   /**
@@ -5562,10 +5561,10 @@ FEValuesBase<dim, spacedim>::dof_indices_ending_at(
 
 
 template <int dim, int spacedim>
-inline boost::integer_range<unsigned int>
+inline std_cxx20::ranges::iota_view<unsigned int>
 FEValuesBase<dim, spacedim>::quadrature_point_indices() const
 {
-  return boost::irange(0U, n_quadrature_points);
+  return std_cxx20::ranges::iota_view<unsigned int>(0U, n_quadrature_points);
 }
 
 


### PR DESCRIPTION
This would fix #10000. It introduces an alias for `std::ranges::iota_view` (see https://en.cppreference.com/w/cpp/ranges/iota_view) using the `boost::integer_range` class that does something sufficiently similar. 

Strictly speaking, `std::ranges::iota_view` is more general since it doesn't just allow integer ranges but in fact ranges over anything that has an `operator++` and this, in particular, includes, iterator ranges. But as a first version, this is good enough for everything we want to do and allows us to use a name that will only require marginal adaptation once we actually use C++20.

I don't have a compiler that already supports C++20, and so haven't added any standard alias as we do in the other `std_cxx??` headers. We can add that at a later time -- for now, we just unconditionally refer to the corresponding boost class.

/rebuild
