### PR TITLE
Avoid use-after-scope when calling MappinQCache::initialize multiply

### DIFF
--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -94,6 +94,7 @@ MappingQCache<dim, spacedim>::initialize(
     const typename Triangulation<dim, spacedim>::cell_iterator &)>
     &compute_points_on_cell)
 {
+  clear_signal.disconnect();
   clear_signal = triangulation.signals.any_change.connect(
     [&]() -> void { this->support_point_cache.reset(); });
 

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -1672,7 +1672,8 @@ TransfiniteInterpolationManifold<dim, spacedim>::initialize(
   const Triangulation<dim, spacedim> &triangulation)
 {
   this->triangulation = &triangulation;
-  // in case the triangulatoin is cleared, remove the pointers by a signal
+  // in case the triangulation is cleared, remove the pointers by a signal
+  clear_signal.disconnect();
   clear_signal = triangulation.signals.clear.connect([&]() -> void {
     this->triangulation = nullptr;
     this->level_coarse  = -1;


### PR DESCRIPTION
After using `AddressSanitizer` in #10455, I thought it would be a good idea to just run the whole test suite with the minimal setup I used there and found one more failing test that triggered the sanitizer.
`mappings/mapping_q_cache_04` calls `MappingQCache::initialize` multiply and overwrites `clear_signal` before it disconnects so we lose track of the first connection. If the Triangulation object is destroyed after the `MappingQCache` object goes out of scope and is destroyed, only the last connected connection is disconnected and the previous ones are still called when the `Triangulation` object is destroyed. At this point, `support_point_cache` doesn't exist anymore, of course, but we still try to access it.