### PR TITLE
Replace TriaObject

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1629,6 +1629,12 @@ private:
   set(const std::initializer_list<int> &o) const;
 
   /**
+   * The same as above but for `unsigned int`.
+   */
+  void
+  set(const std::initializer_list<unsigned int> &o) const;
+
+  /**
    * Set the flag indicating, what <code>line_orientation()</code> will
    * return.
    *

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -52,7 +52,6 @@ namespace internal
 {
   namespace TriangulationImplementation
   {
-    class TriaObject;
     class TriaObjects;
     struct Implementation;
   } // namespace TriangulationImplementation
@@ -1627,7 +1626,7 @@ private:
    * triangulation.
    */
   void
-  set(const dealii::internal::TriangulationImplementation::TriaObject &o) const;
+  set(const std::initializer_list<int> &o) const;
 
   /**
    * Set the flag indicating, what <code>line_orientation()</code> will

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -40,68 +40,6 @@ namespace internal
   namespace TriangulationImplementation
   {
     /**
-     * Class template for the <tt>structdim</tt>-dimensional cells
-     * constituting a dealii::Triangulation of dimension <tt>structdim</tt> or
-     * lower dimensional objects of higher dimensions.  They are characterized
-     * by the (global) indices of their faces, which are cells of dimension
-     * <tt>structdim-1</tt> or vertices if <tt>structdim=1</tt>.
-     *
-     * @note This class is only used during setup of the Triangulation and its
-     *   content is saved into a single long vector inside of `TriaObjects`.
-     *
-     * @author Guido Kanschat, 2007
-     */
-    class TriaObject
-    {
-    public:
-      /**
-       * Constructor.
-       */
-      TriaObject(const std::initializer_list<int> &faces);
-
-      /**
-       * Constructor.
-       */
-      TriaObject(const std::initializer_list<unsigned int> &faces);
-
-      /**
-       * Return the index of the ith face object.
-       */
-      int
-      face(const unsigned int i) const;
-
-      /**
-       * Set the index of the ith face object.
-       */
-      void
-      set_face(const unsigned int i, const int index);
-
-      /**
-       * Determine an estimate for the memory consumption (in bytes) of this
-       * object.
-       */
-      std::size_t
-      memory_consumption();
-
-      /**
-       * Read or write the data of this object to or from a stream for the
-       * purpose of serialization
-       */
-      template <class Archive>
-      void
-      serialize(Archive &ar, const unsigned int version);
-
-    private:
-      /**
-       * Global indices of the face iterators bounding this cell if dim@>1,
-       * and the two vertex indices in 1d.
-       */
-      std::vector<int> faces;
-
-      friend TriaObjectView;
-    };
-
-    /**
      * View onto the current geometric object and its faces.
      *
      * @note The geometric objects are not saved as separate instances of
@@ -123,12 +61,14 @@ namespace internal
        * Store the content of @p other in the vector of TriaObjects.
        */
       TriaObjectView &
-      operator=(const TriaObject &other)
+      operator=(const std::initializer_list<int> &other)
       {
-        AssertDimension(faces.size(), other.faces.size());
+        AssertDimension(faces.size(), other.size());
+
+        const std::vector<int> other_v = other;
 
         for (unsigned int i = 0; i < faces.size(); ++i)
-          faces[i] = other.faces[i];
+          faces[i] = other_v[i];
 
         return *this;
       }
@@ -157,60 +97,6 @@ namespace internal
        */
       const ArrayView<int> faces;
     };
-
-    //----------------------------------------------------------------------//
-
-
-    inline TriaObject::TriaObject(const std::initializer_list<int> &faces)
-    {
-      this->faces = faces;
-    }
-
-
-
-    inline TriaObject::TriaObject(
-      const std::initializer_list<unsigned int> &faces_in)
-    {
-      this->faces.reserve(faces_in.size());
-      for (const auto face : faces_in)
-        this->faces.push_back(face);
-    }
-
-
-
-    inline int
-    TriaObject::face(const unsigned int i) const
-    {
-      AssertIndexRange(i, faces.size());
-      return faces[i];
-    }
-
-
-
-    inline void
-    TriaObject::set_face(const unsigned int i, const int index)
-    {
-      AssertIndexRange(i, faces.size());
-      faces[i] = index;
-    }
-
-
-
-    inline std::size_t
-    TriaObject::memory_consumption()
-    {
-      return MemoryConsumption::memory_consumption(this->faces);
-    }
-
-
-    template <class Archive>
-    void
-    TriaObject::serialize(Archive &ar, const unsigned int)
-    {
-      ar &faces;
-    }
-
-
   } // namespace TriangulationImplementation
 } // namespace internal
 

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -35,7 +35,7 @@ namespace internal
      * @note The geometric objects are not saved as separate instances of
      * TriaObject but in a single vector in TriaObjects.
      */
