### PR TITLE
Remove auto from GridTools::exchange_cell_data_to_level_ghosts()

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2873,7 +2873,8 @@ namespace GridTools
     const std::function<void(const typename MeshType::level_cell_iterator &,
                              const DataType &)> &       unpack,
     const std::function<bool(const typename MeshType::level_cell_iterator &)>
-      &filter = [](const auto &) { return true; });
+      &filter =
+        [](const typename MeshType::level_cell_iterator &) { return true; });
 
   /* Exchange with all processors of the MPI communicator @p mpi_communicator the vector of bounding
    * boxes @p local_bboxes.


### PR DESCRIPTION
...since it has caused assembly errors in the open PRs #10490 and #10516.