### PR TITLE
Remove deprecated parallel::distributed::SolutionTransfer::prepare_serialization()

### DIFF
--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -311,27 +311,6 @@ namespace parallel
       prepare_for_serialization(const std::vector<const VectorType *> &all_in);
 
       /**
-       * Prepare the serialization of the given vector. The serialization is
-       * done by Triangulation::save(). The given vector needs all information
-       * on the locally active DoFs (it must be ghosted). See documentation of
-       * this class for more information.
-       *
-       * @deprecated Use parallel::distributed::SolutionTransfer::prepare_for_serialization() instead.
-       */
-      DEAL_II_DEPRECATED
-      void
-      prepare_serialization(const VectorType &in);
-
-      /**
-       * Same as the function above, only for a list of vectors.
-       *
-       * @deprecated Use parallel::distributed::SolutionTransfer::prepare_for_serialization() instead.
-       */
-      DEAL_II_DEPRECATED
-      void
-      prepare_serialization(const std::vector<const VectorType *> &all_in);
-
-      /**
        * Execute the deserialization of the given vector. This needs to be
        * done after calling Triangulation::load(). The given vector must be a
        * fully distributed vector without ghost elements. See documentation of

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -200,26 +200,6 @@ namespace parallel
 
     template <int dim, typename VectorType, typename DoFHandlerType>
     void
-    SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_serialization(
-      const VectorType &in)
-    {
-      prepare_for_serialization(in);
-    }
-
-
-
-    template <int dim, typename VectorType, typename DoFHandlerType>
-    void
-    SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_serialization(
-      const std::vector<const VectorType *> &all_in)
-    {
-      prepare_for_serialization(all_in);
-    }
-
-
-
-    template <int dim, typename VectorType, typename DoFHandlerType>
-    void
     SolutionTransfer<dim, VectorType, DoFHandlerType>::deserialize(
       VectorType &in)
     {


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/7863.