### PR TITLE
Bug fix: Multiple valid CUDAWrappers::MatrixFree objects is not allowed

### DIFF
--- a/doc/news/changes/minor/20200529Turcksin
+++ b/doc/news/changes/minor/20200529Turcksin
@@ -1,0 +1,6 @@
+Fixed: Fix a bug where only one CUDAWrappers::MatrixFree object was valid at a
+given time. There is now a variable CUDAWrappers::mf_n_concurrent_objects in
+base/cuda_size.h that controls the maximum number of concurrent objects. The
+default value is five.
+<br>
+(Bruno Turcksin, 2020/05/29)

--- a/include/deal.II/base/cuda_size.h
+++ b/include/deal.II/base/cuda_size.h
@@ -38,6 +38,19 @@ namespace CUDAWrappers
    * Define the number of threads in a warp.
    */
   constexpr int warp_size = 32;
+
+  /**
+   * Define the largest finite element degree that can be solved using
+   * CUDAWrappers::MatrixFree. Changing this number will affect the amount of
+   * constant memory being used.
+   */
+  constexpr unsigned int mf_max_elem_degree = 10;
+
+  /**
+   * Define the maximum number of valid CUDAWrappers::MatrixFree object.
+   * Changing this number will affect the amount of constant memory being used.
+   */
+  constexpr unsigned int mf_n_concurrent_objects = 5;
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -316,6 +316,7 @@ namespace CUDAWrappers
     types::global_dof_index *local_to_global;
     unsigned int             n_cells;
     unsigned int             padding_length;
+    const unsigned int       mf_object_id;
 
     const unsigned int constraint_mask;
 
@@ -343,6 +344,7 @@ namespace CUDAWrappers
                  SharedData<dim, Number> *shdata)
     : n_cells(data->n_cells)
     , padding_length(data->padding_length)
+    , mf_object_id(data->id)
     , constraint_mask(data->constraint_mask[cell_id])
     , use_coloring(data->use_coloring)
     , values(shdata->values)
@@ -426,7 +428,7 @@ namespace CUDAWrappers
       fe_degree,
       n_q_points_1d,
       Number>
