### PR TITLE
CMake: Fix C++17/20 detection

### DIFF
--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -20,6 +20,7 @@
 #
 #   DEAL_II_HAVE_CXX14
 #   DEAL_II_HAVE_CXX17
+#   DEAL_II_HAVE_CXX20
 #
 #   DEAL_II_HAVE_FP_EXCEPTIONS
 #   DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS
@@ -47,6 +48,49 @@ MACRO(_set_up_cmake_required)
   SET(CMAKE_REQUIRED_FLAGS "")
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS}")
   ADD_FLAGS(CMAKE_REQUIRED_FLAGS "${DEAL_II_CXX_FLAGS_SAVED}")
+ENDMACRO()
+
+
+#
+# Wrap the following checks into a macro to make it easier to rerun them.
+#
+MACRO(_test_cxx20_support)
+
+  UNSET_IF_CHANGED(CHECK_CXX20_FEATURES_FLAGS_SAVED
+    "${CMAKE_REQUIRED_FLAGS}"
+    DEAL_II_HAVE_CXX20_FEATURES
+    )
+
+  # Strictly speaking "201709L" indicates support for a preliminary version
+  # of C++20 standard (which will have "202002L" when finalized). gcc-10
+  # exports this version number when configured with C++20 support.
+  # clang-10 exports the final "202002L" version instead.
+  CHECK_CXX_SOURCE_COMPILES(
+    "
+    #include <cmath>
+    #include <ranges>
+
+    #if __cplusplus < 201709L && !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
+    #  error \"insufficient support for C++20\"
+    #endif
+
+    #if !(defined __cpp_lib_ranges) || (__cpp_lib_ranges < 201911)
+    #  error \"insufficient support for C++20\"
+    #endif
+
+    int main()
+    {
+    }
+    "
+    DEAL_II_HAVE_CXX20_FEATURES)
+
+  IF(DEAL_II_HAVE_CXX20_FEATURES)
+    MESSAGE(STATUS "C++20 support is enabled.")
+    SET(DEAL_II_HAVE_CXX20 TRUE)
+  ELSE()
+    MESSAGE(STATUS "C++20 support is disabled.")
+    SET(DEAL_II_HAVE_CXX20 FALSE)
+  ENDIF()
 ENDMACRO()
 
 
@@ -256,6 +300,7 @@ MACRO(_test_cxx14_support)
   ENDIF()
 ENDMACRO()
 
+
 #
 # Try to find out what we support:
 #
@@ -281,6 +326,7 @@ IF(NOT DEAL_II_HAVE_CXX14)
 ENDIF()
 
 _test_cxx17_support()
+_test_cxx20_support()
 
 
 ########################################################################

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -291,7 +291,9 @@ _test_cxx17_support()
 
 
 #
