### PR TITLE
Avoid overloaded operator ambiguity with -std=c++20 and clang-10

### DIFF
--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -252,11 +252,13 @@ public:
   bool
   operator==(const DerivedIterator &) const;
 
+#ifndef DEAL_II_HAVE_CXX20
   /**
    * Inverse of operator==().
    */
   bool
   operator!=(const DerivedIterator &) const;
+#endif
 
   /**
    * Comparison operator: uses the same ordering as operator<(), but also
@@ -456,6 +458,7 @@ operator==(const DerivedIterator &other) const
 
 
 
+#ifndef DEAL_II_HAVE_CXX20
 template <class DerivedIterator, class AccessorType>
 inline bool
 LinearIndexIterator<DerivedIterator, AccessorType>::
@@ -463,6 +466,7 @@ operator!=(const DerivedIterator &other) const
 {
   return !(*this == other);
 }
+#endif
 
 
 

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -382,11 +382,13 @@ public:
   bool
   operator==(const TriaRawIterator &) const;
 
+#  ifndef DEAL_II_HAVE_CXX20
   /**
    * Compare for inequality.
    */
   bool
   operator!=(const TriaRawIterator &) const;
+#  endif
 
   /**
    * Ordering relation for iterators.

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -90,6 +90,7 @@ operator==(const TriaRawIterator<Accessor> &other) const
 }
 
 
+#ifndef DEAL_II_HAVE_CXX20
 template <typename Accessor>
 inline bool
 TriaRawIterator<Accessor>::
@@ -97,6 +98,7 @@ operator!=(const TriaRawIterator<Accessor> &other) const
 {
   return !(*this == other);
 }
+#endif
 
 
 template <typename Accessor>


### PR DESCRIPTION
Second try...

 - reimplement LinearIndexIterator::operator@@ as non-member variants

Closes: #10349