### PR TITLE
Augment a test to also check sparse vanka.

### DIFF
--- a/tests/lac/sparse_matrices.cc
+++ b/tests/lac/sparse_matrices.cc
@@ -25,6 +25,7 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparse_matrix_ez.h>
 #include <deal.II/lac/sparse_matrix_ez.templates.h>
+#include <deal.II/lac/sparse_vanka.h>
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
@@ -122,6 +123,45 @@ check_vmult_quadratic(std::vector<double> &residuals,
   PREC_CHECK(prich, Tsolve, block_ssor);
   PREC_CHECK(prich, Tsolve, block_sor);
   PREC_CHECK(prich, Tsolve, block_psor);
+
+  // vanka needs to match the type
+  using value_type = typename MatrixType::value_type;
+  if (std::is_same<MatrixType, SparseMatrix<value_type>>::value)
+    {
+      deallog << "Vanka" << std::endl;
+      const SparseMatrix<value_type> &B =
+        reinterpret_cast<const SparseMatrix<value_type> &>(A);
+
+      std::vector<bool> selected_dofs(B.m(), false);
+      // tag every third dof for vanka
+      for (unsigned int i = 0; i < B.m(); i += 3)
+        selected_dofs[i] = true;
+      SparseVanka<value_type> vanka;
+      vanka.initialize(
+        B, typename SparseVanka<value_type>::AdditionalData(selected_dofs));
+
+      SparseBlockVanka<value_type> block_vanka_1(
+        B,
+        selected_dofs,
+        n_blocks,
+        SparseBlockVanka<value_type>::index_intervals);
+      SparseBlockVanka<value_type> block_vanka_2(
+        B, selected_dofs, n_blocks, SparseBlockVanka<value_type>::adaptive);
+
+      PREC_CHECK(prich, solve, vanka);
+      PREC_CHECK(prich, solve, block_vanka_1);
+      PREC_CHECK(prich, solve, block_vanka_2);
+
+      // since SparseMatrixEZ doesn't support this format remove it from the
+      // residuals:
+      deallog << "vanka residual: " << residuals.back() << std::endl;
+      residuals.pop_back();
+      deallog << "vanka residual: " << residuals.back() << std::endl;
+      residuals.pop_back();
+      deallog << "vanka residual: " << residuals.back() << std::endl;
+      residuals.pop_back();
+    }
+
   deallog.pop();
 }
 

--- a/tests/lac/sparse_matrices.output
+++ b/tests/lac/sparse_matrices.output
@@ -97,6 +97,16 @@ DEAL:5-SparseMatrix<double>:block_sor:RichardsonT::Starting value 4.00
 DEAL:5-SparseMatrix<double>:block_sor:RichardsonT::Failure step 10 value 1.07e-06
 DEAL:5-SparseMatrix<double>:block_psor:RichardsonT::Starting value 4.00
 DEAL:5-SparseMatrix<double>:block_psor:RichardsonT::Failure step 10 value 8.62e-07
+DEAL:5-SparseMatrix<double>::Vanka
+DEAL:5-SparseMatrix<double>:vanka:Richardson::Starting value 4.00
+DEAL:5-SparseMatrix<double>:vanka:Richardson::Failure step 10 value 0.000523
+DEAL:5-SparseMatrix<double>:block_vanka_1:Richardson::Starting value 4.00
+DEAL:5-SparseMatrix<double>:block_vanka_1:Richardson::Failure step 10 value 6.00
+DEAL:5-SparseMatrix<double>:block_vanka_2:Richardson::Starting value 4.00
+DEAL:5-SparseMatrix<double>:block_vanka_2:Richardson::Failure step 10 value 0.0179
+DEAL:5-SparseMatrix<double>::vanka residual: 0.0179
+DEAL:5-SparseMatrix<double>::vanka residual: 6.00
+DEAL:5-SparseMatrix<double>::vanka residual: 0.000523
 DEAL::	0	0	5.00
 DEAL::	0	1	-2.00
 DEAL::	0	4	-1.00
@@ -395,6 +405,16 @@ DEAL:9-SparseMatrix<double>:block_sor:RichardsonT::Starting value 4.00
 DEAL:9-SparseMatrix<double>:block_sor:RichardsonT::Failure step 10 value 2.94e-06
 DEAL:9-SparseMatrix<double>:block_psor:RichardsonT::Starting value 4.00
 DEAL:9-SparseMatrix<double>:block_psor:RichardsonT::Failure step 10 value 1.86e-06
+DEAL:9-SparseMatrix<double>::Vanka
+DEAL:9-SparseMatrix<double>:vanka:Richardson::Starting value 4.00
+DEAL:9-SparseMatrix<double>:vanka:Richardson::Failure step 10 value 1.75e-10
+DEAL:9-SparseMatrix<double>:block_vanka_1:Richardson::Starting value 4.00
+DEAL:9-SparseMatrix<double>:block_vanka_1:Richardson::Failure step 10 value 5.61
+DEAL:9-SparseMatrix<double>:block_vanka_2:Richardson::Starting value 4.00
+DEAL:9-SparseMatrix<double>:block_vanka_2:Richardson::Failure step 10 value 0.00189
+DEAL:9-SparseMatrix<double>::vanka residual: 0.00189
+DEAL:9-SparseMatrix<double>::vanka residual: 5.61
+DEAL:9-SparseMatrix<double>::vanka residual: 1.75e-10
 DEAL::Assemble
 DEAL:9-SparseMatrixEZ<double>:identity:Richardson::Starting value 4.00
 DEAL:9-SparseMatrixEZ<double>:identity:Richardson::Failure step 10 value 2.41


### PR DESCRIPTION
As noted in #10395, we only have one test at the moment that verifies our sparse vanka code. I modified another test to print residuals for a fixed number of iterations - its not perfect but its a lot better than nothing.