### PR TITLE
Delete copy constructor for ThreadLocalStorage

### DIFF
--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -127,16 +127,10 @@ namespace Threads
     explicit ThreadLocalStorage(T &&t);
 
     /**
-     * Copy constructor. Initialize each thread local object with the
-     * corresponding object of the given object.
+     * The copy constructor is deleted. Copying instances of this class is not
+     * allowed.
      */
-    ThreadLocalStorage(const ThreadLocalStorage<T> &t) = default;
-
-    /**
-     * Move constructor. Copies the internal state over from the given
-     * object.
-     */
-    ThreadLocalStorage(ThreadLocalStorage<T> &&t) noexcept = default;
+    ThreadLocalStorage(const ThreadLocalStorage<T> &t) = delete;
 
     /**
      * Return a reference to the data stored by this object for the current


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?buildid=6898.
Neither `std::shared_mutex` nor `std::shared_timed_mutex` are copy-constructible so the implicitly defined defaulted copy constructor (and move constructor) is deleted (https://en.cppreference.com/w/cpp/thread/shared_mutex/shared_mutex). Apparently, we are not using it at all.
We see the error only with older versions because non-matching exception specifiers for defaulted functions (which we have here since these types are not no-throw-move-constructible) should result in implicitly deleted functions according to a correction in the standard. Previously, this should give a compile error directly which we are seeing.

If we need a copy constructor, we need to implement it explicitly.
