### PR TITLE
Fix test output forgotten in #9969

### DIFF
--- a/tests/mpi/tria_ghost_owners_01.mpirun=7.with_p4est=true.output
+++ b/tests/mpi/tria_ghost_owners_01.mpirun=7.with_p4est=true.output
@@ -2,19 +2,19 @@
 DEAL:0:2d::* cycle 0
 DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 
-DEAL:0:2d::total active cells = 149
+DEAL:0:2d::total active cells = 152
 DEAL:0:2d::* cycle 1
 DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 
-DEAL:0:2d::total active cells = 227
+DEAL:0:2d::total active cells = 296
 DEAL:0:2d::* cycle 2
 DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 
-DEAL:0:2d::total active cells = 467
+DEAL:0:2d::total active cells = 581
 DEAL:0:2d::* cycle 3
-DEAL:0:2d::ghost owners: 1 2 
+DEAL:0:2d::ghost owners: 1 
 DEAL:0:2d::level ghost owners: 1 2 
-DEAL:0:2d::total active cells = 728
+DEAL:0:2d::total active cells = 1139
 DEAL:0:2d::OK
 DEAL:0:3d::* cycle 0
 DEAL:0:3d::ghost owners: 1 2 
@@ -23,15 +23,15 @@ DEAL:0:3d::total active cells = 1020
 DEAL:0:3d::* cycle 1
 DEAL:0:3d::ghost owners: 1 2 
 DEAL:0:3d::level ghost owners: 1 2 
-DEAL:0:3d::total active cells = 3785
+DEAL:0:3d::total active cells = 3813
 DEAL:0:3d::* cycle 2
 DEAL:0:3d::ghost owners: 1 2 
 DEAL:0:3d::level ghost owners: 1 2 
-DEAL:0:3d::total active cells = 11702
+DEAL:0:3d::total active cells = 12857
 DEAL:0:3d::* cycle 3
 DEAL:0:3d::ghost owners: 1 2 
 DEAL:0:3d::level ghost owners: 1 2 
-DEAL:0:3d::total active cells = 37833
+DEAL:0:3d::total active cells = 43454
 DEAL:0:3d::OK
 
 DEAL:1:2d::* cycle 0
@@ -41,10 +41,10 @@ DEAL:1:2d::* cycle 1
 DEAL:1:2d::ghost owners: 0 2 3 
 DEAL:1:2d::level ghost owners: 0 2 3 
 DEAL:1:2d::* cycle 2
-DEAL:1:2d::ghost owners: 0 2 
+DEAL:1:2d::ghost owners: 0 2 3 
 DEAL:1:2d::level ghost owners: 0 2 3 
 DEAL:1:2d::* cycle 3
-DEAL:1:2d::ghost owners: 0 2 
+DEAL:1:2d::ghost owners: 0 2 3 
 DEAL:1:2d::level ghost owners: 0 2 3 
 DEAL:1:2d::OK
 DEAL:1:3d::* cycle 0
@@ -69,11 +69,11 @@ DEAL:2:2d::* cycle 1
 DEAL:2:2d::ghost owners: 0 1 3 
 DEAL:2:2d::level ghost owners: 0 1 3 4 
 DEAL:2:2d::* cycle 2
-DEAL:2:2d::ghost owners: 0 1 3 4 
+DEAL:2:2d::ghost owners: 0 1 3 
 DEAL:2:2d::level ghost owners: 0 1 3 4 
 DEAL:2:2d::* cycle 3
-DEAL:2:2d::ghost owners: 0 1 3 
-DEAL:2:2d::level ghost owners: 0 1 3 4 5 
+DEAL:2:2d::ghost owners: 1 3 4 
+DEAL:2:2d::level ghost owners: 0 1 3 4 
 DEAL:2:2d::OK
 DEAL:2:3d::* cycle 0
 DEAL:2:3d::ghost owners: 0 1 3 4 
