### PR TITLE
Replace MPI_COMM_WORLD by mpi_communicator in step-50

### DIFF
--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -547,7 +547,7 @@ void LaplaceProblem<dim, degree>::setup_system()
           TrilinosWrappers::SparsityPattern dsp(locally_owned_dofs,
                                                 locally_owned_dofs,
                                                 locally_relevant_dofs,
-                                                MPI_COMM_WORLD);
+                                                mpi_communicator);
           DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints);
           dsp.compress();
           system_matrix.reinit(dsp);


### PR DESCRIPTION
Replace `MPI_COMM_WORLD` by `mpi_communicator` to be consistent with the rest of the code.

`MPI_COMM_WORLD` is used in other places of step-50.cc, but it can't be replaced by `mpi_communicator` because it is out of scope.