### PR TITLE
consistently use local_size().

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -437,16 +437,16 @@ namespace Utilities
 #endif
 
     /**
-     * Given the number of locally owned elements @p local_size,
-     * create a 1:1 partitioning of the of elements across the MPI communicator @p comm.
-     * The total size of elements is the sum of @p local_size across the MPI communicator.
-     * Each process will store contiguous subset of indices, and the index set
-     * on process p+1 starts at the index one larger than the last one stored on
-     * process p.
+     * Given the number of locally owned elements @p locally_owned_size,
+     * create a 1:1 partitioning of the of elements across the MPI
+     * communicator @p comm. The total size of elements is the sum of @p
+     * locally_owned_size across the MPI communicator.  Each process will
+     * store contiguous subset of indices, and the index set on process p+1
+     * starts at the index one larger than the last one stored on process p.
      */
     std::vector<IndexSet>
     create_ascending_partitioning(const MPI_Comm &          comm,
-                                  const IndexSet::size_type local_size);
+                                  const IndexSet::size_type locally_owned_size);
 
     /**
      * Given the total number of elements @p total_size, create an evenly

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -196,7 +196,7 @@ namespace Utilities
            * the possible end of the index space. Equivalent to
            * `local_range.second - local_range.first`.
            */
-          types::global_dof_index local_size;
+          types::global_dof_index locally_owned_size;
 
           /**
            * The global size of the index space.
@@ -337,7 +337,7 @@ namespace Utilities
                   }
 
                 // 4) receive messages until all dofs in dict are processed
-                while (this->local_size != dic_local_received)
+                while (this->locally_owned_size != dic_local_received)
                   {
                     // wait for an incoming message
                     MPI_Status status;
@@ -515,10 +515,10 @@ namespace Utilities
             local_range.first  = get_index_offset(my_rank);
             local_range.second = get_index_offset(my_rank + 1);
 
-            local_size = local_range.second - local_range.first;
+            locally_owned_size = local_range.second - local_range.first;
 
             actually_owning_ranks = {};
-            actually_owning_ranks.resize(local_size,
+            actually_owning_ranks.resize(locally_owned_size,
                                          numbers::invalid_unsigned_int);
 #else
             (void)owned_indices;

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -123,9 +123,10 @@ namespace Utilities
      * The partitioner includes a mechanism for converting global to local and
      * local to global indices. Internally, this class stores vector elements
      * using the convention as follows: The local range is associated with
-     * local indices [0,@p local_size), and ghost indices are stored
-     * consecutively in [@p local_size, @p local_size + @p n_ghost_indices).
-     * The ghost indices are sorted according to their global index.
+     * local indices [0, locally_owned_size()), and ghost indices are stored
+     * consecutively in [locally_owned_size(), locally_owned_size() +
+     * n_ghost_indices()). The ghost indices are sorted according to their
+     * global index.
      *
      *
      * <h4>Parallel data exchange</h4>
@@ -266,11 +267,22 @@ namespace Utilities
       size() const;
 
       /**
-       * Return the local size, i.e. local_range().second minus
-       * local_range().first.
+       * Return the number of locally owned indices,
+       * i.e., local_range().second minus local_range().first.
+       *
+       * @deprecated Use the more clearly named function locally_owned_size()
+       * instead.
        */
+      DEAL_II_DEPRECATED
       unsigned int
       local_size() const;
+
+      /**
+       * Return the number of locally owned indices,
+       * i.e., local_range().second minus local_range().first.
+       */
+      unsigned int
+      locally_owned_size() const;
 
       /**
        * Return an IndexSet representation of the local range. This class
@@ -301,10 +313,10 @@ namespace Utilities
        * the given global index is neither locally owned nor a ghost, an
        * exception is thrown.
        *
-       * Note that the returned local index for locally owned indices
-       * will be between 0 and
-       * `local_size()-1`, and the local index for ghosts is between
-       * `local_size()` and `local_size()+n_ghost_indices()-1`.
+       * Note that the returned local index for locally owned indices will be
+       * between 0 and locally_owned_size() - 1, and the local index for
+       * ghosts is between locally_owned_size() and locally_owned_size() +
+       * n_ghost_indices() - 1.
        */
       unsigned int
       global_to_local(const types::global_dof_index global_index) const;
@@ -313,8 +325,9 @@ namespace Utilities
        * Return the global index corresponding to the given local index.
        *
        * Note that the local index for locally owned indices must be between 0
-       * and `local_size()-1`, and the local index for ghosts must be between
-       * `local_size()` and `local_size()+n_ghost_indices()-1`.
+       * and locally_owned_size() - 1, and the local index for ghosts must be
+       * between locally_owned_size() and locally_owned_size() +
+       * n_ghost_indices() - 1.
        */
       types::global_dof_index
       local_to_global(const unsigned int local_index) const;
