### PR TITLE
Undo accidental change in test result file with LAPACK

### DIFF
--- a/tests/matrix_free/step-37-inhomogeneous-1.with_lapack=true.with_mpi=true.mpirun=4.with_p4est=true.output
+++ b/tests/matrix_free/step-37-inhomogeneous-1.with_lapack=true.with_mpi=true.mpirun=4.with_p4est=true.output
@@ -147,3 +147,4 @@ DEAL:3:cg::Starting value 9.30402
 DEAL:3:cg::Convergence step 7 value 9.36336e-13
 DEAL:3:cg::Starting value 8.99023
 DEAL:3:cg::Convergence step 7 value 1.22268e-12
+


### PR DESCRIPTION
This was accidentally changed in #10050 when marking this test as depending on LAPACK. Fixes the test failure
https://cdash.43-1.org/testDetails.php?test=43666160&build=6160