### PR TITLE
[9.2] Take over #10241, #10242, #10245

### DIFF
--- a/cmake/configure/configure_p4est.cmake
+++ b/cmake/configure/configure_p4est.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2018 by the deal.II authors
+## Copyright (C) 2012 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/cmake/configure/configure_symengine.cmake
+++ b/cmake/configure/configure_symengine.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2019 - 2020-2020 by the deal.II authors
+## Copyright (C) 2019 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/cmake/modules/FindARPACK.cmake
+++ b/cmake/modules/FindARPACK.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2015 by the deal.II authors
+## Copyright (C) 2012 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/cmake/modules/FindP4EST.cmake
+++ b/cmake/modules/FindP4EST.cmake
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2017 by the deal.II authors
+## Copyright (C) 2012 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/contrib/utilities/makeofflinedoc.sh
+++ b/contrib/utilities/makeofflinedoc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2012 - 2018 by the deal.II authors
+## Copyright (C) 2012 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/contrib/utilities/update-copyright
+++ b/contrib/utilities/update-copyright
@@ -32,10 +32,8 @@ files="
          contrib/utilities/{update-copyright,indent} \
          doc/doxygen/*/*.{h,h.in} \
          doc/doxygen/scripts/{create_anchors,filter,intro2toc,program*,*.pl} \
-         doc/screen.css \
-         examples/*/*.cc \
-         include/deal.II/*/*h \
-         source/*/*.{cc,in})
+         doc/screen.css)
+  $(find include/ source/ examples/ | egrep '\.(h|in|cc|cu)$')
   $(find cmake/ | egrep '\.(cmake|in|cc)$')
   $(find . -name CMakeLists.txt)
   $(find tests/ | egrep '\.(h|cc)$')

--- a/doc/doxygen/scripts/make_gallery.pl
+++ b/doc/doxygen/scripts/make_gallery.pl
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2013 - 2016 by the deal.II authors
+## Copyright (C) 2013 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/doc/external-libs/petsc.html
+++ b/doc/external-libs/petsc.html
@@ -4,7 +4,7 @@
   <head>
     <title>The deal.II Readme on interfacing to PETSc</title>
     <link href="../screen.css" rel="StyleSheet">
-    <meta name="copyright" content="Copyright (C) 2008 - 2019 by the deal.II authors">
+    <meta name="copyright" content="Copyright (C) 2008 - 2020 by the deal.II authors">
     <meta name="keywords" content="deal.II">
   </head>
 

--- a/doc/users/doxygen.html
+++ b/doc/users/doxygen.html
@@ -6,7 +6,7 @@
   <title>deal.II Doxygen documentation</title>
   <link href="../screen.css" rel="StyleSheet">
   <meta name="author" content="the deal.II authors">
