### PR TITLE
Link in step-70 pictures and videos.

### DIFF
--- a/examples/step-70/doc/results.dox
+++ b/examples/step-70/doc/results.dox
@@ -327,28 +327,27 @@ assembling the Stokes part. This depends highly on the number of Gauss points
 In the present case, a relatively low number of tracer particles are used.
 Consequently, tracking their motion is relatively cheap.
 
-The following images present the initial and the final configuration of the
-simulation domain:
+The following movie shows the evolution of the solution over time:
 
-
+@htmlonly
 <p align="center">
-   <div class="img" align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-70.initial_configuration.png"
-           alt = ""
-           width="500">
-    </div>
-</p>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/y4Gypj2jpXw"
+   frameborder="0"
+   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+   allowfullscreen></iframe>
+ </p>
+@endhtmlonly
 
+The movie shows the rotating obstacle in gray (actually a
+superposition of the solid particles plotted with large enough dots
+that they overlap), <a
+href="https://en.wikipedia.org/wiki/Streamlines,_streaklines,_and_pathlines">streamlines
+of the fluid flow</a> in light colors (including the corner vertices
+that form at specific times during the simulation), and the tracer particles in
+bluish tones.
 
-<p align="center">
-   <div class="img" align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-70.final_configuration.png"
-           alt = ""
-           width="500">
-    </div>
-</p>
-
-We see that, generally, the tracer particles have somewhat returned to their
+The simulation shows that at the end time,
+the tracer particles have somewhat returned to their
 original position, although they have been distorted by the flow field. The
 following image compares the initial and the final position of the particles
 after one time unit of flow.
@@ -369,6 +368,7 @@ Euler scheme used to advect the particles, by the loss of accuracy due to the
 fictitious domain and, finally, by the discretization error on the Stokes
 equations. The first two errors are the leading cause of this deformation and
 they could be alleviated by the use of a finer mesh and a lower time step.
+
 
 <h3> Three dimensional test case </h3>
 

--- a/examples/step-70/doc/results.dox
+++ b/examples/step-70/doc/results.dox
@@ -445,13 +445,16 @@ Now, the solver is taking most of the solution time in three dimensions,
 and the particle motion and Nitsche assembly remain relatively
 unimportant as far as run time is concerned.
 
+
+@htmlonly
 <p align="center">
-   <div class="img" align="center">
-      <img src="https://www.dealii.org/images/steps/developer/step-70.2d-3d.gif"
-           alt = ""
-           width="500">
-    </div>
-</p>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/Srwq7zyR9mg"
+   frameborder="0"
+   allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+   allowfullscreen></iframe>
+ </p>
+@endhtmlonly
+
 
 <a name="extensions"></a>
 <h3>Possibilities for extensions</h3>


### PR DESCRIPTION
Addresses the broken links mentioned in #10243 at least for the 2d case. I think that the video is actually a better visualization than the still images in https://gist.github.com/blaisb/a211c601067bb853a23c5beae3af0d9c The youtube video also has more features than embedding an animated gif, so I didn't take that one.

What's still missing are the 3d results, though.