### PR TITLE
Adds the capacity to add properties to particle generators that use the dofs support points or the quadrature points

### DIFF
--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -210,9 +210,9 @@ namespace Particles
                        ParticleHandler<dim, spacedim> &particle_handler,
                        const Mapping<dim, spacedim> &  mapping =
                          StaticMappingQ1<dim, spacedim>::mapping,
+                       const ComponentMask &components = ComponentMask(),
                        const std::vector<std::vector<double>> &properties =
-                         std::vector<std::vector<double>>(),
-                       const ComponentMask &components = ComponentMask());
+                         std::vector<std::vector<double>>());
 
     /**
      * A function that generates particles at the locations of the quadrature

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -194,11 +194,11 @@ namespace Particles
      * @param[in] mapping An optional mapping object that is used to map
      * the DOF locations. If no mapping is provided a MappingQ1 is assumed.
      *
-     * @param[in] properties An optional vector of vector of properties
-     * for each particles to be inserted.
-     *
      * @param[in] components Component mask that decides which subset of the
      * support points of the dof_handler are used to generate the particles.
+     *
+     * @param[in] properties An optional vector of vector of properties
+     * for each particle to be inserted.
      *
      * @author Bruno Blais, Luca Heltai, 2019
      */
@@ -211,8 +211,7 @@ namespace Particles
                        const Mapping<dim, spacedim> &  mapping =
                          StaticMappingQ1<dim, spacedim>::mapping,
                        const ComponentMask &components = ComponentMask(),
-                       const std::vector<std::vector<double>> &properties =
-                         std::vector<std::vector<double>>());
+                       const std::vector<std::vector<double>> &properties = {});
 
     /**
      * A function that generates particles at the locations of the quadrature
@@ -243,7 +242,7 @@ namespace Particles
      * assumed.
      *
      * @param[in] properties An optional vector of vector of properties
-     * for each particles to be inserted.
+     * for each particle to be inserted.
      *
      * @author Bruno Blais, Luca Heltai, 2019
      */
@@ -256,8 +255,7 @@ namespace Particles
                       ParticleHandler<dim, spacedim> &particle_handler,
                       const Mapping<dim, spacedim> &  mapping =
                         StaticMappingQ1<dim, spacedim>::mapping,
-                      const std::vector<std::vector<double>> &properties =
-                        std::vector<std::vector<double>>());
+                      const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles
 

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -194,6 +194,9 @@ namespace Particles
      * @param[in] mapping An optional mapping object that is used to map
      * the DOF locations. If no mapping is provided a MappingQ1 is assumed.
      *
+     * @param[in] properties An optional vector of vector of properties
+     * for each particles to be inserted.
+     *
      * @param[in] components Component mask that decides which subset of the
      * support points of the dof_handler are used to generate the particles.
      *
@@ -207,6 +210,8 @@ namespace Particles
                        ParticleHandler<dim, spacedim> &particle_handler,
                        const Mapping<dim, spacedim> &  mapping =
                          StaticMappingQ1<dim, spacedim>::mapping,
+                       const std::vector<std::vector<double>> &properties =
+                         std::vector<std::vector<double>>(),
                        const ComponentMask &components = ComponentMask());
 
     /**
@@ -237,6 +242,9 @@ namespace Particles
      * the quadrature locations. If no mapping is provided a MappingQ1 is
      * assumed.
      *
+     * @param[in] properties An optional vector of vector of properties
+     * for each particles to be inserted.
+     *
      * @author Bruno Blais, Luca Heltai, 2019
      */
     template <int dim, int spacedim = dim>
@@ -247,7 +255,9 @@ namespace Particles
                         &                             global_bounding_boxes,
                       ParticleHandler<dim, spacedim> &particle_handler,
                       const Mapping<dim, spacedim> &  mapping =
