### PR TITLE
Add get_vector_partitioner and get_dof_handler to CUDAWrappers::MatrixFree

### DIFF
--- a/doc/news/changes/minor/20200706Turcksin
+++ b/doc/news/changes/minor/20200706Turcksin
@@ -1,0 +1,4 @@
+Added the functions CUDAWrappers::MatrixFree::get_vector_partitioner() and
+CUDAWrappers::MatrixFree::get_dof_handler()
+<br>
+(Bruno Turcksin, 2020/07/06)

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -342,9 +342,9 @@ namespace internal
         {
           AssertCuda(cuda_error);
           if (std::is_same<MemorySpaceType, MemorySpace::Host>::value)
-            return attributes.memoryType == cudaMemoryTypeHost;
+            return attributes.type == cudaMemoryTypeHost;
           else
-            return attributes.memoryType == cudaMemoryTypeDevice;
+            return attributes.type == cudaMemoryTypeDevice;
         }
       else
         {

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -20,6 +20,7 @@
 
 #ifdef DEAL_II_COMPILER_CUDA_AWARE
 
+#  include <deal.II/base/cuda_size.h>
 #  include <deal.II/base/utilities.h>
 
 #  include <deal.II/dofs/dof_accessor.h>
@@ -103,10 +104,8 @@ namespace CUDAWrappers
 
     namespace internal
     {
-      // TODO: use a template parameter instead of a macro
-#  define DEAL_II_MAX_ELEM_DEGREE 10
-      __constant__ double constraint_weights[(DEAL_II_MAX_ELEM_DEGREE + 1) *
-                                             (DEAL_II_MAX_ELEM_DEGREE + 1)];
+      __constant__ double
+        constraint_weights[(mf_max_elem_degree + 1) * (mf_max_elem_degree + 1)];
 
       // Here is the system for how we store constraint types in a binary mask.
       // This is not a complete contradiction-free system, i.e., there are

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -340,10 +340,29 @@ namespace CUDAWrappers
       LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> &vec) const;
 
     /**
+     * Return the partitioner that represents the locally owned data and the
+     * ghost indices where access is needed to for the cell loop. The
+     * partitioner is constructed from the locally owned dofs and ghost dofs
+     * given by the respective fields. If you want to have specific information
+     * about these objects, you can query them with the respective access
+     * functions. If you just want to initialize a (parallel) vector, you should
+     * usually prefer this data structure as the data exchange information can
+     * be reused from one vector to another.
+     */
+    const std::shared_ptr<const Utilities::MPI::Partitioner> &
+    get_vector_partitioner() const;
+
+    /**
      * Free all the memory allocated.
      */
     void
     free();
+
+    /**
+     * Return the DoFHandler.
+     */
+    const DoFHandler<dim> &
+    get_dof_handler() const;
 
     /**
      * Return an approximation of the memory consumption of this class in bytes.
@@ -592,6 +611,11 @@ namespace CUDAWrappers
      */
     std::vector<unsigned int> row_start;
 
+    /**
+     * Pointer to the DoFHandler associated with the object.
+     */
+    const DoFHandler<dim> *dof_handler;
+
     friend class internal::ReinitHelper<dim, Number>;
   };
 
@@ -654,7 +678,7 @@ namespace CUDAWrappers
   }
 
 
-
+  /*----------------------- Helper functions ---------------------------------*/
   /**
    * Compute the quadrature point index in the local cell of a given thread.
    *
@@ -709,6 +733,30 @@ namespace CUDAWrappers
     return *(data->q_points + data->padding_length * cell +
              q_point_id_in_cell<dim>(n_q_points_1d));
   }
+
+
+  /*----------------------- Inline functions ---------------------------------*/
+
+#  ifndef DOXYGEN
+
+  template <int dim, typename Number>
+  const std::shared_ptr<const Utilities::MPI::Partitioner> &
+  MatrixFree<dim, Number>::get_vector_partitioner() const
+  {
+    return partitioner;
+  }
+
+  template <int dim, typename Number>
+  const DoFHandler<dim> &
+  MatrixFree<dim, Number>::get_dof_handler() const
+  {
+    Assert(dof_handler != nullptr, ExcNotInitialized());
+
+    return *dof_handler;
+  }
+
+#  endif
+
 } // namespace CUDAWrappers
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1514,7 +1514,7 @@ public:
   get_vector_partitioner(const unsigned int dof_handler_index = 0) const;
 
   /**
-   * Return the set of cells that are oned by the processor.
+   * Return the set of cells that are owned by the processor.
    */
   const IndexSet &
   get_locally_owned_set(const unsigned int dof_handler_index = 0) const;

--- a/tests/cuda/matrix_free_no_index_initialize.cu
+++ b/tests/cuda/matrix_free_no_index_initialize.cu
@@ -47,7 +47,7 @@ public:
     Number *                                                    dst) const
   {
     CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number>
-      fe_eval(0, cell, gpu_data, shared_data);
+      fe_eval(cell, gpu_data, shared_data);
 
     // set to unit vector
     fe_eval.submit_dof_value(1.);


### PR DESCRIPTION
Add `get_vector_partitioner()` and `get_dof_handler()` to `CUDAWrappers::MatrixFree`. These functions exist on the CPU and it is nice to have a common interface between the two classes. This PR also has a couple of minor fixes (typo, removing a macro, ...)