### PR TITLE
Qualify a call to parallel::apply_to_subrange

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -4571,7 +4571,7 @@ namespace internal
           if (range_index == numbers::invalid_unsigned_int)
             {
               // Case with threaded loop -> currently no overlap implemented
-              parallel::apply_to_subranges(
+              dealii::parallel::apply_to_subranges(
                 0U,
                 dof_info.vector_partitioner->local_size(),
                 operation_before_loop,
@@ -4601,7 +4601,7 @@ namespace internal
           if (range_index == numbers::invalid_unsigned_int)
             {
               // Case with threaded loop -> currently no overlap implemented
-              parallel::apply_to_subranges(
+              dealii::parallel::apply_to_subranges(
                 0U,
                 dof_info.vector_partitioner->local_size(),
                 operation_after_loop,


### PR DESCRIPTION
`clang-tidy` reports in #9883 an error in a function introduced in #10084 - there it did not trigger, interestingly. To avoid ambiguity, it is good to fully qualify the call.