-      evaluator_tensor_product;
+      evaluator_tensor_product(mf_object_id);
     if (evaluate_val == true && evaluate_grad == true)
       {
         evaluator_tensor_product.value_and_gradient_at_quad_pts(values,
@@ -463,7 +465,7 @@ namespace CUDAWrappers
       fe_degree,
       n_q_points_1d,
       Number>
-      evaluator_tensor_product;
+      evaluator_tensor_product(mf_object_id);
     if (integrate_val == true && integrate_grad == true)
       {
         evaluator_tensor_product.integrate_value_and_gradient(values,

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -184,6 +184,11 @@ namespace CUDAWrappers
       Number *JxW;
 
       /**
+       * ID of the associated MatrixFree object.
+       */
+      unsigned int id;
+
+      /**
        * Number of cells.
        */
       unsigned int n_cells;
@@ -214,6 +219,11 @@ namespace CUDAWrappers
      * Default constructor.
      */
     MatrixFree();
+
+    /**
+     * Destructor.
+     */
+    ~MatrixFree();
 
     /**
      * Return the length of the padding.
@@ -442,6 +452,11 @@ namespace CUDAWrappers
     distributed_set_constrained_values(
       const Number                                 val,
       LinearAlgebra::CUDAWrappers::Vector<Number> &dst) const;
+
+    /**
+     * Unique ID associated with the object.
+     */
+    int my_id;
 
     /**
      * Parallelization scheme used, parallelization over degrees of freedom or

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -59,7 +59,9 @@ namespace CUDAWrappers
               int              n_q_points_1d,
               typename Number>
     struct EvaluatorTensorProduct
-    {};
+    {
+      const int mf_object_id;
+    };
 
 
 
@@ -82,7 +84,7 @@ namespace CUDAWrappers
         Utilities::pow(n_q_points_1d, dim);
 
       __device__
-      EvaluatorTensorProduct();
+      EvaluatorTensorProduct(int mf_object_id);
 
       /**
        * Evaluate the values of a finite element function at the quadrature
@@ -147,6 +149,8 @@ namespace CUDAWrappers
        */
       __device__ void
       integrate_value_and_gradient(Number *u, Number *grad_u[dim]);
+
+      const int mf_object_id;
     };
 
 
@@ -157,7 +161,8 @@ namespace CUDAWrappers
                            dim,
                            fe_degree,
                            n_q_points_1d,
-                           Number>::EvaluatorTensorProduct()
+                           Number>::EvaluatorTensorProduct(int object_id)
+      : mf_object_id(object_id)
     {}
 
 
@@ -256,37 +261,31 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
           case 2:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<1, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
           case 3:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<1, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<2, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<2, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
@@ -312,37 +311,31 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
           case 2:
             {
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<1, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
           case 3:
             {
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<1, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<2, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<2, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
@@ -370,60 +363,68 @@ namespace CUDAWrappers
           case 1:
             {
               gradients<0, true, false, false>(
-                get_global_shape_gradients<Number>(), u, grad_u[0]);
+                get_global_shape_gradients<Number>(mf_object_id), u, grad_u[0]);
 
               break;
             }
           case 2:
             {
               gradients<0, true, false, false>(
-                get_global_shape_gradients<Number>(), u, grad_u[0]);
-              values<0, true, false, false>(get_global_shape_values<Number>(),
-                                            u,
-                                            grad_u[1]);
+                get_global_shape_gradients<Number>(mf_object_id), u, grad_u[0]);
+              values<0, true, false, false>(
+                get_global_shape_values<Number>(mf_object_id), u, grad_u[1]);
 
               __syncthreads();
 
-              values<1, true, false, true>(get_global_shape_values<Number>(),
+              values<1, true, false, true>(get_global_shape_values<Number>(
+                                             mf_object_id),
                                            grad_u[0],
                                            grad_u[0]);
               gradients<1, true, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[1],
+                grad_u[1]);
 
               break;
             }
           case 3:
             {
               gradients<0, true, false, false>(
-                get_global_shape_gradients<Number>(), u, grad_u[0]);
-              values<0, true, false, false>(get_global_shape_values<Number>(),
-                                            u,
-                                            grad_u[1]);
-              values<0, true, false, false>(get_global_shape_values<Number>(),
-                                            u,
-                                            grad_u[2]);
+                get_global_shape_gradients<Number>(mf_object_id), u, grad_u[0]);
+              values<0, true, false, false>(
+                get_global_shape_values<Number>(mf_object_id), u, grad_u[1]);
+              values<0, true, false, false>(
+                get_global_shape_values<Number>(mf_object_id), u, grad_u[2]);
 
               __syncthreads();
 
-              values<1, true, false, true>(get_global_shape_values<Number>(),
+              values<1, true, false, true>(get_global_shape_values<Number>(
+                                             mf_object_id),
                                            grad_u[0],
                                            grad_u[0]);
               gradients<1, true, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
-              values<1, true, false, true>(get_global_shape_values<Number>(),
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[1],
+                grad_u[1]);
+              values<1, true, false, true>(get_global_shape_values<Number>(
+                                             mf_object_id),
                                            grad_u[2],
                                            grad_u[2]);
 
               __syncthreads();
 
-              values<2, true, false, true>(get_global_shape_values<Number>(),
+              values<2, true, false, true>(get_global_shape_values<Number>(
+                                             mf_object_id),
                                            grad_u[0],
                                            grad_u[0]);
-              values<2, true, false, true>(get_global_shape_values<Number>(),
+              values<2, true, false, true>(get_global_shape_values<Number>(
+                                             mf_object_id),
                                            grad_u[1],
                                            grad_u[1]);
               gradients<2, true, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[2], grad_u[2]);
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[2],
+                grad_u[2]);
 
               break;
             }
@@ -451,55 +452,61 @@ namespace CUDAWrappers
         {
           case 1:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
 
               gradients<0, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[0]);
 
               break;
             }
           case 2:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<1, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
 
               gradients<0, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[0]);
               gradients<1, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[1]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[1]);
 
               break;
             }
           case 3:
             {
-              values<0, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<0, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<1, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<2, true, false, true>(get_global_shape_values<Number>(),
-                                           u,
-                                           u);
+              values<2, true, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
 
               gradients<0, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[0]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[0]);
               gradients<1, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[1]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[1]);
               gradients<2, true, false, false>(
-                get_global_co_shape_gradients<Number>(), u, grad_u[2]);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                u,
+                grad_u[2]);
 
               break;
             }
