### PR TITLE
Parallel direct solver block

### DIFF
--- a/include/deal.II/lac/block_direct_solver.h
+++ b/include/deal.II/lac/block_direct_solver.h
@@ -1,0 +1,407 @@
+/*
+ * block_direct_solver.h
+ *
+ *  Created on: Mar 18, 2020
+ *      Author: mwichro
+ */
+
+#ifndef INCLUDE_BLOCK_DIRECT_SOLVER_H_
+#define INCLUDE_BLOCK_DIRECT_SOLVER_H_
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_solver.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+
+#include <deal.II/multigrid/mg_coarse.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+using namespace dealii;
+
+template <typename LevelNumber>
+class BlockDirectSolver
+  : public MGCoarseGridBase<
+      LinearAlgebra::distributed::BlockVector<LevelNumber>>
+{
+public:
+  friend class BlockCoarseTest;
+  typedef LevelNumber                                          number;
+  typedef LinearAlgebra::distributed::BlockVector<LevelNumber> BlockVectorType;
+
+
+  // Constructor. Requires owned_partitioning[block][MPI process],
+  // relevant_partitioning[block] and MPI communicator.
+  // The owned partitioning for each block may be obtained by using
+  // DoFHandler::compute_locally_owned_dofs_per_processor() or in case of MG
+  // DoFHandler::compute_locally_owned_mg_dofs_per_processor(level)
+
+
+  BlockDirectSolver(
+    const std::vector<std::vector<IndexSet>> &owned_partitioning_,
+    const std::vector<IndexSet> &             relevant_dofs_,
+    const MPI_Comm &                          communicator);
+
+  // Computes TrilinosWrappers::SparseMatrix using internal DoF renumbering,
+  // initializes direct solver (TrilinosWrappers::SolverDirect)
+  // Level will be checked if  operator() is used
+  template <class Operator>
+  void
+  initialize(const Operator &vmult_operator, const unsigned int &lvl = 0);
+  //
+  //	template<class Operator, int dim>
+  //		void initialize(const Operator & vmult_operator,
+  //				const std::vector<DoFHandler<dim>*> &dof_handlers,
+  //				const unsigned int& lvl=0);
+  //
+
+
+  void
+  vmult(BlockVectorType &dst, const BlockVectorType &src) const;
+  // Interface to act as a coarse grid solver.
+  // Applies inverse of operator used in initialize.
+  virtual void
+  operator()(const unsigned int     lvl,
+             BlockVectorType &      dst,
+             const BlockVectorType &src) const;
+
+private:
+  typedef TrilinosWrappers::MPI::Vector InternalVectorType;
+
+  const MPI_Comm     mpi_comm;
+  const unsigned int this_mpi_process;
+  const unsigned int n_mpi_process;
+
+  int                level;
+  const unsigned int n_blocks;
+
+  types::global_dof_index n_local_dofs;
+
+  std::vector<IndexSet> owned_dofs;
+  //[block][process]
+
+
+  const std::vector<std::vector<IndexSet>> owned_partitioning;
+  const std::vector<IndexSet>              relevant_dofs;
+
+  // Searching for owning processor is in order specified by following list
+  mutable std::list<unsigned int> searching_order;
+
+  // Shitfs of dof indices, used for internal renumbering
+  std::vector<std::vector<types::global_dof_index>> dof_shifts;
+
+  std::vector<types::global_dof_index> first_block_index;
+  std::vector<types::global_dof_index> last_block_index;
+
+  // IndexSet of reordered owned dofs.
+  IndexSet shifted_owned;
+
+  std::unique_ptr<TrilinosWrappers::SparseMatrix> matrix;
+  SolverControl                                   solver_control;
+  mutable TrilinosWrappers::SolverDirect          inverse;
+
+
+  // Computes internal DoF number from external (dof, block) numbering.
+  // First checks if dof is locally owned, then searches other index sets, in
+  // order
+  // specified by searching_order.
+  types::global_dof_index
+  ext2int(const types::global_dof_index &external_dof,
+          const unsigned int             block) const;
+
+
+  // Not implemented, not needed.
+//  std::pair<types::global_dof_index, unsigned int>
+//  int2ext(types::global_dof_index &internal_dof) const;
+};
+
+template <typename LevelNumber>
+BlockDirectSolver<LevelNumber>::BlockDirectSolver(
+  const std::vector<std::vector<IndexSet>> &owned_partitioning_,
+  const std::vector<IndexSet> &             relevant_dofs_,
+  const MPI_Comm &                          communicator)
+  : mpi_comm(communicator)
+  , this_mpi_process(Utilities::MPI::this_mpi_process(communicator))
+  , n_mpi_process(Utilities::MPI::n_mpi_processes(mpi_comm))
+  , level(-1)
+  , n_blocks(relevant_dofs_.size())
+  , n_local_dofs(0)
+  , owned_partitioning(owned_partitioning_)
+  , relevant_dofs(relevant_dofs_)
+  , solver_control(10, 1e-14)
+  , inverse(solver_control)
+{
+  AssertDimension(owned_partitioning.size(), n_blocks);
+  owned_dofs.resize(n_blocks);
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      AssertDimension(owned_partitioning[b].size(), n_mpi_process);
+      owned_dofs[b] = owned_partitioning[b][this_mpi_process];
+
+      Assert(owned_dofs[b].is_ascending_and_one_to_one(mpi_comm),
+             ExcMessage("Owned sets have to ve  ascending and one to one!"));
+    }
+
+  searching_order.clear();
+  for (unsigned int i = 0; i < n_mpi_process; ++i)
+    {
+      for (unsigned int b = 0; b < n_blocks; ++b)
+        {
+          Assert(owned_partitioning[b][i].is_contiguous(),
+                 ExcMessage("Owned index set not contiguous"));
+        }
+      searching_order.push_front(i);
+    }
+
+  AssertDimension(searching_order.size(), n_mpi_process);
+
+  Assert(0 != n_blocks, ExcEmptyObject());
+  dof_shifts.resize(n_mpi_process);
+  for (unsigned int p = 0; p < n_mpi_process; ++p)
+    dof_shifts[p].resize(n_blocks);
+
+
+  std::vector<types::global_dof_index> starts(n_mpi_process, 0);
+  types::global_dof_index              n_dofs = 0;
+
+
+
+  for (unsigned int i = 1; i < n_mpi_process; ++i)
+    {
+      starts[i] = starts[i - 1];
+
+      for (unsigned int b = 0; b < n_blocks; ++b)
+        {
+          starts[i] += owned_partitioning[b][i - 1].n_elements();
+        }
+    }
+
+
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    n_dofs += owned_partitioning[b][this_mpi_process].size();
+
+
+  for (unsigned int p = 0; p < n_mpi_process; ++p)
+    {
+      dof_shifts[p][0] =
+        starts[p] - owned_partitioning[0][p].nth_index_in_set(0);
+      for (unsigned int b = 1; b < n_blocks; ++b)
+        dof_shifts[p][b] = owned_partitioning[b - 1][p].nth_index_in_set(0) +
+                           dof_shifts[p][b - 1] +
+                           owned_partitioning[b - 1][p].n_elements() -
+                           owned_partitioning[b][p].nth_index_in_set(0);
+    }
+
+  shifted_owned.set_size(n_dofs);
+
+  const unsigned int begin_range =
+    dof_shifts[this_mpi_process][0] + owned_dofs[0].nth_index_in_set(0);
+  const unsigned int end_range = owned_dofs[n_blocks - 1].nth_index_in_set(0) +
+                                 dof_shifts[this_mpi_process][n_blocks - 1] +
+                                 owned_dofs[n_blocks - 1].n_elements();
+
+  shifted_owned.add_range(begin_range, end_range);
+
+
+  n_local_dofs = 0;
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    n_local_dofs += owned_dofs[b].n_elements();
+
+  AssertDimension(n_local_dofs, shifted_owned.n_elements());
+
+  Assert(shifted_owned.is_ascending_and_one_to_one(mpi_comm),
+         ExcMessage(
+           "The shifted dofs are not valid index set (internal error)"));
+
+
+  first_block_index.resize(n_blocks);
+  last_block_index.resize(n_blocks);
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      first_block_index[b] =
+        dof_shifts[this_mpi_process][b] + owned_dofs[b].nth_index_in_set(0);
+      last_block_index[b] =
+        first_block_index[b] + owned_dofs[b].n_elements() - 1;
+    }
+
+  AssertDimension(last_block_index[n_blocks - 1],
+                  first_block_index[0] + n_local_dofs - 1);
+}
+
+
+
+template <typename LevelNumber>
+template <class Operator>
+void
+BlockDirectSolver<LevelNumber>::initialize(const Operator &    vmult_operator,
+                                           const unsigned int &lvl)
+{
+  matrix = std::make_unique<TrilinosWrappers::SparseMatrix>(shifted_owned,
+                                                            shifted_owned,
+                                                            mpi_comm,
+                                                            100);
+  level  = lvl;
+
+  BlockVectorType dst;
+  BlockVectorType src;
+
+  src.reinit(n_blocks);
+  dst.reinit(n_blocks);
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      src.block(b).reinit(owned_dofs[b], relevant_dofs[b], mpi_comm);
+      dst.block(b).reinit(owned_dofs[b], relevant_dofs[b], mpi_comm);
+    }
+  src.collect_sizes();
+  dst.collect_sizes();
+
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      for (types::global_dof_index i = 0; i < owned_dofs[b].size(); ++i)
+        {
+          src = 0;
+          dst = 0;
+          if (owned_dofs[b].is_element(i))
+            {
+              src.block(b)(i) = 1;
+            }
+
+          src.compress(VectorOperation::insert);
+          vmult_operator.vmult(dst, src);
+
+          dst.update_ghost_values();
+
+
+          for (unsigned int k = 0; k < n_blocks; ++k)
+            {
+              for (IndexSet::ElementIterator index_iter = owned_dofs[k].begin();
+                   index_iter != owned_dofs[k].end();
+                   ++index_iter)
+                {
+                  if (dst.block(k)(*index_iter) != 0)
+                    matrix->set(ext2int(*index_iter, k),
+                                ext2int(i, b),
+                                dst.block(k)(*index_iter));
+                }
+            }
+        }
+    }
+  matrix->compress(VectorOperation::unknown);
+  inverse.initialize(*matrix);
+}
+
+
+template <typename LevelNumber>
+types::global_dof_index
+BlockDirectSolver<LevelNumber>::ext2int(
+  const types::global_dof_index &external_dof,
+  const unsigned int             block) const
+{
+  // the provided dof in in our local range
+  if (owned_dofs[block].is_element(external_dof))
+    {
+      const types::global_dof_index result =
+        external_dof + dof_shifts[this_mpi_process][block];
+      Assert(shifted_owned.is_element(result),
+             ExcMessage(
+               "The computed internal DoF index is not in owned range"));
+      return result;
+    }
+  // the provided dof is in "ghost range", search for the right process
+  // we are going to access dofs owned by only few neigbour MPI processes
+  // We keep the search orders of IndexSets as a list
+  // and bring to front index set that we will find.
+  // assuming that the ghost range of vector is shared with low number of
+  // processors
+  // this is expected to be more efficient that binary search
+
+  AssertDimension(n_mpi_process, searching_order.size());
+  std::list<unsigned int>::iterator iter;
+  for (iter = searching_order.begin(); iter != searching_order.end(); ++iter)
+    if (owned_partitioning[block][*iter].is_element(external_dof))
+      {
+        // compute internal index and return
+        const unsigned int            proc = *iter;
+        const types::global_dof_index result =
+          external_dof + dof_shifts[proc][block];
+
+        searching_order.erase(iter);
+        searching_order.push_front(proc);
+
+        return result;
+      }
+
+
+  Assert(false, ExcInternalError());
+  return -1;
+}
+
+
+
+//template <typename LevelNumber>
+//std::pair<types::global_dof_index, unsigned int>
+//BlockDirectSolver<LevelNumber>::int2ext(
+//  types::global_dof_index &internal_dof) const
+//{
+//  Assert(shifted_owned.is_element(internal_dof),
+//         ExcMessage("The computed internal DoF index is not in owned range"));
+//  Assert(false, ExcNotImplemented());
+//}
+
+
+
+template <typename LevelNumber>
+void
+BlockDirectSolver<LevelNumber>::vmult(BlockVectorType &      dst,
+                                      const BlockVectorType &src) const
+{
+  InternalVectorType src_internal(shifted_owned, mpi_comm);
+  InternalVectorType dst_internal(shifted_owned, mpi_comm);
+
+
+  // Reorder src vector:
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      for (IndexSet::ElementIterator index_iter = owned_dofs[b].begin();
+           index_iter != owned_dofs[b].end();
+           ++index_iter)
+        {
+          src_internal(ext2int(*index_iter, b)) = src.block(b)(*index_iter);
+        }
+    }
+  src_internal.compress(VectorOperation::insert);
+
+  // apply direct solver
+  inverse.solve(dst_internal, src_internal);
+
+  // fill the dst vector
+  for (unsigned int b = 0; b < n_blocks; ++b)
+    {
+      for (IndexSet::ElementIterator index_iter = owned_dofs[b].begin();
+           index_iter != owned_dofs[b].end();
+           ++index_iter)
+        {
+          dst.block(b)(*index_iter) = dst_internal(ext2int(*index_iter, b));
+        }
+    }
+  dst.compress(VectorOperation::insert);
+}
+
+template <typename LevelNumber>
+void
+BlockDirectSolver<LevelNumber>::operator()(const unsigned int     lvl,
+                                           BlockVectorType &      dst,
+                                           const BlockVectorType &src) const
+{
+  AssertDimension(lvl, level);
+  (void) lvl;
+  this->vmult(dst, src);
+}
+
+
+
+#endif /* INCLUDE_BLOCK_DIRECT_SOLVER_H_ */