-                        StaticMappingQ1<dim, spacedim>::mapping);
+                        StaticMappingQ1<dim, spacedim>::mapping,
+                      const std::vector<std::vector<double>> &properties =
+                        std::vector<std::vector<double>>());
   } // namespace Generators
 } // namespace Particles
 

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -409,8 +409,8 @@ namespace Particles
                          &                             global_bounding_boxes,
                        ParticleHandler<dim, spacedim> &particle_handler,
                        const Mapping<dim, spacedim> &  mapping,
-                       const std::vector<std::vector<double>> &properties,
-                       const ComponentMask &                   components)
+                       const ComponentMask &           components,
+                       const std::vector<std::vector<double>> &properties)
     {
       const auto &fe = dof_handler.get_fe();
 
@@ -471,7 +471,8 @@ namespace Particles
             }
         }
       particle_handler.insert_global_particles(points_to_generate,
-                                               global_bounding_boxes);
+                                               global_bounding_boxes,
+                                               properties);
     }
   } // namespace Generators
 } // namespace Particles

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -409,7 +409,8 @@ namespace Particles
                          &                             global_bounding_boxes,
                        ParticleHandler<dim, spacedim> &particle_handler,
                        const Mapping<dim, spacedim> &  mapping,
-                       const ComponentMask &           components)
+                       const std::vector<std::vector<double>> &properties,
+                       const ComponentMask &                   components)
     {
       const auto &fe = dof_handler.get_fe();
 
@@ -433,7 +434,8 @@ namespace Particles
         support_points_vec.push_back(element.second);
 
       particle_handler.insert_global_particles(support_points_vec,
-                                               global_bounding_boxes);
+                                               global_bounding_boxes,
+                                               properties);
     }
 
 
@@ -444,9 +446,10 @@ namespace Particles
       const Quadrature<dim> &             quadrature,
       // const std::vector<Point<dim>> &     particle_reference_locations,
       const std::vector<std::vector<BoundingBox<spacedim>>>
-        &                             global_bounding_boxes,
-      ParticleHandler<dim, spacedim> &particle_handler,
-      const Mapping<dim, spacedim> &  mapping)
+        &                                     global_bounding_boxes,
+      ParticleHandler<dim, spacedim> &        particle_handler,
+      const Mapping<dim, spacedim> &          mapping,
+      const std::vector<std::vector<double>> &properties)
     {
       const std::vector<Point<dim>> &particle_reference_locations =
         quadrature.get_points();

--- a/source/particles/generators.inst.in
+++ b/source/particles/generators.inst.in
@@ -61,8 +61,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           ParticleHandler<deal_II_dimension, deal_II_space_dimension>
             &particle_handler,
           const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping,
-          const std::vector<std::vector<double>> &                   properties,
-          const ComponentMask &components);
+          const ComponentMask &                                      components,
+          const std::vector<std::vector<double>> &properties);
 
         template void
         quadrature_points<deal_II_dimension, deal_II_space_dimension>(

--- a/source/particles/generators.inst.in
+++ b/source/particles/generators.inst.in
@@ -61,6 +61,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           ParticleHandler<deal_II_dimension, deal_II_space_dimension>
             &particle_handler,
           const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping,
+          const std::vector<std::vector<double>> &                   properties,
           const ComponentMask &components);
 
         template void
@@ -72,7 +73,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
             &global_bounding_boxes,
           ParticleHandler<deal_II_dimension, deal_II_space_dimension>
             &particle_handler,
-          const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping);
+          const Mapping<deal_II_dimension, deal_II_space_dimension> &mapping,
+          const std::vector<std::vector<double>> &properties);
 
       \}
     \}


### PR DESCRIPTION
Added the capacity to add properties to the particles that are generated using the particle generator that generates particles at support points or at gauss quadrature points.
Note that we do not check for the size of the properties and the number of particles
as this is done within insert global particles. This is a very simple pull request, but it will be required for step-68 and could actually be used to simplify step-70. Comments are more than welcomed.

@gassmoeller , this fixes the issue I had with adding the particle properties to step-68