### PR TITLE
Make new GridGenerator images appear in the online documentation

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -749,10 +749,16 @@ namespace GridGenerator
    * <table align="center" class="doxtable">
    *   <tr>
    *     <td>
-   *       <img src="hyper_ball_balanced_2d.png" alt="" width="40%">
+   *       \htmlonly <style>div.image
+   *         img[src="hyper_ball_balanced_2d.png"]{width:40%}</style>
+   *       \endhtmlonly
+   *       @image html hyper_ball_balanced_2d.png
    *     </td>
    *     <td>
-   *       <img src="hyper_ball_balanced_3d.png" alt="" width="40%">
+   *       \htmlonly <style>div.image
+   *         img[src="hyper_ball_balanced_3d.png"]{width:40%}</style>
+   *       \endhtmlonly
+   *       @image html hyper_ball_balanced_3d.png
    *     </td>
    *   </tr>
    * </table>
@@ -817,10 +823,16 @@ namespace GridGenerator
    * <table align="center" class="doxtable">
    *   <tr>
    *     <td>
-   *       <img src="quarter_hyper_ball_2d.png" alt="" width="50%">
+   *       \htmlonly <style>div.image
+   *         img[src="quarter_hyper_ball_2d.png"]{width:50%}</style>
+   *       \endhtmlonly
+   *       @image html quarter_hyper_ball_2d.png
    *     </td>
    *     <td>
-   *       <img src="quarter_hyper_ball_3d.png" alt="" width="45%">
+   *       \htmlonly <style>div.image
+   *         img[src="quarter_hyper_ball_3d.png"]{width:46%}</style>
+   *       \endhtmlonly
+   *       @image html quarter_hyper_ball_3d.png
    *     </td>
    *   </tr>
    * </table>


### PR DESCRIPTION
Some figures introduced in #9822 and #9802 do not appear in the online documentation:
https://dealii.org/developer/doxygen/deal.II/namespaceGridGenerator.html#a712f95340c7002afbd5d6fb755e12a61
I think we need to add some specific html/doxygen command as elsewhere in the file. I hope this does the trick - it works locally, but it used to work locally also before.