### PR TITLE
Add a changelog entry.

### DIFF
--- a/doc/news/changes/minor/20200611Bangerth
+++ b/doc/news/changes/minor/20200611Bangerth
@@ -1,0 +1,6 @@
+Fixed: The AffineConstraints class had a bug where, if deal.II was
+compiled without threading, the class used a global variable. If a
+user program used threads nonetheless, this global variable led to
+race conditions. This is now fixed.
+<br>
+(Wolfgang Bangerth, 2020/06/11)


### PR DESCRIPTION
This finally fixes #10284.