### PR TITLE
Test vector_tools/integrate_difference_04_hp_02: Make test less expensive

### DIFF
--- a/tests/vector_tools/integrate_difference_04_hp_02.cc
+++ b/tests/vector_tools/integrate_difference_04_hp_02.cc
@@ -86,7 +86,7 @@ test(VectorTools::NormType norm, double value, double exp = 2.0)
     false,
     parallel::shared::Triangulation<dim>::partition_metis);
   GridGenerator::hyper_cube(tria);
-  tria.refine_global(3);
+  tria.refine_global(2);
 
   hp::FECollection<dim> fe;
   fe.push_back(FESystem<dim>(FE_Q<dim>(4), dim));
@@ -186,5 +186,6 @@ main(int argc, char **argv)
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
+  deallog << std::setprecision(10) << std::endl;
   test<3>();
 }

--- a/tests/vector_tools/integrate_difference_04_hp_02.with_trilinos=true.with_metis=true.mpirun=2.output
+++ b/tests/vector_tools/integrate_difference_04_hp_02.with_trilinos=true.with_metis=true.mpirun=2.output
@@ -1,41 +1,43 @@
 
+DEAL:0::
 DEAL:0::Hdiv_seminorm:
-DEAL:0::computed: 3.05510 expected: 3.05505 difference: 5.01434e-05
+DEAL:0::computed: 3.055252042 expected: 3.055050463 difference: 0.0002015790263
 DEAL:0::L2_norm:
-DEAL:0::computed: 1.95383 expected: 1.95363 difference: 0.000196056
+DEAL:0::computed: 1.954418539 expected: 1.953629102 difference: 0.0007894373030
 DEAL:0::H1_seminorm:
-DEAL:0::computed: 2.70815 expected: 2.70801 difference: 0.000141421
+DEAL:0::computed: 2.708581290 expected: 2.708012802 difference: 0.0005684886150
 DEAL:0::H1_norm:
-DEAL:0::computed: 3.33939 expected: 3.33916 difference: 0.000229397
+DEAL:0::computed: 3.340084495 expected: 3.339161571 difference: 0.0009229231266
 DEAL:0::L1_norm:
-DEAL:0::computed: 2.91682 expected: 2.91667 difference: 0.000153192
+DEAL:0::computed: 2.917282521 expected: 2.916666667 difference: 0.0006158544147
 DEAL:0::Linfty_norm:
-DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::computed: 3.000000000 expected: 3.000000000 difference: 0.000000000
 DEAL:0::mean:
-DEAL:0::computed: -2.91682 expected: -2.91667 difference: 0.000153192
+DEAL:0::computed: -2.917282521 expected: -2.916666667 difference: 0.0006158544147
 DEAL:0::Lp_norm:
-DEAL:0::computed: 1.80871 expected: 1.80849 difference: 0.000224088
+DEAL:0::computed: 1.809390422 expected: 1.808486770 difference: 0.0009036523661
 DEAL:0::W1p_seminorm:
-DEAL:0::computed: 2.31576 expected: 2.31560 difference: 0.000161338
+DEAL:0::computed: 2.316223368 expected: 2.315600000 difference: 0.0006233683746
 DEAL:0::OK
 
+DEAL:1::
 DEAL:1::Hdiv_seminorm:
-DEAL:1::computed: 3.05510 expected: 3.05505 difference: 5.01434e-05
+DEAL:1::computed: 3.055252042 expected: 3.055050463 difference: 0.0002015790263
 DEAL:1::L2_norm:
-DEAL:1::computed: 1.95383 expected: 1.95363 difference: 0.000196056
+DEAL:1::computed: 1.954418539 expected: 1.953629102 difference: 0.0007894373030
 DEAL:1::H1_seminorm:
-DEAL:1::computed: 2.70815 expected: 2.70801 difference: 0.000141421
+DEAL:1::computed: 2.708581290 expected: 2.708012802 difference: 0.0005684886150
 DEAL:1::H1_norm:
-DEAL:1::computed: 3.33939 expected: 3.33916 difference: 0.000229397
+DEAL:1::computed: 3.340084495 expected: 3.339161571 difference: 0.0009229231266
 DEAL:1::L1_norm:
-DEAL:1::computed: 2.91682 expected: 2.91667 difference: 0.000153192
+DEAL:1::computed: 2.917282521 expected: 2.916666667 difference: 0.0006158544147
 DEAL:1::Linfty_norm:
-DEAL:1::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:1::computed: 3.000000000 expected: 3.000000000 difference: 0.000000000
 DEAL:1::mean:
-DEAL:1::computed: -2.91682 expected: -2.91667 difference: 0.000153192
+DEAL:1::computed: -2.917282521 expected: -2.916666667 difference: 0.0006158544147
 DEAL:1::Lp_norm:
-DEAL:1::computed: 1.80871 expected: 1.80849 difference: 0.000224088
+DEAL:1::computed: 1.809390422 expected: 1.808486770 difference: 0.0009036523661
 DEAL:1::W1p_seminorm:
-DEAL:1::computed: 2.31576 expected: 2.31560 difference: 0.000161338
+DEAL:1::computed: 2.316223368 expected: 2.315600000 difference: 0.0006233683746
 DEAL:1::OK
 

--- a/tests/vector_tools/integrate_difference_04_hp_02.with_trilinos=true.with_metis=true.mpirun=3.output
+++ b/tests/vector_tools/integrate_difference_04_hp_02.with_trilinos=true.with_metis=true.mpirun=3.output
@@ -1,62 +1,65 @@
 
+DEAL:0::
 DEAL:0::Hdiv_seminorm:
-DEAL:0::computed: 3.05510 expected: 3.05505 difference: 5.01434e-05
+DEAL:0::computed: 3.055252042 expected: 3.055050463 difference: 0.0002015790263
 DEAL:0::L2_norm:
-DEAL:0::computed: 1.95383 expected: 1.95363 difference: 0.000196056
+DEAL:0::computed: 1.954418539 expected: 1.953629102 difference: 0.0007894373030
 DEAL:0::H1_seminorm:
-DEAL:0::computed: 2.70815 expected: 2.70801 difference: 0.000141421
+DEAL:0::computed: 2.708581290 expected: 2.708012802 difference: 0.0005684886150
 DEAL:0::H1_norm:
-DEAL:0::computed: 3.33939 expected: 3.33916 difference: 0.000229397
+DEAL:0::computed: 3.340084495 expected: 3.339161571 difference: 0.0009229231266
 DEAL:0::L1_norm:
-DEAL:0::computed: 2.91682 expected: 2.91667 difference: 0.000153192
+DEAL:0::computed: 2.917282521 expected: 2.916666667 difference: 0.0006158544147
 DEAL:0::Linfty_norm:
-DEAL:0::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:0::computed: 3.000000000 expected: 3.000000000 difference: 0.000000000
 DEAL:0::mean:
-DEAL:0::computed: -2.91682 expected: -2.91667 difference: 0.000153192
+DEAL:0::computed: -2.917282521 expected: -2.916666667 difference: 0.0006158544147
 DEAL:0::Lp_norm:
-DEAL:0::computed: 1.80871 expected: 1.80849 difference: 0.000224088
+DEAL:0::computed: 1.809390422 expected: 1.808486770 difference: 0.0009036523661
 DEAL:0::W1p_seminorm:
-DEAL:0::computed: 2.31576 expected: 2.31560 difference: 0.000161338
+DEAL:0::computed: 2.316223368 expected: 2.315600000 difference: 0.0006233683746
 DEAL:0::OK
 
+DEAL:1::
 DEAL:1::Hdiv_seminorm:
-DEAL:1::computed: 3.05510 expected: 3.05505 difference: 5.01434e-05
+DEAL:1::computed: 3.055252042 expected: 3.055050463 difference: 0.0002015790263
 DEAL:1::L2_norm:
-DEAL:1::computed: 1.95383 expected: 1.95363 difference: 0.000196056
+DEAL:1::computed: 1.954418539 expected: 1.953629102 difference: 0.0007894373030
 DEAL:1::H1_seminorm:
