### PR TITLE
Implement cell-wise coefficient in MF::LaplaceOperator

### DIFF
--- a/doc/news/changes/minor/20200503MartinKronbichler
+++ b/doc/news/changes/minor/20200503MartinKronbichler
@@ -1,0 +1,5 @@
+Improved: MatrixFreeOperators::LaplaceOperator now also supports cell-wise
+constant coefficient, which can be used by a Table with a single column
+per cell.
+<br>
+(Martin Kronbichler, 2020/05/03)

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -842,16 +842,20 @@ namespace MatrixFreeOperators
     compute_diagonal();
 
     /**
-     * Set the heterogeneous scalar coefficient @p scalar_coefficient to be used at
-     * the quadrature points. The Table should be of correct size, consistent
-     * with the total number of quadrature points in
-     * <code>dim</code>-dimensions,
-     * controlled by the @p n_q_points_1d template parameter. Here,
-     * <code>(*scalar_coefficient)(cell,q)</code> corresponds to the value of
-     * the coefficient, where <code>cell</code> is an index into a set of cell
-     * batches as administered by the MatrixFree framework (which does not work
-     * on individual cells, but instead of batches of cells at once), and
-     * <code>q</code> is the number of the quadrature point within this batch.
+     * Set the heterogeneous scalar coefficient @p scalar_coefficient to be
+     * used at the quadrature points. The Table needs to have as many rows as
+     * there are cell batches in the underlying MatrixFree object,
+     * MatrixFree::n_cell_batches(). The number of batches is related to the
+     * fact that the matrix-free operators do not work on individual cells,
+     * but instead of batches of cells at once due to vectorization. The Table
+     * can take two different numbers of columns.  One case is to select it
+     * equal to the total number of quadrature points in `dim` dimensions,
+     * which is the `dim`th power of the `n_q_points_1d` template
+     * parameter. Here, `(*scalar_coefficient)(cell,q)` corresponds to the
+     * value of the coefficient on cell batch `cell` and quadrature point
+     * index `q`. The second supported variant is a Table with a single
+     * column, in which case the same variable coefficient value is used at
+     * all quadrature points of a cell.
      *
      * Such tables can be initialized by
      * @code
@@ -891,6 +895,10 @@ namespace MatrixFreeOperators
     set_coefficient(
       const std::shared_ptr<Table<2, VectorizedArrayType>> &scalar_coefficient);
 
+    /**
+     * Resets all data structures back to the same state as for a newly
+     * constructed object.
+     */
     virtual void
     clear();
 
@@ -2069,13 +2077,31 @@ namespace MatrixFreeOperators
     phi.evaluate(false, true, false);
     if (scalar_coefficient.get())
       {
-        for (unsigned int q = 0; q < phi.n_q_points; ++q)
+        Assert(scalar_coefficient->size(1) == 1 ||
+                 scalar_coefficient->size(1) == phi.n_q_points,
+               ExcMessage("The number of columns in the coefficient table must "
+                          "be either 1 or the number of quadrature points " +
+                          std::to_string(phi.n_q_points) +
+                          ", but the given value was " +
+                          std::to_string(scalar_coefficient->size(1))));
+        if (scalar_coefficient->size(1) == phi.n_q_points)
+          for (unsigned int q = 0; q < phi.n_q_points; ++q)
+            {
+              Assert(Implementation::non_negative(
+                       (*scalar_coefficient)(cell, q)),
+                     ExcMessage("Coefficient must be non-negative"));
+              phi.submit_gradient((*scalar_coefficient)(cell, q) *
+                                    phi.get_gradient(q),
+                                  q);
+            }
+        else
           {
-            Assert(Implementation::non_negative((*scalar_coefficient)(cell, q)),
+            Assert(Implementation::non_negative((*scalar_coefficient)(cell, 0)),
                    ExcMessage("Coefficient must be non-negative"));
-            phi.submit_gradient((*scalar_coefficient)(cell, q) *
-                                  phi.get_gradient(q),
-                                q);
+            const VectorizedArrayType coefficient =
+              (*scalar_coefficient)(cell, 0);
+            for (unsigned int q = 0; q < phi.n_q_points; ++q)
+              phi.submit_gradient(coefficient * phi.get_gradient(q), q);
           }
       }
     else

--- a/tests/matrix_free/laplace_operator_01.cc
+++ b/tests/matrix_free/laplace_operator_01.cc
@@ -203,32 +203,18 @@ test()
 int
 main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-  deallog.push(Utilities::int_to_string(myid));
+  mpi_initlog();
+  deallog.push("0");
 
-  if (myid == 0)
-    {
-      initlog();
-      deallog << std::setprecision(4);
+  deallog.push("2d");
+  test<2, 1>();
+  test<2, 2>();
+  deallog.pop();
 
-      deallog.push("2d");
-      test<2, 1>();
-      test<2, 2>();
-      deallog.pop();
-
-      deallog.push("3d");
-      test<3, 1>();
-      test<3, 2>();
-      deallog.pop();
-    }
-  else
-    {
-      test<2, 1>();
-      test<2, 2>();
-      test<3, 1>();
-      test<3, 2>();
-    }
+  deallog.push("3d");
+  test<3, 1>();
+  test<3, 2>();
+  deallog.pop();
 }

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -267,32 +267,18 @@ test()
 int
 main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-  deallog.push(Utilities::int_to_string(myid));
