### PR TITLE
ThreadLocalStorage: Reimplement using STL C++14 functionality

### DIFF
--- a/doc/news/changes/incompatibilities/20200526Maier
+++ b/doc/news/changes/incompatibilities/20200526Maier
@@ -1,0 +1,7 @@
+Changed: The ThreadLocalStorage class has been reimplemented with C++14 STL
+primitives and does not depend on the TBB library any more. With that the
+obscure ThreadLocalStorage::get_implementation() function that exposed the
+underlying TBB container has been removed.
+<br>
+(Matthias Maier, 2020/05/23)
+

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -322,6 +322,13 @@ private:
   mutable Threads::ThreadLocalStorage<std::stack<std::string>> prefixes;
 
   /**
+   * We record the thread id of the thread creating this object. We need
+   * this information to "steal" the current prefix from this "master"
+   * thread on first use of deallog on a new thread.
+   */
+  std::thread::id master_thread;
+
+  /**
    * Default stream, where the output is to go to. This stream defaults to
    * <tt>std::cout</tt>, but can be set to another stream through the
    * constructor.
@@ -373,7 +380,7 @@ private:
   get_stream();
 
   /**
-   * We use tbb's thread local storage facility to generate a stringstream for
+   * We use our thread local storage facility to generate a stringstream for
    * every thread that sends log messages.
    */
   Threads::ThreadLocalStorage<std::shared_ptr<std::ostringstream>> outstreams;

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -104,13 +104,16 @@ namespace Threads
     ThreadLocalStorage();
 
     /**
-     * A kind of copy constructor. Initialize each thread local object by
-     * copying the given object.
+     * A kind of copy constructor. Initializes an internal exemplar by the
+     * given object. The exemplar is in turn used to initialize each thread
+     * local object instead of invoking the default constructor.
      */
     explicit ThreadLocalStorage(const T &t);
 
     /**
-     * FIXME
+     * A kind of move constructor. Moves the given object into an internal
+     * exemplar. The exemplar is in turn used to initialize each thread
+     * local object instead of invoking the default constructor.
      */
     explicit ThreadLocalStorage(T &&t);
 
@@ -121,7 +124,8 @@ namespace Threads
     ThreadLocalStorage(const ThreadLocalStorage<T> &t) = default;
 
     /**
-     * Move constructor. FIXME
+     * Move constructor. Copies the internal state over from the given
+     * object.
      */
     ThreadLocalStorage(ThreadLocalStorage<T> &&t) = default;
 
@@ -173,7 +177,17 @@ namespace Threads
 
 
     /**
-     * FIXME
+     * Move the given argument into the storage space used to represent the
+     * current thread. Calling this function as <code>tls_data =
+     * object</code> is equivalent to calling <code>tls_data.get() =
+     * object</code>. The intent of this operator is to make the
+     * ThreadLocalStorage object look more like the object it represents on
+     * the current thread. Move assignment operator.
+     *
+     * @param t The object to be copied into the storage space used for the
+     * current thread.
+     *
+     * @return The current object, after the changes have been made
      */
     ThreadLocalStorage<T> &
     operator=(T &&t);
