### PR TITLE
Fix dim<spacedim case in create_triangulation with TriaDescription

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10749,16 +10749,16 @@ Triangulation<dim, spacedim>::create_triangulation(
           {
             while (cell_info->id != cell->id().template to_binary<dim>())
               ++cell;
-            if (spacedim == 3)
+            if (dim == 3)
               for (unsigned int quad = 0;
-                   quad < GeometryInfo<spacedim>::quads_per_cell;
+                   quad < GeometryInfo<dim>::quads_per_cell;
                    ++quad)
                 cell->quad(quad)->set_manifold_id(
                   cell_info->manifold_quad_ids[quad]);
 
-            if (spacedim >= 2)
+            if (dim >= 2)
               for (unsigned int line = 0;
-                   line < GeometryInfo<spacedim>::lines_per_cell;
+                   line < GeometryInfo<dim>::lines_per_cell;
                    ++line)
                 cell->line(line)->set_manifold_id(
                   cell_info->manifold_line_ids[line]);


### PR DESCRIPTION
The bug that is fixed here was revealed by a warning of gcc-10 and shows that warnings can indeed be useful:
https://cdash.43-1.org/viewBuildError.php?type=1&buildid=6244
The code in question made loops over `spacedim`, but in `dim<spacedim` settings the topology dimension of the mesh is `dim`, so we should only query data structures of that dimension.

This is in the new function for `TriangulationDescription` introduced in #9195 and we apparently do not test it in the `dim<spacedim` case.