@@ -85,7 +85,7 @@ DEAL:2:3d::* cycle 2
 DEAL:2:3d::ghost owners: 0 1 3 4 5 6 
 DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 
 DEAL:2:3d::* cycle 3
-DEAL:2:3d::ghost owners: 0 1 3 4 5 
+DEAL:2:3d::ghost owners: 0 1 3 4 5 6 
 DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 
 DEAL:2:3d::OK
 
@@ -97,10 +97,10 @@ DEAL:3:2d::* cycle 1
 DEAL:3:2d::ghost owners: 1 2 4 5 
 DEAL:3:2d::level ghost owners: 1 2 4 5 
 DEAL:3:2d::* cycle 2
-DEAL:3:2d::ghost owners: 2 4 5 
+DEAL:3:2d::ghost owners: 1 2 4 5 
 DEAL:3:2d::level ghost owners: 1 2 4 5 
 DEAL:3:2d::* cycle 3
-DEAL:3:2d::ghost owners: 2 4 5 
+DEAL:3:2d::ghost owners: 1 2 4 
 DEAL:3:2d::level ghost owners: 1 2 4 5 
 DEAL:3:2d::OK
 DEAL:3:3d::* cycle 0
@@ -125,10 +125,10 @@ DEAL:4:2d::* cycle 1
 DEAL:4:2d::ghost owners: 3 5 6 
 DEAL:4:2d::level ghost owners: 2 3 5 6 
 DEAL:4:2d::* cycle 2
-DEAL:4:2d::ghost owners: 2 3 5 
+DEAL:4:2d::ghost owners: 3 5 6 
 DEAL:4:2d::level ghost owners: 2 3 5 6 
 DEAL:4:2d::* cycle 3
-DEAL:4:2d::ghost owners: 3 5 6 
+DEAL:4:2d::ghost owners: 2 3 5 6 
 DEAL:4:2d::level ghost owners: 2 3 5 6 
 DEAL:4:2d::OK
 DEAL:4:3d::* cycle 0
@@ -156,8 +156,8 @@ DEAL:5:2d::* cycle 2
 DEAL:5:2d::ghost owners: 3 4 6 
 DEAL:5:2d::level ghost owners: 3 4 6 
 DEAL:5:2d::* cycle 3
-DEAL:5:2d::ghost owners: 3 4 6 
-DEAL:5:2d::level ghost owners: 2 3 4 6 
+DEAL:5:2d::ghost owners: 4 6 
+DEAL:5:2d::level ghost owners: 3 4 6 
 DEAL:5:2d::OK
 DEAL:5:3d::* cycle 0
 DEAL:5:3d::ghost owners: 3 4 6 
@@ -181,7 +181,7 @@ DEAL:6:2d::* cycle 1
 DEAL:6:2d::ghost owners: 4 5 
 DEAL:6:2d::level ghost owners: 4 5 
 DEAL:6:2d::* cycle 2
-DEAL:6:2d::ghost owners: 5 
+DEAL:6:2d::ghost owners: 4 5 
 DEAL:6:2d::level ghost owners: 4 5 
 DEAL:6:2d::* cycle 3
 DEAL:6:2d::ghost owners: 4 5 
@@ -197,7 +197,7 @@ DEAL:6:3d::* cycle 2
 DEAL:6:3d::ghost owners: 2 3 4 5 
 DEAL:6:3d::level ghost owners: 2 3 4 5 
 DEAL:6:3d::* cycle 3
-DEAL:6:3d::ghost owners: 3 4 5 
+DEAL:6:3d::ghost owners: 2 3 4 5 
 DEAL:6:3d::level ghost owners: 2 3 4 5 
 DEAL:6:3d::OK
 