@@ -795,6 +808,14 @@ namespace Utilities
     inline unsigned int
     Partitioner::local_size() const
     {
+      return locally_owned_size();
+    }
+
+
+
+    inline unsigned int
+    Partitioner::locally_owned_size() const
+    {
       types::global_dof_index size =
         local_range_data.second - local_range_data.first;
       Assert(size <= std::numeric_limits<unsigned int>::max(),
@@ -836,7 +857,7 @@ namespace Utilities
       if (in_local_range(global_index))
         return static_cast<unsigned int>(global_index - local_range_data.first);
       else if (is_ghost_entry(global_index))
-        return (local_size() +
+        return (locally_owned_size() +
                 static_cast<unsigned int>(
                   ghost_indices_data.index_within_set(global_index)));
       else
@@ -851,11 +872,13 @@ namespace Utilities
     inline types::global_dof_index
     Partitioner::local_to_global(const unsigned int local_index) const
     {
-      AssertIndexRange(local_index, local_size() + n_ghost_indices_data);
-      if (local_index < local_size())
+      AssertIndexRange(local_index,
+                       locally_owned_size() + n_ghost_indices_data);
+      if (local_index < locally_owned_size())
         return local_range_data.first + types::global_dof_index(local_index);
       else
-        return ghost_indices_data.nth_index_in_set(local_index - local_size());
+        return ghost_indices_data.nth_index_in_set(local_index -
+                                                   locally_owned_size());
     }
 
 

--- a/include/deal.II/base/partitioner.templates.h
+++ b/include/deal.II/base/partitioner.templates.h
@@ -58,7 +58,7 @@ namespace Utilities
       const unsigned int n_ghost_targets  = ghost_targets_data.size();
 
       if (n_import_targets > 0)
-        AssertDimension(locally_owned_array.size(), local_size());
+        AssertDimension(locally_owned_array.size(), locally_owned_size());
 
       Assert(requests.size() == 0,
              ExcMessage("Another operation seems to still be running. "
@@ -576,7 +576,7 @@ namespace Utilities
       // first wait for the receive to complete
       if (requests.size() > 0 && n_import_targets > 0)
         {
-          AssertDimension(locally_owned_array.size(), local_size());
+          AssertDimension(locally_owned_array.size(), locally_owned_size());
           const int ierr =
             MPI_Waitall(n_import_targets, requests.data(), MPI_STATUSES_IGNORE);
           AssertThrowMPI(ierr);

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -560,6 +560,14 @@ public:
   size() const;
 
   /**
+   * Return local dimension of the vector. This is the sum of the local
+   * dimensions (i.e., values stored on the current processor) of all
+   * components.
+   */
+  std::size_t
+  local_size() const;
+
+  /**
    * Return an index set that describes which elements of this vector are
    * owned by the current processor. Note that this index set does not include
    * elements this vector may store locally as ghost elements but that are in
@@ -1441,6 +1449,18 @@ inline std::size_t
 BlockVectorBase<VectorType>::size() const
 {
   return block_indices.total_size();
+}
+
+
+
+template <class VectorType>
+inline std::size_t
+BlockVectorBase<VectorType>::local_size() const
+{
+  std::size_t local_size = 0;
+  for (unsigned int b = 0; b < n_blocks(); ++b)
+    local_size += block(b).local_size();
+  return local_size;
 }
 
 

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -565,7 +565,7 @@ public:
    * components.
    */
   std::size_t
-  local_size() const;
+  locally_owned_size() const;
 
   /**
    * Return an index set that describes which elements of this vector are
@@ -1455,11 +1455,11 @@ BlockVectorBase<VectorType>::size() const
 
 template <class VectorType>
 inline std::size_t
-BlockVectorBase<VectorType>::local_size() const
+BlockVectorBase<VectorType>::locally_owned_size() const
 {
   std::size_t local_size = 0;
   for (unsigned int b = 0; b < n_blocks(); ++b)
-    local_size += block(b).local_size();
+    local_size += block(b).locally_owned_size();
   return local_size;
 }
 

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -665,9 +665,9 @@ namespace LinearAlgebra
 
       Number local_result = Number();
       for (unsigned int i = 0; i < this->n_blocks(); ++i)
-        local_result +=
-          this->block(i).mean_value_local() *
-          static_cast<real_type>(this->block(i).partitioner->local_size());
+        local_result += this->block(i).mean_value_local() *
+                        static_cast<real_type>(
+                          this->block(i).partitioner->locally_owned_size());
 
       if (this->block(0).partitioner->n_mpi_processes() > 1)
         return Utilities::MPI::sum(

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -269,7 +269,7 @@ namespace LinearAlgebra
                         &start_ptr);
           AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-          const size_type vec_size = this->block(i).local_size();
+          const size_type vec_size = this->block(i).locally_owned_size();
           petsc_helpers::copy_petsc_vector(start_ptr,
                                            start_ptr + vec_size,
                                            this->block(i).begin());

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -893,7 +893,7 @@ namespace LinearAlgebra
        * the C++ standard library by returning iterators to the start and end
        * of the <i>locally owned</i> elements of this vector.
        *
-       * It holds that end() - begin() == local_size().
+       * It holds that end() - begin() == locally_owned_size().
        *
        * @note For the CUDA memory space, the iterator points to memory on the
        * device.
@@ -975,8 +975,8 @@ namespace LinearAlgebra
       /**
        * Read access to the data field specified by @p local_index. Locally
        * owned indices can be accessed with indices
-       * <code>[0,local_size)</code>, and ghost indices with indices
-       * <code>[local_size,local_size+ n_ghost_entries]</code>.
+       * <code>[0,locally_owned_size)</code>, and ghost indices with indices
+       * <code>[locally_owned_size,locally_owned_size+ n_ghost_entries]</code>.
        *
        * Performance: Direct array access (fast).
        */
@@ -986,8 +986,8 @@ namespace LinearAlgebra
       /**
        * Read and write access to the data field specified by @p local_index.
        * Locally owned indices can be accessed with indices
-       * <code>[0,local_size)</code>, and ghost indices with indices
-       * <code>[local_size,local_size+n_ghosts]</code>.
+       * <code>[0,locally_owned_size())</code>, and ghost indices with indices
+       * <code>[locally_owned_size(), locally_owned_size()+n_ghosts]</code>.
        *
        * Performance: Direct array access (fast).
        */

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1602,7 +1602,7 @@ namespace LinearAlgebra
                        partitioner->locally_owned_size() +
                          partitioner->n_ghost_indices());
       // do not allow reading a vector which is not in ghost mode
-      Assert(local_index < local_size() || vector_is_ghosted == true,
+      Assert(local_index < locally_owned_size() || vector_is_ghosted == true,
              ExcMessage("You tried to read a ghost element of this vector, "
                         "but it has not imported its ghost values."));
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -104,8 +104,9 @@ namespace LinearAlgebra
      * <li> Besides the usual global access operator() it is also possible to
      * access vector entries in the local index space with the function @p
      * local_element(). Locally owned indices are placed first, [0,
-     * local_size()), and then all ghost indices follow after them
-     * contiguously, [local_size(), local_size()+n_ghost_entries()).
+     * locally_owned_size()), and then all ghost indices follow after them
+     * contiguously, [locally_owned_size(),
+     * locally_owned_size()+n_ghost_entries()).
      * </ul>
      *
      * Functions related to parallel functionality:
@@ -866,9 +867,19 @@ namespace LinearAlgebra
       /**
        * Return the local size of the vector, i.e., the number of indices
        * owned locally.
+       *
+       * @deprecated use locally_owned_size() instead.
        */
+      DEAL_II_DEPRECATED
       size_type
       local_size() const;
+
+      /**
+       * Return the local size of the vector, i.e., the number of indices
+       * owned locally.
+       */
+      size_type
+      locally_owned_size() const;
 
       /**
        * Return true if the given global index is in the local range of this
@@ -1437,6 +1448,15 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::local_size() const
     {
       return locally_owned_size();
+    }
+
+
+
+    template <typename Number, typename MemorySpace>
+    inline typename Vector<Number, MemorySpace>::size_type
+    Vector<Number, MemorySpace>::locally_owned_size() const
+    {
+      return partitioner->local_size();
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1436,7 +1436,7 @@ namespace LinearAlgebra
     inline typename Vector<Number, MemorySpace>::size_type
     Vector<Number, MemorySpace>::local_size() const
     {
-      return partitioner->local_size();
+      return locally_owned_size();
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1456,7 +1456,7 @@ namespace LinearAlgebra
     inline typename Vector<Number, MemorySpace>::size_type
     Vector<Number, MemorySpace>::locally_owned_size() const
     {
-      return partitioner->local_size();
+      return partitioner->locally_owned_size();
     }
 
 
@@ -1508,7 +1508,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::end()
     {
       return internal::Policy<Number, MemorySpace>::begin(data) +
-             partitioner->local_size();
+             partitioner->locally_owned_size();
     }
 
 
@@ -1518,7 +1518,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpace>::end() const
     {
       return internal::Policy<Number, MemorySpace>::begin(data) +
-             partitioner->local_size();
+             partitioner->locally_owned_size();
     }
 
 
@@ -1599,7 +1599,7 @@ namespace LinearAlgebra
              ExcMessage(
                "This function is only implemented for the Host memory space"));
       AssertIndexRange(local_index,
-                       partitioner->local_size() +
+                       partitioner->locally_owned_size() +
                          partitioner->n_ghost_indices());
       // do not allow reading a vector which is not in ghost mode
       Assert(local_index < local_size() || vector_is_ghosted == true,
@@ -1620,7 +1620,7 @@ namespace LinearAlgebra
                "This function is only implemented for the Host memory space"));
 
       AssertIndexRange(local_index,
-                       partitioner->local_size() +
+                       partitioner->locally_owned_size() +
                          partitioner->n_ghost_indices());
 
       return data.values[local_index];

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -559,7 +559,7 @@ namespace LinearAlgebra
 
       thread_loop_partitioner = v.thread_loop_partitioner;
 
-      const size_type this_size = local_size();
+      const size_type this_size = locally_owned_size();
       if (this_size > 0)
         {
           dealii::internal::VectorOperations::
@@ -1165,7 +1165,7 @@ namespace LinearAlgebra
         }
       Vector<Number, ::dealii::MemorySpace::Host> tmp_vector(comm_pattern);
 
-      data.copy_to(tmp_vector.begin(), local_size());
+      data.copy_to(tmp_vector.begin(), locally_owned_size());
 
       // fill entries from ReadWriteVector into the distributed vector,
       // including ghost entries. this is not really efficient right now
@@ -1214,7 +1214,7 @@ namespace LinearAlgebra
         }
       tmp_vector.compress(operation);
 
-      data.copy_from(tmp_vector.begin(), local_size());
+      data.copy_from(tmp_vector.begin(), locally_owned_size());
     }
 
     template <typename Number, typename MemorySpaceType>
@@ -1273,7 +1273,7 @@ namespace LinearAlgebra
     Vector<Number, MemorySpaceType> &
     Vector<Number, MemorySpaceType>::operator=(const Number s)
     {
-      const size_type this_size = local_size();
+      const size_type this_size = locally_owned_size();
       if (this_size > 0)
         {
           dealii::internal::VectorOperations::
@@ -1318,7 +1318,7 @@ namespace LinearAlgebra
              ExcVectorTypeNotCompatible());
       const VectorType &v = dynamic_cast<const VectorType &>(vv);
 
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::add_vector(
@@ -1346,7 +1346,7 @@ namespace LinearAlgebra
              ExcVectorTypeNotCompatible());
       const VectorType &v = dynamic_cast<const VectorType &>(vv);
 
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::subtract_vector(
@@ -1392,7 +1392,7 @@ namespace LinearAlgebra
       const VectorType &v = dynamic_cast<const VectorType &>(vv);
 
       AssertIsFinite(a);
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       // nothing to do if a is zero
       if (a == Number(0.))
@@ -1441,8 +1441,8 @@ namespace LinearAlgebra
       AssertIsFinite(a);
       AssertIsFinite(b);
 
-      AssertDimension(local_size(), v.local_size());
-      AssertDimension(local_size(), w.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
+      AssertDimension(locally_owned_size(), w.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::add_avpbw(
@@ -1480,7 +1480,7 @@ namespace LinearAlgebra
       const Vector<Number, MemorySpaceType> &v)
     {
       AssertIsFinite(x);
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::sadd_xv(
@@ -1511,7 +1511,7 @@ namespace LinearAlgebra
 
       AssertIsFinite(x);
       AssertIsFinite(a);
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::sadd_xav(
@@ -1580,11 +1580,11 @@ namespace LinearAlgebra
              ExcVectorTypeNotCompatible());
       const VectorType &v = dynamic_cast<const VectorType &>(vv);
 
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::scale(
-          thread_loop_partitioner, local_size(), v.data, data);
+          thread_loop_partitioner, locally_owned_size(), v.data, data);
 
       if (vector_is_ghosted)
         update_ghost_values();
@@ -1604,7 +1604,7 @@ namespace LinearAlgebra
       const VectorType &v = dynamic_cast<const VectorType &>(vv);
 
       AssertIsFinite(a);
-      AssertDimension(local_size(), v.local_size());
+      AssertDimension(locally_owned_size(), v.locally_owned_size());
 
       dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::equ_au(
@@ -1824,10 +1824,10 @@ namespace LinearAlgebra
     {
       real_type max = 0.;
 
-      const size_type local_size = partitioner->locally_owned_size();
+      const size_type locally_owned_size = partitioner->locally_owned_size();
       internal::la_parallel_vector_templates_functions<
         Number,
-        MemorySpaceType>::linfty_norm_local(data, local_size, max);
+        MemorySpaceType>::linfty_norm_local(data, locally_owned_size, max);
 
       return max;
     }
@@ -1856,8 +1856,8 @@ namespace LinearAlgebra
       const Vector<Number, MemorySpaceType> &w)
     {
       const size_type vec_size = partitioner->locally_owned_size();
-      AssertDimension(vec_size, v.local_size());
-      AssertDimension(vec_size, w.local_size());
+      AssertDimension(vec_size, v.locally_owned_size());
+      AssertDimension(vec_size, w.locally_owned_size());
 
       Number sum = dealii::internal::VectorOperations::
         functions<Number, Number, MemorySpaceType>::add_and_dot(

--- a/include/deal.II/lac/petsc_block_vector.h
+++ b/include/deal.II/lac/petsc_block_vector.h
@@ -91,13 +91,13 @@ namespace PETScWrappers
       /**
        * Constructor. Generate a block vector with @p n_blocks blocks, each of
        * which is a parallel vector across @p communicator with @p block_size
-       * elements of which @p local_size elements are stored on the present
-       * process.
+       * elements of which @p locally_owned_size elements are stored on the
+       * present process.
        */
       explicit BlockVector(const unsigned int n_blocks,
                            const MPI_Comm &   communicator,
                            const size_type    block_size,
-                           const size_type    local_size);
+                           const size_type    locally_owned_size);
 
       /**
        * Copy constructor. Set all the properties of the parallel vector to
@@ -152,9 +152,9 @@ namespace PETScWrappers
 
       /**
        * Reinitialize the BlockVector to contain @p n_blocks of size @p
-       * block_size, each of which stores @p local_size elements locally. The
-       * @p communicator argument denotes which MPI channel each of these
-       * blocks shall communicate.
+       * block_size, each of which stores @p locally_owned_size elements
+       * locally. The @p communicator argument denotes which MPI channel each
+       * of these blocks shall communicate.
        *
        * If <tt>omit_zeroing_entries==false</tt>, the vector is filled with
        * zeros.
@@ -163,14 +163,14 @@ namespace PETScWrappers
       reinit(const unsigned int n_blocks,
              const MPI_Comm &   communicator,
              const size_type    block_size,
-             const size_type    local_size,
+             const size_type    locally_owned_size,
              const bool         omit_zeroing_entries = false);
 
       /**
        * Reinitialize the BlockVector such that it contains
        * <tt>block_sizes.size()</tt> blocks. Each block is reinitialized to
        * dimension <tt>block_sizes[i]</tt>. Each of them stores
-       * <tt>local_sizes[i]</tt> elements on the present process.
+       * <tt>locally_owned_sizes[i]</tt> elements on the present process.
        *
        * If the number of blocks is the same as before this function was
        * called, all vectors remain the same and reinit() is called for each
@@ -189,7 +189,7 @@ namespace PETScWrappers
       void
       reinit(const std::vector<size_type> &block_sizes,
              const MPI_Comm &              communicator,
-             const std::vector<size_type> &local_sizes,
+             const std::vector<size_type> &locally_owned_sizes,
              const bool                    omit_zeroing_entries = false);
 
       /**
@@ -293,9 +293,9 @@ namespace PETScWrappers
     inline BlockVector::BlockVector(const unsigned int n_blocks,
                                     const MPI_Comm &   communicator,
                                     const size_type    block_size,
-                                    const size_type    local_size)
+                                    const size_type    locally_owned_size)
     {
-      reinit(n_blocks, communicator, block_size, local_size);
+      reinit(n_blocks, communicator, block_size, locally_owned_size);
     }
 
 
@@ -366,12 +366,12 @@ namespace PETScWrappers
     BlockVector::reinit(const unsigned int n_blocks,
                         const MPI_Comm &   communicator,
                         const size_type    block_size,
-                        const size_type    local_size,
+                        const size_type    locally_owned_size,
                         const bool         omit_zeroing_entries)
     {
       reinit(std::vector<size_type>(n_blocks, block_size),
              communicator,
-             std::vector<size_type>(n_blocks, local_size),
+             std::vector<size_type>(n_blocks, locally_owned_size),
              omit_zeroing_entries);
     }
 
@@ -380,7 +380,7 @@ namespace PETScWrappers
     inline void
     BlockVector::reinit(const std::vector<size_type> &block_sizes,
                         const MPI_Comm &              communicator,
-                        const std::vector<size_type> &local_sizes,
+                        const std::vector<size_type> &locally_owned_sizes,
                         const bool                    omit_zeroing_entries)
     {
       this->block_indices.reinit(block_sizes);
@@ -390,7 +390,7 @@ namespace PETScWrappers
       for (unsigned int i = 0; i < this->n_blocks(); ++i)
         this->components[i].reinit(communicator,
                                    block_sizes[i],
-                                   local_sizes[i],
+                                   locally_owned_sizes[i],
                                    omit_zeroing_entries);
     }
 

--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -172,8 +172,8 @@ namespace PETScWrappers
        * Constructor. Set dimension to @p n and initialize all elements with
        * zero.
        *
-       * @arg local_size denotes the size of the chunk that shall be stored on
-       * the present process.
+       * @arg locally_owned_size denotes the size of the chunk that shall be
+       * stored on the present process.
        *
        * @arg communicator denotes the MPI communicator over which the
        * different parts of the vector shall communicate
@@ -186,15 +186,14 @@ namespace PETScWrappers
        */
       explicit Vector(const MPI_Comm &communicator,
                       const size_type n,
-                      const size_type local_size);
-
+                      const size_type locally_owned_size);
 
       /**
        * Copy-constructor from deal.II vectors. Sets the dimension to that of
        * the given vector, and copies all elements.
        *
-       * @arg local_size denotes the size of the chunk that shall be stored on
-       * the present process.
+       * @arg locally_owned_size denotes the size of the chunk that shall be
+       * stored on the present process.
        *
        * @arg communicator denotes the MPI communicator over which the
        * different parts of the vector shall communicate
@@ -202,7 +201,7 @@ namespace PETScWrappers
       template <typename Number>
       explicit Vector(const MPI_Comm &              communicator,
                       const dealii::Vector<Number> &v,
-                      const size_type               local_size);
+                      const size_type               locally_owned_size);
 
 
       /**
@@ -310,8 +309,8 @@ namespace PETScWrappers
        * actually also reduces memory consumption, or if for efficiency the
        * same amount of memory is used
        *
-       * @p local_size denotes how many of the @p N values shall be stored
-       * locally on the present process. for less data.
+       * @p locally_owned_size denotes how many of the @p N values shall be
+       * stored locally on the present process. for less data.
        *
        * @p communicator denotes the MPI communicator henceforth to be used
        * for this vector.
@@ -322,7 +321,7 @@ namespace PETScWrappers
       void
       reinit(const MPI_Comm &communicator,
              const size_type N,
-             const size_type local_size,
+             const size_type locally_owned_size,
              const bool      omit_zeroing_entries = false);
 
       /**
@@ -331,7 +330,7 @@ namespace PETScWrappers
        * The same applies as for the other @p reinit function.
        *
        * The elements of @p v are not copied, i.e. this function is the same
-       * as calling <tt>reinit(v.size(), v.local_size(),
+       * as calling <tt>reinit(v.size(), v.locally_owned_size(),
        * omit_zeroing_entries)</tt>.
        */
       void
@@ -396,22 +395,22 @@ namespace PETScWrappers
       /**
        * Create a vector of length @p n. For this class, we create a parallel
        * vector. @p n denotes the total size of the vector to be created. @p
-       * local_size denotes how many of these elements shall be stored
+       * locally_owned_size denotes how many of these elements shall be stored
        * locally.
        */
       virtual void
-      create_vector(const size_type n, const size_type local_size);
+      create_vector(const size_type n, const size_type locally_owned_size);
 
 
 
       /**
-       * Create a vector of global length @p n, local size @p local_size and
-       * with the specified ghost indices. Note that you need to call
-       * update_ghost_values() before accessing those.
+       * Create a vector of global length @p n, local size @p
+       * locally_owned_size and with the specified ghost indices. Note that
+       * you need to call update_ghost_values() before accessing those.
        */
       virtual void
       create_vector(const size_type n,
-                    const size_type local_size,
+                    const size_type locally_owned_size,
                     const IndexSet &ghostnodes);
 
 
@@ -446,10 +445,10 @@ namespace PETScWrappers
     template <typename number>
     Vector::Vector(const MPI_Comm &              communicator,
                    const dealii::Vector<number> &v,
-                   const size_type               local_size)
+                   const size_type               locally_owned_size)
       : communicator(communicator)
     {
-      Vector::create_vector(v.size(), local_size);
+      Vector::create_vector(v.size(), locally_owned_size);
 
       *this = v;
     }

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -347,9 +347,23 @@ namespace PETScWrappers
      *
      * To figure out which elements exactly are stored locally, use
      * local_range().
+     *
+     * @deprecated use locally_owned_size() instead.
      */
+    DEAL_II_DEPRECATED
     size_type
     local_size() const;
+
+    /**
+     * Return the local dimension of the vector, i.e. the number of elements
+     * stored on the present MPI process. For sequential vectors, this number
+     * is the same as size(), but for parallel vectors it may be smaller.
+     *
+     * To figure out which elements exactly are stored locally, use
+     * local_range().
+     */
+    size_type
+    locally_owned_size() const;
 
     /**
      * Return a pair of indices indicating which elements of this vector are

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -371,7 +371,7 @@ namespace PETScWrappers
      * stored, the second the index of the one past the last one that is
      * stored locally. If this is a sequential vector, then the result will be
      * the pair (0,N), otherwise it will be a pair (i,i+n), where
-     * <tt>n=local_size()</tt>.
+     * <tt>n=locally_owned_size()</tt>.
      */
     std::pair<size_type, size_type>
     local_range() const;

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2135,12 +2135,12 @@ namespace internal
     template <typename Number>
     __global__ void
     set_initial_guess_kernel(const types::global_dof_index offset,
-                             const unsigned int            local_size,
+                             const unsigned int            locally_owned_size,
                              Number *                      values)
 
     {
       const unsigned int index = threadIdx.x + blockDim.x * blockIdx.x;
-      if (index < local_size)
+      if (index < locally_owned_size)
         values[index] = (index + offset) % 11;
     }
 

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2030,7 +2030,7 @@ namespace internal
                                 solution_old.begin(),
                                 temp_vector1.begin(),
                                 solution.begin());
-      VectorUpdatesRange<Number>(upd, rhs.local_size());
+      VectorUpdatesRange<Number>(upd, rhs.locally_owned_size());
 
       // swap vectors x^{n+1}->x^{n}, given the updates in the function above
       if (iteration_index == 0)
@@ -2123,7 +2123,7 @@ namespace internal
       types::global_dof_index first_local_range = 0;
       if (!vector.locally_owned_elements().is_empty())
         first_local_range = vector.locally_owned_elements().nth_index_in_set(0);
-      for (unsigned int i = 0; i < vector.local_size(); ++i)
+      for (unsigned int i = 0; i < vector.locally_owned_size(); ++i)
         vector.local_element(i) = (i + first_local_range) % 11;
 
       const Number mean_value = vector.mean_value();
@@ -2160,7 +2160,7 @@ namespace internal
       if (!vector.locally_owned_elements().is_empty())
         first_local_range = vector.locally_owned_elements().nth_index_in_set(0);
 
-      const auto n_local_elements = vector.local_size();
+      const auto n_local_elements = vector.locally_owned_size();
       const int  n_blocks =
         1 + (n_local_elements - 1) / CUDAWrappers::block_size;
       set_initial_guess_kernel<<<n_blocks, CUDAWrappers::block_size>>>(

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -401,9 +401,20 @@ namespace LinearAlgebra
      * This function returns the number of elements stored. It is smaller or
      * equal to the dimension of the vector space that is modeled by an object
      * of this kind. This dimension is return by size().
+     *
+     * @deprecated use local_size() instead.
      */
+    DEAL_II_DEPRECATED
     size_type
     n_elements() const;
+
+    /**
+     * Return the local size of the vector, i.e., the number of indices
+     * owned locally.
+     */
+    size_type
+    local_size() const;
+
 
     /**
      * Return the IndexSet that represents the indices of the elements stored.
@@ -817,6 +828,15 @@ namespace LinearAlgebra
   template <typename Number>
   inline typename ReadWriteVector<Number>::size_type
   ReadWriteVector<Number>::n_elements() const
+  {
+    return stored_elements.n_elements();
+  }
+
+
+
+  template <typename Number>
+  inline typename ReadWriteVector<Number>::size_type
+  ReadWriteVector<Number>::local_size() const
   {
     return stored_elements.n_elements();
   }

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -402,7 +402,7 @@ namespace LinearAlgebra
      * equal to the dimension of the vector space that is modeled by an object
      * of this kind. This dimension is return by size().
      *
-     * @deprecated use local_size() instead.
+     * @deprecated use locally_owned_size() instead.
      */
     DEAL_II_DEPRECATED
     size_type
@@ -413,8 +413,7 @@ namespace LinearAlgebra
      * owned locally.
      */
     size_type
-    local_size() const;
-
+    locally_owned_size() const;
 
     /**
      * Return the IndexSet that represents the indices of the elements stored.
@@ -836,7 +835,7 @@ namespace LinearAlgebra
 
   template <typename Number>
   inline typename ReadWriteVector<Number>::size_type
-  ReadWriteVector<Number>::local_size() const
+  ReadWriteVector<Number>::locally_owned_size() const
   {
     return stored_elements.n_elements();
   }

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -494,7 +494,7 @@ namespace LinearAlgebra
       VecGetArray(static_cast<const Vec &>(petsc_vec), &start_ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const size_type vec_size = petsc_vec.local_size();
+    const size_type vec_size = petsc_vec.locally_owned_size();
     internal::copy_petsc_vector(start_ptr, start_ptr + vec_size, begin());
 
     // restore the representation of the vector

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -130,7 +130,8 @@ namespace LinearAlgebra
         distributed::Vector<Number, ::dealii::MemorySpace::Host> tmp_vector(
           communication_pattern);
 
-        const unsigned int n_elements = communication_pattern->local_size();
+        const unsigned int n_elements =
+          communication_pattern->locally_owned_size();
         std::copy(values, values + n_elements, tmp_vector.begin());
         tmp_vector.update_ghost_values();
 
@@ -173,8 +174,9 @@ namespace LinearAlgebra
         distributed::Vector<Number, ::dealii::MemorySpace::Host> tmp_vector(
           communication_pattern);
 
-        const unsigned int n_elements = communication_pattern->local_size();
-        cudaError_t        cuda_error_code = cudaMemcpy(tmp_vector.begin(),
+        const unsigned int n_elements =
+          communication_pattern->locally_owned_size();
+        cudaError_t cuda_error_code = cudaMemcpy(tmp_vector.begin(),
                                                  values,
                                                  n_elements * sizeof(Number),
                                                  cudaMemcpyDeviceToHost);

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -286,6 +286,13 @@ namespace LinearAlgebra
       size() const override;
 
       /**
+       * Return the local size of the vector, i.e., the number of indices
+       * owned locally.
+       */
+      size_type
+      local_size() const;
+
+      /**
        * Return the MPI communicator object in use with this object.
        */
       MPI_Comm

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -290,7 +290,7 @@ namespace LinearAlgebra
        * owned locally.
        */
       size_type
-      local_size() const;
+      locally_owned_size() const;
 
       /**
        * Return the MPI communicator object in use with this object.

--- a/include/deal.II/lac/trilinos_precondition.h
+++ b/include/deal.II/lac/trilinos_precondition.h
@@ -2159,9 +2159,9 @@ namespace TrilinosWrappers
     LinearAlgebra::distributed::Vector<double> &      dst,
     const LinearAlgebra::distributed::Vector<double> &src) const
   {
-    AssertDimension(dst.local_size(),
+    AssertDimension(dst.locally_owned_size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(src.local_size(),
+    AssertDimension(src.locally_owned_size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),
@@ -2179,9 +2179,9 @@ namespace TrilinosWrappers
     LinearAlgebra::distributed::Vector<double> &      dst,
     const LinearAlgebra::distributed::Vector<double> &src) const
   {
-    AssertDimension(dst.local_size(),
+    AssertDimension(dst.locally_owned_size(),
                     preconditioner->OperatorDomainMap().NumMyElements());
-    AssertDimension(src.local_size(),
+    AssertDimension(src.locally_owned_size(),
                     preconditioner->OperatorRangeMap().NumMyElements());
     Epetra_Vector tril_dst(View,
                            preconditioner->OperatorDomainMap(),

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -309,6 +309,13 @@ namespace LinearAlgebra
       size() const override;
 
       /**
+       * Return the local size of the vector, i.e., the number of indices
+       * owned locally.
+       */
+      size_type
+      local_size() const;
+
+      /**
        * Return the MPI communicator object in use with this object.
        */
       MPI_Comm

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -313,7 +313,7 @@ namespace LinearAlgebra
        * owned locally.
        */
       size_type
-      local_size() const;
+      locally_owned_size() const;
 
       /**
        * Return the MPI communicator object in use with this object.

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -550,7 +550,7 @@ namespace LinearAlgebra
 
     template <typename Number>
     typename Vector<Number>::size_type
-    Vector<Number>::local_size() const
+    Vector<Number>::locally_owned_size() const
     {
       return vector->getLocalLength();
     }

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -549,6 +549,15 @@ namespace LinearAlgebra
 
 
     template <typename Number>
+    typename Vector<Number>::size_type
+    Vector<Number>::local_size() const
+    {
+      return vector->getLocalLength();
+    }
+
+
+
+    template <typename Number>
     MPI_Comm
     Vector<Number>::get_mpi_communicator() const
     {

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -735,9 +735,19 @@ namespace TrilinosWrappers
        *
        * If the vector contains ghost elements, they are included in this
        * number.
+       *
+       * @deprecated This function is deprecated.
        */
+      DEAL_II_DEPRECATED
       size_type
       local_size() const;
+
+      /**
+       * Return the local size of the vector, i.e., the number of indices
+       * owned locally.
+       */
+      size_type
+      locally_owned_size() const;
 
       /**
        * Return a pair of indices indicating which elements of this vector are
@@ -1726,6 +1736,14 @@ namespace TrilinosWrappers
     Vector::local_size() const
     {
       return vector->Map().NumMyElements();
+    }
+
+
+
+    inline Vector::size_type
+    Vector::locally_owned_size() const
+    {
+      return owned_elements.n_elements();
     }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -960,7 +960,7 @@ public:
    * LinearAlgebra::ReadWriteVector.
    */
   size_type
-  local_size() const;
+  locally_owned_size() const;
 
   /**
    * Return whether the vector contains only elements with value zero. This
@@ -1100,7 +1100,7 @@ Vector<Number>::size() const
 
 template <typename Number>
 inline typename Vector<Number>::size_type
-Vector<Number>::local_size() const
+Vector<Number>::locally_owned_size() const
 {
   return values.size();
 }

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -953,6 +953,16 @@ public:
   size() const;
 
   /**
+   * Return local dimension of the vector. Since this vector does not support
+   * distributed data this is always the same value as size().
+   *
+   * @note This function exists for compatibility with
+   * LinearAlgebra::ReadWriteVector.
+   */
+  size_type
+  local_size() const;
+
+  /**
    * Return whether the vector contains only elements with value zero. This
    * function is mainly for internal consistency checks and should seldom be
    * used when not in debug mode since it uses quite some time.
@@ -1085,6 +1095,16 @@ Vector<Number>::size() const
 {
   return values.size();
 }
+
+
+
+template <typename Number>
+inline typename Vector<Number>::size_type
+Vector<Number>::local_size() const
+{
+  return values.size();
+}
+
 
 
 template <typename Number>

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -1261,7 +1261,7 @@ namespace CUDAWrappers
     internal::copy_constrained_dofs<Number>
       <<<constraint_grid_dim, constraint_block_dim>>>(constrained_dofs,
                                                       n_constrained_dofs,
-                                                      src.local_size(),
+                                                      src.locally_owned_size(),
                                                       src.get_values(),
                                                       dst.get_values());
     AssertCudaKernel();
@@ -1306,7 +1306,7 @@ namespace CUDAWrappers
     internal::set_constrained_dofs<Number>
       <<<constraint_grid_dim, constraint_block_dim>>>(constrained_dofs,
                                                       n_constrained_dofs,
-                                                      dst.local_size(),
+                                                      dst.locally_owned_size(),
                                                       val,
                                                       dst.get_values());
     AssertCudaKernel();

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3292,11 +3292,11 @@ namespace internal
 
           part.export_to_ghosted_array_start(
             component_in_block_vector + channel_shift,
-            ArrayView<const Number>(vec.begin(), part.local_size()),
+            ArrayView<const Number>(vec.begin(), part.locally_owned_size()),
             ArrayView<Number>(tmp_data[component_in_block_vector]->begin(),
                               part.n_import_indices()),
             ArrayView<Number>(const_cast<Number *>(vec.begin()) +
-                                vec.get_partitioner()->local_size(),
+                                vec.get_partitioner()->locally_owned_size(),
                               vec.get_partitioner()->n_ghost_indices()),
             this->requests[component_in_block_vector]);
 #  endif
@@ -3386,7 +3386,7 @@ namespace internal
 
           part.export_to_ghosted_array_finish(
             ArrayView<Number>(const_cast<Number *>(vec.begin()) +
-                                vec.get_partitioner()->local_size(),
+                                vec.get_partitioner()->locally_owned_size(),
                               vec.get_partitioner()->n_ghost_indices()),
             this->requests[component_in_block_vector]);
 
@@ -3507,7 +3507,8 @@ namespace internal
           part.import_from_ghosted_array_start(
             dealii::VectorOperation::add,
             component_in_block_vector + channel_shift,
-            ArrayView<Number>(vec.begin() + vec.get_partitioner()->local_size(),
+            ArrayView<Number>(vec.begin() +
+                                vec.get_partitioner()->locally_owned_size(),
                               vec.get_partitioner()->n_ghost_indices()),
             ArrayView<Number>(tmp_data[component_in_block_vector]->begin(),
                               part.n_import_indices()),
@@ -3601,8 +3602,9 @@ namespace internal
             ArrayView<const Number>(
               tmp_data[component_in_block_vector]->begin(),
               part.n_import_indices()),
-            ArrayView<Number>(vec.begin(), part.local_size()),
-            ArrayView<Number>(vec.begin() + vec.get_partitioner()->local_size(),
+            ArrayView<Number>(vec.begin(), part.locally_owned_size()),
+            ArrayView<Number>(vec.begin() +
+                                vec.get_partitioner()->locally_owned_size(),
                               vec.get_partitioner()->n_ghost_indices()),
             this->requests[component_in_block_vector]);
 
@@ -3693,7 +3695,7 @@ namespace internal
                   {
                     const_cast<LinearAlgebra::distributed::Vector<Number> &>(
                       vec)
-                      .local_element(j + part.local_size()) = 0.;
+                      .local_element(j + part.locally_owned_size()) = 0.;
                   }
             }
 
@@ -4573,7 +4575,7 @@ namespace internal
               // Case with threaded loop -> currently no overlap implemented
               dealii::parallel::apply_to_subranges(
                 0U,
-                dof_info.vector_partitioner->local_size(),
+                dof_info.vector_partitioner->locally_owned_size(),
                 operation_before_loop,
                 internal::VectorImplementation::minimum_parallel_grain_size);
             }
@@ -4603,7 +4605,7 @@ namespace internal
               // Case with threaded loop -> currently no overlap implemented
               dealii::parallel::apply_to_subranges(
                 0U,
-                dof_info.vector_partitioner->local_size(),
+                dof_info.vector_partitioner->locally_owned_size(),
                 operation_after_loop,
                 internal::VectorImplementation::minimum_parallel_grain_size);
             }

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1463,7 +1463,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                        di.row_starts[(cell + 1) * di.start_components.back()]
                          .first;
                        ++i)
-                    if (di.dof_indices[i] >= part.local_size())
+                    if (di.dof_indices[i] >= part.locally_owned_size())
                       ghost_indices.push_back(
                         part.local_to_global(di.dof_indices[i]));
 
@@ -1476,7 +1476,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                   for (unsigned int i = di.row_starts_plain_indices[cell];
                        i < di.row_starts_plain_indices[cell] + dofs_this_cell;
                        ++i)
-                    if (di.plain_dof_indices[i] >= part.local_size())
+                    if (di.plain_dof_indices[i] >= part.locally_owned_size())
                       ghost_indices.push_back(
                         part.local_to_global(di.plain_dof_indices[i]));
                 }
@@ -1610,7 +1610,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                              IndexStorageVariants::contiguous &&
                          di.dof_indices_contiguous
                              [internal::MatrixFreeFunctions::DoFInfo::
-                                dof_access_cell][p] >= part.local_size()))
+                                dof_access_cell][p] >=
+                           part.locally_owned_size()))
                       {
                         const unsigned int stride =
                           di.dof_indices_interleave_strides[2][p];
@@ -1732,7 +1733,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
                              IndexStorageVariants::contiguous &&
                          di.dof_indices_contiguous
                              [internal::MatrixFreeFunctions::DoFInfo::
-                                dof_access_cell][p] >= part.local_size()))
+                                dof_access_cell][p] >=
+                           part.locally_owned_size()))
                       {
                         const unsigned int stride =
                           di.dof_indices_interleave_strides[2][p];

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1392,11 +1392,14 @@ namespace MatrixFreeOperators
 
         // If not, assert that the local ranges are the same and reset to the
         // current partitioner
-        Assert(
-          BlockHelper::subblock(src, i).get_partitioner()->local_size() ==
-            data->get_dof_info(mf_component).vector_partitioner->local_size(),
-          ExcMessage("The vector passed to the vmult() function does not have "
-                     "the correct size for compatibility with MatrixFree."));
+        Assert(BlockHelper::subblock(src, i)
+                   .get_partitioner()
+                   ->locally_owned_size() ==
+                 data->get_dof_info(mf_component)
+                   .vector_partitioner->locally_owned_size(),
+               ExcMessage(
+                 "The vector passed to the vmult() function does not have "
+                 "the correct size for compatibility with MatrixFree."));
 
         // copy the vector content to a temporary vector so that it does not get
         // lost

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1545,7 +1545,7 @@ namespace MatrixFreeOperators
               .local_element(edge_constrained_indices[j][i]) =
               edge_constrained_values[j][i].first;
           }
-        for (; c < BlockHelper::subblock(dst, j).local_size(); ++c)
+        for (; c < BlockHelper::subblock(dst, j).locally_owned_size(); ++c)
           BlockHelper::subblock(dst, j).local_element(c) = 0.;
       }
   }
@@ -1579,7 +1579,7 @@ namespace MatrixFreeOperators
               BlockHelper::subblock(src_cpy, j).local_element(c) = 0.;
             ++c;
           }
-        for (; c < BlockHelper::subblock(src_cpy, j).local_size(); ++c)
+        for (; c < BlockHelper::subblock(src_cpy, j).locally_owned_size(); ++c)
           BlockHelper::subblock(src_cpy, j).local_element(c) = 0.;
       }
 
@@ -1814,8 +1814,9 @@ namespace MatrixFreeOperators
     this->set_constrained_entries_to_one(diagonal_vector);
     inverse_diagonal_vector = diagonal_vector;
 
-    const unsigned int local_size = inverse_diagonal_vector.local_size();
-    for (unsigned int i = 0; i < local_size; ++i)
+    const unsigned int locally_owned_size =
+      inverse_diagonal_vector.locally_owned_size();
+    for (unsigned int i = 0; i < locally_owned_size; ++i)
       inverse_diagonal_vector.local_element(i) =
         Number(1.) / inverse_diagonal_vector.local_element(i);
 
@@ -2006,7 +2007,8 @@ namespace MatrixFreeOperators
 
     inverse_diagonal_vector = diagonal_vector;
 
-    for (unsigned int i = 0; i < inverse_diagonal_vector.local_size(); ++i)
+    for (unsigned int i = 0; i < inverse_diagonal_vector.locally_owned_size();
+         ++i)
       if (std::abs(inverse_diagonal_vector.local_element(i)) >
           std::sqrt(std::numeric_limits<Number>::epsilon()))
         inverse_diagonal_vector.local_element(i) =

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -432,7 +432,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_to_mg(
 
   for (unsigned int level = dst.min_level(); level <= dst.max_level(); ++level)
     if (dst[level].size() != dof_handler.n_dofs(level) ||
-        dst[level].local_size() !=
+        dst[level].locally_owned_size() !=
           dof_handler.locally_owned_mg_dofs(level).n_elements())
       {
         // In case a ghosted level vector has been initialized, we can simply
@@ -460,14 +460,17 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_to_mg(
   if (perform_plain_copy)
     {
       // In this case, we can simply copy the local range.
-      AssertDimension(dst[dst.max_level()].local_size(), src.local_size());
+      AssertDimension(dst[dst.max_level()].locally_owned_size(),
+                      src.locally_owned_size());
       dst[dst.max_level()].copy_locally_owned_data_from(src);
       return;
     }
   else if (perform_renumbered_plain_copy)
     {
-      AssertDimension(dst[dst.max_level()].local_size(), src.local_size());
-      AssertDimension(this_copy_indices.back().n_cols(), src.local_size());
+      AssertDimension(dst[dst.max_level()].locally_owned_size(),
+                      src.locally_owned_size());
+      AssertDimension(this_copy_indices.back().n_cols(),
+                      src.locally_owned_size());
       Assert(copy_indices_level_mine.back().n_rows() == 0, ExcInternalError());
       LinearAlgebra::distributed::Vector<Number> &dst_level =
         dst[dst.max_level()];
@@ -482,7 +485,8 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_to_mg(
 
   // the ghosted vector should already have the correct local size (but
   // different parallel layout)
-  AssertDimension(ghosted_global_vector.local_size(), src.local_size());
+  AssertDimension(ghosted_global_vector.locally_owned_size(),
+                  src.locally_owned_size());
 
   // copy the source vector to the temporary vector that we hold for the
   // purpose of data exchange
@@ -532,14 +536,16 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_from_mg(
       // stray data in ghost entries of the destination, make sure to clear
       // them here.
       dst.zero_out_ghosts();
-      AssertDimension(src[src.max_level()].local_size(), dst.local_size());
+      AssertDimension(src[src.max_level()].locally_owned_size(),
+                      dst.locally_owned_size());
       dst.copy_locally_owned_data_from(src[src.max_level()]);
       return;
     }
   else if (perform_renumbered_plain_copy)
     {
-      AssertDimension(src[src.max_level()].local_size(), dst.local_size());
-      AssertDimension(copy_indices.back().n_cols(), dst.local_size());
+      AssertDimension(src[src.max_level()].locally_owned_size(),
+                      dst.locally_owned_size());
+      AssertDimension(copy_indices.back().n_cols(), dst.locally_owned_size());
       Assert(copy_indices_global_mine.back().n_rows() == 0, ExcInternalError());
       Assert(copy_indices_global_mine.back().empty(), ExcInternalError());
       const LinearAlgebra::distributed::Vector<Number> &src_level =
@@ -560,8 +566,8 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_from_mg(
     {
       // the ghosted vector should already have the correct local size (but
       // different parallel layout)
-      AssertDimension(ghosted_level_vector[level].local_size(),
-                      src[level].local_size());
+      AssertDimension(ghosted_level_vector[level].locally_owned_size(),
+                      src[level].locally_owned_size());
 
       // the first time around, we copy the source vector to the temporary
       // vector that we hold for the purpose of data exchange
@@ -607,8 +613,8 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::
     {
       // the ghosted vector should already have the correct local size (but
       // different parallel layout)
-      AssertDimension(ghosted_level_vector[level].local_size(),
-                      src[level].local_size());
+      AssertDimension(ghosted_level_vector[level].locally_owned_size(),
+                      src[level].locally_owned_size());
 
       // the first time around, we copy the source vector to the temporary
       // vector that we hold for the purpose of data exchange

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -524,7 +524,7 @@ MGTransferMatrixFree<dim, Number>::interpolate_to_mg(
                                                     relevant_dofs[level]);
       if (dst[level].size() !=
             dof_handler.locally_owned_mg_dofs(level).size() ||
-          dst[level].local_size() !=
+          dst[level].locally_owned_size() !=
             dof_handler.locally_owned_mg_dofs(level).n_elements())
         dst[level].reinit(dof_handler.locally_owned_mg_dofs(level),
                           relevant_dofs[level],
@@ -658,7 +658,7 @@ MGTransferBlockMatrixFree<dim, Number>::copy_to_mg(
             LinearAlgebra::distributed::Vector<Number> &v = dst[level].block(b);
             if (v.size() !=
                   dof_handler[b]->locally_owned_mg_dofs(level).size() ||
-                v.local_size() !=
+                v.locally_owned_size() !=
                   dof_handler[b]->locally_owned_mg_dofs(level).n_elements())
               {
                 do_reinit[level] = true;

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -240,11 +240,11 @@ namespace Utilities
 
     std::vector<IndexSet>
     create_ascending_partitioning(const MPI_Comm &          comm,
-                                  const IndexSet::size_type local_size)
+                                  const IndexSet::size_type locally_owned_size)
     {
       const unsigned int                     n_proc = n_mpi_processes(comm);
       const std::vector<IndexSet::size_type> sizes =
-        all_gather(comm, local_size);
+        all_gather(comm, locally_owned_size);
       const auto total_size =
         std::accumulate(sizes.begin(), sizes.end(), IndexSet::size_type(0));
 
@@ -688,9 +688,9 @@ namespace Utilities
 
     std::vector<IndexSet>
     create_ascending_partitioning(const MPI_Comm & /*comm*/,
-                                  const IndexSet::size_type local_size)
+                                  const IndexSet::size_type locally_owned_size)
     {
-      return std::vector<IndexSet>(1, complete_index_set(local_size));
+      return std::vector<IndexSet>(1, complete_index_set(locally_owned_size));
     }
 
     IndexSet

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -193,7 +193,7 @@ namespace Utilities
           return;
         }
 
