### PR TITLE
CUDA matrix-free: overlap communication and computation

### DIFF
--- a/doc/news/changes/minor/20200506PeterMunchBrunoTurcksin
+++ b/doc/news/changes/minor/20200506PeterMunchBrunoTurcksin
@@ -1,0 +1,4 @@
+New: Add a flag to overlap MPI communication and computation when using CUDA
+matrix-free and CUDA-aware MPI.
+<br>
+(Peter Munch and Bruno Turcksin, 2020/05/06)

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -515,6 +515,9 @@ namespace LinearAlgebra
        * warning to prevent this situation.
        *
        * Must follow a call to the @p compress_start function.
+       *
+       * When the MemorySpace is CUDA and MPI is not CUDA-aware, data changed on
+       * the device after the call to compress_start will be lost.
        */
       void
       compress_finish(::dealii::VectorOperation::values operation);


### PR DESCRIPTION
Superseed #8882 This PR fixes a few problems with #8882: missing synchronization before starting the MPI communication, fix the serial case, and fix the case where some processors do not own any cells.