--- a/tests/mpi/tria_ghost_owners_02.mpirun=11.with_p4est=true.output
+++ b/tests/mpi/tria_ghost_owners_02.mpirun=11.with_p4est=true.output
@@ -10,11 +10,11 @@ DEAL:0:2d::total active cells = 496
 DEAL:0:2d::* cycle 2
 DEAL:0:2d::ghost owners: 1 2 3 5 
 DEAL:0:2d::level ghost owners: 1 2 3 5 6 8 
-DEAL:0:2d::total active cells = 733
+DEAL:0:2d::total active cells = 940
 DEAL:0:2d::* cycle 3
 DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 3 5 8 
-DEAL:0:2d::total active cells = 1288
+DEAL:0:2d::total active cells = 1852
 DEAL:0:2d::OK
 DEAL:0:3d::* cycle 0
 DEAL:0:3d::ghost owners: 2 3 4 6 7 8 10 
@@ -23,15 +23,15 @@ DEAL:0:3d::total active cells = 197
 DEAL:0:3d::* cycle 1
 DEAL:0:3d::ghost owners: 1 2 4 7 8 
 DEAL:0:3d::level ghost owners: 1 2 4 7 8 
-DEAL:0:3d::total active cells = 617
+DEAL:0:3d::total active cells = 631
 DEAL:0:3d::* cycle 2
-DEAL:0:3d::ghost owners: 1 2 3 4 6 9 10 
-DEAL:0:3d::level ghost owners: 1 2 3 4 6 9 10 
-DEAL:0:3d::total active cells = 1793
+DEAL:0:3d::ghost owners: 1 2 3 4 5 6 9 
+DEAL:0:3d::level ghost owners: 1 2 3 4 5 6 9 
+DEAL:0:3d::total active cells = 2052
 DEAL:0:3d::* cycle 3
-DEAL:0:3d::ghost owners: 1 2 3 4 5 6 8 9 10 
-DEAL:0:3d::level ghost owners: 1 2 3 4 5 6 8 9 10 
-DEAL:0:3d::total active cells = 6357
+DEAL:0:3d::ghost owners: 1 2 3 4 5 6 7 8 9 10 
+DEAL:0:3d::level ghost owners: 1 2 3 4 5 6 7 8 9 10 
+DEAL:0:3d::total active cells = 7645
 DEAL:0:3d::OK
 
 DEAL:1:2d::* cycle 0
@@ -44,8 +44,8 @@ DEAL:1:2d::* cycle 2
 DEAL:1:2d::ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::level ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::* cycle 3
-DEAL:1:2d::ghost owners: 0 2 3 
-DEAL:1:2d::level ghost owners: 0 2 3 5 6 
+DEAL:1:2d::ghost owners: 0 2 3 5 6 
+DEAL:1:2d::level ghost owners: 0 2 3 5 6 8 
 DEAL:1:2d::OK
 DEAL:1:3d::* cycle 0
 DEAL:1:3d::ghost owners: 
@@ -54,11 +54,11 @@ DEAL:1:3d::* cycle 1
 DEAL:1:3d::ghost owners: 0 2 4 5 7 8 
 DEAL:1:3d::level ghost owners: 0 2 4 5 7 8 
 DEAL:1:3d::* cycle 2
-DEAL:1:3d::ghost owners: 0 2 3 4 6 7 9 10 
-DEAL:1:3d::level ghost owners: 0 2 3 4 6 7 9 10 
+DEAL:1:3d::ghost owners: 0 2 3 4 5 6 7 9 10 
+DEAL:1:3d::level ghost owners: 0 2 3 4 5 6 7 9 10 
 DEAL:1:3d::* cycle 3
-DEAL:1:3d::ghost owners: 0 2 3 4 5 6 8 9 10 
-DEAL:1:3d::level ghost owners: 0 2 3 4 5 6 8 9 10 
+DEAL:1:3d::ghost owners: 0 2 3 4 5 6 7 8 9 
+DEAL:1:3d::level ghost owners: 0 2 3 4 5 6 7 8 9 10 
 DEAL:1:3d::OK
 
 