--- a/include/deal.II/numerics/vector_tools_copy_to_different_dof_handler.h
+++ b/include/deal.II/numerics/vector_tools_copy_to_different_dof_handler.h
@@ -1,0 +1,335 @@
+/*
+ * copy_to_different_dof_handler.h
+ *
+ *  Created on: Apr 29, 2020
+ *      Author: mwichro
+ */
+
+#ifndef INCLUDE_INTERPOLATE_TO_DIFFERENT_DOF_HANDLER_H_
+#define INCLUDE_INTERPOLATE_TO_DIFFERENT_DOF_HANDLER_H_
+
+#include <deal.II/base/quadrature.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+// apply_transform is defined here
+// I am probably including wrong file, so please check this
+#include <deal.II/numerics/vector_tools_interpolate.templates.h>
+
+namespace dealii
+{
+  namespace VectorTools
+  {
+    // Modyfied internal interpolate
+    //
+    template <int dim,
+              int spacedim,
+              typename VectorType,
+              template <int, int> class DoFHandlerType>
+    void
+    interpolate_to_different_dof_handler(
+      VectorType &                                      dst,
+      const DoFHandlerType<dim, spacedim> &             dof_handler,
+      const unsigned int &                              dst_component,
+      const LinearAlgebra::distributed::Vector<double> &src,
+      const DoFHandlerType<dim, spacedim> &             src_dofs,
+      const unsigned int &                              src_component,
+      const types::material_id on_material_id = numbers::invalid_material_id,
+      const Mapping<dim, spacedim> &mapping   = StaticMappingQ1<dim>::mapping)
+    {
+      src.update_ghost_values();
+
+      FEValuesExtractors::Scalar src_extractor(src_component);
+      ComponentMask              component_mask(
+        dof_handler.get_fe_collection().n_components(), false);
+      component_mask.set(dst_component, true);
+
+      Assert(component_mask.n_selected_components(
+               dof_handler.get_fe_collection().n_components()),
+             ComponentMask::ExcNoComponentSelected());
+
+      Assert(dst.size() == dof_handler.n_dofs(),
+             ExcDimensionMismatch(dst.size(), dof_handler.n_dofs()));
+
+      Assert(component_mask.n_selected_components(
+               dof_handler.get_fe_collection().n_components()) > 0,
+             ComponentMask::ExcNoComponentSelected());
+
+      //
+      // Computing the generalized interpolant isn't quite as straightforward
+      // as for classical Lagrange elements. A major complication is the fact
+      // it generally doesn't hold true that a function evaluates to the same
+      // dof coefficient on different cells. This means *setting* the value
+      // of a (global) degree of freedom computed on one cell doesn't
+      // necessarily lead to the same result when computed on a neighboring
+      // cell (that shares the same global degree of freedom).
+      //
+      // We thus, do the following operation:
+      //
+      // On each cell:
+      //
+      //  - We first determine all function values u(x_i) in generalized
+      //    support points
+      //
+      //  - We transform these function values back to the unit cell
+      //    according to the conformity of the component (scalar, Hdiv, or
+      //    Hcurl conforming); see [Monk, Finite Element Methods for Maxwell's
+      //    Equations, p.77ff Section 3.9] for details. This results in
+      //    \hat u(\hat x_i)
+      //
+      //  - We convert these generalized support point values to nodal values
+      //
+      //  - For every global dof we take the average 1 / n_K \sum_{K} dof_K
+      //    where n_K is the number of cells sharing the global dof and dof_K
+      //    is the computed value on the cell K.
+      //
+      // For every degree of freedom that is shared by k cells, we compute
+      // its value on all k cells and take the weighted average with respect
+      // to the JxW values.
+      //
+
+      using number = typename VectorType::value_type;
+
+      const hp::FECollection<dim, spacedim> &fe(
+        dof_handler.get_fe_collection());
+
+      std::vector<types::global_dof_index> dofs_on_cell(fe.max_dofs_per_cell());
+
+      // Temporary storage for cell-wise interpolation operation. We store a
+      // variant for every fe we encounter to speed up resizing operations.
+      // The first vector is used for local function evaluation. The vector
+      // dof_values is used to store intermediate cell-wise interpolation
+      // results (see the detailed explanation in the for loop further down
+      // below).
+
+      std::vector<std::vector<Vector<number>>> fe_function_values(fe.size());
+      std::vector<std::vector<number>>         fe_dof_values(fe.size());
+
+      // We will need two temporary global vectors that store the new values
+      //  and weights.
+      VectorType interpolation;
+      VectorType weights;
+      interpolation.reinit(dst);
+      weights.reinit(dst);
+
+
+      // Store locally owned dofs, so that we can skip all non-local dofs,
+      // if they do not need to be interpolated.
+      const IndexSet locally_owned_dofs = dst.locally_owned_elements();
+
+      // We use an FEValues object to transform all generalized support
+      // points from the unit cell to the real cell coordinates. Thus,
+      // initialize a quadrature with all generalized support points and
+      // create an FEValues object with it.
+
+      hp::QCollection<dim> support_quadrature;
+      for (unsigned int fe_index = 0; fe_index < fe.size(); ++fe_index)
+        {
+          const auto &points = fe[fe_index].get_generalized_support_points();
+          support_quadrature.push_back(Quadrature<dim>(points));
+        }
+
+      const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
+
+      // An FEValues object to evaluate (generalized) support point
+      // locations as well as Jacobians and their inverses.
+      // the latter are only needed for Hcurl or Hdiv conforming elements,
+      // but we'll just always include them.
+      hp::FEValues<dim, spacedim> fe_values(mapping_collection,
+                                            fe,
+                                            support_quadrature,
+                                            update_quadrature_points |
+                                              update_values | update_jacobians |
+                                              update_inverse_jacobians);
+
+      const hp::FECollection<dim, spacedim> &fe_src(
+        src_dofs.get_fe_collection());
+
+      hp::FEValues<dim, spacedim> fe_values_source(mapping_collection,
+                                                   fe_src,
+                                                   support_quadrature,
+                                                   update_values);
+
+      //
+      // Now loop over all locally owned, active cells.
+      //
+
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          // If this cell is not locally owned, do nothing.
+          if (!cell->is_locally_owned())
+            continue;
+
+          const unsigned int fe_index = cell->active_fe_index();
+
+          // Do nothing if there are no local degrees of freedom.
+          if (fe[fe_index].dofs_per_cell == 0)
+            continue;
+          if (cell->material_id() != on_material_id &&
+              on_material_id != numbers::invalid_material_id)
+            continue;
+
+
+
+          // Get transformed, generalized support points
+          fe_values.reinit(cell);
+          const std::vector<Point<spacedim>> &generalized_support_points =
+            fe_values.get_present_fe_values().get_quadrature_points();
+
+          // Get indices of the dofs on this cell
+          const auto n_dofs = fe[fe_index].dofs_per_cell;
+          dofs_on_cell.resize(n_dofs);
+          cell->get_dof_indices(dofs_on_cell);
+
+          // Prepare temporary storage
+          auto &function_values = fe_function_values[fe_index];
+          auto &dof_values      = fe_dof_values[fe_index];
+
+          const auto n_components = fe[fe_index].n_components();
+          function_values.resize(generalized_support_points.size(),
+                                 Vector<number>(n_components));
+          dof_values.resize(n_dofs);
+
+
+
+          // Interpolate extisting values on cell with other material ID
+          //          if (cell->material_id() != on_material_id
+          //        		  && on_material_id != numbers::invalid_material_id){
+          //        	  fe_values.get_present_fe_values()
+          //        			  .get_function_values(dst,function_values  );
+          //
+          //          }else
+
+          {
+            // Get cell iterator with src DoFHandler
+
+            typename DoFHandlerType<dim, spacedim>::active_cell_iterator
+              src_cell(&(src_dofs.get_triangulation()),
+                       cell->level(),
+                       cell->index(),
+                       &src_dofs);
+            // reinit fe_values_source
+            fe_values_source.reinit(src_cell);
+
+            // And get all function values:
+            std::vector<double> source_values(
+              generalized_support_points.size());
+            fe_values_source.get_present_fe_values()[src_extractor]
+              .get_function_values(src, source_values);
+            for (unsigned int i = 0; i < source_values.size(); ++i)
+              function_values[i](dst_component) = source_values[i];
+          }
+
+          //          function(cell)->vector_value_list(generalized_support_points,
+          //                                            function_values);
+
+          {
+            // Before we can average, we have to transform all function values
+            // from the real cell back to the unit cell. We query the finite
+            // element for the correct transformation. Matters get a bit more
+            // complicated because we have to apply said transformation for
+            // every base element.
+
+            const unsigned int offset =
+              internal::apply_transform(fe[fe_index],
+                                        /* starting_offset = */ 0,
+                                        fe_values,
+                                        function_values);
+            (void)offset;
+            Assert(offset == n_components, ExcInternalError());
+          }
+
+          FETools::convert_generalized_support_point_values_to_dof_values(
+            fe[fe_index], function_values, dof_values);
+
+          for (unsigned int i = 0; i < n_dofs; ++i)
+            {
+              const auto &nonzero_components =
+                fe[fe_index].get_nonzero_components(i);
+
+              // Figure out whether the component mask applies. We assume
+              // that we are allowed to set degrees of freedom if at least
+              // one of the components (of the dof) is selected.
+              bool selected = false;
+              for (unsigned int c = 0; c < nonzero_components.size(); ++c)
+                selected =
+                  selected || (nonzero_components[c] && component_mask[c]);
+
+              if (selected)
+                {
+#ifdef DEBUG
+                  // make sure that all selected base elements are indeed
+                  // interpolatory
+
+                  if (const auto fe_system =
+                        dynamic_cast<const FESystem<dim> *>(&fe[fe_index]))
+                    {
+                      const auto index =
+                        fe_system->system_to_base_index(i).first.first;
+                      Assert(fe_system->base_element(index)
+                               .has_generalized_support_points(),
+                             ExcMessage("The component mask supplied to "
+                                        "VectorTools::interpolate selects a "
+                                        "non-interpolatory element."));
+                    }
+#endif
+
+                  // Add local values to the global vectors
+                  ::dealii::internal::ElementAccess<VectorType>::add(
+                    dof_values[i], dofs_on_cell[i], interpolation);
+                  ::dealii::internal::ElementAccess<VectorType>::add(
+                    typename VectorType::value_type(1.0),
+                    dofs_on_cell[i],
+                    weights);
+                }
+              else
+                {
+                  // If a component is ignored, copy the dof values
+                  // from the vector "dst", but only if they are locally
+                  // available
+                  if (locally_owned_dofs.is_element(dofs_on_cell[i]))
+                    {
+                      const auto value =
+                        ::dealii::internal::ElementAccess<VectorType>::get(
+                          dst, dofs_on_cell[i]);
+                      ::dealii::internal::ElementAccess<VectorType>::add(
+                        value, dofs_on_cell[i], interpolation);
+                      ::dealii::internal::ElementAccess<VectorType>::add(
+                        typename VectorType::value_type(1.0),
+                        dofs_on_cell[i],
+                        weights);
+                    }
+                }
+            }
+        } /* loop over dof_handler.active_cell_iterators() */
+
+      interpolation.compress(VectorOperation::add);
+      weights.compress(VectorOperation::add);
+
+      for (const auto i : interpolation.locally_owned_elements())
+        {
+          const auto weight =
+            ::dealii::internal::ElementAccess<VectorType>::get(weights, i);
+
+          // See if we touched this DoF at all. If so, set the average
+          // of the value we computed in the output vector. Otherwise,
+          // don't touch the value at all.
+          if (weight != number(0))
+            {
+              const auto value =
+                ::dealii::internal::ElementAccess<VectorType>::get(
+                  interpolation, i);
+              ::dealii::internal::ElementAccess<VectorType>::set(value / weight,
+                                                                 i,
+                                                                 dst);
+            }
+        }
+      //      dst.compress(VectorOperation::insert);
+      dst.update_ghost_values();
+    }
+
+  } // namespace VectorTools
+} // namespace dealii
+#endif /* INCLUDE_INTERPOLATE_TO_DIFFERENT_DOF_HANDLER_H_ */


### PR DESCRIPTION
The initial application was solving coarse Stokes problem for matrix-free mg solver.
The initialization assembles the matrix using N vmults, than initializes Trilinos direct solver.
The internal DoF renumbering is implemented, so the internal matrix is standar SparseMatrix (non-block).
It could be extended to be initialized from BlockSparseMatrix by reordering rows (reordering is already implemented)

This is related to PR #9723 