-    class TriaObjectView
+    class TriaObject
     {
     public:
       /**
@@ -43,14 +43,14 @@ namespace internal
        *
        * @param faces ArrayView inside of the vector in TriaObjects.
        */
-      TriaObjectView(const ArrayView<int> &faces)
+      TriaObject(const ArrayView<int> &faces)
         : faces(faces)
       {}
 
       /**
        * Store the content of @p other in the vector of TriaObjects.
        */
-      TriaObjectView &
+      TriaObject &
       operator=(const std::initializer_list<int> &other)
       {
         AssertDimension(faces.size(), other.size());
@@ -66,7 +66,7 @@ namespace internal
       /**
        * The same as above but for `unsigned int`.
        */
-      TriaObjectView &
+      TriaObject &
       operator=(const std::initializer_list<unsigned int> &other)
       {
         AssertDimension(faces.size(), other.size());

--- a/include/deal.II/grid/tria_object.h
+++ b/include/deal.II/grid/tria_object.h
@@ -25,16 +25,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#ifndef DOXYGEN
-namespace internal
-{
-  namespace TriangulationImplementation
-  {
-    class TriaObjectView;
-  }
-} // namespace internal
-#endif
-
 namespace internal
 {
   namespace TriangulationImplementation
@@ -66,6 +56,22 @@ namespace internal
         AssertDimension(faces.size(), other.size());
 
         const std::vector<int> other_v = other;
+
+        for (unsigned int i = 0; i < faces.size(); ++i)
+          faces[i] = other_v[i];
+
+        return *this;
+      }
+
+      /**
+       * The same as above but for `unsigned int`.
+       */
+      TriaObjectView &
+      operator=(const std::initializer_list<unsigned int> &other)
+      {
+        AssertDimension(faces.size(), other.size());
+
+        const std::vector<unsigned int> other_v = other;
 
         for (unsigned int i = 0; i < faces.size(); ++i)
           faces[i] = other_v[i];

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -86,7 +86,7 @@ namespace internal
       /**
        * Return a view on the @p index-th geometric object.
        */
-      TriaObjectView
+      TriaObject
       get_object(const unsigned int index);
 
       /**
@@ -424,7 +424,7 @@ namespace internal
 
 
 
-    inline TriaObjectView
+    inline TriaObject
     TriaObjects::get_object(const unsigned int index)
     {
       // assume that each cell has the same number of faces

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2243,8 +2243,7 @@ namespace internal
       struct QuadComparator
       {
         inline bool
-        operator()(const std::vector<int> &q1,
-                   const std::vector<int> &q2) const
+        operator()(const std::vector<int> &q1, const std::vector<int> &q2) const
         {
           Assert(q1.size() == 4, ExcInternalError());
           Assert(q2.size() == 4, ExcInternalError());
@@ -2256,12 +2255,10 @@ namespace internal
           // compiler will probably
           // take care of most of
           // it anyway
-          if ((q1[0] < q2[0]) ||
-              ((q1[0] == q2[0]) && (q1[1] < q2[1])) ||
-              ((q1[0] == q2[0]) && (q1[1] == q2[1]) &&
-               (q1[2] < q2[2])) ||
-              ((q1[0] == q2[0]) && (q1[1] == q2[1]) &&
-               (q1[2] == q2[2]) && (q1[3] < q2[3])))
+          if ((q1[0] < q2[0]) || ((q1[0] == q2[0]) && (q1[1] < q2[1])) ||
+              ((q1[0] == q2[0]) && (q1[1] == q2[1]) && (q1[2] < q2[2])) ||
+              ((q1[0] == q2[0]) && (q1[1] == q2[1]) && (q1[2] == q2[2]) &&
+               (q1[3] < q2[3])))
             return true;
           else
             return false;
@@ -2540,10 +2537,10 @@ namespace internal
 
 
                 const std::vector<int> quad(
-                  {face_line_list[0],
-                   face_line_list[1],
-                   face_line_list[2],
-                   face_line_list[3]});
+                  {static_cast<int>(face_line_list[0]),
+                   static_cast<int>(face_line_list[1]),
+                   static_cast<int>(face_line_list[2]),
+                   static_cast<int>(face_line_list[3])});
 
                 // insert quad, with
                 // invalid iterator
@@ -2588,43 +2585,37 @@ namespace internal
                    quad[3],
                    quad[0],
                    quad[1]}), // face_orientation=false, face_flip=false,
-                                   // face_rotation=false
-                  test_quad_2(
-                    {quad[0],
-                     quad[1],
-                     quad[3],
-                     quad[2]}), // face_orientation=false, face_flip=false,
-                                     // face_rotation=true
-                  test_quad_3(
-                    {quad[3],
-                     quad[2],
-                     quad[1],
-                     quad[0]}), // face_orientation=false, face_flip=true,
-                                     // face_rotation=false
-                  test_quad_4(
-                    {quad[1],
-                     quad[0],
-                     quad[2],
-                     quad[3]}), // face_orientation=false, face_flip=true,
-                                     // face_rotation=true
-                  test_quad_5(
-                    {quad[2],
-                     quad[3],
-                     quad[1],
-                     quad[0]}), // face_orientation=true,  face_flip=false,
-                                     // face_rotation=true
-                  test_quad_6(
-                    {quad[1],
-                     quad[0],
-                     quad[3],
-                     quad[2]}), // face_orientation=true,  face_flip=true,
-                                     // face_rotation=false
-                  test_quad_7(
-                    {quad[3],
-                     quad[2],
-                     quad[0],
-                     quad[1]}); // face_orientation=true,  face_flip=true,
-                                     // face_rotation=true
+                              // face_rotation=false
+                  test_quad_2({quad[0],
+                               quad[1],
+                               quad[3],
+                               quad[2]}), // face_orientation=false,
+                                          // face_flip=false, face_rotation=true
+                  test_quad_3({quad[3],
+                               quad[2],
+                               quad[1],
+                               quad[0]}), // face_orientation=false,
+                                          // face_flip=true, face_rotation=false
+                  test_quad_4({quad[1],
+                               quad[0],
+                               quad[2],
+                               quad[3]}), // face_orientation=false,
+                                          // face_flip=true, face_rotation=true
+                  test_quad_5({quad[2],
+                               quad[3],
+                               quad[1],
+                               quad[0]}), // face_orientation=true,
+                                          // face_flip=false, face_rotation=true
+                  test_quad_6({quad[1],
+                               quad[0],
+                               quad[3],
+                               quad[2]}), // face_orientation=true,
+                                          // face_flip=true, face_rotation=false
+                  test_quad_7({quad[3],
+                               quad[2],
+                               quad[0],
+                               quad[1]}); // face_orientation=true,
+                                          // face_flip=true, face_rotation=true
                 if (needed_quads.find(test_quad_1) == needed_quads.end() &&
                     needed_quads.find(test_quad_2) == needed_quads.end() &&
                     needed_quads.find(test_quad_3) == needed_quads.end() &&
@@ -2657,7 +2648,7 @@ namespace internal
           for (q = needed_quads.begin(); quad != triangulation.end_quad();
                ++quad, ++q)
             {
-              quad->set(q->first);
+              quad->set({q->first[0], q->first[1], q->first[2], q->first[3]});
               quad->set_used_flag();
               quad->clear_user_flag();
               quad->clear_user_data();
@@ -2750,10 +2741,10 @@ namespace internal
                           ->index();
 
                   const std::vector<int> quad(
-                    {face_line_list[0],
-                     face_line_list[1],
-                     face_line_list[2],
-                     face_line_list[3]});
+                    {static_cast<int>(face_line_list[0]),
+                     static_cast<int>(face_line_list[1]),
+                     static_cast<int>(face_line_list[2]),
+                     static_cast<int>(face_line_list[3])});
 
                   if (needed_quads.find(quad) != needed_quads.end())
                     {
@@ -2783,43 +2774,43 @@ namespace internal
                          quad[3],
                          quad[0],
                          quad[1]}), // face_orientation=false,
-                                         // face_flip=false, face_rotation=false
+                                    // face_flip=false, face_rotation=false
                         test_quad_2(
                           {quad[0],
                            quad[1],
                            quad[3],
                            quad[2]}), // face_orientation=false,
-                                   // face_flip=false, face_rotation=true
+                                      // face_flip=false, face_rotation=true
                         test_quad_3(
                           {quad[3],
                            quad[2],
                            quad[1],
                            quad[0]}), // face_orientation=false,
-                                   // face_flip=true,  face_rotation=false
+                                      // face_flip=true,  face_rotation=false
                         test_quad_4(
                           {quad[1],
                            quad[0],
                            quad[2],
                            quad[3]}), // face_orientation=false,
-                                           // face_flip=true, face_rotation=true
+                                      // face_flip=true, face_rotation=true
                         test_quad_5(
                           {quad[2],
                            quad[3],
                            quad[1],
                            quad[0]}), // face_orientation=true,
-                                   // face_flip=false, face_rotation=true
+                                      // face_flip=false, face_rotation=true
                         test_quad_6(
                           {quad[1],
                            quad[0],
                            quad[3],
                            quad[2]}), // face_orientation=true,
-                                   // face_flip=true,  face_rotation=false
+                                      // face_flip=true,  face_rotation=false
                         test_quad_7(
                           {quad[3],
                            quad[2],
                            quad[0],
                            quad[1]}); // face_orientation=true,
-                                           // face_flip=true, face_rotation=true
+                                      // face_flip=true, face_rotation=true
                       if (needed_quads.find(test_quad_1) != needed_quads.end())
                         {
                           face_iterator[face] = needed_quads[test_quad_1].first;
@@ -3169,16 +3160,14 @@ namespace internal
             // and because boundary quad
             // orientation does not carry
             // any information.
-            std::vector<int> quad_compare_1(
-              {line[0]->index(),
-               line[1]->index(),
-               line[2]->index(),
-               line[3]->index()});
-            std::vector<int> quad_compare_2(
-              {line[2]->index(),
-               line[3]->index(),
-               line[0]->index(),
-               line[1]->index()});
+            std::vector<int> quad_compare_1({line[0]->index(),
+                                             line[1]->index(),
+                                             line[2]->index(),
+                                             line[3]->index()});
+            std::vector<int> quad_compare_2({line[2]->index(),
+                                             line[3]->index(),
+                                             line[0]->index(),
+                                             line[1]->index()});
 
             // try to find the quad with
             // lines situated as
@@ -3218,8 +3207,10 @@ namespace internal
                 // lexicographic ordering)
                 for (unsigned int i = 0; i < 4; ++i)
                   {
-                    quad_compare_1[i] = line_counterclock[lex2cclock[i]]->index();
-                    quad_compare_2[(i + 2) % 4] = line_counterclock[lex2cclock[i]]->index();
+                    quad_compare_1[i] =
+                      line_counterclock[lex2cclock[i]]->index();
+                    quad_compare_2[(i + 2) % 4] =
+                      line_counterclock[lex2cclock[i]]->index();
                   }
 
                 ++n_rotations;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1779,8 +1779,7 @@ namespace internal
               ++next_free_line;
 
             next_free_line->set(
-              internal::TriangulationImplementation::TriaObject(
-                {cells[cell].vertices[0], cells[cell].vertices[1]}));
+              {cells[cell].vertices[0], cells[cell].vertices[1]});
             next_free_line->set_used_flag();
             next_free_line->set_material_id(cells[cell].material_id);
             next_free_line->set_manifold_id(cells[cell].manifold_id);
@@ -2054,8 +2053,7 @@ namespace internal
           for (i = needed_lines.begin(); line != triangulation.end_line();
                ++line, ++i)
             {
-              line->set(internal::TriangulationImplementation::TriaObject(
-                {i->first.first, i->first.second}));
+              line->set({i->first.first, i->first.second});
               line->set_used_flag();
               line->clear_user_flag();
               line->clear_user_data();
@@ -2088,11 +2086,10 @@ namespace internal
                   cells[c].vertices[GeometryInfo<dim>::line_to_cell_vertices(
                     line, 1)])];
 
-              cell->set(internal::TriangulationImplementation::TriaObject(
-                {lines[0]->index(),
-                 lines[1]->index(),
-                 lines[2]->index(),
-                 lines[3]->index()}));
+              cell->set({lines[0]->index(),
+                         lines[1]->index(),
+                         lines[2]->index(),
+                         lines[3]->index()});
 
               cell->set_used_flag();
               cell->set_material_id(cells[c].material_id);
@@ -2238,21 +2235,20 @@ namespace internal
 
       /**
        * Invent an object which compares two
-       * internal::TriangulationImplementation::TriaObject against each
+       * std::initializer_list objects against each
        * other. This comparison is needed in order to establish a map of
-       * TriaObject to iterators in the
+       * vertex index tuples to iterators in the
        * Triangulation<3,3>::create_triangulation function.
-       *
-       * Since this comparison is not canonical, we do not include it into the
-       * general internal::TriangulationImplementation::TriaObject class.
        */
       struct QuadComparator
       {
         inline bool
-        operator()(
-          const internal::TriangulationImplementation::TriaObject &q1,
-          const internal::TriangulationImplementation::TriaObject &q2) const
+        operator()(const std::vector<int> &q1,
+                   const std::vector<int> &q2) const
         {
+          Assert(q1.size() == 4, ExcInternalError());
+          Assert(q2.size() == 4, ExcInternalError());
+
           // here is room to
           // optimize the repeated
           // equality test of the
@@ -2260,12 +2256,12 @@ namespace internal
           // compiler will probably
           // take care of most of
           // it anyway
-          if ((q1.face(0) < q2.face(0)) ||
-              ((q1.face(0) == q2.face(0)) && (q1.face(1) < q2.face(1))) ||
-              ((q1.face(0) == q2.face(0)) && (q1.face(1) == q2.face(1)) &&
-               (q1.face(2) < q2.face(2))) ||
-              ((q1.face(0) == q2.face(0)) && (q1.face(1) == q2.face(1)) &&
-               (q1.face(2) == q2.face(2)) && (q1.face(3) < q2.face(3))))
+          if ((q1[0] < q2[0]) ||
+              ((q1[0] == q2[0]) && (q1[1] < q2[1])) ||
+              ((q1[0] == q2[0]) && (q1[1] == q2[1]) &&
+               (q1[2] < q2[2])) ||
+              ((q1[0] == q2[0]) && (q1[1] == q2[1]) &&
+               (q1[2] == q2[2]) && (q1[3] < q2[3])))
             return true;
           else
             return false;
@@ -2434,8 +2430,7 @@ namespace internal
           for (i = needed_lines.begin(); line != triangulation.end_line();
                ++line, ++i)
             {
-              line->set(internal::TriangulationImplementation::TriaObject(
-                {i->first.first, i->first.second}));
+              line->set({i->first.first, i->first.second});
               line->set_used_flag();
               line->clear_user_flag();
               line->clear_user_data();
@@ -2461,7 +2456,7 @@ namespace internal
         // note that QuadComparator is a
         // class declared and defined in
         // this file
-        std::map<internal::TriangulationImplementation::TriaObject,
+        std::map<std::vector<int>,
                  std::pair<typename Triangulation<dim, spacedim>::quad_iterator,
                            std::array<bool, GeometryInfo<dim>::lines_per_face>>,
                  QuadComparator>
@@ -2544,7 +2539,7 @@ namespace internal
                     }
 
 
-                internal::TriangulationImplementation::TriaObject quad(
+                const std::vector<int> quad(
                   {face_line_list[0],
                    face_line_list[1],
                    face_line_list[2],
@@ -2588,48 +2583,47 @@ namespace internal
                 // new one and instead
                 // later set the
                 // face_orientation flag
-                const internal::TriangulationImplementation::TriaObject
-                  test_quad_1(
-                    {quad.face(2),
-                     quad.face(3),
-                     quad.face(0),
-                     quad.face(1)}), // face_orientation=false, face_flip=false,
-                                     // face_rotation=false
+                const std::initializer_list<int> test_quad_1(
+                  {quad[2],
+                   quad[3],
+                   quad[0],
+                   quad[1]}), // face_orientation=false, face_flip=false,
+                                   // face_rotation=false
                   test_quad_2(
-                    {quad.face(0),
-                     quad.face(1),
-                     quad.face(3),
-                     quad.face(2)}), // face_orientation=false, face_flip=false,
+                    {quad[0],
+                     quad[1],
+                     quad[3],
+                     quad[2]}), // face_orientation=false, face_flip=false,
                                      // face_rotation=true
                   test_quad_3(
-                    {quad.face(3),
-                     quad.face(2),
-                     quad.face(1),
-                     quad.face(0)}), // face_orientation=false, face_flip=true,
+                    {quad[3],
+                     quad[2],
+                     quad[1],
+                     quad[0]}), // face_orientation=false, face_flip=true,
                                      // face_rotation=false
                   test_quad_4(
-                    {quad.face(1),
-                     quad.face(0),
-                     quad.face(2),
-                     quad.face(3)}), // face_orientation=false, face_flip=true,
+                    {quad[1],
+                     quad[0],
+                     quad[2],
+                     quad[3]}), // face_orientation=false, face_flip=true,
                                      // face_rotation=true
                   test_quad_5(
-                    {quad.face(2),
-                     quad.face(3),
-                     quad.face(1),
-                     quad.face(0)}), // face_orientation=true,  face_flip=false,
+                    {quad[2],
+                     quad[3],
+                     quad[1],
+                     quad[0]}), // face_orientation=true,  face_flip=false,
                                      // face_rotation=true
                   test_quad_6(
-                    {quad.face(1),
-                     quad.face(0),
-                     quad.face(3),
-                     quad.face(2)}), // face_orientation=true,  face_flip=true,
+                    {quad[1],
+                     quad[0],
+                     quad[3],
+                     quad[2]}), // face_orientation=true,  face_flip=true,
                                      // face_rotation=false
                   test_quad_7(
-                    {quad.face(3),
-                     quad.face(2),
-                     quad.face(0),
-                     quad.face(1)}); // face_orientation=true,  face_flip=true,
+                    {quad[3],
+                     quad[2],
+                     quad[0],
+                     quad[1]}); // face_orientation=true,  face_flip=true,
                                      // face_rotation=true
                 if (needed_quads.find(test_quad_1) == needed_quads.end() &&
                     needed_quads.find(test_quad_2) == needed_quads.end() &&
@@ -2656,7 +2650,7 @@ namespace internal
           typename Triangulation<dim, spacedim>::raw_quad_iterator quad =
             triangulation.begin_raw_quad();
           typename std::map<
-            internal::TriangulationImplementation::TriaObject,
+            std::vector<int>,
             std::pair<typename Triangulation<dim, spacedim>::quad_iterator,
                       std::array<bool, GeometryInfo<dim>::lines_per_face>>,
             QuadComparator>::iterator q;
@@ -2755,7 +2749,7 @@ namespace internal
                                        dim>::face_to_cell_lines(face, l)]]
                           ->index();
 
-                  internal::TriangulationImplementation::TriaObject quad(
+                  const std::vector<int> quad(
                     {face_line_list[0],
                      face_line_list[1],
                      face_line_list[2],
@@ -2784,53 +2778,47 @@ namespace internal
                       // then. construct all
                       // possibilities and check
                       // them one after the other
-                      const internal::TriangulationImplementation::TriaObject
-                        test_quad_1(
-                          {quad.face(2),
-                           quad.face(3),
-                           quad.face(0),
-                           quad.face(
-                             1)}), // face_orientation=false,
-                                   // face_flip=false, face_rotation=false
+                      const std::initializer_list<int> test_quad_1(
+                        {quad[2],
+                         quad[3],
+                         quad[0],
+                         quad[1]}), // face_orientation=false,
+                                         // face_flip=false, face_rotation=false
                         test_quad_2(
-                          {quad.face(0),
-                           quad.face(1),
-                           quad.face(3),
-                           quad.face(
-                             2)}), // face_orientation=false,
+                          {quad[0],
+                           quad[1],
+                           quad[3],
+                           quad[2]}), // face_orientation=false,
                                    // face_flip=false, face_rotation=true
                         test_quad_3(
-                          {quad.face(3),
-                           quad.face(2),
-                           quad.face(1),
-                           quad.face(
-                             0)}), // face_orientation=false,
+                          {quad[3],
+                           quad[2],
+                           quad[1],
+                           quad[0]}), // face_orientation=false,
                                    // face_flip=true,  face_rotation=false
                         test_quad_4(
-                          {quad.face(1),
-                           quad.face(0),
-                           quad.face(2),
-                           quad.face(3)}), // face_orientation=false,
+                          {quad[1],
+                           quad[0],
+                           quad[2],
+                           quad[3]}), // face_orientation=false,
                                            // face_flip=true, face_rotation=true
                         test_quad_5(
-                          {quad.face(2),
-                           quad.face(3),
-                           quad.face(1),
-                           quad.face(
-                             0)}), // face_orientation=true,
+                          {quad[2],
+                           quad[3],
+                           quad[1],
+                           quad[0]}), // face_orientation=true,
                                    // face_flip=false, face_rotation=true
                         test_quad_6(
-                          {quad.face(1),
-                           quad.face(0),
-                           quad.face(3),
-                           quad.face(
-                             2)}), // face_orientation=true,
+                          {quad[1],
+                           quad[0],
+                           quad[3],
+                           quad[2]}), // face_orientation=true,
                                    // face_flip=true,  face_rotation=false
                         test_quad_7(
-                          {quad.face(3),
-                           quad.face(2),
-                           quad.face(0),
-                           quad.face(1)}); // face_orientation=true,
+                          {quad[3],
+                           quad[2],
+                           quad[0],
+                           quad[1]}); // face_orientation=true,
                                            // face_flip=true, face_rotation=true
                       if (needed_quads.find(test_quad_1) != needed_quads.end())
                         {
@@ -2899,13 +2887,12 @@ namespace internal
 
               // make the cell out of
               // these iterators
-              cell->set(internal::TriangulationImplementation::TriaObject(
-                {face_iterator[0]->index(),
-                 face_iterator[1]->index(),
-                 face_iterator[2]->index(),
-                 face_iterator[3]->index(),
-                 face_iterator[4]->index(),
-                 face_iterator[5]->index()}));
+              cell->set({face_iterator[0]->index(),
+                         face_iterator[1]->index(),
+                         face_iterator[2]->index(),
+                         face_iterator[3]->index(),
+                         face_iterator[4]->index(),
+                         face_iterator[5]->index()});
 
               cell->set_used_flag();
               cell->set_material_id(cells[c].material_id);
@@ -3182,12 +3169,12 @@ namespace internal
             // and because boundary quad
             // orientation does not carry
             // any information.
-            internal::TriangulationImplementation::TriaObject quad_compare_1(
+            std::vector<int> quad_compare_1(
               {line[0]->index(),
                line[1]->index(),
                line[2]->index(),
                line[3]->index()});
-            internal::TriangulationImplementation::TriaObject quad_compare_2(
+            std::vector<int> quad_compare_2(
               {line[2]->index(),
                line[3]->index(),
                line[0]->index(),
@@ -3231,10 +3218,8 @@ namespace internal
                 // lexicographic ordering)
                 for (unsigned int i = 0; i < 4; ++i)
                   {
-                    quad_compare_1.set_face(
-                      i, line_counterclock[lex2cclock[i]]->index());
-                    quad_compare_2.set_face(
-                      (i + 2) % 4, line_counterclock[lex2cclock[i]]->index());
+                    quad_compare_1[i] = line_counterclock[lex2cclock[i]]->index();
+                    quad_compare_2[(i + 2) % 4] = line_counterclock[lex2cclock[i]]->index();
                   }
 
                 ++n_rotations;
@@ -3955,12 +3940,10 @@ namespace internal
                               const bool switch_1_user_flag =
                                 switch_1->user_flag_set();
 
-                              switch_1->set(
-                                internal::TriangulationImplementation::
-                                  TriaObject({switch_2->line_index(0),
-                                              switch_2->line_index(1),
-                                              switch_2->line_index(2),
-                                              switch_2->line_index(3)}));
+                              switch_1->set({switch_2->line_index(0),
+                                             switch_2->line_index(1),
+                                             switch_2->line_index(2),
+                                             switch_2->line_index(3)});
                               switch_1->set_line_orientation(
                                 0, switch_2->line_orientation(0));
                               switch_1->set_line_orientation(
@@ -3979,12 +3962,10 @@ namespace internal
                               else
                                 switch_1->clear_user_flag();
 
-                              switch_2->set(
-                                internal::TriangulationImplementation::
-                                  TriaObject({switch_1_lines[0],
-                                              switch_1_lines[1],
-                                              switch_1_lines[2],
-                                              switch_1_lines[3]}));
+                              switch_2->set({switch_1_lines[0],
+                                             switch_1_lines[1],
+                                             switch_1_lines[2],
+                                             switch_1_lines[3]});
                               switch_2->set_line_orientation(
                                 0, switch_1_line_orientations[0]);
                               switch_2->set_line_orientation(
@@ -4419,16 +4400,10 @@ namespace internal
                 new_lines[l] = cell->line(face_no)->child(c);
             Assert(l == 8, ExcInternalError());
 
-            new_lines[8]->set(internal::TriangulationImplementation::TriaObject(
-              {new_vertices[6], new_vertices[8]}));
-            new_lines[9]->set(internal::TriangulationImplementation::TriaObject(
-              {new_vertices[8], new_vertices[7]}));
-            new_lines[10]->set(
-              internal::TriangulationImplementation::TriaObject(
-                {new_vertices[4], new_vertices[8]}));
-            new_lines[11]->set(
-              internal::TriangulationImplementation::TriaObject(
-                {new_vertices[8], new_vertices[5]}));
+            new_lines[8]->set({new_vertices[6], new_vertices[8]});
+            new_lines[9]->set({new_vertices[8], new_vertices[7]});
+            new_lines[10]->set({new_vertices[4], new_vertices[8]});
+            new_lines[11]->set({new_vertices[8], new_vertices[5]});
           }
         else if (ref_case == RefinementCase<dim>::cut_x)
           {
@@ -4443,8 +4418,7 @@ namespace internal
             new_lines[3] = cell->line(2)->child(1);
             new_lines[4] = cell->line(3)->child(0);
             new_lines[5] = cell->line(3)->child(1);
-            new_lines[6]->set(internal::TriangulationImplementation::TriaObject(
-              {new_vertices[6], new_vertices[7]}));
+            new_lines[6]->set({new_vertices[6], new_vertices[7]});
           }
         else
           {
@@ -4460,8 +4434,7 @@ namespace internal
             new_lines[3] = cell->line(1)->child(1);
             new_lines[4] = cell->line(2);
             new_lines[5] = cell->line(3);
-            new_lines[6]->set(internal::TriangulationImplementation::TriaObject(
-              {new_vertices[4], new_vertices[5]}));
+            new_lines[6]->set({new_vertices[4], new_vertices[5]});
           }
 
         for (unsigned int l = lmin; l < lmax; ++l)
@@ -4511,26 +4484,22 @@ namespace internal
             //   .-10.11-.
             //   0   8   2
             //   .-4-.-5-.
-            subcells[0]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[0]->index(),
-               new_lines[8]->index(),
-               new_lines[4]->index(),
-               new_lines[10]->index()}));
-            subcells[1]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[8]->index(),
-               new_lines[2]->index(),
-               new_lines[5]->index(),
-               new_lines[11]->index()}));
-            subcells[2]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[1]->index(),
-               new_lines[9]->index(),
-               new_lines[10]->index(),
-               new_lines[6]->index()}));
-            subcells[3]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[9]->index(),
-               new_lines[3]->index(),
-               new_lines[11]->index(),
-               new_lines[7]->index()}));
+            subcells[0]->set({new_lines[0]->index(),
+                              new_lines[8]->index(),
+                              new_lines[4]->index(),
+                              new_lines[10]->index()});
+            subcells[1]->set({new_lines[8]->index(),
+                              new_lines[2]->index(),
+                              new_lines[5]->index(),
+                              new_lines[11]->index()});
+            subcells[2]->set({new_lines[1]->index(),
+                              new_lines[9]->index(),
+                              new_lines[10]->index(),
+                              new_lines[6]->index()});
+            subcells[3]->set({new_lines[9]->index(),
+                              new_lines[3]->index(),
+                              new_lines[11]->index(),
+                              new_lines[7]->index()});
           }
         else if (ref_case == RefinementCase<dim>::cut_x)
           {
@@ -4546,16 +4515,14 @@ namespace internal
             //   0   6   1
             //   |   |   |
             //   .-2-.-3-.
-            subcells[0]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[0]->index(),
-               new_lines[6]->index(),
-               new_lines[2]->index(),
-               new_lines[4]->index()}));
-            subcells[1]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[6]->index(),
-               new_lines[1]->index(),
-               new_lines[3]->index(),
-               new_lines[5]->index()}));
+            subcells[0]->set({new_lines[0]->index(),
+                              new_lines[6]->index(),
+                              new_lines[2]->index(),
+                              new_lines[4]->index()});
+            subcells[1]->set({new_lines[6]->index(),
+                              new_lines[1]->index(),
+                              new_lines[3]->index(),
+                              new_lines[5]->index()});
           }
         else
           {
@@ -4572,16 +4539,14 @@ namespace internal
             //   .---6---.
             //   0       2
             //   .---4---.
-            subcells[0]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[0]->index(),
-               new_lines[2]->index(),
-               new_lines[4]->index(),
-               new_lines[6]->index()}));
-            subcells[1]->set(internal::TriangulationImplementation::TriaObject(
-              {new_lines[1]->index(),
-               new_lines[3]->index(),
-               new_lines[6]->index(),
-               new_lines[5]->index()}));
+            subcells[0]->set({new_lines[0]->index(),
+                              new_lines[2]->index(),
+                              new_lines[4]->index(),
+                              new_lines[6]->index()});
+            subcells[1]->set({new_lines[1]->index(),
+                              new_lines[3]->index(),
+                              new_lines[6]->index(),
+                              new_lines[5]->index()});
           }
 
         types::subdomain_id subdomainid = cell->subdomain_id();
