### PR TITLE
tests: add additional output file for intel

### DIFF
--- a/tests/parameter_handler/parameter_handler_25.output2
+++ b/tests/parameter_handler/parameter_handler_25.output2
@@ -1,0 +1,28 @@
+
+DEAL::
+DEAL::successful
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::set(const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> &)
+The violated condition was: 
+    false
+Additional information: 
+    You can't ask for entry <Precison> you have not yet declared.
+--------------------------------------------------------
+
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::assert_that_entries_have_been_set() const
+The violated condition was: 
+    entries_wrongly_not_set.size() == 0
+Additional information: 
+    Not all entries of the parameter handler that were declared with `has_to_be_set = true` have been set. The following parameters 
+
+  General.Precision
+  General.dim
+
+ have not been set. A possible reason might be that you did not add these parameter to the input file or that their spelling is not correct.
+--------------------------------------------------------
+


### PR DESCRIPTION
arguments of ``::set(`` are different.

Also see https://cdash.43-1.org/testDetails.php?test=44332754&build=6387

@tamiko FYI. 1 down, 93 to go. 