### PR TITLE
doxygen filter: do not try to link step- without number

### DIFF
--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -119,7 +119,7 @@
  *    truncation of the Taylor scheme; dual numbers do not contain any higher-order terms in their first derivative,
  *    while for the complex-step method these existent higher-order terms are neglected. It can be shown that
  *    both of these methods are not subject to subtractive cancellation errors and that, within their
- *    finite-difference scheme, they are not numerically sensitive to the internal \step-size chosen for the
+ *    finite-difference scheme, they are not numerically sensitive to the internal step-size chosen for the
  *    numerical perturbation. The dual number approach thus produces exact first derivatives, while the
  *    complex-step approximation does not. The standard implementation of the dual numbers, however, cannot yield
  *    exact values for second derivatives. Hyper-dual numbers take a different view of this idea, with numbers

--- a/doc/doxygen/scripts/filter
+++ b/doc/doxygen/scripts/filter
@@ -87,12 +87,12 @@ while (<>)
     # - things like step-12.solution.png that typically appear in
     #   @image commands.
     # - things in headings
-    s/(?<![\"\\\/])step-(\w+)(?!\")/\@ref step_\1 \"step-\1\"/gi
+    s/(?<![\"\\\/])step-(\d\w*)(?!\")/\@ref step_\1 \"step-\1\"/gi
         if !m/(\@page|\<img|\@image|<h\d>)/i;
 
     # If step-xx was explicitly escaped with a backslash, remove the
     # latter
-    s/\\(step-\w+)/\1/g;
+    s/\\(step-\d\w*)/\1/g;
 
     # doxygen version 1.7.1 and later have the habit of thinking that
     # everything that starts with "file:" is the beginning of a link,

--- a/doc/news/5.1.0-vs-5.2.0.h
+++ b/doc/news/5.1.0-vs-5.2.0.h
@@ -217,7 +217,7 @@ inconvenience this causes.
 
   <li> <p>
        New: If there are references to other example programs in any of the
-       \step-XX programs, then they will now show up as crosslinks in the HTML
+       step-XX programs, then they will now show up as crosslinks in the HTML
        version for simpler navigation of the tutorial.
        <br>
        (WB, 2005/04/04)

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2348,7 +2348,7 @@ namespace Step32
   // The task to be performed by the next three functions is to calculate a
   // mass matrix and a Laplace matrix on the temperature system. These will be
   // combined in order to yield the semi-implicit time stepping matrix that
-  // consists of the mass matrix plus a time \step-dependent weight factor
+  // consists of the mass matrix plus a time step-dependent weight factor
   // times the Laplace matrix. This function is again essentially the body of
   // the loop over all cells from step-31.
   //
@@ -2626,7 +2626,7 @@ namespace Step32
   // In the function that runs the WorkStream for actually calculating the
   // right hand side, we also generate the final matrix. As mentioned above,
   // it is a sum of the mass matrix and the Laplace matrix, times some time
-  // \step-dependent weight. This weight is specified by the BDF-2 time
+  // step-dependent weight. This weight is specified by the BDF-2 time
   // integration scheme, see the introduction in step-31. What is new in this
   // tutorial program (in addition to the use of MPI parallelization and the
   // WorkStream class), is that we now precompute the temperature

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -707,7 +707,7 @@ namespace Step57
   //
   // This function will provide us with an initial guess by using a
   // continuation method as we discussed in the introduction. The Reynolds
-  // number is increased \step-by-step until we reach the target value. By
+  // number is increased step-by-step until we reach the target value. By
   // experiment, the solution to Stokes is good enough to be the initial guess
   // of NSE with Reynolds number 1000 so we start there.  To make sure the
   // solution from previous problem is close enough to the next one, the step

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -367,7 +367,7 @@ namespace Step69
   // <code>U</code> and a time point <code>t</code> (as input arguments)
   // computes the updated solution, stores it in the vector
   // <code>temp</code>, swaps its contents with the vector <code>U</code>,
-  // and returns the chosen \step-size $\tau$.
+  // and returns the chosen step-size $\tau$.
   //
   // The other important method is <code>prepare()</code> which primarily
   // sets the proper partition and sparsity pattern for the temporary

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -248,7 +248,7 @@ namespace Step8
 
   // The big changes in this program are in the creation of matrix and right
   // hand side, since they are problem-dependent. We will go through that
-  // process \step-by-step, since it is a bit more complicated than in previous
+  // process step-by-step, since it is a bit more complicated than in previous
   // examples.
   //
   // The first parts of this function are the same as before, however: setting


### PR DESCRIPTION
We are currently trying to create a hyperlink for every occurance of
step-BLA found in the documentation. This requires escaping words like
"step-by-step" using a backslash. This is confusing.
Instead, only do this if the dash is followed by a digit.

Fixes #10489