@@ -82,11 +82,11 @@ DEAL:2:3d::* cycle 1
 DEAL:2:3d::ghost owners: 0 1 3 4 5 6 7 8 9 
 DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 7 8 9 
 DEAL:2:3d::* cycle 2
-DEAL:2:3d::ghost owners: 0 1 3 4 5 6 7 9 10 
-DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 7 9 10 
+DEAL:2:3d::ghost owners: 0 1 3 4 5 6 7 8 9 10 
+DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 7 8 9 10 
 DEAL:2:3d::* cycle 3
-DEAL:2:3d::ghost owners: 0 1 3 4 5 6 8 9 10 
-DEAL:2:3d::level ghost owners: 0 1 3 4 5 6 8 9 10 
+DEAL:2:3d::ghost owners: 0 1 3 4 8 9 10 
+DEAL:2:3d::level ghost owners: 0 1 3 4 5 7 8 9 10 
 DEAL:2:3d::OK
 
 
@@ -100,7 +100,7 @@ DEAL:3:2d::* cycle 2
 DEAL:3:2d::ghost owners: 0 1 2 4 6 8 9 
 DEAL:3:2d::level ghost owners: 0 1 2 4 6 8 9 
 DEAL:3:2d::* cycle 3
-DEAL:3:2d::ghost owners: 1 2 4 5 
+DEAL:3:2d::ghost owners: 1 2 4 
 DEAL:3:2d::level ghost owners: 0 1 2 4 5 6 8 9 
 DEAL:3:2d::OK
 DEAL:3:3d::* cycle 0
@@ -110,11 +110,11 @@ DEAL:3:3d::* cycle 1
 DEAL:3:3d::ghost owners: 2 4 6 7 8 9 
 DEAL:3:3d::level ghost owners: 2 4 6 7 8 9 
 DEAL:3:3d::* cycle 2
-DEAL:3:3d::ghost owners: 0 1 2 4 5 6 8 9 10 
-DEAL:3:3d::level ghost owners: 0 1 2 4 5 6 8 9 10 
+DEAL:3:3d::ghost owners: 0 1 2 4 5 6 7 8 9 10 
+DEAL:3:3d::level ghost owners: 0 1 2 4 5 6 7 8 9 10 
 DEAL:3:3d::* cycle 3
-DEAL:3:3d::ghost owners: 0 1 2 4 5 9 10 
-DEAL:3:3d::level ghost owners: 0 1 2 4 5 8 9 10 
+DEAL:3:3d::ghost owners: 0 1 2 4 6 7 8 9 10 
+DEAL:3:3d::level ghost owners: 0 1 2 4 5 6 7 8 9 10 
 DEAL:3:3d::OK
 
 
@@ -141,8 +141,8 @@ DEAL:4:3d::* cycle 2
 DEAL:4:3d::ghost owners: 0 1 2 3 5 6 8 9 10 
 DEAL:4:3d::level ghost owners: 0 1 2 3 5 6 8 9 10 
 DEAL:4:3d::* cycle 3
-DEAL:4:3d::ghost owners: 0 1 2 3 5 6 8 9 10 
-DEAL:4:3d::level ghost owners: 0 1 2 3 5 6 8 9 10 
+DEAL:4:3d::ghost owners: 0 1 2 3 5 8 9 10 
+DEAL:4:3d::level ghost owners: 0 1 2 3 5 7 8 9 10 
 DEAL:4:3d::OK
 
 
@@ -156,7 +156,7 @@ DEAL:5:2d::* cycle 2
 DEAL:5:2d::ghost owners: 0 1 4 6 7 9 
 DEAL:5:2d::level ghost owners: 0 1 4 6 7 8 9 
 DEAL:5:2d::* cycle 3
