### PR TITLE
Introduce internal::TriangulationImplementation::Policy

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -90,6 +90,9 @@ namespace internal
 
     class TriaObjects;
 
+    template <int, int>
+    class Policy;
+
     /**
      * Forward declaration of a class into which we put much of the
      * implementation of the Triangulation class. See the .cc file for more
@@ -3502,6 +3505,14 @@ protected:
 
 
 private:
+  /**
+   * Policy with the Triangulation-specific tasks related to creation,
+   * refinement, and coarsening.
+   */
+  std::unique_ptr<
+    dealii::internal::TriangulationImplementation::Policy<dim, spacedim>>
+    policy;
+
   /**
    * If add_periodicity() is called, this variable stores the given periodic
    * face pairs on level 0 for later access during the identification of ghost


### PR DESCRIPTION
This PR adds a `Policy` to `Triangulation`. The policy encapsulates the dimension- and triangulation type-dependent way to create a triangulation, to refine it and to coarsen it. 

This change enables to switch the policy during run-time. See: 

https://github.com/dealii/dealii/blob/688377740bff862a0de9e380c33b52f706ff5bd0/source/grid/tria.cc#L11261-L11281

The reason why this PR is so long is that it is not possible to make templated methods virtual.

What exactly will be part of the policy is open and will be probably extended/refined during the next weeks. This should not be a problem since the policy is not visible to the user.

Locally, the tests pass.