### PR TITLE
Fix some more doxygen issues.

### DIFF
--- a/doc/doxygen/extra.sty
+++ b/doc/doxygen/extra.sty
@@ -18,7 +18,7 @@
 
 % Note: If you add an entry here, also put it into
 % ./doc/doxygen/scripts/mod_header.pl.in
-\newcommand{\vcentcolon}{\mathrel{\mathop{:}}}
-\newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}
+\newcommand{\dealvcentcolon}{\mathrel{\mathop{:}}}
+\newcommand{\dealcoloneq}{\dealvcentcolon\mathrel{\mkern-1.2mu}=}
 \newcommand{\jump}[1]{\left[\!\left[ #1 \right]\!\right]}
 \newcommand{\average}[1]{\left\{\!\left\{ #1 \right\}\!\right\}}

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -134,7 +134,7 @@ GENERATE_LATEX         = NO
 
 # but set a few flags for when processing formulas embedded
 # in the documentation.
-PAPER_TYPE             = a4wide
+PAPER_TYPE             = a4
 EXTRA_PACKAGES         = amsmath amsfonts mathtools @_extra_packages@
 LATEX_BATCHMODE        = YES
 

--- a/doc/doxygen/scripts/mod_header.pl.in
+++ b/doc/doxygen/scripts/mod_header.pl.in
@@ -43,8 +43,8 @@ if (eof)
 {
     print '<!--Extra macros for MathJax:-->', "\n";
     print '<div style="display:none">', "\n";
-    print '\(\newcommand{\vcentcolon}{\mathrel{\mathop{:}}}\)', "\n";
-    print '\(\newcommand{\dealcoloneq}{\vcentcolon\mathrel{\mkern-1.2mu}=}\)', "\n";
+    print '\(\newcommand{\dealvcentcolon}{\mathrel{\mathop{:}}}\)', "\n";
+    print '\(\newcommand{\dealcoloneq}{\dealvcentcolon\mathrel{\mkern-1.2mu}=}\)', "\n";
     print '\(\newcommand{\jump}[1]{\left[\!\left[ #1 \right]\!\right]}\)', "\n";
     print '\(\newcommand{\average}[1]{\left\{\!\left\{ #1 \right\}\!\right\}}\)', "\n";
     print '</div>', "\n";

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -370,8 +370,8 @@ public:
  * @relatesalso LinearOperator
  *
  * Addition of two linear operators @p first_op and @p second_op given by
- * $(\text{first_op}+\text{second_op})x \dealcoloneq \text{first_op}(x) +
- * \text{second_op}(x)$
+ * $(\mathrm{first\_op}+\mathrm{second\_op})x \dealcoloneq \mathrm{first\_op}(x)
+ * + \mathrm{second\_op}(x)$
  *
  * @ingroup LAOperators
  */
@@ -429,8 +429,8 @@ operator+(const LinearOperator<Range, Domain, Payload> &first_op,
  * @relatesalso LinearOperator
  *
  * Subtraction of two linear operators @p first_op and @p second_op given by
- * $(\text{first_op}-\text{second_op})x \dealcoloneq \text{first_op}(x) -
- * \text{second_op}(x)$
+ * $(\mathrm{first\_op}-\mathrm{second\_op})x \dealcoloneq \mathrm{first\_op}(x)
+ * - \mathrm{second\_op}(x)$
  *
  * @ingroup LAOperators
  */
@@ -564,8 +564,8 @@ operator*(const LinearOperator<Range, Domain, Payload> &op,
  * @relatesalso LinearOperator
  *
  * Composition of two linear operators @p first_op and @p second_op given by
- * $(\text{first_op}*\text{second_op})x \dealcoloneq
- * \text{first_op}(\text{econd_op}(x))$
+ * $(\mathrm{first\_op}*\mathrm{second\_op})x \dealcoloneq
+ * \mathrm{first\_op}(\mathrm{second\_op}(x))$
  *
  * @ingroup LAOperators
  */


### PR DESCRIPTION
Another followup to #10007.

1. I now get a warning about paper sizes with doxygen 1.8.18:

warning: argument 'a4wide' for option PAPER_TYPE is not a valid enum value
Using the default: a4!

   Get around this by just using a4.

2. My LaTeX distribution already defines vcentcolon, so rename our own version
   to dealvcentcolon to preserve compatibility with older tex distributions.

3. Use mathrm instead of text to get underscores to work correctly with
   backslashes with both MathJax and LaTeX. This is the solution we use
   elsewhere in the library.