### PR TITLE
Route all variations of Threads::new_task() through one instance.

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1459,7 +1459,7 @@ namespace Threads
   {
     using return_type = decltype(function_object());
     dealii::MultithreadInfo::initialize_multithreading();
-    return Task<return_type>(std::function<return_type()>(function_object));
+    return new_task(std::function<return_type()>(function_object));
   }
 
 


### PR DESCRIPTION
Right now, there are two that are the end points of all overloads. Reduce this to one
to make some further clean-ups simpler.