@@ -4773,9 +4738,7 @@ namespace internal
                   // insert first child
                   cell->set_children(0, first_child->index());
                   first_child->clear_children();
-                  first_child->set(
-                    internal::TriangulationImplementation::TriaObject(
-                      {cell->vertex_index(0), next_unused_vertex}));
+                  first_child->set({cell->vertex_index(0), next_unused_vertex});
                   first_child->set_material_id(cell->material_id());
                   first_child->set_manifold_id(cell->manifold_id());
                   first_child->set_subdomain_id(subdomainid);
@@ -4825,8 +4788,7 @@ namespace internal
                   // insert second child
                   second_child->clear_children();
                   second_child->set(
-                    internal::TriangulationImplementation::TriaObject(
-                      {next_unused_vertex, cell->vertex_index(1)}));
+                    {next_unused_vertex, cell->vertex_index(1)});
                   second_child->set_neighbor(0, first_child);
                   second_child->set_material_id(cell->material_id());
                   second_child->set_manifold_id(cell->manifold_id());
@@ -5101,12 +5063,8 @@ namespace internal
                   ExcMessage(
                     "Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                children[0]->set(
-                  internal::TriangulationImplementation::TriaObject(
-                    {line->vertex_index(0), next_unused_vertex}));
-                children[1]->set(
-                  internal::TriangulationImplementation::TriaObject(
-                    {next_unused_vertex, line->vertex_index(1)}));
+                children[0]->set({line->vertex_index(0), next_unused_vertex});
+                children[1]->set({next_unused_vertex, line->vertex_index(1)});
 
                 children[0]->set_used_flag();
                 children[1]->set_used_flag();
