### PR TITLE
Move a class out of a surrounding class.

### DIFF
--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -141,11 +141,11 @@ namespace internal
 {
   namespace AffineConstraints
   {
-#define SCRATCH_INITIALIZER(number, Name)                                     \
-  AffineConstraintsData<number>::ScratchData scratch_data_initializer_##Name; \
-  template <>                                                                 \
-  Threads::ThreadLocalStorage<AffineConstraintsData<number>::ScratchData>     \
-    AffineConstraintsData<number>::scratch_data(                              \
+#define SCRATCH_INITIALIZER(number, Name)              \
+  ScratchData<number> scratch_data_initializer_##Name; \
+  template <>                                          \
+  Threads::ThreadLocalStorage<ScratchData<number>>     \
+    AffineConstraintsData<number>::scratch_data(       \
       scratch_data_initializer_##Name)
 
     SCRATCH_INITIALIZER(double, d);


### PR DESCRIPTION
Part of #10284. I'll have to get that `ScratchData` object into the `AffineConstraints` class. This is step 1, moving it out of the surrounding class.

/rebuild