### PR TITLE
Fix default mapping parameter in VectorTools boundary functions

### DIFF
--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -553,7 +553,7 @@ namespace VectorTools
     const Function<dim, double> &boundary_function,
     const types::boundary_id     boundary_component,
     AffineConstraints<double> &  constraints,
-    const Mapping<dim> &         mapping = StaticMappingQ1<dim>::mapping);
+    const Mapping<dim> &         mapping);
 
   /**
    * Same as above for the hp-namespace.
@@ -697,7 +697,8 @@ namespace VectorTools
     const Function<dim, number> &          boundary_function,
     const types::boundary_id               boundary_component,
     AffineConstraints<number> &            constraints,
-    const hp::MappingCollection<dim, dim> &mapping_collection);
+    const hp::MappingCollection<dim, dim> &mapping_collection =
+      hp::StaticMappingQ1<dim>::mapping_collection);
 
 
   /**
@@ -772,7 +773,8 @@ namespace VectorTools
     const Function<dim, double> &          boundary_function,
     const types::boundary_id               boundary_component,
     AffineConstraints<double> &            constraints,
-    const hp::MappingCollection<dim, dim> &mapping_collection);
+    const hp::MappingCollection<dim, dim> &mapping_collection =
+      hp::StaticMappingQ1<dim>::mapping_collection);
 
   // @}
 } // namespace VectorTools


### PR DESCRIPTION
Fixes https://cdash.43-1.org/testDetails.php?test=49754466&build=8201.