### PR TITLE
Remove deprecated FiniteElement::compare_for_face_domination and FECollection::find_least_face_dominating_fe

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1344,21 +1344,6 @@ public:
   hp_quad_dof_identities(const FiniteElement<dim, spacedim> &fe_other) const;
 
   /**
-   * Return whether this element dominates the one given as argument when they
-   * meet at a common face, whether it is the other way around, whether
-   * neither dominates, or if either could dominate.
-   *
-   * For a definition of domination, see FiniteElementDomination::Domination
-   * and in particular the
-   * @ref hp_paper "hp paper".
-   *
-   * @deprecated Use compare_for_domination() with `codim=1` instead.
-   */
-  DEAL_II_DEPRECATED virtual FiniteElementDomination::Domination
-  compare_for_face_domination(
-    const FiniteElement<dim, spacedim> &fe_other) const final;
-
-  /**
    * Return whether this element dominates another one given as argument
    * @p fe_other, whether it is the other way around, whether neither dominates,
    * or if either could dominate. The @p codim parameter describes the codimension

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -302,56 +302,6 @@ namespace hp
     hp_constraints_are_implemented() const;
 
     /**
-     * Try to find a least dominant finite element inside this FECollection
-     * which dominates all of those finite elements in the current collection
-     * indexed by the numbers provided through @p fes . In other words, we
-     * first form the set of elements in this collection that dominate
-     * all of the ones that are indexed by the argument @p fes, and then
-     * within that set of dominating elements, we find the <i>least</i>
-     * dominant one.
-     *
-     * For example, if an FECollection consists of
-     * `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` elements
-     * and the argument @p fes equals `{2,3}`, then the set of dominating
-     * elements consists of `{0,1,2}`, of which `2` (i.e., the `FE_Q(3)`) is the
-     * least dominant one, and then that's what the function returns.
-     *
-     * On the other hand, if the FECollection consists of
-     * `{FE_Q(1)xFE_Q(1),FE_Q(2)xFE_Q(2),FE_Q(2)xFE_Q(3),FE_Q(3)xFE_Q(2)}`
-     * elements and the argument is again @p fes equal to `{2,3}`, then the set of dominating
-     * elements consists of `{0,1}` because now neither of the last two
-     * elements dominates the other, of which `1` (i.e., the `FE_Q(2)xFE_Q(2)`)
-     * is the least dominant one -- so that's what the function returns in
-     * this case.
-     *
-     * For the purpose of this function by domination we consider either
-     * FiniteElementDomination::Domination::this_element_dominates or
-     * FiniteElementDomination::Domination::either_element_can_dominate;
-     * therefore the element can dominate itself. Thus, if an FECollection
-     * contains `{FE_Q(1),FE_Q(2),FE_Q(3),FE_Q(4)}` and @p fes only has
-     * a single element `{3}`, then the function returns 3.
-     *
-     * If the function is not able to find a finite element that satisfies
-     * the description above, the function returns
-     * numbers::invalid_unsigned_int. An example would go like this:
-     * If the FECollection consists of `{FE_Nothing x FE_Nothing, FE_Q(1)xFE_Q(2), FE_Q(2)xFE_Q(1)}` with @p fes as `{1}`,
-     * the function will not find a most dominating element as the default
-     * behavior of FE_Nothing is to return
-     * FiniteElementDomination::no_requirements when comparing for face
-     * domination with any other element. In other words, the set of dominating
-     * elements is empty, and we can not find a least dominant one among it. The
-     * return value is therefore numbers::invalid_unsigned_int.
-     *
-     * @deprecated This function has been succeeded by
-     * `hp::FECollection::find_dominating_fe_extended(fes, 1)`.
-     * To recreate its exact behavior, use code such as
-     * `fe_collection.find_dominated_fe(
-     * fe_collection.find_common_fes(fes, 1), 1)`.
-     */
-    DEAL_II_DEPRECATED unsigned int
-    find_least_face_dominating_fe(const std::set<unsigned int> &fes) const;
-
-    /**
      * Return the indices of finite elements in this FECollection that dominate
      * all elements associated with the provided set of indices @p fes.
      *

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -941,16 +941,6 @@ FiniteElement<dim, spacedim>::hp_quad_dof_identities(
 
 template <int dim, int spacedim>
 FiniteElementDomination::Domination
-FiniteElement<dim, spacedim>::compare_for_face_domination(
-  const FiniteElement<dim, spacedim> &fe_other) const
-{
-  return this->compare_for_domination(fe_other, 1);
-}
-
-
-
-template <int dim, int spacedim>
-FiniteElementDomination::Domination
 FiniteElement<dim, spacedim>::compare_for_domination(
   const FiniteElement<dim, spacedim> &,
   const unsigned int) const

--- a/source/hp/fe_collection.cc
+++ b/source/hp/fe_collection.cc
@@ -23,17 +23,6 @@ DEAL_II_NAMESPACE_OPEN
 namespace hp
 {
   template <int dim, int spacedim>
-  unsigned int
-  FECollection<dim, spacedim>::find_least_face_dominating_fe(
-    const std::set<unsigned int> &fes) const
-  {
-    return find_dominated_fe(find_common_fes(fes, /*codim*/ 1),
-                             /*codim*/ 1);
-  }
-
-
-
-  template <int dim, int spacedim>
   std::set<unsigned int>
   FECollection<dim, spacedim>::find_common_fes(
     const std::set<unsigned int> &fes,


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/7337.