@@ -5572,12 +5530,8 @@ namespace internal
                   ExcMessage(
                     "Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                children[0]->set(
-                  internal::TriangulationImplementation::TriaObject(
-                    {line->vertex_index(0), next_unused_vertex}));
-                children[1]->set(
-                  internal::TriangulationImplementation::TriaObject(
-                    {next_unused_vertex, line->vertex_index(1)}));
+                children[0]->set({line->vertex_index(0), next_unused_vertex});
+                children[1]->set({next_unused_vertex, line->vertex_index(1)});
 
                 children[0]->set_used_flag();
                 children[1]->set_used_flag();
@@ -5711,9 +5665,7 @@ namespace internal
                           quad->line(1)->child(0)->vertex_index(1);
                       }
 
-                    new_line->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {vertex_indices[0], vertex_indices[1]}));
+                    new_line->set({vertex_indices[0], vertex_indices[1]});
                     new_line->set_used_flag();
                     new_line->clear_user_flag();
                     new_line->clear_user_data();
@@ -5756,48 +5708,44 @@ namespace internal
                     if (aniso_quad_ref_case == RefinementCase<dim - 1>::cut_x)
                       {
                         new_quads[0]->set(
-                          internal::TriangulationImplementation::TriaObject(
-                            {static_cast<int>(quad->line_index(0)),
-                             new_line->index(),
-                             quad->line(2)
-                               ->child(index[0][quad->line_orientation(2)])
-                               ->index(),
-                             quad->line(3)
-                               ->child(index[0][quad->line_orientation(3)])
-                               ->index()}));
+                          {static_cast<int>(quad->line_index(0)),
+                           new_line->index(),
+                           quad->line(2)
+                             ->child(index[0][quad->line_orientation(2)])
+                             ->index(),
+                           quad->line(3)
+                             ->child(index[0][quad->line_orientation(3)])
+                             ->index()});
                         new_quads[1]->set(
-                          internal::TriangulationImplementation::TriaObject(
-                            {new_line->index(),
-                             static_cast<int>(quad->line_index(1)),
-                             quad->line(2)
-                               ->child(index[1][quad->line_orientation(2)])
-                               ->index(),
-                             quad->line(3)
-                               ->child(index[1][quad->line_orientation(3)])
-                               ->index()}));
+                          {new_line->index(),
+                           static_cast<int>(quad->line_index(1)),
+                           quad->line(2)
+                             ->child(index[1][quad->line_orientation(2)])
+                             ->index(),
+                           quad->line(3)
+                             ->child(index[1][quad->line_orientation(3)])
+                             ->index()});
                       }
                     else
                       {
                         new_quads[0]->set(
-                          internal::TriangulationImplementation::TriaObject(
-                            {quad->line(0)
-                               ->child(index[0][quad->line_orientation(0)])
-                               ->index(),
-                             quad->line(1)
-                               ->child(index[0][quad->line_orientation(1)])
-                               ->index(),
-                             static_cast<int>(quad->line_index(2)),
-                             new_line->index()}));
+                          {quad->line(0)
+                             ->child(index[0][quad->line_orientation(0)])
+                             ->index(),
+                           quad->line(1)
+                             ->child(index[0][quad->line_orientation(1)])
+                             ->index(),
+                           static_cast<int>(quad->line_index(2)),
+                           new_line->index()});
                         new_quads[1]->set(
-                          internal::TriangulationImplementation::TriaObject(
-                            {quad->line(0)
-                               ->child(index[1][quad->line_orientation(0)])
-                               ->index(),
-                             quad->line(1)
-                               ->child(index[1][quad->line_orientation(1)])
-                               ->index(),
-                             new_line->index(),
-                             static_cast<int>(quad->line_index(3))}));
+                          {quad->line(0)
+                             ->child(index[1][quad->line_orientation(0)])
+                             ->index(),
+                           quad->line(1)
+                             ->child(index[1][quad->line_orientation(1)])
+                             ->index(),
+                           new_line->index(),
+                           static_cast<int>(quad->line_index(3))});
                       }
 
                     for (const auto &new_quad : new_quads)
