### PR TITLE
fix copyright update script updating itself

### DIFF
--- a/contrib/utilities/update-copyright
+++ b/contrib/utilities/update-copyright
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2015 -  by the deal.II authors
+## Copyright (C) 2015 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/contrib/utilities/update-copyright
+++ b/contrib/utilities/update-copyright
@@ -17,7 +17,7 @@
 
 # Purpose: Update the copyright year of every file based on the last
 #          modification recorded in the git logs
-
+#
 
 if test ! -d source -o ! -d include -o ! -d examples ; then
   echo "*** This script must be run from the top-level directory of deal.II."


### PR DESCRIPTION
When updating the update-copyright script, we happen to ignore all commits to this file (as they itself contain the words "update copyright"). This breaks the formatting of the year. To repair:
- add a nonsensical commit that does not use a message that contains "update copyright"
- run the update-copyright script.

