### PR TITLE
Add missing instantiation for PETSc with complex values

### DIFF
--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -109,6 +109,14 @@ INSTANTIATE_DLTG_BLOCK_VECTORMATRIX(PETScWrappers::MPI::BlockSparseMatrix,
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::SparseMatrix);
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::MPI::SparseMatrix);
 INSTANTIATE_DLTG_MATRIX(PETScWrappers::MPI::BlockSparseMatrix);
+#  ifndef DOXYGEN
+#    ifdef DEAL_II_PETSC_WITH_COMPLEX
+template void
+dealii::AffineConstraints<double>::distribute<
+  dealii::PETScWrappers::MPI::Vector>(
+  dealii::PETScWrappers::MPI::Vector &) const;
+#    endif
+#  endif
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?buildid=7282.