### PR TITLE
Generalize line_orientation() for 2D general meshes

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -724,10 +724,18 @@ namespace internal
 
       template <int spacedim>
       inline static bool
-      line_orientation(const TriaAccessor<2, 2, spacedim> &, const unsigned int)
+      line_orientation(const TriaAccessor<2, 2, spacedim> &accessor,
+                       const unsigned int                  line)
       {
-        // quads in 2d have no non-standard orientation
-        return true;
+        if (accessor.tria->levels[accessor.present_level]
+              ->face_orientations.size() == 0)
+          return true; // quads in 2d have no non-standard orientation and
+                       // the array TriaLevel::face_orientations is left empty
+        else
+          return accessor.tria->levels[accessor.present_level]
+            ->face_orientations[accessor.present_index *
+                                  GeometryInfo<2>::faces_per_cell +
+                                line];
       }
 
 


### PR DESCRIPTION
... for triangles `TriaLevel::face_orientations` will be filled and used here.

Currently, no test can be added.