-      types::global_dof_index my_size = local_size();
+      types::global_dof_index my_size = locally_owned_size();
 
       // Allow non-zero start index for the vector. Part 1:
       // Assume for now that the index set of rank 0 starts with 0
@@ -224,9 +224,10 @@ namespace Utilities
       // information.
       if (local_range_data.first == 0 && my_shift != 0)
         {
-          const types::global_dof_index old_local_size = local_size();
-          local_range_data.first                       = my_shift;
-          local_range_data.second = my_shift + old_local_size;
+          const types::global_dof_index old_locally_owned_size =
+            locally_owned_size();
+          local_range_data.first  = my_shift;
+          local_range_data.second = my_shift + old_locally_owned_size;
         }
 
       std::vector<unsigned int> owning_ranks_of_ghosts(
@@ -359,8 +360,8 @@ namespace Utilities
       if (larger_ghost_index_set.size() == 0)
         {
           ghost_indices_subset_chunks_by_rank_data.clear();
-          ghost_indices_subset_data.emplace_back(local_size(),
-                                                 local_size() +
+          ghost_indices_subset_data.emplace_back(locally_owned_size(),
+                                                 locally_owned_size() +
                                                    n_ghost_indices());
           n_ghost_indices_in_larger_set = n_ghost_indices_data;
         }

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1376,9 +1376,9 @@ namespace DoFRenumbering
             &dof_handler.get_triangulation()))
       {
 #ifdef DEAL_II_WITH_MPI
-        types::global_dof_index local_size =
+        types::global_dof_index locally_owned_size =
           dof_handler.locally_owned_dofs().n_elements();
-        MPI_Exscan(&local_size,
+        MPI_Exscan(&locally_owned_size,
                    &my_starting_index,
                    1,
                    DEAL_II_DOF_INDEX_MPI_TYPE,

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -90,9 +90,11 @@ namespace PETScWrappers
       , communicator(v.communicator)
     {
       if (v.has_ghost_elements())
-        Vector::create_vector(v.size(), v.local_size(), v.ghost_indices);
+        Vector::create_vector(v.size(),
+                              v.locally_owned_size(),
+                              v.ghost_indices);
       else
-        Vector::create_vector(v.size(), v.local_size());
+        Vector::create_vector(v.size(), v.locally_owned_size());
 
       this->operator=(v);
     }
@@ -128,7 +130,7 @@ namespace PETScWrappers
           if (v.has_ghost_elements())
             reinit(v.locally_owned_elements(), v.ghost_indices, v.communicator);
           else
-            reinit(v.communicator, v.size(), v.local_size(), true);
+            reinit(v.communicator, v.size(), v.locally_owned_size(), true);
         }
 
       PetscErrorCode ierr = VecCopy(v.vector, vector);
@@ -168,7 +170,7 @@ namespace PETScWrappers
       // only do something if the sizes
       // mismatch (may not be true for every proc)
 
-      int k_global, k = ((size() != n) || (local_size() != local_sz));
+      int k_global, k = ((size() != n) || (locally_owned_size() != local_sz));
       {
         const int ierr =
           MPI_Allreduce(&k, &k_global, 1, MPI_INT, MPI_LOR, communicator);
@@ -213,7 +215,10 @@ namespace PETScWrappers
             }
         }
       else
-        reinit(v.communicator, v.size(), v.local_size(), omit_zeroing_entries);
+        reinit(v.communicator,
+               v.size(),
+               v.locally_owned_size(),
+               omit_zeroing_entries);
     }
 
 