@@ -282,7 +296,6 @@ namespace Threads
     {
       // Take a unique ("writer") lock for manipulating the std::map. This
       // lock ensures that no other threat does a lookup at the same time.
-      //
       std::unique_lock<decltype(insertion_mutex)> lock(insertion_mutex);
 
       if constexpr (std::is_copy_constructible<
@@ -295,7 +308,7 @@ namespace Threads
 
       if constexpr (std::is_default_constructible<T>::value)
         {
-          return data[my_id]; // default construct
+          return data[my_id]; // invokes default constructor
         }
 
       Assert(false, ExcInternalError());

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -39,7 +39,7 @@ class LogStream;
 namespace Threads
 {
 #  ifndef DOXYGEN
-  namespace
+  namespace internal
   {
     /*
      * Workaround: The standard unfortunately has an unfortunate design
@@ -66,7 +66,7 @@ namespace Threads
     {
       using type = T;
     };
-  } // namespace
+  } // namespace internal
 #  endif
 
   /**
@@ -100,7 +100,8 @@ namespace Threads
   class ThreadLocalStorage
   {
     static_assert(
-      std::is_copy_constructible<typename unpack_container<T>::type>::value ||
+      std::is_copy_constructible<
+        typename internal::unpack_container<T>::type>::value ||
         std::is_default_constructible<T>::value,
       "The stored type must be either copyable, or default constructible");
 
@@ -182,7 +183,6 @@ namespace Threads
      */
     ThreadLocalStorage<T> &
     operator=(const T &t);
-
 
     /**
      * Move the given argument into the storage space used to represent the

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -252,10 +252,10 @@ namespace Threads
 
     // Note that std::map<..>::emplace guarantees that no iterators or
     // references to stored objects are invalidated. We thus only have to
-    // ensure that we do not performa a lookup while writing, and that we
+    // ensure that we do not perform a lookup while writing, and that we
     // do not write concurrently. This is precisely the "reader-writer
     // lock" paradigm supported by C++14 by means of the std::shared_lock
-    // and th std::unique_lock
+    // and the std::unique_lock.
 
     {
       // Take a shared ("reader") lock for lookup and record the fact

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -31,6 +31,9 @@ DEAL_II_NAMESPACE_OPEN
 /*!@addtogroup threads */
 /*@{*/
 
+#  ifndef DOXYGEN
+class LogStream;
+#  endif
 
 namespace Threads
 {
@@ -216,6 +219,8 @@ namespace Threads
      * An exemplar for creating a new (thread specific) copy.
      */
     std::shared_ptr<const T> exemplar;
+
+    friend class dealii::LogStream;
   };
 } // namespace Threads
 /**

--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -230,6 +230,11 @@ namespace Threads
 
     /**
      * A mutex to guard insertion into the data object.
+     *
+     * We use a std::shared_timed_mutex (or std::shared_mutex if available)
+     * here to be able to use std::unique_lock and std::shared_lock for a
+     * readers-writer lock
+     * (https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock).
      */
 #  ifdef DEAL_II_HAVE_CXX17
     std::shared_mutex insertion_mutex;

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -211,6 +211,13 @@ namespace WorkStream
               , currently_in_use(in_use)
             {}
 
+            // Provide a copy constructor that actually doesn't copy the
+            // internal state. This makes handling ScratchAndCopyDataObjects
+            // easier to handle with STL containers.
+            ScratchDataObject(const ScratchDataObject &)
+              : currently_in_use(false)
+            {}
+
             ScratchDataObject(ScratchDataObject &&o) noexcept = default;
           };
 
@@ -710,19 +717,11 @@ namespace WorkStream
           , currently_in_use(in_use)
         {}
 
-        // TODO: when we push back an object to the list of scratch objects, in
-        //      Worker::operator(), we first create an object and then copy
-        //      it to the end of this list. this involves having two objects
-        //      of the current type having pointers to it, each with their own
-        //      currently_in_use flag. there is probably little harm in this
-        //      because the original one goes out of scope right away again, but
-        //      it's certainly awkward. one way to avoid this would be to use
-        //      unique_ptr but we'd need to figure out a way to use it in
-        //      non-C++11 mode
-        ScratchAndCopyDataObjects(const ScratchAndCopyDataObjects &o)
-          : scratch_data(o.scratch_data)
-          , copy_data(o.copy_data)
-          , currently_in_use(o.currently_in_use)
+        // Provide a copy constructor that actually doesn't copy the
+        // internal state. This makes handling ScratchAndCopyDataObjects
+        // easier to handle with STL containers.
+        ScratchAndCopyDataObjects(const ScratchAndCopyDataObjects &)
+          : currently_in_use(false)
         {}
       };
 

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -385,6 +385,7 @@ LogStream::get_prefixes() const
   bool                     exists         = false;
   std::stack<std::string> &local_prefixes = prefixes.get(exists);
 
+#  if 0 // FIXME
   // If this is a new locally stored stack, copy the "blessed" prefixes
   // from the initial thread that created logstream.
   if (!exists)
@@ -402,6 +403,7 @@ LogStream::get_prefixes() const
           local_prefixes = *first_elem;
         }
     }
+#  endif
 
   return local_prefixes;
 

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -73,7 +73,8 @@ LogStream::Prefix::~Prefix()
 
 
 LogStream::LogStream()
-  : std_out(&std::cout)
+  : master_thread(std::this_thread::get_id())
+  , std_out(&std::cout)
   , file(nullptr)
   , std_depth(0)
   , file_depth(10000)
@@ -385,25 +386,14 @@ LogStream::get_prefixes() const
   bool                     exists         = false;
   std::stack<std::string> &local_prefixes = prefixes.get(exists);
 
-#  if 0 // FIXME
   // If this is a new locally stored stack, copy the "blessed" prefixes
   // from the initial thread that created logstream.
   if (!exists)
     {
-      const tbb::enumerable_thread_specific<std::stack<std::string>> &impl =
-        prefixes.get_implementation();
-
-      // The thread that created this LogStream object should be the first
-      // in tbb's enumerable_thread_specific container.
-      const tbb::enumerable_thread_specific<
-        std::stack<std::string>>::const_iterator first_elem = impl.begin();
-
-      if (first_elem != impl.end())
-        {
-          local_prefixes = *first_elem;
-        }
+      auto it = prefixes.data.find(master_thread);
+      if (it != prefixes.data.end())
+        local_prefixes = it->second;
     }
-#  endif
 
   return local_prefixes;
 


### PR DESCRIPTION
This obviously doesn't compile at the moment.

@bangerth This is what I suggest: Simply reimplement the functionality with C++11 STL functionality.

Closes #10284