### PR TITLE
Fix doxygen underscores.

### DIFF
--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -410,7 +410,8 @@ apply_transformation(const DerivativeForm<1, dim, spacedim, Number> &grad_F,
 /**
  * Similar to the previous apply_transformation().
  * Each row of the result corresponds to one of the rows of @p D_X transformed
- * by @p grad_F, equivalent to $\text{D\_X} \, \text{grad\_F}^T$ in matrix notation.
+ * by @p grad_F, equivalent to $\mathrm{D\_X} \, \mathrm{grad\_F}^T$ in matrix
+ * notation.
  *
  * @relatesalso DerivativeForm
  * @author Sebastian Pauletti, 2011, Reza Rastak, 2019

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -50,7 +50,7 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * A class that represents a subset of indices among a larger set. For
  * example, it can be used to denote the set of degrees of freedom within the
- * range $[0,\text{dof\_handler.n\_dofs})$ that belongs to a particular
+ * range $[0,\mathrm{dof\_handler.n\_dofs()})$ that belongs to a particular
  * subdomain, or those among all degrees of freedom that are stored on a
  * particular processor in a distributed parallel computation.
  *

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -237,9 +237,9 @@ namespace TensorAccessors
    *
    * @f[
    *   \text{result}_{i_1,..,i_{r1},j_1,..,j_{r2}}
-   *   = \sum_{k_1,..,k_{\text{no\_contr}}}
-   *     \text{left}_{i_1,..,i_{r1},k_1,..,k_{\text{no\_contr}}}
-   *     \text{right}_{j_1,..,j_{r2},k_1,..,k_{\text{no\_contr}}}
+   *   = \sum_{k_1,..,k_{\mathrm{no\_contr}}}
+   *     \mathrm{left}_{i_1,..,i_{r1},k_1,..,k_{\mathrm{no\_contr}}}
+   *     \mathrm{right}_{j_1,..,j_{r2},k_1,..,k_{\mathrm{no\_contr}}}
    * @f]
    *
    * Calling this function is equivalent of writing the following low level

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1398,9 +1398,9 @@ namespace GridGenerator
    * radius of the $k$th shell is given by
    *
    * @f[
-   *     r = r_{\text{inner}} + (r_\text{outer} - r_\text{inner})
-   *     \frac{1 - \tanh(\text{skewness}(1 - k/\text{n\_shells}))}
-   *          {\tanh(\text{skewness})}
+   *     r = r_{\mathrm{inner}} + (r_\mathrm{outer} - r_\mathrm{inner})
+   *     \frac{1 - \tanh(\mathrm{skewness}(1 - k/\mathrm{n\_shells}))}
+   *          {\tanh(\mathrm{skewness})}
    * @f]
    *
    * where @p skewness is a parameter controlling the shell spacing in the

--- a/include/deal.II/lac/slepc_solver.h
+++ b/include/deal.II/lac/slepc_solver.h
@@ -313,7 +313,7 @@ namespace SLEPcWrappers
     /**
      * Access the real parts of solutions for a solved eigenvector problem,
      * pair index solutions, $\text{index}\,\in\,0\dots
-     * \text{n\_converged}-1$.
+     * \mathrm{n\_converged}-1$.
      */
     void
     get_eigenpair(const unsigned int         index,
@@ -323,7 +323,7 @@ namespace SLEPcWrappers
     /**
      * Access the real and imaginary parts of solutions for a solved
      * eigenvector problem, pair index solutions, $\text{index}\,\in\,0\dots
-     * \text{n\_converged}-1$.
+     * \mathrm{n\_converged}-1$.
      */
     void
     get_eigenpair(const unsigned int         index,

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -153,12 +153,12 @@ namespace Physics
        *  \dealcoloneq \{ \bullet \} - \frac{1}{\textrm{dim}}
        *  \left[ \{ \bullet \} : \mathbf{I} \right]\mathbf{I}
        *  = \mathcal{P}^{T} : \{ \bullet \}
-       *  = \texttt{dev\_P} \left( \{ \bullet \} \right)
+       *  = \mathtt{dev\_P} \left( \{ \bullet \} \right)
        * @f]
        * and, therefore,
        * @f[
-       * \texttt{dev\_P} \left( \{ \bullet \} \right) : \mathbf{I}
-       *   = \textrm{trace}(\texttt{dev\_P} \left( \{ \bullet \} \right)) = 0 \,
+       * \mathtt{dev\_P} \left( \{ \bullet \} \right) : \mathbf{I}
+       *   = \mathrm{trace}(\mathtt{dev\_P} \left( \{ \bullet \} \right)) = 0 \,
        * .
        * @f]
        *
@@ -201,12 +201,12 @@ namespace Physics
        *  \{ \bullet \} : \hat{\mathcal{P}}
        *    \dealcoloneq J^{-2/\textrm{dim}} \left[ \{ \bullet \} -
        * \frac{1}{\textrm{dim}}\left[\mathbf{C} : \{ \bullet \}\right]
-       * \mathbf{C}^{-1} \right] = \texttt{Dev\_P} \left( \{ \bullet \} \right)
+       * \mathbf{C}^{-1} \right] = \mathtt{Dev\_P} \left( \{ \bullet \} \right)
        * \, .
        * @f]
        * It can therefore be readily shown that
        * @f[
-       *  \texttt{Dev\_P} \left( \{ \bullet \} \right) : \mathbf{C} = 0 \, .
+       *  \mathtt{Dev\_P} \left( \{ \bullet \} \right) : \mathbf{C} = 0 \, .
        * @f]
        *
        * @note It may be observed that we have defined the tensor as the
@@ -244,7 +244,7 @@ namespace Physics
        *  \hat{\mathcal{P}}^{T} : \{ \bullet \}
        *    = J^{-2/\textrm{dim}} \left[ \{ \bullet \} - \frac{1}{\textrm{dim}}
        * \left[\mathbf{C}^{-1} : \{ \bullet \}\right] \mathbf{C} \right] =
-       * \texttt{Dev\_P\_T} \{ \bullet \}
+       * \mathtt{Dev\_P\_T} \{ \bullet \}
        * @f]
        */
       template <typename Number>


### PR DESCRIPTION
We need to use `$\mathrm{A\_B}$` and not `$\texttt{A\_B}$` to correctly print an underscore and not the backslash.