### PR TITLE
fix taskflow quicktest and fix taskflow linker error

### DIFF
--- a/bundled/taskflow-2.5.0/include/taskflow/core/flow_builder.hpp
+++ b/bundled/taskflow-2.5.0/include/taskflow/core/flow_builder.hpp
@@ -913,7 +913,7 @@ class Subflow : public FlowBuilder {
 };
 
 // Constructor
-Subflow::Subflow(Executor& executor, Node* parent, Graph& graph) :
+inline Subflow::Subflow(Executor& executor, Node* parent, Graph& graph) :
   FlowBuilder {graph},
   _executor   {executor},
   _parent     {parent} {

--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -104,8 +104,8 @@ IF (DEAL_II_WITH_TBB)
   make_quicktest("tbb" ${_mybuild} "")
 ENDIF()
 
-# test cpp-taskflow
-IF (DEAL_II_WITH_CPP_TASKFLOW)
+# test taskflow
+IF (DEAL_II_WITH_TASKFLOW)
   make_quicktest("taskflow" ${_mybuild} "")
 ENDIF()
 


### PR DESCRIPTION
The macro was renamed and we forgot to change this.