### PR TITLE
Remove some "dealii::"s from code examples.

### DIFF
--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -63,33 +63,33 @@ class PackagedOperation;
  *
  * As an example consider the addition of multiple vectors
  * @code
- *   dealii::Vector<double> a, b, c, d;
+ *   Vector<double> a, b, c, d;
  *   // ..
- *   dealii::Vector<double> result = a + b - c + d;
+ *   Vector<double> result = a + b - c + d;
  * @endcode
  * or the computation of a residual $b-Ax$:
  * @code
- *   dealii::SparseMatrix<double> A;
- *   dealii::Vector<double> b, x;
+ *   SparseMatrix<double> A;
+ *   Vector<double> b, x;
  *   // ..
  *   const auto op_a = linear_operator(A);
  *
- *   dealii::Vector<double> residual =  b - op_a * x;
+ *   auto residual =  b - op_a * x;
  * @endcode
  * The expression <code>residual</code> is of type
- * <code>PackagedOperation<dealii::Vector<double>></code>. It stores
+ * <code>PackagedOperation<Vector<double>></code>. It stores
  * references to <code>A</code>, <code>b</code> and <code>x</code> and defers
  * the actual computation until <code>apply</code>, or <code>apply_add</code>
  * are explicitly invoked,
  * @code
- *   dealii::Vector<double> y;
+ *   Vector<double> y;
  *   residual.reinit_vector(y);
  *   residual.apply(y);
  *   residual.apply_add(y);
  * @endcode
  * or until the @p PackagedOperation object is implicitly converted:
  * @code
- *   dealii::Vector<double> y;
+ *   Vector<double> y;
  *   y = residual;
  *   y += residual;
  *   y -= residual;


### PR DESCRIPTION
These are converted to "::" by our doxygen preprocessing script, which looks weird.