-DEAL:5:2d::ghost owners: 2 3 4 6 8 9 
+DEAL:5:2d::ghost owners: 1 2 4 6 8 9 
 DEAL:5:2d::level ghost owners: 0 1 2 3 4 6 7 8 9 
 DEAL:5:2d::OK
 DEAL:5:3d::* cycle 0
@@ -166,10 +166,10 @@ DEAL:5:3d::* cycle 1
 DEAL:5:3d::ghost owners: 1 2 4 6 7 8 9 10 
 DEAL:5:3d::level ghost owners: 1 2 4 6 7 8 9 10 
 DEAL:5:3d::* cycle 2
-DEAL:5:3d::ghost owners: 2 3 4 6 8 9 10 
-DEAL:5:3d::level ghost owners: 2 3 4 6 8 9 10 
+DEAL:5:3d::ghost owners: 0 1 2 3 4 6 8 9 10 
+DEAL:5:3d::level ghost owners: 0 1 2 3 4 6 7 8 9 10 
 DEAL:5:3d::* cycle 3
-DEAL:5:3d::ghost owners: 0 1 2 3 4 6 7 9 10 
+DEAL:5:3d::ghost owners: 0 1 4 6 7 8 9 10 
 DEAL:5:3d::level ghost owners: 0 1 2 3 4 6 7 8 9 10 
 DEAL:5:3d::OK
 
@@ -184,7 +184,7 @@ DEAL:6:2d::* cycle 2
 DEAL:6:2d::ghost owners: 1 3 5 7 8 10 
 DEAL:6:2d::level ghost owners: 0 1 3 5 7 8 10 
 DEAL:6:2d::* cycle 3
-DEAL:6:2d::ghost owners: 2 4 5 7 8 9 
+DEAL:6:2d::ghost owners: 1 2 4 5 7 8 9 
 DEAL:6:2d::level ghost owners: 1 2 3 4 5 7 8 9 
 DEAL:6:2d::OK
 DEAL:6:3d::* cycle 0
@@ -197,8 +197,8 @@ DEAL:6:3d::* cycle 2
 DEAL:6:3d::ghost owners: 0 1 2 3 4 5 7 8 9 10 
 DEAL:6:3d::level ghost owners: 0 1 2 3 4 5 7 8 9 10 
 DEAL:6:3d::* cycle 3
-DEAL:6:3d::ghost owners: 0 1 2 4 5 7 8 9 
-DEAL:6:3d::level ghost owners: 0 1 2 4 5 7 8 9 10 
+DEAL:6:3d::ghost owners: 0 1 3 5 7 8 9 10 
+DEAL:6:3d::level ghost owners: 0 1 3 5 7 8 9 10 
 DEAL:6:3d::OK
 
 
@@ -212,8 +212,8 @@ DEAL:7:2d::* cycle 2
 DEAL:7:2d::ghost owners: 5 6 8 
 DEAL:7:2d::level ghost owners: 5 6 8 10 
 DEAL:7:2d::* cycle 3
-DEAL:7:2d::ghost owners: 6 8 9 
-DEAL:7:2d::level ghost owners: 5 6 8 9 
+DEAL:7:2d::ghost owners: 6 8 9 10 
+DEAL:7:2d::level ghost owners: 5 6 8 9 10 
 DEAL:7:2d::OK
 DEAL:7:3d::* cycle 0
 DEAL:7:3d::ghost owners: 0 2 3 4 6 8 10 
@@ -222,11 +222,11 @@ DEAL:7:3d::* cycle 1
 DEAL:7:3d::ghost owners: 0 1 2 3 4 5 6 8 9 10 
 DEAL:7:3d::level ghost owners: 0 1 2 3 4 5 6 8 9 10 
 DEAL:7:3d::* cycle 2
-DEAL:7:3d::ghost owners: 1 2 6 8 9 10 
-DEAL:7:3d::level ghost owners: 1 2 6 8 9 10 
+DEAL:7:3d::ghost owners: 1 2 3 6 8 9 10 
+DEAL:7:3d::level ghost owners: 1 2 3 5 6 8 9 10 
 DEAL:7:3d::* cycle 3