@@ -257,8 +262,10 @@ namespace PETScWrappers
       AssertIndexRange(locally_owned_size, n + 1);
       ghosted = false;
 
-      const PetscErrorCode ierr =
-        VecCreateMPI(communicator, locally_owned_size, PETSC_DETERMINE, &vector);
+      const PetscErrorCode ierr = VecCreateMPI(communicator,
+                                               locally_owned_size,
+                                               PETSC_DETERMINE,
+                                               &vector);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
 
       Assert(size() == n, ExcDimensionMismatch(size(), n));
@@ -302,7 +309,8 @@ namespace PETScWrappers
         ierr = VecGetOwnershipRange(vector, &begin, &end);
         AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-        AssertDimension(locally_owned_size, static_cast<size_type>(end - begin));
+        AssertDimension(locally_owned_size,
+                        static_cast<size_type>(end - begin));
 
         Vec l;
         ierr = VecGhostGetLocalForm(vector, &l);

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -606,8 +606,9 @@ namespace PETScWrappers
     PetscErrorCode ierr = VecGetArray(vector, &start_ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const PetscScalar *ptr = start_ptr, *eptr = start_ptr + local_size();
-    bool               flag = true;
+    const PetscScalar *ptr  = start_ptr,
+                      *eptr = start_ptr + locally_owned_size();
+    bool flag               = true;
     while (ptr != eptr)
       {
         if (*ptr != value_type())
@@ -659,8 +660,9 @@ namespace PETScWrappers
     PetscErrorCode ierr = VecGetArray(vector, &start_ptr);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    const PetscScalar *ptr = start_ptr, *eptr = start_ptr + local_size();
-    bool               flag = true;
+    const PetscScalar *ptr  = start_ptr,
+                      *eptr = start_ptr + locally_owned_size();
+    bool flag               = true;
     while (ptr != eptr)
       {
         if (!internal::is_non_negative(*ptr))

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -258,6 +258,18 @@ namespace PETScWrappers
 
 
   VectorBase::size_type
+  VectorBase::locally_owned_size() const
+  {
+    PetscInt             sz;
+    const PetscErrorCode ierr = VecGetLocalSize(vector, &sz);
+    AssertThrow(ierr == 0, ExcPETScError(ierr));
+
+    return sz;
+  }
+
+
+
+  VectorBase::size_type
   VectorBase::local_size() const
   {
     PetscInt             sz;
@@ -869,10 +881,10 @@ namespace PETScWrappers
       out.setf(std::ios::fixed, std::ios::floatfield);
 
     if (across)
-      for (size_type i = 0; i < local_size(); ++i)
+      for (size_type i = 0; i < locally_owned_size(); ++i)
         out << val[i] << ' ';
     else
-      for (size_type i = 0; i < local_size(); ++i)
+      for (size_type i = 0; i < locally_owned_size(); ++i)
         out << val[i] << std::endl;
     out << std::endl;
 
@@ -915,7 +927,7 @@ namespace PETScWrappers
     // TH: I am relatively sure that PETSc is
     // storing the local data in a contiguous
     // block without indices:
-    mem += local_size() * sizeof(PetscScalar);
+    mem += locally_owned_size() * sizeof(PetscScalar);
     // assume that PETSc is storing one index
     // and one double per ghost element
     if (ghosted)

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -540,6 +540,14 @@ namespace LinearAlgebra
 
 
 
+    Vector::size_type
+    Vector::local_size() const
+    {
+      return vector->MyLength();
+    }
+
+
+
     MPI_Comm
     Vector::get_mpi_communicator() const
     {

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -541,7 +541,7 @@ namespace LinearAlgebra
 
 
     Vector::size_type
-    Vector::local_size() const
+    Vector::locally_owned_size() const
     {
       return vector->MyLength();
     }

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -208,8 +208,8 @@ MGTransferMatrixFree<dim, Number>::prolongate(
           this->vector_partitioners[to_level].get())
         this->ghosted_level_vector[to_level].reinit(
           this->vector_partitioners[to_level]);
-      AssertDimension(this->ghosted_level_vector[to_level].local_size(),
-                      dst.local_size());
+      AssertDimension(this->ghosted_level_vector[to_level].locally_owned_size(),
+                      dst.locally_owned_size());
       this->ghosted_level_vector[to_level] = 0.;
     }
   else
@@ -288,8 +288,9 @@ MGTransferMatrixFree<dim, Number>::restrict_and_add(
           this->vector_partitioners[from_level - 1].get())
         this->ghosted_level_vector[from_level - 1].reinit(
           this->vector_partitioners[from_level - 1]);
-      AssertDimension(this->ghosted_level_vector[from_level - 1].local_size(),
-                      dst.local_size());
+      AssertDimension(
+        this->ghosted_level_vector[from_level - 1].locally_owned_size(),
+        dst.locally_owned_size());
       this->ghosted_level_vector[from_level - 1] = 0.;
     }
 

--- a/tests/mpi/local_size.cc
+++ b/tests/mpi/local_size.cc
@@ -1,0 +1,167 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// check Vector::local_size() for all supported vector types
+
+#include <deal.II/base/index_set.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/la_vector.h>
+#include <deal.II/lac/petsc_block_vector.h>
+#include <deal.II/lac/petsc_vector.h>
+#include <deal.II/lac/trilinos_epetra_vector.h>
+#include <deal.II/lac/trilinos_parallel_block_vector.h>
+#include <deal.II/lac/trilinos_tpetra_vector.h>
+#include <deal.II/lac/trilinos_vector.h>
+#include <deal.II/lac/vector.h>
+
+#include "../tests.h"
+
+
+template <typename VEC>
+void
+check_serial()
+{
+  const auto dofs_per_proc = 4;
+  VEC vec(dofs_per_proc);
+  deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
+  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "size: " << vec.size() << std::endl;
+}
+
+
+
+template <typename VEC>
+void
+check_unghosted_parallel()
+{
+  const auto n_procs = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  const auto dofs_per_proc = 4;
+  const auto n_dofs = dofs_per_proc*n_procs;
+
+  IndexSet local_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc*my_rank;
+  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  local_indices.add_range(my_dofs_begin, my_dofs_end);
+  local_indices.compress();
+
+  VEC vec(local_indices, MPI_COMM_WORLD);
+  deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
+  deallog << "index set size: " << local_indices.n_elements() << std::endl;
+  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "size: " << vec.size() << std::endl;
+}
+
+
+
+template <typename VEC>
+void
+check_ghosted_parallel()
+{
+  const auto n_procs = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  const auto dofs_per_proc = 4;
+  const auto n_dofs = dofs_per_proc*n_procs;
+
+  IndexSet local_indices(n_dofs);
+  IndexSet ghost_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc*my_rank;
+  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  local_indices.add_range(my_dofs_begin, my_dofs_end);
+  local_indices.compress();
+  if (my_rank == 0)
+    {
+      ghost_indices.add_index(my_dofs_end);
+    }
+  else
+    {
+      ghost_indices.add_index(my_dofs_begin - 1);
+      ghost_indices.add_index(my_dofs_end % n_dofs);
+    }
+
+  VEC vec(local_indices, ghost_indices, MPI_COMM_WORLD);
+  deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
+  deallog << "index set size: " << local_indices.n_elements() << std::endl;
+  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "size: " << vec.size() << std::endl;
+}
+
+
+
+template <typename VEC>
+void
+check_ghosted_parallel_block()
+{
+  const auto n_procs = dealii::Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  const auto dofs_per_proc = 4;
+  const auto n_dofs = dofs_per_proc*n_procs;
+
+  IndexSet local_indices(n_dofs);
+  IndexSet ghost_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc*my_rank;
+  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  local_indices.add_range(my_dofs_begin, my_dofs_end);
+  local_indices.compress();
+  if (my_rank == 0)
+    {
+      ghost_indices.add_index(my_dofs_end);
+    }
+  else
+    {
+      ghost_indices.add_index(my_dofs_begin - 1);
+      ghost_indices.add_index(my_dofs_end % n_dofs);
+    }
+
+  std::vector<IndexSet> local_blocks {local_indices, local_indices};
+  // for variety do not ghost the second component
+  std::vector<IndexSet> ghost_blocks {ghost_indices, IndexSet()};
+
+  VEC vec(local_blocks, ghost_blocks, MPI_COMM_WORLD);
+  deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
+  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "size: " << vec.size() << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  // non-block vectors:
+  check_serial<Vector<double>>();
+  check_serial<LinearAlgebra::Vector<double>>();
+
+  check_unghosted_parallel<LinearAlgebra::EpetraWrappers::Vector>();
+  check_unghosted_parallel<LinearAlgebra::TpetraWrappers::Vector<double>>();
+
+  check_ghosted_parallel<LinearAlgebra::distributed::Vector<double>>();
+  check_ghosted_parallel<PETScWrappers::MPI::Vector>();
+  check_ghosted_parallel<TrilinosWrappers::MPI::Vector>();
+
+  // block vectors:
+  check_ghosted_parallel_block<LinearAlgebra::distributed::BlockVector<double>>();
+  check_ghosted_parallel_block<PETScWrappers::MPI::BlockVector>();
+  check_ghosted_parallel_block<TrilinosWrappers::MPI::BlockVector>();
+}

--- a/tests/mpi/local_size.cc
+++ b/tests/mpi/local_size.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// check Vector::local_size() for all supported vector types
+// check Vector::locally_owned_size() for all supported vector types
 
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/utilities.h>
@@ -37,9 +37,9 @@ void
 check_serial()
 {
   const auto dofs_per_proc = 4;
-  VEC vec(dofs_per_proc);
+  VEC        vec(dofs_per_proc);
   deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
-  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "local size: " << vec.locally_owned_size() << std::endl;
   deallog << "size: " << vec.size() << std::endl;
 }
 
@@ -53,18 +53,18 @@ check_unghosted_parallel()
   const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
   const auto dofs_per_proc = 4;
-  const auto n_dofs = dofs_per_proc*n_procs;
+  const auto n_dofs        = dofs_per_proc * n_procs;
 
-  IndexSet local_indices(n_dofs);
-  const auto my_dofs_begin = dofs_per_proc*my_rank;
-  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  IndexSet   local_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc * my_rank;
+  const auto my_dofs_end   = dofs_per_proc * (my_rank + 1);
   local_indices.add_range(my_dofs_begin, my_dofs_end);
   local_indices.compress();
 
   VEC vec(local_indices, MPI_COMM_WORLD);
   deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
   deallog << "index set size: " << local_indices.n_elements() << std::endl;
-  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "local size: " << vec.locally_owned_size() << std::endl;
   deallog << "size: " << vec.size() << std::endl;
 }
 
@@ -78,12 +78,12 @@ check_ghosted_parallel()
   const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
   const auto dofs_per_proc = 4;
-  const auto n_dofs = dofs_per_proc*n_procs;
+  const auto n_dofs        = dofs_per_proc * n_procs;
 
-  IndexSet local_indices(n_dofs);
-  IndexSet ghost_indices(n_dofs);
-  const auto my_dofs_begin = dofs_per_proc*my_rank;
-  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  IndexSet   local_indices(n_dofs);
+  IndexSet   ghost_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc * my_rank;
+  const auto my_dofs_end   = dofs_per_proc * (my_rank + 1);
   local_indices.add_range(my_dofs_begin, my_dofs_end);
   local_indices.compress();
   if (my_rank == 0)
@@ -99,7 +99,7 @@ check_ghosted_parallel()
   VEC vec(local_indices, ghost_indices, MPI_COMM_WORLD);
   deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
   deallog << "index set size: " << local_indices.n_elements() << std::endl;
-  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "local size: " << vec.locally_owned_size() << std::endl;
   deallog << "size: " << vec.size() << std::endl;
 }
 
@@ -113,12 +113,12 @@ check_ghosted_parallel_block()
   const auto my_rank = dealii::Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
   const auto dofs_per_proc = 4;
-  const auto n_dofs = dofs_per_proc*n_procs;
+  const auto n_dofs        = dofs_per_proc * n_procs;
 
-  IndexSet local_indices(n_dofs);
-  IndexSet ghost_indices(n_dofs);
-  const auto my_dofs_begin = dofs_per_proc*my_rank;
-  const auto my_dofs_end = dofs_per_proc*(my_rank + 1);
+  IndexSet   local_indices(n_dofs);
+  IndexSet   ghost_indices(n_dofs);
+  const auto my_dofs_begin = dofs_per_proc * my_rank;
+  const auto my_dofs_end   = dofs_per_proc * (my_rank + 1);
   local_indices.add_range(my_dofs_begin, my_dofs_end);
   local_indices.compress();
   if (my_rank == 0)
@@ -131,13 +131,13 @@ check_ghosted_parallel_block()
       ghost_indices.add_index(my_dofs_end % n_dofs);
     }
 
