### PR TITLE
Switch flip and rotation bit in quad orientation

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -671,7 +671,7 @@ namespace internal
         return get_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
-          1 /*=flip_bit*/);
+          2 /*=flip_bit*/);
       }
 
 
@@ -707,7 +707,7 @@ namespace internal
         return get_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
-          2 /*=rotation_bit*/);
+          1 /*=rotation_bit*/);
       }
 
       /**
@@ -864,7 +864,7 @@ namespace internal
         set_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
-          1 /*=flip_bit*/,
+          2 /*=flip_bit*/,
           value);
       }
 
@@ -897,7 +897,7 @@ namespace internal
         set_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
-          2 /*=rotation_bit*/,
+          1 /*=rotation_bit*/,
           value);
       }
 


### PR DESCRIPTION
After the changes in PR #10326, the orientation of quads are described by an `unsigned char` with three bits relevant with the meaning of the bits:

- bit 0: orientation
- bit 1: flip
- bit 2: rotation

This PR proposes to switch the flip and rotation flip, since these two bits - interpreted as a single number - describe the number of rotation steps:
- 00 -> 0 -> no rotation
- 01 -> 1 -> rotation by 90 degree 
- 10 -> 2 -> rotation by 180 degree 
- 11 -> 3 -> rotation by 270 degree 

For triangles, this interpretation is applicable with rotations by 60 degree and max. 2 rotation steps.

I have run all tests locally. 