### PR TITLE
DiscreteTime::set_next_step_size() added

### DIFF
--- a/doc/news/changes/minor/20200627RezaRastak
+++ b/doc/news/changes/minor/20200627RezaRastak
@@ -1,0 +1,3 @@
+New: The member function DiscreteTime::set_next_step_size() is added.
+<br>
+(Reza Rastak, 2020/06/27)

--- a/include/deal.II/base/discrete_time.h
+++ b/include/deal.II/base/discrete_time.h
@@ -350,6 +350,22 @@ public:
   set_desired_next_step_size(const double time_step_size);
 
   /**
+   * Set the *actual* value of the next time step size. By calling this
+   * method, we are indicating the next time advance_time() is called,
+   * @p time_step_size is to be used to advance the simulation time.
+   *
+   * @note The difference between set_next_step_size() and
+   * set_desired_next_step_size() is that the former uses the provided $dt$
+   * exactly without any adjustment, but produces an
+   * error (in debug mode) if $dt$ is not in the acceptable range.
+   * Generally, set_desired_next_step_size() is the preferred method because
+   * it can adjust the $dt$ intelligently, based on $T_{\text{end}}$.
+   * @pre $0 < dt \le T_{\text{end}} - t$.
+   */
+  void
+  set_next_step_size(const double time_step_size);
+
+  /**
    * Advance the current time based on the value of the current step.
    * If you want to adjust the next time step size, call the method
    * set_desired_next_step_size() before calling this method.

--- a/source/base/discrete_time.cc
+++ b/source/base/discrete_time.cc
@@ -67,6 +67,20 @@ DiscreteTime::set_desired_next_step_size(const double next_step_size)
 
 
 void
+DiscreteTime::set_next_step_size(const double next_step_size)
+{
+  Assert(next_step_size > 0,
+         ExcMessage("Only positive time step size is allowed."));
+  next_time = current_time + next_step_size;
+  Assert(
+    next_time <= end_time,
+    ExcMessage(
+      "Time step size is too large. The next time cannot exceed the end time."));
+}
+
+
+
+void
 DiscreteTime::advance_time()
 {
   Assert(next_time > current_time,

--- a/tests/base/discrete_time_1.cc
+++ b/tests/base/discrete_time_1.cc
@@ -69,7 +69,7 @@ test_adjust_time_step_size()
   print_time(time);
   time.advance_time();
   print_time(time);
-  time.set_desired_next_step_size(0.36);
+  time.set_next_step_size(0.36);
   time.advance_time();
   print_time(time);
   time.advance_time();


### PR DESCRIPTION
Sometimes (such as #9973) we know what the `dt` should be. We don't want the `DiscreteTime` class to potentially adjust it.

Here we introduce the member function `set_next_step_size()` as a companion to `set_desired_next_step_size()`. It is more strict in the input arguments. For example, it checks that we are not jumping over the end time. It guarantees to not change the provided `dt`.