### PR TITLE
Remove redundant instantiation of ShapeInfo

### DIFF
--- a/source/matrix_free/matrix_free.cc
+++ b/source/matrix_free/matrix_free.cc
@@ -30,11 +30,4 @@ DEAL_II_NAMESPACE_OPEN
 #endif
 #include "matrix_free.inst"
 
-#if SPLIT_INSTANTIATIONS_INDEX == 0
-
-template struct internal::MatrixFreeFunctions::ShapeInfo<double>;
-template struct internal::MatrixFreeFunctions::ShapeInfo<float>;
-
-#endif
-
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
Currently, `ShapeInfo` is (partly) instantiated twice. Here:

https://github.com/dealii/dealii/blob/23d6ef5ba0e9addbdc0ac7836c164213acbde042/source/matrix_free/shape_info.cc#L29-L30

but also here (although `deal.II/matrix_free/shape_info.templates.h` is not included):

https://github.com/dealii/dealii/blob/23d6ef5ba0e9addbdc0ac7836c164213acbde042/source/matrix_free/matrix_free.cc#L35-L36

This PR only keeps the first one. 