### PR TITLE
Update solver Vector documentation.

### DIFF
--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -83,6 +83,9 @@ class Vector;
  * class Vector
  * {
  *   public:
+ *     // Define value type of the entries
+ *     using value_type = double;
+ *
  *     // Resize the current object to have the same size and layout as
  *     // the model_vector argument provided. The second argument
  *     // indicates whether to clear the current object after resizing.
@@ -92,6 +95,13 @@ class Vector;
  *
  *     // Inner product between the current object and the argument.
  *     double operator * (const Vector &v) const;
+ *
+ *     // Set all the vector entries to a constant scalar.
+ *     Vector & operator = (const double a);
+ *
+ *     // Deep copy of the vector.
+ *     // Important if Vector contains pointers to data to duplicate data.
+ *     Vector & operator = (const Vector &x);
  *
  *     // Addition of vectors
  *     void add (const Vector &x);


### PR DESCRIPTION
Requires 2 more function definition for a compatible Vector to use GMRES and PreconditionIdentity.

Vector & operator = (const double a)
Vector & operator = (const Vector &x)

Also requires
using value_type = double; // (or whichever type is being used)

See https://github.com/dealii/dealii/blob/301fce157e88add9a6a41e307d7cc5767b679cf1/include/deal.II/lac/solver_gmres.h#L1013
See:
https://github.com/dealii/dealii/blob/301fce157e88add9a6a41e307d7cc5767b679cf1/include/deal.II/lac/precondition.h#L1273

Found out the need for the copy assignment the hard way since the "default" = operator performs a shallow copy when my vector's data was stored in a pointer. Found it odd that GMRES with PreconditionIdentity did not solve my 300x300 system in ~300 iterations (no restarts).