### PR TITLE
Remove lapack_templates.h from more public headers.

### DIFF
--- a/include/deal.II/lac/utilities.h
+++ b/include/deal.II/lac/utilities.h
@@ -22,7 +22,6 @@
 #include <deal.II/base/signaling_nan.h>
 
 #include <deal.II/lac/lapack_support.h>
-#include <deal.II/lac/lapack_templates.h>
 #include <deal.II/lac/vector_memory.h>
 
 #include <array>
@@ -211,6 +210,28 @@ namespace Utilities
 
 #ifndef DOXYGEN
 
+namespace internal
+{
+  namespace UtilitiesImplementation
+  {
+    // We want to avoid including our own LAPACK wrapper header in any external
+    // headers to avoid possible conflicts with other packages that may define
+    // their own such header. At the same time we want to be able to call some
+    // LAPACK functions from the template functions below. To resolve both
+    // problems define some extra wrappers here that can be in the header:
+    template <typename Number>
+    void
+    call_stev(const char            jobz,
+              const types::blas_int n,
+              Number *              d,
+              Number *              e,
+              Number *              z,
+              const types::blas_int ldz,
+              Number *              work,
+              types::blas_int *     info);
+  } // namespace UtilitiesImplementation
+} // namespace internal
+
 namespace Utilities
 {
   namespace LinearAlgebra
@@ -380,14 +401,14 @@ namespace Utilities
       std::vector<double>   work;    // ^^
       types::blas_int       info;
       // call lapack_templates.h wrapper:
-      stev("N",
-           &n,
-           diagonal.data(),
-           subdiagonal.data(),
-           Z.data(),
-           &ldz,
-           work.data(),
-           &info);
+      internal::UtilitiesImplementation::call_stev('N',
+                                                   n,
+                                                   diagonal.data(),
+                                                   subdiagonal.data(),
+                                                   Z.data(),
+                                                   ldz,
+                                                   work.data(),
+                                                   &info);
 
       Assert(info == 0, LAPACKSupport::ExcErrorCode("dstev", info));
 

--- a/source/lac/CMakeLists.txt
+++ b/source/lac/CMakeLists.txt
@@ -53,9 +53,11 @@ SET(_unity_include_src
 SET(_separate_src
   full_matrix.cc
   lapack_full_matrix.cc
+  qr.cc
   sparse_matrix.cc
   sparse_matrix_inst2.cc
   tridiagonal_matrix.cc
+  utilities.cc
   )
 
 # Add CUDA wrapper files

--- a/source/lac/qr.cc
+++ b/source/lac/qr.cc
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/lapack_templates.h>
+#include <deal.II/lac/qr.h>
+
+#include <complex>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  namespace QRImplementation
+  {
+    // see the corresponding note in the header
+    template <typename Number>
+    void
+    call_trmv(const char            uplo,
+              const char            trans,
+              const char            diag,
+              const types::blas_int n,
+              const Number *        a,
+              const types::blas_int lda,
+              Number *              x,
+              const types::blas_int incx)
+    {
+      trmv(&uplo, &trans, &diag, &n, a, &lda, x, &incx);
+    }
+
+    template <typename Number>
+    void
+    call_trtrs(const char            uplo,
+               const char            trans,
+               const char            diag,
+               const types::blas_int n,
+               const types::blas_int nrhs,
+               const Number *        a,
+               const types::blas_int lda,
+               Number *              b,
+               const types::blas_int ldb,
+               types::blas_int *     info)
+    {
+      trtrs(&uplo, &trans, &diag, &n, &nrhs, a, &lda, b, &ldb, info);
+    }
+
+    template void
+    call_trmv(const char,
+              const char,
+              const char,
+              const types::blas_int,
+              const float *,
+              const types::blas_int,
+              float *,
+              const types::blas_int);
+
+    template void
+    call_trmv(const char,
+              const char,
+              const char,
+              const types::blas_int,
+              const double *,
+              const types::blas_int,
+              double *,
+              const types::blas_int);
+
+    template void
+    call_trmv(const char,
+              const char,
+              const char,
+              const types::blas_int,
+              const std::complex<float> *,
+              const types::blas_int,
+              std::complex<float> *,
+              const types::blas_int);
+
+    template void
+    call_trmv(const char,
+              const char,
+              const char,
+              const types::blas_int,
+              const std::complex<double> *,
+              const types::blas_int,
+              std::complex<double> *,
+              const types::blas_int);
+
+    template void
+    call_trtrs(const char,
+               const char,
+               const char,
+               const types::blas_int,
+               const types::blas_int,
+               const float *,
+               const types::blas_int,
+               float *,
+               const types::blas_int,
+               types::blas_int *);
+
+    template void
+    call_trtrs(const char,
+               const char,
+               const char,
+               const types::blas_int,
+               const types::blas_int,
+               const double *,
+               const types::blas_int,
+               double *,
+               const types::blas_int,
+               types::blas_int *);
+
+    template void
+    call_trtrs(const char,
+               const char,
+               const char,
+               const types::blas_int,
+               const types::blas_int,
+               const std::complex<float> *,
+               const types::blas_int,
+               std::complex<float> *,
+               const types::blas_int,
+               types::blas_int *);
+
+    template void
+    call_trtrs(const char,
+               const char,
+               const char,
+               const types::blas_int,
+               const types::blas_int,
+               const std::complex<double> *,
+               const types::blas_int,
+               std::complex<double> *,
+               const types::blas_int,
+               types::blas_int *);
+  } // namespace QRImplementation
+} // namespace internal
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/utilities.cc
+++ b/source/lac/utilities.cc
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/lac/lapack_templates.h>
+#include <deal.II/lac/utilities.h>
+
+#include <complex>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  namespace UtilitiesImplementation
+  {
+    // see the corresponding note in the header
+    template <typename Number>
+    void
+    call_stev(const char            jobz,
+              const types::blas_int n,
+              Number *              d,
+              Number *              e,
+              Number *              z,
+              const types::blas_int ldz,
+              Number *              work,
+              types::blas_int *     info)
+    {
+      stev(&jobz, &n, d, e, z, &ldz, work, info);
+    }
+
+
+    template void
+    call_stev(const char,
+              const types::blas_int,
+              float *,
+              float *,
+              float *,
+              const types::blas_int,
+              float *,
+              types::blas_int *);
+
+    template void
+    call_stev(const char,
+              const types::blas_int,
+              double *,
+              double *,
+              double *,
+              const types::blas_int,
+              double *,
+              types::blas_int *);
+
+    template void
+    call_stev(const char,
+              const types::blas_int,
+              std::complex<float> *,
+              std::complex<float> *,
+              std::complex<float> *,
+              const types::blas_int,
+              std::complex<float> *,
+              types::blas_int *);
+
+    template void
+    call_stev(const char,
+              const types::blas_int,
+              std::complex<double> *,
+              std::complex<double> *,
+              std::complex<double> *,
+              const types::blas_int,
+              std::complex<double> *,
+              types::blas_int *);
+  } // namespace UtilitiesImplementation
+} // namespace internal
+
+
+
+DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
As mentioned previously, this file can conflict with other packages' LAPACK
wrapper headers. Fortunately we only currently use three LAPACK functions in
headers - its easy enough to special-case these so that we can get rid of the
header inclusion.

Fixes #9135.