### PR TITLE
Applying user constraints after prolongation and restriction in MG

### DIFF
--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -86,8 +86,8 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
   prolongation_matrices[to_level - 1]->vmult(dst, src);
-  this->mg_constrained_dofs->get_user_constraint_matrix(to_level)
-    .distribute(dst);
+  this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(
+    dst);
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -85,15 +85,8 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
   Assert((to_level >= 1) && (to_level <= prolongation_matrices.size()),
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
-#ifdef DEBUG
-  if (this->mg_constrained_dofs != nullptr)
-    Assert(this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
-               .get_local_lines()
-               .size() == 0,
-           ExcNotImplemented());
-#endif
-
   prolongation_matrices[to_level - 1]->vmult(dst, src);
+  this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(dst);
 }
 
 
@@ -109,6 +102,7 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
   (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
+  this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1).distribute(dst);
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -86,7 +86,8 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
   prolongation_matrices[to_level - 1]->vmult(dst, src);
-  this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(dst);
+  this->mg_constrained_dofs->get_user_constraint_matrix(to_level)
+    .distribute(dst);
 }
 
 
@@ -102,7 +103,8 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
   (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
-  this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1).distribute(dst);
+  this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1)
+    .distribute(dst);
 }
 
 


### PR DESCRIPTION
So far only no_normal_flux and zero_boundary_constraints can be used with MGConstrainedDoFs in Multigrid. Since recently, users can also add custom constraints to MGConstrainedDoFs.

In this pull request, I simply apply these user_constraints after the prolongation or restriction in the Multigrid method.

User group post: https://groups.google.com/forum/#!topic/dealii/17V-XvANXGM