### PR TITLE
Fix assert that wrongly triggered

### DIFF
--- a/doc/news/changes/minor/20200514Gassmoeller
+++ b/doc/news/changes/minor/20200514Gassmoeller
@@ -1,0 +1,5 @@
+Fixed: The parallel::distributed::Triangulation::DataTransfer class triggered
+an assert if one MPI rank did not receive any data during a distribution of
+cell data, even if this was intended. This is fixed now.
+<br>
+(Rene Gassmoeller, Luca Heltai, 2020/05/14)

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1615,12 +1615,14 @@ namespace parallel
              ExcMessage("No data has been packed!"));
       if (quad_cell_relations.size() > 0)
         {
+          // Even if only variable data is transferred there has to
+          // be fixed data, which contains the variable data size per cell.
           Assert(dest_data_fixed.size() > 0,
                  ExcMessage("No data has been received!"));
 
-          if (callback_variable_transfer)
-            Assert(dest_data_variable.size() > 0,
-                   ExcMessage("No data has been received!"));
+          // We do not check for the existence of the variable data, since
+          // it may happen that a process is not expected to get any variable
+          // data
         }
 
       std::vector<char>::const_iterator dest_data_it;

--- a/tests/mpi/attach_data_03.cc
+++ b/tests/mpi/attach_data_03.cc
@@ -1,0 +1,185 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2009 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check register_data_attach and notify_ready_to_unpack
+// for variable size transfer. In particular check that the
+// transfer succeeds if one process does not get any data.
+
+#include <deal.II/base/tensor.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+std::vector<char>
+pack_function(
+  const typename parallel::distributed::Triangulation<dim, dim>::cell_iterator
+    &cell,
+  const typename parallel::distributed::Triangulation<dim, dim>::CellStatus
+    status)
+{
+  // Only pack data for one cell. The test is run for 3 ranks. The cell is
+  // chosen to be one that is transferred from rank 0 to rank 1 so that we
+  // test both that the transfer from 0 to 1 is successful, and that rank
+  // 3 does not complain about not receiving any data.
+  unsigned int      some_number = (cell->id().to_string() == "0_1:2") ? 5 : 0;
+  char              some_char   = 'a';
+  std::vector<char> buffer(some_number, some_char);
+
+  deallog << "packing cell " << cell->id()
+          << " with data size =" << buffer.size() << " status=";
+  if (status == parallel::distributed::Triangulation<dim, dim>::CELL_PERSIST)
+    deallog << "PERSIST";
+  else if (status ==
+           parallel::distributed::Triangulation<dim, dim>::CELL_REFINE)
+    deallog << "REFINE";
+  else if (status ==
+           parallel::distributed::Triangulation<dim, dim>::CELL_COARSEN)
+    deallog << "COARSEN";
+  deallog << std::endl;
+
+  if (status == parallel::distributed::Triangulation<dim, dim>::CELL_COARSEN)
+    {
+      Assert(cell->has_children(), ExcInternalError());
+    }
+  else
+    {
+      Assert(!cell->has_children(), ExcInternalError());
+    }
+
+  return buffer;
+}
+
+template <int dim>
+void
+unpack_function(
+  const typename parallel::distributed::Triangulation<dim, dim>::cell_iterator
+    &cell,
+  const typename parallel::distributed::Triangulation<dim, dim>::CellStatus
+                                                                  status,
+  const boost::iterator_range<std::vector<char>::const_iterator> &data_range)
+{
+  const unsigned int data_in_bytes =
+    std::distance(data_range.begin(), data_range.end());
+
+  deallog << "unpacking cell " << cell->id() << " with data size="
+          << std::distance(data_range.begin(), data_range.end())
+          << " and data: '" << std::string(data_range.begin(), data_range.end())
+          << "' status=";
+  if (status == parallel::distributed::Triangulation<dim, dim>::CELL_PERSIST)
+    deallog << "PERSIST";
+  else if (status ==
+           parallel::distributed::Triangulation<dim, dim>::CELL_REFINE)
+    deallog << "REFINE";
+  else if (status ==
+           parallel::distributed::Triangulation<dim, dim>::CELL_COARSEN)
+    deallog << "COARSEN";
+  deallog << std::endl;
+
+  if (status == parallel::distributed::Triangulation<dim, dim>::CELL_REFINE)
+    {
+      Assert(cell->has_children(), ExcInternalError());
+    }
+  else
+    {
+      Assert(!cell->has_children(), ExcInternalError());
+    }
+}
+
+
+template <int dim>
+void
+test()
+{
+  unsigned int myid     = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  unsigned int numprocs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+
+  if (true)
+    {
+      parallel::distributed::Triangulation<dim> tr(MPI_COMM_WORLD);
+
+      GridGenerator::subdivided_hyper_cube(tr, 2);
+      tr.refine_global(1);
+      deallog << "cells before: " << tr.n_global_active_cells() << std::endl;
+
+      typename Triangulation<dim, dim>::active_cell_iterator cell;
+
+      for (cell = tr.begin_active(); cell != tr.end(); ++cell)
+        {
+          if (cell->is_locally_owned())
+            {
+              if (cell->id().to_string() == "0_1:0")
+                cell->set_refine_flag();
+              else if (cell->parent()->id().to_string() == "3_0:")
+                cell->set_coarsen_flag();
+
+              deallog << "myid=" << myid << " cellid=" << cell->id();
+              if (cell->coarsen_flag_set())
+                deallog << " coarsening" << std::endl;
+              else if (cell->refine_flag_set())
+                deallog << " refining" << std::endl;
+              else
+                deallog << std::endl;
+            }
+        }
+
+      unsigned int handle =
+        tr.register_data_attach(pack_function<dim>,
+                                /*returns_variable_size_data=*/true);
+
+      deallog << "handle=" << handle << std::endl;
+      tr.execute_coarsening_and_refinement();
+
+      deallog << "cells after: " << tr.n_global_active_cells() << std::endl;
+
+      /*
+      for (cell = tr.begin_active();
+           cell != tr.end();
+           ++cell)
+        {
+      if (cell->is_locally_owned())
+      deallog << "myid=" << myid << " cellid=" << cell->id() << std::endl;
+      }*/
+
+      tr.notify_ready_to_unpack(handle, unpack_function<dim>);
+
+      const unsigned int checksum = tr.get_checksum();
+      deallog << "Checksum: " << checksum << std::endl;
+    }
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test<2>();
+}

