### PR TITLE
Fix CUDA build: make insertion_mutex mutable

### DIFF
--- a/include/deal.II/base/thread_local_storage.h
+++ b/include/deal.II/base/thread_local_storage.h
@@ -248,9 +248,9 @@ namespace Threads
      * (https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock).
      */
 #  ifdef DEAL_II_HAVE_CXX17
-    std::shared_mutex insertion_mutex;
+    mutable std::shared_mutex insertion_mutex;
 #  else
-    std::shared_timed_mutex insertion_mutex;
+    mutable std::shared_timed_mutex insertion_mutex;
 #  endif
 
     /**


### PR DESCRIPTION
The constructor of std::shared_lock cannot take a const ref