### PR TITLE
[CI] add githubactions indent/documentation check

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -1,0 +1,26 @@
+name: indent
+
+on: [push, pull_request]
+
+jobs:
+  indent:
+    # run the indent checks
+
+    name: indent
+    runs-on: [ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        ./contrib/utilities/download_clang_format
+        sudo apt-get install doxygen graphviz perl texlive-bibtex-extra
+        doxygen --version
+    - name: indent
+      run: |
+        ./contrib/utilities/check_indentation.sh
+    - name: documentation
+      run: |
+        cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON .
+        make -j 2 documentation
+        cat doxygen.log && ! [ -s doxygen.log ]


### PR DESCRIPTION
Add a new "indent" check on github actions that mirrors what we do on
travisci (to ultimately replace it).

I checked that clang-format and doxygen errors get propagated into a failure status.

(as discussed on slack)