### PR TITLE
Archive documentation

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -21,6 +21,14 @@ jobs:
         ./contrib/utilities/check_indentation.sh
     - name: documentation
       run: |
-        cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON .
+        mkdir build
+        cd build
+        cmake -DDEAL_II_COMPONENT_DOCUMENTATION=ON -DDEAL_II_DOXYGEN_USE_MATHJAX=ON ..
         make -j 2 documentation
         cat doxygen.log && ! [ -s doxygen.log ]
+        tar -czf doxygen_documentation.tar.gz doc/doxygen
+    - name: archive documentation
+      uses: actions/upload-artifact@v1
+      with:
+        name: doxygen_documentation.tar.gz
+        path: build/doxygen_documentation.tar.gz


### PR DESCRIPTION
Sometimes, I find it really useful to have a look at the documentation generated by a pull request but checking out the appropriate branch and building the documentation is pretty annoying.
This pull request simply exports the documentation we build anyway. Downloading and extracting is, at least for me, much easier.