-DEAL:7:3d::ghost owners: 5 6 8 9 10 
-DEAL:7:3d::level ghost owners: 5 6 8 9 10 
+DEAL:7:3d::ghost owners: 0 1 3 5 6 8 9 10 
+DEAL:7:3d::level ghost owners: 0 1 2 3 4 5 6 8 9 10 
 DEAL:7:3d::OK
 
 
@@ -241,7 +241,7 @@ DEAL:8:2d::ghost owners: 1 3 4 6 7 9 10
 DEAL:8:2d::level ghost owners: 0 1 3 4 5 6 7 9 10 
 DEAL:8:2d::* cycle 3
 DEAL:8:2d::ghost owners: 2 4 5 6 7 9 10 
-DEAL:8:2d::level ghost owners: 0 2 3 4 5 6 7 9 10 
+DEAL:8:2d::level ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:2d::OK
 DEAL:8:3d::* cycle 0
 DEAL:8:3d::ghost owners: 0 2 3 4 6 7 10 
@@ -250,10 +250,10 @@ DEAL:8:3d::* cycle 1
 DEAL:8:3d::ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:3d::level ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:3d::* cycle 2
-DEAL:8:3d::ghost owners: 3 4 5 6 7 9 10 
-DEAL:8:3d::level ghost owners: 3 4 5 6 7 9 10 
+DEAL:8:3d::ghost owners: 2 3 4 5 6 7 9 10 
+DEAL:8:3d::level ghost owners: 2 3 4 5 6 7 9 10 
 DEAL:8:3d::* cycle 3
-DEAL:8:3d::ghost owners: 0 1 2 4 6 7 9 10 
+DEAL:8:3d::ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:3d::level ghost owners: 0 1 2 3 4 5 6 7 9 10 
 DEAL:8:3d::OK
 
@@ -296,8 +296,8 @@ DEAL:10:2d::* cycle 2
 DEAL:10:2d::ghost owners: 6 8 9 
 DEAL:10:2d::level ghost owners: 6 7 8 9 
 DEAL:10:2d::* cycle 3
-DEAL:10:2d::ghost owners: 8 9 
-DEAL:10:2d::level ghost owners: 8 9 
+DEAL:10:2d::ghost owners: 7 8 9 
+DEAL:10:2d::level ghost owners: 7 8 9 
 DEAL:10:2d::OK
 DEAL:10:3d::* cycle 0
 DEAL:10:3d::ghost owners: 0 2 3 4 6 7 8 
@@ -306,10 +306,10 @@ DEAL:10:3d::* cycle 1
 DEAL:10:3d::ghost owners: 4 5 6 7 8 9 
 DEAL:10:3d::level ghost owners: 4 5 6 7 8 9 
 DEAL:10:3d::* cycle 2
-DEAL:10:3d::ghost owners: 0 1 2 3 4 5 6 7 8 9 
-DEAL:10:3d::level ghost owners: 0 1 2 3 4 5 6 7 8 9 
+DEAL:10:3d::ghost owners: 1 2 3 4 5 6 7 8 9 
+DEAL:10:3d::level ghost owners: 1 2 3 4 5 6 7 8 9 
 DEAL:10:3d::* cycle 3
-DEAL:10:3d::ghost owners: 0 1 2 3 4 5 7 8 9 
+DEAL:10:3d::ghost owners: 0 2 3 4 5 6 7 8 9 
 DEAL:10:3d::level ghost owners: 0 1 2 3 4 5 6 7 8 9 
 DEAL:10:3d::OK
 

