### PR TITLE
Introduce n_vertices(), n_lines(), n_face() in TriaAccessor 

### DIFF
--- a/doc/news/changes/minor/20200623Munch
+++ b/doc/news/changes/minor/20200623Munch
@@ -1,0 +1,7 @@
+New: The class TriaAccessor provides now the capability to query
+the number of vertices, lines, and faces (with n_vertices(), 
+n_lines(), n_faces(), vertex_indices(), 
+line_indices(), face_indices()). The new methods can be used as an 
+alternative to the methods in GeometryInfo.
+<br>
+(Peter Munch, 2020/06/23)

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1606,6 +1606,49 @@ public:
     const TriaIterator<TriaAccessor<structdim, dim, spacedim>> &o) const;
 
   /**
+   * Number of vertices.
+   */
+  inline unsigned int
+  n_vertices() const;
+
+  /**
+   * Number of lines.
+   */
+  inline unsigned int
+  n_lines() const;
+
+  /**
+   * Number of faces.
+   *
+   * @note Only implemented for cells (dim==spacedim).
+   */
+  inline unsigned int
+  n_faces() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all indices
+   * from zero to n_vertices().
+   */
+  inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  vertex_indices() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all indices
+   * from zero to n_lines().
+   */
+  inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  line_indices() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all indices
+   * from zero to n_faces().
+   *
+   * @note Only implemented for cells (dim==spacedim).
+   */
+  inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  face_indices() const;
+
+  /**
    * @}
    */
 
@@ -2628,6 +2671,32 @@ public:
   bool
   used() const;
 
+  /**
+   * Number of vertices.
+   */
+  inline unsigned int
+  n_vertices() const;
+
+  /**
+   * Number of lines.
+   */
+  inline unsigned int
+  n_lines() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all indices
+   * from zero to n_vertices().
+   */
+  inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  vertex_indices() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all indices
+   * from zero to n_lines().
+   */
+  inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  line_indices() const;
+
 protected:
   /**
    * Pointer to the triangulation we operate on.
@@ -2766,8 +2835,9 @@ public:
   /**
    * Return an array of iterators to all faces of this cell.
    */
-  std::array<TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>,
-             GeometryInfo<dim>::faces_per_cell>
+  boost::container::small_vector<
+    TriaIterator<TriaAccessor<dim - 1, dim, spacedim>>,
+    GeometryInfo<dim>::faces_per_cell>
   face_iterators() const;
 
   /**

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -3384,7 +3384,7 @@ namespace DoFTools
           cell_dofs.resize(fe.dofs_per_cell);
           cell->get_dof_indices(cell_dofs);
 
-          for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
+          for (const auto face_no : cell->face_indices())
             {
               const typename DoFHandlerType<dim, spacedim>::face_iterator face =
                 cell->face(face_no);

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -757,8 +757,7 @@ namespace GridTools
     // the halo layer
     for (const auto &cell : mesh.active_cell_iterators())
       if (predicate(cell)) // True predicate --> Part of subdomain
-        for (const unsigned int v :
-             GeometryInfo<MeshType::dimension>::vertex_indices())
+        for (const auto v : cell->vertex_indices())
           locally_active_vertices_on_subdomain[cell->vertex_index(v)] = true;
 
     // Find the cells that do not conform to the predicate
@@ -766,8 +765,7 @@ namespace GridTools
     // These comprise the halo layer
     for (const auto &cell : mesh.active_cell_iterators())
       if (!predicate(cell)) // False predicate --> Potential halo cell
-        for (const unsigned int v :
-             GeometryInfo<MeshType::dimension>::vertex_indices())
+        for (const auto v : cell->vertex_indices())
           if (locally_active_vertices_on_subdomain[cell->vertex_index(v)] ==
               true)
             {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10972,16 +10972,12 @@ Triangulation<dim, spacedim>::create_triangulation(
             while (cell_info->id != cell->id().template to_binary<dim>())
               ++cell;
             if (dim == 3)
-              for (unsigned int quad = 0;
-                   quad < GeometryInfo<dim>::quads_per_cell;
-                   ++quad)
+              for (const auto quad : cell->face_indices())
                 cell->quad(quad)->set_manifold_id(
                   cell_info->manifold_quad_ids[quad]);
 
             if (dim >= 2)
-              for (unsigned int line = 0;
-                   line < GeometryInfo<dim>::lines_per_cell;
-                   ++line)
+              for (const auto line : cell->line_indices())
                 cell->line(line)->set_manifold_id(
                   cell_info->manifold_line_ids[line]);
 


### PR DESCRIPTION
.. and use it within `TriaAccessor`.

This PR introduces the methods:
- `n_vertices()`, `vertex_indices()`
- `n_lines()`, `line_indices()`
- `n_faces()`, `face_indices()`

in `TriaAccessor`. At the moment, these methods delegate the call to `GeometryInfo`. However, this will change to be able to support different geometric entity types. 

Once this PR is merged, we should revisit the usage of `GeometryInfo` throughout the library and should look out for opportunities to replace the usage of `GeometryInfo` by the usage of the new methods.