### PR TITLE
Particles as indexable.

### DIFF
--- a/doc/news/changes/minor/20200615LucaHeltai
+++ b/doc/news/changes/minor/20200615LucaHeltai
@@ -1,0 +1,3 @@
+New: Particles::Particle and Particles::ParticleAccessor can now be used as
+indexable in boost::rtree objects. 
+<br> (Luca Heltai, 2020/06/15)

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -432,4 +432,39 @@ namespace Particles
 
 DEAL_II_NAMESPACE_CLOSE
 
+
+namespace boost
+{
+  namespace geometry
+  {
+    namespace index
+    {
+      // Forward declaration of bgi::indexable
+      template <class T>
+      struct indexable;
+
+      /**
+       * Make sure we can construct an RTree of Particles::Particle objects.
+       */
+      template <int dim, int spacedim>
+      struct indexable<dealii::Particles::Particle<dim, spacedim>>
+      {
+        /**
+         * boost::rtree expects a const reference to an indexable object. For
+         * a Particles::Particle object, this is its reference location.
+         */
+        using result_type = const dealii::Point<spacedim> &;
+
+        result_type
+        operator()(
+          const dealii::Particles::Particle<dim, spacedim> &particle) const
+        {
+          return particle.get_location();
+        }
+      };
+
+    } // namespace index
+  }   // namespace geometry
+} // namespace boost
+
 #endif

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -252,4 +252,38 @@ namespace Particles
 
 DEAL_II_NAMESPACE_CLOSE
 
+namespace boost
+{
+  namespace geometry
+  {
+    namespace index
+    {
+      // Forward declaration of bgi::indexable
+      template <class T>
+      struct indexable;
+
+      /**
+       * Make sure we can construct an RTree from Particles::ParticleAccessor
+       * objects.
+       */
+      template <int dim, int spacedim>
+      struct indexable<dealii::Particles::ParticleAccessor<dim, spacedim>>
+      {
+        /**
+         * boost::rtree expects a const reference to an indexable object. For
+         * a Particles::Particle object, this is its reference location.
+         */
+        using result_type = const dealii::Point<spacedim> &;
+
+        result_type
+        operator()(const dealii::Particles::ParticleAccessor<dim, spacedim>
+                     &accessor) const
+        {
+          return accessor.get_location();
+        }
+      };
+    } // namespace index
+  }   // namespace geometry
+} // namespace boost
+
 #endif

--- a/tests/particles/particle_09.cc
+++ b/tests/particles/particle_09.cc
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test constructing an rtree of particles.
+
+#include <deal.II/numerics/rtree.h>
+
+#include <deal.II/particles/particle.h>
+
+#include "../tests.h"
+
+namespace bgi = boost::geometry::index;
+
+template <int dim, int spacedim>
+void
+test()
+{
+  const int                                       n_particles = 10;
+  std::vector<Particles::Particle<dim, spacedim>> particles(n_particles);
+
+  unsigned int id = 0;
+  for (auto &p : particles)
+    {
+      p.set_location(random_point<spacedim>());
+      p.set_id(id++);
+    }
+
+  auto tree = pack_rtree(particles);
+
+  auto p = random_point<spacedim>();
+  for (const auto part : tree | bgi::adaptors::queried(bgi::nearest(p, 3)))
+    deallog << "Particle " << part.get_id() << " is close to " << p
+            << " (location = " << part.get_location() << ")" << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+  test<2, 2>();
+}

--- a/tests/particles/particle_09.output
+++ b/tests/particles/particle_09.output
@@ -1,0 +1,4 @@
+
+DEAL::Particle 6 is close to 0.0163006 0.242887 (location = 0.364784 0.513401)
+DEAL::Particle 4 is close to 0.0163006 0.242887 (location = 0.277775 0.553970)
+DEAL::Particle 9 is close to 0.0163006 0.242887 (location = 0.141603 0.606969)

--- a/tests/particles/particle_handler_serial_08.cc
+++ b/tests/particles/particle_handler_serial_08.cc
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2019 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test constructing an rtree of particles from a ParticleHandler object.
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/rtree.h>
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+namespace bgi = boost::geometry::index;
+
+template <int dim, int spacedim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  Particles::ParticleHandler<dim, spacedim> particle_handler(
+    tria, StaticMappingQ1<dim, spacedim>::mapping);
+
+  const int                    n_particles = 10;
+  std::vector<Point<spacedim>> particles(n_particles);
+
+  for (auto &p : particles)
+    p = random_point<spacedim>();
+
+  particle_handler.insert_particles(particles);
+
+  auto tree = pack_rtree(particle_handler.begin(), particle_handler.end());
+
+  auto p = random_point<spacedim>();
+  for (const auto &part : tree | bgi::adaptors::queried(bgi::nearest(p, 3)))
+    deallog << "Particle " << part.get_id() << " is close to " << p
+            << " (location = " << part.get_location() << ")" << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+  test<2, 2>();
+}

--- a/tests/particles/particle_handler_serial_08.output
+++ b/tests/particles/particle_handler_serial_08.output
@@ -1,0 +1,4 @@
+
+DEAL::Particle 6 is close to 0.0163006 0.242887 (location = 0.364784 0.513401)
+DEAL::Particle 9 is close to 0.0163006 0.242887 (location = 0.141603 0.606969)
+DEAL::Particle 4 is close to 0.0163006 0.242887 (location = 0.277775 0.553970)


### PR DESCRIPTION
Allow Particles::Particle and Particles::ParticleAccessor to be used directly in RTree objects.