### PR TITLE
add tolerance to BoundingBox::point_inside()

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -182,7 +182,10 @@ public:
   merge_with(const BoundingBox<spacedim, Number> &other_bbox);
 
   /**
-   * Return true if the point is inside the Bounding Box, false otherwise.
+   * Return true if the point is inside the Bounding Box, false otherwise. The
+   * parameter @p tolerance is a factor by which the bounding box is enlarged
+   * relative to the dimensions of the bounding box in order to determine in a
+   * numerically robust way whether the point is inside.
    */
   bool
   point_inside(

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -185,7 +185,9 @@ public:
    * Return true if the point is inside the Bounding Box, false otherwise.
    */
   bool
-  point_inside(const Point<spacedim, Number> &p) const;
+  point_inside(
+    const Point<spacedim, Number> &p,
+    const double tolerance = std::numeric_limits<Number>::epsilon()) const;
 
   /**
    * Increase (or decrease) the size of the bounding box by the given amount.

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -27,10 +27,12 @@ BoundingBox<spacedim, Number>::point_inside(const Point<spacedim, Number> &p,
       // Bottom left-top right convention: the point is outside if it's smaller
       // than the first or bigger than the second boundary point The bounding
       // box is defined as a closed set
-      if (tolerance * std::abs(this->boundary_points.first[i] + p[i]) <
-            this->boundary_points.first[i] - p[i] ||
-          tolerance * std::abs(this->boundary_points.second[i] + p[i]) <
-            p[i] - this->boundary_points.second[i])
+      if ((p[i] < this->boundary_points.first[i] -
+                    tolerance * std::abs(this->boundary_points.second[i] -
+                                         this->boundary_points.first[i])) ||
+          (p[i] > this->boundary_points.second[i] +
+                    tolerance * std::abs(this->boundary_points.second[i] -
+                                         this->boundary_points.first[i])))
         return false;
     }
   return true;

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -19,19 +19,17 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int spacedim, typename Number>
 bool
-BoundingBox<spacedim, Number>::point_inside(
-  const Point<spacedim, Number> &p) const
+BoundingBox<spacedim, Number>::point_inside(const Point<spacedim, Number> &p,
+                                            const double tolerance) const
 {
   for (unsigned int i = 0; i < spacedim; ++i)
     {
       // Bottom left-top right convention: the point is outside if it's smaller
       // than the first or bigger than the second boundary point The bounding
       // box is defined as a closed set
-      if (std::numeric_limits<Number>::epsilon() *
-              (std::abs(this->boundary_points.first[i] + p[i])) <
+      if (tolerance * std::abs(this->boundary_points.first[i] + p[i]) <
             this->boundary_points.first[i] - p[i] ||
-          std::numeric_limits<Number>::epsilon() *
-              (std::abs(this->boundary_points.second[i] + p[i])) <
+          tolerance * std::abs(this->boundary_points.second[i] + p[i]) <
             p[i] - this->boundary_points.second[i])
         return false;
     }

--- a/tests/base/bounding_box_1.cc
+++ b/tests/base/bounding_box_1.cc
@@ -116,6 +116,20 @@ test_unitary()
           << b.point_inside(p3) << " " << b.point_inside(p1 + p2) << " "
           << b.point_inside(p2 + p3) << " " << b.point_inside(p1 + p3) << " "
           << std::endl;
+
+  double eps = std::numeric_limits<double>::epsilon();
+  AssertThrow(b.point_inside(Point<3>(0.0, 0.0, 1.0 + 1.0 * eps), 10. * eps) ==
+                true,
+              ExcMessage("failed."));
+  AssertThrow(b.point_inside(Point<3>(0.0, 0.0, 1.0 + 10. * eps), 1.0 * eps) ==
+                false,
+              ExcMessage("failed."));
+  AssertThrow(b.point_inside(Point<3>(0.0 - 1.0 * eps, 0.0, 0.0), 10. * eps) ==
+                true,
+              ExcMessage("failed."));
+  AssertThrow(b.point_inside(Point<3>(0.0 - 10. * eps, 0.0, 0.0), 1.0 * eps) ==
+                false,
+              ExcMessage("failed."));
 }
 
 int


### PR DESCRIPTION
Provide a user defined tolerance to make the code robust w.r.t. numerical rounding errors related to the point position.