-DEAL:1::computed: 2.70815 expected: 2.70801 difference: 0.000141421
+DEAL:1::computed: 2.708581290 expected: 2.708012802 difference: 0.0005684886150
 DEAL:1::H1_norm:
-DEAL:1::computed: 3.33939 expected: 3.33916 difference: 0.000229397
+DEAL:1::computed: 3.340084495 expected: 3.339161571 difference: 0.0009229231266
 DEAL:1::L1_norm:
-DEAL:1::computed: 2.91682 expected: 2.91667 difference: 0.000153192
+DEAL:1::computed: 2.917282521 expected: 2.916666667 difference: 0.0006158544147
 DEAL:1::Linfty_norm:
-DEAL:1::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:1::computed: 3.000000000 expected: 3.000000000 difference: 0.000000000
 DEAL:1::mean:
-DEAL:1::computed: -2.91682 expected: -2.91667 difference: 0.000153192
+DEAL:1::computed: -2.917282521 expected: -2.916666667 difference: 0.0006158544147
 DEAL:1::Lp_norm:
-DEAL:1::computed: 1.80871 expected: 1.80849 difference: 0.000224088
+DEAL:1::computed: 1.809390422 expected: 1.808486770 difference: 0.0009036523661
 DEAL:1::W1p_seminorm:
-DEAL:1::computed: 2.31576 expected: 2.31560 difference: 0.000161338
+DEAL:1::computed: 2.316223368 expected: 2.315600000 difference: 0.0006233683746
 DEAL:1::OK
 
 
+DEAL:2::
 DEAL:2::Hdiv_seminorm:
-DEAL:2::computed: 3.05510 expected: 3.05505 difference: 5.01434e-05
+DEAL:2::computed: 3.055252042 expected: 3.055050463 difference: 0.0002015790263
 DEAL:2::L2_norm:
-DEAL:2::computed: 1.95383 expected: 1.95363 difference: 0.000196056
+DEAL:2::computed: 1.954418539 expected: 1.953629102 difference: 0.0007894373030
 DEAL:2::H1_seminorm:
-DEAL:2::computed: 2.70815 expected: 2.70801 difference: 0.000141421
+DEAL:2::computed: 2.708581290 expected: 2.708012802 difference: 0.0005684886150
 DEAL:2::H1_norm:
-DEAL:2::computed: 3.33939 expected: 3.33916 difference: 0.000229397
+DEAL:2::computed: 3.340084495 expected: 3.339161571 difference: 0.0009229231266
 DEAL:2::L1_norm:
-DEAL:2::computed: 2.91682 expected: 2.91667 difference: 0.000153192
+DEAL:2::computed: 2.917282521 expected: 2.916666667 difference: 0.0006158544147
 DEAL:2::Linfty_norm:
-DEAL:2::computed: 3.00000 expected: 3.00000 difference: 0.00000
+DEAL:2::computed: 3.000000000 expected: 3.000000000 difference: 0.000000000
 DEAL:2::mean:
-DEAL:2::computed: -2.91682 expected: -2.91667 difference: 0.000153192
+DEAL:2::computed: -2.917282521 expected: -2.916666667 difference: 0.0006158544147
 DEAL:2::Lp_norm:
-DEAL:2::computed: 1.80871 expected: 1.80849 difference: 0.000224088
+DEAL:2::computed: 1.809390422 expected: 1.808486770 difference: 0.0009036523661
 DEAL:2::W1p_seminorm:
-DEAL:2::computed: 2.31576 expected: 2.31560 difference: 0.000161338
+DEAL:2::computed: 2.316223368 expected: 2.315600000 difference: 0.0006233683746
 DEAL:2::OK
 


### PR DESCRIPTION
The test runs in 3D in debug mode on a 3 times globally refined mesh.
Depending on workload of the machine this test is running on this might
imply to hit the 10 minute timeout. Make the test 8 times less expensive
by reducing the number of global refinement steps

In reference to #10073
See also: https://cdash.43-1.org/viewTest.php?onlydelta&buildid=6260