### PR TITLE
Pass number of vertices to CellData

### DIFF
--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -121,7 +121,8 @@ struct CellData
    * - boundary or material id zero (the default for boundary or material ids)
    * - manifold id to numbers::flat_manifold_id
    */
-  CellData();
+  CellData(
+    const unsigned int n_vertices = GeometryInfo<structdim>::vertices_per_cell);
 
   /**
    * Comparison operator.

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -29,9 +29,8 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int structdim>
-CellData<structdim>::CellData()
-  : vertices(GeometryInfo<structdim>::vertices_per_cell,
-             numbers::invalid_unsigned_int)
+CellData<structdim>::CellData(const unsigned int n_vertices)
+  : vertices(n_vertices, numbers::invalid_unsigned_int)
   , material_id(0)
   , manifold_id(numbers::flat_manifold_id)
 {}


### PR DESCRIPTION
... as far as I see it, it is possible to exactly determine the geometric entity type from the dimension and the number of vertices.

At a later stage, I would like to introduce a second constructor, which takes an enum for the entity type.