@@ -528,63 +535,73 @@ namespace CUDAWrappers
           case 1:
             {
               gradients<0, false, add, false>(
-                get_global_shape_gradients<Number>(), grad_u[dim], u);
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[dim],
+                u);
 
               break;
             }
           case 2:
             {
               gradients<0, false, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[0], grad_u[0]);
-              values<0, false, false, true>(get_global_shape_values<Number>(),
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[0],
+                grad_u[0]);
+              values<0, false, false, true>(get_global_shape_values<Number>(
+                                              mf_object_id),
                                             grad_u[1],
                                             grad_u[1]);
 
               __syncthreads();
 
-              values<1, false, add, false>(get_global_shape_values<Number>(),
-                                           grad_u[0],
-                                           u);
+              values<1, false, add, false>(
+                get_global_shape_values<Number>(mf_object_id), grad_u[0], u);
               __syncthreads();
               gradients<1, false, true, false>(
-                get_global_shape_gradients<Number>(), grad_u[1], u);
+                get_global_shape_gradients<Number>(mf_object_id), grad_u[1], u);
 
               break;
             }
           case 3:
             {
               gradients<0, false, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[0], grad_u[0]);
-              values<0, false, false, true>(get_global_shape_values<Number>(),
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[0],
+                grad_u[0]);
+              values<0, false, false, true>(get_global_shape_values<Number>(
+                                              mf_object_id),
                                             grad_u[1],
                                             grad_u[1]);
-              values<0, false, false, true>(get_global_shape_values<Number>(),
+              values<0, false, false, true>(get_global_shape_values<Number>(
+                                              mf_object_id),
                                             grad_u[2],
                                             grad_u[2]);
 
               __syncthreads();
 
-              values<1, false, false, true>(get_global_shape_values<Number>(),
+              values<1, false, false, true>(get_global_shape_values<Number>(
+                                              mf_object_id),
                                             grad_u[0],
                                             grad_u[0]);
               gradients<1, false, false, true>(
-                get_global_shape_gradients<Number>(), grad_u[1], grad_u[1]);
-              values<1, false, false, true>(get_global_shape_values<Number>(),
+                get_global_shape_gradients<Number>(mf_object_id),
+                grad_u[1],
+                grad_u[1]);
+              values<1, false, false, true>(get_global_shape_values<Number>(
+                                              mf_object_id),
                                             grad_u[2],
                                             grad_u[2]);
 
               __syncthreads();
 
-              values<2, false, add, false>(get_global_shape_values<Number>(),
-                                           grad_u[0],
-                                           u);
+              values<2, false, add, false>(
+                get_global_shape_values<Number>(mf_object_id), grad_u[0], u);
               __syncthreads();
-              values<2, false, true, false>(get_global_shape_values<Number>(),
-                                            grad_u[1],
-                                            u);
+              values<2, false, true, false>(
+                get_global_shape_values<Number>(mf_object_id), grad_u[1], u);
               __syncthreads();
               gradients<2, false, true, false>(
-                get_global_shape_gradients<Number>(), grad_u[2], u);
+                get_global_shape_gradients<Number>(mf_object_id), grad_u[2], u);
 
               break;
             }
@@ -613,31 +630,34 @@ namespace CUDAWrappers
           case 1:
             {
               gradients<0, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[0], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[0],
+                u);
               __syncthreads();
 
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
 
               break;
             }
           case 2:
             {
               gradients<1, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[1], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[1],
+                u);
               __syncthreads();
               gradients<0, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[0], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[0],
+                u);
               __syncthreads();
 
-              values<1, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<1, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
 
               break;
@@ -645,26 +665,29 @@ namespace CUDAWrappers
           case 3:
             {
               gradients<2, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[2], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[2],
+                u);
               __syncthreads();
               gradients<1, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[1], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[1],