@@ -5935,10 +5883,8 @@ namespace internal
                                        ExcInternalError());
 
                                 new_child[i]->set(
-                                  internal::TriangulationImplementation::
-                                    TriaObject(
-                                      {old_child[i]->vertex_index(0),
-                                       old_child[i]->vertex_index(1)}));
+                                  {old_child[i]->vertex_index(0),
+                                   old_child[i]->vertex_index(1)});
                                 new_child[i]->set_boundary_id_internal(
                                   old_child[i]->boundary_id());
                                 new_child[i]->set_manifold_id(
@@ -6061,12 +6007,10 @@ namespace internal
                                  switch_1->child_index(2) :
                                  -1);
 
-                            switch_1->set(
-                              internal::TriangulationImplementation::TriaObject(
-                                {switch_2->line_index(0),
-                                 switch_2->line_index(1),
-                                 switch_2->line_index(2),
-                                 switch_2->line_index(3)}));
+                            switch_1->set({switch_2->line_index(0),
+                                           switch_2->line_index(1),
+                                           switch_2->line_index(2),
+                                           switch_2->line_index(3)});
                             switch_1->set_line_orientation(
                               0, switch_2->line_orientation(0));
                             switch_1->set_line_orientation(
@@ -6095,12 +6039,10 @@ namespace internal
                               switch_1->set_children(2,
                                                      switch_2->child_index(2));
 
-                            switch_2->set(
-                              internal::TriangulationImplementation::TriaObject(
-                                {switch_1_lines[0],
-                                 switch_1_lines[1],
-                                 switch_1_lines[2],
-                                 switch_1_lines[3]}));
+                            switch_2->set({switch_1_lines[0],
+                                           switch_1_lines[1],
+                                           switch_1_lines[2],
+                                           switch_1_lines[3]});
                             switch_2->set_line_orientation(
                               0, switch_1_line_orientations[0]);
                             switch_2->set_line_orientation(
@@ -6248,14 +6190,10 @@ namespace internal
                               ExcMessage(
                                 "Internal error: We want to use a cell during refinement that should be unused, but turns out not to be."));
 
-                            children[0]->set(
-                              internal::TriangulationImplementation::TriaObject(
-                                {middle_line->vertex_index(0),
-                                 next_unused_vertex}));
-                            children[1]->set(
-                              internal::TriangulationImplementation::TriaObject(
-                                {next_unused_vertex,
-                                 middle_line->vertex_index(1)}));
+                            children[0]->set({middle_line->vertex_index(0),
+                                              next_unused_vertex});
+                            children[1]->set({next_unused_vertex,
+                                              middle_line->vertex_index(1)});
 
                             children[0]->set_used_flag();
                             children[1]->set_used_flag();
@@ -6365,18 +6303,10 @@ namespace internal
                       quad->line(3)->child(0)->vertex_index(1),
                       next_unused_vertex};
 