+  mpi_initlog();
+  deallog.push("0");
 
-  if (myid == 0)
-    {
-      initlog();
-      deallog << std::setprecision(4);
+  deallog.push("2d");
+  test<2, 1>();
+  test<2, 2>();
+  deallog.pop();
 
-      deallog.push("2d");
-      test<2, 1>();
-      test<2, 2>();
-      deallog.pop();
-
-      deallog.push("3d");
-      test<3, 1>();
-      test<3, 2>();
-      deallog.pop();
-    }
-  else
-    {
-      test<2, 1>();
-      test<2, 2>();
-      test<3, 1>();
-      test<3, 2>();
-    }
+  deallog.push("3d");
+  test<3, 1>();
+  test<3, 2>();
+  deallog.pop();
 }

--- a/tests/matrix_free/laplace_operator_03.cc
+++ b/tests/matrix_free/laplace_operator_03.cc
@@ -1,0 +1,236 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// the same as laplace_operator_01, but heterogeneous Laplace operator with a
+// single constant coefficient per cell
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_sparsity_pattern.h>
+
+#include <deal.II/matrix_free/operators.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+
+template <int dim, int fe_degree>
+void
+test()
+{
+  typedef double number;
+
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      if (cell->center().norm() < 0.2)
+        cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  if (dim < 3 && fe_degree < 2)
+    tria.refine_global(2);
+  else
+    tria.refine_global(1);
+  if (tria.begin(tria.n_levels() - 1)->is_locally_owned())
+    tria.begin(tria.n_levels() - 1)->set_refine_flag();
+  if (tria.last()->is_locally_owned())
+    tria.last()->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+  for (unsigned int i = 0; i < 10 - 3 * dim; ++i)
+    {
+      unsigned int counter = 0;
+      for (const auto &cell : tria.active_cell_iterators())
+        if (cell->is_locally_owned())
+          if (counter++ % (7 - i) == 0)
+            cell->set_refine_flag();
+      tria.execute_coarsening_and_refinement();
+    }
+
+  FE_Q<dim>       fe(fe_degree);
+  DoFHandler<dim> dof(tria);
+  dof.distribute_dofs(fe);
+
+  IndexSet owned_set = dof.locally_owned_dofs();
+  IndexSet relevant_set;
+  DoFTools::extract_locally_relevant_dofs(dof, relevant_set);
+
+  AffineConstraints<double> constraints(relevant_set);
+  DoFTools::make_hanging_node_constraints(dof, constraints);
+  VectorTools::interpolate_boundary_values(dof,
+                                           0,
+                                           Functions::ZeroFunction<dim>(),
+                                           constraints);
+  constraints.close();
+
+  deallog << "Testing " << dof.get_fe().get_name() << std::endl;
+  // std::cout << "Number of cells: " << tria.n_global_active_cells() <<
+  // std::endl; std::cout << "Number of degrees of freedom: " << dof.n_dofs() <<
+  // std::endl; std::cout << "Number of constraints: " <<
+  // constraints.n_constraints() << std::endl;
+
+  std::shared_ptr<MatrixFree<dim, number>> mf_data(
+    new MatrixFree<dim, number>());
+  {
+    const QGauss<1>                                  quad(fe_degree + 1);
+    typename MatrixFree<dim, number>::AdditionalData data;
+    data.tasks_parallel_scheme = MatrixFree<dim, number>::AdditionalData::none;
+    data.tasks_block_size      = 7;
+    data.mapping_update_flags =
+      update_quadrature_points | update_gradients | update_JxW_values;
+    mf_data->reinit(dof, constraints, quad, data);
+  }
+
+  std::shared_ptr<Table<2, VectorizedArray<number>>> coefficient;
+  coefficient = std::make_shared<Table<2, VectorizedArray<number>>>();
+  {
+    coefficient->reinit(mf_data->n_cell_batches(), 1);
+    for (unsigned int cell = 0; cell < mf_data->n_cell_batches(); ++cell)
+      for (unsigned int v = 0;
+           v < mf_data->n_active_entries_per_cell_batch(cell);
+           ++v)
+        (*coefficient)(cell, 0)[v] =
+          1. + std::sqrt(static_cast<double>(
+                 mf_data->get_cell_iterator(cell, v)->active_cell_index()));
+  }
+
+  MatrixFreeOperators::LaplaceOperator<
+    dim,
+    fe_degree,
+    fe_degree + 1,
+    1,
+    LinearAlgebra::distributed::Vector<number>>
+    mf;
+  mf.initialize(mf_data);
+  mf.set_coefficient(coefficient);
+  mf.compute_diagonal();
+  LinearAlgebra::distributed::Vector<number> in, out, ref;
+  mf_data->initialize_dof_vector(in);
+  out.reinit(in);
+  ref.reinit(in);
+
+  for (unsigned int i = 0; i < in.local_size(); ++i)
+    {
+      const unsigned int glob_index = owned_set.nth_index_in_set(i);
+      if (constraints.is_constrained(glob_index))
+        continue;
+      in.local_element(i) = random_value<double>();
+    }
+
+  mf.vmult(out, in);
+
+
+  // assemble trilinos sparse matrix with
+  // (v, u) for reference
+  TrilinosWrappers::SparseMatrix sparse_matrix;
+  {
+    TrilinosWrappers::SparsityPattern csp(owned_set, MPI_COMM_WORLD);
+    DoFTools::make_sparsity_pattern(dof,
+                                    csp,
+                                    constraints,
+                                    true,
+                                    Utilities::MPI::this_mpi_process(
+                                      MPI_COMM_WORLD));
+    csp.compress();
+    sparse_matrix.reinit(csp);
+  }
+  {
+    QGauss<dim> quadrature_formula(fe_degree + 1);
+
+    FEValues<dim> fe_values(dof.get_fe(),
+                            quadrature_formula,
+                            update_gradients | update_JxW_values |
+                              update_quadrature_points);
+
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+    typename DoFHandler<dim>::active_cell_iterator cell = dof.begin_active(),
+                                                   endc = dof.end();
+    for (; cell != endc; ++cell)
+      if (cell->is_locally_owned())
+        {
+          cell_matrix = 0;
+          fe_values.reinit(cell);
+
+          const double coefficient =
+            1. + std::sqrt(static_cast<double>(cell->active_cell_index()));
+
+          for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  cell_matrix(i, j) += (fe_values.shape_grad(i, q_point) *
+                                        fe_values.shape_grad(j, q_point)) *
+                                       coefficient * fe_values.JxW(q_point);
+              }
+
+          cell->get_dof_indices(local_dof_indices);
+          constraints.distribute_local_to_global(cell_matrix,
+                                                 local_dof_indices,
+                                                 sparse_matrix);
+        }
+  }
+  sparse_matrix.compress(VectorOperation::add);
+
+  sparse_matrix.vmult(ref, in);
+  out -= ref;
+  const double diff_norm = out.linfty_norm();
+
+  deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  mpi_initlog();
+
+  deallog << std::setprecision(4);
+
+  deallog.push("2d");
+  test<2, 1>();
+  test<2, 2>();
+  deallog.pop();
+
+  deallog.push("3d");
+  test<3, 1>();
+  test<3, 2>();
+  deallog.pop();
+}

