### PR TITLE
FiniteElementData: select number of objects based on cell type

### DIFF
--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -20,6 +20,8 @@
 
 #include <deal.II/base/exceptions.h>
 
+#include <deal.II/grid/reference_cell.h>
+
 #include <deal.II/lac/block_indices.h>
 
 #include <vector>
@@ -346,6 +348,17 @@ public:
    * elements such as FESystem will want to pass a different value here.
    */
   FiniteElementData(const std::vector<unsigned int> &dofs_per_object,
+                    const unsigned int               n_components,
+                    const unsigned int               degree,
+                    const Conformity                 conformity = unknown,
+                    const BlockIndices &block_indices = BlockIndices());
+
+  /**
+   * The same as above but with the difference that also the type of the
+   * underlying geometric entity can be specified.
+   */
+  FiniteElementData(const std::vector<unsigned int> &dofs_per_object,
+                    const ReferenceCell::Type        cell_type,
                     const unsigned int               n_components,
                     const unsigned int               degree,
                     const Conformity                 conformity = unknown,

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -229,6 +229,18 @@ namespace ReferenceCell
 
           return true;
         }
+
+        /**
+         * Return reference-cell type of face @p face_no.
+         */
+        virtual ReferenceCell::Type
+        face_reference_cell_type(const unsigned int face_no) const
+        {
+          Assert(false, ExcNotImplemented());
+          (void)face_no;
+
+          return ReferenceCell::Type::Invalid;
+        }
       };
 
 
@@ -263,7 +275,14 @@ namespace ReferenceCell
        * Vertex.
        */
       struct Vertex : public TensorProductBase<0>
-      {};
+      {
+        ReferenceCell::Type
+        face_reference_cell_type(const unsigned int face_no) const override
+        {
+          (void)face_no;
+          return ReferenceCell::Type::Invalid;
+        }
+      };
 
 
 
@@ -271,7 +290,14 @@ namespace ReferenceCell
        * Line.
        */
       struct Line : public TensorProductBase<1>
-      {};
+      {
+        ReferenceCell::Type
+        face_reference_cell_type(const unsigned int face_no) const override
+        {
+          (void)face_no;
+          return ReferenceCell::Type::Vertex;
+        }
+      };
 
 
 
@@ -298,6 +324,13 @@ namespace ReferenceCell
 
           return GeometryInfo<2>::standard_to_real_line_vertex(
             vertex, line_orientation);
+        }
+
+        ReferenceCell::Type
+        face_reference_cell_type(const unsigned int face_no) const override
+        {
+          (void)face_no;
+          return ReferenceCell::Type::Line;
         }
       };
 
@@ -381,7 +414,52 @@ namespace ReferenceCell
             get_bit(face_orientation, 2),
             get_bit(face_orientation, 1));
         }
+
+        ReferenceCell::Type
+        face_reference_cell_type(const unsigned int face_no) const override
+        {
+          (void)face_no;
+          return ReferenceCell::Type::Quad;
+        }
       };
+
+      /**
+       * Return for a given reference-cell type @p the right Info.
+       */
+      inline const ReferenceCell::internal::Info::Base &
+      get_cell(const ReferenceCell::Type &type)
+      {
+        static ReferenceCell::internal::Info::Base   gei_invalid;
+        static ReferenceCell::internal::Info::Vertex gei_vertex;
+        static ReferenceCell::internal::Info::Line   gei_line;
+        static ReferenceCell::internal::Info::Quad   gei_quad;
+        static ReferenceCell::internal::Info::Hex    gei_hex;
+
+        switch (type)
+          {
+            case ReferenceCell::Type::Vertex:
+              return gei_vertex;
+            case ReferenceCell::Type::Line:
+              return gei_line;
+            case ReferenceCell::Type::Quad:
+              return gei_quad;
+            case ReferenceCell::Type::Hex:
+              return gei_hex;
+            default:
+              Assert(false, StandardExceptions::ExcNotImplemented());
+              return gei_invalid;
+          }
+      }
+
+      /**
+       * Return for a given reference-cell type @p and face number @p face_no the
+       * right Info of the @p face_no-th face.
+       */
+      inline const ReferenceCell::internal::Info::Base &
+      get_face(const ReferenceCell::Type &type, const unsigned int face_no)
+      {
+        return get_cell(get_cell(type).face_reference_cell_type(face_no));
+      }
 
     } // namespace Info
   }   // namespace internal


### PR DESCRIPTION
First step in generalizing the `FiniteElement` classes.

Number of vertices, lines, and faces are decoupled from `GeometryInfo` and depended on the cell type (default Line/Quad/Hex).

I have introduced for this purpose new internal functions `vertices_per_cell()`, ... . This is probably not the best approach, but nevertheless let's not over-engineer this at the moment. I would like to collect needed reference-cell type dependent functionalities (in the `FiniteElement` classes) during the next weeks (when we extend the number of application codes) and settle then on an appropriate data structure.