### PR TITLE
matrix-free: do not use bool args

### DIFF
--- a/examples/step-37/doc/results.dox
+++ b/examples/step-37/doc/results.dox
@@ -574,13 +574,13 @@ void LaplaceProblem<dim>::assemble_rhs()
     {
       phi.reinit(cell);
       phi.read_dof_values_plain(solution);
-      phi.evaluate(false, true);
+      phi.evaluate(EvaluationFlags::gradients);
       for (unsigned int q = 0; q < phi.n_q_points; ++q)
         {
           phi.submit_gradient(-coefficient(cell, q) * phi.get_gradient(q), q);
           phi.submit_value(make_vectorized_array<double>(1.0), q);
         }
-      phi.integrate(true, true);
+      phi.integrate(EvaluationFlags::values|EvaluationFlags::gradients);
       phi.distribute_local_to_global(system_rhs);
     }
   system_rhs.compress(VectorOperation::add);
@@ -662,7 +662,7 @@ void LaplaceProblem<dim>::assemble_rhs()
       phi.reinit(cell);
       for (unsigned int q = 0; q < phi.n_q_points; ++q)
         phi.submit_value(make_vectorized_array<double>(1.0), q);
-      phi.integrate(true, false);
+      phi.integrate(EvaluationFlags::values);
       phi.distribute_local_to_global(system_rhs);
     }
   system_rhs.compress(VectorOperation::add);

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -403,10 +403,10 @@ namespace Step37
 
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(coefficient(cell, q) * phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -630,11 +630,11 @@ namespace Step37
               phi.submit_dof_value(VectorizedArray<number>(), j);
             phi.submit_dof_value(make_vectorized_array<number>(1.), i);
 
-            phi.evaluate(false, true);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(coefficient(cell, q) * phi.get_gradient(q),
                                   q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             diagonal[i] = phi.get_dof_value(i);
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -911,7 +911,7 @@ namespace Step37
         phi.reinit(cell);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_value(make_vectorized_array<double>(1.0), q);
-        phi.integrate(true, false);
+        phi.integrate(EvaluationFlags::values);
         phi.distribute_local_to_global(system_rhs);
       }
     system_rhs.compress(VectorOperation::add);

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -132,7 +132,7 @@ namespace Step48
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(make_vectorized_array(1.), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate();
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
 
@@ -198,8 +198,8 @@ namespace Step48
         current.read_dof_values(*src[0]);
         old.read_dof_values(*src[1]);
 
-        current.evaluate(true, true, false);
-        old.evaluate(true, false, false);
+        current.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+        old.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < current.n_q_points; ++q)
           {
@@ -212,7 +212,7 @@ namespace Step48
             current.submit_gradient(-delta_t_sqr * current.get_gradient(q), q);
           }
 
-        current.integrate(true, true);
+        current.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         current.distribute_local_to_global(dst);
       }
   }

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -132,7 +132,7 @@ namespace Step48
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(make_vectorized_array(1.), q);
-        fe_eval.integrate();
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
 

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -951,7 +951,7 @@ void LaplaceProblem<dim, degree>::assemble_rhs()
     {
       phi.reinit(cell);
       phi.read_dof_values_plain(solution_copy);
-      phi.evaluate(false, true, false);
+      phi.evaluate(EvaluationFlags::gradients);
 
       for (unsigned int q = 0; q < phi.n_q_points; ++q)
         {
@@ -962,7 +962,9 @@ void LaplaceProblem<dim, degree>::assemble_rhs()
             right_hand_side_function.value(phi.quadrature_point(q)), q);
         }
 
-      phi.integrate_scatter(true, true, right_hand_side_copy);
+      phi.integrate_scatter(EvaluationFlags::values |
+                              EvaluationFlags::gradients,
+                            right_hand_side_copy);
     }
 
   right_hand_side_copy.compress(VectorOperation::add);

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1066,7 +1066,7 @@ namespace Euler_DG
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
         phi.reinit(cell);
-        phi.gather_evaluate(src, true, false);
+        phi.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
@@ -1089,7 +1089,11 @@ namespace Euler_DG
               }
           }
 
-        phi.integrate_scatter(body_force.get() != nullptr, true, dst);
+        phi.integrate_scatter(((body_force.get() != nullptr) ?
+                                 EvaluationFlags::values :
+                                 EvaluationFlags::nothing) |
+                                EvaluationFlags::gradients,
+                              dst);
       }
   }
 
@@ -1148,10 +1152,10 @@ namespace Euler_DG
     for (unsigned int face = face_range.first; face < face_range.second; ++face)
       {
         phi_p.reinit(face);
-        phi_p.gather_evaluate(src, true, false);
+        phi_p.gather_evaluate(src, EvaluationFlags::values);
 
         phi_m.reinit(face);
-        phi_m.gather_evaluate(src, true, false);
+        phi_m.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
           {
@@ -1163,8 +1167,8 @@ namespace Euler_DG
             phi_p.submit_value(numerical_flux, q);
           }
 
-        phi_p.integrate_scatter(true, false, dst);
-        phi_m.integrate_scatter(true, false, dst);
+        phi_p.integrate_scatter(EvaluationFlags::values, dst);
+        phi_m.integrate_scatter(EvaluationFlags::values, dst);
       }
   }
 
@@ -1233,7 +1237,7 @@ namespace Euler_DG
     for (unsigned int face = face_range.first; face < face_range.second; ++face)
       {
         phi.reinit(face);
-        phi.gather_evaluate(src, true, false);
+        phi.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
@@ -1289,7 +1293,7 @@ namespace Euler_DG
             phi.submit_value(-flux, q);
           }
 
-        phi.integrate_scatter(true, false, dst);
+        phi.integrate_scatter(EvaluationFlags::values, dst);
       }
   }
 
@@ -1621,7 +1625,7 @@ namespace Euler_DG
     for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         phi.reinit(cell);
-        phi.gather_evaluate(solution, true, false);
+        phi.gather_evaluate(solution, EvaluationFlags::values);
         VectorizedArray<Number> local_errors_squared[3] = {};
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
@@ -1703,7 +1707,7 @@ namespace Euler_DG
     for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         phi.reinit(cell);
-        phi.gather_evaluate(solution, true, false);
+        phi.gather_evaluate(solution, EvaluationFlags::values);
         VectorizedArray<Number> local_max = 0.;
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -58,29 +58,36 @@ class FEEvaluation;
 
 
 /**
- * @brief The EvaluationFlags enum
+ * @brief The namespace for the EvaluationFlags enum
+ *
+ * This namespace contains the enum EvaluationFlags used in FEEvaluation
+ * to control evaluation and integration of values, gradients, etc..
  */
 namespace EvaluationFlags
 {
   /**
-   * @brief The type enum
+   * @brief The EvaluationFlags enum
+   *
+   * This enum contains a set of flags used by FEEvaluation::integrate(),
+   * FEEvaluation::evaluate() and others to determine if values, gradients,
+   * hessians, or a combination of them is being used.
    */
   enum EvaluationFlags
   {
     /**
-     *
+     * Do not use or compute anything.
      */
     nothing = 0,
     /**
-     *
+     * Use or evaluate values.
      */
     values = 0x1,
     /**
-     *
+     * Use or evaluate gradients.
      */
     gradients = 0x2,
     /**
-     *
+     * Use or evaluate hessians.
      */
     hessians = 0x4
   };
@@ -93,7 +100,7 @@ namespace EvaluationFlags
    * integer which would in turn trigger a compiler warning when we tried to
    * assign it to an object of type UpdateFlags.
    *
-   * @ref type
+   * @ref EvaluationFlags
    */
   inline EvaluationFlags
   operator|(const EvaluationFlags f1, const EvaluationFlags f2)
@@ -108,7 +115,7 @@ namespace EvaluationFlags
    * Global operator which sets the bits from the second argument also in the
    * first one.
    *
-   * @ref type
+   * @ref EvaluationFlags
    */
   inline EvaluationFlags &
   operator|=(EvaluationFlags &f1, const EvaluationFlags f2)
@@ -125,7 +132,7 @@ namespace EvaluationFlags
    * an integer which would in turn trigger a compiler warning when we tried to
    * assign it to an object of type UpdateFlags.
    *
-   * @ref UpdateFlags
+   * @ref EvaluationFlags
    */
   inline EvaluationFlags operator&(const EvaluationFlags f1,
                                    const EvaluationFlags f2)
@@ -139,7 +146,7 @@ namespace EvaluationFlags
    * Global operator which clears all the bits in the first argument if they are
    * not also set in the second argument.
    *
-   * @ref UpdateFlags
+   * @ref EvaluationFlags
    */
   inline EvaluationFlags &
   operator&=(EvaluationFlags &f1, const EvaluationFlags f2)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -58,6 +58,99 @@ class FEEvaluation;
 
 
 /**
+ * @brief The EvaluationFlags enum
+ */
+namespace EvaluationFlags
+{
+  /**
+   * @brief The type enum
+   */
+  enum EvaluationFlags
+  {
+    /**
+     *
+     */
+    nothing = 0,
+    /**
+     *
+     */
+    values = 0x1,
+    /**
+     *
+     */
+    gradients = 0x2,
+    /**
+     *
+     */
+    hessians = 0x4
+  };
+
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * either set in the first or the second argument. This operator exists since
+   * if it did not then the result of the bit-or <tt>operator |</tt> would be an
+   * integer which would in turn trigger a compiler warning when we tried to
+   * assign it to an object of type UpdateFlags.
+   *
+   * @ref type
+   */
+  inline EvaluationFlags
+  operator|(const EvaluationFlags f1, const EvaluationFlags f2)
+  {
+    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) |
+                                        static_cast<unsigned int>(f2));
+  }
+
+
+
+  /**
+   * Global operator which sets the bits from the second argument also in the
+   * first one.
+   *
+   * @ref type
+   */
+  inline EvaluationFlags &
+  operator|=(EvaluationFlags &f1, const EvaluationFlags f2)
+  {
+    f1 = f1 | f2;
+    return f1;
+  }
+
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * set in the first as well as the second argument. This operator exists since
+   * if it did not then the result of the bit-and <tt>operator &</tt> would be
+   * an integer which would in turn trigger a compiler warning when we tried to
+   * assign it to an object of type UpdateFlags.
+   *
+   * @ref UpdateFlags
+   */
+  inline EvaluationFlags operator&(const EvaluationFlags f1,
+                                   const EvaluationFlags f2)
+  {
+    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) &
+                                        static_cast<unsigned int>(f2));
+  }
+
+
+  /**
+   * Global operator which clears all the bits in the first argument if they are
+   * not also set in the second argument.
+   *
+   * @ref UpdateFlags
+   */
+  inline EvaluationFlags &
+  operator&=(EvaluationFlags &f1, const EvaluationFlags f2)
+  {
+    f1 = f1 & f2;
+    return f1;
+  }
+
+} // namespace EvaluationFlags
+
+/**
  * This is the base class for the FEEvaluation classes. This class is a base
  * class and needs usually not be called in user code. It does not have any
  * public constructor. The usage is through the class FEEvaluation instead. It
@@ -2509,6 +2602,14 @@ public:
    * manually).
    */
   void
