### PR TITLE
Petsc vector space vector

### DIFF
--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -275,20 +275,16 @@ namespace PETScWrappers
       clear() override;
 
       /**
+       * Explicitly use the base class operator= functions.
+       */
+      using VectorBase::operator=;
+
+      /**
        * Copy the given vector. Resize the present vector if necessary. Also
        * take over the MPI communicator of @p v.
        */
       Vector &
       operator=(const Vector &v);
-
-      /**
-       * Set all components of the vector to the given number @p s. Simply
-       * pass this down to the base class, but we still need to declare this
-       * function to make the example given in the discussion about making the
-       * constructor explicit work.
-       */
-      Vector &
-      operator=(const PetscScalar s);
 
       /**
        * Copy the values of a deal.II vector (as opposed to those of the PETSc
@@ -302,6 +298,11 @@ namespace PETScWrappers
       template <typename number>
       Vector &
       operator=(const dealii::Vector<number> &v);
+
+      /**
+       * Explicitly use the base class reinit functions.
+       */
+      using VectorBase::reinit;
 
       /**
        * Change the dimension of the vector to @p N. It is unspecified how
@@ -377,11 +378,11 @@ namespace PETScWrappers
        * that the right thing happens for parallel vectors that are
        * distributed across processors.
        */
-      void
+      virtual void
       print(std::ostream &     out,
             const unsigned int precision  = 3,
             const bool         scientific = true,
-            const bool         across     = true) const;
+            const bool         across     = true) const override;
 
       /**
        * @copydoc PETScWrappers::VectorBase::all_zero()
@@ -389,8 +390,8 @@ namespace PETScWrappers
        * @note This function overloads the one in the base class to make this
        * a collective operation.
        */
-      bool
-      all_zero() const;
+      virtual bool
+      all_zero() const override;
 
     protected:
       /**
@@ -452,16 +453,6 @@ namespace PETScWrappers
       Vector::create_vector(v.size(), local_size);
 
       *this = v;
-    }
-
-
-
-    inline Vector &
-    Vector::operator=(const PetscScalar s)
-    {
-      VectorBase::operator=(s);
-
-      return *this;
     }
 
 

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -364,7 +364,6 @@ namespace PETScWrappers
 #  ifdef DEBUG
 #    ifdef DEAL_II_WITH_MPI
       // Check that all processors agree that last_action is the same (or none!)
-
       int my_int_last_action = last_action;
       int all_int_last_action;
 
@@ -390,28 +389,18 @@ namespace PETScWrappers
       ExcMessage(
         "Missing compress() or calling with wrong VectorOperation argument."));
 
-    // note that one may think that
-    // we only need to do something
-    // if in fact the state is
-    // anything but
-    // last_action::unknown. but
-    // that's not true: one
-    // frequently gets into
-    // situations where only one
-    // processor (or a subset of
-    // processors) actually writes
-    // something into a vector, but
-    // we still need to call
-    // VecAssemblyBegin/End on all
-    // processors.
+    // note that one may think that we only need to do something if in fact
+    // the state is anything but last_action::unknown. but that's not true:
+    // one frequently gets into situations where only one processor (or a
+    // subset of processors) actually writes something into a vector, but we
+    // still need to call VecAssemblyBegin/End on all processors.
     PetscErrorCode ierr = VecAssemblyBegin(vector);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
     ierr = VecAssemblyEnd(vector);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    // reset the last action field to
-    // indicate that we're back to a
-    // pristine state
+    // reset the last action field to indicate that we're back to a pristine
+    // state
     last_action = ::dealii::VectorOperation::unknown;
   }
 


### PR DESCRIPTION
This is most of the work to get our petsc vector class inheriting from VectorSpaceVector. There are still a couple of TODOs:
1. We should shrink the public interface of this class by deprecating things like `operator=(dealii::Vector &)` so that it lines up with what the `VectorSpaceVector` family provides.
2. I still need to implement `import` and `reinit`.
3. This breaks a couple of the PETSc solver tests - I need to investigate.