### PR TITLE
Correct documentation of a MatrixFree additional data parameter

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -447,9 +447,9 @@ public:
     DEAL_II_DEPRECATED unsigned int &level_mg_handler;
 
     /**
-     * Controls whether to allow reading from vectors without resolving
+     * Controls whether to enable reading from vectors without resolving
      * constraints, i.e., just read the local values of the vector. By
-     * default, this option is disabled, so if you want to use
+     * default, this option is enabled. In case you want to use
      * FEEvaluationBase::read_dof_values_plain, this flag needs to be set.
      */
     bool store_plain_indices;


### PR DESCRIPTION
According to our source code, the default state of `store_plain_indices` is `true`:
https://github.com/dealii/dealii/blob/b901dbd07c23a75e8ded5df87abe321e087a8270/include/deal.II/matrix_free/matrix_free.h#L224
