### PR TITLE
Fix warning in step-70

### DIFF
--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -677,7 +677,7 @@ namespace Step70
     using map_type  = std::map<types::manifold_id, std::string>;
     using Converter = Patterns::Tools::Convert<map_type>;
 
-    for (const auto pair : Converter::to_value(ids_and_cad_file_names))
+    for (const auto &pair : Converter::to_value(ids_and_cad_file_names))
       {
         const auto &manifold_id   = pair.first;
         const auto &cad_file_name = pair.second;


### PR DESCRIPTION
This should fix the warning displayed on clang compilations:
https://cdash.43-1.org/viewBuildError.php?type=1&buildid=6404
Candidate for the 9.2 release branch.