-  std::vector<IndexSet> local_blocks {local_indices, local_indices};
+  std::vector<IndexSet> local_blocks{local_indices, local_indices};
   // for variety do not ghost the second component
-  std::vector<IndexSet> ghost_blocks {ghost_indices, IndexSet()};
+  std::vector<IndexSet> ghost_blocks{ghost_indices, IndexSet()};
 
   VEC vec(local_blocks, ghost_blocks, MPI_COMM_WORLD);
   deallog << "type: " << Utilities::type_to_string(vec) << std::endl;
-  deallog << "local size: " << vec.local_size() << std::endl;
+  deallog << "local size: " << vec.locally_owned_size() << std::endl;
   deallog << "size: " << vec.size() << std::endl;
 }
 
@@ -161,7 +161,8 @@ main(int argc, char *argv[])
   check_ghosted_parallel<TrilinosWrappers::MPI::Vector>();
 
   // block vectors:
-  check_ghosted_parallel_block<LinearAlgebra::distributed::BlockVector<double>>();
+  check_ghosted_parallel_block<
+    LinearAlgebra::distributed::BlockVector<double>>();
   check_ghosted_parallel_block<PETScWrappers::MPI::BlockVector>();
   check_ghosted_parallel_block<TrilinosWrappers::MPI::BlockVector>();
 }

