### PR TITLE
Applied user constraints before prolongation in MGTransferPrebuilt

### DIFF
--- a/doc/news/changes/minor/20200525Roth
+++ b/doc/news/changes/minor/20200525Roth
@@ -1,4 +1,0 @@
-New: Applying user constraints 
-after prolongation and restriction in MGTransferPrebuilt.
-<br>
-(Julian Roth, 2020/05/25)

--- a/doc/news/changes/minor/20200525Roth
+++ b/doc/news/changes/minor/20200525Roth
@@ -1,0 +1,4 @@
+New: Applying user constraints 
+after prolongation and restriction in MGTransferPrebuilt.
+<br>
+(Julian Roth, 2020/05/25)

--- a/doc/news/changes/minor/20200605Roth
+++ b/doc/news/changes/minor/20200605Roth
@@ -1,0 +1,4 @@
+New: Applying user constraints 
+before prolongation in MGTransferPrebuilt.
+<br>
+(Julian Roth, 2020/06/05)

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -86,8 +86,9 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
   prolongation_matrices[to_level - 1]->vmult(dst, src);
-  this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(
-    dst);
+  if (this->mg_constrained_dofs != nullptr)
+    this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(
+      dst);
 }
 
 
@@ -103,8 +104,9 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
   (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
-  this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1)
-    .distribute(dst);
+  if (this->mg_constrained_dofs != nullptr)
+    this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1)
+      .distribute(dst);
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -85,14 +85,20 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
   Assert((to_level >= 1) && (to_level <= prolongation_matrices.size()),
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
-  VectorType copy_src(src);
   if (this->mg_constrained_dofs != nullptr &&
       this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
           .get_local_lines()
           .size() > 0)
-    this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
-      .distribute(copy_src);
-  prolongation_matrices[to_level - 1]->vmult(dst, copy_src);
+    {
+      VectorType copy_src(src);
+      this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
+        .distribute(copy_src);
+      prolongation_matrices[to_level - 1]->vmult(dst, copy_src);
+    }
+  else
+    {
+      prolongation_matrices[to_level - 1]->vmult(dst, src);
+    }
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -85,10 +85,11 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
   Assert((to_level >= 1) && (to_level <= prolongation_matrices.size()),
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
-  prolongation_matrices[to_level - 1]->vmult(dst, src);
+  VectorType copy_src(src);
   if (this->mg_constrained_dofs != nullptr)
-    this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(
-      dst);
+    this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
+      .distribute(copy_src);
+  prolongation_matrices[to_level - 1]->vmult(dst, copy_src);
 }
 
 
@@ -104,9 +105,6 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
   (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
-  if (this->mg_constrained_dofs != nullptr)
-    this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1)
-      .distribute(dst);
 }
 
 

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -86,7 +86,10 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
   VectorType copy_src(src);
-  if (this->mg_constrained_dofs != nullptr)
+  if (this->mg_constrained_dofs != nullptr &&
+      this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
+          .get_local_lines()
+          .size() > 0)
     this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
       .distribute(copy_src);
   prolongation_matrices[to_level - 1]->vmult(dst, copy_src);

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -85,15 +85,9 @@ MGTransferPrebuilt<VectorType>::prolongate(const unsigned int to_level,
   Assert((to_level >= 1) && (to_level <= prolongation_matrices.size()),
          ExcIndexRange(to_level, 1, prolongation_matrices.size() + 1));
 
-#ifdef DEBUG
-  if (this->mg_constrained_dofs != nullptr)
-    Assert(this->mg_constrained_dofs->get_user_constraint_matrix(to_level - 1)
-               .get_local_lines()
-               .size() == 0,
-           ExcNotImplemented());
-#endif
-
   prolongation_matrices[to_level - 1]->vmult(dst, src);
+  this->mg_constrained_dofs->get_user_constraint_matrix(to_level).distribute(
+    dst);
 }
 
 
@@ -109,6 +103,8 @@ MGTransferPrebuilt<VectorType>::restrict_and_add(const unsigned int from_level,
   (void)from_level;
 
   prolongation_matrices[from_level - 1]->Tvmult_add(dst, src);
+  this->mg_constrained_dofs->get_user_constraint_matrix(from_level - 1)
+    .distribute(dst);
 }
 
 


### PR DESCRIPTION
Currently only no_normal_flux and zero_boundary_constraints can be used with MGConstrainedDoFs in Multigrid. Since recently, users can also add custom constraints to MGConstrainedDoFs.

In this pull request, I simply apply these user_constraints after the prolongation or restriction in the Multigrid method.

User group post: https://groups.google.com/forum/#!topic/dealii/17V-XvANXGM