### PR TITLE
Avoid using std::cout in a test.

### DIFF
--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output
@@ -1,3 +1,4 @@
+
 Cycle 0:
    Number of active cells      : 768
    Number of degrees of freedom: 3264

--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output.petsc3.13.0
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=1.output.petsc3.13.0
@@ -1,3 +1,4 @@
+
 Cycle 0:
    Number of active cells      : 768
    Number of degrees of freedom: 3264

--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output
@@ -1,3 +1,4 @@
+
 Cycle 0:
    Number of active cells      : 768
    Number of degrees of freedom: 3264

--- a/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output.petsc3.13.0
+++ b/tests/mpi/petsc_step-27.with_p4est=true.with_petsc_with_hypre=true.with_petsc_with_complex=false.mpirun=2.output.petsc3.13.0
@@ -1,3 +1,4 @@
+
 Cycle 0:
    Number of active cells      : 768
    Number of degrees of freedom: 3264


### PR DESCRIPTION
This is problematic on misconfigured MPI implementations that print warnings for one reason or another every time they are run (e.g., the default MPI implementation on Ubuntu 16.04).

It is easy enough in this case to do the normal thing and print everything to deallog.

I think that the small number of failing MPI tests on this platform all fail for this reason.