### PR TITLE
remove boost include to fix compilation

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -44,7 +44,6 @@
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <boost/archive/binary_iarchive.hpp>
 #  include <boost/archive/binary_oarchive.hpp>
-#  include <boost/geometry/index/detail/serialization.hpp>
 #  include <boost/geometry/index/rtree.hpp>
 #  include <boost/serialization/array.hpp>
 #  include <boost/serialization/vector.hpp>


### PR DESCRIPTION
fixes #10088

I don't see a reason to include this header (detail/ is probably not supposed to be included directly).