--- a/tests/mpi/local_size.with_trilinos_with_tpetra=on.with_petsc=on.mpirun=4.output
+++ b/tests/mpi/local_size.with_trilinos_with_tpetra=on.with_petsc=on.mpirun=4.output
@@ -1,0 +1,147 @@
+
+DEAL:0::type: dealii::Vector<double>
+DEAL:0::local size: 4
+DEAL:0::size: 4
+DEAL:0::type: dealii::LinearAlgebra::Vector<double>
+DEAL:0::local size: 4
+DEAL:0::size: 4
+DEAL:0::type: dealii::LinearAlgebra::EpetraWrappers::Vector
+DEAL:0::index set size: 4
+DEAL:0::local size: 4
+DEAL:0::size: 16
+DEAL:0::type: dealii::LinearAlgebra::TpetraWrappers::Vector<double>
+DEAL:0::index set size: 4
+DEAL:0::local size: 4
+DEAL:0::size: 16
+DEAL:0::type: dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>
+DEAL:0::index set size: 4
+DEAL:0::local size: 4
+DEAL:0::size: 16
+DEAL:0::type: dealii::PETScWrappers::MPI::Vector
+DEAL:0::index set size: 4
+DEAL:0::local size: 4
+DEAL:0::size: 16
+DEAL:0::type: dealii::TrilinosWrappers::MPI::Vector
+DEAL:0::index set size: 4
+DEAL:0::local size: 5
+DEAL:0::size: 16
+DEAL:0::type: dealii::LinearAlgebra::distributed::BlockVector<double>
+DEAL:0::local size: 8
+DEAL:0::size: 32
+DEAL:0::type: dealii::PETScWrappers::MPI::BlockVector
+DEAL:0::local size: 8
+DEAL:0::size: 32
+DEAL:0::type: dealii::TrilinosWrappers::MPI::BlockVector
+DEAL:0::local size: 9
+DEAL:0::size: 32
+
+DEAL:1::type: dealii::Vector<double>
+DEAL:1::local size: 4
+DEAL:1::size: 4
+DEAL:1::type: dealii::LinearAlgebra::Vector<double>
+DEAL:1::local size: 4
+DEAL:1::size: 4
+DEAL:1::type: dealii::LinearAlgebra::EpetraWrappers::Vector
+DEAL:1::index set size: 4
+DEAL:1::local size: 4
+DEAL:1::size: 16
+DEAL:1::type: dealii::LinearAlgebra::TpetraWrappers::Vector<double>
+DEAL:1::index set size: 4
+DEAL:1::local size: 4
+DEAL:1::size: 16
+DEAL:1::type: dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>
+DEAL:1::index set size: 4
+DEAL:1::local size: 4
+DEAL:1::size: 16
+DEAL:1::type: dealii::PETScWrappers::MPI::Vector
+DEAL:1::index set size: 4
+DEAL:1::local size: 4
+DEAL:1::size: 16
+DEAL:1::type: dealii::TrilinosWrappers::MPI::Vector
+DEAL:1::index set size: 4
+DEAL:1::local size: 6
+DEAL:1::size: 16
+DEAL:1::type: dealii::LinearAlgebra::distributed::BlockVector<double>
+DEAL:1::local size: 8
+DEAL:1::size: 32
+DEAL:1::type: dealii::PETScWrappers::MPI::BlockVector
+DEAL:1::local size: 8
+DEAL:1::size: 32
+DEAL:1::type: dealii::TrilinosWrappers::MPI::BlockVector
+DEAL:1::local size: 10
+DEAL:1::size: 32
+
+
+DEAL:2::type: dealii::Vector<double>
+DEAL:2::local size: 4
+DEAL:2::size: 4
+DEAL:2::type: dealii::LinearAlgebra::Vector<double>
+DEAL:2::local size: 4
+DEAL:2::size: 4
+DEAL:2::type: dealii::LinearAlgebra::EpetraWrappers::Vector
+DEAL:2::index set size: 4
+DEAL:2::local size: 4
+DEAL:2::size: 16
+DEAL:2::type: dealii::LinearAlgebra::TpetraWrappers::Vector<double>
+DEAL:2::index set size: 4
+DEAL:2::local size: 4
+DEAL:2::size: 16
+DEAL:2::type: dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>
+DEAL:2::index set size: 4
+DEAL:2::local size: 4
+DEAL:2::size: 16
+DEAL:2::type: dealii::PETScWrappers::MPI::Vector
+DEAL:2::index set size: 4
+DEAL:2::local size: 4
+DEAL:2::size: 16
+DEAL:2::type: dealii::TrilinosWrappers::MPI::Vector
+DEAL:2::index set size: 4
+DEAL:2::local size: 6
+DEAL:2::size: 16
+DEAL:2::type: dealii::LinearAlgebra::distributed::BlockVector<double>
+DEAL:2::local size: 8
+DEAL:2::size: 32
+DEAL:2::type: dealii::PETScWrappers::MPI::BlockVector
+DEAL:2::local size: 8
+DEAL:2::size: 32
+DEAL:2::type: dealii::TrilinosWrappers::MPI::BlockVector
+DEAL:2::local size: 10
+DEAL:2::size: 32
+
+
+DEAL:3::type: dealii::Vector<double>
+DEAL:3::local size: 4
+DEAL:3::size: 4
+DEAL:3::type: dealii::LinearAlgebra::Vector<double>
+DEAL:3::local size: 4
+DEAL:3::size: 4
+DEAL:3::type: dealii::LinearAlgebra::EpetraWrappers::Vector
+DEAL:3::index set size: 4
+DEAL:3::local size: 4
+DEAL:3::size: 16
+DEAL:3::type: dealii::LinearAlgebra::TpetraWrappers::Vector<double>
+DEAL:3::index set size: 4
+DEAL:3::local size: 4
+DEAL:3::size: 16
+DEAL:3::type: dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>
+DEAL:3::index set size: 4
+DEAL:3::local size: 4
+DEAL:3::size: 16
+DEAL:3::type: dealii::PETScWrappers::MPI::Vector
+DEAL:3::index set size: 4
+DEAL:3::local size: 4
+DEAL:3::size: 16
+DEAL:3::type: dealii::TrilinosWrappers::MPI::Vector
+DEAL:3::index set size: 4
+DEAL:3::local size: 6
+DEAL:3::size: 16
+DEAL:3::type: dealii::LinearAlgebra::distributed::BlockVector<double>
+DEAL:3::local size: 8
+DEAL:3::size: 32
+DEAL:3::type: dealii::PETScWrappers::MPI::BlockVector
+DEAL:3::local size: 8
+DEAL:3::size: 32
+DEAL:3::type: dealii::TrilinosWrappers::MPI::BlockVector
+DEAL:3::local size: 10
+DEAL:3::size: 32
+