+                u);
               __syncthreads();
               gradients<0, false, true, false>(
-                get_global_co_shape_gradients<Number>(), grad_u[0], u);
+                get_global_co_shape_gradients<Number>(mf_object_id),
+                grad_u[0],
+                u);
               __syncthreads();
 
-              values<2, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<2, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<1, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<1, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
-              values<0, false, false, true>(get_global_shape_values<Number>(),
-                                            u,
-                                            u);
+              values<0, false, false, true>(
+                get_global_shape_values<Number>(mf_object_id), u, u);
               __syncthreads();
 
               break;

--- a/tests/cuda/cuda_evaluate_1d_shape.cu
+++ b/tests/cuda/cuda_evaluate_1d_shape.cu
@@ -42,14 +42,14 @@ evaluate_tensor_product(double *dst, double *src)
     M - 1,
     N,
     double>
-    evaluator;
+    evaluator(0);
 
   if (type == 0)
     evaluator.template values<0, dof_to_quad, add, false>(
-      CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
+      CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
   if (type == 1)
     evaluator.template gradients<0, dof_to_quad, add, false>(
-      CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
+      CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
 }
 
 template <int M, int N, int type, bool add>
@@ -98,16 +98,17 @@ test()
 
   unsigned int size_shape_values = M * N * sizeof(double);
 
-  cudaError_t cuda_error = cudaMemcpyToSymbol(
-    CUDAWrappers::internal::get_global_shape_values<double>(),
-    shape_host.begin(),
-    size_shape_values,
-    0,
-    cudaMemcpyHostToDevice);
+  cudaError_t cuda_error =
+    cudaMemcpyToSymbol(CUDAWrappers::internal::get_global_shape_values<double>(
+                         0),
+                       shape_host.begin(),
+                       size_shape_values,
+                       0,
+                       cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
   cuda_error = cudaMemcpyToSymbol(
-    CUDAWrappers::internal::get_global_shape_gradients<double>(),
+    CUDAWrappers::internal::get_global_shape_gradients<double>(0),
     shape_host.begin(),
     size_shape_values,
     0,

--- a/tests/cuda/cuda_evaluate_2d_shape.cu
+++ b/tests/cuda/cuda_evaluate_2d_shape.cu
@@ -42,23 +42,23 @@ evaluate_tensor_product(double *dst, double *src)
     M - 1,
     N,
     double>
-    evaluator;
+    evaluator(0);
 
   if (type == 0)
     {
       evaluator.template values<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(), src, src);
+        CUDAWrappers::internal::get_global_shape_values<double>(0), src, src);
       __syncthreads();
       evaluator.template values<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
+        CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
     }
   if (type == 1)
     {
       evaluator.template gradients<0, dof_to_quad, false, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(), src, src);
+        CUDAWrappers::internal::get_global_shape_values<double>(0), src, src);
       __syncthreads();
       evaluator.template gradients<1, dof_to_quad, add, false>(
-        CUDAWrappers::internal::get_global_shape_values<double>(), src, dst);
+        CUDAWrappers::internal::get_global_shape_values<double>(0), src, dst);
     }
 }
 
@@ -123,16 +123,17 @@ test()
 
   unsigned int size_shape_values = M * N * sizeof(double);
 
