### PR TITLE
Fix a bug in CUDAWrappers::MatrixFree::cell_loop

### DIFF
--- a/doc/news/changes/minor/20200610Turcksin
+++ b/doc/news/changes/minor/20200610Turcksin
@@ -1,0 +1,5 @@
+Fixed: Fix a bug where CUDAWrappers::MatrixFree::cell_loop() would set the
+destination vector to zero if the partitioner of the MatrixFree object was
+different from the partitioner of the source or destination vector.
+<br>
+(Bruno Turcksin, 2020/06/10)

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -907,7 +907,7 @@ namespace CUDAWrappers
       {
         ++my_id;
         Assert(
-          my_id < mf_n_concurrent_objects,
+          my_id < static_cast<int>(mf_n_concurrent_objects),
           ExcMessage(
             "Maximum number of concurrents MatrixFree objects reached. Increase mf_n_concurrent_objects"));
         bool f = false;

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -1230,6 +1230,7 @@ namespace CUDAWrappers
         LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA>
           ghosted_dst(ghosted_src);
         ghosted_src = src;
+        ghosted_dst = dst;
 
         // Execute the loop on the cells
         for (unsigned int i = 0; i < n_colors; ++i)


### PR DESCRIPTION
Fix a bug where `CUDAWrappers::MatrixFree::cell_loop()` would set the destination vector to zero if the `partitioner` of the `MatrixFree` object was different that the `partitioner` of the source vector or of the destination vector. In that case it was impossible to implement `vmult_add`.