### PR TITLE
Check in GridRefinement::refine()/coarsen() if cell is locally owned

### DIFF
--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -71,7 +71,8 @@ GridRefinement::refine(Triangulation<dim, spacedim> &tria,
 
   unsigned int marked = 0;
   for (const auto &cell : tria.active_cell_iterators())
-    if (std::fabs(criteria(cell->active_cell_index())) >= new_threshold)
+    if (cell->is_locally_owned() &&
+        std::fabs(criteria(cell->active_cell_index())) >= new_threshold)
       {
         if (max_to_mark != numbers::invalid_unsigned_int &&
             marked >= max_to_mark)
@@ -94,7 +95,8 @@ GridRefinement::coarsen(Triangulation<dim, spacedim> &tria,
   Assert(criteria.is_non_negative(), ExcNegativeCriteria());
 
   for (const auto &cell : tria.active_cell_iterators())
-    if (std::fabs(criteria(cell->active_cell_index())) <= threshold)
+    if (cell->is_locally_owned() &&
+        std::fabs(criteria(cell->active_cell_index())) <= threshold)
       if (!cell->refine_flag_set())
         cell->set_coarsen_flag();
 }


### PR DESCRIPTION
`p:d:t`s are passed to the functions `GridRefinement::refine()/coarsen()`  i.a. in the following tests:

```
	3909 - mpi/multigrid_adaptive.mpirun=4.debug
	4303 - multigrid/step-16-50-mpi-smoother.mpirun=3.debug
	4305 - multigrid/step-16-50-mpi.mpirun=3.debug
	4306 - multigrid/step-16-50-mpi.mpirun=7.debug
```

However, the operations are only useful on locally-owned cells, in particular, not on artificial cells.

references #10530