### PR TITLE
Revert "disable using c++ 20 iota-view and always use boost"

### DIFF
--- a/include/deal.II/base/std_cxx20/iota_view.h
+++ b/include/deal.II/base/std_cxx20/iota_view.h
@@ -17,9 +17,11 @@
 
 #include <deal.II/base/config.h>
 
-// For now we unconditionally use the boost implementation, even though gcc-10
-// has an implementation (which does not contain the iterator typedef):
-#include <boost/range/irange.hpp>
+#ifdef DEAL_II_HAVE_CXX20
+#  include <ranges>
+#else
+#  include <boost/range/irange.hpp>
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -27,6 +29,7 @@ namespace std_cxx20
 {
   namespace ranges
   {
+#ifndef DEAL_II_HAVE_CXX20
     /**
      * A poor-man's implementation of std::ranges::iota_view using
      * boost's integer_range class. The two classes are not completely
@@ -41,6 +44,9 @@ namespace std_cxx20
      */
     template <typename IncrementableType, typename /*BoundType*/>
     using iota_view = boost::integer_range<IncrementableType>;
+#else
+    using std::ranges::iota_view;
+#endif
   } // namespace ranges
 } // namespace std_cxx20
 


### PR DESCRIPTION
As I commented in https://github.com/dealii/dealii/pull/10432#issuecomment-636555712, I believe it is correct that `std::ranges::iota_view` is fully implemented in `gcc-10` and in particular that `std::ranges::iota_view::iterator` is not required to exist (and we don't use it anymore).
To make sure that the wrapper is indeed forward-compatible we should try to use the C++20 feature if we can.