-  cudaError_t cuda_error = cudaMemcpyToSymbol(
-    CUDAWrappers::internal::get_global_shape_values<double>(),
-    shape_host.begin(),
-    size_shape_values,
-    0,
-    cudaMemcpyHostToDevice);
+  cudaError_t cuda_error =
+    cudaMemcpyToSymbol(CUDAWrappers::internal::get_global_shape_values<double>(
+                         0),
+                       shape_host.begin(),
+                       size_shape_values,
+                       0,
+                       cudaMemcpyHostToDevice);
   AssertCuda(cuda_error);
 
   cuda_error = cudaMemcpyToSymbol(
-    CUDAWrappers::internal::get_global_shape_gradients<double>(),
+    CUDAWrappers::internal::get_global_shape_gradients<double>(0),
     shape_host.begin(),
     size_shape_values,
     0,

--- a/tests/cuda/matrix_free_multiple_objects.cu
+++ b/tests/cuda/matrix_free_multiple_objects.cu
@@ -1,0 +1,216 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Reproduce a bug where only one matrix-free object is valid
+
+#include <deal.II/base/logstream.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_values.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/cuda_vector.h>
+#include <deal.II/lac/dynamic_sparsity_pattern.h>
+#include <deal.II/lac/la_parallel_vector.h>
+#include <deal.II/lac/read_write_vector.h>
+#include <deal.II/lac/sparse_matrix.h>
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <iostream>
+
+#include "../tests.h"
+
+#include "matrix_vector_mf.h"
+
+template <int fe_degree, int n_q_points_1d>
+void
+do_test(const DoFHandler<2> &            dof,
+        MatrixFreeTest<2,
+                       fe_degree,
+                       double,
+                       LinearAlgebra::CUDAWrappers::Vector<double>,
+                       n_q_points_1d> &  mf,
+        unsigned int                     n_dofs,
+        MappingQGeneric<2> &             mapping,
+        const AffineConstraints<double> &constraints)
+{
+  Vector<double>                              in_host(n_dofs), out_host(n_dofs);
+  LinearAlgebra::ReadWriteVector<double>      in(n_dofs), out(n_dofs);
+  LinearAlgebra::CUDAWrappers::Vector<double> in_device(n_dofs);
+  LinearAlgebra::CUDAWrappers::Vector<double> out_device(n_dofs);
+
+  for (unsigned int i = 0; i < n_dofs; ++i)
+    {
+      if (constraints.is_constrained(i))
+        continue;
+      const double entry = Testing::rand() / (double)RAND_MAX;
+      in(i)              = entry;
+    }
+
+  in_device.import(in, VectorOperation::insert);
+  mf.vmult(out_device, in_device);
+  cudaDeviceSynchronize();
+  out.import(out_device, VectorOperation::insert);
+
+  // assemble sparse matrix with (\nabla v, \nabla u) + (v, 10 * u)
+  SparsityPattern sparsity;
+  {
+    DynamicSparsityPattern csp(n_dofs, n_dofs);
+    DoFTools::make_sparsity_pattern(dof, csp, constraints, true);
+    sparsity.copy_from(csp);
+  }
+  SparseMatrix<double> sparse_matrix(sparsity);
+  {
+    QGauss<2> quadrature_formula(n_q_points_1d);
+
+    FEValues<2> fe_values(mapping,
+                          dof.get_fe(),
+                          quadrature_formula,
+                          update_values | update_gradients |
+                            update_quadrature_points | update_JxW_values);
+
+    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int n_q_points    = quadrature_formula.size();
+
+    FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+    typename DoFHandler<2>::active_cell_iterator cell = dof.begin_active(),
+                                                 endc = dof.end();
+    for (; cell != endc; ++cell)
+      {
+        cell_matrix = 0;
+        fe_values.reinit(cell);
+
+        for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
+          {
+            const auto coef = 10.;
+            for (unsigned int i = 0; i < dofs_per_cell; ++i)
+              {
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  cell_matrix(i, j) +=
+                    ((fe_values.shape_grad(i, q_point) *
+                        fe_values.shape_grad(j, q_point) +
+                      coef * fe_values.shape_value(i, q_point) *
+                        fe_values.shape_value(j, q_point)) *
+                     fe_values.JxW(q_point));
+              }
+          }
+
+        cell->get_dof_indices(local_dof_indices);
+        constraints.distribute_local_to_global(cell_matrix,
+                                               local_dof_indices,
+                                               sparse_matrix);
+      }
+  }
+  for (unsigned i = 0; i < n_dofs; ++i)
+    in_host[i] = in[i];
+  sparse_matrix.vmult(out_host, in_host);
+
+  double out_norm = 0.;
+  for (unsigned i = 0; i < n_dofs; ++i)
+    out_norm += std::pow(out[i] - out_host[i], 2);
+  const double diff_norm = std::sqrt(out_norm) / out_host.linfty_norm();
+
+  deallog << "Norm of difference: " << diff_norm << std::endl << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+  deallog.depth_console(0);
+
+  deallog << std::setprecision(3);
+
+  init_cuda();
+
+  Triangulation<2> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(5 - 2);
+  AffineConstraints<double> constraints;
+  constraints.close();
+  bool constant_coefficient = true;
+
+  // Create the first MatrixFree object
+  constexpr unsigned int fe_degree_1     = 1;
+  constexpr unsigned int n_q_points_1d_1 = fe_degree_1 + 1;
+  FE_Q<2>                fe_1(fe_degree_1);
+  DoFHandler<2>          dof_1(tria);
+  dof_1.distribute_dofs(fe_1);
+  MappingQGeneric<2>                                  mapping_1(fe_degree_1);
+  CUDAWrappers::MatrixFree<2, double>                 mf_data_1;
+  CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_1;
+  additional_data_1.mapping_update_flags = update_values | update_gradients |
+                                           update_JxW_values |
+                                           update_quadrature_points;
+  const QGauss<1> quad_1(n_q_points_1d_1);
+  mf_data_1.reinit(mapping_1, dof_1, constraints, quad_1, additional_data_1);
+  const unsigned int n_dofs_1 = dof_1.n_dofs();
+  MatrixFreeTest<2,
+                 fe_degree_1,
+                 double,
+                 LinearAlgebra::CUDAWrappers::Vector<double>,
+                 n_q_points_1d_1>
+    mf_1(mf_data_1,
+         n_dofs_1 * std::pow(n_q_points_1d_1, 2),
+         constant_coefficient);
+
+  // Create the second MatrixFree object
+  constexpr unsigned int fe_degree_2     = 2;
+  constexpr unsigned int n_q_points_1d_2 = fe_degree_2 + 1;
+  FE_Q<2>                fe_2(fe_degree_2);
+  DoFHandler<2>          dof_2(tria);
+  dof_2.distribute_dofs(fe_2);
+  MappingQGeneric<2>                                  mapping_2(fe_degree_2);
+  CUDAWrappers::MatrixFree<2, double>                 mf_data_2;
+  CUDAWrappers::MatrixFree<2, double>::AdditionalData additional_data_2;
+  additional_data_2.mapping_update_flags = update_values | update_gradients |
+                                           update_JxW_values |
+                                           update_quadrature_points;
+  const QGauss<1> quad_2(n_q_points_1d_2);
+  mf_data_2.reinit(mapping_2, dof_2, constraints, quad_2, additional_data_2);
+  const unsigned int n_dofs_2 = dof_2.n_dofs();
+  MatrixFreeTest<2,
+                 fe_degree_2,
+                 double,
+                 LinearAlgebra::CUDAWrappers::Vector<double>,
+                 n_q_points_1d_2>
+    mf_2(mf_data_2,
+         n_dofs_2 * std::pow(n_q_points_1d_2, 2),
+         constant_coefficient);
+
+  // Perform MV with the first object
+  do_test<fe_degree_1, n_q_points_1d_1>(
+    dof_1, mf_1, n_dofs_1, mapping_1, constraints);
+
+  // Perform MV with the second object
+  do_test<fe_degree_2, n_q_points_1d_2>(
+    dof_2, mf_2, n_dofs_2, mapping_2, constraints);
+
+  return 0;
+}

--- a/tests/cuda/matrix_free_multiple_objects.output
+++ b/tests/cuda/matrix_free_multiple_objects.output
@@ -1,0 +1,5 @@
+
+DEAL::Norm of difference: 1.57e-15
+DEAL::
+DEAL::Norm of difference: 2.37e-15
+DEAL::

--- a/tests/cuda/matrix_free_no_index_initialize.cu
+++ b/tests/cuda/matrix_free_no_index_initialize.cu
@@ -47,7 +47,7 @@ public:
     Number *                                                    dst) const
   {
     CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number>
-      fe_eval(cell, gpu_data, shared_data);
+      fe_eval(0, cell, gpu_data, shared_data);
 
     // set to unit vector
     fe_eval.submit_dof_value(1.);


### PR DESCRIPTION
The new interface is incompatible in purpose. We could have an interface that's backward compatible but that would lead to bugs hard to debug

Fixes #10214 