### PR TITLE
Fix compilation with gcc-10

### DIFF
--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -3841,7 +3841,8 @@ namespace Differentiation
               typename ScalarType>
     template <typename ExtractorType>
     typename internal::Extractor<dim, ExtractorType>::template tensor_type<
-      typename HelperBase<ADNumberTypeCode, ScalarType>::ad_type>
+      typename PointLevelFunctionsBase<dim, ADNumberTypeCode, ScalarType>::
+        ad_type>
     PointLevelFunctionsBase<dim, ADNumberTypeCode, ScalarType>::
       get_sensitive_variables(const ExtractorType &extractor) const
     {


### PR DESCRIPTION
When compiling deal.II with the new gcc-10.1, I observed an error in `ad_helpers.cc`. It turns out that the compiler is insisting on getting the exact type of `ad_type` in the definition of the declaration
https://github.com/dealii/dealii/blob/68a7a68f5e2d3e47619bf78970f6fd67bacbe775/include/deal.II/differentiation/ad/ad_helpers.h#L2807-L2810
and ignores the reference to the base class
https://github.com/dealii/dealii/blob/68a7a68f5e2d3e47619bf78970f6fd67bacbe775/include/deal.II/differentiation/ad/ad_helpers.h#L2661-L2662

I'm not sure at the moment whether the compiler is to blame or rules really have become more strict, but since my time to investigate this further is limited and the new way of doing things is not wrong, I think we can happy with this.