### PR TITLE
Make a few tests check what they are supposed to

### DIFF
--- a/tests/matrix_free/pre_and_post_loops_01.cc
+++ b/tests/matrix_free/pre_and_post_loops_01.cc
@@ -159,11 +159,13 @@ test()
 
   for (unsigned int i = 0; i < vec1.local_size(); ++i)
     {
-      double entry          = random_value<double>();
+      // Multiply by 0.01 to make float error with roundoff less than the
+      // numdiff absolute tolerance
+      double entry          = 0.01 * random_value<double>();
       vec1.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec2.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec3.local_element(i) = entry;
     }
 
@@ -172,7 +174,7 @@ test()
   LinearAlgebra::distributed::Vector<number> ref3 = vec3;
 
   mf.vmult_with_update_basic(ref3, ref2, ref1);
-  mf.vmult_with_update_basic(vec3, vec2, vec1);
+  mf.vmult_with_update_merged(vec3, vec2, vec1);
 
   vec3 -= ref3;
   deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
@@ -181,10 +183,10 @@ test()
   ref3 = 0;
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   vec3 -= ref3;
   deallog << "Error in 2x merged operation: " << vec3.linfty_norm()

--- a/tests/matrix_free/pre_and_post_loops_02.cc
+++ b/tests/matrix_free/pre_and_post_loops_02.cc
@@ -172,11 +172,13 @@ test()
             vec1.get_partitioner()->local_to_global(i)))
         continue;
 
-      double entry          = random_value<double>();
+      // Multiply by 0.01 to make float error with roundoff less than the
+      // numdiff absolute tolerance
+      double entry          = 0.01 * random_value<double>();
       vec1.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec2.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec3.local_element(i) = entry;
     }
 
@@ -185,7 +187,7 @@ test()
   LinearAlgebra::distributed::Vector<number> ref3 = vec3;
 
   mf.vmult_with_update_basic(ref3, ref2, ref1);
-  mf.vmult_with_update_basic(vec3, vec2, vec1);
+  mf.vmult_with_update_merged(vec3, vec2, vec1);
 
   vec3 -= ref3;
   deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
@@ -194,10 +196,10 @@ test()
   ref3 = 0;
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   vec3 -= ref3;
   deallog << "Error in 2x merged operation: " << vec3.linfty_norm()

--- a/tests/matrix_free/pre_and_post_loops_03.cc
+++ b/tests/matrix_free/pre_and_post_loops_03.cc
@@ -161,11 +161,13 @@ test()
 
   for (unsigned int i = 0; i < vec1.local_size(); ++i)
     {
-      double entry          = random_value<double>();
+      // Multiply by 0.01 to make float error with roundoff less than the
+      // numdiff absolute tolerance
+      double entry          = 0.01 * random_value<double>();
       vec1.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec2.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec3.local_element(i) = entry;
     }
 
@@ -174,7 +176,7 @@ test()
   LinearAlgebra::distributed::Vector<number> ref3 = vec3;
 
   mf.vmult_with_update_basic(ref3, ref2, ref1);
-  mf.vmult_with_update_basic(vec3, vec2, vec1);
+  mf.vmult_with_update_merged(vec3, vec2, vec1);
 
   vec3 -= ref3;
   deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
@@ -183,10 +185,10 @@ test()
   ref3 = 0;
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   vec3 -= ref3;
   deallog << "Error in 2x merged operation: " << vec3.linfty_norm()

--- a/tests/matrix_free/pre_and_post_loops_04.cc
+++ b/tests/matrix_free/pre_and_post_loops_04.cc
@@ -158,11 +158,13 @@ test()
 
   for (unsigned int i = 0; i < vec1.local_size(); ++i)
     {
-      double entry          = random_value<double>();
+      // Multiply by 0.01 to make float error with roundoff less than the
+      // numdiff absolute tolerance
+      double entry          = 0.01 * random_value<double>();
       vec1.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec2.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec3.local_element(i) = entry;
     }
 
@@ -171,7 +173,7 @@ test()
   LinearAlgebra::distributed::Vector<number> ref3 = vec3;
 
   mf.vmult_with_update_basic(ref3, ref2, ref1);
-  mf.vmult_with_update_basic(vec3, vec2, vec1);
+  mf.vmult_with_update_merged(vec3, vec2, vec1);
 
   vec3 -= ref3;
   deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
@@ -180,10 +182,10 @@ test()
   ref3 = 0;
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   vec3 -= ref3;
   deallog << "Error in 2x merged operation: " << vec3.linfty_norm()

--- a/tests/matrix_free/pre_and_post_loops_05.cc
+++ b/tests/matrix_free/pre_and_post_loops_05.cc
@@ -175,11 +175,13 @@ test()
 
   for (unsigned int i = 0; i < vec1.local_size(); ++i)
     {
-      double entry          = random_value<double>();
+      // Multiply by 0.01 to make float error with roundoff less than the
+      // numdiff absolute tolerance
+      double entry          = 0.01 * random_value<double>();
       vec1.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec2.local_element(i) = entry;
-      entry                 = random_value<double>();
+      entry                 = 0.01 * random_value<double>();
       vec3.local_element(i) = entry;
     }
 
@@ -188,7 +190,7 @@ test()
   LinearAlgebra::distributed::Vector<number> ref3 = vec3;
 
   mf.vmult_with_update_basic(ref3, ref2, ref1);
-  mf.vmult_with_update_basic(vec3, vec2, vec1);
+  mf.vmult_with_update_merged(vec3, vec2, vec1);
 
   vec3 -= ref3;
   deallog << "Error in 1x merged operation: " << vec3.linfty_norm()
@@ -197,10 +199,10 @@ test()
   ref3 = 0;
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   mf.vmult_with_update_basic(ref1, ref2, ref3);
-  mf.vmult_with_update_basic(vec1, vec2, vec3);
+  mf.vmult_with_update_merged(vec1, vec2, vec3);
 
   vec3 -= ref3;
   deallog << "Error in 2x merged operation: " << vec3.linfty_norm()


### PR DESCRIPTION
These tests, created in #8728, are supposed to compare matrix-free loops with merged operations to those without. However, I created a big bug in the test and compared the reference output (`_basic`) with the reference output (`_basic`), rather than `_merged`. While fixing the test, I also changed the size of the input vector by multiplication with `0.01` so that relative float roundoff differences in the range 1e-6..1e-5 give absolute errors less than the numdiff absolute tolerance of 1e-6.

Found while working on #9405.