### PR TITLE
Remove an unnecessary include file.

### DIFF
--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
-#include <deal.II/base/logstream.h>
 #include <deal.II/base/subscriptor.h>
 
 #include <deal.II/differentiation/ad/ad_number_traits.h>


### PR DESCRIPTION
Specifically, vector.h doesn't reference LogStream or deallog and so doesn't need
the include file.

/rebuild