### PR TITLE
Fix umlaut in tooltip of tutorial graph

### DIFF
--- a/examples/step-58/doc/tooltip
+++ b/examples/step-58/doc/tooltip
@@ -1,1 +1,1 @@
-The complex-valued Nonlinear Schr&ouml;dinger Equation
+The complex-valued Nonlinear Schrödinger Equation


### PR DESCRIPTION
The html code for the umlaut in step-58 breaks the generation of the
graph for me (strangely, it works fine online), while using the umlaut directly seems to work.