-                    new_lines[0]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {vertex_indices[2], vertex_indices[4]}));
-                    new_lines[1]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {vertex_indices[4], vertex_indices[3]}));
-                    new_lines[2]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {vertex_indices[0], vertex_indices[4]}));
-                    new_lines[3]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {vertex_indices[4], vertex_indices[1]}));
+                    new_lines[0]->set({vertex_indices[2], vertex_indices[4]});
+                    new_lines[1]->set({vertex_indices[4], vertex_indices[3]});
+                    new_lines[2]->set({vertex_indices[0], vertex_indices[4]});
+                    new_lines[3]->set({vertex_indices[4], vertex_indices[1]});
 
                     for (const auto &new_line : new_lines)
                       {
@@ -6480,39 +6410,29 @@ namespace internal
                     // note these quads as children to the present one
                     quad->set_children(0, new_quads[0]->index());
                     quad->set_children(2, new_quads[2]->index());
-                    new_quads[0]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {line_indices[0],
-                         line_indices[8],
-                         line_indices[4],
-                         line_indices[10]}));
+                    new_quads[0]->set({line_indices[0],
+                                       line_indices[8],
+                                       line_indices[4],
+                                       line_indices[10]});
 
                     quad->set_refinement_case(RefinementCase<2>::cut_xy);
 
-                    new_quads[0]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {line_indices[0],
-                         line_indices[8],
-                         line_indices[4],
-                         line_indices[10]}));
-                    new_quads[1]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {line_indices[8],
-                         line_indices[2],
-                         line_indices[5],
-                         line_indices[11]}));
-                    new_quads[2]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {line_indices[1],
-                         line_indices[9],
-                         line_indices[10],
-                         line_indices[6]}));
-                    new_quads[3]->set(
-                      internal::TriangulationImplementation::TriaObject(
-                        {line_indices[9],
-                         line_indices[3],
-                         line_indices[11],
-                         line_indices[7]}));
+                    new_quads[0]->set({line_indices[0],
+                                       line_indices[8],
+                                       line_indices[4],
+                                       line_indices[10]});
+                    new_quads[1]->set({line_indices[8],
+                                       line_indices[2],
+                                       line_indices[5],
+                                       line_indices[11]});
+                    new_quads[2]->set({line_indices[1],
+                                       line_indices[9],
+                                       line_indices[10],
+                                       line_indices[6]});
+                    new_quads[3]->set({line_indices[9],
+                                       line_indices[3],
+                                       line_indices[11],
+                                       line_indices[7]});
                     for (const auto &new_quad : new_quads)
                       {
                         new_quad->set_used_flag();
@@ -6925,12 +6845,10 @@ namespace internal
 
                           // set up the new quad, line numbering is as
                           // indicated above
-                          new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[0],
-                               line_indices[1],
-                               line_indices[2],
-                               line_indices[3]}));
+                          new_quads[0]->set({line_indices[0],
+                                             line_indices[1],
+                                             line_indices[2],
+                                             line_indices[3]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[0]);
@@ -7013,22 +6931,18 @@ namespace internal
 
                           };
 
-                          new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[1],
-                               quad_indices[0],
-                               quad_indices[3],
-                               quad_indices[5],
-                               quad_indices[7],
-                               quad_indices[9]}));
-                          new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[0],
-                               quad_indices[2],
-                               quad_indices[4],
-                               quad_indices[6],
-                               quad_indices[8],
-                               quad_indices[10]}));
+                          new_hexes[0]->set({quad_indices[1],
+                                             quad_indices[0],
+                                             quad_indices[3],
+                                             quad_indices[5],
+                                             quad_indices[7],
+                                             quad_indices[9]});
+                          new_hexes[1]->set({quad_indices[0],
+                                             quad_indices[2],
+                                             quad_indices[4],
+                                             quad_indices[6],
+                                             quad_indices[8],
+                                             quad_indices[10]});
                           break;
                         }
 
@@ -7154,12 +7068,10 @@ namespace internal
 
                           // set up the new quad, line numbering is as
                           // indicated above
-                          new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[2],
-                               line_indices[3],
-                               line_indices[0],
-                               line_indices[1]}));
+                          new_quads[0]->set({line_indices[2],
+                                             line_indices[3],
+                                             line_indices[0],
+                                             line_indices[1]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[2]);
@@ -7242,22 +7154,18 @@ namespace internal
 
                           };
 
-                          new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[1],
-                               quad_indices[3],
-                               quad_indices[5],
-                               quad_indices[0],
-                               quad_indices[7],
-                               quad_indices[9]}));
-                          new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[2],
-                               quad_indices[4],
-                               quad_indices[0],
-                               quad_indices[6],
-                               quad_indices[8],
-                               quad_indices[10]}));
+                          new_hexes[0]->set({quad_indices[1],
+                                             quad_indices[3],
+                                             quad_indices[5],
+                                             quad_indices[0],
+                                             quad_indices[7],
+                                             quad_indices[9]});
+                          new_hexes[1]->set({quad_indices[2],
+                                             quad_indices[4],
+                                             quad_indices[0],
+                                             quad_indices[6],
+                                             quad_indices[8],
+                                             quad_indices[10]});
                           break;
                         }
 
@@ -7385,12 +7293,10 @@ namespace internal
 
                           // set up the new quad, line numbering is as
                           // indicated above
-                          new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[0],
-                               line_indices[1],
-                               line_indices[2],
-                               line_indices[3]}));
+                          new_quads[0]->set({line_indices[0],
+                                             line_indices[1],
+                                             line_indices[2],
+                                             line_indices[3]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[0]);
@@ -7473,22 +7379,18 @@ namespace internal
                             hex->face(5)->index() // 10
                           };
 
-                          new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[1],
-                               quad_indices[3],
-                               quad_indices[5],
-                               quad_indices[7],
-                               quad_indices[9],
-                               quad_indices[0]}));
-                          new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[2],
-                               quad_indices[4],
-                               quad_indices[6],
-                               quad_indices[8],
-                               quad_indices[0],
-                               quad_indices[10]}));
+                          new_hexes[0]->set({quad_indices[1],
+                                             quad_indices[3],
+                                             quad_indices[5],
+                                             quad_indices[7],
+                                             quad_indices[9],
+                                             quad_indices[0]});
+                          new_hexes[1]->set({quad_indices[2],
+                                             quad_indices[4],
+                                             quad_indices[6],
+                                             quad_indices[8],
+                                             quad_indices[0],
+                                             quad_indices[10]});
                           break;
                         }
 
@@ -7515,10 +7417,8 @@ namespace internal
 
                           // first, create the new internal line
                           new_lines[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {middle_vertex_index<dim, spacedim>(hex->face(4)),
-                               middle_vertex_index<dim, spacedim>(
-                                 hex->face(5))}));
+                            {middle_vertex_index<dim, spacedim>(hex->face(4)),
+                             middle_vertex_index<dim, spacedim>(hex->face(5))});
 
                           // again, first collect some data about the
                           // indices of the lines, with the following
@@ -7753,30 +7653,22 @@ namespace internal
                           //  |   |   |      |   |   |
                           //  *---*---*y     *-6-*-7-*
 
-                          new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[2],
-                               line_indices[12],
-                               line_indices[4],
-                               line_indices[8]}));
-                          new_quads[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[12],
-                               line_indices[3],
-                               line_indices[5],
-                               line_indices[9]}));
-                          new_quads[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[6],
-                               line_indices[10],
-                               line_indices[0],
-                               line_indices[12]}));
-                          new_quads[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[7],
-                               line_indices[11],
-                               line_indices[12],
-                               line_indices[1]}));
+                          new_quads[0]->set({line_indices[2],
+                                             line_indices[12],
+                                             line_indices[4],
+                                             line_indices[8]});
+                          new_quads[1]->set({line_indices[12],
+                                             line_indices[3],
+                                             line_indices[5],
+                                             line_indices[9]});
+                          new_quads[2]->set({line_indices[6],
+                                             line_indices[10],
+                                             line_indices[0],
+                                             line_indices[12]});
+                          new_quads[3]->set({line_indices[7],
+                                             line_indices[11],
+                                             line_indices[12],
+                                             line_indices[1]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[2]);
@@ -7901,38 +7793,30 @@ namespace internal
                               GeometryInfo<dim>::standard_to_real_face_vertex(
                                 3, f_or[5], f_fl[5], f_ro[5]))};
 
