### PR TITLE
Fix implicit capture warning in step-32

### DIFF
--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2692,9 +2692,10 @@ namespace Step32
       FilteredIterator<typename DoFHandler<2>::active_cell_iterator>;
 
     auto worker =
-      [=](const typename DoFHandler<dim>::active_cell_iterator &cell,
-          Assembly::Scratch::TemperatureRHS<dim> &              scratch,
-          Assembly::CopyData::TemperatureRHS<dim> &             data) {
+      [this, global_T_range, maximal_velocity, global_entropy_variation](
+        const typename DoFHandler<dim>::active_cell_iterator &cell,
+        Assembly::Scratch::TemperatureRHS<dim> &              scratch,
+        Assembly::CopyData::TemperatureRHS<dim> &             data) {
         this->local_assemble_temperature_rhs(global_T_range,
                                              maximal_velocity,
                                              global_entropy_variation,


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?type=1&buildid=7021 partly
```
/home/darndt/dealii/examples/step-32/step-32.cc: In lambda function:
/home/darndt/dealii/examples/step-32/step-32.cc:2695:7: error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Werror=deprecated]
 2695 |       [=](const typename DoFHandler<dim>::active_cell_iterator &cell,
      |       ^
/home/darndt/dealii/examples/step-32/step-32.cc:2695:7: note: add explicit ‘this’ or ‘*this’ capt
```