### PR TITLE
hide boost deprecation warning with 1.73

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -20,11 +20,15 @@
 #include <deal.II/base/path_search.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/algorithm/string.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <algorithm>
 #include <cctype>

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -20,10 +20,14 @@
 #include <deal.II/base/patterns.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/io/ios_state.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <algorithm>
 #include <cctype>

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -28,13 +28,15 @@
 #include <deal.II/base/thread_local_storage.h>
 #include <deal.II/base/utilities.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/archive/iterators/base64_from_binary.hpp>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/iostreams/copy.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/random.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <algorithm>

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -42,6 +42,7 @@
 #include <deal.II/multigrid/mg_tools.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/config.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/bandwidth.hpp>
@@ -51,6 +52,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/graph/properties.hpp>
 #include <boost/random.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <algorithm>


### PR DESCRIPTION
boost 1.73 deprecated boost/bind.hpp but uses it internally. Defining
this macro silences the warnings.

fixes #10090