### PR TITLE
Rename namespace internals:: to internal::AffineConstraints::.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -48,11 +48,14 @@ class SparseMatrix;
 template <typename number>
 class BlockSparseMatrix;
 
-namespace internals
+namespace internal
 {
-  template <typename number>
-  class GlobalRowsFromLocal;
-}
+  namespace AffineConstraints
+  {
+    template <typename number>
+    class GlobalRowsFromLocal;
+  }
+} // namespace internal
 
 namespace internal
 {
@@ -1560,9 +1563,9 @@ private:
    * the global row indices.
    */
   void
-  make_sorted_row_list(
-    const std::vector<size_type> &          local_dof_indices,
-    internals::GlobalRowsFromLocal<number> &global_rows) const;
+  make_sorted_row_list(const std::vector<size_type> &local_dof_indices,
+                       internal::AffineConstraints::GlobalRowsFromLocal<number>
+                         &global_rows) const;
 
   /**
    * Internal helper function for add_entries_local_to_global function.
@@ -1581,11 +1584,11 @@ private:
   template <typename MatrixScalar, typename VectorScalar>
   typename ProductType<VectorScalar, MatrixScalar>::type
   resolve_vector_entry(
-    const size_type                               i,
-    const internals::GlobalRowsFromLocal<number> &global_rows,
-    const Vector<VectorScalar> &                  local_vector,
-    const std::vector<size_type> &                local_dof_indices,
-    const FullMatrix<MatrixScalar> &              local_matrix) const;
+    const size_type                                                 i,
+    const internal::AffineConstraints::GlobalRowsFromLocal<number> &global_rows,
+    const Vector<VectorScalar> &    local_vector,
+    const std::vector<size_type> &  local_dof_indices,
+    const FullMatrix<MatrixScalar> &local_matrix) const;
 };
 
 /* ---------------- template and inline functions ----------------- */

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -174,7 +174,7 @@ namespace internal
       read_dof_indices(
         const std::vector<types::global_dof_index> &local_indices,
         const std::vector<unsigned int> &           lexicographic_inv,
-        const AffineConstraints<number> &           constraints,
+        const dealii::AffineConstraints<number> &   constraints,
         const unsigned int                          cell_number,
         ConstraintValues<double> &                  constraint_values,
         bool &                                      cell_at_boundary);

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -214,7 +214,7 @@ namespace internal
     DoFInfo::read_dof_indices(
       const std::vector<types::global_dof_index> &local_indices,
       const std::vector<unsigned int> &           lexicographic_inv,
-      const AffineConstraints<number> &           constraints,
+      const dealii::AffineConstraints<number> &   constraints,
       const unsigned int                          cell_number,
       ConstraintValues<double> &                  constraint_values,
       bool &                                      cell_at_subdomain_boundary)

--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -137,8 +137,10 @@ INSTANTIATE_DLTG_MATRIX(TrilinosWrappers::BlockSparseMatrix);
  * place).
  */
 
-namespace internals
+namespace internal
 {
+  namespace AffineConstraints
+  {
 #define SCRATCH_INITIALIZER(number, Name)                                     \
   AffineConstraintsData<number>::ScratchData scratch_data_initializer_##Name; \
   template <>                                                                 \
@@ -146,13 +148,14 @@ namespace internals
     AffineConstraintsData<number>::scratch_data(                              \
       scratch_data_initializer_##Name)
 
-  SCRATCH_INITIALIZER(double, d);
-  SCRATCH_INITIALIZER(float, f);
+    SCRATCH_INITIALIZER(double, d);
+    SCRATCH_INITIALIZER(float, f);
 #ifdef DEAL_II_WITH_COMPLEX_VALUES
-  SCRATCH_INITIALIZER(std::complex<double>, cd);
-  SCRATCH_INITIALIZER(std::complex<float>, cf);
+    SCRATCH_INITIALIZER(std::complex<double>, cd);
+    SCRATCH_INITIALIZER(std::complex<float>, cf);
 #endif
 #undef SCRATCH_INITIALIZER
-} // namespace internals
+  } // namespace AffineConstraints
+} // namespace internal
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -35,7 +35,7 @@ namespace internal
     DoFInfo::read_dof_indices<double>(
       const std::vector<types::global_dof_index> &,
       const std::vector<unsigned int> &,
-      const AffineConstraints<double> &,
+      const dealii::AffineConstraints<double> &,
       const unsigned int,
       ConstraintValues<double> &,
       bool &);
@@ -44,7 +44,7 @@ namespace internal
     DoFInfo::read_dof_indices<float>(
       const std::vector<types::global_dof_index> &,
       const std::vector<unsigned int> &,
-      const AffineConstraints<float> &,
+      const dealii::AffineConstraints<float> &,
       const unsigned int,
       ConstraintValues<double> &,
       bool &);


### PR DESCRIPTION
The AffineConstraints class and friends put things into a namespace 'internals'. That's
an uncommon name: We typically use 'internal::'. But a lot of the things in that namespace
also have rather generic names, so do as we often do in such cases: further qualify
the name to indicate what class the internals correspond to.

Almost all of the changes you see here are whitespace changes, so look at the patch with `?w=1`. There are a couple of places where we now need to qualify an `AffineConstraints` class name when used from inside another `internal::` namespace.

/rebuild