### PR TITLE
Bugfix: Return a reference to *this in operator=

### DIFF
--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -353,6 +353,8 @@ namespace Threads
     std::unique_lock<decltype(insertion_mutex)> writer_lock(insertion_mutex);
 
     data = std::move(t.data);
+
+    return *this;
   }
 
 


### PR DESCRIPTION
Wow. I missed this. Surprising that we did not get a compiler warning
for this.

This fixes tests bits/periodicity_06/07 [1, 2].

[1] The tests test something entirely different but luckily happen to trigger this.

[2] https://cdash.43-1.org/testDetails.php?test=47189344&build=7349

terminate called after throwing an instance of 'std::system_error'
  what():  Operation not permitted

In reference to #10473