### PR TITLE
Equip GridTools::find_active_cell_around_point() with tolerance

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1580,7 +1580,8 @@ namespace GridTools
     const std::vector<std::vector<Tensor<1, spacedim>>> &vertex_to_cell_centers,
     const typename MeshType<dim, spacedim>::active_cell_iterator &cell_hint,
     const std::vector<bool> &                              marked_vertices,
-    const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree)
+    const RTree<std::pair<Point<spacedim>, unsigned int>> &used_vertices_rtree,
+    const double                                           tolerance)
   {
     std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
               Point<dim>>
@@ -1670,9 +1671,8 @@ namespace GridTools
                   comp);
         // It is possible the vertex is close
         // to an edge, thus we add a tolerance
-        // setting it initially to 1e-10
         // to keep also the "best" cell
-        double best_distance = 1e-10;
+        double best_distance = tolerance;
 
         // Search all of the cells adjacent to the closest vertex of the cell
         // hint Most likely we will find the point in them.
@@ -1684,7 +1684,7 @@ namespace GridTools
                 std::advance(cell, neighbor_permutation[i]);
                 const Point<dim> p_unit =
                   mapping.transform_real_to_unit_cell(*cell, p);
-                if (GeometryInfo<dim>::is_inside_unit_cell(p_unit))
+                if (GeometryInfo<dim>::is_inside_unit_cell(p_unit, tolerance))
                   {
                     cell_and_position.first  = *cell;
                     cell_and_position.second = p_unit;
@@ -1727,10 +1727,8 @@ namespace GridTools
         // domain, or that we've had problems with the algorithm above. Try as a
         // last resort the other (simpler) algorithm.
         if (current_cell.state() != IteratorState::valid)
-          return find_active_cell_around_point(mapping,
-                                               mesh,
-                                               p,
-                                               marked_vertices);
+          return find_active_cell_around_point(
+            mapping, mesh, p, marked_vertices, tolerance);
 
         current_cell = typename MeshType<dim, spacedim>::active_cell_iterator();
       }
@@ -5225,7 +5223,8 @@ namespace GridTools
     const Point<spacedim> &     p,
     const typename Triangulation<dim, spacedim>::active_cell_iterator
       &                      cell_hint,
-    const std::vector<bool> &marked_vertices)
+    const std::vector<bool> &marked_vertices,
+    const double             tolerance)
   {
     const auto &mesh            = cache.get_triangulation();
     const auto &mapping         = cache.get_mapping();
@@ -5241,7 +5240,8 @@ namespace GridTools
                                          vertex_to_cell_centers,
                                          cell_hint,
                                          marked_vertices,
-                                         used_vertices_rtree);
+                                         used_vertices_rtree,
+                                         tolerance);
   }
 
   template <int spacedim>

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -37,7 +37,8 @@ for (X : TRIANGULATIONS; deal_II_dimension : DIMENSIONS;
                                                    deal_II_space_dimension,
                                                    X>::type &,
         const std::vector<bool> &,
-        const RTree<std::pair<Point<deal_II_space_dimension>, unsigned int>> &);
+        const RTree<std::pair<Point<deal_II_space_dimension>, unsigned int>> &,
+        const double);
 
       template std::vector<BoundingBox<deal_II_space_dimension>>
       compute_mesh_predicate_bounding_box<X>(
@@ -92,7 +93,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const typename Triangulation<
           deal_II_dimension,
           deal_II_space_dimension>::active_cell_iterator &,
-        const std::vector<bool> &);
+        const std::vector<bool> &,
+        const double);
 
       template std::tuple<std::vector<typename Triangulation<
                             deal_II_dimension,

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -43,7 +43,8 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS;
         ActiveCellIterator<deal_II_dimension, deal_II_space_dimension, X>::type
         find_active_cell_around_point(const X &,
                                       const Point<deal_II_space_dimension> &,
-                                      const std::vector<bool> &);
+                                      const std::vector<bool> &,
+                                      const double);
 
       template std::pair<
         dealii::internal::ActiveCellIterator<deal_II_dimension,
@@ -54,7 +55,8 @@ for (X : TRIANGULATION_AND_DOFHANDLERS; deal_II_dimension : DIMENSIONS;
         const Mapping<deal_II_dimension, deal_II_space_dimension> &,
         const X &,
         const Point<deal_II_space_dimension> &,
-        const std::vector<bool> &);
+        const std::vector<bool> &,
+        const double);
 
       template std::vector<
         std::pair<dealii::internal::ActiveCellIterator<deal_II_dimension,
@@ -159,7 +161,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
           &,
         const hp::DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const Point<deal_II_space_dimension> &);
+        const Point<deal_II_space_dimension> &,
+        const double);
 
     \}
 #endif


### PR DESCRIPTION
The tolerance has been hard-coded at some places, but should generally be a parameter set by the user. Otherwise, different modules using different hard-coded tolerances lead to conflicts.