### PR TITLE
Enable non-default VectorizedArrayType in read_cell_data()

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3839,8 +3839,7 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   const auto cells = this->get_cell_ids();
 
   // 2) actually gather values
-  VectorizedArrayType out =
-    make_vectorized_array<VectorizedArrayType>(Number(1.));
+  VectorizedArrayType out = Number(1.);
   for (unsigned int i = 0; i < VectorizedArrayType::size(); ++i)
     if (cells[i] != numbers::invalid_unsigned_int)
       out[i] = array[cells[i] / VectorizedArrayType::size()]
@@ -6057,7 +6056,7 @@ inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, VectorizedArrayType>
   // copy from generic function into dim-specialization function
   const Tensor<2, dim, VectorizedArrayType> grad = get_gradient(q_point);
   VectorizedArrayType                       symmetrized[(dim * dim + dim) / 2];
-  VectorizedArrayType half = make_vectorized_array<Number>(0.5);
+  VectorizedArrayType                       half = Number(0.5);
   for (unsigned int d = 0; d < dim; ++d)
     symmetrized[d] = grad[d][d];
   switch (dim)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3839,7 +3839,8 @@ FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   const auto cells = this->get_cell_ids();
 
   // 2) actually gather values
-  VectorizedArrayType out = make_vectorized_array<Number>(Number(1.));
+  VectorizedArrayType out =
+    make_vectorized_array<VectorizedArrayType>(Number(1.));
   for (unsigned int i = 0; i < VectorizedArrayType::size(); ++i)
     if (cells[i] != numbers::invalid_unsigned_int)
       out[i] = array[cells[i] / VectorizedArrayType::size()]


### PR DESCRIPTION
Trying to compile `read_cell_data()` with a non-default `VectorizedArray<Number>` type in my code fails and the changed template argument fixed it for me.

The same issue might be here (but I have not tested/changed it):

https://github.com/dealii/dealii/blob/5fc5452285efbc2e879e7ec943bce0c65d928b37/include/deal.II/matrix_free/fe_evaluation.h#L6059