-                          new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[4],
-                               quad_indices[0],
-                               quad_indices[8],
-                               quad_indices[2],
-                               quad_indices[12],
-                               quad_indices[16]}));
-                          new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[0],
-                               quad_indices[6],
-                               quad_indices[9],
-                               quad_indices[3],
-                               quad_indices[13],
-                               quad_indices[17]}));
-                          new_hexes[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[5],
-                               quad_indices[1],
-                               quad_indices[2],
-                               quad_indices[10],
-                               quad_indices[14],
-                               quad_indices[18]}));
-                          new_hexes[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[1],
-                               quad_indices[7],
-                               quad_indices[3],
-                               quad_indices[11],
-                               quad_indices[15],
-                               quad_indices[19]}));
+                          new_hexes[0]->set({quad_indices[4],
+                                             quad_indices[0],
+                                             quad_indices[8],
+                                             quad_indices[2],
+                                             quad_indices[12],
+                                             quad_indices[16]});
+                          new_hexes[1]->set({quad_indices[0],
+                                             quad_indices[6],
+                                             quad_indices[9],
+                                             quad_indices[3],
+                                             quad_indices[13],
+                                             quad_indices[17]});
+                          new_hexes[2]->set({quad_indices[5],
+                                             quad_indices[1],
+                                             quad_indices[2],
+                                             quad_indices[10],
+                                             quad_indices[14],
+                                             quad_indices[18]});
+                          new_hexes[3]->set({quad_indices[1],
+                                             quad_indices[7],
+                                             quad_indices[3],
+                                             quad_indices[11],
+                                             quad_indices[15],
+                                             quad_indices[19]});
                           break;
                         }
 
@@ -7959,10 +7843,8 @@ namespace internal
 
                           // first, create the new internal line
                           new_lines[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {middle_vertex_index<dim, spacedim>(hex->face(2)),
-                               middle_vertex_index<dim, spacedim>(
-                                 hex->face(3))}));
+                            {middle_vertex_index<dim, spacedim>(hex->face(2)),
+                             middle_vertex_index<dim, spacedim>(hex->face(3))});
 
                           // again, first collect some data about the
                           // indices of the lines, with the following
@@ -8197,30 +8079,22 @@ namespace internal
                           //   /    /    /      /    /    /
                           //  *----*----*x     *--6-*--7-*
 
-                          new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[0],
-                               line_indices[12],
-                               line_indices[6],
-                               line_indices[10]}));
-                          new_quads[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[12],
-                               line_indices[1],
-                               line_indices[7],
-                               line_indices[11]}));
-                          new_quads[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[4],
-                               line_indices[8],
-                               line_indices[2],
-                               line_indices[12]}));
-                          new_quads[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[5],
-                               line_indices[9],
-                               line_indices[12],
-                               line_indices[3]}));
+                          new_quads[0]->set({line_indices[0],
+                                             line_indices[12],
+                                             line_indices[6],
+                                             line_indices[10]});
+                          new_quads[1]->set({line_indices[12],
+                                             line_indices[1],
+                                             line_indices[7],
+                                             line_indices[11]});
+                          new_quads[2]->set({line_indices[4],
+                                             line_indices[8],
+                                             line_indices[2],
+                                             line_indices[12]});
+                          new_quads[3]->set({line_indices[5],
+                                             line_indices[9],
+                                             line_indices[12],
+                                             line_indices[3]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[0]);
@@ -8355,38 +8229,30 @@ namespace internal
                           // *---*---*
                           // | 0 | 2 |
                           // *---*---*
-                          new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[4],
-                               quad_indices[2],
-                               quad_indices[8],
-                               quad_indices[12],
-                               quad_indices[16],
-                               quad_indices[0]}));
-                          new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[5],
-                               quad_indices[3],
-                               quad_indices[9],
-                               quad_indices[13],
-                               quad_indices[0],
-                               quad_indices[18]}));
-                          new_hexes[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[2],
-                               quad_indices[6],
-                               quad_indices[10],
-                               quad_indices[14],
-                               quad_indices[17],
-                               quad_indices[1]}));
-                          new_hexes[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[3],
-                               quad_indices[7],
-                               quad_indices[11],
-                               quad_indices[15],
-                               quad_indices[1],
-                               quad_indices[19]}));
+                          new_hexes[0]->set({quad_indices[4],
+                                             quad_indices[2],
+                                             quad_indices[8],
+                                             quad_indices[12],
+                                             quad_indices[16],
+                                             quad_indices[0]});
+                          new_hexes[1]->set({quad_indices[5],
+                                             quad_indices[3],
+                                             quad_indices[9],
+                                             quad_indices[13],
+                                             quad_indices[0],
+                                             quad_indices[18]});
+                          new_hexes[2]->set({quad_indices[2],
+                                             quad_indices[6],
+                                             quad_indices[10],
+                                             quad_indices[14],
+                                             quad_indices[17],
+                                             quad_indices[1]});
+                          new_hexes[3]->set({quad_indices[3],
+                                             quad_indices[7],
+                                             quad_indices[11],
+                                             quad_indices[15],
+                                             quad_indices[1],
+                                             quad_indices[19]});
                           break;
                         }
 
@@ -8414,10 +8280,9 @@ namespace internal
                           // first, create the new
                           // internal line
                           new_lines[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {middle_vertex_index<dim, spacedim>(hex->face(0)),
-                               middle_vertex_index<dim, spacedim>(
-                                 hex->face(1))}));
+
+                            {middle_vertex_index<dim, spacedim>(hex->face(0)),
+                             middle_vertex_index<dim, spacedim>(hex->face(1))});
 
                           // again, first collect some data about the
                           // indices of the lines, with the following
@@ -8649,29 +8514,29 @@ namespace internal
                           //  *---------*x     *----0----*
 
                           new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[6],
-                               line_indices[10],
-                               line_indices[0],
-                               line_indices[12]}));
+
+                            {line_indices[6],
+                             line_indices[10],
+                             line_indices[0],
+                             line_indices[12]});
                           new_quads[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[7],
-                               line_indices[11],
-                               line_indices[12],
-                               line_indices[1]}));
+
+                            {line_indices[7],
+                             line_indices[11],
+                             line_indices[12],
+                             line_indices[1]});
                           new_quads[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[2],
-                               line_indices[12],
-                               line_indices[4],
-                               line_indices[8]}));
+
+                            {line_indices[2],
+                             line_indices[12],
+                             line_indices[4],
+                             line_indices[8]});
                           new_quads[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[12],
-                               line_indices[3],
-                               line_indices[5],
-                               line_indices[9]}));
+
+                            {line_indices[12],
+                             line_indices[3],
+                             line_indices[5],
+                             line_indices[9]});
 
                           new_quads[0]->set_line_orientation(
                             0, line_orientation[6]);
@@ -8798,37 +8663,37 @@ namespace internal
                                               1][f_fl[5]][f_ro[5]])};
 
                           new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[4],
-                               quad_indices[8],
-                               quad_indices[12],
-                               quad_indices[2],
-                               quad_indices[16],
-                               quad_indices[0]}));
+
+                            {quad_indices[4],
+                             quad_indices[8],
+                             quad_indices[12],
+                             quad_indices[2],
+                             quad_indices[16],
+                             quad_indices[0]});
                           new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[5],
-                               quad_indices[9],
-                               quad_indices[2],
-                               quad_indices[14],
-                               quad_indices[17],
-                               quad_indices[1]}));
+
+                            {quad_indices[5],
+                             quad_indices[9],
+                             quad_indices[2],
+                             quad_indices[14],
+                             quad_indices[17],
+                             quad_indices[1]});
                           new_hexes[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[6],
-                               quad_indices[10],
-                               quad_indices[13],
-                               quad_indices[3],
-                               quad_indices[0],
-                               quad_indices[18]}));
+
+                            {quad_indices[6],
+                             quad_indices[10],
+                             quad_indices[13],
+                             quad_indices[3],
+                             quad_indices[0],
+                             quad_indices[18]});
                           new_hexes[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[7],
-                               quad_indices[11],
-                               quad_indices[3],
-                               quad_indices[15],
-                               quad_indices[1],
-                               quad_indices[19]}));
+
+                            {quad_indices[7],
+                             quad_indices[11],
+                             quad_indices[3],
+                             quad_indices[15],
+                             quad_indices[1],
+                             quad_indices[19]});
                           break;
                         }
 