--- a/tests/mpi/attach_data_03.with_p4est=true.mpirun=3.output
+++ b/tests/mpi/attach_data_03.with_p4est=true.mpirun=3.output
@@ -1,0 +1,62 @@
+
+DEAL:0::cells before: 16
+DEAL:0::myid=0 cellid=0_1:0 refining
+DEAL:0::myid=0 cellid=0_1:1
+DEAL:0::myid=0 cellid=0_1:2
+DEAL:0::myid=0 cellid=0_1:3
+DEAL:0::handle=0
+DEAL:0::packing cell 0_1:0 with data size =0 status=REFINE
+DEAL:0::packing cell 0_1:1 with data size =0 status=PERSIST
+DEAL:0::packing cell 0_1:2 with data size =5 status=PERSIST
+DEAL:0::packing cell 0_1:3 with data size =0 status=PERSIST
+DEAL:0::cells after: 16
+DEAL:0::unpacking cell 0_1:0 with data size=0 and data: '' status=REFINE
+DEAL:0::unpacking cell 0_1:1 with data size=0 and data: '' status=PERSIST
+DEAL:0::Checksum: 2822439380
+DEAL:0::OK
+
+DEAL:1::cells before: 16
+DEAL:1::myid=1 cellid=1_1:0
+DEAL:1::myid=1 cellid=1_1:1
+DEAL:1::myid=1 cellid=1_1:2
+DEAL:1::myid=1 cellid=1_1:3
+DEAL:1::myid=1 cellid=2_1:0
+DEAL:1::myid=1 cellid=2_1:1
+DEAL:1::myid=1 cellid=2_1:2
+DEAL:1::myid=1 cellid=2_1:3
+DEAL:1::handle=0
+DEAL:1::packing cell 1_1:0 with data size =0 status=PERSIST
+DEAL:1::packing cell 1_1:1 with data size =0 status=PERSIST
+DEAL:1::packing cell 1_1:2 with data size =0 status=PERSIST
+DEAL:1::packing cell 1_1:3 with data size =0 status=PERSIST
+DEAL:1::packing cell 2_1:0 with data size =0 status=PERSIST
+DEAL:1::packing cell 2_1:1 with data size =0 status=PERSIST
+DEAL:1::packing cell 2_1:2 with data size =0 status=PERSIST
+DEAL:1::packing cell 2_1:3 with data size =0 status=PERSIST
+DEAL:1::cells after: 16
+DEAL:1::unpacking cell 0_1:2 with data size=5 and data: 'aaaaa' status=PERSIST
+DEAL:1::unpacking cell 0_1:3 with data size=0 and data: '' status=PERSIST
+DEAL:1::unpacking cell 1_1:0 with data size=0 and data: '' status=PERSIST
+DEAL:1::unpacking cell 1_1:1 with data size=0 and data: '' status=PERSIST
+DEAL:1::unpacking cell 1_1:2 with data size=0 and data: '' status=PERSIST
+DEAL:1::unpacking cell 1_1:3 with data size=0 and data: '' status=PERSIST
+DEAL:1::Checksum: 0
+DEAL:1::OK
+
+
+DEAL:2::cells before: 16
+DEAL:2::myid=2 cellid=3_1:0 coarsening
+DEAL:2::myid=2 cellid=3_1:1 coarsening
+DEAL:2::myid=2 cellid=3_1:2 coarsening
+DEAL:2::myid=2 cellid=3_1:3 coarsening
+DEAL:2::handle=0
+DEAL:2::packing cell 3_0: with data size =0 status=COARSEN
+DEAL:2::cells after: 16
+DEAL:2::unpacking cell 2_1:0 with data size=0 and data: '' status=PERSIST
+DEAL:2::unpacking cell 2_1:1 with data size=0 and data: '' status=PERSIST
+DEAL:2::unpacking cell 2_1:2 with data size=0 and data: '' status=PERSIST
+DEAL:2::unpacking cell 2_1:3 with data size=0 and data: '' status=PERSIST
+DEAL:2::unpacking cell 3_0: with data size=0 and data: '' status=COARSEN
+DEAL:2::Checksum: 0
+DEAL:2::OK
+


### PR DESCRIPTION
This fixes one of the two bug reported in #9078 (also discussed in #10211 and geodynamics/aspect#3354). I created a test that failed on master and passes and gives correct results with this change. This was already present in deal.II 9.1.1, but did not appear, because it is only triggered in certain situations when using particles. @luca-heltai do you agree?