--- a/tests/mpi/local_size.with_trilinos_with_tpetra=on.with_petsc=on.mpirun=4.output
+++ b/tests/mpi/local_size.with_trilinos_with_tpetra=on.with_petsc=on.mpirun=4.output
@@ -23,7 +23,7 @@ DEAL:0::local size: 4
 DEAL:0::size: 16
 DEAL:0::type: dealii::TrilinosWrappers::MPI::Vector
 DEAL:0::index set size: 4
-DEAL:0::local size: 5
+DEAL:0::local size: 4
 DEAL:0::size: 16
 DEAL:0::type: dealii::LinearAlgebra::distributed::BlockVector<double>
 DEAL:0::local size: 8
@@ -32,7 +32,7 @@ DEAL:0::type: dealii::PETScWrappers::MPI::BlockVector
 DEAL:0::local size: 8
 DEAL:0::size: 32
 DEAL:0::type: dealii::TrilinosWrappers::MPI::BlockVector
-DEAL:0::local size: 9
+DEAL:0::local size: 8
 DEAL:0::size: 32
 
 DEAL:1::type: dealii::Vector<double>
@@ -59,7 +59,7 @@ DEAL:1::local size: 4
 DEAL:1::size: 16
 DEAL:1::type: dealii::TrilinosWrappers::MPI::Vector
 DEAL:1::index set size: 4