@@ -8906,23 +8771,23 @@ namespace internal
                             next_unused_vertex};
 
                           new_lines[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[2], vertex_indices[6]}));
+
+                            {vertex_indices[2], vertex_indices[6]});
                           new_lines[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[6], vertex_indices[3]}));
+
+                            {vertex_indices[6], vertex_indices[3]});
                           new_lines[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[0], vertex_indices[6]}));
+
+                            {vertex_indices[0], vertex_indices[6]});
                           new_lines[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[6], vertex_indices[1]}));
+
+                            {vertex_indices[6], vertex_indices[1]});
                           new_lines[4]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[4], vertex_indices[6]}));
+
+                            {vertex_indices[4], vertex_indices[6]});
                           new_lines[5]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {vertex_indices[6], vertex_indices[5]}));
+
+                            {vertex_indices[6], vertex_indices[5]});
 
                           // again, first collect some data about the
                           // indices of the lines, with the following
@@ -9241,77 +9106,77 @@ namespace internal
                           //  *----*----*x     *--8-*--9-*
 
                           new_quads[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[10],
-                               line_indices[28],
-                               line_indices[16],
-                               line_indices[24]}));
+
+                            {line_indices[10],
+                             line_indices[28],
+                             line_indices[16],
+                             line_indices[24]});
                           new_quads[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[28],
-                               line_indices[14],
-                               line_indices[17],
-                               line_indices[25]}));
+
+                            {line_indices[28],
+                             line_indices[14],
+                             line_indices[17],
+                             line_indices[25]});
                           new_quads[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[11],
-                               line_indices[29],
-                               line_indices[24],
-                               line_indices[20]}));
+
+                            {line_indices[11],
+                             line_indices[29],
+                             line_indices[24],
+                             line_indices[20]});
                           new_quads[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[29],
-                               line_indices[15],
-                               line_indices[25],
-                               line_indices[21]}));
+
+                            {line_indices[29],
+                             line_indices[15],
+                             line_indices[25],
+                             line_indices[21]});
                           new_quads[4]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[18],
-                               line_indices[26],
-                               line_indices[0],
-                               line_indices[28]}));
+
+                            {line_indices[18],
+                             line_indices[26],
+                             line_indices[0],
+                             line_indices[28]});
                           new_quads[5]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[26],
-                               line_indices[22],
-                               line_indices[1],
-                               line_indices[29]}));
+
+                            {line_indices[26],
+                             line_indices[22],
+                             line_indices[1],
+                             line_indices[29]});
                           new_quads[6]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[19],
-                               line_indices[27],
-                               line_indices[28],
-                               line_indices[4]}));
+
+                            {line_indices[19],
+                             line_indices[27],
+                             line_indices[28],
+                             line_indices[4]});
                           new_quads[7]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[27],
-                               line_indices[23],
-                               line_indices[29],
-                               line_indices[5]}));
+
+                            {line_indices[27],
+                             line_indices[23],
+                             line_indices[29],
+                             line_indices[5]});
                           new_quads[8]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[2],
-                               line_indices[24],
-                               line_indices[8],
-                               line_indices[26]}));
+
+                            {line_indices[2],
+                             line_indices[24],
+                             line_indices[8],
+                             line_indices[26]});
                           new_quads[9]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[24],
-                               line_indices[6],
-                               line_indices[9],
-                               line_indices[27]}));
+
+                            {line_indices[24],
+                             line_indices[6],
+                             line_indices[9],
+                             line_indices[27]});
                           new_quads[10]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[3],
-                               line_indices[25],
-                               line_indices[26],
-                               line_indices[12]}));
+
+                            {line_indices[3],
+                             line_indices[25],
+                             line_indices[26],
+                             line_indices[12]});
                           new_quads[11]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {line_indices[25],
-                               line_indices[7],
-                               line_indices[27],
-                               line_indices[13]}));
+
+                            {line_indices[25],
+                             line_indices[7],
+                             line_indices[27],
+                             line_indices[13]});
 
                           // now reset the line_orientation flags of outer
                           // lines as they cannot be set in a loop (at
@@ -9509,71 +9374,71 @@ namespace internal
 
                           // bottom children
                           new_hexes[0]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[12],
-                               quad_indices[0],
-                               quad_indices[20],
-                               quad_indices[4],
-                               quad_indices[28],
-                               quad_indices[8]}));
+
+                            {quad_indices[12],
+                             quad_indices[0],
+                             quad_indices[20],
+                             quad_indices[4],
+                             quad_indices[28],
+                             quad_indices[8]});
                           new_hexes[1]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[0],
-                               quad_indices[16],
-                               quad_indices[22],
-                               quad_indices[6],
-                               quad_indices[29],
-                               quad_indices[9]}));
+
+                            {quad_indices[0],
+                             quad_indices[16],
+                             quad_indices[22],
+                             quad_indices[6],
+                             quad_indices[29],
+                             quad_indices[9]});
                           new_hexes[2]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[13],
-                               quad_indices[1],
-                               quad_indices[4],
-                               quad_indices[24],
-                               quad_indices[30],
-                               quad_indices[10]}));
+
+                            {quad_indices[13],
+                             quad_indices[1],
+                             quad_indices[4],
+                             quad_indices[24],
+                             quad_indices[30],
+                             quad_indices[10]});
                           new_hexes[3]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[1],
-                               quad_indices[17],
-                               quad_indices[6],
-                               quad_indices[26],
-                               quad_indices[31],
-                               quad_indices[11]}));
+
+                            {quad_indices[1],
+                             quad_indices[17],
+                             quad_indices[6],
+                             quad_indices[26],
+                             quad_indices[31],
+                             quad_indices[11]});
 
                           // top children
                           new_hexes[4]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[14],
-                               quad_indices[2],
-                               quad_indices[21],
-                               quad_indices[5],
-                               quad_indices[8],
-                               quad_indices[32]}));
+
+                            {quad_indices[14],
+                             quad_indices[2],
+                             quad_indices[21],
+                             quad_indices[5],
+                             quad_indices[8],
+                             quad_indices[32]});
                           new_hexes[5]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[2],
-                               quad_indices[18],
-                               quad_indices[23],
-                               quad_indices[7],
-                               quad_indices[9],
-                               quad_indices[33]}));
+
+                            {quad_indices[2],
+                             quad_indices[18],
+                             quad_indices[23],
+                             quad_indices[7],
+                             quad_indices[9],
+                             quad_indices[33]});
                           new_hexes[6]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[15],
-                               quad_indices[3],
-                               quad_indices[5],
-                               quad_indices[25],
-                               quad_indices[10],
-                               quad_indices[34]}));
+
+                            {quad_indices[15],
+                             quad_indices[3],
+                             quad_indices[5],
+                             quad_indices[25],
+                             quad_indices[10],
+                             quad_indices[34]});
                           new_hexes[7]->set(
-                            internal::TriangulationImplementation::TriaObject(
-                              {quad_indices[3],
-                               quad_indices[19],
-                               quad_indices[7],
-                               quad_indices[27],
-                               quad_indices[11],
-                               quad_indices[35]}));
+
+                            {quad_indices[3],
+                             quad_indices[19],
+                             quad_indices[7],
+                             quad_indices[27],
+                             quad_indices[11],
+                             quad_indices[35]});
                           break;
                         }
                       default:

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1497,6 +1497,16 @@ TriaAccessor<structdim, dim, spacedim>::set(
 
 
 template <int structdim, int dim, int spacedim>
+void
+TriaAccessor<structdim, dim, spacedim>::set(
+  const std::initializer_list<unsigned int> &object) const
+{
+  this->objects().get_object(this->present_index) = object;
+}
+
+
+
+template <int structdim, int dim, int spacedim>
 Point<spacedim>
 TriaAccessor<structdim, dim, spacedim>::barycenter() const
 {

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1489,7 +1489,7 @@ const unsigned int
 template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::set(
-  const internal::TriangulationImplementation::TriaObject &object) const
+  const std::initializer_list<int> &object) const
 {
   this->objects().get_object(this->present_index) = object;
 }


### PR DESCRIPTION
This PR removes the old `TriaObject`, replaces its usage by the use of `std::initializer_list`, and renames `TriaObjectView` to `TriaObject`.

@bangerth Thanks for working on this! You were already at 95%! 