### PR TITLE
Fix C++20 warnings and errors

### DIFF
--- a/bundled/boost-1.70.0/include/boost/signals2/detail/auto_buffer.hpp
+++ b/bundled/boost-1.70.0/include/boost/signals2/detail/auto_buffer.hpp
@@ -142,7 +142,11 @@ namespace detail
         typedef typename Allocator::size_type            size_type;
         typedef typename Allocator::difference_type      difference_type;
         typedef T*                                       pointer;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename Allocator::pointer              allocator_pointer;
+#else
+        typedef typename std::allocator_traits<Allocator>::pointer allocator_pointer;
+#endif
         typedef const T*                                 const_pointer;
         typedef T&                                       reference;
         typedef const T&                                 const_reference;

--- a/bundled/tbb-2018_U2/src/tbb/arena.cpp
+++ b/bundled/tbb-2018_U2/src/tbb/arena.cpp
@@ -202,7 +202,8 @@ arena::arena ( market& m, unsigned num_slots, unsigned num_reserved_slots ) {
     my_max_num_workers = num_slots-num_reserved_slots;
     my_references = ref_external; // accounts for the master
 #if __TBB_TASK_PRIORITY
-    my_bottom_priority = my_top_priority = normalized_normal_priority;
+    my_bottom_priority = normalized_normal_priority;
+    my_top_priority = normalized_normal_priority;
 #endif /* __TBB_TASK_PRIORITY */
     my_aba_epoch = m.my_arenas_aba_epoch;
 #if __TBB_ARENA_OBSERVER

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -1797,7 +1797,7 @@ namespace Step69
     // velocity $u$, and pressure $p$) into a conserved n-dimensional state
     // (density $\rho$, momentum $\mathbf{m}$, and total energy $E$).
 
-    initial_state = [=](const Point<dim> & /*point*/, double /*t*/) {
+    initial_state = [this](const Point<dim> & /*point*/, double /*t*/) {
       const double            rho   = initial_1d_state[0];
       const double            u     = initial_1d_state[1];
       const double            p     = initial_1d_state[2];


### PR DESCRIPTION
- Avoid allocator::pointer removed in C++20 in Boost
- Avoid volatile assignment in TBB
- Avoid deprecated implicit this capture