### PR TITLE
Generalize vertex/line/quad_index

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2312,6 +2312,19 @@ struct GeometryInfo
                              const bool         face_flip        = false,
                              const bool         face_rotation    = false);
 
+  static unsigned int
+  standard_to_real_line_vertex(const unsigned int line,
+                               const bool         face_orientation = true);
+
+  static std::array<unsigned int, 2>
+  standard_corner_to_line_vertex_index(const unsigned int corner);
+
+  static std::array<unsigned int, 2>
+  standard_corner_to_quad_vertex_index(const unsigned int corner);
+
+  static std::array<unsigned int, 2>
+  standard_line_to_quad_line_index(const unsigned int line);
+
   /**
    * Map the line index @p line of a face with arbitrary @p face_orientation,
    * @p face_flip and @p face_rotation to a face in standard orientation. The
@@ -4047,6 +4060,118 @@ GeometryInfo<dim>::standard_to_real_face_line(const unsigned int line,
 {
   Assert(false, ExcNotImplemented());
   return line;
+}
+
+
+
+template <>
+inline unsigned int
+GeometryInfo<2>::standard_to_real_line_vertex(const unsigned int corner,
+                                              const bool line_orientation)
+{
+  return line_orientation ? corner : (1 - corner);
+}
+
+
+
+template <int dim>
+inline unsigned int
+GeometryInfo<dim>::standard_to_real_line_vertex(const unsigned int corner,
+                                                const bool)
+{
+  Assert(false, ExcNotImplemented());
+  return corner;
+}
+
+
+
+template <>
+inline std::array<unsigned int, 2>
+GeometryInfo<2>::standard_corner_to_line_vertex_index(const unsigned int corner)
+{
+  return {{corner % 2, corner / 2}};
+}
+
+
+
+template <int dim>
+inline std::array<unsigned int, 2>
+GeometryInfo<dim>::standard_corner_to_line_vertex_index(
+  const unsigned int corner)
+{
+  Assert(false, ExcNotImplemented());
+  (void)corner;
+  return {{0, 0}};
+}
+
+
+
+template <>
+inline std::array<unsigned int, 2>
+GeometryInfo<3>::standard_line_to_quad_line_index(const unsigned int i)
+{
+  // set up a table that for each
+  // line describes a) from which
+  // quad to take it, b) which line
+  // therein it is if the face is
+  // oriented correctly
+  static const unsigned int lookup_table[GeometryInfo<3>::lines_per_cell][2] = {
+    {4, 0}, // take first four lines from bottom face
+    {4, 1},
+    {4, 2},
+    {4, 3},
+
+    {5, 0}, // second four lines from top face
+    {5, 1},
+    {5, 2},
+    {5, 3},
+
+    {0, 0}, // the rest randomly
+    {1, 0},
+    {0, 1},
+    {1, 1}};
+
+  return {{lookup_table[i][0], lookup_table[i][1]}};
+}
+
+
+
+template <int dim>
+inline std::array<unsigned int, 2>
+GeometryInfo<dim>::standard_line_to_quad_line_index(const unsigned int corner)
+{
+  Assert(false, ExcNotImplemented());
+  (void)corner;
+  return {{0, 0}};
+}
+
+
+
+template <>
+inline std::array<unsigned int, 2>
+GeometryInfo<3>::standard_corner_to_quad_vertex_index(const unsigned int corner)
+{
+  // get the corner indices by asking either
+  // the bottom or the top face for its
+  // vertices. handle non-standard faces by
+  // calling the vertex reordering function
+  // from GeometryInfo
+
+  // bottom face (4) for first four vertices,
+  // top face (5) for the rest
+  return {{4 + corner / 4, corner % 4}};
+}
+
+
+
+template <int dim>
+inline std::array<unsigned int, 2>
+GeometryInfo<dim>::standard_corner_to_quad_vertex_index(
+  const unsigned int corner)
+{
+  Assert(false, ExcNotImplemented());
+  (void)corner;
+  return {{0, 0}};
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -632,45 +632,15 @@ namespace internal
       line_index(const TriaAccessor<3, dim, spacedim> &accessor,
                  const unsigned int                    i)
       {
-        // get the line index by asking the
-        // quads. first assume standard orientation
-        //
-        // set up a table that for each
-        // line describes a) from which
-        // quad to take it, b) which line
-        // therein it is if the face is
-        // oriented correctly
-        static const unsigned int
-          lookup_table[GeometryInfo<3>::lines_per_cell][2] = {
-            {4, 0}, // take first four lines from bottom face
-            {4, 1},
-            {4, 2},
-            {4, 3},
+        const auto pair = GeometryInfo<3>::standard_line_to_quad_line_index(i);
+        const auto quad_index = pair[0];
+        const auto line_index = GeometryInfo<3>::standard_to_real_face_line(
+          pair[1],
+          accessor.face_orientation(quad_index),
+          accessor.face_flip(quad_index),
+          accessor.face_rotation(quad_index));
 
-            {5, 0}, // second four lines from top face
-            {5, 1},
-            {5, 2},
-            {5, 3},
-
-            {0, 0}, // the rest randomly
-            {1, 0},
-            {0, 1},
-            {1, 1}};
-
-        // respect non-standard faces by calling the
-        // reordering function from GeometryInfo
-
-        const unsigned int quad_index     = lookup_table[i][0];
-        const unsigned int std_line_index = lookup_table[i][1];
-
-        const unsigned int line_index =
-          GeometryInfo<dim>::standard_to_real_face_line(
-            std_line_index,
-            accessor.face_orientation(quad_index),
-            accessor.face_flip(quad_index),
-            accessor.face_rotation(quad_index));
-
-        return (accessor.quad(quad_index)->line_index(line_index));
+        return accessor.quad(quad_index)->line_index(line_index);
       }
 
 
@@ -696,7 +666,6 @@ namespace internal
       quad_index(const TriaAccessor<3, dim, spacedim> &accessor,
                  const unsigned int                    i)
       {
-        AssertIndexRange(i, GeometryInfo<3>::quads_per_cell);
         return accessor.tria->levels[accessor.present_level]
           ->cells.cells[accessor.present_index]
           .face(i);
@@ -1100,20 +1069,13 @@ namespace internal
       vertex_index(const TriaAccessor<2, dim, spacedim> &accessor,
                    const unsigned int                    corner)
       {
-        // table used to switch the vertices, if the
-        // line orientation is wrong,
-        //
-        // first index: line orientation 0: false or
-        // 1: true=standard
-        //
-        // second index: vertex index to be switched
-        // (or not)
+        const auto pair =
+          GeometryInfo<2>::standard_corner_to_line_vertex_index(corner);
+        const auto line_index   = pair[0];
+        const auto vertex_index = GeometryInfo<2>::standard_to_real_line_vertex(
+          pair[1], accessor.line_orientation(line_index));
 
-        static const unsigned int switch_table[2][2] = {{1, 0}, {0, 1}};
-
-        return accessor.line(corner % 2)
-          ->vertex_index(
-            switch_table[accessor.line_orientation(corner % 2)][corner / 2]);
+        return accessor.line(line_index)->vertex_index(vertex_index);
       }
 
 
@@ -1123,22 +1085,16 @@ namespace internal
       vertex_index(const TriaAccessor<3, dim, spacedim> &accessor,
                    const unsigned int                    corner)
       {
-        // get the corner indices by asking either
-        // the bottom or the top face for its
-        // vertices. handle non-standard faces by
-        // calling the vertex reordering function
-        // from GeometryInfo
+        const auto pair =
+          GeometryInfo<3>::standard_corner_to_quad_vertex_index(corner);
+        const auto face_index   = pair[0];
+        const auto vertex_index = GeometryInfo<3>::standard_to_real_face_vertex(
+          pair[1],
+          accessor.face_orientation(face_index),
+          accessor.face_flip(face_index),
+          accessor.face_rotation(face_index));
 
-        // bottom face (4) for first four vertices,
-        // top face (5) for the rest
-        const unsigned int face_index = 4 + corner / 4;
-
-        return accessor.quad(face_index)
-          ->vertex_index(GeometryInfo<dim>::standard_to_real_face_vertex(
-            corner % 4,
-            accessor.face_orientation(face_index),
-            accessor.face_flip(face_index),
-            accessor.face_rotation(face_index)));
+        return accessor.quad(face_index)->vertex_index(vertex_index);
       }
     };
   } // namespace TriaAccessorImplementation


### PR DESCRIPTION
Rely in `internal::TriaAccessorImplementation::Implementation::quad_index()`, `internal::TriaAccessorImplementation::Implementation::line_index()`, and `internal::TriaAccessorImplementation::Implementation::vertex_index()` completely on `GeometryInfo`. 

**Note:** This is solely an internal change.

**internal::TriaAccessorImplementation::Implementation::quad_index()**:
```cpp
      template <int dim, int spacedim>
      inline static unsigned int
      quad_index(const TriaAccessor<3, dim, spacedim> &accessor,
                 const unsigned int                    i)
      {
        return accessor.tria->levels[accessor.present_level]
          ->cells.cells[accessor.present_index]
          .face(i);
      }
```

**internal::TriaAccessorImplementation::Implementation::line_index()**:
```cpp
      template <int dim, int spacedim>
      inline static unsigned int
      line_index(const TriaAccessor<2, dim, spacedim> &accessor,
                 const unsigned int                    i)
      {
        return accessor.objects().cells[accessor.present_index].face(i);
      }


      template <int dim, int spacedim>
      inline static unsigned int
      line_index(const TriaAccessor<3, dim, spacedim> &accessor,
                 const unsigned int                    i)
      {
        const auto pair = GeometryInfo<3>::standard_line_to_quad_line_index(i);
        const auto quad_index = pair[0];
        const auto line_index = GeometryInfo<3>::standard_to_real_face_line(
          pair[1],
          accessor.face_orientation(quad_index),
          accessor.face_flip(quad_index),
          accessor.face_rotation(quad_index));

        return accessor.quad(quad_index)->line_index(line_index);
      }
```

**internal::TriaAccessorImplementation::Implementation::vertex_index()**:
```cpp

      template <int dim, int spacedim>
      inline static unsigned int
      vertex_index(const TriaAccessor<1, dim, spacedim> &accessor,
                   const unsigned int                    corner)
      {
        return accessor.objects().cells[accessor.present_index].face(corner);
      }


      template <int dim, int spacedim>
      inline static unsigned int
      vertex_index(const TriaAccessor<2, dim, spacedim> &accessor,
                   const unsigned int                    corner)
      {
        const auto pair =
          GeometryInfo<2>::standard_corner_to_line_vertex_index(corner);
        const auto line_index   = pair[0];
        const auto vertex_index = GeometryInfo<2>::standard_to_real_line_vertex(
          pair[1], accessor.line_orientation(line_index));

        return accessor.line(line_index)->vertex_index(vertex_index);
      }


      template <int dim, int spacedim>
      inline static unsigned int
      vertex_index(const TriaAccessor<3, dim, spacedim> &accessor,
                   const unsigned int                    corner)
      {
        const auto pair =
          GeometryInfo<3>::standard_corner_to_quad_vertex_index(corner);
        const auto face_index   = pair[0];
        const auto vertex_index = GeometryInfo<3>::standard_to_real_face_vertex(
          pair[1],
          accessor.face_orientation(face_index),
          accessor.face_flip(face_index),
          accessor.face_rotation(face_index));

        return accessor.quad(face_index)->vertex_index(vertex_index);
      }
```

This code is extendable to arbitrary mesh entity types once `Geometry` info depends on the entity type and orientation/flip/rotation is merged to a single number.