### PR TITLE
remove const from static_cast

### DIFF
--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -115,7 +115,7 @@ protected:
 template <int N>
 template <typename... T>
 constexpr TableIndices<N>::TableIndices(const T... args)
-  : indices{static_cast<const unsigned int>(args)...}
+  : indices{static_cast<std::size_t>(args)...}
 {
   static_assert(internal::TemplateConstraints::all_true<
                   std::is_integral<T>::value...>::value,


### PR DESCRIPTION
nvcc with gcc 8 complains that the const here is unnecessary.