### PR TITLE
work around clang10 warnings

### DIFF
--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -30,10 +30,12 @@
 #include <tuple>
 
 #ifdef DEAL_II_WITH_TBB
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <tbb/blocked_range.h>
 #  include <tbb/parallel_for.h>
 #  include <tbb/parallel_reduce.h>
 #  include <tbb/partitioner.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #endif
 
 

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -54,8 +54,10 @@
 #include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/vector_tools_integrate_difference.h>
 
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_real_distribution.hpp>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <array>
 #include <cmath>


### PR DESCRIPTION
This fixes several Wdeprecated-copy warnings from tbb and some boost warnings.