### PR TITLE
Default the second template argument of Particles::DataOut.

### DIFF
--- a/doc/news/changes/minor/20200521Bangerth
+++ b/doc/news/changes/minor/20200521Bangerth
@@ -1,0 +1,5 @@
+Changed: In many other classes that are templated on `dim` and
+`spacedim`, the second template argument `spacedim` had a default
+value equal to `dim`. Particles::DataOut did not, but now does.
+<br>
+(Wolfgang Bangerth, 2020/05/21)

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1764,7 +1764,7 @@ namespace Step70
     const unsigned int                          iter,
     const double                                time) const
   {
-    Particles::DataOut<spacedim, spacedim> particles_out;
+    Particles::DataOut<spacedim> particles_out;
     particles_out.build_patches(particles);
     const std::string filename =
       (fprefix + "-" + Utilities::int_to_string(iter) + ".vtu");

--- a/include/deal.II/particles/data_out.h
+++ b/include/deal.II/particles/data_out.h
@@ -40,7 +40,7 @@ namespace Particles
    *
    * @author Bruno Blais, Luca Heltai 2019
    */
-  template <int dim, int spacedim>
+  template <int dim, int spacedim = dim>
   class DataOut : public dealii::DataOutInterface<0, spacedim>
   {
   public:


### PR DESCRIPTION
Like in many other classes, default 'spacedim' to 'dim'.