### PR TITLE
Test adolc/helper_scalar_coupled_3_components_01* - fix race condition

### DIFF
--- a/tests/arpack/step-36_ar.cc
+++ b/tests/arpack/step-36_ar.cc
@@ -223,12 +223,15 @@ namespace Step36
     ArpackSolver::AdditionalData additional_data(
       num_arnoldi_vectors, ArpackSolver::largest_magnitude, true);
     ArpackSolver eigensolver(solver_control, additional_data);
-    eigensolver.solve(stiffness_matrix,
-                      mass_matrix,
-                      inverse,
-                      eigenvalues,
-                      eigenfunctions,
-                      eigenvalues.size());
+    check_solver_within_range(eigensolver.solve(stiffness_matrix,
+                                                mass_matrix,
+                                                inverse,
+                                                eigenvalues,
+                                                eigenfunctions,
+                                                eigenvalues.size()),
+                              solver_control.last_step(),
+                              2,
+                              10);
 
     // make sure that we have eigenvectors and they are mass-orthonormal:
     // a) (A*x_i-\lambda*B*x_i).L2() == 0

--- a/tests/arpack/step-36_ar.with_umfpack=true.output
+++ b/tests/arpack/step-36_ar.with_umfpack=true.output
@@ -1,5 +1,5 @@
 
-DEAL::Convergence step 8 value 0.00000
+DEAL::Solver stopped within 2 - 10 iterations
 DEAL::      Eigenvalue 0 : (4.93877,0.00000)
 DEAL::      Eigenvalue 1 : (12.3707,0.00000)
 DEAL::      Eigenvalue 2 : (12.3707,0.00000)

--- a/tests/arpack/step-36_ar_with_iterations.cc
+++ b/tests/arpack/step-36_ar_with_iterations.cc
@@ -223,12 +223,15 @@ namespace Step36
     ArpackSolver::AdditionalData additional_data(
       num_arnoldi_vectors, ArpackSolver::largest_magnitude, true);
     ArpackSolver eigensolver(solver_control, additional_data);
-    eigensolver.solve(stiffness_matrix,
-                      mass_matrix,
-                      inverse,
-                      eigenvalues,
-                      eigenfunctions,
-                      eigenvalues.size());
+    check_solver_within_range(eigensolver.solve(stiffness_matrix,
+                                                mass_matrix,
+                                                inverse,
+                                                eigenvalues,
+                                                eigenfunctions,
+                                                eigenvalues.size()),
+                              solver_control.last_step(),
+                              2,
+                              10);
 
     // make sure that we have eigenvectors and they are mass-orthonormal:
     // a) (A*x_i-\lambda*B*x_i).L2() == 0

--- a/tests/arpack/step-36_ar_with_iterations.with_umfpack=true.output
+++ b/tests/arpack/step-36_ar_with_iterations.with_umfpack=true.output
@@ -1,5 +1,5 @@
 
-DEAL::Convergence step 8 value 0.00000
+DEAL::Solver stopped within 2 - 10 iterations
 DEAL::8 iterations used
 DEAL::      Eigenvalue 0 : (4.93877,0.00000)
 DEAL::      Eigenvalue 1 : (12.3707,0.00000)


### PR DESCRIPTION
All tests of a test variant have to be annotated by
"with_mpi=true.mpirun=" otherwise we risk the chance of the executable
being temporarily deleted and recompiled.

In reference to #10073
See also: https://cdash.43-1.org/testDetails.php?test=43888682&build=6235