### PR TITLE
Fix if-statements with check_for_distorted_cells.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2197,7 +2197,7 @@ namespace internal
               // to exist. If a cell has negative measure, then it must be
               // distorted (the converse is not necessarily true); hence
               // throw an exception if no such cells should exist.
-              if (!tria.check_for_distorted_cells)
+              if (tria.check_for_distorted_cells)
                 {
                   const double cell_measure =
                     GridTools::cell_measure<dim>(vertices,
@@ -4453,7 +4453,7 @@ namespace internal
                                   next_unused_cell,
                                   cell);
 
-                  if ((check_for_distorted_cells == true) &&
+                  if (check_for_distorted_cells &&
                       has_distorted_children(
                         cell,
                         std::integral_constant<int, dim>(),
@@ -8820,7 +8820,7 @@ namespace internal
 
                   // now see if we have created cells that are
                   // distorted and if so add them to our list
-                  if ((check_for_distorted_cells == true) &&
+                  if (check_for_distorted_cells &&
                       has_distorted_children(
                         hex,
                         std::integral_constant<int, dim>(),
@@ -9685,7 +9685,7 @@ Triangulation<dim, spacedim>::create_triangulation(
   // now verify that there are indeed no distorted cells. as per the
   // documentation of this class, we first collect all distorted cells
   // and then throw an exception if there are any
-  if (check_for_distorted_cells == true)
+  if (check_for_distorted_cells)
     {
       DistortedCellList distorted_cells = collect_distorted_coarse_cells(*this);
       // throw the array (and fill the various location fields) if

--- a/tests/bits/distorted_cells_01.cc
+++ b/tests/bits/distorted_cells_01.cc
@@ -83,6 +83,11 @@ check(const unsigned int testcase)
       Assert(dcv.distorted_cells.front() == coarse_grid.begin(0),
              ExcInternalError());
     }
+  catch (ExceptionBase &exc)
+    {
+      deallog << exc.get_exc_name() << std::endl;
+      flag = true;
+    }
 
   Assert(flag == true, ExcInternalError());
 }

--- a/tests/bits/distorted_cells_01.debug.output
+++ b/tests/bits/distorted_cells_01.debug.output
@@ -1,13 +1,13 @@
 
 DEAL::Pinched cell in 1d
-DEAL::1 distorted cells
+DEAL::ExcGridHasInvalidCell(cell_no)
 DEAL::Pinched cell in 2d
 DEAL::1 distorted cells
 DEAL::Pinched cell in 3d
 DEAL::1 distorted cells
 DEAL::Twisted cell in 1d
-DEAL::1 distorted cells
+DEAL::ExcGridHasInvalidCell(cell_no)
 DEAL::Twisted cell in 2d
-DEAL::1 distorted cells
+DEAL::ExcGridHasInvalidCell(cell_no)
 DEAL::Twisted cell in 3d
 DEAL::1 distorted cells

--- a/tests/bits/distorted_cells_02.cc
+++ b/tests/bits/distorted_cells_02.cc
@@ -53,18 +53,13 @@ check()
     {
       gi.read_ucd(in);
     }
-  catch (typename Triangulation<dim>::DistortedCellList &dcv)
+  catch (ExceptionBase &exc)
     {
+      deallog << exc.get_exc_name() << std::endl;
       flag = true;
-
-      deallog << dcv.distorted_cells.size() << " distorted cells" << std::endl;
-      Assert(dcv.distorted_cells.front() == coarse_grid.begin(0),
-             ExcInternalError());
     }
 
   Assert(flag == true, ExcInternalError());
-  Assert(coarse_grid.n_levels() == 1, ExcInternalError());
-  Assert(coarse_grid.n_active_cells() == 1, ExcInternalError());
 }
 
 

--- a/tests/bits/distorted_cells_02.debug.output
+++ b/tests/bits/distorted_cells_02.debug.output
@@ -1,3 +1,3 @@
 
-DEAL::1 distorted cells
-DEAL::1 distorted cells
+DEAL::ExcGridHasInvalidCell(cell_no)
+DEAL::ExcGridHasInvalidCell(cell_no)

--- a/tests/bits/distorted_cells_07.cc
+++ b/tests/bits/distorted_cells_07.cc
@@ -74,23 +74,28 @@ check(const unsigned int testcase)
   catch (typename Triangulation<dim>::DistortedCellList &dcv)
     {
       flag = true;
+
+      // now build an FEValues object and compute quadrature points on that cell
+      FE_Nothing<dim> dummy;
+      QGauss<dim>     quadrature(2);
+      FEValues<dim>   fe_values(dummy, quadrature, update_JxW_values);
+      // should throw an assertion
+      try
+        {
+          fe_values.reinit(coarse_grid.begin());
+        }
+      catch (ExceptionBase &e)
+        {
+          deallog << e.get_exc_name() << std::endl;
+        }
+    }
+  catch (ExceptionBase &exc)
+    {
+      deallog << exc.get_exc_name() << std::endl;
+      flag = true;
     }
 
   Assert(flag == true, ExcInternalError());
-
-  // now build an FEValues object and compute quadrature points on that cell
-  FE_Nothing<dim> dummy;
-  QGauss<dim>     quadrature(2);
-  FEValues<dim>   fe_values(dummy, quadrature, update_JxW_values);
-  // should throw an assertion
-  try
-    {
-      fe_values.reinit(coarse_grid.begin());
-    }
-  catch (ExceptionBase &e)
-    {
-      deallog << e.get_exc_name() << std::endl;
-    }
 }
 
 

--- a/tests/bits/distorted_cells_07.debug.output
+++ b/tests/bits/distorted_cells_07.debug.output
@@ -1,7 +1,7 @@
 
 DEAL::Twisted cell in 1d
-DEAL::(typename Mapping<dim,spacedim>::ExcDistortedMappedCell(cell->center(), det, point))
+DEAL::ExcGridHasInvalidCell(cell_no)
 DEAL::Twisted cell in 2d
-DEAL::(typename Mapping<dim,spacedim>::ExcDistortedMappedCell(cell->center(), det, point))
+DEAL::ExcGridHasInvalidCell(cell_no)
 DEAL::Twisted cell in 3d
-DEAL::(typename Mapping<dim,spacedim>::ExcDistortedMappedCell(cell->center(), det, point))
+DEAL::(typename Mapping<dim, spacedim>::ExcDistortedMappedCell( cell->center(), det, point))


### PR DESCRIPTION
If `check_for_distorted_cells`, we should check for negative measures. Previously it was `!check_for_distorted_cells`.

Also replaced some `if (check_for_distorted_cells == true)`, to if `(check_for_distorted_cells)`. I don't see the advantage in readability (correct me if I'm wrong).