-DEAL:1::local size: 6
+DEAL:1::local size: 4
 DEAL:1::size: 16
 DEAL:1::type: dealii::LinearAlgebra::distributed::BlockVector<double>
 DEAL:1::local size: 8
@@ -68,7 +68,7 @@ DEAL:1::type: dealii::PETScWrappers::MPI::BlockVector
 DEAL:1::local size: 8
 DEAL:1::size: 32
 DEAL:1::type: dealii::TrilinosWrappers::MPI::BlockVector
-DEAL:1::local size: 10
+DEAL:1::local size: 8
 DEAL:1::size: 32
 
 
@@ -96,7 +96,7 @@ DEAL:2::local size: 4
 DEAL:2::size: 16
 DEAL:2::type: dealii::TrilinosWrappers::MPI::Vector
 DEAL:2::index set size: 4
-DEAL:2::local size: 6
+DEAL:2::local size: 4
 DEAL:2::size: 16
 DEAL:2::type: dealii::LinearAlgebra::distributed::BlockVector<double>
 DEAL:2::local size: 8
@@ -105,7 +105,7 @@ DEAL:2::type: dealii::PETScWrappers::MPI::BlockVector
 DEAL:2::local size: 8
 DEAL:2::size: 32
 DEAL:2::type: dealii::TrilinosWrappers::MPI::BlockVector
-DEAL:2::local size: 10
+DEAL:2::local size: 8
 DEAL:2::size: 32
 
 
@@ -133,7 +133,7 @@ DEAL:3::local size: 4
 DEAL:3::size: 16
 DEAL:3::type: dealii::TrilinosWrappers::MPI::Vector
 DEAL:3::index set size: 4
-DEAL:3::local size: 6
+DEAL:3::local size: 4
 DEAL:3::size: 16
 DEAL:3::type: dealii::LinearAlgebra::distributed::BlockVector<double>
 DEAL:3::local size: 8
@@ -142,6 +142,6 @@ DEAL:3::type: dealii::PETScWrappers::MPI::BlockVector
 DEAL:3::local size: 8
 DEAL:3::size: 32
 DEAL:3::type: dealii::TrilinosWrappers::MPI::BlockVector
-DEAL:3::local size: 10
+DEAL:3::local size: 8
 DEAL:3::size: 32
 


### PR DESCRIPTION
I first thought that this change would be uncontroversial but in the process of writing a test I learned that `TrilinosWrappers::MPI::local_size()` behaves differently from the other two ghosted vectors - it returns the total number of entries (both ghosted and locally owned) while the other two return just the number of locally owned elements.

The documentation of this class clearly states that this behavior is intentional. My proposal: lets deprecate `local_size()` everywhere and implement `locally_owned_size()` in all vector classes. Thoughts?