### PR TITLE
CUDA: multiple fixes

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -105,7 +105,8 @@ namespace CUDAWrappers
       AdditionalData(
         const ParallelizationScheme parallelization_scheme = parallel_in_elem,
         const UpdateFlags           mapping_update_flags   = update_gradients |
-                                                 update_JxW_values,
+                                                 update_JxW_values |
+                                                 update_quadrature_points,
         const bool use_coloring                      = false,
         const bool n_colors                          = 1,
         const bool overlap_communication_computation = false)

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -108,12 +108,10 @@ namespace CUDAWrappers
                                                  update_JxW_values |
                                                  update_quadrature_points,
         const bool use_coloring                      = false,
-        const bool n_colors                          = 1,
         const bool overlap_communication_computation = false)
         : parallelization_scheme(parallelization_scheme)
         , mapping_update_flags(mapping_update_flags)
         , use_coloring(use_coloring)
-        , n_colors(n_colors)
         , overlap_communication_computation(overlap_communication_computation)
       {
 #  ifndef DEAL_II_MPI_WITH_CUDA_SUPPORT
@@ -150,11 +148,6 @@ namespace CUDAWrappers
        * newer architectures.
        */
       bool use_coloring;
-
-      /**
-       * Number of colors created by the graph coloring algorithm.
-       */
-      unsigned int n_colors;
 
       /**
        *  Overlap MPI communications with computation. This requires CUDA-aware

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -643,7 +643,7 @@ namespace CUDAWrappers
   /**
    * Compute the quadrature point index in the local cell of a given thread.
    *
-   * @relates MatrixFree
+   * @relates CUDAWrappers::MatrixFree
    */
   template <int dim>
   __device__ inline unsigned int
@@ -663,7 +663,7 @@ namespace CUDAWrappers
    * Return the quadrature point index local of a given thread. The index is
    * only unique for a given MPI process.
    *
-   * @relates MatrixFree
+   * @relates CUDAWrappers::MatrixFree
    */
   template <int dim, typename Number>
   __device__ inline unsigned int
@@ -682,7 +682,7 @@ namespace CUDAWrappers
   /**
    * Return the quadrature point associated with a given thread.
    *
-   * @relates MatrixFree
+   * @relates CUDAWrappers::MatrixFree
    */
   template <int dim, typename Number>
   __device__ inline typename CUDAWrappers::MatrixFree<dim, Number>::point_type &

--- a/tests/cuda/parallel_vector_11.cu
+++ b/tests/cuda/parallel_vector_11.cu
@@ -131,7 +131,8 @@ test()
 
   if (myid == 0)
     deallog << "Check sadd (factor, factor, vector, factor, vector): ";
-  y.sadd(2., 3., v, 2., w);
+  y.sadd(2., 3., v);
+  y.add(2., w);
   y_rw.import(y, VectorOperation::insert);
   for (int i = 0; i < actual_local_size; ++i)
     {
@@ -144,7 +145,8 @@ test()
   if (myid == 0)
     deallog
       << "Check sadd (factor, factor, vector, factor, vector, factor, vector): ";
-  y.sadd(-1., 1., v, 2., w);
+  y.sadd(-1., 1., v);
+  y.add(2., w);
   y.add(2., x);
   y_rw.import(y, VectorOperation::insert);
   for (int i = 0; i < actual_local_size; ++i)
@@ -202,7 +204,8 @@ test()
 
   if (myid == 0)
     deallog << "Check equ (factor, vector, factor, vector): ";
-  y.equ(10., v, -2., w);
+  y.equ(10., v);
+  y.add(-2., w);
   y_rw.import(y, VectorOperation::insert);
   for (int i = 0; i < actual_local_size; ++i)
     AssertThrow(y_rw.local_element(i) == 6. * (i + my_start) - 2000,
@@ -212,7 +215,8 @@ test()
 
   if (myid == 0)
     deallog << "Check equ (factor, vector, factor, vector, factor, vector): ";
-  y.equ(10., v, -2., w);
+  y.equ(10., v);
+  y.add(-2., w);
   y.add(3., x);
   y_rw.import(y, VectorOperation::insert);
   for (int i = 0; i < actual_local_size; ++i)


### PR DESCRIPTION
I would like this PR to be merged and cherry-picked for the release. Here is what it does:
 - fix a [failing test](https://cdash.43-1.org/testDetails.php?test=44174781&build=6319). Some functions were removed in #9886 but the test was not updated
 - change a default parameter in CUDAWrappers::MatrixFree::AdditionalData(), the problem with the current default value is that they make no sense and the code crashes. Having a default value that's not valid makes no sense.
 - This commit remove a variable from CUDAWrappers::MatrixFree::AdditionalData() and so technically it's an incompatible change but this variable actually never worked. It's supposed to return a value that is computed in MatrixFree but AdditionalData is always const and we never set the value. So nobody could have used it for what it was intended to. I want to remove it because we have introduced a new useful variable that is defined after the useless one and I don't want people to have to set a variable that make no sense.
 - Doxygen seems to have a problem with the related functions in CUDAWrappers::MatrixFree. They appears on the CPU version of MatrixFree instead of the GPU version
 - #8838 deprecated a bunch of function in CUDAWrappers::FEEvaluation but the new functions call the deprecated ones. This means that compiling step-64 produces a lot of deprecation warnings. I went the dirty road and copy/paste the code.