### PR TITLE
More updates to step-70

### DIFF
--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -176,6 +176,8 @@ namespace Particles
      * This function uses insert_global_particles and consequently may induce
      * considerable mpi communication overhead.
      *
+     * This function is used in step-70.
+     *
      * @param[in] dof_handler A DOF handler that may live on another
      * triangulation that is used to establsh the positions of the particles.
      *

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -52,6 +52,8 @@ namespace Particles
    * and particles that belong to neighbor processes and live in the ghost cells
    * around the locally owned domain "ghost particles".
    *
+   * This class is used in step-70.
+   *
    * @ingroup Particle
    */
   template <int dim, int spacedim = dim>
@@ -240,7 +242,8 @@ namespace Particles
      * at these positions, which are then distributed and added to the local
      * particle collection of a procesor. Note that this function uses
      * GridTools::distributed_compute_point_locations(). Consequently, it can
-     * require intense communications between the processors.
+     * require intense communications between the processors. This function
+     * is used in step-70.
      *
      * This function figures out what mpi process owns the points that do not
      * fall within the locally owned part of the triangulation, it sends


### PR DESCRIPTION
Specifically, rename a variable as mentioned in #10262. Also add a few more references to step-70 from other functions.

Since we're still waiting on other things to shake out about step-70, might as well put that into 9.2 -- though that's not critical.

Fixes #10262.

/rebuild