### PR TITLE
Avoid warning of unused variable in release mode

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3830,6 +3830,7 @@ namespace internal
     VectorizedArrayType2 &                              out,
     const FU &                                          fu)
   {
+    (void)matrix_info;
     Assert(matrix_info != nullptr, ExcNotImplemented());
     AssertDimension(array.size(),
                     matrix_info->get_task_info().cell_partition_data.back());


### PR DESCRIPTION
This should fix warnings seen here:
https://cdash.43-1.org/viewBuildError.php?type=1&buildid=7944
The origin is #10562.