### PR TITLE
Check for deprecated functions in tutorials

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,11 @@ IF(DEAL_II_COMPONENT_EXAMPLES)
 
   IF(DEAL_II_COMPILE_EXAMPLES)
     #
+    # Make sure that there are no deprecated functions used in the tutorials.
+    #
+    STRIP_FLAG(DEAL_II_CXX_FLAGS "-Wno-deprecated-declarations")
+
+    #
     # Set up all executables:
     #
     FILE(GLOB _steps

--- a/include/deal.II/base/timer.h
+++ b/include/deal.II/base/timer.h
@@ -973,7 +973,7 @@ inline TimerOutput::Scope::Scope(dealii::TimerOutput &timer_,
   , section_name(section_name_)
   , in(true)
 {
-  timer.enter_section(section_name);
+  timer.enter_subsection(section_name);
 }
 
 
@@ -985,7 +985,7 @@ TimerOutput::Scope::stop()
     return;
   in = false;
 
-  timer.exit_section(section_name);
+  timer.leave_subsection(section_name);
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3274,7 +3274,7 @@ template <>
 inline dealii::internal::SubfaceCase<2>
 CellAccessor<2>::subface_case(const unsigned int face_no) const
 {
-  Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
+  Assert(is_active(), TriaAccessorExceptions::ExcCellNotActive());
   AssertIndexRange(face_no, GeometryInfo<2>::faces_per_cell);
   return ((face(face_no)->has_children()) ?
             dealii::internal::SubfaceCase<2>::case_x :
@@ -3285,7 +3285,7 @@ template <>
 inline dealii::internal::SubfaceCase<2>
 CellAccessor<2, 3>::subface_case(const unsigned int face_no) const
 {
-  Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
+  Assert(is_active(), TriaAccessorExceptions::ExcCellNotActive());
   AssertIndexRange(face_no, GeometryInfo<2>::faces_per_cell);
   return ((face(face_no)->has_children()) ?
             dealii::internal::SubfaceCase<2>::case_x :
@@ -3297,7 +3297,7 @@ template <>
 inline dealii::internal::SubfaceCase<3>
 CellAccessor<3>::subface_case(const unsigned int face_no) const
 {
-  Assert(active(), TriaAccessorExceptions::ExcCellNotActive());
+  Assert(is_active(), TriaAccessorExceptions::ExcCellNotActive());
   AssertIndexRange(face_no, GeometryInfo<3>::faces_per_cell);
   switch (static_cast<std::uint8_t>(face(face_no)->refinement_case()))
     {

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -207,6 +207,12 @@ public:
       color = internal::MatrixFreeFunctions::TaskInfo::color
     };
 
+    // clang-format off
+    // Remove with level_mg_handler
+#ifdef DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
+    _Pragma("GCC diagnostic push")
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+#endif
     /**
      * Constructor for AdditionalData.
      */
@@ -266,6 +272,9 @@ public:
       , cell_vectorization_categories_strict(
           other.cell_vectorization_categories_strict)
     {}
+#ifdef DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
+    _Pragma("GCC diagnostic pop")
+#endif
 
     /**
      * Copy assignment.
@@ -294,6 +303,7 @@ public:
 
       return *this;
     }
+    // clang-format on
 
     /**
      * Set the scheme for task parallelism. There are four options available.

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -207,12 +207,9 @@ public:
       color = internal::MatrixFreeFunctions::TaskInfo::color
     };
 
-    // clang-format off
-    // Remove with level_mg_handler
-#ifdef DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
-    _Pragma("GCC diagnostic push")
-    _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-#endif
+    // remove with level_mg_handler
+    DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+
     /**
      * Constructor for AdditionalData.
      */
@@ -272,9 +269,9 @@ public:
       , cell_vectorization_categories_strict(
           other.cell_vectorization_categories_strict)
     {}
-#ifdef DEAL_II_COMPILER_HAS_DIAGNOSTIC_PRAGMA
-    _Pragma("GCC diagnostic pop")
-#endif
+
+    // remove with level_mg_handler
+    DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
     /**
      * Copy assignment.
@@ -303,7 +300,6 @@ public:
 
       return *this;
     }
-    // clang-format on
 
     /**
      * Set the scheme for task parallelism. There are four options available.


### PR DESCRIPTION
Fixes #10566.
For some reason, `clang-format` messes up the indentation in `include/deal.II/matrix_free/matrix_free.h` so I had to disable it.