### PR TITLE
Fix number_cache.ghost_owners

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -231,6 +231,14 @@ namespace parallel
       virtual bool
       is_multilevel_hierarchy_constructed() const override;
 
+      /**
+       * @copydoc dealii::Triangulation::add_periodicity()
+       */
+      void
+      add_periodicity(
+        const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
+          &periodicity_vector) override;
+
     private:
       virtual unsigned int
       coarse_cell_id_to_coarse_cell_index(

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -253,6 +253,14 @@ namespace parallel
       is_multilevel_hierarchy_constructed() const override;
 
       /**
+       * @copydoc dealii::Triangulation::add_periodicity()
+       */
+      void
+      add_periodicity(
+        const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
+          &periodicity_vector) override;
+
+      /**
        * Coarsen and refine the mesh according to refinement and coarsening
        * flags set.
        *
@@ -413,6 +421,11 @@ namespace parallel
       : public dealii::parallel::TriangulationBase<dim, spacedim>
     {
     public:
+      using active_cell_iterator =
+        typename dealii::Triangulation<dim, spacedim>::active_cell_iterator;
+      using cell_iterator =
+        typename dealii::Triangulation<dim, spacedim>::cell_iterator;
+
       /**
        * Constructor. Deleted to make sure that objects of this type cannot be
        * constructed (see also the class documentation).
@@ -424,6 +437,14 @@ namespace parallel
        */
       virtual bool
       is_multilevel_hierarchy_constructed() const override;
+
+      /**
+       * @copydoc dealii::Triangulation::add_periodicity()
+       */
+      void
+      add_periodicity(
+        const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
+          &periodicity_vector) override;
 
       /**
        * A dummy function to return empty vector.

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -391,6 +391,18 @@ namespace parallel
 
 
 
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::add_periodicity(
+      const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
+        &periodicity_vector)
+    {
+      dealii::Triangulation<dim, spacedim>::add_periodicity(periodicity_vector);
+      this->update_number_cache();
+    }
+
+
+
   } // namespace fullydistributed
 } // namespace parallel
 

--- a/source/distributed/shared_tria.cc
+++ b/source/distributed/shared_tria.cc
@@ -80,6 +80,18 @@ namespace parallel
 
     template <int dim, int spacedim>
     void
+    Triangulation<dim, spacedim>::add_periodicity(
+      const std::vector<dealii::GridTools::PeriodicFacePair<cell_iterator>>
+        &periodicity_vector)
+    {
+      dealii::Triangulation<dim, spacedim>::add_periodicity(periodicity_vector);
+      this->update_number_cache();
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
     Triangulation<dim, spacedim>::partition()
     {
 #  ifdef DEBUG

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -164,9 +164,14 @@ namespace parallel
 
     {
       // find ghost owners
-      for (const auto &cell : this->active_cell_iterators())
-        if (cell->is_ghost())
-          number_cache.ghost_owners.insert(cell->subdomain_id());
+      {
+        const auto vertices_with_ghost_neighbors =
+          GridTools::compute_vertices_with_ghost_neighbors(*this);
+        for (const auto &vertex_with_ghost_neighbors :
+             vertices_with_ghost_neighbors)
+          for (const auto &ghost_neigbor : vertex_with_ghost_neighbors.second)
+            number_cache.ghost_owners.insert(ghost_neigbor);
+      }
 
       Assert(number_cache.ghost_owners.size() <
                Utilities::MPI::n_mpi_processes(mpi_communicator),


### PR DESCRIPTION
The following code to set up `parallel::TriangulationBase::number_cache::ghost_owners` only works if there is a single layer of ghost cells (which is the normal case):

https://github.com/dealii/dealii/blob/116256d3e3ac6993e6e5b30da6ee39843a6d298f/source/distributed/tria_base.cc#L167-L169

However, in the case of `p:s:t` this might not be the case. Example (run with 2 processes):
```cpp
using namespace dealii;

int
main(int argc, char **argv)
{
  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);

  const int dim = 2;
  
  parallel::shared::Triangulation<dim> tria(
    MPI_COMM_WORLD,
    ::Triangulation<dim>::none,
    false /*all cells keep the subdomain id!!!*/,
    parallel::shared::Triangulation<dim>::partition_metis);
  GridGenerator::hyper_cube(tria);
  
  // this function actually uses ghost_owners!!!
  GridTools::exchange_cell_data_to_ghosts<types::global_cell_index>(
      tria,
      [](const auto &cell) {(void) cell; return 0; },
      [](const auto &cell, const auto &id) {(void) cell; (void) id;});
}
```

This PR forces that only a single layer of ghost cells is processed for determining `ghost_owners`!

references #10530