### PR TITLE
Fix 64-bit compilation.

### DIFF
--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -295,7 +295,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  unsigned int
+  types::particle_index
   ParticleHandler<dim, spacedim>::n_particles_in_cell(
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
     const


### PR DESCRIPTION
This fixes a mistake I introduced in #10320 whereby I changed the return type
of a function in the .h file but not the .cc file. This didn't matter in 32-bit
compilations, but does in 64-bit mode.

I am surprised that this passed the testers. Didn't we run at least one check
in 64-bit mode?