### PR TITLE
Mark LaplaceOperator::apply_add as override

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -918,7 +918,7 @@ namespace MatrixFreeOperators
      * using initialize_dof_vector().
      */
     virtual void
-    apply_add(VectorType &dst, const VectorType &src) const;
+    apply_add(VectorType &dst, const VectorType &src) const override;
 
     /**
      * Applies the Laplace operator on a cell.


### PR DESCRIPTION
In #9883 for `step-50` we got another error about a missing `override` statement. I went through the class in question again and I hope we now got them all.