### PR TITLE
Remove the deprecated DoFTools::extract_locally_owned_dofs

### DIFF
--- a/doc/doxygen/headers/distributed.h
+++ b/doc/doxygen/headers/distributed.h
@@ -251,7 +251,7 @@
  * The remaining question is how to identify the set of indices that
  * correspond to degrees of freedom we need to worry about on each
  * processor. To this end, you can use the
- * DoFTools::extract_locally_owned_dofs() function to get at all the
+ * DoFHandler::locally_owned_dofs() function to get at all the
  * indices a processor owns. Note that this is a subset of the degrees
  * of freedom that are defined on the locally owned cells (since some
  * of the degrees of freedom at the interface between two different

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1137,18 +1137,6 @@ namespace DoFTools
 
   template <typename DoFHandlerType>
   void
-  extract_locally_owned_dofs(const DoFHandlerType &dof_handler,
-                             IndexSet &            dof_set)
-  {
-    // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_dofs();
-    dof_set.compress();
-  }
-
-
-
-  template <typename DoFHandlerType>
-  void
   extract_locally_active_dofs(const DoFHandlerType &dof_handler,
                               IndexSet &            dof_set)
   {

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -36,13 +36,6 @@ for (DoFHandler : DOFHANDLER_TEMPLATES;
         IndexSet &         dof_set);
 
       template void
-      extract_locally_owned_dofs<
-        DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
-          &       dof_handler,
-        IndexSet &dof_set);
-
-      template void
       extract_locally_active_dofs<
         DoFHandler<deal_II_dimension, deal_II_space_dimension>>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension>

--- a/tests/mpi/condense_01.cc
+++ b/tests/mpi/condense_01.cc
@@ -76,7 +76,7 @@ test()
   constraints.close();
 
   IndexSet locally_owned_dofs, locally_relevant_dofs;
-  DoFTools::extract_locally_owned_dofs(dof_handler, locally_owned_dofs);
+  locally_owned_dofs = dof_handler.locally_owned_dofs();
   DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
 
   PETScWrappers::MPI::Vector vec(locally_owned_dofs, MPI_COMM_WORLD);


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/5247. Fixes https://cdash.43-1.org/testDetails.php?test=48220130&build=7706.