+  evaluate(const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * Like above but with separate bool flags.
+   * @deprecated use evaluate() with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
+  void
   evaluate(const bool evaluate_values,
            const bool evaluate_gradients,
            const bool evaluate_hessians = false);
@@ -2525,6 +2626,15 @@ public:
    * functions @p get_value(), @p get_gradient() or @p get_laplacian give
    * useful information (unless these values have been set manually).
    */
+  void
+  evaluate(const VectorizedArrayType *            values_array,
+           const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * Like above but using separate bool flags.
+   * @deprecated use evaluate() with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
   void
   evaluate(const VectorizedArrayType *values_array,
            const bool                 evaluate_values,
@@ -2546,6 +2656,14 @@ public:
    */
   template <typename VectorType>
   void
+  gather_evaluate(const VectorType &                     input_vector,
+                  const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * @deprecated Please use the gather_evaluate() function with the EvaluationFlags argument.
+   */
+  template <typename VectorType>
+  DEAL_II_DEPRECATED void
   gather_evaluate(const VectorType &input_vector,
                   const bool        evaluate_values,
                   const bool        evaluate_gradients,
@@ -2562,6 +2680,13 @@ public:
    * distribute_local_to_global() or set_dof_values() methods).
    */
   void
+  integrate(const EvaluationFlags::EvaluationFlags integration_flag);
+
+
+  /**
+   * @deprecated Please use the integrate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED void
   integrate(const bool integrate_values, const bool integrate_gradients);
 
   /**
@@ -2575,6 +2700,14 @@ public:
    * whose previous results is overwritten, rather than writing it on the
    * internal data structures behind begin_dof_values().
    */
+  void
+  integrate(const EvaluationFlags::EvaluationFlags integration_flag,
+            VectorizedArrayType *                  values_array);
+
+  /**
+   * @deprecated Please use the integrate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
   void
   integrate(const bool           integrate_values,
             const bool           integrate_gradients,
@@ -2595,6 +2728,14 @@ public:
    */
   template <typename VectorType>
   void
+  integrate_scatter(const EvaluationFlags::EvaluationFlags evaluation_flag,
+                    VectorType &                           output_vector);
+
+  /**
+   * @deprecated Please use the integrate_scatter() function with the EvaluationFlags argument.
+   */
+  template <typename VectorType>
+  DEAL_II_DEPRECATED void
   integrate_scatter(const bool  integrate_values,
                     const bool  integrate_gradients,
                     VectorType &output_vector);
@@ -2849,6 +2990,13 @@ public:
    * accessing the internal data pointers).
    */
   void
+  evaluate(const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * @deprecated Please use the evaluate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
+  void
   evaluate(const bool evaluate_values, const bool evaluate_gradients);
 
   /**
@@ -2863,6 +3011,14 @@ public:
    * get_normal_derivative() give useful information (unless these values have
    * been set manually).
    */
+  void
+  evaluate(const VectorizedArrayType *            values_array,
+           const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * @deprecated Please use the evaluate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
   void
   evaluate(const VectorizedArrayType *values_array,
            const bool                 evaluate_values,
@@ -2881,6 +3037,14 @@ public:
    */
   template <typename VectorType>
   void
+  gather_evaluate(const VectorType &                     input_vector,
+                  const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * @deprecated Please use the gather_evaluate() function with the EvaluationFlags argument.
+   */
+  template <typename VectorType>
+  DEAL_II_DEPRECATED void
   gather_evaluate(const VectorType &input_vector,
                   const bool        evaluate_values,
                   const bool        evaluate_gradients);
@@ -2895,6 +3059,13 @@ public:
    * distribute_local_to_global() or set_dof_values() methods).
    */
   void
+  integrate(const EvaluationFlags::EvaluationFlags evaluation_flag);
+
+  /**
+   * @deprecated Please use the integrate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
+  void
   integrate(const bool integrate_values, const bool integrate_gradients);
 
   /**
@@ -2905,6 +3076,14 @@ public:
    * values or gradients. As opposed to the other integrate() method, this
    * call stores the result of the testing in the given array `values_array`.
    */
+  void
+  integrate(const EvaluationFlags::EvaluationFlags evaluation_flag,
+            VectorizedArrayType *                  values_array);
+
+  /**
+   * @deprecated Please use the integrate() function with the EvaluationFlags argument.
+   */
+  DEAL_II_DEPRECATED
   void
   integrate(const bool           integrate_values,
             const bool           integrate_gradients,
@@ -2923,6 +3102,14 @@ public:
    */
   template <typename VectorType>
   void
+  integrate_scatter(const EvaluationFlags::EvaluationFlags evaluation_flag,
+                    VectorType &                           output_vector);
+
+  /**
+   * @deprecated Please use the integrate_scatter() function with the EvaluationFlags argument.
+   */
+  template <typename VectorType>
+  DEAL_II_DEPRECATED void
   integrate_scatter(const bool  integrate_values,
                     const bool  integrate_gradients,
                     VectorType &output_vector);
@@ -6971,6 +7158,29 @@ FEEvaluation<dim,
 }
 
 
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  evaluate(const EvaluationFlags::EvaluationFlags evaluation_flags)
+{
+#  ifdef DEBUG
+  Assert(this->dof_values_initialized == true,
+         internal::ExcAccessToUninitializedField());
+#  endif
+  evaluate(this->values_dofs[0], evaluation_flags);
+}
+
+
 
 template <int dim,
           int fe_degree,
@@ -7024,6 +7234,49 @@ template <int dim,
           int n_components_,
           typename Number,
           typename VectorizedArrayType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  evaluate(const VectorizedArrayType *            values_array,
+           const EvaluationFlags::EvaluationFlags evaluation_flags)
+{
+  SelectEvaluator<dim,
+                  fe_degree,
+                  n_q_points_1d,
+                  n_components,
+                  VectorizedArrayType>::
+    evaluate(*this->data,
+             const_cast<VectorizedArrayType *>(values_array),
+             this->values_quad[0],
+             this->gradients_quad[0][0],
+             this->hessians_quad[0][0],
+             this->scratch_data,
+             evaluation_flags & EvaluationFlags::values,
+             evaluation_flags & EvaluationFlags::gradients,
+             evaluation_flags & EvaluationFlags::hessians);
+
+#  ifdef DEBUG
+  if (evaluation_flags & EvaluationFlags::values)
+    this->values_quad_initialized = true;
+  if (evaluation_flags & EvaluationFlags::gradients)
+    this->gradients_quad_initialized = true;
+  if (evaluation_flags & EvaluationFlags::hessians)
+    this->hessians_quad_initialized = true;
+#  endif
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
 template <typename VectorType>
 inline void
 FEEvaluation<
@@ -7033,9 +7286,37 @@ FEEvaluation<
   n_components_,
   Number,
   VectorizedArrayType>::gather_evaluate(const VectorType &input_vector,
-                                        const bool        evaluate_values,
-                                        const bool        evaluate_gradients,
-                                        const bool        evaluate_hessians)
+
+                                        const bool evaluate_values,
+                                        const bool evaluate_gradients,
+                                        const bool evaluate_hessians)
+{
+  const EvaluationFlags::EvaluationFlags flag =
+    ((evaluate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((evaluate_gradients) ? EvaluationFlags::gradients :
+                            EvaluationFlags::nothing) |
+    ((evaluate_hessians) ? EvaluationFlags::hessians :
+                           EvaluationFlags::nothing);
+
+  gather_evaluate(input_vector, flag);
+}
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+template <typename VectorType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  gather_evaluate(const VectorType &                     input_vector,
+                  const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
   // If the index storage is interleaved and contiguous and the vector storage
   // has the correct alignment, we can directly pass the pointer into the
@@ -7066,17 +7347,17 @@ FEEvaluation<
             VectorizedArrayType::size());
 
       evaluate(vec_values,
-               evaluate_values,
-               evaluate_gradients,
-               evaluate_hessians);
+               evaluation_flag & EvaluationFlags::values,
+               evaluation_flag & EvaluationFlags::gradients,
+               evaluation_flag & EvaluationFlags::hessians);
     }
   else
     {
       this->read_dof_values(input_vector);
       evaluate(this->begin_dof_values(),
-               evaluate_values,
-               evaluate_gradients,
-               evaluate_hessians);
+               evaluation_flag & EvaluationFlags::values,
+               evaluation_flag & EvaluationFlags::gradients,
+               evaluation_flag & EvaluationFlags::hessians);
     }
 }
 
@@ -7098,6 +7379,30 @@ FEEvaluation<dim,
                                              const bool integrate_gradients)
 {
   integrate(integrate_values, integrate_gradients, this->values_dofs[0]);
+
+#  ifdef DEBUG
+  this->dof_values_initialized = true;
+#  endif
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  integrate(const EvaluationFlags::EvaluationFlags integration_flag)
+{
+  integrate(integration_flag, this->values_dofs[0]);
 
 #  ifdef DEBUG
   this->dof_values_initialized = true;
@@ -7160,6 +7465,62 @@ template <int dim,
           int n_components_,
           typename Number,
           typename VectorizedArrayType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  integrate(const EvaluationFlags::EvaluationFlags integration_flag,
+            VectorizedArrayType *                  values_array)
+{
+#  ifdef DEBUG
+  if (integration_flag & EvaluationFlags::values)
+    Assert(this->values_quad_submitted == true,
+           internal::ExcAccessToUninitializedField());
+  if (integration_flag & EvaluationFlags::gradients)
+    Assert(this->gradients_quad_submitted == true,
+           internal::ExcAccessToUninitializedField());
+#  endif
+  Assert(this->matrix_info != nullptr ||
+           this->mapped_geometry->is_initialized(),
+         ExcNotInitialized());
+
+  Assert(
+    (integration_flag &
+     ~(EvaluationFlags::values | EvaluationFlags::gradients)) == 0,
+    ExcMessage(
+      "Only EvaluationFlags::values and EvaluationFlags::gradients are supported."));
+
+  SelectEvaluator<dim,
+                  fe_degree,
+                  n_q_points_1d,
+                  n_components,
+                  VectorizedArrayType>::integrate(*this->data,
+                                                  values_array,
+                                                  this->values_quad[0],
+                                                  this->gradients_quad[0][0],
+                                                  this->scratch_data,
+                                                  integration_flag &
+                                                    EvaluationFlags::values,
+                                                  integration_flag &
+                                                    EvaluationFlags::gradients,
+                                                  false);
+
+#  ifdef DEBUG
+  this->dof_values_initialized = true;
+#  endif
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
 template <typename VectorType>
 inline void
 FEEvaluation<
@@ -7171,6 +7532,33 @@ FEEvaluation<
   VectorizedArrayType>::integrate_scatter(const bool  integrate_values,
                                           const bool  integrate_gradients,
                                           VectorType &destination)
+{
+  const EvaluationFlags::EvaluationFlags flag =
+    ((integrate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((integrate_gradients) ? EvaluationFlags::gradients :
+                             EvaluationFlags::nothing);
+
+  integrate_scatter(flag, destination);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+template <typename VectorType>
+inline void
+FEEvaluation<dim,
+             fe_degree,
+             n_q_points_1d,
+             n_components_,
+             Number,
+             VectorizedArrayType>::
+  integrate_scatter(const EvaluationFlags::EvaluationFlags evaluation_flag,
+                    VectorType &                           destination)
 {
   // If the index storage is interleaved and contiguous and the vector storage
   // has the correct alignment, we can directly pass the pointer into the
@@ -7199,24 +7587,26 @@ FEEvaluation<
             ->component_dof_indices_offset[this->active_fe_index]
                                           [this->first_selected_component] *
           VectorizedArrayType::size());
-      SelectEvaluator<dim,
-                      fe_degree,
-                      n_q_points_1d,
-                      n_components,
-                      VectorizedArrayType>::integrate(*this->data,
-                                                      vec_values,
-                                                      this->values_quad[0],
-                                                      this
-                                                        ->gradients_quad[0][0],
-                                                      this->scratch_data,
-                                                      integrate_values,
-                                                      integrate_gradients,
-                                                      true);
+      SelectEvaluator<
+        dim,
+        fe_degree,
+        n_q_points_1d,
+        n_components,
+        VectorizedArrayType>::integrate(*this->data,
+                                        vec_values,
+                                        this->values_quad[0],
+                                        this->gradients_quad[0][0],
+                                        this->scratch_data,
+                                        evaluation_flag &
+                                          EvaluationFlags::values,
+                                        evaluation_flag &
+                                          EvaluationFlags::gradients,
+                                        true);
     }
   else
     {
-      integrate(integrate_values,
-                integrate_gradients,
+      integrate(evaluation_flag & EvaluationFlags::values,
+                evaluation_flag & EvaluationFlags::gradients,
                 this->begin_dof_values());
       this->distribute_local_to_global(destination);
     }
@@ -7443,12 +7833,69 @@ FEFaceEvaluation<dim,
                  n_q_points_1d,
                  n_components,
                  Number,
+                 VectorizedArrayType>::
+  evaluate(const EvaluationFlags::EvaluationFlags evaluation_flag)
+{
+#  ifdef DEBUG
+  Assert(this->dof_values_initialized, ExcNotInitialized());
+#  endif
+
+  evaluate(this->values_dofs[0], evaluation_flag);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components,
+                 Number,
                  VectorizedArrayType>::evaluate(const VectorizedArrayType
                                                   *        values_array,
                                                 const bool evaluate_values,
                                                 const bool evaluate_gradients)
 {
-  if (!(evaluate_values + evaluate_gradients))
+  const EvaluationFlags::EvaluationFlags flag =
+    ((evaluate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((evaluate_gradients) ? EvaluationFlags::gradients :
+                            EvaluationFlags::nothing);
+
+  evaluate(values_array, flag);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components,
+                 Number,
+                 VectorizedArrayType>::
+  evaluate(const VectorizedArrayType *            values_array,
+           const EvaluationFlags::EvaluationFlags evaluation_flag)
+{
+  Assert(
+    (evaluation_flag &
+     ~(EvaluationFlags::values | EvaluationFlags::gradients)) == 0,
+    ExcMessage(
+      "Only EvaluationFlags::values and EvaluationFlags::gradients are supported."));
+
+  if (!(evaluation_flag & EvaluationFlags::values) &&
+      !(evaluation_flag & EvaluationFlags::gradients))
     return;
 
   internal::FEFaceEvaluationSelector<
@@ -7462,8 +7909,8 @@ FEFaceEvaluation<dim,
                                    this->begin_values(),
                                    this->begin_gradients(),
                                    this->scratch_data,
-                                   evaluate_values,
-                                   evaluate_gradients,
+                                   evaluation_flag & EvaluationFlags::values,
+                                   evaluation_flag & EvaluationFlags::gradients,
                                    this->face_no,
                                    this->subface_index,
                                    this->face_orientation,
@@ -7472,10 +7919,34 @@ FEFaceEvaluation<dim,
                                      .face_orientations);
 
 #  ifdef DEBUG
-  if (evaluate_values == true)
+  if (evaluation_flag & EvaluationFlags::values)
     this->values_quad_initialized = true;
-  if (evaluate_gradients == true)
+  if (evaluation_flag & EvaluationFlags::gradients)
     this->gradients_quad_initialized = true;
+#  endif
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components,
+                 Number,
+                 VectorizedArrayType>::
+  integrate(const EvaluationFlags::EvaluationFlags evaluation_flag)
+{
+  integrate(evaluation_flag, this->values_dofs[0]);
+
+#  ifdef DEBUG
+  this->dof_values_initialized = true;
 #  endif
 }
 
@@ -7522,28 +7993,60 @@ FEFaceEvaluation<dim,
                                                  VectorizedArrayType
                                                    *values_array)
 {
-  if (!(integrate_values + integrate_gradients))
+  const EvaluationFlags::EvaluationFlags flag =
+    ((integrate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((integrate_gradients) ? EvaluationFlags::gradients :
+                             EvaluationFlags::nothing);
+
+  integrate(flag, values_array);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components,
+          typename Number,
+          typename VectorizedArrayType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components,
+                 Number,
+                 VectorizedArrayType>::
+  integrate(const EvaluationFlags::EvaluationFlags evaluation_flag,
+            VectorizedArrayType *                  values_array)
+{
+  Assert(
+    (evaluation_flag &
+     ~(EvaluationFlags::values | EvaluationFlags::gradients)) == 0,
+    ExcMessage(
+      "Only EvaluationFlags::values and EvaluationFlags::gradients are supported."));
+
+  if (!(evaluation_flag & EvaluationFlags::values) &&
+      !(evaluation_flag & EvaluationFlags::gradients))
     return;
 
-  internal::FEFaceEvaluationSelector<
-    dim,
-    fe_degree,
-    n_q_points_1d,
-    n_components,
-    Number,
-    VectorizedArrayType>::integrate(*this->data,
-                                    values_array,
-                                    this->begin_values(),
-                                    this->begin_gradients(),
-                                    this->scratch_data,
-                                    integrate_values,
-                                    integrate_gradients,
-                                    this->face_no,
-                                    this->subface_index,
-                                    this->face_orientation,
-                                    this->mapping_data
-                                      ->descriptor[this->active_fe_index]
-                                      .face_orientations);
+  internal::FEFaceEvaluationSelector<dim,
+                                     fe_degree,
+                                     n_q_points_1d,
+                                     n_components,
+                                     Number,
+                                     VectorizedArrayType>::
+    integrate(
+      *this->data,
+      values_array,
+      this->begin_values(),
+      this->begin_gradients(),
+      this->scratch_data,
+      evaluation_flag & EvaluationFlags::values,
+      evaluation_flag & EvaluationFlags::gradients,
+      this->face_no,
+      this->subface_index,
+      this->face_orientation,
+      this->mapping_data->descriptor[this->active_fe_index].face_orientations);
 }
 
 
@@ -7566,6 +8069,33 @@ FEFaceEvaluation<
                                         const bool        evaluate_values,
                                         const bool        evaluate_gradients)
 {
+  const EvaluationFlags::EvaluationFlags flag =
+    ((evaluate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((evaluate_gradients) ? EvaluationFlags::gradients :
+                            EvaluationFlags::nothing);
+
+  gather_evaluate(input_vector, flag);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+template <typename VectorType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components_,
+                 Number,
+                 VectorizedArrayType>::
+  gather_evaluate(const VectorType &                     input_vector,
+                  const EvaluationFlags::EvaluationFlags evaluation_flag)
+{
   static_assert(internal::has_begin<VectorType>::value &&
                   (std::is_same<decltype(std::declval<VectorType>().begin()),
                                 double *>::value ||
@@ -7574,6 +8104,12 @@ FEFaceEvaluation<
                 "This function requires a vector type with begin() function "
                 "evaluating to a pointer to basic number (float,double). "
                 "Use read_dof_values() followed by evaluate() instead.");
+
+  Assert(
+    (evaluation_flag &
+     ~(EvaluationFlags::values | EvaluationFlags::gradients)) == 0,
+    ExcMessage(
+      "Only EvaluationFlags::values and EvaluationFlags::gradients are supported."));
 
   if (!internal::FEFaceEvaluationSelector<dim,
                                           fe_degree,
@@ -7587,8 +8123,8 @@ FEFaceEvaluation<
                         this->begin_values(),
                         this->begin_gradients(),
                         this->scratch_data,
-                        evaluate_values,
-                        evaluate_gradients,
+                        evaluation_flag & EvaluationFlags::values,
+                        evaluation_flag & EvaluationFlags::gradients,
                         this->active_fe_index,
                         this->first_selected_component,
                         this->cell,
@@ -7600,13 +8136,13 @@ FEFaceEvaluation<
                           .face_orientations))
     {
       this->read_dof_values(input_vector);
-      this->evaluate(evaluate_values, evaluate_gradients);
+      this->evaluate(evaluation_flag);
     }
 
 #  ifdef DEBUG
-  if (evaluate_values == true)
+  if (evaluation_flag & EvaluationFlags::values)
     this->values_quad_initialized = true;
-  if (evaluate_gradients == true)
+  if (evaluation_flag & EvaluationFlags::gradients)
     this->gradients_quad_initialized = true;
 #  endif
 }
@@ -7631,6 +8167,33 @@ FEFaceEvaluation<
                                           const bool  integrate_gradients,
                                           VectorType &destination)
 {
+  const EvaluationFlags::EvaluationFlags flag =
+    ((integrate_values) ? EvaluationFlags::values : EvaluationFlags::nothing) |
+    ((integrate_gradients) ? EvaluationFlags::gradients :
+                             EvaluationFlags::nothing);
+
+  integrate_scatter(flag, destination);
+}
+
+
+
+template <int dim,
+          int fe_degree,
+          int n_q_points_1d,
+          int n_components_,
+          typename Number,
+          typename VectorizedArrayType>
+template <typename VectorType>
+inline void
+FEFaceEvaluation<dim,
+                 fe_degree,
+                 n_q_points_1d,
+                 n_components_,
+                 Number,
+                 VectorizedArrayType>::
+  integrate_scatter(const EvaluationFlags::EvaluationFlags evaluation_flag,
+                    VectorType &                           destination)
+{
   static_assert(internal::has_begin<VectorType>::value &&
                   (std::is_same<decltype(std::declval<VectorType>().begin()),
                                 double *>::value ||
@@ -7654,8 +8217,8 @@ FEFaceEvaluation<
                           this->begin_values(),
                           this->begin_gradients(),
                           this->scratch_data,
-                          integrate_values,
-                          integrate_gradients,
+                          evaluation_flag & EvaluationFlags::values,
+                          evaluation_flag & EvaluationFlags::gradients,
                           this->active_fe_index,
                           this->first_selected_component,
                           this->cell,

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -2615,7 +2615,6 @@ public:
    * Like above but with separate bool flags.
    * @deprecated use evaluate() with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   evaluate(const bool evaluate_values,
            const bool evaluate_gradients,
@@ -2641,7 +2640,6 @@ public:
    * Like above but using separate bool flags.
    * @deprecated use evaluate() with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   evaluate(const VectorizedArrayType *values_array,
            const bool                 evaluate_values,
@@ -2670,7 +2668,7 @@ public:
    * @deprecated Please use the gather_evaluate() function with the EvaluationFlags argument.
    */
   template <typename VectorType>
-  DEAL_II_DEPRECATED void
+  void
   gather_evaluate(const VectorType &input_vector,
                   const bool        evaluate_values,
                   const bool        evaluate_gradients,
@@ -2693,7 +2691,7 @@ public:
   /**
    * @deprecated Please use the integrate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED void
+  void
   integrate(const bool integrate_values, const bool integrate_gradients);
 
   /**
@@ -2714,7 +2712,6 @@ public:
   /**
    * @deprecated Please use the integrate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   integrate(const bool           integrate_values,
             const bool           integrate_gradients,
@@ -2742,7 +2739,7 @@ public:
    * @deprecated Please use the integrate_scatter() function with the EvaluationFlags argument.
    */
   template <typename VectorType>
-  DEAL_II_DEPRECATED void
+  void
   integrate_scatter(const bool  integrate_values,
                     const bool  integrate_gradients,
                     VectorType &output_vector);
@@ -3002,7 +2999,6 @@ public:
   /**
    * @deprecated Please use the evaluate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   evaluate(const bool evaluate_values, const bool evaluate_gradients);
 
@@ -3025,7 +3021,6 @@ public:
   /**
    * @deprecated Please use the evaluate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   evaluate(const VectorizedArrayType *values_array,
            const bool                 evaluate_values,
@@ -3051,7 +3046,7 @@ public:
    * @deprecated Please use the gather_evaluate() function with the EvaluationFlags argument.
    */
   template <typename VectorType>
-  DEAL_II_DEPRECATED void
+  void
   gather_evaluate(const VectorType &input_vector,
                   const bool        evaluate_values,
                   const bool        evaluate_gradients);
@@ -3071,7 +3066,6 @@ public:
   /**
    * @deprecated Please use the integrate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   integrate(const bool integrate_values, const bool integrate_gradients);
 
@@ -3090,7 +3084,6 @@ public:
   /**
    * @deprecated Please use the integrate() function with the EvaluationFlags argument.
    */
-  DEAL_II_DEPRECATED
   void
   integrate(const bool           integrate_values,
             const bool           integrate_gradients,
@@ -3116,7 +3109,7 @@ public:
    * @deprecated Please use the integrate_scatter() function with the EvaluationFlags argument.
    */
   template <typename VectorType>
-  DEAL_II_DEPRECATED void
+  void
   integrate_scatter(const bool  integrate_values,
                     const bool  integrate_gradients,
                     VectorType &output_vector);

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -436,7 +436,7 @@ public:
 
   /**
    * Return the value of a finite element function at quadrature point number
-   * @p q_point after a call to @p evaluate(true,...), or the value that has
+   * @p q_point after a call to @p evaluate() with EvaluationFlags::value set, or the value that has
    * been stored there with a call to @p submit_value. If the object is
    * vector-valued, a vector-valued return argument is given. Note that when
    * vectorization is enabled, values from several cells are grouped together.
@@ -451,7 +451,7 @@ public:
   /**
    * Write a value to the field containing the values on quadrature points
    * with component @p q_point. Access to the same field as through @p
-   * get_value. If applied before the function @p integrate(true,...) is
+   * get_value. If applied before the function @p integrate() with EvaluationFlags::values set is
    * called, this specifies the value which is tested by all basis function on
    * the current cell and integrated over.
    *
@@ -464,7 +464,7 @@ public:
 
   /**
    * Return the gradient of a finite element function at quadrature point
-   * number @p q_point after a call to @p evaluate(...,true,...), or the value
+   * number @p q_point after a call to @p evaluate() with EvaluationFlags::gradients, or the value
    * that has been stored there with a call to @p submit_gradient.
    *
    * Note that the derived class FEEvaluationAccess overloads this operation
@@ -1835,8 +1835,8 @@ protected:
  *   {
  *     phi.reinit(cell_index);
  *     phi.read_dof_values(vector);
- *     phi.evaluate(true, false);   // interpolate values, but not gradients
- *     for (unsigned int q_index=0; q_index<phi.n_q_points; ++q_index)
+ *     phi.evaluate(EvaluationFlags::values);   // interpolate values, but not
+ * gradients for (unsigned int q_index=0; q_index<phi.n_q_points; ++q_index)
  *       {
  *         VectorizedArray<double> val = phi.get_value(q_index);
  *         // do something with val
@@ -1885,7 +1885,7 @@ protected:
  *           }
  *         phi.submit_value(f_value, q);
  *       }
- *     phi.integrate(true, false);
+ *     phi.integrate(EvaluationFlags::values);
  *     phi.distribute_local_to_global(dst);
  *   }
  * @endcode
@@ -1984,13 +1984,13 @@ protected:
  *
  *         // Apply operator on unit vector to generate the next few matrix
  *         // columns
- *         fe_eval.evaluate(true, true);
+ *         fe_eval.evaluate(EvaluationFlags::values|EvaluationFlags::gradients);
  *         for (unsigned int q=0; q<n_q_points; ++q)
  *           {
  *             fe_eval.submit_value(10.*fe_eval.get_value(q), q);
  *             fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
  *           }
- *         fe_eval.integrate(true, true);
+ *         fe_eval.integrate(EvaluationFlags::values|EvaluationFlags::gradients);
  *
  *         // Insert computed entries in matrix
  *         for (unsigned int v=0; v<n_items; ++v)
@@ -2227,10 +2227,10 @@ protected:
  *   {
  *     velocity.reinit (cell);
  *     velocity.read_dof_values (src.block(0));
- *     velocity.evaluate (false,true);
+ *     velocity.evaluate (EvaluationFlags::gradients);
  *     pressure.reinit (cell);
  *     pressure.read_dof_values (src.block(1));
- *     pressure.evaluate (true,false);
+ *     pressure.evaluate (EvaluationFlags::values);
  *
  *     for (unsigned int q=0; q<velocity.n_q_points; ++q)
  *       {
@@ -2247,9 +2247,9 @@ protected:
  *         velocity.submit_symmetric_gradient(sym_grad_u, q);
  *      }
  *
- *     velocity.integrate (false,true);
+ *     velocity.integrate (EvaluationFlags::gradients);
  *     velocity.distribute_local_to_global (dst.block(0));
- *     pressure.integrate (true,false);
+ *     pressure.integrate (EvaluationFlags::values);
  *     pressure.distribute_local_to_global (dst.block(1));
  *   }
  * @endcode
@@ -2284,8 +2284,8 @@ protected:
  * points:
  *
  * @code
- * phi1.evaluate(true, false);
- * phi2.evaluate(false, true);
+ * phi1.evaluate(EvaluationFlags::values);
+ * phi2.evaluate(EvaluationFlags::gradients);
  * for (unsigned int q_index=0; q_index<phi1.n_q_points; ++q_index)
  *   {
  *     VectorizedArray<double> val1 = phi1.get_value(q);

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -728,12 +728,13 @@ public:
 
     /**
      * The loop does only involve FEFaceEvaluation access into neighbors by
-     * function values, such as `FEFaceEvaluation::gather_evaluate(src, true,
-     * false)`, but no access to shape function derivatives (which typically
-     * need to access more data). For FiniteElement types where only some of
-     * the shape functions have support on a face, such as an FE_DGQ element
-     * with Lagrange polynomials with nodes on the element surface, the data
-     * exchange is reduced from `(k+1)^dim` to `(k+1)^(dim-1)`.
+     * function values, such as `FEFaceEvaluation::gather_evaluate() with
+     * argument EvaluationFlags::values, but no access to shape function
+     * derivatives (which typically need to access more data). For FiniteElement
+     * types where only some of the shape functions have support on a face, such
+     * as an FE_DGQ element with Lagrange polynomials with nodes on the element
+     * surface, the data exchange is reduced from `(k+1)^dim` to
+     * `(k+1)^(dim-1)`.
      */
     values,
 
@@ -750,12 +751,12 @@ public:
     /**
      * The loop does involve FEFaceEvaluation access into neighbors by
      * function values and gradients, but no second derivatives, such as
-     * `FEFaceEvaluation::gather_evaluate(src, true, true)`. For
-     * FiniteElement types where only some of the shape functions have
-     * non-zero value and first derivative on a face, such as an FE_DGQHermite
-     * element, the data exchange is reduced, e.g. from `(k+1)^dim` to
-     * `2(k+1)^(dim-1)`. Note that for bases that do not have this special
-     * property, the full neighboring data is sent anyway.
+     * FEFaceEvaluation::gather_evaluate() with EvaluationFlags::values and
+     * EvaluationFlags::gradients set. For FiniteElement types where only some
+     * of the shape functions have non-zero value and first derivative on a
+     * face, such as an FE_DGQHermite element, the data exchange is reduced,
+     * e.g. from `(k+1)^dim` to `2(k+1)^(dim-1)`. Note that for bases that do
+     * not have this special property, the full neighboring data is sent anyway.
      */
     gradients,
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -728,7 +728,7 @@ public:
 
     /**
      * The loop does only involve FEFaceEvaluation access into neighbors by
-     * function values, such as `FEFaceEvaluation::gather_evaluate() with
+     * function values, such as FEFaceEvaluation::gather_evaluate() with
      * argument EvaluationFlags::values, but no access to shape function
      * derivatives (which typically need to access more data). For FiniteElement
      * types where only some of the shape functions have support on a face, such

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -684,7 +684,7 @@ namespace MatrixFreeOperators
      * @code
      * for (unsigned int q=0; q<phi.n_q_points; ++q)
      *   phi.submit_value(array[q], q);
-     * phi.integrate(true, false);
+     * phi.integrate(EvaluationFlags::values);
      * inverse_mass.apply(coefficients, 1, phi.begin_dof_values(),
      *                    phi.begin_dof_values());
      * @endcode
@@ -1878,10 +1878,10 @@ namespace MatrixFreeOperators
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(true, false, false);
+        phi.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_value(phi.get_value(q), q);
-        phi.integrate(true, false);
+        phi.integrate(EvaluationFlags::values);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -2074,7 +2074,7 @@ namespace MatrixFreeOperators
         typename Base<dim, VectorType, VectorizedArrayType>::value_type> &phi,
       const unsigned int cell) const
   {
-    phi.evaluate(false, true, false);
+    phi.evaluate(EvaluationFlags::gradients);
     if (scalar_coefficient.get())
       {
         Assert(scalar_coefficient->size(1) == 1 ||
@@ -2111,7 +2111,7 @@ namespace MatrixFreeOperators
             phi.submit_gradient(phi.get_gradient(q), q);
           }
       }
-    phi.integrate(false, true);
+    phi.integrate(EvaluationFlags::gradients);
   }
 
 

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -230,11 +230,11 @@ namespace VectorTools
           {
             phi.reinit(cell);
             phi.read_dof_values_plain(inhomogeneities);
-            phi.evaluate(true, false);
+            phi.evaluate(EvaluationFlags::values);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_value(phi.get_value(q), q);
 
-            phi.integrate(true, false);
+            phi.integrate(EvaluationFlags::values);
             phi.distribute_local_to_global(rhs);
           }
         rhs.compress(VectorOperation::add);
@@ -758,7 +758,7 @@ namespace VectorTools
             for (unsigned int q = 0; q < n_q_points; ++q)
               fe_eval.submit_value(func(cell, q), q);
 
-            fe_eval.integrate(true, false);
+            fe_eval.integrate(EvaluationFlags::values);
             fe_eval.distribute_local_to_global(rhs);
           }
         rhs.compress(VectorOperation::add);

--- a/tests/lac/utilities_02.cc
+++ b/tests/lac/utilities_02.cc
@@ -147,7 +147,7 @@ test()
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(one, q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
     inv_mass_matrix.compress(VectorOperation::add);

--- a/tests/matrix_free/advect_1d.cc
+++ b/tests/matrix_free/advect_1d.cc
@@ -112,10 +112,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(true, false);
+        phi.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(advection * phi.get_value(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -141,10 +141,10 @@ private:
       {
         phi_m.reinit(face);
         phi_m.read_dof_values(src);
-        phi_m.evaluate(true, false);
+        phi_m.evaluate(EvaluationFlags::values);
         phi_p.reinit(face);
         phi_p.read_dof_values(src);
-        phi_p.evaluate(true, false);
+        phi_p.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
           {
@@ -160,9 +160,9 @@ private:
             phi_p.submit_value(flux_times_normal, q);
           }
 
-        phi_m.integrate(true, false);
+        phi_m.integrate(EvaluationFlags::values);
         phi_m.distribute_local_to_global(dst);
-        phi_p.integrate(true, false);
+        phi_p.integrate(EvaluationFlags::values);
         phi_p.distribute_local_to_global(dst);
       }
   }
@@ -186,7 +186,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           {
@@ -201,7 +201,7 @@ private:
             fe_eval.submit_value(-flux_times_normal, q);
           }
 
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/advect_1d_system.cc
+++ b/tests/matrix_free/advect_1d_system.cc
@@ -112,7 +112,7 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(true, false);
+        phi.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
             Tensor<1, n_components, Tensor<1, dim, VectorizedArray<number>>>
@@ -122,7 +122,7 @@ private:
                 grad[c][d] = advection[d] * phi.get_value(q)[c];
             phi.submit_gradient(grad, q);
           }
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -148,10 +148,10 @@ private:
       {
         phi_m.reinit(face);
         phi_m.read_dof_values(src);
-        phi_m.evaluate(true, false);
+        phi_m.evaluate(EvaluationFlags::values);
         phi_p.reinit(face);
         phi_p.read_dof_values(src);
-        phi_p.evaluate(true, false);
+        phi_p.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
           {
@@ -167,9 +167,9 @@ private:
             phi_p.submit_value(flux_times_normal, q);
           }
 
-        phi_m.integrate(true, false);
+        phi_m.integrate(EvaluationFlags::values);
         phi_m.distribute_local_to_global(dst);
-        phi_p.integrate(true, false);
+        phi_p.integrate(EvaluationFlags::values);
         phi_p.distribute_local_to_global(dst);
       }
   }
@@ -193,7 +193,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           {
@@ -208,7 +208,7 @@ private:
             fe_eval.submit_value(-flux_times_normal, q);
           }
 
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/advect_1d_vectorization_mask.cc
+++ b/tests/matrix_free/advect_1d_vectorization_mask.cc
@@ -113,10 +113,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(true, false);
+        phi.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(advection * phi.get_value(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         for (unsigned int v = 0; v < n_vect; ++v)
           {
             std::bitset<n_vect> mask;
@@ -149,10 +149,10 @@ private:
       {
         phi_m.reinit(face);
         phi_m.read_dof_values(src);
-        phi_m.evaluate(true, false);
+        phi_m.evaluate(EvaluationFlags::values);
         phi_p.reinit(face);
         phi_p.read_dof_values(src);
-        phi_p.evaluate(true, false);
+        phi_p.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
           {
@@ -168,14 +168,14 @@ private:
             phi_p.submit_value(flux_times_normal, q);
           }
 
-        phi_m.integrate(true, false);
+        phi_m.integrate(EvaluationFlags::values);
         for (unsigned int v = 0; v < n_vect; ++v)
           {
             std::bitset<n_vect> mask;
             mask[v] = true;
             phi_m.distribute_local_to_global(dst, 0, mask);
           }
-        phi_p.integrate(true, false);
+        phi_p.integrate(EvaluationFlags::values);
         for (unsigned int v = 0; v < n_vect; ++v)
           {
             std::bitset<n_vect> mask;
@@ -206,7 +206,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           {
@@ -221,7 +221,7 @@ private:
             fe_eval.submit_value(-flux_times_normal, q);
           }
 
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         for (unsigned int v = 0; v < n_vect; ++v)
           {
             std::bitset<n_vect> mask =

--- a/tests/matrix_free/assemble_matrix_01.cc
+++ b/tests/matrix_free/assemble_matrix_01.cc
@@ -100,13 +100,15 @@ do_test(const DoFHandler<dim> &dof)
             for (unsigned int v = 0; v < n_items; ++v)
               fe_eval.begin_dof_values()[i + v][v] = 1.;
 
-            fe_eval.evaluate(true, true);
+            fe_eval.evaluate(EvaluationFlags::values |
+                             EvaluationFlags::gradients);
             for (unsigned int q = 0; q < n_q_points; ++q)
               {
                 fe_eval.submit_value(10. * fe_eval.get_value(q), q);
                 fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
               }
-            fe_eval.integrate(true, true);
+            fe_eval.integrate(EvaluationFlags::values |
+                              EvaluationFlags::gradients);
 
             for (unsigned int v = 0; v < n_items; ++v)
               for (unsigned int j = 0; j < dofs_per_cell; ++j)

--- a/tests/matrix_free/assemble_matrix_02.cc
+++ b/tests/matrix_free/assemble_matrix_02.cc
@@ -123,7 +123,7 @@ do_test(const DoFHandler<dim> &dof)
             for (unsigned int v = 0; v < n_items; ++v)
               phi_u.begin_dof_values()[i + v][v] = 1.;
 
-            phi_u.evaluate(false, true);
+            phi_u.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < n_q_points; ++q)
               {
                 VectorizedArray<double> div_u = phi_u.get_divergence(q);
@@ -131,8 +131,8 @@ do_test(const DoFHandler<dim> &dof)
                                                 q);
                 phi_p.submit_value(-div_u, q);
               }
-            phi_u.integrate(false, true);
-            phi_p.integrate(true, false);
+            phi_u.integrate(EvaluationFlags::gradients);
+            phi_p.integrate(EvaluationFlags::values);
 
             for (unsigned int v = 0; v < n_items; ++v)
               {
@@ -159,12 +159,12 @@ do_test(const DoFHandler<dim> &dof)
             for (unsigned int v = 0; v < n_items; ++v)
               phi_p.begin_dof_values()[i + v][v] = 1.;
 
-            phi_p.evaluate(true, false);
+            phi_p.evaluate(EvaluationFlags::values);
             for (unsigned int q = 0; q < n_q_points; ++q)
               {
                 phi_u.submit_divergence(-phi_p.get_value(q), q);
               }
-            phi_u.integrate(false, true);
+            phi_u.integrate(EvaluationFlags::gradients);
 
             for (unsigned int v = 0; v < n_items; ++v)
               for (unsigned int j = 0; j < dofs_per_cell_u; ++j)

--- a/tests/matrix_free/assemble_matrix_03.cc
+++ b/tests/matrix_free/assemble_matrix_03.cc
@@ -121,13 +121,13 @@ assemble_on_cell(const typename DoFHandler<dim>::active_cell_iterator &cell,
       for (unsigned int v = 0; v < n_items; ++v)
         fe_eval.begin_dof_values()[i + v][v] = 1.;
 
-      fe_eval.evaluate(true, true);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(10. * fe_eval.get_value(q), q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
 
       for (unsigned int v = 0; v < n_items; ++v)
         for (unsigned int j = 0; j < dofs_per_cell; ++j)

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -149,13 +149,14 @@ private:
         // Compute phi part
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
-        phi_outer.evaluate(true, true);
+        phi_outer.evaluate(EvaluationFlags::values |
+                           EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -169,7 +170,7 @@ private:
                 phi.submit_normal_derivative(-average_value, q);
                 phi.submit_value(average_valgrad, q);
               }
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -182,13 +183,14 @@ private:
                  (number)(std::max(fe_degree, 1) * (fe_degree + 1.0)) * 2.0;
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi.begin_dof_values()[j] = VectorizedArray<number>();
-        phi.evaluate(true, true);
+        phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
             phi_outer.begin_dof_values()[i] = 1.;
-            phi_outer.evaluate(true, true);
+            phi_outer.evaluate(EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -202,7 +204,8 @@ private:
                 phi_outer.submit_normal_derivative(-average_value, q);
                 phi_outer.submit_value(-average_valgrad, q);
               }
-            phi_outer.integrate(true, true);
+            phi_outer.integrate(EvaluationFlags::values |
+                                EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi_outer.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -235,7 +238,7 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -246,7 +249,7 @@ private:
                 phi.submit_normal_derivative(-average_value, q);
                 phi.submit_value(average_valgrad, q);
               }
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -293,7 +296,8 @@ private:
                 for (unsigned int j = 0; j < phif.dofs_per_cell; ++j)
                   phif.begin_dof_values()[j] = VectorizedArray<number>();
                 phif.begin_dof_values()[i] = 1.;
-                phif.evaluate(true, true);
+                phif.evaluate(EvaluationFlags::values |
+                              EvaluationFlags::gradients);
                 for (unsigned int q = 0; q < phif.n_q_points; ++q)
                   {
                     VectorizedArray<number> average_value =
@@ -305,7 +309,8 @@ private:
                     phif.submit_normal_derivative(-average_value, q);
                     phif.submit_value(average_valgrad, q);
                   }
-                phif.integrate(true, true);
+                phif.integrate(EvaluationFlags::values |
+                               EvaluationFlags::gradients);
                 local_diagonal_vector[i] += phif.begin_dof_values()[i];
               }
           }

--- a/tests/matrix_free/copy_feevaluation.cc
+++ b/tests/matrix_free/copy_feevaluation.cc
@@ -84,10 +84,10 @@ public:
       {
         velocity[0].reinit(cell);
         velocity[0].read_dof_values(src.block(0));
-        velocity[0].evaluate(false, true, false);
+        velocity[0].evaluate(EvaluationFlags::gradients);
         pressure2.reinit(cell);
         pressure2.read_dof_values(src.block(1));
-        pressure2.evaluate(true, false, false);
+        pressure2.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity[0].n_q_points; ++q)
           {
@@ -104,9 +104,9 @@ public:
             velocity[0].submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity[0].integrate(false, true);
+        velocity[0].integrate(EvaluationFlags::gradients);
         velocity[0].distribute_local_to_global(dst.block(0));
-        pressure2.integrate(true, false);
+        pressure2.integrate(EvaluationFlags::values);
         pressure2.distribute_local_to_global(dst.block(1));
       }
   }

--- a/tests/matrix_free/estimate_condition_number_mass.cc
+++ b/tests/matrix_free/estimate_condition_number_mass.cc
@@ -59,12 +59,12 @@ mass_operator(const MatrixFree<dim, Number> &              data,
     {
       fe_eval.reinit(cell);
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, false, false);
+      fe_eval.evaluate(EvaluationFlags::values);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(fe_eval.get_value(q), q);
         }
-      fe_eval.integrate(true, false);
+      fe_eval.integrate(EvaluationFlags::values);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/faces_value_optimization.cc
+++ b/tests/matrix_free/faces_value_optimization.cc
@@ -81,8 +81,8 @@ private:
         check.reinit(face);
 
         ref.read_dof_values(src);
-        ref.evaluate(true, false);
-        check.gather_evaluate(src, true, false);
+        ref.evaluate(EvaluationFlags::values);
+        check.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < ref.n_q_points; ++q)
           {
@@ -129,8 +129,8 @@ private:
         checkr.reinit(face);
 
         refr.read_dof_values(src);
-        refr.evaluate(true, false);
-        checkr.gather_evaluate(src, true, false);
+        refr.evaluate(EvaluationFlags::values);
+        checkr.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < ref.n_q_points; ++q)
           {

--- a/tests/matrix_free/faces_value_optimization_02.cc
+++ b/tests/matrix_free/faces_value_optimization_02.cc
@@ -81,8 +81,8 @@ private:
         check.reinit(face);
 
         ref.read_dof_values(src);
-        ref.evaluate(true, false);
-        check.gather_evaluate(src, true, false);
+        ref.evaluate(EvaluationFlags::values);
+        check.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < ref.n_q_points; ++q)
           {
@@ -129,8 +129,8 @@ private:
         checkr.reinit(face);
 
         refr.read_dof_values(src);
-        refr.evaluate(true, false);
-        checkr.gather_evaluate(src, true, false);
+        refr.evaluate(EvaluationFlags::values);
+        checkr.gather_evaluate(src, EvaluationFlags::values);
 
         for (unsigned int q = 0; q < ref.n_q_points; ++q)
           {

--- a/tests/matrix_free/get_functions_common.h
+++ b/tests/matrix_free/get_functions_common.h
@@ -96,7 +96,8 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                         EvaluationFlags::hessians);
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference

--- a/tests/matrix_free/get_functions_faces.cc
+++ b/tests/matrix_free/get_functions_faces.cc
@@ -74,7 +74,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
         // Only one vectorization component is filled in this case because we
         // only have one cell (otherwise the output will not be stable among

--- a/tests/matrix_free/get_functions_multife.cc
+++ b/tests/matrix_free/get_functions_multife.cc
@@ -83,11 +83,13 @@ public:
       {
         fe_eval0.reinit(cell);
         fe_eval0.read_dof_values(src[0]);
-        fe_eval0.evaluate(true, true, true);
+        fe_eval0.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians);
 
         fe_eval1.reinit(cell);
         fe_eval1.read_dof_values(src[1]);
-        fe_eval1.evaluate(true, true, true);
+        fe_eval1.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians);
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference

--- a/tests/matrix_free/get_functions_multife2.cc
+++ b/tests/matrix_free/get_functions_multife2.cc
@@ -92,15 +92,18 @@ public:
       {
         fe_eval0.reinit(cell);
         fe_eval0.read_dof_values(src[0]);
-        fe_eval0.evaluate(true, true, true);
+        fe_eval0.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians);
 
         fe_eval1.reinit(cell);
         fe_eval1.read_dof_values(src[1]);
-        fe_eval1.evaluate(true, true, true);
+        fe_eval1.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians);
 
         fe_eval2.reinit(cell);
         fe_eval2.read_dof_values(src[2]);
-        fe_eval2.evaluate(true, true, true);
+        fe_eval2.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians);
 
         // compare values with the ones the FEValues
         // gives us. Those are seen as reference

--- a/tests/matrix_free/get_functions_variants.cc
+++ b/tests/matrix_free/get_functions_variants.cc
@@ -104,27 +104,28 @@ operator()(const MatrixFree<dim, Number> &data,
     {
       fe_eval.reinit(cell);
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, true);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                       EvaluationFlags::hessians);
 
       // only for values (additional test)
       fe_eval2.reinit(cell);
       fe_eval2.read_dof_values(src);
-      fe_eval2.evaluate(true, false, false);
+      fe_eval2.evaluate(EvaluationFlags::values);
 
       // only gradients
       fe_eval3.reinit(cell);
       fe_eval3.read_dof_values(src);
-      fe_eval3.evaluate(false, true, false);
+      fe_eval3.evaluate(EvaluationFlags::gradients);
 
       // only values and gradients
       fe_eval4.reinit(cell);
       fe_eval4.read_dof_values(src);
-      fe_eval4.evaluate(true, true, false);
+      fe_eval4.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
       // only laplacians
       fe_eval5.reinit(cell);
       fe_eval5.read_dof_values(src);
-      fe_eval5.evaluate(false, false, true);
+      fe_eval5.evaluate(EvaluationFlags::hessians);
 
 
       // compare values with the values that we get

--- a/tests/matrix_free/get_functions_variants_gl.cc
+++ b/tests/matrix_free/get_functions_variants_gl.cc
@@ -100,27 +100,28 @@ operator()(const MatrixFree<dim, Number> &data,
     {
       fe_eval.reinit(cell);
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, true);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                       EvaluationFlags::hessians);
 
       // only for values (additional test)
       fe_eval2.reinit(cell);
       fe_eval2.read_dof_values(src);
-      fe_eval2.evaluate(true, false, false);
+      fe_eval2.evaluate(EvaluationFlags::values);
 
       // only gradients
       fe_eval3.reinit(cell);
       fe_eval3.read_dof_values(src);
-      fe_eval3.evaluate(false, true, false);
+      fe_eval3.evaluate(EvaluationFlags::gradients);
 
       // only values and gradients
       fe_eval4.reinit(cell);
       fe_eval4.read_dof_values(src);
-      fe_eval4.evaluate(true, true, false);
+      fe_eval4.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
       // only laplacians
       fe_eval5.reinit(cell);
       fe_eval5.read_dof_values(src);
-      fe_eval5.evaluate(false, false, true);
+      fe_eval5.evaluate(EvaluationFlags::hessians);
 
 
       // compare values with the values that we get

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -140,7 +140,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients[q * dim + d];
           fe_eval.submit_gradient(submit, q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(*dst[0]);
     }
 }

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -203,7 +203,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients0[q * dim + d];
           fe_eval0.submit_gradient(submit, q);
         }
-      fe_eval0.integrate(true, true);
+      fe_eval0.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval0.distribute_local_to_global(dst[0]);
 
       // FE 1, Quad 1
@@ -215,7 +215,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients1[q * dim + d];
           fe_eval1.submit_gradient(submit, q);
         }
-      fe_eval1.integrate(true, true);
+      fe_eval1.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval1.distribute_local_to_global(dst[2]);
 
       // FE 0, Quad 1
@@ -227,7 +227,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients1[q * dim + d];
           fe_eval01.submit_gradient(submit, q);
         }
-      fe_eval01.integrate(true, true);
+      fe_eval01.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval01.distribute_local_to_global(dst[4]);
     }
 }

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -204,7 +204,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients0[q * dim + d];
           fe_eval0.submit_gradient(submit, q);
         }
-      fe_eval0.integrate(true, true);
+      fe_eval0.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval0.distribute_local_to_global(dst[0]);
 
       // FE 1, Quad 1
@@ -216,7 +216,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients1[q * dim + d];
           fe_eval1.submit_gradient(submit, q);
         }
-      fe_eval1.integrate(true, true);
+      fe_eval1.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval1.distribute_local_to_global(dst[2]);
 
       // FE 0, Quad 1
@@ -228,7 +228,7 @@ operator()(const MatrixFree<dim, Number> &data,
             submit[d] = gradients1[q * dim + d];
           fe_eval01.submit_gradient(submit, q);
         }
-      fe_eval01.integrate(true, true);
+      fe_eval01.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval01.distribute_local_to_global(dst[4]);
     }
 }

--- a/tests/matrix_free/interpolate_functions_common.h
+++ b/tests/matrix_free/interpolate_functions_common.h
@@ -86,7 +86,8 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                         EvaluationFlags::hessians);
 
         for (unsigned int j = 0; j < data.n_components_filled(cell); ++j)
           for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
@@ -125,10 +126,10 @@ public:
       {
         fe_evalm.reinit(face);
         fe_evalm.read_dof_values(src);
-        fe_evalm.evaluate(true, true);
+        fe_evalm.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_evalp.reinit(face);
         fe_evalp.read_dof_values(src);
-        fe_evalp.evaluate(true, true);
+        fe_evalp.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
         for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {
@@ -191,7 +192,7 @@ public:
       {
         fe_evalm.reinit(face);
         fe_evalm.read_dof_values(src);
-        fe_evalm.evaluate(true, true);
+        fe_evalm.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
         for (unsigned int j = 0; j < VectorizedArray<Number>::size(); ++j)
           {

--- a/tests/matrix_free/inverse_mass_01.cc
+++ b/tests/matrix_free/inverse_mass_01.cc
@@ -65,10 +65,10 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(fe_eval.get_value(q), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/inverse_mass_02.cc
+++ b/tests/matrix_free/inverse_mass_02.cc
@@ -65,10 +65,10 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(fe_eval.get_value(q), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/inverse_mass_03.cc
+++ b/tests/matrix_free/inverse_mass_03.cc
@@ -66,7 +66,7 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           {
             Tensor<1, 3, VectorizedArray<double>> val = fe_eval.get_value(q);
@@ -75,7 +75,7 @@ public:
             val[2] *= make_vectorized_array(1.98);
             fe_eval.submit_value(val, q);
           }
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/inverse_mass_05.cc
+++ b/tests/matrix_free/inverse_mass_05.cc
@@ -66,10 +66,10 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(fe_eval.get_value(q), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/inverse_mass_06.cc
+++ b/tests/matrix_free/inverse_mass_06.cc
@@ -65,10 +65,10 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(fe_eval.get_value(q), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.set_dof_values(dst);
       }
   }

--- a/tests/matrix_free/inverse_mass_07.cc
+++ b/tests/matrix_free/inverse_mass_07.cc
@@ -66,10 +66,10 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, false);
+        fe_eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(fe_eval.get_value(q), q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.set_dof_values(dst);
       }
   }

--- a/tests/matrix_free/loop_boundary.cc
+++ b/tests/matrix_free/loop_boundary.cc
@@ -83,13 +83,15 @@ do_test(const unsigned int n_refine, const bool overlap_communication)
     for (unsigned int cell = range.first; cell < range.second; ++cell)
       {
         eval.reinit(cell);
-        eval.gather_evaluate(in, false, true);
+        eval.gather_evaluate(in, EvaluationFlags::gradients);
         for (unsigned int q = 0; q < eval.n_q_points; ++q)
           {
             eval.submit_gradient(eval.get_gradient(q), q);
             eval.submit_value(eval.quadrature_point(q).square(), q);
           }
-        eval.integrate_scatter(true, true, out);
+        eval.integrate_scatter(EvaluationFlags::values |
+                                 EvaluationFlags::gradients,
+                               out);
       }
   };
 
@@ -107,14 +109,14 @@ do_test(const unsigned int n_refine, const bool overlap_communication)
     for (unsigned int face = range.first; face < range.second; ++face)
       {
         eval.reinit(face);
-        eval.gather_evaluate(in, true, false);
+        eval.gather_evaluate(in, EvaluationFlags::values);
         for (unsigned int q = 0; q < eval.n_q_points; ++q)
           {
             eval.submit_value(eval.quadrature_point(q).square() -
                                 6. * eval.get_value(q),
                               q);
           }
-        eval.integrate_scatter(true, false, out);
+        eval.integrate_scatter(EvaluationFlags::values, out);
       }
   };
 

--- a/tests/matrix_free/loop_boundary_02.cc
+++ b/tests/matrix_free/loop_boundary_02.cc
@@ -85,13 +85,15 @@ do_test(const unsigned int n_refine)
       {
         eval.reinit(cell);
         eval.read_dof_values_plain(in);
-        eval.evaluate(false, true);
+        eval.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < eval.n_q_points; ++q)
           {
             eval.submit_gradient(eval.get_gradient(q), q);
             eval.submit_value(eval.quadrature_point(q).square(), q);
           }
-        eval.integrate_scatter(true, true, out);
+        eval.integrate_scatter(EvaluationFlags::values |
+                                 EvaluationFlags::gradients,
+                               out);
       }
   };
 
@@ -110,14 +112,14 @@ do_test(const unsigned int n_refine)
       {
         eval.reinit(face);
         eval.read_dof_values_plain(in);
-        eval.evaluate(true, false);
+        eval.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < eval.n_q_points; ++q)
           {
             eval.submit_value(eval.quadrature_point(q).square() -
                                 6. * eval.get_value(q),
                               q);
           }
-        eval.integrate_scatter(true, false, out);
+        eval.integrate_scatter(EvaluationFlags::values, out);
       }
   };
 

--- a/tests/matrix_free/matrix_vector_12.cc
+++ b/tests/matrix_free/matrix_vector_12.cc
@@ -63,7 +63,7 @@ helmholtz_operator(
       fe_eval.reinit(cell);
 
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(make_vectorized_array(Number(10)) *
@@ -71,7 +71,7 @@ helmholtz_operator(
                                q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/matrix_vector_13.cc
+++ b/tests/matrix_free/matrix_vector_13.cc
@@ -63,7 +63,7 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
       fe_eval.reinit(cell);
 
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(make_vectorized_array(Number(10)) *
@@ -71,7 +71,7 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
                                q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/matrix_vector_15.cc
+++ b/tests/matrix_free/matrix_vector_15.cc
@@ -74,13 +74,13 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src_cpy);
-        fe_eval.evaluate(true, true, false);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           {
             fe_eval.submit_value(Number(10) * fe_eval.get_value(q), q);
             fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
     constraints.condense(dst);

--- a/tests/matrix_free/matrix_vector_16.cc
+++ b/tests/matrix_free/matrix_vector_16.cc
@@ -74,7 +74,7 @@ public:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src_cpy);
-        fe_eval.evaluate(true, true, false);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           {
             fe_eval.submit_value(make_vectorized_array<Number>(10.) *
@@ -82,7 +82,7 @@ public:
                                  q);
             fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
     constraints.condense(dst);

--- a/tests/matrix_free/matrix_vector_18.cc
+++ b/tests/matrix_free/matrix_vector_18.cc
@@ -87,7 +87,8 @@ private:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(in);
-        fe_eval.evaluate(true, true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                         EvaluationFlags::hessians);
         for (unsigned int q = 0; q < n_q_points; ++q)
           {
             fe_eval.submit_value(Number(10) * fe_eval.get_value(q), q);
@@ -96,7 +97,7 @@ private:
                                         (fe_eval.get_hessian(q) * ones),
                                     q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(out);
       }
   }

--- a/tests/matrix_free/matrix_vector_20.cc
+++ b/tests/matrix_free/matrix_vector_20.cc
@@ -68,8 +68,8 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
 
       phi0.read_dof_values(src, 0);
       phi1.read_dof_values(src, 1);
-      phi0.evaluate(true, true, false);
-      phi1.evaluate(true, true, false);
+      phi0.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+      phi1.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           phi0.submit_value(make_vectorized_array(Number(10)) *
@@ -81,9 +81,9 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
                             q);
           phi1.submit_gradient(phi1.get_gradient(q), q);
         }
-      phi0.integrate(true, true);
+      phi0.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       phi0.distribute_local_to_global(dst, 0);
-      phi1.integrate(true, true);
+      phi1.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       phi1.distribute_local_to_global(dst, 1);
     }
 }

--- a/tests/matrix_free/matrix_vector_21.cc
+++ b/tests/matrix_free/matrix_vector_21.cc
@@ -65,7 +65,7 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
       fe_eval.reinit(cell);
 
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(make_vectorized_array(Number(10)) *
@@ -73,7 +73,7 @@ helmholtz_operator(const MatrixFree<dim, Number> &                        data,
                                q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/matrix_vector_22.cc
+++ b/tests/matrix_free/matrix_vector_22.cc
@@ -64,7 +64,7 @@ helmholtz_operator(
       fe_eval.reinit(cell);
 
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(make_vectorized_array(Number(10)) *
@@ -72,7 +72,7 @@ helmholtz_operator(
                                q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/matrix_vector_23.cc
+++ b/tests/matrix_free/matrix_vector_23.cc
@@ -67,9 +67,9 @@ helmholtz_operator(
       fe_eval2.reinit(cell);
 
       fe_eval2.read_dof_values(src);
-      fe_eval2.evaluate(true, true, false);
+      fe_eval2.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.read_dof_values(src, 1);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(make_vectorized_array(Number(10)) *
@@ -81,10 +81,10 @@ helmholtz_operator(
                                 q);
           fe_eval2.submit_gradient(fe_eval2.get_gradient(q), q);
         }
-      fe_eval2.integrate(true, true);
+      fe_eval2.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval2.distribute_local_to_global(dst);
 
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst, 1);
     }
 }

--- a/tests/matrix_free/matrix_vector_blocks.cc
+++ b/tests/matrix_free/matrix_vector_blocks.cc
@@ -75,13 +75,17 @@ private:
         phi.reinit(cell);
         for (unsigned int block = 0; block < src.n_blocks(); ++block)
           {
-            phi.gather_evaluate(src.block(block), true, true, false);
+            phi.gather_evaluate(src.block(block),
+                                EvaluationFlags::values |
+                                  EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
                 phi.submit_value(Number(10) * phi.get_value(q), q);
                 phi.submit_gradient(phi.get_gradient(q), q);
               }
-            phi.integrate_scatter(true, true, dst.block(block));
+            phi.integrate_scatter(EvaluationFlags::values |
+                                    EvaluationFlags::gradients,
+                                  dst.block(block));
           }
       }
   }

--- a/tests/matrix_free/matrix_vector_curl.cc
+++ b/tests/matrix_free/matrix_vector_curl.cc
@@ -77,12 +77,12 @@ public:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
 
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_curl(coeff * phi.get_curl(q), q);
 
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/matrix_vector_div.cc
+++ b/tests/matrix_free/matrix_vector_div.cc
@@ -79,12 +79,12 @@ public:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
 
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_divergence(coeff * phi.get_divergence(q), q);
 
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/matrix_vector_mf.h
+++ b/tests/matrix_free/matrix_vector_mf.h
@@ -43,13 +43,13 @@ helmholtz_operator(const MatrixFree<dim, typename VectorType::value_type> &data,
     {
       fe_eval.reinit(cell);
       fe_eval.read_dof_values(src);
-      fe_eval.evaluate(true, true, false);
+      fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
       for (unsigned int q = 0; q < n_q_points; ++q)
         {
           fe_eval.submit_value(Number(10) * fe_eval.get_value(q), q);
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
         }
-      fe_eval.integrate(true, true);
+      fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
       fe_eval.distribute_local_to_global(dst);
     }
 }

--- a/tests/matrix_free/matrix_vector_stokes.cc
+++ b/tests/matrix_free/matrix_vector_stokes.cc
@@ -78,10 +78,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src, 0);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src, dim);
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -97,9 +97,9 @@ public:
             velocity.submit_gradient(grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst, 0);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst, dim);
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_base.cc
+++ b/tests/matrix_free/matrix_vector_stokes_base.cc
@@ -71,10 +71,10 @@ protected:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src.block(0));
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src.block(1));
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -91,9 +91,9 @@ protected:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst.block(0));
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst.block(1));
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_flux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_flux.cc
@@ -87,10 +87,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values_plain(src);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values_plain(src);
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -107,9 +107,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_noflux.cc
+++ b/tests/matrix_free/matrix_vector_stokes_noflux.cc
@@ -78,10 +78,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src.block(0));
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src.block(1));
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -98,9 +98,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst.block(0));
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst.block(1));
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_notempl.cc
+++ b/tests/matrix_free/matrix_vector_stokes_notempl.cc
@@ -74,10 +74,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src.block(0));
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src.block(1));
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -94,9 +94,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst.block(0));
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst.block(1));
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_onedof.cc
+++ b/tests/matrix_free/matrix_vector_stokes_onedof.cc
@@ -84,10 +84,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src);
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -104,9 +104,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_qdg0.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0.cc
@@ -79,10 +79,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src, 0);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src, dim);
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -99,9 +99,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst, 0);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst, dim);
       }
   }

--- a/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
+++ b/tests/matrix_free/matrix_vector_stokes_qdg0b.cc
@@ -79,10 +79,10 @@ public:
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src, 0);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src, dim);
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -99,9 +99,9 @@ public:
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst, 0);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst, dim);
       }
   }

--- a/tests/matrix_free/multigrid_dg_periodic.cc
+++ b/tests/matrix_free/multigrid_dg_periodic.cc
@@ -179,10 +179,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -205,9 +205,10 @@ private:
         fe_eval_neighbor.reinit(face);
 
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval_neighbor.read_dof_values(src);
-        fe_eval_neighbor.evaluate(true, true);
+        fe_eval_neighbor.evaluate(EvaluationFlags::values |
+                                  EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           (std::abs((fe_eval.get_normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
@@ -229,9 +230,10 @@ private:
             fe_eval.submit_value(average_valgrad, q);
             fe_eval_neighbor.submit_value(-average_valgrad, q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
-        fe_eval_neighbor.integrate(true, true);
+        fe_eval_neighbor.integrate(EvaluationFlags::values |
+                                   EvaluationFlags::gradients);
         fe_eval_neighbor.distribute_local_to_global(dst);
       }
   }
@@ -249,7 +251,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           std::abs((fe_eval.get_normal_vector(0) *
                     fe_eval.inverse_jacobian(0))[dim - 1]) *
@@ -265,7 +267,7 @@ private:
             fe_eval.submit_value(average_valgrad, q);
           }
 
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
   }
@@ -309,10 +311,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.static_dofs_per_cell; ++i)
@@ -348,13 +350,14 @@ private:
         // Compute phi part
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
-        phi_outer.evaluate(true, true);
+        phi_outer.evaluate(EvaluationFlags::values |
+                           EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -368,7 +371,7 @@ private:
                 phi.submit_normal_derivative(-average_value, q);
                 phi.submit_value(average_valgrad, q);
               }
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -378,13 +381,14 @@ private:
         // Compute phi_outer part
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi.begin_dof_values()[j] = VectorizedArray<number>();
-        phi.evaluate(true, true);
+        phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
             phi_outer.begin_dof_values()[i] = 1.;
-            phi_outer.evaluate(true, true);
+            phi_outer.evaluate(EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -398,7 +402,8 @@ private:
                 phi_outer.submit_normal_derivative(-average_value, q);
                 phi_outer.submit_value(-average_valgrad, q);
               }
-            phi_outer.integrate(true, true);
+            phi_outer.integrate(EvaluationFlags::values |
+                                EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi_outer.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -431,7 +436,7 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -443,7 +448,7 @@ private:
                 phi.submit_value(average_valgrad, q);
               }
 
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -188,10 +188,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -214,9 +214,10 @@ private:
         fe_eval_neighbor.reinit(face);
 
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval_neighbor.read_dof_values(src);
-        fe_eval_neighbor.evaluate(true, true);
+        fe_eval_neighbor.evaluate(EvaluationFlags::values |
+                                  EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           (std::abs((fe_eval.get_normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
@@ -238,9 +239,10 @@ private:
             fe_eval.submit_value(average_valgrad, q);
             fe_eval_neighbor.submit_value(-average_valgrad, q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
-        fe_eval_neighbor.integrate(true, true);
+        fe_eval_neighbor.integrate(EvaluationFlags::values |
+                                   EvaluationFlags::gradients);
         fe_eval_neighbor.distribute_local_to_global(dst);
       }
   }
@@ -258,7 +260,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           std::abs((fe_eval.get_normal_vector(0) *
                     fe_eval.inverse_jacobian(0))[dim - 1]) *
@@ -274,7 +276,7 @@ private:
             fe_eval.submit_value(average_valgrad, q);
           }
 
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
   }
@@ -316,10 +318,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.static_dofs_per_cell; ++i)
@@ -355,13 +357,14 @@ private:
         // Compute phi part
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
-        phi_outer.evaluate(true, true);
+        phi_outer.evaluate(EvaluationFlags::values |
+                           EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -375,7 +378,7 @@ private:
                 phi.submit_normal_derivative(-average_value, q);
                 phi.submit_value(average_valgrad, q);
               }
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -385,13 +388,14 @@ private:
         // Compute phi_outer part
         for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
           phi.begin_dof_values()[j] = VectorizedArray<number>();
-        phi.evaluate(true, true);
+        phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
           {
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi_outer.begin_dof_values()[j] = VectorizedArray<number>();
             phi_outer.begin_dof_values()[i] = 1.;
-            phi_outer.evaluate(true, true);
+            phi_outer.evaluate(EvaluationFlags::values |
+                               EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -405,7 +409,8 @@ private:
                 phi_outer.submit_normal_derivative(-average_value, q);
                 phi_outer.submit_value(-average_valgrad, q);
               }
-            phi_outer.integrate(true, true);
+            phi_outer.integrate(EvaluationFlags::values |
+                                EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi_outer.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -438,7 +443,7 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(true, true);
+            phi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               {
@@ -450,7 +455,7 @@ private:
                 phi.submit_value(average_valgrad, q);
               }
 
-            phi.integrate(true, true);
+            phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -191,10 +191,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -217,9 +217,10 @@ private:
         fe_eval_neighbor.reinit(face);
 
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval_neighbor.read_dof_values(src);
-        fe_eval_neighbor.evaluate(true, true);
+        fe_eval_neighbor.evaluate(EvaluationFlags::values |
+                                  EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           (std::abs((fe_eval.get_normal_vector(0) *
                      fe_eval.inverse_jacobian(0))[dim - 1]) +
@@ -241,9 +242,10 @@ private:
             fe_eval.submit_value(average_valgrad, q);
             fe_eval_neighbor.submit_value(-average_valgrad, q);
           }
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
-        fe_eval_neighbor.integrate(true, true);
+        fe_eval_neighbor.integrate(EvaluationFlags::values |
+                                   EvaluationFlags::gradients);
         fe_eval_neighbor.distribute_local_to_global(dst);
       }
   }
@@ -261,7 +263,7 @@ private:
       {
         fe_eval.reinit(face);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
         VectorizedArray<number> sigmaF =
           std::abs((fe_eval.get_normal_vector(0) *
                     fe_eval.inverse_jacobian(0))[dim - 1]) *
@@ -277,7 +279,7 @@ private:
             fe_eval.submit_value(average_valgrad, q);
           }
 
-        fe_eval.integrate(true, true);
+        fe_eval.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
   }
@@ -318,10 +320,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (const unsigned int face : GeometryInfo<dim>::face_indices())
@@ -346,7 +348,8 @@ private:
                 for (unsigned int j = 0; j < phif.dofs_per_cell; ++j)
                   phif.begin_dof_values()[j] = VectorizedArray<number>();
                 phif.begin_dof_values()[i] = 1.;
-                phif.evaluate(true, true);
+                phif.evaluate(EvaluationFlags::values |
+                              EvaluationFlags::gradients);
                 for (unsigned int q = 0; q < phif.n_q_points; ++q)
                   {
                     VectorizedArray<number> average_value =
@@ -358,7 +361,8 @@ private:
                     phif.submit_normal_derivative(-average_value, q);
                     phif.submit_value(average_valgrad, q);
                   }
-                phif.integrate(true, true);
+                phif.integrate(EvaluationFlags::values |
+                               EvaluationFlags::gradients);
                 local_diagonal_vector[i] += phif.begin_dof_values()[i];
               }
           }

--- a/tests/matrix_free/no_index_initialize.cc
+++ b/tests/matrix_free/no_index_initialize.cc
@@ -81,7 +81,8 @@ public:
         else
           for (unsigned int e = 0; e < fe_eval.dofs_per_cell; ++e)
             fe_eval.submit_dof_value(make_vectorized_array<Number>(1.), e);
-        fe_eval.evaluate(true, true, true);
+        fe_eval.evaluate(EvaluationFlags::values | EvaluationFlags::gradients |
+                         EvaluationFlags::hessians);
 
         // values should evaluate to one, derivatives to zero
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)

--- a/tests/matrix_free/parallel_multigrid.cc
+++ b/tests/matrix_free/parallel_multigrid.cc
@@ -210,10 +210,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -255,10 +255,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -318,10 +318,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -374,10 +374,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -325,10 +325,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -381,10 +381,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -322,10 +322,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -378,10 +378,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -146,10 +146,10 @@ private:
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
         phi.reinit(cell);
-        phi.gather_evaluate(src, false, true);
+        phi.gather_evaluate(src, EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate_scatter(false, true, dst);
+        phi.integrate_scatter(EvaluationFlags::gradients, dst);
       }
   }
 

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -214,10 +214,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -259,10 +259,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -210,10 +210,10 @@ private:
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -255,10 +255,10 @@ private:
             for (unsigned int j = 0; j < phi.dofs_per_cell; ++j)
               phi.begin_dof_values()[j] = VectorizedArray<number>();
             phi.begin_dof_values()[i] = 1.;
-            phi.evaluate(false, true, false);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(phi.get_gradient(q), q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             local_diagonal_vector[i] = phi.begin_dof_values()[i];
           }
         for (unsigned int i = 0; i < phi.tensor_dofs_per_cell; ++i)

--- a/tests/matrix_free/pre_and_post_loops_05.cc
+++ b/tests/matrix_free/pre_and_post_loops_05.cc
@@ -125,10 +125,10 @@ private:
       {
         fe_eval.reinit(cell);
         fe_eval.read_dof_values(src);
-        fe_eval.evaluate(false, true);
+        fe_eval.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
           fe_eval.submit_gradient(fe_eval.get_gradient(q), q);
-        fe_eval.integrate(false, true);
+        fe_eval.integrate(EvaluationFlags::gradients);
         fe_eval.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/step-37-inhomogeneous-1.cc
+++ b/tests/matrix_free/step-37-inhomogeneous-1.cc
@@ -243,10 +243,10 @@ namespace Step37
 
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(coefficient(cell, q) * phi.get_gradient(q), q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }
@@ -317,11 +317,11 @@ namespace Step37
               phi.submit_dof_value(VectorizedArray<number>(), j);
             phi.submit_dof_value(make_vectorized_array<number>(1.), i);
 
-            phi.evaluate(false, true);
+            phi.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < phi.n_q_points; ++q)
               phi.submit_gradient(coefficient(cell, q) * phi.get_gradient(q),
                                   q);
-            phi.integrate(false, true);
+            phi.integrate(EvaluationFlags::gradients);
             diagonal[i] = phi.get_dof_value(i);
           }
         for (unsigned int i = 0; i < phi.dofs_per_cell; ++i)
@@ -495,13 +495,13 @@ namespace Step37
       {
         phi.reinit(cell);
         phi.read_dof_values_plain(solution);
-        phi.evaluate(false, true);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
             phi.submit_gradient(-coefficient(cell, q) * phi.get_gradient(q), q);
             phi.submit_value(forcing.value(phi.quadrature_point(q)), q);
           }
-        phi.integrate(true, true);
+        phi.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         phi.distribute_local_to_global(system_rhs);
       }
     system_rhs.compress(VectorOperation::add);

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -262,12 +262,12 @@ namespace Step37
       {
         phi.reinit(cell);
         phi.read_dof_values(src);
-        phi.evaluate(false, true, false);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           phi.submit_gradient(coefficient[cell * phi.n_q_points + q] *
                                 phi.get_gradient(q),
                               q);
-        phi.integrate(false, true);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -102,7 +102,7 @@ namespace Step48
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(one, q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
 
@@ -135,8 +135,8 @@ namespace Step48
         current.read_dof_values(*src[0]);
         old.read_dof_values(*src[1]);
 
-        current.evaluate(true, true, false);
-        old.evaluate(true, false, false);
+        current.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+        old.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < current.n_q_points; ++q)
           {
@@ -149,7 +149,7 @@ namespace Step48
             current.submit_gradient(-delta_t_sqr * current.get_gradient(q), q);
           }
 
-        current.integrate(true, true);
+        current.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         current.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/step-48b.cc
+++ b/tests/matrix_free/step-48b.cc
@@ -96,7 +96,7 @@ namespace Step48
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(one, q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
 
@@ -130,8 +130,8 @@ namespace Step48
         current.read_dof_values(*src[0]);
         old.read_dof_values(*src[1]);
 
-        current.evaluate(true, true, false);
-        old.evaluate(true, false, false);
+        current.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+        old.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < current.n_q_points; ++q)
           {
@@ -157,7 +157,7 @@ namespace Step48
                         << sin_value[v] << std::endl;
           }
 
-        current.integrate(true, true);
+        current.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         current.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -102,7 +102,7 @@ namespace Step48
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)
           fe_eval.submit_value(one, q);
-        fe_eval.integrate(true, false);
+        fe_eval.integrate(EvaluationFlags::values);
         fe_eval.distribute_local_to_global(inv_mass_matrix);
       }
 
@@ -135,8 +135,8 @@ namespace Step48
         current.read_dof_values(*src[0]);
         old.read_dof_values(*src[1]);
 
-        current.evaluate(true, true, false);
-        old.evaluate(true, false, false);
+        current.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+        old.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < current.n_q_points; ++q)
           {
@@ -147,7 +147,7 @@ namespace Step48
             current.submit_gradient(-delta_t_sqr * current.get_gradient(q), q);
           }
 
-        current.integrate(true, true);
+        current.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
         current.distribute_local_to_global(dst);
       }
   }

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -514,10 +514,10 @@ namespace StokesClass
       {
         velocity.reinit(cell);
         velocity.read_dof_values(src.block(0));
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         pressure.reinit(cell);
         pressure.read_dof_values(src.block(1));
-        pressure.evaluate(true, false, false);
+        pressure.evaluate(EvaluationFlags::values);
 
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
@@ -535,9 +535,9 @@ namespace StokesClass
             velocity.submit_symmetric_gradient(sym_grad_u, q);
           }
 
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst.block(0));
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst.block(1));
       }
   }
@@ -648,12 +648,12 @@ namespace StokesClass
 
         pressure.reinit(cell);
         pressure.read_dof_values(src);
-        pressure.evaluate(true, false);
+        pressure.evaluate(EvaluationFlags::values);
         for (unsigned int q = 0; q < pressure.n_q_points; ++q)
           pressure.submit_value(one_over_viscosity(cell, q) *
                                   pressure.get_value(q),
                                 q);
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(dst);
       }
   }
@@ -721,12 +721,12 @@ namespace StokesClass
               pressure.begin_dof_values()[j] = VectorizedArray<number>();
             pressure.begin_dof_values()[i] = make_vectorized_array<number>(1.);
 
-            pressure.evaluate(true, false, false);
+            pressure.evaluate(EvaluationFlags::values);
             for (unsigned int q = 0; q < pressure.n_q_points; ++q)
               pressure.submit_value(one_over_viscosity(cell, q) *
                                       pressure.get_value(q),
                                     q);
-            pressure.integrate(true, false);
+            pressure.integrate(EvaluationFlags::values);
 
             diagonal[i] = pressure.begin_dof_values()[i];
           }
@@ -828,13 +828,13 @@ namespace StokesClass
 
         velocity.reinit(cell);
         velocity.read_dof_values(src);
-        velocity.evaluate(false, true, false);
+        velocity.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < velocity.n_q_points; ++q)
           {
             velocity.submit_symmetric_gradient(
               viscosity_x_2(cell, q) * velocity.get_symmetric_gradient(q), q);
           }
-        velocity.integrate(false, true);
+        velocity.integrate(EvaluationFlags::gradients);
         velocity.distribute_local_to_global(dst);
       }
   }
@@ -893,14 +893,14 @@ namespace StokesClass
               velocity.begin_dof_values()[j] = VectorizedArray<number>();
             velocity.begin_dof_values()[i] = make_vectorized_array<number>(1.);
 
-            velocity.evaluate(false, true, false);
+            velocity.evaluate(EvaluationFlags::gradients);
             for (unsigned int q = 0; q < velocity.n_q_points; ++q)
               {
                 velocity.submit_symmetric_gradient(
                   viscosity_x_2(cell, q) * velocity.get_symmetric_gradient(q),
                   q);
               }
-            velocity.integrate(false, true);
+            velocity.integrate(EvaluationFlags::gradients);
 
             diagonal[i] = velocity.begin_dof_values()[i];
           }
@@ -1237,9 +1237,9 @@ namespace StokesClass
             velocity.submit_value(rhs_u, q);
             pressure.submit_value(rhs_p, q);
           }
-        velocity.integrate(true, false);
+        velocity.integrate(EvaluationFlags::values);
         velocity.distribute_local_to_global(system_rhs.block(0));
-        pressure.integrate(true, false);
+        pressure.integrate(EvaluationFlags::values);
         pressure.distribute_local_to_global(system_rhs.block(1));
       }
     system_rhs.compress(VectorOperation::add);

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -356,14 +356,14 @@ namespace Step37
       {
         phi.reinit(cell);
         phi.read_dof_values_plain(solution);
-        phi.evaluate(false, true);
+        phi.evaluate(EvaluationFlags::gradients);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)
           {
             phi.submit_gradient(-phi.get_gradient(q), q);
             // phi.submit_value(make_vectorized_array<double>(1.0), q);
           }
-        // phi.integrate(true, true);
-        phi.integrate(false, true);
+        // phi.integrate(EvaluationFlags::values|EvaluationFlags::gradients);
+        phi.integrate(EvaluationFlags::gradients);
         phi.distribute_local_to_global(system_rhs);
       }
     system_rhs.compress(VectorOperation::add);


### PR DESCRIPTION
Functions with several bool arguments in matrix-free have annoyed me for quite a while but seeing Martin show the code today, made me propose this.

This is obviously incomplete, but I am looking for comments now. I just started with:

- replace evaluate*, integrate* calls in FEEvaluation

Note: I am not using an ``enum class`` because that doesn't behave well with flags to ``or`` together. I put it in a namespace for scoping, but that is debatable. 