### PR TITLE
[CI] github-actions windows: disable zlib

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
         mkdir build
         mkdir c:/project
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_CXX_FLAGS="-WX" -T host=x64 ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_WITH_ZLIB=off -DDEAL_II_CXX_FLAGS="-WX" -T host=x64 ..
     - name: archive logs
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
The zlib found on the system is a x86 lib that is not compatible with
our x64 build. Disable auto detection for now.

```
#        DEAL_II_WITH_ZLIB set up with external dependencies
#            ZLIB_VERSION = 1.2.11
#            ZLIB_INCLUDE_DIRS = C:/Program Files/PostgreSQL/12/include
#            ZLIB_LIBRARIES = C:/Program Files/PostgreSQL/12/lib/zlib.lib
```

error:
```
deal_II.g.lib(zlib.obj) : error LNK2019: unresolved external symbol _deflate referenced in function "protected: int __thiscall boost::iostreams::detail::zlib_base::xdeflate(int)" (?xdeflate@zlib_base@detail@iostreams@boost@@IAEHH@Z) 
```

fixes #10494