### PR TITLE
Fix warning about missing copy constructors

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -93,8 +93,12 @@ namespace PETScWrappers
        */
       VectorReference(const VectorBase &vector, const size_type index);
 
-
     public:
+      /*
+       * Copy constrcutor.
+       */
+      VectorReference(const VectorReference &vector) = default;
+
       /**
        * This looks like a copy operator, but does something different than
        * usual. In particular, it does not copy the member variables of this

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -108,6 +108,11 @@ namespace TrilinosWrappers
 
     public:
       /**
+       * Copy constructor.
+       */
+      VectorReference(const VectorReference &) = default;
+
+      /**
        * This looks like a copy operator, but does something different than
        * usual. In particular, it does not copy the member variables of this
        * reference. Rather, it handles the situation where we have two vectors


### PR DESCRIPTION
Fixes warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=6843.