-# In the following we have to avoid
+# Some compilers are too generous in accepting some of the language
+# features that we test below and do not issue an error but a warning. Set
+# -Werror to make the feature detection more reliable.
 #
 SET(_werror_flag "")
 IF(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")

--- a/cmake/checks/check_01_cxx_features.cmake
+++ b/cmake/checks/check_01_cxx_features.cmake
@@ -64,11 +64,21 @@ MACRO(_test_cxx17_support)
   # Test that the c++17 attributes are supported.
   CHECK_CXX_SOURCE_COMPILES(
     "
+    #include <cmath>
     #include <iostream>
+    #include <optional>
+    #include <tuple>
 
     #if __cplusplus < 201703L && !defined(_MSC_VER) && !defined(__INTEL_COMPILER)
     #  error \"insufficient support for C++17\"
     #endif
+
+    //check for some C++17 features that we use in our headers:
+    using std::apply;
+    using std::cyl_bessel_j;
+    using std::cyl_bessel_jf;
+    using std::cyl_bessel_jl;
+    using std::optional;
 
     [[nodiscard]] int test_nodiscard()
     {

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -133,6 +133,7 @@
 
 #cmakedefine DEAL_II_HAVE_CXX14
 #cmakedefine DEAL_II_HAVE_CXX17
+#cmakedefine DEAL_II_HAVE_CXX20
 
 #cmakedefine DEAL_II_HAVE_FP_EXCEPTIONS
 #cmakedefine DEAL_II_HAVE_COMPLEX_OPERATOR_OVERLOADS

--- a/include/deal.II/base/std_cxx17/cmath.h
+++ b/include/deal.II/base/std_cxx17/cmath.h
@@ -17,16 +17,17 @@
 
 #include <deal.II/base/config.h>
 
-#ifndef __cpp_lib_math_special_functions
+#ifdef DEAL_II_HAVE_CXX17
+#  include <cmath>
+#else
 #  include <boost/math/special_functions/bessel.hpp>
-#endif // __cpp_lib_math_special_functions
+#endif
 
-#include <cmath>
 
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
-#ifndef __cpp_lib_math_special_functions
+#ifndef DEAL_II_HAVE_CXX17
   double (&cyl_bessel_j)(double,
                          double) = boost::math::cyl_bessel_j<double, double>;
   float (&cyl_bessel_jf)(float,
@@ -37,7 +38,7 @@ namespace std_cxx17
   using std::cyl_bessel_j;
   using std::cyl_bessel_jf;
   using std::cyl_bessel_jl;
-#endif // __cpp_lib_math_special_functions
+#endif
 } // namespace std_cxx17
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/base/std_cxx17/optional.h
+++ b/include/deal.II/base/std_cxx17/optional.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef __cpp_lib_optional
+#ifdef DEAL_II_HAVE_CXX17
 #  include <optional>
 #else
 #  include <boost/optional.hpp>
@@ -26,10 +26,10 @@
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
-#ifdef __cpp_lib_optional
-  using std::optional;
-#else
+#ifndef DEAL_II_HAVE_CXX17
   using boost::optional;
+#else
+  using std::optional;
 #endif
 } // namespace std_cxx17
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/base/std_cxx17/tuple.h
+++ b/include/deal.II/base/std_cxx17/tuple.h
@@ -19,14 +19,10 @@
 
 #include <tuple>
 
-#ifndef __cpp_lib_apply
-#  include <utility>
-#endif // __cpp_lib_apply
-
 DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
-#ifndef __cpp_lib_apply
+#ifndef DEAL_II_HAVE_CXX17
   template <typename F, typename Tuple, size_t... S>
   auto
   apply_impl(F &&fn, Tuple &&t, std::index_sequence<S...>)
@@ -51,7 +47,7 @@ namespace std_cxx17
   }
 #else
   using std::apply;
-#endif // __cpp_lib_apply
+#endif
 } // namespace std_cxx17
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -17,7 +17,7 @@
 
 #include <deal.II/base/config.h>
 
-#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
+#ifdef DEAL_II_HAVE_CXX20
 #  include <ranges>
 #else
 #  include <boost/range/irange.hpp>
@@ -29,9 +29,7 @@ namespace std_cxx20
 {
   namespace ranges
   {
-#if defined __cpp_lib_ranges && __cpp_lib_ranges >= 201911
-    using std::ranges::iota_view;
-#else
+#ifndef DEAL_II_HAVE_CXX20
     /**
      * A poor-man's implementation of std::ranges::iota_view using
      * boost's integer_range class. The two classes are not completely
@@ -46,6 +44,8 @@ namespace std_cxx20
      */
     template <typename IncrementableType, typename /*BoundType*/>
     using iota_view = boost::integer_range<IncrementableType>;
+#else
+    using std::ranges::iota_view;
 #endif
   } // namespace ranges
 } // namespace std_cxx20


### PR DESCRIPTION
- base/std_cxx17: Make selection of boost/std a configure time constant
 - introduce DEAL_II_HAVE_CXX20 check

Closes #10340