### PR TITLE
Fix a missing mapping argument

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1638,8 +1638,8 @@ namespace GridTools
               }
             else
               {
-                closest_vertex_index =
-                  GridTools::find_closest_vertex(mesh, p, marked_vertices);
+                closest_vertex_index = GridTools::find_closest_vertex(
+                  mapping, mesh, p, marked_vertices);
               }
             vertex_to_point = p - mesh.get_vertices()[closest_vertex_index];
           }


### PR DESCRIPTION
This was found by @luca-heltai in a call today. If the function `GridTools::find_active_cell_around_point` was called without an rtree of vertices it would call a function without a mapping argument. This is only a problem if a mapping is used that does not preserve vertex locations.