--- a/tests/matrix_free/laplace_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/laplace_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,13 @@
+
+DEAL:2d::Testing FE_Q<2>(1)
+DEAL:2d::Norm of difference: 2.593e-13
+DEAL:2d::
+DEAL:2d::Testing FE_Q<2>(2)
+DEAL:2d::Norm of difference: 4.974e-14
+DEAL:2d::
+DEAL:3d::Testing FE_Q<3>(1)
+DEAL:3d::Norm of difference: 3.553e-15
+DEAL:3d::
+DEAL:3d::Testing FE_Q<3>(2)
+DEAL:3d::Norm of difference: 4.885e-15
+DEAL:3d::

--- a/tests/matrix_free/mass_operator_01.cc
+++ b/tests/matrix_free/mass_operator_01.cc
@@ -211,32 +211,18 @@ test()
 int
 main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
-  deallog.push(Utilities::int_to_string(myid));
+  mpi_initlog();
+  deallog.push("0");
 
-  if (myid == 0)
-    {
-      initlog();
-      deallog << std::setprecision(4);
+  deallog.push("2d");
+  test<2, 1>();
+  test<2, 2>();
+  deallog.pop();
 
-      deallog.push("2d");
-      test<2, 1>();
-      test<2, 2>();
-      deallog.pop();
-
-      deallog.push("3d");
-      test<3, 1>();
-      test<3, 2>();
-      deallog.pop();
-    }
-  else
-    {
-      test<2, 1>();
-      test<2, 2>();
-      test<3, 1>();
-      test<3, 2>();
-    }
+  deallog.push("3d");
+  test<3, 1>();
+  test<3, 2>();
+  deallog.pop();
 }

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -194,8 +194,7 @@ test()
 int
 main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   mpi_initlog();
 

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -191,8 +191,7 @@ test()
 int
 main(int argc, char **argv)
 {
-  Utilities::MPI::MPI_InitFinalize mpi_initialization(
-    argc, argv, testing_max_num_threads());
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
   mpi_initlog();
 


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/9883#discussion_r418564041, it makes sense to support cell-wise constant coefficients in `MatrixFreeOperators::LaplaceOperator`.

Given the already present interface, in particular `get_coefficient()`, I think that the best way to do things is to simply pass in a table with a single column for the value at all quadrature points. Providing a second set of a coefficient, taking only a vector, would be more complicated I believe. What do other think?

I also added a test and, while there, simplified some other tests that used a very complicated way of creating the logfile.