### PR TITLE
Simplify get_dof_indices() and set_dof_indices()

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1289,6 +1289,16 @@ public:
   DoFInvalidAccessor(const OtherAccessor &);
 
   /**
+   * Return the index of the <i>i</i>th degree of freedom of this object to
+   * @p index. Since the current object doesn't point to anything useful, like
+   * all other functions in this class this function only throws an exception.
+   */
+  types::global_dof_index
+  dof_index(const unsigned int i,
+            const unsigned int fe_index =
+              DoFHandler<dim, spacedim>::default_fe_index) const;
+
+  /**
    * Set the index of the <i>i</i>th degree of freedom of this object to @p
    * index. Since the current object doesn't point to anything useful, like
    * all other functions in this class this function only throws an exception.

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -76,6 +76,18 @@ DoFInvalidAccessor<structdim, dim, spacedim>::DoFInvalidAccessor(
 
 
 template <int structdim, int dim, int spacedim>
+types::global_dof_index
+DoFInvalidAccessor<structdim, dim, spacedim>::dof_index(
+  const unsigned int,
+  const unsigned int) const
+{
+  Assert(false, ExcInternalError());
+  return 0;
+}
+
+
+
+template <int structdim, int dim, int spacedim>
 void
 DoFInvalidAccessor<structdim, dim, spacedim>::set_dof_index(
   const unsigned int,
@@ -118,8 +130,11 @@ DoFCellAccessor<DoFHandlerType, lda>::set_dof_indices(
 
   Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
-  internal::DoFCellAccessorImplementation::Implementation::set_dof_indices(
-    *this, local_dof_indices);
+  AssertDimension(local_dof_indices.size(), this->get_fe().dofs_per_cell);
+
+  internal::DoFAccessorImplementation::Implementation::
+    template set_dof_indices<DoFHandlerType, lda, DoFHandlerType::dimension>(
+      *this, local_dof_indices, this->active_fe_index());
 }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1671,8 +1671,11 @@ namespace internal
                   std::vector<types::global_dof_index> dof_indices(
                     cell->get_fe().dofs_per_cell);
 
-                  internal::DoFAccessorImplementation::get_dof_indices(
-                    *cell, dof_indices, cell->active_fe_index());
+                  // circumvent cache
+                  internal::DoFAccessorImplementation::Implementation::
+                    get_dof_indices(*cell,
+                                    dof_indices,
+                                    cell->active_fe_index());
 
                   for (auto &dof_index : dof_indices)
                     if (dof_index == numbers::invalid_dof_index)


### PR DESCRIPTION
This PR makes the functions `get_dof_indices()` and `get_dof_indices()` similar. 

The functions differ now at a handful places as shown by the following diff:
```diff
@@ -1,10 +1,10 @@
       template <typename DoFHandlerType, bool level_dof_access, int structdim>
       static void
-      get_dof_indices(
+      set_dof_indices(
         const dealii::DoFAccessor<structdim, DoFHandlerType, level_dof_access>
-          &                                   accessor,
-        std::vector<types::global_dof_index> &dof_indices,
-        const unsigned int                    fe_index)
+          &                                         accessor,
+        const std::vector<types::global_dof_index> &dof_indices,
+        const unsigned int                          fe_index)
       {
         const unsigned int                                             //
           dofs_per_vertex = accessor.get_fe(fe_index).dofs_per_vertex, //
@@ -22,9 +22,10 @@
         for (const unsigned int vertex :
              GeometryInfo<structdim>::vertex_indices())
           for (unsigned int d = 0; d < dofs_per_vertex; ++d, ++index)
-            dof_indices[index] = accessor.vertex_dof_index(vertex, 
-                                                           d, 
-                                                           fe_index);
+            accessor.set_vertex_dof_index(vertex,
+                                          d,
+                                          dof_indices[index],
+                                          fe_index);
 
         // 2) LINE dofs (2D/3D - see notes in get_dof_indices)
         if (structdim == 2 || structdim == 3)
@@ -32,13 +33,14 @@
                line < GeometryInfo<structdim>::lines_per_cell;
                ++line)
             for (unsigned int d = 0; d < dofs_per_line; ++d, ++index)
-              dof_indices[index] = accessor.line(line)->dof_index(
+              accessor.line(line)->set_dof_index(
                 structdim == 2 ? accessor.get_fe(fe_index)
                                    .adjust_line_dof_index_for_line_orientation(
                                      d, accessor.line_orientation(line)) :
                                  accessor.get_fe(fe_index)
                                    .adjust_line_dof_index_for_line_orientation(
                                      d, accessor.line_orientation(line)),
+                dof_indices[index],
                 fe_index);
 
         // 3) FACE dofs (3D - see notes in get_dof_indices)
@@ -47,18 +49,19 @@
                quad < GeometryInfo<structdim>::quads_per_cell;
                ++quad)
             for (unsigned int d = 0; d < dofs_per_quad; ++d, ++index)
-              dof_indices[index] = accessor.quad(quad)->dof_index(
+              accessor.quad(quad)->set_dof_index(
                 accessor.get_fe(fe_index)
                   .adjust_quad_dof_index_for_face_orientation(
                     d,
                     accessor.face_orientation(quad),
                     accessor.face_flip(quad),
                     accessor.face_rotation(quad)),
+                dof_indices[index],
                 fe_index);
 
         // 4) INNER dofs
         for (unsigned int d = 0; d < inner_dofs; ++d, ++index)
-          dof_indices[index] = accessor.dof_index(d, fe_index);
+          accessor.set_dof_index(d, dof_indices[index], fe_index);
 
         AssertDimension(dof_indices.size(), index);
       }
```