### PR TITLE
Refactor GridTools::DistributedComputePointLocations

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -908,8 +908,7 @@ namespace GridTools
    * @return A tuple containing the quadrature information
    *
    * The elements of the output tuple are:
-   * - cells : a vector of cells of the all cells containing at
-   *  least a point.
+   * - cells : a vector of all cells containing at least one point.
    * - qpoints : a vector of vector of points; containing in @p qpoints[i]
    *   the reference positions of all points that fall within the cell @p cells[i] .
    * - maps : a vector of vector of integers, containing the mapping between


### PR DESCRIPTION
This should be strictly a renaming and reordering of arguments, no functional changes expected. I tried to follow our usual naming conventions and at the same time make the code easier to read. Feel free to suggest other renaming changes (I want to keep functional changes separate, because we have other plans for these functions). @luca-heltai or @blaisb could you take a look?