### PR TITLE
hide instantiations in Utilities from doxygen

### DIFF
--- a/cmake/scripts/expand_instantiations.cc
+++ b/cmake/scripts/expand_instantiations.cc
@@ -439,7 +439,17 @@ process_instantiations()
   //   for (X:Y; A:B) { INST }
   while (whole_file.size() != 0)
     {
+      // skip space, tabs, comments:
       skip_space(whole_file);
+
+      // output preprocessor defines as is:
+      if (has_prefix(whole_file, "#"))
+      {
+        std::cout << get_substring_with_delim(whole_file, "\n") << '\n';
+        skip_space(whole_file);
+        continue;
+      }
+
       if (!has_prefix(whole_file, "for"))
         {
           std::cerr << "Invalid instantiation list: missing 'for'" << std::endl;

--- a/source/base/mpi.inst.in
+++ b/source/base/mpi.inst.in
@@ -14,6 +14,8 @@
 // ---------------------------------------------------------------------
 
 
+#ifndef DOXYGEN
+
 for (S : REAL_SCALARS)
   {
     template void sum<S>(const SparseMatrix<S> &,
@@ -65,7 +67,6 @@ for (S : MPI_SCALARS)
                          const MPI_Comm &,
                          const ArrayView<S> &);
 
-#ifndef DOXYGEN
     // The fixed-length array (i.e., things declared like T(&values)[N])
     // versions of the functions above live in the header file mpi.h since the
     // length (N) is a compile-time constant. Those functions all call
@@ -85,7 +86,6 @@ for (S : MPI_SCALARS)
       const ArrayView<const S> &,
       const MPI_Comm &,
       const ArrayView<S> &);
-#endif
   }
 
 
@@ -105,3 +105,6 @@ for (S : REAL_SCALARS; dim : SPACE_DIMENSIONS)
     template SymmetricTensor<4, dim, S> sum<4, dim, S>(
       const SymmetricTensor<4, dim, S> &, const MPI_Comm &);
   }
+
+
+#endif

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -1217,6 +1217,7 @@ namespace Utilities
 
 #endif
 
+#ifndef DOXYGEN
   template std::string
   to_string<int>(int, unsigned int);
   template std::string
@@ -1273,6 +1274,7 @@ namespace Utilities
   template std::uint64_t
   pack_integers<3>(const std::array<std::uint64_t, 3> &, const int);
 
+#endif
 
 } // namespace Utilities
 


### PR DESCRIPTION
If you look at
https://www.dealii.org/developer/doxygen/deal.II/namespaceUtilities_1_1MPI.html
you see several pages of instantiations of sum/min/max/etc. without
documentation.

Similary, Utilities contains pack_integers,
inverse_Hilbert_space_filling_curve, and other instantiations.

Hide these from doxygen.