### PR TITLE
disable using c++ 20 iota-view and always use boost

### DIFF
--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -17,11 +17,9 @@
 
 #include <deal.II/base/config.h>
 
-#ifdef DEAL_II_HAVE_CXX20
-#  include <ranges>
-#else
-#  include <boost/range/irange.hpp>
-#endif
+// For now we unconditionally use the boost implementation, even though gcc-10
+// has an implementation (which does not contain the iterator typedef):
+#include <boost/range/irange.hpp>
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -29,7 +27,6 @@ namespace std_cxx20
 {
   namespace ranges
   {
-#ifndef DEAL_II_HAVE_CXX20
     /**
      * A poor-man's implementation of std::ranges::iota_view using
      * boost's integer_range class. The two classes are not completely
@@ -44,9 +41,6 @@ namespace std_cxx20
      */
     template <typename IncrementableType, typename /*BoundType*/>
     using iota_view = boost::integer_range<IncrementableType>;
-#else
-    using std::ranges::iota_view;
-#endif
   } // namespace ranges
 } // namespace std_cxx20
 


### PR DESCRIPTION
gcc-10 does not contain the ``iterator`` typedef, which makes the usage
somewhat incompatible to what we want. For now, disable the c++20
support.

see #10426