### PR TITLE
run indent on expand_instantiations.cc

### DIFF
--- a/cmake/.clang-format
+++ b/cmake/.clang-format
@@ -1,6 +1,0 @@
-#
-# The clang-format (Clang 6) style file used by deal.II.
-# This directory shall not be formatted.
-#
-
-DisableFormat: true

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -56,22 +56,22 @@ checks
 # Process all source and header files:
 #
 
-process_changed "tests include source examples contrib/python-bindings" ".*\.(cc|h|cu|cuh)" format_file
+process_changed "tests include source examples cmake/scripts contrib/python-bindings" ".*\.(cc|h|cu|cuh)" format_file
 process_changed "source" ".*\.inst.in" format_inst
 
 #
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process_changed "tests include source examples contrib/python-bindings" \
+process_changed "tests include source examples cmake/scripts contrib/python-bindings" \
   ".*\.(cc|h|cu|cuh|inst.in|output.*|cmake)" fix_permissions
 
-process_changed "tests include source examples contrib/python-bindings" \
+process_changed "tests include source examples cmake/scripts contrib/python-bindings" \
   ".*\.(cc|h|cu|cuh|inst.in|cmake)" dos_to_unix
 
 #
 # Removing trailing whitespace
 #
 
-process_changed "include source examples contrib/python-bindings doc" \
+process_changed "tests include source examples cmake/scripts contrib/python-bindings doc" \
   ".*\.(cc|h|cu|cuh|html|dox|txt)" remove_trailing_whitespace

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -67,15 +67,15 @@ process "source" ".*\.inst.in" format_inst
 # Fix permissions and convert to unix line ending if necessary:
 #
 
-process "tests include source examples contrib/python-bindings" \
+process "tests include source examples cmake/scripts contrib/python-bindings" \
   ".*\.(cc|h|cu|cuh|inst.in|output.*|cmake)" fix_permissions
 
-process "tests include source examples contrib/python-bindings" \
+process "tests include source examples cmake/scripts contrib/python-bindings" \
   ".*\.(cc|h|cu|cuh|inst.in|cmake)" dos_to_unix
 
 #
 # Removing trailing whitespace
 #
 
-process "include source examples contrib/python-bindings doc" \
+process "tests include source examples cmake/scripts contrib/python-bindings doc" \
   ".*\.(cc|h|cu|cuh|html|dox|txt)" remove_trailing_whitespace


### PR DESCRIPTION
Also run clang-format on cmake/scripts/*.cc.

While I am here, add "tests" to remove_trailing_whitespace that was
missing.