-  <meta name="copyright" content="Copyright (C) 2012 - 2019 by the deal.II authors">
+  <meta name="copyright" content="Copyright (C) 2012 - 2020 by the deal.II authors">
   <meta name="keywords" content="deal dealii finite elements fem triangulation">
   <meta http-equiv="content-language" content="en">
 </head>

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -1,6 +1,6 @@
 /* ---------------------------------------------------------------------
  *
- * Copyright (C) 2019 by the deal.II authors
+ * Copyright (C) 2019 - 2020 by the deal.II authors
  *
  * This file is part of the deal.II library.
  *

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2018 by the deal.II authors
+// Copyright (C) 2012 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/revision.h.in
+++ b/include/deal.II/base/revision.h.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2015 by the deal.II authors
+// Copyright (C) 2014 - 2017 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/array.h
+++ b/include/deal.II/base/std_cxx11/array.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/bind.h
+++ b/include/deal.II/base/std_cxx11/bind.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/condition_variable.h
+++ b/include/deal.II/base/std_cxx11/condition_variable.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/function.h
+++ b/include/deal.II/base/std_cxx11/function.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/iterator.h
+++ b/include/deal.II/base/std_cxx11/iterator.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/mutex.h
+++ b/include/deal.II/base/std_cxx11/mutex.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/shared_ptr.h
+++ b/include/deal.II/base/std_cxx11/shared_ptr.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/thread.h
+++ b/include/deal.II/base/std_cxx11/thread.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/tuple.h
+++ b/include/deal.II/base/std_cxx11/tuple.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2009 - 2014 by the deal.II authors
+// Copyright (C) 2009 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/type_traits.h
+++ b/include/deal.II/base/std_cxx11/type_traits.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2012 - 2015 by the deal.II authors
+// Copyright (C) 2012 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx11/unique_ptr.h
+++ b/include/deal.II/base/std_cxx11/unique_ptr.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015, 2016 by the deal.II authors
+// Copyright (C) 2015 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx14/algorithm.h
+++ b/include/deal.II/base/std_cxx14/algorithm.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx14/memory.h
+++ b/include/deal.II/base/std_cxx14/memory.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx14/utility.h
+++ b/include/deal.II/base/std_cxx14/utility.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/std_cxx17/cmath.h
+++ b/include/deal.II/base/std_cxx17/cmath.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/ad_drivers.h
+++ b/include/deal.II/differentiation/ad/ad_drivers.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 - 2018 by the deal.II authors
+// Copyright (C) 2017 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/ad_number_traits.h
+++ b/include/deal.II/differentiation/ad/ad_number_traits.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/ad_number_types.h
+++ b/include/deal.II/differentiation/ad/ad_number_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017, 2019 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/adolc_math.h
+++ b/include/deal.II/differentiation/ad/adolc_math.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/adolc_number_types.h
+++ b/include/deal.II/differentiation/ad/adolc_number_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/adolc_product_types.h
+++ b/include/deal.II/differentiation/ad/adolc_product_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/sacado_math.h
+++ b/include/deal.II/differentiation/ad/sacado_math.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/sacado_number_types.h
+++ b/include/deal.II/differentiation/ad/sacado_number_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/ad/sacado_product_types.h
+++ b/include/deal.II/differentiation/ad/sacado_product_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015, 2017 by the deal.II authors
+// Copyright (C) 2015 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd.h
+++ b/include/deal.II/differentiation/sd.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 - 2020-2020 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_math.h
+++ b/include/deal.II/differentiation/sd/symengine_math.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_types.h
+++ b/include/deal.II/differentiation/sd/symengine_types.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/differentiation/sd/symengine_utilities.h
+++ b/include/deal.II/differentiation/sd/symengine_utilities.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019-2020 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2019 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2015 - 2020-2016 by the deal.II authors
+// Copyright (C) 2015 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/optimization/rol/vector_adaptor.h
+++ b/include/deal.II/optimization/rol/vector_adaptor.h
@@ -1,6 +1,6 @@
 //-----------------------------------------------------------
 //
-//    Copyright (C) 2017 by the deal.II authors
+//    Copyright (C) 2017 - 2020 by the deal.II authors
 //
 //    This file is part of the deal.II library.
 //

--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/base/partitioner.cu
+++ b/source/base/partitioner.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1999 - 2017 by the deal.II authors
+// Copyright (C) 1999 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/CMakeLists.txt
+++ b/source/differentiation/CMakeLists.txt
@@ -1,6 +1,6 @@
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2017 - 2019-2019 by the deal.II authors
+## Copyright (C) 2017 - 2020 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##

--- a/source/differentiation/ad/ad_drivers.cc
+++ b/source/differentiation/ad/ad_drivers.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_drivers.inst.in
+++ b/source/differentiation/ad/ad_drivers.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_drivers.inst1.in
+++ b/source/differentiation/ad/ad_drivers.inst1.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_drivers.inst2.in
+++ b/source/differentiation/ad/ad_drivers.inst2.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_helpers.cc
+++ b/source/differentiation/ad/ad_helpers.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_helpers.inst1.in
+++ b/source/differentiation/ad/ad_helpers.inst1.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/ad_helpers.inst2.in
+++ b/source/differentiation/ad/ad_helpers.inst2.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/adolc_number_types.cc
+++ b/source/differentiation/ad/adolc_number_types.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/adolc_number_types.inst.in
+++ b/source/differentiation/ad/adolc_number_types.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/ad/sacado_number_types.cc
+++ b/source/differentiation/ad/sacado_number_types.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 by the deal.II authors
+// Copyright (C) 2017 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/sd/symengine_scalar_operations.cc
+++ b/source/differentiation/sd/symengine_scalar_operations.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/sd/symengine_tensor_operations.cc
+++ b/source/differentiation/sd/symengine_tensor_operations.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/differentiation/sd/symengine_utilities.cc
+++ b/source/differentiation/sd/symengine_utilities.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2019-2020 by the deal.II authors
+// Copyright (C) 2019 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/distributed/error_predictor.inst.in
+++ b/source/distributed/error_predictor.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2010 - 2018 by the deal.II authors
+// Copyright (C) 2010 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/dummy.cc
+++ b/source/dummy.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 by the deal.II authors
+// Copyright (C) 2013 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/lac/cuda_kernels.cu
+++ b/source/lac/cuda_kernels.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/lac/la_parallel_vector.cu
+++ b/source/lac/la_parallel_vector.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2017 by the deal.II authors
+// Copyright (C) 2016 - 2019 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/matrix_free/cuda_matrix_free.cu
+++ b/source/matrix_free/cuda_matrix_free.cu
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/opencascade/boundary_lib.inst.in
+++ b/source/opencascade/boundary_lib.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/opencascade/manifold_lib.cc
+++ b/source/opencascade/manifold_lib.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2019 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/opencascade/manifold_lib.inst.in
+++ b/source/opencascade/manifold_lib.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/physics/elasticity/kinematics.inst.in
+++ b/source/physics/elasticity/kinematics.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/physics/elasticity/standard_tensors.cc
+++ b/source/physics/elasticity/standard_tensors.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/source/physics/elasticity/standard_tensors.inst.in
+++ b/source/physics/elasticity/standard_tensors.inst.in
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 by the deal.II authors
+// Copyright (C) 2016 - 2018 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/boost/extract_representative_set_01.cc
+++ b/tests/boost/extract_representative_set_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 by the deal.II authors
+// Copyright (C) 2018 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/dofs/count_dofs_on_patch.cc
+++ b/tests/dofs/count_dofs_on_patch.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018-2015 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/dofs/get_dofs_on_patch.cc
+++ b/tests/dofs/get_dofs_on_patch.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018-2015 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/grid/build_global_description_tree.cc
+++ b/tests/grid/build_global_description_tree.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2020-2019 by the deal.II authors
+// Copyright (C) 2018 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 - 2020-2018 by the deal.II authors
+// Copyright (C) 2017 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2017 - 2020-2018 by the deal.II authors
+// Copyright (C) 2017 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/lapack/full_matrix_00.cc
+++ b/tests/lapack/full_matrix_00.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018-2015 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/lapack/full_matrix_26.cc
+++ b/tests/lapack/full_matrix_26.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2018-2015 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/matrix_free/get_functions_faces.cc
+++ b/tests/matrix_free/get_functions_faces.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2020-2014 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2013 - 2020-2014 by the deal.II authors
+// Copyright (C) 2013 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/mpi/cell_data_transfer_03.cc
+++ b/tests/mpi/cell_data_transfer_03.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2018 - 2019 by the deal.II authors
+// Copyright (C) 2018 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/stl_creation_single_patch.cc
+++ b/tests/opencascade/stl_creation_single_patch.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2019 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/opencascade/stl_creation_watertight.cc
+++ b/tests/opencascade/stl_creation_watertight.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2014 - 2019 by the deal.II authors
+// Copyright (C) 2014 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //


### PR DESCRIPTION
#10241: fix update-copyright not going 2 levels deep into src/include
#10242: Fixed a few copyright years manually.
#10245: update copyright years
See also #10072