### PR TITLE
Suppress TBB deprecation warnings

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -64,12 +64,13 @@
 #cmakedefine DEAL_II_WITH_UMFPACK
 #cmakedefine DEAL_II_WITH_ZLIB
 
+#ifdef DEAL_II_WITH_TBB
 /*
  * Backward compatibility setting:
  * FIXME: Update once transition to taskflow is complete
  */
-#ifdef DEAL_II_WITH_TBB
 #define DEAL_II_WITH_THREADS
+#define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
 #endif
 
 /***********************************************************************

--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -21,9 +21,7 @@
 #include <thread>
 
 #ifdef DEAL_II_WITH_TBB
-#  define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
 #  include <tbb/task_scheduler_init.h>
-#  undef TBB_SUPPRESS_DEPRECATED_MESSAGES
 #endif
 
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -27,10 +27,8 @@
 #ifdef DEAL_II_WITH_TBB
 #  include <tbb/blocked_range.h>
 #  include <tbb/parallel_for.h>
-#  define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
 #  include <tbb/task.h>
 #  include <tbb/task_scheduler_init.h>
-#  undef TBB_SUPPRESS_DEPRECATED_MESSAGES
 #endif
 
 #include <iostream>

--- a/tests/quick_tests/tbb.cc
+++ b/tests/quick_tests/tbb.cc
@@ -18,9 +18,7 @@
 #include <deal.II/base/thread_management.h>
 #include <deal.II/base/work_stream.h>
 
-#define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
 #include <tbb/task_scheduler_init.h>
-#undef TBB_SUPPRESS_DEPRECATED_MESSAGES
 
 #include <iostream>
 


### PR DESCRIPTION
This suppresses the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=8030. It turns out that defining the macro locally doesn't work reliably since we might include the header file defining the deprecation message warning before the header file with deprecated classes.