### PR TITLE
Remove Task::operator==.

### DIFF
--- a/doc/news/changes/incompatibilities/20200526Bangerth
+++ b/doc/news/changes/incompatibilities/20200526Bangerth
@@ -1,0 +1,8 @@
+Removed: The Threads::Task class had an `operator==` that allowed
+comparing objects of this type for equality. This operator has been
+removed. If you want to store objects of this kind in a collection
+that requires this kind of operator (say, `std::set`), then you
+probably can't do so any more in a reasonable way. However, this is
+exactly what the Threads::TaskGroup class is there for.
+<br>
+(Wolfgang Bangerth, 2020/05/26)

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1337,18 +1337,6 @@ namespace Threads
 
 
     /**
-     * Check for equality of task objects. Since objects of this class store
-     * an implicit pointer to an object that exists exactly once for each
-     * task, the check is simply to compare these pointers.
-     */
-    bool
-    operator==(const Task &t) const
-    {
-      AssertThrow(joinable(), ExcNoTask());
-      return task_descriptor == t.task_descriptor;
-    }
-
-    /**
      * @addtogroup Exceptions
      * @{
      */


### PR DESCRIPTION
I don't see how to implement in the scheme I have in my head, and it's hard to see
why anyone would want to use it to begin with.

I verified that this passes all tests that have 'task' in their name.