### PR TITLE
Reverse order of mapping and triangulation in compute_aspect_ratio

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -260,8 +260,8 @@ namespace GridTools
    */
   template <int dim>
   Vector<double>
-  compute_aspect_ratio_of_cells(const Triangulation<dim> &triangulation,
-                                const Mapping<dim> &      mapping,
+  compute_aspect_ratio_of_cells(const Mapping<dim> &      mapping,
+                                const Triangulation<dim> &triangulation,
                                 const Quadrature<dim> &   quadrature);
 
   /**
@@ -275,8 +275,8 @@ namespace GridTools
    */
   template <int dim>
   double
-  compute_maximum_aspect_ratio(const Triangulation<dim> &triangulation,
-                               const Mapping<dim> &      mapping,
+  compute_maximum_aspect_ratio(const Mapping<dim> &      mapping,
+                               const Triangulation<dim> &triangulation,
                                const Quadrature<dim> &   quadrature);
 
   /**

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -189,8 +189,8 @@ namespace GridTools
 
   template <int dim>
   Vector<double>
-  compute_aspect_ratio_of_cells(const Triangulation<dim> &triangulation,
-                                const Mapping<dim> &      mapping,
+  compute_aspect_ratio_of_cells(const Mapping<dim> &      mapping,
+                                const Triangulation<dim> &triangulation,
                                 const Quadrature<dim> &   quadrature)
   {
     FE_Nothing<dim> fe;
@@ -255,12 +255,12 @@ namespace GridTools
 
   template <int dim>
   double
-  compute_maximum_aspect_ratio(const Triangulation<dim> &triangulation,
-                               const Mapping<dim> &      mapping,
+  compute_maximum_aspect_ratio(const Mapping<dim> &      mapping,
+                               const Triangulation<dim> &triangulation,
                                const Quadrature<dim> &   quadrature)
   {
     Vector<double> aspect_ratio_vector =
-      compute_aspect_ratio_of_cells(triangulation, mapping, quadrature);
+      compute_aspect_ratio_of_cells(mapping, triangulation, quadrature);
 
     return VectorTools::compute_global_error(triangulation,
                                              aspect_ratio_vector,

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -178,13 +178,13 @@ for (deal_II_space_dimension : SPACE_DIMENSIONS)
       const std::vector<BoundingBox<deal_II_space_dimension>> &, MPI_Comm);
 
     template Vector<double> GridTools::compute_aspect_ratio_of_cells(
-      const Triangulation<deal_II_space_dimension> &,
       const Mapping<deal_II_space_dimension> &,
+      const Triangulation<deal_II_space_dimension> &,
       const Quadrature<deal_II_space_dimension> &);
 
     template double GridTools::compute_maximum_aspect_ratio(
-      const Triangulation<deal_II_space_dimension> &,
       const Mapping<deal_II_space_dimension> &,
+      const Triangulation<deal_II_space_dimension> &,
       const Quadrature<deal_II_space_dimension> &);
   }
 

--- a/tests/grid/grid_generator_open_torus.cc
+++ b/tests/grid/grid_generator_open_torus.cc
@@ -52,9 +52,9 @@ test()
   QGauss<3> const          gauss(4);
 
   double const ar_full_torus =
-    GridTools::compute_maximum_aspect_ratio(tria, mapping, gauss);
+    GridTools::compute_maximum_aspect_ratio(mapping, tria, gauss);
   double const ar_open_torus =
-    GridTools::compute_maximum_aspect_ratio(tria_open, mapping, gauss);
+    GridTools::compute_maximum_aspect_ratio(mapping, tria_open, gauss);
 
   deallog << "N_active_cells_full = " << tria.n_global_active_cells()
           << std::endl;

--- a/tests/grid/grid_tools_aspect_ratio.cc
+++ b/tests/grid/grid_tools_aspect_ratio.cc
@@ -76,7 +76,7 @@ compute_aspect_ratio_hyper_rectangle(
   QGauss<dim> const          gauss(n_q_points);
 
   Vector<double> ratios =
-    GridTools::compute_aspect_ratio_of_cells(tria, mapping, gauss);
+    GridTools::compute_aspect_ratio_of_cells(mapping, tria, gauss);
 
   deallog << std::endl
           << "Parameters:"
@@ -87,7 +87,7 @@ compute_aspect_ratio_hyper_rectangle(
   deallog << "Aspect ratio vector = " << std::endl;
   ratios.print(deallog.get_file_stream());
 
-  return GridTools::compute_maximum_aspect_ratio(tria, mapping, gauss);
+  return GridTools::compute_maximum_aspect_ratio(mapping, tria, gauss);
 }
 
 int


### PR DESCRIPTION
Closes #10109.

This makes the order consistent with the other functions in the `GridTools` namespace and elsewhere in deal.II. The function was not released before, so changing it should be uncritical.