--- a/tests/mpi/tria_ghost_owners_02.mpirun=5.with_p4est=true.output
+++ b/tests/mpi/tria_ghost_owners_02.mpirun=5.with_p4est=true.output
@@ -6,15 +6,15 @@ DEAL:0:2d::total active cells = 130
 DEAL:0:2d::* cycle 1
 DEAL:0:2d::ghost owners: 1 2 3 
 DEAL:0:2d::level ghost owners: 1 2 3 
-DEAL:0:2d::total active cells = 214
+DEAL:0:2d::total active cells = 247
 DEAL:0:2d::* cycle 2
 DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 3 
-DEAL:0:2d::total active cells = 418
+DEAL:0:2d::total active cells = 493
 DEAL:0:2d::* cycle 3
-DEAL:0:2d::ghost owners: 1 2 3 
+DEAL:0:2d::ghost owners: 1 2 
 DEAL:0:2d::level ghost owners: 1 2 3 
-DEAL:0:2d::total active cells = 625
+DEAL:0:2d::total active cells = 967
 DEAL:0:2d::OK
 DEAL:0:3d::* cycle 0
 DEAL:0:3d::ghost owners: 1 2 3 4 
@@ -23,15 +23,15 @@ DEAL:0:3d::total active cells = 197
 DEAL:0:3d::* cycle 1
 DEAL:0:3d::ghost owners: 1 2 3 4 
 DEAL:0:3d::level ghost owners: 1 2 3 4 
-DEAL:0:3d::total active cells = 701
+DEAL:0:3d::total active cells = 708
 DEAL:0:3d::* cycle 2
 DEAL:0:3d::ghost owners: 1 2 3 4 
 DEAL:0:3d::level ghost owners: 1 2 3 4 
-DEAL:0:3d::total active cells = 1989
+DEAL:0:3d::total active cells = 2339
 DEAL:0:3d::* cycle 3
 DEAL:0:3d::ghost owners: 1 2 3 4 
 DEAL:0:3d::level ghost owners: 1 2 3 4 
-DEAL:0:3d::total active cells = 7001
+DEAL:0:3d::total active cells = 8233
 DEAL:0:3d::OK
 
 DEAL:1:2d::* cycle 0
@@ -41,7 +41,7 @@ DEAL:1:2d::* cycle 1
 DEAL:1:2d::ghost owners: 0 2 3 4 
 DEAL:1:2d::level ghost owners: 0 2 3 4 
 DEAL:1:2d::* cycle 2
-DEAL:1:2d::ghost owners: 0 2 3 
+DEAL:1:2d::ghost owners: 0 2 3 4 
 DEAL:1:2d::level ghost owners: 0 2 3 4 
 DEAL:1:2d::* cycle 3
 DEAL:1:2d::ghost owners: 0 2 3 
@@ -100,7 +100,7 @@ DEAL:3:2d::* cycle 2
 DEAL:3:2d::ghost owners: 1 2 4 
 DEAL:3:2d::level ghost owners: 0 1 2 4 
 DEAL:3:2d::* cycle 3
-DEAL:3:2d::ghost owners: 0 1 2 4 
+DEAL:3:2d::ghost owners: 1 2 4 
 DEAL:3:2d::level ghost owners: 0 1 2 4 
 DEAL:3:2d::OK
 DEAL:3:3d::* cycle 0
@@ -125,7 +125,7 @@ DEAL:4:2d::* cycle 1
 DEAL:4:2d::ghost owners: 1 2 3 
 DEAL:4:2d::level ghost owners: 1 2 3 
 DEAL:4:2d::* cycle 2
-DEAL:4:2d::ghost owners: 2 3 
+DEAL:4:2d::ghost owners: 1 2 3 
 DEAL:4:2d::level ghost owners: 1 2 3 
 DEAL:4:2d::* cycle 3
 DEAL:4:2d::ghost owners: 2 3 


### PR DESCRIPTION
This fixes the test error recorded at
https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=6397
due to the adjustment of the parallel grid refinement algorithm.
The CI won't run over this, otherwise we would not have merged #9969, so it can be merged quickly.