### PR TITLE
base/utilities_pack_unpack_07: Add a variant for clang-10/libc++

### DIFF
--- a/tests/base/utilities_pack_unpack_07.with_zlib=on.output.libc++
+++ b/tests/base/utilities_pack_unpack_07.with_zlib=on.output.libc++
@@ -1,0 +1,8 @@
+
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 14690
+DEAL::unpacked array: 80000
+DEAL::packed array without compression: 80048
+DEAL::packed array with compression: 75570
+DEAL::OK!


### PR DESCRIPTION
Unfortunately, the compression level changes significantly for
clang-10/libc++. Add an output variant