### PR TITLE
Replace FiniteElementData::dofs_per_* with FiniteElementData::n_dofs_per_*

### DIFF
--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -301,7 +301,8 @@ namespace Step12
     const auto cell_worker = [&](const Iterator &  cell,
                                  ScratchData<dim> &scratch_data,
                                  CopyData &        copy_data) {
-      const unsigned int n_dofs = scratch_data.fe_values.get_fe().dofs_per_cell;
+      const unsigned int n_dofs =
+        scratch_data.fe_values.get_fe().n_dofs_per_cell();
       copy_data.reinit(cell, n_dofs);
       scratch_data.fe_values.reinit(cell);
 
@@ -476,7 +477,7 @@ namespace Step12
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;
 
     // then assign the matrix to it and set the right block size:
-    preconditioner.initialize(system_matrix, fe.dofs_per_cell);
+    preconditioner.initialize(system_matrix, fe.n_dofs_per_cell());
 
     // After these preparations we are ready to start the linear solver.
     solver.solve(system_matrix, solution, right_hand_side, preconditioner);

--- a/examples/step-12b/step-12b.cc
+++ b/examples/step-12b/step-12b.cc
@@ -515,7 +515,7 @@ namespace Step12
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;
 
     // then assign the matrix to it and set the right block size:
-    preconditioner.initialize(system_matrix, fe.dofs_per_cell);
+    preconditioner.initialize(system_matrix, fe.n_dofs_per_cell());
 
     // After these preparations we are ready to start the linear solver.
     solver.solve(system_matrix, solution, right_hand_side, preconditioner);

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -876,7 +876,7 @@ namespace Step13
       AssemblyScratchData &                                 scratch_data,
       AssemblyCopyData &                                    copy_data) const
     {
-      const unsigned int dofs_per_cell = fe->dofs_per_cell;
+      const unsigned int dofs_per_cell = fe->n_dofs_per_cell();
       const unsigned int n_q_points    = quadrature->size();
 
       copy_data.cell_matrix.reinit(dofs_per_cell, dofs_per_cell);
@@ -1052,7 +1052,7 @@ namespace Step13
                               update_values | update_quadrature_points |
                                 update_JxW_values);
 
-      const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
+      const unsigned int dofs_per_cell = this->fe->n_dofs_per_cell();
       const unsigned int n_q_points    = this->quadrature->size();
 
       Vector<double>                       cell_rhs(dofs_per_cell);

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -580,7 +580,7 @@ namespace Step14
       AssemblyScratchData &                                 scratch_data,
       AssemblyCopyData &                                    copy_data) const
     {
-      const unsigned int dofs_per_cell = fe->dofs_per_cell;
+      const unsigned int dofs_per_cell = fe->n_dofs_per_cell();
       const unsigned int n_q_points    = quadrature->size();
 
       copy_data.cell_matrix.reinit(dofs_per_cell, dofs_per_cell);
@@ -764,7 +764,7 @@ namespace Step14
                               update_values | update_quadrature_points |
                                 update_JxW_values);
 
-      const unsigned int dofs_per_cell = this->fe->dofs_per_cell;
+      const unsigned int dofs_per_cell = this->fe->n_dofs_per_cell();
       const unsigned int n_q_points    = this->quadrature->size();
 
       Vector<double>                       cell_rhs(dofs_per_cell);

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -240,7 +240,7 @@ namespace Step15
                             update_gradients | update_quadrature_points |
                               update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -506,7 +506,7 @@ namespace Step15
                             update_gradients | update_quadrature_points |
                               update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     Vector<double>              cell_residual(dofs_per_cell);

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -338,7 +338,7 @@ namespace Step16
     FEValues<dim> &fe_values = scratch_data.fe_values;
     fe_values.reinit(cell);
 
-    const unsigned int dofs_per_cell = fe_values.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = fe_values.get_fe().n_dofs_per_cell();
     const unsigned int n_q_points    = fe_values.get_quadrature().size();
 
     copy_data.reinit(cell, dofs_per_cell);

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -436,7 +436,7 @@ namespace Step17
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-18/doc/results.dox
+++ b/examples/step-18/doc/results.dox
@@ -532,7 +532,7 @@ general approach to this would go like this:
       {
         history_field[i][j].reinit(history_dof_handler.n_dofs());
         local_history_values_at_qpoints[i][j].reinit(quadrature.size());
-        local_history_fe_values[i][j].reinit(history_fe.dofs_per_cell);
+        local_history_fe_values[i][j].reinit(history_fe.n_dofs_per_cell());
       }
 
     FullMatrix<double> qpoint_to_dof_matrix (history_fe.dofs_per_cell,
@@ -582,7 +582,7 @@ general approach to this would go like this:
   will do that:
   @code
     FullMatrix<double> dof_to_qpoint_matrix (quadrature.size(),
-                                             history_fe.dofs_per_cell);
+                                             history_fe.n_dofs_per_cell());
     FETools::compute_interpolation_to_quadrature_points_matrix
               (history_fe,
                quadrature,

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -924,7 +924,7 @@ namespace Step18
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -464,7 +464,7 @@ namespace Step20
                                        update_quadrature_points |
                                        update_JxW_values);
 
-    const unsigned int dofs_per_cell   = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell   = fe.n_dofs_per_cell();
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -631,7 +631,7 @@ namespace Step21
                                        update_quadrature_points |
                                        update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
@@ -785,7 +785,7 @@ namespace Step21
                                               face_quadrature_formula,
                                               update_values);
 
-    const unsigned int dofs_per_cell   = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell   = fe.n_dofs_per_cell();
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -620,7 +620,7 @@ namespace Step22
                             update_values | update_quadrature_points |
                               update_JxW_values | update_gradients);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
     const unsigned int n_q_points = quadrature_formula.size();
 

--- a/examples/step-24/step-24.cc
+++ b/examples/step-24/step-24.cc
@@ -333,7 +333,7 @@ namespace Step24
                                   quadrature_formula,
                                   update_values | update_JxW_values);
 
-      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
       const unsigned int n_q_points    = quadrature_formula.size();
 
       FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-25/step-25.cc
+++ b/examples/step-25/step-25.cc
@@ -401,7 +401,7 @@ namespace Step25
                             update_values | update_JxW_values |
                               update_quadrature_points);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     Vector<double>                       local_nl_term(dofs_per_cell);
@@ -461,7 +461,7 @@ namespace Step25
                             update_values | update_JxW_values |
                               update_quadrature_points);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> local_nl_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -329,7 +329,7 @@ namespace Step27
 
     for (const auto &cell : dof_handler.active_cell_iterators())
       {
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
 
         cell_matrix.reinit(dofs_per_cell, dofs_per_cell);
         cell_matrix = 0;
@@ -677,7 +677,7 @@ namespace Step27
         // that has to be provided with the <code>local_dof_values</code>,
         // <code>cell->active_fe_index()</code> and a Table to store
         // coefficients.
-        local_dof_values.reinit(cell->get_fe().dofs_per_cell);
+        local_dof_values.reinit(cell->get_fe().n_dofs_per_cell());
         cell->get_dof_values(solution, local_dof_values);
 
         fourier->calculate(local_dof_values,

--- a/examples/step-28/step-28.cc
+++ b/examples/step-28/step-28.cc
@@ -664,7 +664,7 @@ namespace Step28
                             update_values | update_gradients |
                               update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -729,7 +729,7 @@ namespace Step28
 
     const QGauss<dim> quadrature_formula(fe.degree + 1);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FEValues<dim> fe_values(fe,
@@ -801,7 +801,7 @@ namespace Step28
 
     for (const auto &cell_pair : cell_list)
       {
-        FullMatrix<double> unit_matrix(fe.dofs_per_cell);
+        FullMatrix<double> unit_matrix(fe.n_dofs_per_cell());
         for (unsigned int i = 0; i < unit_matrix.m(); ++i)
           unit_matrix(i, i) = 1;
         assemble_cross_group_rhs_recursive(g_prime,
@@ -875,14 +875,14 @@ namespace Step28
                                           group,
                                           cell_g_prime->material_id());
 
-        FullMatrix<double> local_mass_matrix_f(fe.dofs_per_cell,
-                                               fe.dofs_per_cell);
-        FullMatrix<double> local_mass_matrix_g(fe.dofs_per_cell,
-                                               fe.dofs_per_cell);
+        FullMatrix<double> local_mass_matrix_f(fe.n_dofs_per_cell(),
+                                               fe.n_dofs_per_cell());
+        FullMatrix<double> local_mass_matrix_g(fe.n_dofs_per_cell(),
+                                               fe.n_dofs_per_cell());
 
         for (unsigned int q_point = 0; q_point < n_q_points; ++q_point)
-          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
-            for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+          for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+            for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
               {
                 local_mass_matrix_f(i, j) +=
                   (fission_dist_XS * fe_values.shape_value(i, q_point) *
@@ -903,13 +903,13 @@ namespace Step28
         // or the product with the transpose matrix using <code>Tvmult</code>.
         // After doing so, we transfer the result into the global right hand
         // side vector of energy group $g$.
-        Vector<double> g_prime_new_values(fe.dofs_per_cell);
-        Vector<double> g_prime_old_values(fe.dofs_per_cell);
+        Vector<double> g_prime_new_values(fe.n_dofs_per_cell());
+        Vector<double> g_prime_old_values(fe.n_dofs_per_cell());
         cell_g_prime->get_dof_values(g_prime.solution_old, g_prime_old_values);
         cell_g_prime->get_dof_values(g_prime.solution, g_prime_new_values);
 
-        Vector<double> cell_rhs(fe.dofs_per_cell);
-        Vector<double> tmp(fe.dofs_per_cell);
+        Vector<double> cell_rhs(fe.n_dofs_per_cell());
+        Vector<double> tmp(fe.n_dofs_per_cell());
 
         if (cell_g->level() > cell_g_prime->level())
           {
@@ -929,10 +929,10 @@ namespace Step28
           }
 
         std::vector<types::global_dof_index> local_dof_indices(
-          fe.dofs_per_cell);
+          fe.n_dofs_per_cell());
         cell_g->get_dof_indices(local_dof_indices);
 
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           system_rhs(local_dof_indices[i]) += cell_rhs(i);
       }
 
@@ -948,7 +948,8 @@ namespace Step28
            child < GeometryInfo<dim>::max_children_per_cell;
            ++child)
         {
-          FullMatrix<double> new_matrix(fe.dofs_per_cell, fe.dofs_per_cell);
+          FullMatrix<double> new_matrix(fe.n_dofs_per_cell(),
+                                        fe.n_dofs_per_cell());
           fe.get_prolongation_matrix(child).mmult(new_matrix,
                                                   prolongation_matrix);
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -541,7 +541,7 @@ namespace Step29
 
     const unsigned int n_q_points      = quadrature_formula.size(),
                        n_face_q_points = face_quadrature_formula.size(),
-                       dofs_per_cell   = fe.dofs_per_cell;
+                       dofs_per_cell   = fe.n_dofs_per_cell();
 
     // The FEValues objects will evaluate the shape functions for us.  For the
     // part of the bilinear form that involves integration on $\Omega$, we'll

--- a/examples/step-3/doc/intro.dox
+++ b/examples/step-3/doc/intro.dox
@@ -390,7 +390,7 @@ following piece of the code:
 @endcode
 where <code>local_dof_indices</code> is declared as
 @code
-  std::vector<types::global_dof_index> local_dof_indices (fe.dofs_per_cell);
+  std::vector<types::global_dof_index> local_dof_indices (fe.n_dofs_per_cell());
 @endcode
 The name of this variable might be a bit of a misnomer -- it stands for "the
 global indices of those degrees of freedom locally defined on the current

--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -364,7 +364,7 @@ void Step3::assemble_system()
   // loops a bit more readable. You will see such shortcuts in many places in
   // larger programs, and `dofs_per_cell` is one that is more or less the
   // conventional name for this kind of object.
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
   // Now, we said that we wanted to assemble the global matrix and vector
   // cell-by-cell. We could write the results directly into the global matrix,

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -376,7 +376,7 @@ namespace Step30
                             (GeometryInfo<dim>::faces_per_cell *
                                GeometryInfo<dim>::max_children_per_face +
                              1) *
-                              fe.dofs_per_cell);
+                              fe.n_dofs_per_cell());
 
     DoFTools::make_flux_sparsity_pattern(dof_handler, sparsity_pattern);
 
@@ -403,7 +403,7 @@ namespace Step30
   template <int dim>
   void DGMethod<dim>::assemble_system()
   {
-    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_neighbor(dofs_per_cell);
 
@@ -646,7 +646,7 @@ namespace Step30
 
     PreconditionBlockSSOR<SparseMatrix<double>> preconditioner;
 
-    preconditioner.initialize(system_matrix, fe.dofs_per_cell);
+    preconditioner.initialize(system_matrix, fe.n_dofs_per_cell());
 
     solver.solve(system_matrix, solution, right_hand_side, preconditioner);
   }

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1045,7 +1045,7 @@ namespace Step31
                                    update_JxW_values | update_values |
                                      update_gradients);
 
-    const unsigned int dofs_per_cell = stokes_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = stokes_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
@@ -1250,7 +1250,7 @@ namespace Step31
                                         quadrature_formula,
                                         update_values);
 
-    const unsigned int dofs_per_cell = stokes_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = stokes_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> local_matrix(dofs_per_cell, dofs_per_cell);
@@ -1414,7 +1414,7 @@ namespace Step31
                                         update_values | update_gradients |
                                           update_JxW_values);
 
-    const unsigned int dofs_per_cell = temperature_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = temperature_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> local_mass_matrix(dofs_per_cell, dofs_per_cell);
@@ -1522,7 +1522,7 @@ namespace Step31
                                    quadrature_formula,
                                    update_values);
 
-    const unsigned int dofs_per_cell = temperature_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = temperature_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     Vector<double> local_rhs(dofs_per_cell);

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -366,8 +366,8 @@ namespace Step32
         const Mapping<dim> &      mapping,
         const UpdateFlags         update_flags)
         : stokes_fe_values(mapping, stokes_fe, stokes_quadrature, update_flags)
-        , grad_phi_u(stokes_fe.dofs_per_cell)
-        , phi_p(stokes_fe.dofs_per_cell)
+        , grad_phi_u(stokes_fe.n_dofs_per_cell())
+        , phi_p(stokes_fe.n_dofs_per_cell())
       {}
 
 
@@ -434,9 +434,9 @@ namespace Step32
                                 temperature_fe,
                                 stokes_quadrature,
                                 temperature_update_flags)
-        , phi_u(stokes_fe.dofs_per_cell)
-        , grads_phi_u(stokes_fe.dofs_per_cell)
-        , div_phi_u(stokes_fe.dofs_per_cell)
+        , phi_u(stokes_fe.n_dofs_per_cell())
+        , grads_phi_u(stokes_fe.n_dofs_per_cell())
+        , div_phi_u(stokes_fe.n_dofs_per_cell())
         , old_temperature_values(stokes_quadrature.size())
       {}
 
@@ -486,8 +486,8 @@ namespace Step32
                                 temperature_quadrature,
                                 update_values | update_gradients |
                                   update_JxW_values)
-        , phi_T(temperature_fe.dofs_per_cell)
-        , grad_phi_T(temperature_fe.dofs_per_cell)
+        , phi_T(temperature_fe.n_dofs_per_cell())
+        , grad_phi_T(temperature_fe.n_dofs_per_cell())
       {}
 
 
@@ -562,8 +562,8 @@ namespace Step32
                            stokes_fe,
                            quadrature,
                            update_values | update_gradients)
-        , phi_T(temperature_fe.dofs_per_cell)
-        , grad_phi_T(temperature_fe.dofs_per_cell)
+        , phi_T(temperature_fe.n_dofs_per_cell())
+        , grad_phi_T(temperature_fe.n_dofs_per_cell())
         ,
 
         old_velocity_values(quadrature.size())
@@ -637,8 +637,8 @@ namespace Step32
       template <int dim>
       StokesPreconditioner<dim>::StokesPreconditioner(
         const FiniteElement<dim> &stokes_fe)
-        : local_matrix(stokes_fe.dofs_per_cell, stokes_fe.dofs_per_cell)
-        , local_dof_indices(stokes_fe.dofs_per_cell)
+        : local_matrix(stokes_fe.n_dofs_per_cell(), stokes_fe.n_dofs_per_cell())
+        , local_dof_indices(stokes_fe.n_dofs_per_cell())
       {}
 
       template <int dim>
@@ -661,7 +661,7 @@ namespace Step32
       template <int dim>
       StokesSystem<dim>::StokesSystem(const FiniteElement<dim> &stokes_fe)
         : StokesPreconditioner<dim>(stokes_fe)
-        , local_rhs(stokes_fe.dofs_per_cell)
+        , local_rhs(stokes_fe.n_dofs_per_cell())
       {}
 
 
@@ -679,11 +679,11 @@ namespace Step32
       template <int dim>
       TemperatureMatrix<dim>::TemperatureMatrix(
         const FiniteElement<dim> &temperature_fe)
-        : local_mass_matrix(temperature_fe.dofs_per_cell,
-                            temperature_fe.dofs_per_cell)
-        , local_stiffness_matrix(temperature_fe.dofs_per_cell,
-                                 temperature_fe.dofs_per_cell)
-        , local_dof_indices(temperature_fe.dofs_per_cell)
+        : local_mass_matrix(temperature_fe.n_dofs_per_cell(),
+                            temperature_fe.n_dofs_per_cell())
+        , local_stiffness_matrix(temperature_fe.n_dofs_per_cell(),
+                                 temperature_fe.n_dofs_per_cell())
+        , local_dof_indices(temperature_fe.n_dofs_per_cell())
       {}
 
 
@@ -701,10 +701,10 @@ namespace Step32
       template <int dim>
       TemperatureRHS<dim>::TemperatureRHS(
         const FiniteElement<dim> &temperature_fe)
-        : local_rhs(temperature_fe.dofs_per_cell)
-        , local_dof_indices(temperature_fe.dofs_per_cell)
-        , matrix_for_bc(temperature_fe.dofs_per_cell,
-                        temperature_fe.dofs_per_cell)
+        : local_rhs(temperature_fe.n_dofs_per_cell())
+        , local_dof_indices(temperature_fe.n_dofs_per_cell())
+        , matrix_for_bc(temperature_fe.n_dofs_per_cell(),
+                        temperature_fe.n_dofs_per_cell())
       {}
     } // namespace CopyData
   }   // namespace Assembly
@@ -2016,7 +2016,7 @@ namespace Step32
     Assembly::Scratch::StokesPreconditioner<dim> &        scratch,
     Assembly::CopyData::StokesPreconditioner<dim> &       data)
   {
-    const unsigned int dofs_per_cell = stokes_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = stokes_fe.n_dofs_per_cell();
     const unsigned int n_q_points =
       scratch.stokes_fe_values.n_quadrature_points;
 
@@ -2213,7 +2213,7 @@ namespace Step32
     Assembly::CopyData::StokesSystem<dim> &               data)
   {
     const unsigned int dofs_per_cell =
-      scratch.stokes_fe_values.get_fe().dofs_per_cell;
+      scratch.stokes_fe_values.get_fe().n_dofs_per_cell();
     const unsigned int n_q_points =
       scratch.stokes_fe_values.n_quadrature_points;
 
@@ -2360,7 +2360,7 @@ namespace Step32
     Assembly::CopyData::TemperatureMatrix<dim> &          data)
   {
     const unsigned int dofs_per_cell =
-      scratch.temperature_fe_values.get_fe().dofs_per_cell;
+      scratch.temperature_fe_values.get_fe().n_dofs_per_cell();
     const unsigned int n_q_points =
       scratch.temperature_fe_values.n_quadrature_points;
 
@@ -2477,7 +2477,7 @@ namespace Step32
     const bool use_bdf2_scheme = (timestep_number != 0);
 
     const unsigned int dofs_per_cell =
-      scratch.temperature_fe_values.get_fe().dofs_per_cell;
+      scratch.temperature_fe_values.get_fe().n_dofs_per_cell();
     const unsigned int n_q_points =
       scratch.temperature_fe_values.n_quadrature_points;
 
@@ -3155,11 +3155,11 @@ namespace Step32
 
     {
       std::vector<types::global_dof_index> local_joint_dof_indices(
-        joint_fe.dofs_per_cell);
+        joint_fe.n_dofs_per_cell());
       std::vector<types::global_dof_index> local_stokes_dof_indices(
-        stokes_fe.dofs_per_cell);
+        stokes_fe.n_dofs_per_cell());
       std::vector<types::global_dof_index> local_temperature_dof_indices(
-        temperature_fe.dofs_per_cell);
+        temperature_fe.n_dofs_per_cell());
 
       typename DoFHandler<dim>::active_cell_iterator
         joint_cell       = joint_dof_handler.begin_active(),
@@ -3174,7 +3174,7 @@ namespace Step32
             stokes_cell->get_dof_indices(local_stokes_dof_indices);
             temperature_cell->get_dof_indices(local_temperature_dof_indices);
 
-            for (unsigned int i = 0; i < joint_fe.dofs_per_cell; ++i)
+            for (unsigned int i = 0; i < joint_fe.n_dofs_per_cell(); ++i)
               if (joint_fe.system_to_base_index(i).first.first == 0)
                 {
                   Assert(joint_fe.system_to_base_index(i).second <

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -447,7 +447,7 @@ namespace Step33
                                   const Vector<double> & solution,
                                   Vector<double> &       refinement_indicators)
     {
-      const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+      const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
       std::vector<unsigned int> dofs(dofs_per_cell);
 
       const QMidpoint<dim> quadrature_formula;
@@ -1439,7 +1439,7 @@ namespace Step33
   template <int dim>
   void ConservationLaw<dim>::assemble_system()
   {
-    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
 
     std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
     std::vector<types::global_dof_index> dof_indices_neighbor(dofs_per_cell);

--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -564,7 +564,8 @@ namespace Step34
 
     const unsigned int n_q_points = fe_v.n_quadrature_points;
 
-    std::vector<types::global_dof_index> local_dof_indices(fe.dofs_per_cell);
+    std::vector<types::global_dof_index> local_dof_indices(
+      fe.n_dofs_per_cell());
 
     std::vector<Vector<double>> cell_wind(n_q_points, Vector<double>(dim));
     double                      normal_wind;
@@ -576,7 +577,7 @@ namespace Step34
     // cell. This is done using a vector of fe.dofs_per_cell elements, which
     // will then be distributed to the matrix in the global row $i$. The
     // following object will hold this information:
-    Vector<double> local_matrix_row_i(fe.dofs_per_cell);
+    Vector<double> local_matrix_row_i(fe.n_dofs_per_cell());
 
     // The index $i$ runs on the collocation points, which are the support
     // points of the $i$th basis function, while $j$ runs on inner integration
@@ -617,7 +618,7 @@ namespace Step34
             bool         is_singular    = false;
             unsigned int singular_index = numbers::invalid_unsigned_int;
 
-            for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+            for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
               if (local_dof_indices[j] == i)
                 {
                   singular_index = j;
@@ -642,7 +643,7 @@ namespace Step34
                     system_rhs(i) += (LaplaceKernel::single_layer(R) *
                                       normal_wind * fe_v.JxW(q));
 
-                    for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
 
                       local_matrix_row_i(j) -=
                         ((LaplaceKernel::double_layer(R) * normals[q]) *
@@ -702,7 +703,7 @@ namespace Step34
                     system_rhs(i) += (LaplaceKernel::single_layer(R) *
                                       normal_wind * fe_v_singular.JxW(q));
 
-                    for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
                       {
                         local_matrix_row_i(j) -=
                           ((LaplaceKernel::double_layer(R) *
@@ -715,7 +716,7 @@ namespace Step34
 
             // Finally, we need to add the contributions of the current cell
             // to the global matrix.
-            for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+            for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
               system_matrix(i, local_dof_indices[j]) += local_matrix_row_i(j);
           }
       }
@@ -866,11 +867,12 @@ namespace Step34
     const DoFHandler<2, 3>::active_cell_iterator &,
     const unsigned int index) const
   {
-    Assert(index < fe.dofs_per_cell, ExcIndexRange(0, fe.dofs_per_cell, index));
+    Assert(index < fe.n_dofs_per_cell(),
+           ExcIndexRange(0, fe.n_dofs_per_cell(), index));
 
     static std::vector<QGaussOneOverR<2>> quadratures;
     if (quadratures.size() == 0)
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         quadratures.emplace_back(singular_quadrature_order,
                                  fe.get_unit_support_points()[i],
                                  true);
@@ -883,7 +885,8 @@ namespace Step34
     const DoFHandler<1, 2>::active_cell_iterator &cell,
     const unsigned int                            index) const
   {
-    Assert(index < fe.dofs_per_cell, ExcIndexRange(0, fe.dofs_per_cell, index));
+    Assert(index < fe.n_dofs_per_cell(),
+           ExcIndexRange(0, fe.n_dofs_per_cell(), index));
 
     static Quadrature<1> *q_pointer = nullptr;
     if (q_pointer)
@@ -936,7 +939,7 @@ namespace Step34
 
     const unsigned int n_q_points = fe_v.n_quadrature_points;
 
-    std::vector<types::global_dof_index> dofs(fe.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs(fe.n_dofs_per_cell());
 
     std::vector<double>         local_phi(n_q_points);
     std::vector<double>         normal_wind(n_q_points);

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -636,7 +636,7 @@ namespace Step35
                            const QGauss<dim> &quad,
                            const UpdateFlags  flags)
         : nqp(quad.size())
-        , dpc(fe.dofs_per_cell)
+        , dpc(fe.n_dofs_per_cell())
         , u_star_local(nqp)
         , grad_u_star(nqp)
         , u_star_tmp(nqp)
@@ -885,8 +885,8 @@ namespace Step35
     }
 
     InitGradPerTaskData per_task_data(0,
-                                      fe_velocity.dofs_per_cell,
-                                      fe_pressure.dofs_per_cell);
+                                      fe_velocity.n_dofs_per_cell(),
+                                      fe_pressure.n_dofs_per_cell());
     InitGradScratchData scratch_data(fe_velocity,
                                      fe_pressure,
                                      quadrature_velocity,
@@ -1133,7 +1133,7 @@ namespace Step35
   void NavierStokesProjection<dim>::assemble_advection_term()
   {
     vel_Advection = 0.;
-    AdvectionPerTaskData data(fe_velocity.dofs_per_cell);
+    AdvectionPerTaskData data(fe_velocity.n_dofs_per_cell());
     AdvectionScratchData scratch(fe_velocity,
                                  quadrature_velocity,
                                  update_values | update_JxW_values |
@@ -1197,8 +1197,8 @@ namespace Step35
   void NavierStokesProjection<dim>::copy_advection_local_to_global(
     const AdvectionPerTaskData &data)
   {
-    for (unsigned int i = 0; i < fe_velocity.dofs_per_cell; ++i)
-      for (unsigned int j = 0; j < fe_velocity.dofs_per_cell; ++j)
+    for (unsigned int i = 0; i < fe_velocity.n_dofs_per_cell(); ++i)
+      for (unsigned int j = 0; j < fe_velocity.n_dofs_per_cell(); ++j)
         vel_Advection.add(data.local_dof_indices[i],
                           data.local_dof_indices[j],
                           data.local_advection(i, j));
@@ -1306,9 +1306,9 @@ namespace Step35
            ExcInternalError());
     Vector<double> joint_solution(joint_dof_handler.n_dofs());
     std::vector<types::global_dof_index> loc_joint_dof_indices(
-      joint_fe.dofs_per_cell),
-      loc_vel_dof_indices(fe_velocity.dofs_per_cell),
-      loc_pres_dof_indices(fe_pressure.dofs_per_cell);
+      joint_fe.n_dofs_per_cell()),
+      loc_vel_dof_indices(fe_velocity.n_dofs_per_cell()),
+      loc_pres_dof_indices(fe_pressure.n_dofs_per_cell());
     typename DoFHandler<dim>::active_cell_iterator
       joint_cell = joint_dof_handler.begin_active(),
       joint_endc = joint_dof_handler.end(),
@@ -1319,7 +1319,7 @@ namespace Step35
         joint_cell->get_dof_indices(loc_joint_dof_indices);
         vel_cell->get_dof_indices(loc_vel_dof_indices);
         pres_cell->get_dof_indices(loc_pres_dof_indices);
-        for (unsigned int i = 0; i < joint_fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < joint_fe.n_dofs_per_cell(); ++i)
           switch (joint_fe.system_to_base_index(i).first.first)
             {
               case 0:
@@ -1390,7 +1390,7 @@ namespace Step35
                              quadrature_velocity,
                              update_gradients | update_JxW_values |
                                update_values);
-    const unsigned int dpc = fe_velocity.dofs_per_cell,
+    const unsigned int dpc = fe_velocity.n_dofs_per_cell(),
                        nqp = quadrature_velocity.size();
     std::vector<types::global_dof_index> ldi(dpc);
     Vector<double>                       loc_rot(dpc);

--- a/examples/step-36/step-36.cc
+++ b/examples/step-36/step-36.cc
@@ -244,7 +244,7 @@ namespace Step36
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_stiffness_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-37/doc/intro.dox
+++ b/examples/step-37/doc/intro.dox
@@ -103,7 +103,7 @@ Matrixfree<dim>::vmult (Vector<double>       &dst,
                            update_gradients | update_JxW_values|
                            update_quadrature_points);
 
-  const unsigned int   dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int   dofs_per_cell = fe.n_dofs_per_cell();
   const unsigned int   n_q_points    = quadrature_formula.size();
 
   FullMatrix<double>   cell_matrix (dofs_per_cell, dofs_per_cell);

--- a/examples/step-38/step-38.cc
+++ b/examples/step-38/step-38.cc
@@ -362,7 +362,7 @@ namespace Step38
                                         update_quadrature_points |
                                         update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -342,7 +342,7 @@ void Step4<dim>::assemble_system()
   // are presently using, but the FiniteElement class does all the necessary
   // work for you and you don't have to care about the dimension dependent
   // parts:
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
   Vector<double>     cell_rhs(dofs_per_cell);

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -366,7 +366,7 @@ namespace Step40
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -276,7 +276,7 @@ namespace Step41
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -350,7 +350,7 @@ namespace Step41
                             quadrature_formula,
                             update_values | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -445,7 +445,7 @@ namespace Step41
     for (const auto &cell : dof_handler.active_cell_iterators())
       for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
         {
-          Assert(dof_handler.get_fe().dofs_per_cell ==
+          Assert(dof_handler.get_fe().n_dofs_per_cell() ==
                    GeometryInfo<dim>::vertices_per_cell,
                  ExcNotImplemented());
 

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1132,7 +1132,7 @@ namespace Step42
                                      face_quadrature_formula,
                                      update_values | update_JxW_values);
 
-    const unsigned int dofs_per_cell   = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell   = fe.n_dofs_per_cell();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -1224,7 +1224,7 @@ namespace Step42
                                      face_quadrature,
                                      update_quadrature_points);
 
-    const unsigned int dofs_per_face   = fe.dofs_per_face;
+    const unsigned int dofs_per_face   = fe.n_dofs_per_face();
     const unsigned int n_face_q_points = face_quadrature.size();
 
     std::vector<types::global_dof_index> dof_indices(dofs_per_face);
@@ -1342,7 +1342,7 @@ namespace Step42
                                      update_values | update_quadrature_points |
                                        update_JxW_values);
 
-    const unsigned int dofs_per_cell   = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell   = fe.n_dofs_per_cell();
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 
@@ -1495,7 +1495,7 @@ namespace Step42
                                      update_values | update_quadrature_points |
                                        update_JxW_values);
 
-    const unsigned int dofs_per_cell   = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell   = fe.n_dofs_per_cell();
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -864,7 +864,7 @@ namespace Step43
                                        quadrature_formula,
                                        update_values);
 
-    const unsigned int dofs_per_cell = darcy_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = darcy_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     std::vector<Tensor<2, dim>> k_inverse_values(n_q_points);
@@ -1008,7 +1008,7 @@ namespace Step43
                                              update_quadrature_points |
                                              update_JxW_values);
 
-    const unsigned int dofs_per_cell = darcy_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = darcy_fe.n_dofs_per_cell();
 
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
@@ -1198,7 +1198,7 @@ namespace Step43
                                        quadrature_formula,
                                        update_values | update_JxW_values);
 
-    const unsigned int dofs_per_cell = saturation_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = saturation_fe.n_dofs_per_cell();
 
     const unsigned int n_q_points = quadrature_formula.size();
 
@@ -1282,7 +1282,7 @@ namespace Step43
       saturation_fe, face_quadrature_formula, update_values);
 
     const unsigned int dofs_per_cell =
-      saturation_dof_handler.get_fe().dofs_per_cell;
+      saturation_dof_handler.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
     const double                    global_max_u_F_prime = get_max_u_F_prime();
@@ -1753,11 +1753,11 @@ namespace Step43
 
     {
       std::vector<types::global_dof_index> local_joint_dof_indices(
-        joint_fe.dofs_per_cell);
+        joint_fe.n_dofs_per_cell());
       std::vector<types::global_dof_index> local_darcy_dof_indices(
-        darcy_fe.dofs_per_cell);
+        darcy_fe.n_dofs_per_cell());
       std::vector<types::global_dof_index> local_saturation_dof_indices(
-        saturation_fe.dofs_per_cell);
+        saturation_fe.n_dofs_per_cell());
 
       auto       joint_cell      = joint_dof_handler.begin_active();
       const auto joint_endc      = joint_dof_handler.end();
@@ -1771,7 +1771,7 @@ namespace Step43
           darcy_cell->get_dof_indices(local_darcy_dof_indices);
           saturation_cell->get_dof_indices(local_saturation_dof_indices);
 
-          for (unsigned int i = 0; i < joint_fe.dofs_per_cell; ++i)
+          for (unsigned int i = 0; i < joint_fe.n_dofs_per_cell(); ++i)
             if (joint_fe.system_to_base_index(i).first.first == 0)
               {
                 Assert(joint_fe.system_to_base_index(i).second <

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1063,7 +1063,7 @@ namespace Step44
        1)
     , // dilatation
     dof_handler(triangulation)
-    , dofs_per_cell(fe.dofs_per_cell)
+    , dofs_per_cell(fe.n_dofs_per_cell())
     , u_fe(first_u_component)
     , p_fe(p_component)
     , J_fe(J_component)
@@ -1196,12 +1196,12 @@ namespace Step44
                   const QGauss<dim> &       qf_cell,
                   const UpdateFlags         uf_cell)
       : fe_values(fe_cell, qf_cell, uf_cell)
-      , Nx(qf_cell.size(), std::vector<double>(fe_cell.dofs_per_cell))
+      , Nx(qf_cell.size(), std::vector<double>(fe_cell.n_dofs_per_cell()))
       , grad_Nx(qf_cell.size(),
-                std::vector<Tensor<2, dim>>(fe_cell.dofs_per_cell))
+                std::vector<Tensor<2, dim>>(fe_cell.n_dofs_per_cell()))
       , symm_grad_Nx(qf_cell.size(),
                      std::vector<SymmetricTensor<2, dim>>(
-                       fe_cell.dofs_per_cell))
+                       fe_cell.n_dofs_per_cell()))
     {}
 
     ScratchData_K(const ScratchData_K &rhs)
@@ -1271,10 +1271,10 @@ namespace Step44
                     const UpdateFlags         uf_face)
       : fe_values(fe_cell, qf_cell, uf_cell)
       , fe_face_values(fe_cell, qf_face, uf_face)
-      , Nx(qf_cell.size(), std::vector<double>(fe_cell.dofs_per_cell))
+      , Nx(qf_cell.size(), std::vector<double>(fe_cell.n_dofs_per_cell()))
       , symm_grad_Nx(qf_cell.size(),
                      std::vector<SymmetricTensor<2, dim>>(
-                       fe_cell.dofs_per_cell))
+                       fe_cell.n_dofs_per_cell()))
     {}
 
     ScratchData_RHS(const ScratchData_RHS &rhs)
@@ -1613,7 +1613,7 @@ namespace Step44
     element_indices_p.clear();
     element_indices_J.clear();
 
-    for (unsigned int k = 0; k < fe.dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < fe.n_dofs_per_cell(); ++k)
       {
         const unsigned int k_group = fe.system_to_base_index(k).first.first;
         if (k_group == u_dof)

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -560,7 +560,7 @@ namespace Step45
                             update_values | update_quadrature_points |
                               update_JxW_values | update_gradients);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
     const unsigned int n_q_points = quadrature_formula.size();
 

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -181,7 +181,7 @@ comes in: it describes a finite dimensional function space of
 functions that are constant zero. A particular property of this
 peculiar linear vector space is that it has no degrees of freedom: it
 isn't just finite dimensional, it is in fact zero dimensional, and
-consequently for objects of this type, FiniteElement::dofs_per_cell
+consequently for objects of this type, FiniteElement::n_dofs_per_cell()
 will return zero. For discussion below, let us give this space a
 proper symbol:
 @f[

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -364,7 +364,7 @@ namespace Step46
     // introduction:
     {
       std::vector<types::global_dof_index> local_face_dof_indices(
-        stokes_fe.dofs_per_face);
+        stokes_fe.n_dofs_per_face());
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (cell_is_in_fluid_domain(cell))
           for (unsigned int face_no : GeometryInfo<dim>::face_indices())
@@ -498,8 +498,9 @@ namespace Step46
 
     // ...to objects that are needed to describe the local contributions to
     // the global linear system...
-    const unsigned int stokes_dofs_per_cell     = stokes_fe.dofs_per_cell;
-    const unsigned int elasticity_dofs_per_cell = elasticity_fe.dofs_per_cell;
+    const unsigned int stokes_dofs_per_cell = stokes_fe.n_dofs_per_cell();
+    const unsigned int elasticity_dofs_per_cell =
+      elasticity_fe.n_dofs_per_cell();
 
     FullMatrix<double> local_matrix;
     FullMatrix<double> local_interface_matrix(elasticity_dofs_per_cell,
@@ -538,9 +539,9 @@ namespace Step46
 
         const FEValues<dim> &fe_values = hp_fe_values.get_present_fe_values();
 
-        local_matrix.reinit(cell->get_fe().dofs_per_cell,
-                            cell->get_fe().dofs_per_cell);
-        local_rhs.reinit(cell->get_fe().dofs_per_cell);
+        local_matrix.reinit(cell->get_fe().n_dofs_per_cell(),
+                            cell->get_fe().n_dofs_per_cell());
+        local_rhs.reinit(cell->get_fe().n_dofs_per_cell());
 
         // With all of this done, we continue to assemble the cell terms for
         // cells that are part of the Stokes and elastic regions. While we
@@ -558,7 +559,7 @@ namespace Step46
         // documentation module for the elasticity equations:
         if (cell_is_in_fluid_domain(cell))
           {
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
             Assert(dofs_per_cell == stokes_dofs_per_cell, ExcInternalError());
 
             for (unsigned int q = 0; q < fe_values.n_quadrature_points; ++q)
@@ -584,7 +585,7 @@ namespace Step46
           }
         else
           {
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
             Assert(dofs_per_cell == elasticity_dofs_per_cell,
                    ExcInternalError());
 
@@ -622,7 +623,7 @@ namespace Step46
         // along since the elimination of nonzero boundary values requires the
         // modification of local and consequently also global right hand side
         // values:
-        local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
         cell->get_dof_indices(local_dof_indices);
         constraints.distribute_local_to_global(local_matrix,
                                                local_rhs,

--- a/examples/step-47/step-47.cc
+++ b/examples/step-47/step-47.cc
@@ -401,7 +401,7 @@ namespace Step47
       const ExactSolution::RightHandSide<dim> right_hand_side;
 
       const unsigned int dofs_per_cell =
-        scratch_data.fe_values.get_fe().dofs_per_cell;
+        scratch_data.fe_values.get_fe().n_dofs_per_cell();
 
       for (unsigned int qpoint = 0; qpoint < fe_values.n_quadrature_points;
            ++qpoint)
@@ -713,7 +713,7 @@ namespace Step47
                                   update_values | update_gradients |
                                     update_hessians | update_quadrature_points |
                                     update_JxW_values | update_normal_vectors);
-    CopyData           copy_data(dof_handler.get_fe().dofs_per_cell);
+    CopyData           copy_data(dof_handler.get_fe().n_dofs_per_cell());
     MeshWorker::mesh_loop(dof_handler.begin_active(),
                           dof_handler.end(),
                           cell_worker,

--- a/examples/step-5/step-5.cc
+++ b/examples/step-5/step-5.cc
@@ -169,7 +169,7 @@ void Step5<dim>::assemble_system()
                           update_values | update_gradients |
                             update_quadrature_points | update_JxW_values);
 
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
   Vector<double>     cell_rhs(dofs_per_cell);

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -744,7 +744,7 @@ void LaplaceProblem<dim, degree>::assemble_system()
                           update_values | update_gradients |
                             update_quadrature_points | update_JxW_values);
 
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
   const unsigned int n_q_points    = quadrature_formula.size();
 
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -816,7 +816,7 @@ void LaplaceProblem<dim, degree>::assemble_multigrid()
                           update_values | update_gradients |
                             update_quadrature_points | update_JxW_values);
 
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
   const unsigned int n_q_points    = quadrature_formula.size();
 
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -436,7 +436,7 @@ namespace Step51
     {
       DynamicSparsityPattern dsp(dof_handler.n_dofs());
       DoFTools::make_sparsity_pattern(dof_handler, dsp, constraints, false);
-      sparsity_pattern.copy_from(dsp, fe.dofs_per_face);
+      sparsity_pattern.copy_from(dsp, fe.n_dofs_per_face());
     }
     system_matrix.reinit(sparsity_pattern);
   }
@@ -531,31 +531,31 @@ namespace Step51
                              face_quadrature_formula,
                              local_face_flags)
       , fe_face_values(fe, face_quadrature_formula, flags)
-      , ll_matrix(fe_local.dofs_per_cell, fe_local.dofs_per_cell)
-      , lf_matrix(fe_local.dofs_per_cell, fe.dofs_per_cell)
-      , fl_matrix(fe.dofs_per_cell, fe_local.dofs_per_cell)
-      , tmp_matrix(fe.dofs_per_cell, fe_local.dofs_per_cell)
-      , l_rhs(fe_local.dofs_per_cell)
-      , tmp_rhs(fe_local.dofs_per_cell)
-      , q_phi(fe_local.dofs_per_cell)
-      , q_phi_div(fe_local.dofs_per_cell)
-      , u_phi(fe_local.dofs_per_cell)
-      , u_phi_grad(fe_local.dofs_per_cell)
-      , tr_phi(fe.dofs_per_cell)
+      , ll_matrix(fe_local.n_dofs_per_cell(), fe_local.n_dofs_per_cell())
+      , lf_matrix(fe_local.n_dofs_per_cell(), fe.n_dofs_per_cell())
+      , fl_matrix(fe.n_dofs_per_cell(), fe_local.n_dofs_per_cell())
+      , tmp_matrix(fe.n_dofs_per_cell(), fe_local.n_dofs_per_cell())
+      , l_rhs(fe_local.n_dofs_per_cell())
+      , tmp_rhs(fe_local.n_dofs_per_cell())
+      , q_phi(fe_local.n_dofs_per_cell())
+      , q_phi_div(fe_local.n_dofs_per_cell())
+      , u_phi(fe_local.n_dofs_per_cell())
+      , u_phi_grad(fe_local.n_dofs_per_cell())
+      , tr_phi(fe.n_dofs_per_cell())
       , trace_values(face_quadrature_formula.size())
       , fe_local_support_on_face(GeometryInfo<dim>::faces_per_cell)
       , fe_support_on_face(GeometryInfo<dim>::faces_per_cell)
       , exact_solution()
     {
       for (unsigned int face_no : GeometryInfo<dim>::face_indices())
-        for (unsigned int i = 0; i < fe_local.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe_local.n_dofs_per_cell(); ++i)
           {
             if (fe_local.has_support_on_face(i, face_no))
               fe_local_support_on_face[face_no].push_back(i);
           }
 
       for (unsigned int face_no : GeometryInfo<dim>::face_indices())
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             if (fe.has_support_on_face(i, face_no))
               fe_support_on_face[face_no].push_back(i);
@@ -618,9 +618,9 @@ namespace Step51
       , fe_values(fe, quadrature_formula, flags)
       , u_values(quadrature_formula.size())
       , u_gradients(quadrature_formula.size())
-      , cell_matrix(fe.dofs_per_cell, fe.dofs_per_cell)
-      , cell_rhs(fe.dofs_per_cell)
-      , cell_sol(fe.dofs_per_cell)
+      , cell_matrix(fe.n_dofs_per_cell(), fe.n_dofs_per_cell())
+      , cell_rhs(fe.n_dofs_per_cell())
+      , cell_sol(fe.n_dofs_per_cell())
     {}
 
     PostProcessScratchData(const PostProcessScratchData &sd)
@@ -670,7 +670,7 @@ namespace Step51
     const UpdateFlags flags(update_values | update_normal_vectors |
                             update_quadrature_points | update_JxW_values);
 
-    PerTaskData task_data(fe.dofs_per_cell, trace_reconstruct);
+    PerTaskData task_data(fe.n_dofs_per_cell(), trace_reconstruct);
     ScratchData scratch(fe,
                         fe_local,
                         quadrature_formula,
@@ -712,7 +712,7 @@ namespace Step51
       scratch.fe_face_values_local.get_quadrature().size();
 
     const unsigned int loc_dofs_per_cell =
-      scratch.fe_values_local.get_fe().dofs_per_cell;
+      scratch.fe_values_local.get_fe().n_dofs_per_cell();
 
     const FEValuesExtractors::Vector fluxes(0);
     const FEValuesExtractors::Scalar scalar(dim);

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -207,7 +207,7 @@ namespace Step52
                           update_values | update_gradients | update_JxW_values);
 
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -301,7 +301,7 @@ namespace Step52
                             update_JxW_values);
 
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     Vector<double> cell_source(dofs_per_cell);

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -497,7 +497,7 @@ namespace Step55
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -620,7 +620,7 @@ namespace Step56
                             update_values | update_quadrature_points |
                               update_JxW_values | update_gradients);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
     const unsigned int n_q_points = quadrature_formula.size();
 
@@ -718,7 +718,7 @@ namespace Step56
                             update_values | update_quadrature_points |
                               update_JxW_values | update_gradients);
 
-    const unsigned int dofs_per_cell = velocity_fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = velocity_fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -375,7 +375,7 @@ namespace Step57
                             update_values | update_quadrature_points |
                               update_JxW_values | update_gradients);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     const FEValuesExtractors::Vector velocities(0);

--- a/examples/step-58/step-58.cc
+++ b/examples/step-58/step-58.cc
@@ -263,7 +263,7 @@ namespace Step58
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<std::complex<double>> cell_matrix_lhs(dofs_per_cell,

--- a/examples/step-6/step-6.cc
+++ b/examples/step-6/step-6.cc
@@ -264,7 +264,7 @@ void Step6<dim>::assemble_system()
                           update_values | update_gradients |
                             update_quadrature_points | update_JxW_values);
 
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
   FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
   Vector<double>     cell_rhs(dofs_per_cell);

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -412,8 +412,8 @@ namespace Step61
                                             update_quadrature_points |
                                             update_JxW_values);
 
-    const unsigned int dofs_per_cell      = fe.dofs_per_cell;
-    const unsigned int dofs_per_cell_dgrt = fe_dgrt.dofs_per_cell;
+    const unsigned int dofs_per_cell      = fe.n_dofs_per_cell();
+    const unsigned int dofs_per_cell_dgrt = fe_dgrt.n_dofs_per_cell();
 
     const unsigned int n_q_points      = fe_values.get_quadrature().size();
     const unsigned int n_q_points_dgrt = fe_values_dgrt.get_quadrature().size();
@@ -666,8 +666,8 @@ namespace Step61
                                             update_quadrature_points |
                                             update_JxW_values);
 
-    const unsigned int dofs_per_cell      = fe.dofs_per_cell;
-    const unsigned int dofs_per_cell_dgrt = fe_dgrt.dofs_per_cell;
+    const unsigned int dofs_per_cell      = fe.n_dofs_per_cell();
+    const unsigned int dofs_per_cell_dgrt = fe_dgrt.n_dofs_per_cell();
 
     const unsigned int n_q_points      = fe_values.get_quadrature().size();
     const unsigned int n_q_points_dgrt = fe_values_dgrt.get_quadrature().size();

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -794,7 +794,7 @@ namespace step62
                             quadrature_formula,
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<std::complex<double>> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -1228,7 +1228,7 @@ namespace step62
 
     quadrature_cache.resize(triangulation.n_locally_owned_active_cells() *
                               quadrature_formula.size(),
-                            QuadratureCache<dim>(fe.dofs_per_cell));
+                            QuadratureCache<dim>(fe.n_dofs_per_cell()));
     unsigned int cache_index = 0;
     for (const auto &cell : triangulation.active_cell_iterators())
       if (cell->is_locally_owned())

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -701,7 +701,7 @@ namespace Step63
     copy_data.level = cell->level();
 
     const unsigned int dofs_per_cell =
-      scratch_data.fe_values.get_fe().dofs_per_cell;
+      scratch_data.fe_values.get_fe().n_dofs_per_cell();
     copy_data.dofs_per_cell = dofs_per_cell;
     copy_data.cell_matrix.reinit(dofs_per_cell, dofs_per_cell);
 

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -450,7 +450,7 @@ namespace Step64
                             update_values | update_quadrature_points |
                               update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     Vector<double> cell_rhs(dofs_per_cell);

--- a/examples/step-65/step-65.cc
+++ b/examples/step-65/step-65.cc
@@ -381,7 +381,7 @@ namespace Step65
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -767,7 +767,8 @@ namespace Step69
 
       DynamicSparsityPattern dsp(n_locally_relevant, n_locally_relevant);
 
-      const auto dofs_per_cell = discretization->finite_element.dofs_per_cell;
+      const auto dofs_per_cell =
+        discretization->finite_element.n_dofs_per_cell();
       std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
 
       for (const auto &cell : dof_handler.active_cell_iterators())
@@ -1016,8 +1017,9 @@ namespace Step69
     for (auto &matrix : nij_matrix)
       matrix = 0.;
 
-    unsigned int dofs_per_cell = discretization->finite_element.dofs_per_cell;
-    unsigned int n_q_points    = discretization->quadrature.size();
+    unsigned int dofs_per_cell =
+      discretization->finite_element.n_dofs_per_cell();
+    unsigned int n_q_points = discretization->quadrature.size();
 
     // What follows is the initialization of the scratch data required by
     // WorkStream

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -539,7 +539,7 @@ namespace Step7
     const unsigned int n_q_points      = quadrature_formula.size();
     const unsigned int n_face_q_points = face_quadrature_formula.size();
 
-    const unsigned int dofs_per_cell = fe->dofs_per_cell;
+    const unsigned int dofs_per_cell = fe->n_dofs_per_cell();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
     Vector<double>     cell_rhs(dofs_per_cell);

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1380,7 +1380,7 @@ namespace Step70
                                    update_quadrature_points |
                                    update_JxW_values);
 
-    const unsigned int dofs_per_cell = fluid_fe->dofs_per_cell;
+    const unsigned int dofs_per_cell = fluid_fe->n_dofs_per_cell();
     const unsigned int n_q_points    = fluid_quadrature_formula->size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);
@@ -1473,11 +1473,11 @@ namespace Step70
     SolidVelocity<spacedim> solid_velocity(par.angular_velocity);
 
     std::vector<types::global_dof_index> fluid_dof_indices(
-      fluid_fe->dofs_per_cell);
+      fluid_fe->n_dofs_per_cell());
 
-    FullMatrix<double>     local_matrix(fluid_fe->dofs_per_cell,
-                                    fluid_fe->dofs_per_cell);
-    dealii::Vector<double> local_rhs(fluid_fe->dofs_per_cell);
+    FullMatrix<double>     local_matrix(fluid_fe->n_dofs_per_cell(),
+                                    fluid_fe->n_dofs_per_cell());
+    dealii::Vector<double> local_rhs(fluid_fe->n_dofs_per_cell());
 
     const auto penalty_parameter =
       1.0 / GridTools::minimal_cell_diameter(fluid_tria);
@@ -1527,13 +1527,14 @@ namespace Step70
             const auto &real_q = p.get_location();
             const auto &JxW    = p.get_properties()[0];
 
-            for (unsigned int i = 0; i < fluid_fe->dofs_per_cell; ++i)
+            for (unsigned int i = 0; i < fluid_fe->n_dofs_per_cell(); ++i)
               {
                 const auto comp_i =
                   fluid_fe->system_to_component_index(i).first;
                 if (comp_i < spacedim)
                   {
-                    for (unsigned int j = 0; j < fluid_fe->dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < fluid_fe->n_dofs_per_cell();
+                         ++j)
                       {
                         const auto comp_j =
                           fluid_fe->system_to_component_index(j).first;

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -271,7 +271,7 @@ namespace Step8
                             update_values | update_gradients |
                               update_quadrature_points | update_JxW_values);
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points    = quadrature_formula.size();
 
     FullMatrix<double> cell_matrix(dofs_per_cell, dofs_per_cell);

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -609,7 +609,7 @@ namespace Step9
     AssemblyCopyData &                                    copy_data)
   {
     // We define some abbreviations to avoid unnecessarily long lines:
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int n_q_points =
       scratch_data.fe_values.get_quadrature().size();
     const unsigned int n_face_q_points =

--- a/include/deal.II/base/quadrature_point_data.h
+++ b/include/deal.II/base/quadrature_point_data.h
@@ -897,8 +897,8 @@ namespace parallel
           std::unique_ptr<const FiniteElement<dim>>(projection_fe_.clone()))
       , data_size_in_bytes(0)
       , n_q_points(rhs_quadrature.size())
-      , project_to_fe_matrix(projection_fe->dofs_per_cell, n_q_points)
-      , project_to_qp_matrix(n_q_points, projection_fe->dofs_per_cell)
+      , project_to_fe_matrix(projection_fe->n_dofs_per_cell(), n_q_points)
+      , project_to_qp_matrix(n_q_points, projection_fe->n_dofs_per_cell())
       , handle(numbers::invalid_unsigned_int)
       , data_storage(nullptr)
       , triangulation(nullptr)
@@ -1014,7 +1014,7 @@ namespace parallel
         {
           // we need to first use prolongation matrix to get dofvalues on child
           // cells based on dofvalues stored in the parent's data_store
-          matrix_dofs_child.reinit(projection_fe->dofs_per_cell,
+          matrix_dofs_child.reinit(projection_fe->n_dofs_per_cell(),
                                    number_of_values);
           for (unsigned int child = 0; child < cell->n_children(); ++child)
             if (cell->child(child)->is_locally_owned())

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1810,7 +1810,7 @@ public:
    *
    * @param[out] dof_indices The vector into which the indices will be
    * written. It has to have the right size (namely,
-   * <code>fe.dofs_per_cell</code>, <code>fe.dofs_per_face</code>, or
+   * <code>fe.n_dofs_per_cell()</code>, <code>fe.dofs_per_face</code>, or
    * <code>fe.dofs_per_line</code>, depending on which kind of object this
    * function is called) before being passed to this function.
    *
@@ -1827,7 +1827,7 @@ public:
    * argument to this function is called <code>local_dof_indices</code> by
    * convention. The name is not meant to indicate the <i>local</i> numbers of
    * degrees of freedom (which are always between zero and
-   * <code>fe.dofs_per_cell</code>) but instead that the returned values are
+   * <code>fe.n_dofs_per_cell()</code>) but instead that the returned values are
    * the <i>global</i> indices of those degrees of freedom that are located
    * locally on the current cell.
    *

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -247,7 +247,7 @@ namespace internal
 
             if (d == 0)
               dof_handler.object_dof_indices
-                [0][0][obj_index * dof_handler.get_fe().dofs_per_vertex +
+                [0][0][obj_index * dof_handler.get_fe().n_dofs_per_vertex() +
                        local_index] = global_index;
             else
               dof_handler.object_dof_indices
@@ -347,7 +347,7 @@ namespace internal
 
             if (d == 0)
               return dof_handler.object_dof_indices
-                [0][0][obj_index * dof_handler.get_fe().dofs_per_vertex +
+                [0][0][obj_index * dof_handler.get_fe().n_dofs_per_vertex() +
                        local_index];
             else
               return dof_handler.object_dof_indices
@@ -432,7 +432,7 @@ namespace internal
                  "hp::DoFHandler does not implement multilevel DoFs."));
 
         return dof_handler.mg_vertex_dofs[vertex_index].get_index(
-          level, i, dof_handler.get_fe().dofs_per_vertex);
+          level, i, dof_handler.get_fe().n_dofs_per_vertex());
       }
 
 
@@ -450,7 +450,7 @@ namespace internal
                  "hp::DoFHandler does not implement multilevel DoFs."));
 
         return dof_handler.mg_vertex_dofs[vertex_index].set_index(
-          level, i, dof_handler.get_fe().dofs_per_vertex, index);
+          level, i, dof_handler.get_fe().n_dofs_per_vertex(), index);
       }
 
 
@@ -610,7 +610,7 @@ namespace internal
           dof_indices.begin();
 
         for (const unsigned int vertex : accessor.vertex_indices())
-          for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
 
@@ -635,7 +635,7 @@ namespace internal
           dof_indices.begin();
 
         for (const unsigned int vertex : accessor.vertex_indices())
-          for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
 
@@ -665,7 +665,7 @@ namespace internal
           dof_indices.begin();
 
         for (const unsigned int vertex : accessor.vertex_indices())
-          for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
 
@@ -806,11 +806,11 @@ namespace internal
         const unsigned int fe_index,
         const DoFOperation &)
       {
-        const unsigned int                                             //
-          dofs_per_vertex = accessor.get_fe(fe_index).dofs_per_vertex, //
-          dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line,   //
-          dofs_per_quad   = accessor.get_fe(fe_index).dofs_per_quad,   //
-          dofs_per_hex    = accessor.get_fe(fe_index).dofs_per_hex;    //
+        const unsigned int                                                 //
+          dofs_per_vertex = accessor.get_fe(fe_index).n_dofs_per_vertex(), //
+          dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line,       //
+          dofs_per_quad   = accessor.get_fe(fe_index).dofs_per_quad,       //
+          dofs_per_hex    = accessor.get_fe(fe_index).dofs_per_hex;        //
 
         const unsigned int inner_dofs =
           structdim == 1 ? dofs_per_line :
@@ -1187,13 +1187,13 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::mg_vertex_dof_index(
   (void)fe_index;
   Assert(this->dof_handler != nullptr, ExcInvalidObject());
   AssertIndexRange(vertex, this->n_vertices());
-  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).dofs_per_vertex);
+  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).n_dofs_per_vertex());
 
   Assert(dof_handler->hp_capability_enabled == false,
          ExcMessage("hp::DoFHandler does not implement multilevel DoFs."));
 
   return this->dof_handler->mg_vertex_dofs[this->vertex_index(vertex)]
-    .get_index(level, i, this->dof_handler->get_fe().dofs_per_vertex);
+    .get_index(level, i, this->dof_handler->get_fe().n_dofs_per_vertex());
 }
 
 
@@ -1239,13 +1239,13 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::
   (void)fe_index;
   Assert(this->dof_handler != nullptr, ExcInvalidObject());
   AssertIndexRange(vertex, this->n_vertices());
-  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).dofs_per_vertex);
+  AssertIndexRange(i, this->dof_handler->get_fe(fe_index).n_dofs_per_vertex());
 
   Assert(dof_handler->hp_capability_enabled == false,
          ExcMessage("hp::DoFHandler does not implement multilevel DoFs."));
 
   this->dof_handler->mg_vertex_dofs[this->vertex_index(vertex)].set_index(
-    level, i, this->dof_handler->get_fe().dofs_per_vertex, index);
+    level, i, this->dof_handler->get_fe().n_dofs_per_vertex(), index);
 }
 
 
@@ -1293,7 +1293,7 @@ namespace internal
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
       for (const unsigned int vertex : accessor.vertex_indices())
-        for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
       for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
@@ -1318,7 +1318,7 @@ namespace internal
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
       for (const unsigned int vertex : accessor.vertex_indices())
-        for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
       for (unsigned int line = 0; line < accessor.n_lines(); ++line)
@@ -1347,7 +1347,7 @@ namespace internal
       std::vector<types::global_dof_index>::iterator next = dof_indices.begin();
 
       for (const unsigned int vertex : accessor.vertex_indices())
-        for (unsigned int dof = 0; dof < fe.dofs_per_vertex; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
       for (unsigned int line = 0; line < accessor.n_lines(); ++line)
@@ -1406,14 +1406,14 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
       case 1:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->dof_handler->get_fe(fe_index).dofs_per_line),
                ExcVectorDoesNotMatch());
         break;
       case 2:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
                     this->dof_handler->get_fe(fe_index).dofs_per_line +
                   this->dof_handler->get_fe(fe_index).dofs_per_quad),
@@ -1422,7 +1422,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
       case 3:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
                     this->dof_handler->get_fe(fe_index).dofs_per_line +
                   this->n_faces() *
@@ -1447,9 +1447,9 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
   // not allocated for this
   // non-active thing
   Assert(this->fe_index_is_active(fe_index) ||
-           (this->dof_handler->get_fe(fe_index).dofs_per_cell ==
+           (this->dof_handler->get_fe(fe_index).n_dofs_per_cell() ==
             this->n_vertices() *
-              this->dof_handler->get_fe(fe_index).dofs_per_vertex),
+              this->dof_handler->get_fe(fe_index).n_dofs_per_vertex()),
          ExcInternalError());
 
   // now do the actual work
@@ -1479,14 +1479,14 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
       case 1:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->dof_handler->get_fe(fe_index).dofs_per_line),
                ExcVectorDoesNotMatch());
         break;
       case 2:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
                     this->dof_handler->get_fe(fe_index).dofs_per_line +
                   this->dof_handler->get_fe(fe_index).dofs_per_quad),
@@ -1495,7 +1495,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
       case 3:
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
                     this->dof_handler->get_fe(fe_index).dofs_per_line +
                   this->n_faces() *
@@ -1535,7 +1535,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
         {
           Assert(dof_indices.size() ==
                    this->n_vertices() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                      this->dof_handler->get_fe(fe_index).dofs_per_line,
                  ExcVectorDoesNotMatch());
           break;
@@ -1545,7 +1545,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
         {
           Assert(dof_indices.size() ==
                    this->n_vertices() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                      this->n_lines() *
                        this->dof_handler->get_fe(fe_index).dofs_per_line +
                      this->dof_handler->get_fe(fe_index).dofs_per_quad,
@@ -1557,7 +1557,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
         {
           Assert(dof_indices.size() ==
                    this->n_vertices() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_vertex +
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                      this->n_lines() *
                        this->dof_handler->get_fe(fe_index).dofs_per_line +
                      this->n_faces() *
@@ -2013,7 +2013,7 @@ namespace internal
         // FE_Nothing
         if (accessor.has_children())
           return;
-        const unsigned int dofs_per_cell = accessor.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = accessor.get_fe().n_dofs_per_cell();
         if (dofs_per_cell == 0)
           return;
 
@@ -2407,9 +2407,9 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
          ExcMessage("get_dof_indices() only works on active cells."));
   Assert(this->is_artificial() == false,
          ExcMessage("Can't ask for DoF indices on artificial cells."));
-  AssertDimension(dof_indices.size(), this->get_fe().dofs_per_cell);
+  AssertDimension(dof_indices.size(), this->get_fe().n_dofs_per_cell());
 
-  const auto dofs_per_cell = this->get_fe().dofs_per_cell;
+  const auto dofs_per_cell = this->get_fe().n_dofs_per_cell();
   if (dofs_per_cell > 0)
     {
       const types::global_dof_index *cache =
@@ -2488,7 +2488,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_dof_values(
   Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
   Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
-           this->get_fe().dofs_per_cell,
+           this->get_fe().n_dofs_per_cell(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert(values.size() == this->get_dof_handler().n_dofs(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
@@ -2498,11 +2498,11 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_dof_values(
       this->dof_handler,
       this->present_level,
       this->present_index,
-      this->get_fe().dofs_per_cell);
+      this->get_fe().n_dofs_per_cell());
   dealii::internal::DoFAccessorImplementation::Implementation::
     extract_subvector_to(values,
                          cache,
-                         cache + this->get_fe().dofs_per_cell,
+                         cache + this->get_fe().n_dofs_per_cell(),
                          local_values_begin);
 }
 
@@ -2522,7 +2522,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_dof_values(
   Assert(this->is_active(), ExcMessage("Cell must be active."));
 
   Assert(static_cast<unsigned int>(local_values_end - local_values_begin) ==
-           this->get_fe().dofs_per_cell,
+           this->get_fe().n_dofs_per_cell(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert(values.size() == this->get_dof_handler().n_dofs(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
@@ -2533,7 +2533,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_dof_values(
       this->dof_handler,
       this->present_level,
       this->present_index,
-      this->get_fe().dofs_per_cell);
+      this->get_fe().n_dofs_per_cell());
 
   constraints.get_dof_values(values,
                              *cache,
@@ -2555,7 +2555,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::set_dof_values(
   Assert(this->is_active(), ExcMessage("Cell must be active."));
 
   Assert(static_cast<unsigned int>(local_values.size()) ==
-           this->get_fe().dofs_per_cell,
+           this->get_fe().n_dofs_per_cell(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
   Assert(values.size() == this->get_dof_handler().n_dofs(),
          typename DoFCellAccessor::ExcVectorDoesNotMatch());
@@ -2567,9 +2567,9 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::set_dof_values(
       this->dof_handler,
       this->present_level,
       this->present_index,
-      this->get_fe().dofs_per_cell);
+      this->get_fe().n_dofs_per_cell());
 
-  for (unsigned int i = 0; i < this->get_fe().dofs_per_cell; ++i, ++cache)
+  for (unsigned int i = 0; i < this->get_fe().n_dofs_per_cell(); ++i, ++cache)
     internal::ElementAccess<OutputVector>::set(local_values(i), *cache, values);
 }
 
@@ -2775,7 +2775,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   Assert(this->dof_handler != nullptr,
          (typename std::decay<decltype(*this)>::type::ExcInvalidObject()));
   Assert(static_cast<unsigned int>(local_source_end - local_source_begin) ==
-           this->get_fe().dofs_per_cell,
+           this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_destination.size(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
@@ -2806,7 +2806,8 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 {
   Assert(this->dof_handler != nullptr,
          (typename std::decay<decltype(*this)>::type::ExcInvalidObject()));
-  Assert(local_source_end - local_source_begin == this->get_fe().dofs_per_cell,
+  Assert(local_source_end - local_source_begin ==
+           this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_destination.size(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
@@ -2837,9 +2838,9 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 {
   Assert(this->dof_handler != nullptr,
          (typename std::decay<decltype(*this)>::type::ExcInvalidObject()));
-  Assert(local_source.m() == this->get_fe().dofs_per_cell,
+  Assert(local_source.m() == this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
-  Assert(local_source.n() == this->get_fe().dofs_per_cell,
+  Assert(local_source.n() == this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_destination.m(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
@@ -2872,22 +2873,22 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 {
   Assert(this->dof_handler != nullptr,
          (typename std::decay<decltype(*this)>::type::ExcInvalidObject()));
-  Assert(local_matrix.m() == this->get_fe().dofs_per_cell,
+  Assert(local_matrix.m() == this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
-  Assert(local_matrix.n() == this->get_fe().dofs_per_cell,
+  Assert(local_matrix.n() == this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_matrix.m(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_matrix.n(),
          (typename std::decay<decltype(*this)>::type::ExcMatrixDoesNotMatch()));
-  Assert(local_vector.size() == this->get_fe().dofs_per_cell,
+  Assert(local_vector.size() == this->get_fe().n_dofs_per_cell(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
   Assert(this->dof_handler->n_dofs() == global_vector.size(),
          (typename std::decay<decltype(*this)>::type::ExcVectorDoesNotMatch()));
 
   Assert(!this->has_children(), ExcMessage("Cell must be active."));
 
-  const unsigned int             n_dofs = this->get_fe().dofs_per_cell;
+  const unsigned int             n_dofs = this->get_fe().n_dofs_per_cell();
   const types::global_dof_index *dofs =
     dealii::internal::DoFAccessorImplementation::Implementation::get_cache_ptr(
       this->dof_handler, this->level(), this->present_index, n_dofs);

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -614,7 +614,7 @@ namespace internal
             accessor.set_mg_vertex_dof_index(
               level, vertex, dof, *next++, fe_index);
 
-        for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
           accessor.set_mg_dof_index(level, dof, *next++);
 
         Assert(next == dof_indices.end(), ExcInternalError());
@@ -640,10 +640,10 @@ namespace internal
               level, vertex, dof, *next++, fe_index);
 
         for (unsigned int line = 0; line < accessor.n_lines(); ++line)
-          for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
             accessor.line(line)->set_mg_dof_index(level, dof, *next++);
 
-        for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_quad(); ++dof)
           accessor.set_mg_dof_index(level, dof, *next++);
 
         Assert(next == dof_indices.end(), ExcInternalError());
@@ -670,7 +670,7 @@ namespace internal
               level, vertex, dof, *next++, fe_index);
 
         for (unsigned int line = 0; line < accessor.n_lines(); ++line)
-          for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
             accessor.line(line)->set_mg_dof_index(
               level,
               fe.adjust_line_dof_index_for_line_orientation(
@@ -678,7 +678,7 @@ namespace internal
               *next++);
 
         for (unsigned int quad = 0; quad < accessor.n_faces(); ++quad)
-          for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
+          for (unsigned int dof = 0; dof < fe.n_dofs_per_quad(); ++dof)
             accessor.quad(quad)->set_mg_dof_index(
               level,
               fe.adjust_quad_dof_index_for_face_orientation(
@@ -688,7 +688,7 @@ namespace internal
                 accessor.face_rotation(quad)),
               *next++);
 
-        for (unsigned int dof = 0; dof < fe.dofs_per_hex; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_hex(); ++dof)
           accessor.set_mg_dof_index(level, dof, *next++);
 
         Assert(next == dof_indices.end(), ExcInternalError());
@@ -808,9 +808,9 @@ namespace internal
       {
         const unsigned int                                                 //
           dofs_per_vertex = accessor.get_fe(fe_index).n_dofs_per_vertex(), //
-          dofs_per_line   = accessor.get_fe(fe_index).dofs_per_line,       //
-          dofs_per_quad   = accessor.get_fe(fe_index).dofs_per_quad,       //
-          dofs_per_hex    = accessor.get_fe(fe_index).dofs_per_hex;        //
+          dofs_per_line   = accessor.get_fe(fe_index).n_dofs_per_line(),   //
+          dofs_per_quad   = accessor.get_fe(fe_index).n_dofs_per_quad(),   //
+          dofs_per_hex    = accessor.get_fe(fe_index).n_dofs_per_hex();    //
 
         const unsigned int inner_dofs =
           structdim == 1 ? dofs_per_line :
@@ -1296,7 +1296,7 @@ namespace internal
         for (unsigned int dof = 0; dof < fe.n_dofs_per_vertex(); ++dof)
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
-      for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+      for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
         *next++ = accessor.mg_dof_index(level, dof);
 
       Assert(next == dof_indices.end(), ExcInternalError());
@@ -1322,10 +1322,10 @@ namespace internal
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
       for (unsigned int line = 0; line < accessor.n_lines(); ++line)
-        for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
           *next++ = accessor.line(line)->mg_dof_index(level, dof);
 
-      for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
+      for (unsigned int dof = 0; dof < fe.n_dofs_per_quad(); ++dof)
         *next++ = accessor.mg_dof_index(level, dof);
 
       Assert(next == dof_indices.end(), ExcInternalError());
@@ -1351,7 +1351,7 @@ namespace internal
           *next++ = accessor.mg_vertex_dof_index(level, vertex, dof);
 
       for (unsigned int line = 0; line < accessor.n_lines(); ++line)
-        for (unsigned int dof = 0; dof < fe.dofs_per_line; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_line(); ++dof)
           *next++ = accessor.line(line)->mg_dof_index(
             level,
             accessor.get_fe(fe_index)
@@ -1359,7 +1359,7 @@ namespace internal
                 dof, accessor.line_orientation(line)));
 
       for (unsigned int quad = 0; quad < accessor.n_faces(); ++quad)
-        for (unsigned int dof = 0; dof < fe.dofs_per_quad; ++dof)
+        for (unsigned int dof = 0; dof < fe.n_dofs_per_quad(); ++dof)
           *next++ = accessor.quad(quad)->mg_dof_index(
             level,
             accessor.get_fe(fe_index)
@@ -1369,7 +1369,7 @@ namespace internal
                 accessor.face_flip(quad),
                 accessor.face_rotation(quad)));
 
-      for (unsigned int dof = 0; dof < fe.dofs_per_hex; ++dof)
+      for (unsigned int dof = 0; dof < fe.n_dofs_per_hex(); ++dof)
         *next++ = accessor.mg_dof_index(level, dof);
 
       Assert(next == dof_indices.end(), ExcInternalError());
@@ -1407,7 +1407,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
-                  this->dof_handler->get_fe(fe_index).dofs_per_line),
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_line()),
                ExcVectorDoesNotMatch());
         break;
       case 2:
@@ -1415,8 +1415,8 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_line +
-                  this->dof_handler->get_fe(fe_index).dofs_per_quad),
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_quad()),
                ExcVectorDoesNotMatch());
         break;
       case 3:
@@ -1424,10 +1424,10 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_dof_indices(
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_line +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
                   this->n_faces() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_quad +
-                  this->dof_handler->get_fe(fe_index).dofs_per_hex),
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_quad() +
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_hex()),
                ExcVectorDoesNotMatch());
         break;
       default:
@@ -1480,7 +1480,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
         Assert(dof_indices.size() ==
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
-                  this->dof_handler->get_fe(fe_index).dofs_per_line),
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_line()),
                ExcVectorDoesNotMatch());
         break;
       case 2:
@@ -1488,8 +1488,8 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_line +
-                  this->dof_handler->get_fe(fe_index).dofs_per_quad),
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_quad()),
                ExcVectorDoesNotMatch());
         break;
       case 3:
@@ -1497,10 +1497,10 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_mg_dof_indices(
                  (this->n_vertices() *
                     this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                   this->n_lines() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_line +
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
                   this->n_faces() *
-                    this->dof_handler->get_fe(fe_index).dofs_per_quad +
-                  this->dof_handler->get_fe(fe_index).dofs_per_hex),
+                    this->dof_handler->get_fe(fe_index).n_dofs_per_quad() +
+                  this->dof_handler->get_fe(fe_index).n_dofs_per_hex()),
                ExcVectorDoesNotMatch());
         break;
       default:
@@ -1536,7 +1536,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
           Assert(dof_indices.size() ==
                    this->n_vertices() *
                        this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
-                     this->dof_handler->get_fe(fe_index).dofs_per_line,
+                     this->dof_handler->get_fe(fe_index).n_dofs_per_line(),
                  ExcVectorDoesNotMatch());
           break;
         }
@@ -1547,8 +1547,8 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
                    this->n_vertices() *
                        this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                      this->n_lines() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_line +
-                     this->dof_handler->get_fe(fe_index).dofs_per_quad,
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
+                     this->dof_handler->get_fe(fe_index).n_dofs_per_quad(),
                  ExcVectorDoesNotMatch());
           break;
         }
@@ -1559,10 +1559,10 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::set_mg_dof_indices(
                    this->n_vertices() *
                        this->dof_handler->get_fe(fe_index).n_dofs_per_vertex() +
                      this->n_lines() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_line +
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_line() +
                      this->n_faces() *
-                       this->dof_handler->get_fe(fe_index).dofs_per_quad +
-                     this->dof_handler->get_fe(fe_index).dofs_per_hex,
+                       this->dof_handler->get_fe(fe_index).n_dofs_per_quad() +
+                     this->dof_handler->get_fe(fe_index).n_dofs_per_hex(),
                  ExcVectorDoesNotMatch());
           break;
         }

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1352,7 +1352,7 @@ private:
      * on the various levels this vertex exists on.
      *
      * The starting offset of the DoFs that belong to a @p level are given by
-     * <code>dofs_per_vertex * (level-coarsest_level)</code>. @p dofs_per_vertex
+     * <code>n_dofs_per_vertex() * (level-coarsest_level)</code>. @p n_dofs_per_vertex()
      * must therefore be passed as an argument to the functions that set or
      * read an index.
      */

--- a/include/deal.II/dofs/dof_levels.h
+++ b/include/deal.II/dofs/dof_levels.h
@@ -71,7 +71,7 @@ namespace internal
     public:
       /**
        * Cache for the DoF indices on cells. The size of this array equals the
-       * number of cells on a given level times selected_fe.dofs_per_cell.
+       * number of cells on a given level times selected_fe.n_dofs_per_cell().
        */
       std::vector<types::global_dof_index> cell_dof_indices_cache;
 

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -484,10 +484,10 @@ class FESystem;
  * following piece of code in the constructor of a class derived from
  * FiniteElement to compute the $M$ matrix:
  * @code
- * FullMatrix<double> M(this->dofs_per_cell, this->dofs_per_cell);
+ * FullMatrix<double> M(this->n_dofs_per_cell(), this->n_dofs_per_cell());
  * FETools::compute_node_matrix(M, *this);
- * this->inverse_node_matrix.reinit(this->dofs_per_cell, this->dofs_per_cell);
- * this->inverse_node_matrix.invert(M);
+ * this->inverse_node_matrix.reinit(this->n_dofs_per_cell(),
+ * this->n_dofs_per_cell()); this->inverse_node_matrix.invert(M);
  * @endcode
  * Don't forget to make sure
  * that #unit_support_points or #generalized_support_points are initialized
@@ -509,8 +509,8 @@ class FESystem;
  * In the latter case, all that is required is the following piece of code:
  * @code
  * for (unsigned int c=0; c<GeometryInfo<dim>::max_children_per_cell; ++c)
- *   this->prolongation[c].reinit (this->dofs_per_cell,
- *                                 this->dofs_per_cell);
+ *   this->prolongation[c].reinit (this->n_dofs_per_cell(),
+ *                                 this->n_dofs_per_cell());
  * FETools::compute_embedding_matrices (*this, this->prolongation);
  * @endcode
  * As in this example, prolongation is almost always implemented via
@@ -824,7 +824,7 @@ public:
    * version hp::DoFHandler, since one can then write code like this:
    * @code
    * dofs_per_cell =
-   *   dof_handler->get_fe()[cell->active_fe_index()].dofs_per_cell;
+   *   dof_handler->get_fe()[cell->active_fe_index()].n_dofs_per_cell();
    * @endcode
    *
    * This code doesn't work in both situations without the present operator
@@ -1321,10 +1321,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(const FiniteElement<dim, spacedim> &fe_other) const;
@@ -3205,7 +3205,7 @@ inline std::pair<unsigned int, types::global_dof_index>
 FiniteElement<dim, spacedim>::system_to_block_index(
   const unsigned int index) const
 {
-  AssertIndexRange(index, this->dofs_per_cell);
+  AssertIndexRange(index, this->n_dofs_per_cell());
   // The block is computed simply as
   // first block of this base plus
   // the index within the base blocks
@@ -3222,7 +3222,7 @@ inline bool
 FiniteElement<dim, spacedim>::restriction_is_additive(
   const unsigned int index) const
 {
-  AssertIndexRange(index, this->dofs_per_cell);
+  AssertIndexRange(index, this->n_dofs_per_cell());
   return restriction_is_additive_flags[index];
 }
 
@@ -3232,7 +3232,7 @@ template <int dim, int spacedim>
 inline const ComponentMask &
 FiniteElement<dim, spacedim>::get_nonzero_components(const unsigned int i) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return nonzero_components[i];
 }
 
@@ -3242,7 +3242,7 @@ template <int dim, int spacedim>
 inline unsigned int
 FiniteElement<dim, spacedim>::n_nonzero_components(const unsigned int i) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return n_nonzero_components_table[i];
 }
 
@@ -3261,7 +3261,7 @@ template <int dim, int spacedim>
 inline bool
 FiniteElement<dim, spacedim>::is_primitive(const unsigned int i) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
 
   // return primitivity of a shape
   // function by checking whether it
@@ -3285,7 +3285,7 @@ inline GeometryPrimitive
 FiniteElement<dim, spacedim>::get_associated_geometry_primitive(
   const unsigned int cell_dof_index) const
 {
-  AssertIndexRange(cell_dof_index, this->dofs_per_cell);
+  AssertIndexRange(cell_dof_index, this->n_dofs_per_cell());
 
   // just go through the usual cases, taking into account how DoFs
   // are enumerated on the reference cell

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -3289,11 +3289,11 @@ FiniteElement<dim, spacedim>::get_associated_geometry_primitive(
 
   // just go through the usual cases, taking into account how DoFs
   // are enumerated on the reference cell
-  if (cell_dof_index < this->first_line_index)
+  if (cell_dof_index < this->get_first_line_index())
     return GeometryPrimitive::vertex;
-  else if (cell_dof_index < this->first_quad_index)
+  else if (cell_dof_index < this->get_first_quad_index())
     return GeometryPrimitive::line;
-  else if (cell_dof_index < this->first_hex_index)
+  else if (cell_dof_index < this->get_first_hex_index())
     return GeometryPrimitive::quad;
   else
     return GeometryPrimitive::hex;

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -446,6 +446,36 @@ public:
    */
   bool
   operator==(const FiniteElementData &) const;
+
+  /**
+   * Return first index of dof on a line.
+   */
+  unsigned int
+  get_first_line_index() const;
+
+  /**
+   * Return first index of dof on a quad.
+   */
+  unsigned int
+  get_first_quad_index() const;
+
+  /**
+   * Return first index of dof on a hexahedron.
+   */
+  unsigned int
+  get_first_hex_index() const;
+
+  /**
+   * Return first index of dof on a line for face data.
+   */
+  unsigned int
+  get_first_face_line_index() const;
+
+  /**
+   * Return first index of dof on a quad for face data.
+   */
+  unsigned int
+  get_first_face_quad_index() const;
 };
 
 
@@ -620,6 +650,43 @@ inline bool
 FiniteElementData<dim>::conforms(const Conformity space) const
 {
   return ((space & conforming_space) == space);
+}
+
+
+
+template <int dim>
+unsigned int
+FiniteElementData<dim>::get_first_line_index() const
+{
+  return first_line_index;
+}
+
+template <int dim>
+unsigned int
+FiniteElementData<dim>::get_first_quad_index() const
+{
+  return first_quad_index;
+}
+
+template <int dim>
+unsigned int
+FiniteElementData<dim>::get_first_hex_index() const
+{
+  return first_hex_index;
+}
+
+template <int dim>
+unsigned int
+FiniteElementData<dim>::get_first_face_line_index() const
+{
+  return first_face_line_index;
+}
+
+template <int dim>
+unsigned int
+FiniteElementData<dim>::get_first_face_quad_index() const
+{
+  return first_face_quad_index;
 }
 
 

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -150,10 +150,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -337,10 +337,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * This being a discontinuous element, the set of such constraints is of
    * course empty.

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -312,10 +312,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * This being a discontinuous element, the set of such constraints is of
    * course empty.
@@ -368,7 +368,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one. The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are only available if the source element is also a @p FE_Q
    * element. Otherwise, an exception of type

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -426,10 +426,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * This being a discontinuous element, the set of such constraints is of
    * course empty.

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -129,7 +129,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one. The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are only available if the source element is also a @p
    * FE_DGQ element. Otherwise, an exception of type
@@ -235,10 +235,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * This being a discontinuous element, the set of such constraints is of
    * course empty.

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -426,10 +426,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -134,10 +134,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * The set of such constraints is non-empty only for dim==1.
    */
@@ -284,10 +284,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    *
    * The set of such constraints is non-empty only for dim==1.
    */

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -203,10 +203,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(const FiniteElement<dim> &fe_other) const override;

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -273,13 +273,13 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      update_flags & update_values ? this->dofs_per_cell : 0);
+      update_flags & update_values ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      update_flags & update_gradients ? this->dofs_per_cell : 0);
+      update_flags & update_gradients ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<2, dim>> grad_grads(
-      update_flags & update_hessians ? this->dofs_per_cell : 0);
+      update_flags & update_hessians ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      update_flags & update_3rd_derivatives ? this->dofs_per_cell : 0);
+      update_flags & update_3rd_derivatives ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -302,16 +302,16 @@ protected:
     if ((update_flags & update_values) &&
         !((output_data.shape_values.n_rows() > 0) &&
           (output_data.shape_values.n_cols() == n_q_points)))
-      data.shape_values.reinit(this->dofs_per_cell, n_q_points);
+      data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
     if (update_flags & update_gradients)
-      data.shape_gradients.reinit(this->dofs_per_cell, n_q_points);
+      data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
     if (update_flags & update_hessians)
-      data.shape_hessians.reinit(this->dofs_per_cell, n_q_points);
+      data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
     if (update_flags & update_3rd_derivatives)
-      data.shape_3rd_derivatives.reinit(this->dofs_per_cell, n_q_points);
+      data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
@@ -338,10 +338,10 @@ protected:
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
-                  for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+                  for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
                     output_data.shape_values[k][i] = values[k];
                 else
-                  for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+                  for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
                     data.shape_values[k][i] = values[k];
               }
 
@@ -349,15 +349,15 @@ protected:
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
           if (update_flags & update_gradients)
-            for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+            for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
           if (update_flags & update_hessians)
-            for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+            for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
           if (update_flags & update_3rd_derivatives)
-            for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+            for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }
     return data_ptr;

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -59,7 +59,7 @@ double
 FE_Poly<dim, spacedim>::shape_value(const unsigned int i,
                                     const Point<dim> & p) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return poly_space->compute_value(i, p);
 }
 
@@ -72,7 +72,7 @@ FE_Poly<dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   return poly_space->compute_value(i, p);
 }
@@ -84,7 +84,7 @@ Tensor<1, dim>
 FE_Poly<dim, spacedim>::shape_grad(const unsigned int i,
                                    const Point<dim> & p) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return poly_space->template compute_derivative<1>(i, p);
 }
 
@@ -97,7 +97,7 @@ FE_Poly<dim, spacedim>::shape_grad_component(const unsigned int i,
                                              const unsigned int component) const
 {
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   return poly_space->template compute_derivative<1>(i, p);
 }
@@ -109,7 +109,7 @@ Tensor<2, dim>
 FE_Poly<dim, spacedim>::shape_grad_grad(const unsigned int i,
                                         const Point<dim> & p) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return poly_space->template compute_derivative<2>(i, p);
 }
 
@@ -123,7 +123,7 @@ FE_Poly<dim, spacedim>::shape_grad_grad_component(
   const unsigned int component) const
 {
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   return poly_space->template compute_derivative<2>(i, p);
 }
@@ -135,7 +135,7 @@ Tensor<3, dim>
 FE_Poly<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                              const Point<dim> & p) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return poly_space->template compute_derivative<3>(i, p);
 }
 
@@ -149,7 +149,7 @@ FE_Poly<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   return poly_space->template compute_derivative<3>(i, p);
 }
@@ -161,7 +161,7 @@ Tensor<4, dim>
 FE_Poly<dim, spacedim>::shape_4th_derivative(const unsigned int i,
                                              const Point<dim> & p) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   return poly_space->template compute_derivative<4>(i, p);
 }
 
@@ -175,7 +175,7 @@ FE_Poly<dim, spacedim>::shape_4th_derivative_component(
   const unsigned int component) const
 {
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   return poly_space->template compute_derivative<4>(i, p);
 }
@@ -295,7 +295,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // we were in get_data()
   if (flags & update_gradients &&
       cell_similarity != CellSimilarity::translation)
-    for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
                         mapping_covariant,
                         mapping_internal,
@@ -303,7 +303,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
 
   if (flags & update_hessians && cell_similarity != CellSimilarity::translation)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_hessians, k),
                           mapping_covariant_gradient,
                           mapping_internal,
@@ -316,7 +316,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   if (flags & update_3rd_derivatives &&
       cell_similarity != CellSimilarity::translation)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives, k),
                           mapping_covariant_hessian,
                           mapping_internal,
@@ -377,12 +377,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
   if (flags & update_values)
-    for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
   if (flags & update_gradients)
-    for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
         mapping_covariant,
@@ -391,7 +391,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
 
   if (flags & update_hessians)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
           make_array_view(fe_data.shape_hessians, k, offset, quadrature.size()),
           mapping_covariant_gradient,
@@ -404,7 +404,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
 
   if (flags & update_3rd_derivatives)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,
                                           k,
                                           offset,
@@ -471,12 +471,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
   if (flags & update_values)
-    for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
   if (flags & update_gradients)
-    for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+    for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
         mapping_covariant,
@@ -485,7 +485,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
 
   if (flags & update_hessians)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
           make_array_view(fe_data.shape_hessians, k, offset, quadrature.size()),
           mapping_covariant_gradient,
@@ -498,7 +498,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
 
   if (flags & update_3rd_derivatives)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,
                                           k,
                                           offset,
@@ -524,7 +524,7 @@ FE_Poly<dim, spacedim>::correct_hessians(
     &                mapping_data,
   const unsigned int n_q_points) const
 {
-  for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+  for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int j = 0; j < spacedim; ++j)
         output_data.shape_hessians[dof][i] -=
@@ -543,7 +543,7 @@ FE_Poly<dim, spacedim>::correct_third_derivatives(
     &                mapping_data,
   const unsigned int n_q_points) const
 {
-  for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+  for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int j = 0; j < spacedim; ++j)
         for (unsigned int k = 0; k < spacedim; ++k)

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -134,7 +134,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
   if (fe_data.update_each & update_values)
     for (unsigned int i = 0; i < quadrature.size(); ++i)
       {
-        for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+        for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
           output_data.shape_values(k, i) = 0.;
         switch (dim)
           {
@@ -182,7 +182,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
             case 1:
               {
                 // Fill data for vertex shape functions
-                if (this->dofs_per_vertex != 0)
+                if (this->n_dofs_per_vertex() != 0)
                   for (unsigned int lvertex = 0;
                        lvertex < GeometryInfo<dim>::vertices_per_face;
                        ++lvertex)
@@ -227,7 +227,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
 
   if (fe_data.update_each & update_values)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)
           output_data.shape_values(k, i) = 0.;
       for (unsigned int k = 0; k < fe_data.shape_values.size(); ++k)

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -141,14 +141,16 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
             case 3:
               {
                 // Fill data for quad shape functions
-                if (this->dofs_per_quad != 0)
+                if (this->n_dofs_per_quad() != 0)
                   {
                     const unsigned int foffset =
-                      this->first_quad_index + this->dofs_per_quad * face_no;
-                    for (unsigned int k = 0; k < this->dofs_per_quad; ++k)
+                      this->get_first_quad_index() +
+                      this->n_dofs_per_quad() * face_no;
+                    for (unsigned int k = 0; k < this->n_dofs_per_quad(); ++k)
                       output_data.shape_values(foffset + k, i) =
                         fe_data
-                          .shape_values[k + this->first_face_quad_index][i];
+                          .shape_values[k + this->get_first_face_quad_index()]
+                                       [i];
                   }
               }
               DEAL_II_FALLTHROUGH;
@@ -156,24 +158,24 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
             case 2:
               {
                 // Fill data for line shape functions
-                if (this->dofs_per_line != 0)
+                if (this->n_dofs_per_line() != 0)
                   {
-                    const unsigned int foffset = this->first_line_index;
+                    const unsigned int foffset = this->get_first_line_index();
                     for (unsigned int line = 0;
                          line < GeometryInfo<dim>::lines_per_face;
                          ++line)
                       {
-                        for (unsigned int k = 0; k < this->dofs_per_line; ++k)
+                        for (unsigned int k = 0; k < this->n_dofs_per_line();
+                             ++k)
                           output_data.shape_values(
                             foffset +
                               GeometryInfo<dim>::face_to_cell_lines(face_no,
                                                                     line) *
-                                this->dofs_per_line +
+                                this->n_dofs_per_line() +
                               k,
-                            i) =
-                            fe_data
-                              .shape_values[k + (line * this->dofs_per_line) +
-                                            this->first_face_line_index][i];
+                            i) = fe_data.shape_values
+                                   [k + (line * this->n_dofs_per_line()) +
+                                    this->get_first_face_line_index()][i];
                       }
                   }
               }

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -260,7 +260,7 @@ protected:
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
     if (update_flags & (update_values | update_gradients | update_hessians))
-      data.sign_change.resize(this->dofs_per_cell);
+      data.sign_change.resize(this->n_dofs_per_cell());
 
     // initialize fields only if really
     // necessary. otherwise, don't
@@ -284,16 +284,16 @@ protected:
 
     if (update_flags & update_values)
       {
-        values.resize(this->dofs_per_cell);
-        data.shape_values.reinit(this->dofs_per_cell, n_q_points);
+        values.resize(this->n_dofs_per_cell());
+        data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
         if (update_transformed_shape_values)
           data.transformed_shape_values.resize(n_q_points);
       }
 
     if (update_flags & update_gradients)
       {
-        grads.resize(this->dofs_per_cell);
-        data.shape_grads.reinit(this->dofs_per_cell, n_q_points);
+        grads.resize(this->n_dofs_per_cell());
+        data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
         data.transformed_shape_grads.resize(n_q_points);
 
         if (update_transformed_shape_grads)
@@ -302,8 +302,8 @@ protected:
 
     if (update_flags & update_hessians)
       {
-        grad_grads.resize(this->dofs_per_cell);
-        data.shape_grad_grads.reinit(this->dofs_per_cell, n_q_points);
+        grad_grads.resize(this->n_dofs_per_cell());
+        data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
         data.transformed_shape_hessians.resize(n_q_points);
         if (update_transformed_shape_hessian_tensors)
           data.untransformed_shape_hessian_tensors.resize(n_q_points);
@@ -329,13 +329,13 @@ protected:
           if (update_flags & update_values)
             {
               if (inverse_node_matrix.n_cols() == 0)
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   data.shape_values[i][k] = values[i];
               else
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   {
                     Tensor<1, dim> add_values;
-                    for (unsigned int j = 0; j < this->dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
                       add_values += inverse_node_matrix(j, i) * values[j];
                     data.shape_values[i][k] = add_values;
                   }
@@ -344,13 +344,13 @@ protected:
           if (update_flags & update_gradients)
             {
               if (inverse_node_matrix.n_cols() == 0)
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   data.shape_grads[i][k] = grads[i];
               else
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   {
                     Tensor<2, dim> add_grads;
-                    for (unsigned int j = 0; j < this->dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
                       add_grads += inverse_node_matrix(j, i) * grads[j];
                     data.shape_grads[i][k] = add_grads;
                   }
@@ -359,13 +359,13 @@ protected:
           if (update_flags & update_hessians)
             {
               if (inverse_node_matrix.n_cols() == 0)
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   data.shape_grad_grads[i][k] = grad_grads[i];
               else
-                for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
                   {
                     Tensor<3, dim> add_grad_grads;
-                    for (unsigned int j = 0; j < this->dofs_per_cell; ++j)
+                    for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
                       add_grad_grads +=
                         inverse_node_matrix(j, i) * grad_grads[j];
                     data.shape_grad_grads[i][k] = add_grad_grads;

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -50,7 +50,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one. The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are only available if the source element is also a @p FE_Q
    * element. Otherwise, an exception of type
@@ -234,10 +234,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -115,7 +115,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one.  The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are only available if the source element is also a @p
    * FE_Q_Bubbles element. Otherwise, an exception of type

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -270,7 +270,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one.  The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are only available if the source element is also a @p
    * FE_Q_DG0 element. Otherwise, an exception of type

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -606,10 +606,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(const FiniteElement<dim> &fe_other) const override;

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -721,7 +721,7 @@ public:
   /**
    * Return the matrix interpolating from the given finite element to the
    * present one. The size of the matrix is then @p dofs_per_cell times
-   * <tt>source.dofs_per_cell</tt>.
+   * <tt>source.n_dofs_per_cell()</tt>.
    *
    * These matrices are available if source and destination element are both
    * @p FESystem elements, have the same number of base elements with same
@@ -938,10 +938,10 @@ public:
    * reference to a finite element object representing one of the other finite
    * elements active on this particular vertex. The function computes which of
    * the degrees of freedom of the two finite element objects are equivalent,
-   * both numbered between zero and the corresponding value of dofs_per_vertex
-   * of the two finite elements. The first index of each pair denotes one of
-   * the vertex dofs of the present element, whereas the second is the
-   * corresponding index of the other finite element.
+   * both numbered between zero and the corresponding value of
+   * n_dofs_per_vertex() of the two finite elements. The first index of each
+   * pair denotes one of the vertex dofs of the present element, whereas the
+   * second is the corresponding index of the other finite element.
    */
   virtual std::vector<std::pair<unsigned int, unsigned int>>
   hp_vertex_dof_identities(

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -183,7 +183,7 @@ namespace FETools
   /**
    * Compute the interpolation matrix that interpolates a @p fe1-function to a
    * @p fe2-function on each cell. The interpolation_matrix needs to be of
-   * size <tt>(fe2.dofs_per_cell, fe1.dofs_per_cell)</tt>.
+   * size <tt>(fe2.n_dofs_per_cell(), fe1.n_dofs_per_cell())</tt>.
    *
    * Note, that if the finite element space @p fe1 is a subset of the finite
    * element space @p fe2 then the @p interpolation_matrix is an embedding
@@ -199,7 +199,7 @@ namespace FETools
    * Compute the interpolation matrix that interpolates a @p fe1-function to a
    * @p fe2-function, and interpolates this to a second @p fe1-function on
    * each cell. The interpolation_matrix needs to be of size
-   * <tt>(fe1.dofs_per_cell, fe1.dofs_per_cell)</tt>.
+   * <tt>(fe1.n_dofs_per_cell(), fe1.n_dofs_per_cell())</tt>.
    *
    * Note, that this function only makes sense if the finite element space due
    * to @p fe1 is not a subset of the finite element space due to @p fe2, as
@@ -214,8 +214,8 @@ namespace FETools
 
   /**
    * Compute the identity matrix minus the back interpolation matrix.
-   * The @p difference_matrix will be of size <tt>(fe1.dofs_per_cell,
-   * fe1.dofs_per_cell)</tt> after this function. Previous content
+   * The @p difference_matrix will be of size <tt>(fe1.n_dofs_per_cell(),
+   * fe1.n_dofs_per_cell())</tt> after this function. Previous content
    * of the argument will be overwritten.
    *
    * This function computes the matrix that transforms a @p fe1 function $z$ to
@@ -569,7 +569,7 @@ namespace FETools
    * This method implements the
    * FETools::compute_projection_from_quadrature_points_matrix method for
    * faces of a mesh.  The matrix that it returns, X, is face specific and its
-   * size is fe.dofs_per_cell by rhs_quadrature.size().  The dimension, dim
+   * size is fe.n_dofs_per_cell() by rhs_quadrature.size().  The dimension, dim
    * must be larger than 1 for this class, since Quadrature<dim-1> objects are
    * required. See the documentation on the Quadrature class for more
    * information.

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -109,10 +109,11 @@ namespace FETools
             multiplied_dofs_per_vertex +=
               fes[i]->n_dofs_per_vertex() * multiplicities[i];
             multiplied_dofs_per_line +=
-              fes[i]->dofs_per_line * multiplicities[i];
+              fes[i]->n_dofs_per_line() * multiplicities[i];
             multiplied_dofs_per_quad +=
-              fes[i]->dofs_per_quad * multiplicities[i];
-            multiplied_dofs_per_hex += fes[i]->dofs_per_hex * multiplicities[i];
+              fes[i]->n_dofs_per_quad() * multiplicities[i];
+            multiplied_dofs_per_hex +=
+              fes[i]->n_dofs_per_hex() * multiplicities[i];
 
             multiplied_n_components +=
               fes[i]->n_components() * multiplicities[i];
@@ -255,12 +256,12 @@ namespace FETools
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_line;
+                   local_index < fes[base]->n_dofs_per_line();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_line * line_number + local_index +
-                     fes[base]->first_line_index);
+                    (fes[base]->n_dofs_per_line() * line_number + local_index +
+                     fes[base]->get_first_line_index());
 
                   Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
@@ -277,12 +278,12 @@ namespace FETools
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_quad;
+                   local_index < fes[base]->n_dofs_per_quad();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_quad * quad_number + local_index +
-                     fes[base]->first_quad_index);
+                    (fes[base]->n_dofs_per_quad() * quad_number + local_index +
+                     fes[base]->get_first_quad_index());
 
                   Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
@@ -299,12 +300,12 @@ namespace FETools
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_hex;
+                   local_index < fes[base]->n_dofs_per_hex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_hex * hex_number + local_index +
-                     fes[base]->first_hex_index);
+                    (fes[base]->n_dofs_per_hex() * hex_number + local_index +
+                     fes[base]->get_first_hex_index());
 
                   Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
@@ -460,12 +461,12 @@ namespace FETools
                               comp_start +=
                               fes[base]->n_components() * do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_line;
+                   local_index < fes[base]->n_dofs_per_line();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_line * line_number + local_index +
-                     fes[base]->first_line_index);
+                    (fes[base]->n_dofs_per_line() * line_number + local_index +
+                     fes[base]->get_first_line_index());
 
                   Assert(comp_start + fes[base]->n_components() <=
                            retval[total_index].size(),
@@ -494,12 +495,12 @@ namespace FETools
                               comp_start +=
                               fes[base]->n_components() * do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_quad;
+                   local_index < fes[base]->n_dofs_per_quad();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_quad * quad_number + local_index +
-                     fes[base]->first_quad_index);
+                    (fes[base]->n_dofs_per_quad() * quad_number + local_index +
+                     fes[base]->get_first_quad_index());
 
                   Assert(comp_start + fes[base]->n_components() <=
                            retval[total_index].size(),
@@ -528,12 +529,12 @@ namespace FETools
                               comp_start +=
                               fes[base]->n_components() * do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_hex;
+                   local_index < fes[base]->n_dofs_per_hex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_hex * hex_number + local_index +
-                     fes[base]->first_hex_index);
+                    (fes[base]->n_dofs_per_hex() * hex_number + local_index +
+                     fes[base]->get_first_hex_index());
 
                   Assert(comp_start + fes[base]->n_components() <=
                            retval[total_index].size(),
@@ -711,12 +712,13 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_line;
+                   local_index < fe.base_element(base).n_dofs_per_line();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_line * line_number +
-                     local_index + fe.base_element(base).first_line_index);
+                    (fe.base_element(base).n_dofs_per_line() * line_number +
+                     local_index +
+                     fe.base_element(base).get_first_line_index());
 
                   system_to_base_table[total_index] =
                     std::make_pair(std::make_pair(base, m), index_in_base);
@@ -754,12 +756,13 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_quad;
+                   local_index < fe.base_element(base).n_dofs_per_quad();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_quad * quad_number +
-                     local_index + fe.base_element(base).first_quad_index);
+                    (fe.base_element(base).n_dofs_per_quad() * quad_number +
+                     local_index +
+                     fe.base_element(base).get_first_quad_index());
 
                   system_to_base_table[total_index] =
                     std::make_pair(std::make_pair(base, m), index_in_base);
@@ -797,12 +800,12 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_hex;
+                   local_index < fe.base_element(base).n_dofs_per_hex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_hex * hex_number +
-                     local_index + fe.base_element(base).first_hex_index);
+                    (fe.base_element(base).n_dofs_per_hex() * hex_number +
+                     local_index + fe.base_element(base).get_first_hex_index());
 
                   system_to_base_table[total_index] =
                     std::make_pair(std::make_pair(base, m), index_in_base);
@@ -916,17 +919,18 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_line;
+                   local_index < fe.base_element(base).n_dofs_per_line();
                    ++local_index, ++total_index)
                 {
                   // do everything alike for this type of object
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_line * line_number +
-                     local_index + fe.base_element(base).first_line_index);
+                    (fe.base_element(base).n_dofs_per_line() * line_number +
+                     local_index +
+                     fe.base_element(base).get_first_line_index());
 
                   const unsigned int face_index_in_base =
-                    (fe.base_element(base).first_face_line_index +
-                     fe.base_element(base).dofs_per_line * line_number +
+                    (fe.base_element(base).get_first_face_line_index() +
+                     fe.base_element(base).n_dofs_per_line() * line_number +
                      local_index);
 
                   face_system_to_base_table[total_index] =
@@ -965,17 +969,18 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_quad;
+                   local_index < fe.base_element(base).n_dofs_per_quad();
                    ++local_index, ++total_index)
                 {
                   // do everything alike for this type of object
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_quad * quad_number +
-                     local_index + fe.base_element(base).first_quad_index);
+                    (fe.base_element(base).n_dofs_per_quad() * quad_number +
+                     local_index +
+                     fe.base_element(base).get_first_quad_index());
 
                   const unsigned int face_index_in_base =
-                    (fe.base_element(base).first_face_quad_index +
-                     fe.base_element(base).dofs_per_quad * quad_number +
+                    (fe.base_element(base).get_first_face_quad_index() +
+                     fe.base_element(base).n_dofs_per_quad() * quad_number +
                      local_index);
 
                   face_system_to_base_table[total_index] =
@@ -1000,7 +1005,7 @@ namespace FETools
                       non_primitive_index;
                 }
         }
-      Assert(total_index == fe.dofs_per_face, ExcInternalError());
+      Assert(total_index == fe.n_dofs_per_face(), ExcInternalError());
       Assert(total_index == face_system_to_component_table.size(),
              ExcInternalError());
       Assert(total_index == face_system_to_base_table.size(),
@@ -1919,7 +1924,7 @@ namespace FETools
     Assert(face_fine == 0, ExcNotImplemented());
 
     const unsigned int nc     = GeometryInfo<dim>::max_children_per_face;
-    const unsigned int n      = fe.dofs_per_face;
+    const unsigned int n      = fe.n_dofs_per_face();
     const unsigned int nd     = fe.n_components();
     const unsigned int degree = fe.degree;
 
@@ -1959,14 +1964,14 @@ namespace FETools
       for (unsigned int i = 1; i <= GeometryInfo<dim>::lines_per_face; ++i)
         {
           const unsigned int offset_c =
-            fe.first_line_index +
+            fe.get_first_line_index() +
             GeometryInfo<dim>::face_to_cell_lines(face_coarse, i - 1) *
-              fe.dofs_per_line;
+              fe.n_dofs_per_line();
           const unsigned int offset_f =
-            fe.first_line_index +
+            fe.get_first_line_index() +
             GeometryInfo<dim>::face_to_cell_lines(face_fine, i - 1) *
-              fe.dofs_per_line;
-          for (unsigned int j = 0; j < fe.dofs_per_line; ++j)
+              fe.n_dofs_per_line();
+          for (unsigned int j = 0; j < fe.n_dofs_per_line(); ++j)
             {
               face_c_dofs[face_dof] = offset_c + j;
               face_f_dofs[face_dof] = offset_f + j;
@@ -1976,17 +1981,17 @@ namespace FETools
       for (unsigned int i = 1; i <= GeometryInfo<dim>::quads_per_face; ++i)
         {
           const unsigned int offset_c =
-            fe.first_quad_index + face_coarse * fe.dofs_per_quad;
+            fe.get_first_quad_index() + face_coarse * fe.n_dofs_per_quad();
           const unsigned int offset_f =
-            fe.first_quad_index + face_fine * fe.dofs_per_quad;
-          for (unsigned int j = 0; j < fe.dofs_per_quad; ++j)
+            fe.get_first_quad_index() + face_fine * fe.n_dofs_per_quad();
+          for (unsigned int j = 0; j < fe.n_dofs_per_quad(); ++j)
             {
               face_c_dofs[face_dof] = offset_c + j;
               face_f_dofs[face_dof] = offset_f + j;
               ++face_dof;
             }
         }
-      Assert(face_dof == fe.dofs_per_face, ExcInternalError());
+      Assert(face_dof == fe.n_dofs_per_face(), ExcInternalError());
     }
 
     // Set up meshes, one with a single
@@ -3289,7 +3294,7 @@ namespace FETools
   {
     Assert(h2l.size() == fe.n_dofs_per_cell(),
            ExcDimensionMismatch(h2l.size(), fe.n_dofs_per_cell()));
-    hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1, h2l);
+    hierarchic_to_lexicographic_numbering<dim>(fe.n_dofs_per_line() + 1, h2l);
   }
 
 
@@ -3299,7 +3304,7 @@ namespace FETools
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe)
   {
     Assert(fe.n_components() == 1, ExcInvalidFE());
-    return hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1);
+    return hierarchic_to_lexicographic_numbering<dim>(fe.n_dofs_per_line() + 1);
   }
 
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -107,7 +107,7 @@ namespace FETools
         if (multiplicities[i] > 0)
           {
             multiplied_dofs_per_vertex +=
-              fes[i]->dofs_per_vertex * multiplicities[i];
+              fes[i]->n_dofs_per_vertex() * multiplicities[i];
             multiplied_dofs_per_line +=
               fes[i]->dofs_per_line * multiplicities[i];
             multiplied_dofs_per_quad +=
@@ -156,7 +156,7 @@ namespace FETools
 
       for (unsigned int base = 0; base < fes.size(); ++base)
         for (unsigned int m = 0; m < multiplicities[base]; ++m)
-          block_indices.push_back(fes[base]->dofs_per_cell);
+          block_indices.push_back(fes[base]->n_dofs_per_cell());
 
       return FiniteElementData<dim>(dpo,
                                     (do_tensor_product ?
@@ -213,7 +213,7 @@ namespace FETools
       unsigned int n_shape_functions = 0;
       for (unsigned int i = 0; i < fes.size(); ++i)
         if (multiplicities[i] > 0) // check needed as fe might be nullptr
-          n_shape_functions += fes[i]->dofs_per_cell * multiplicities[i];
+          n_shape_functions += fes[i]->n_dofs_per_cell() * multiplicities[i];
 
       // generate the array that will hold the output
       std::vector<bool> retval(n_shape_functions, false);
@@ -233,13 +233,14 @@ namespace FETools
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_vertex;
+                   local_index < fes[base]->n_dofs_per_vertex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_vertex * vertex_number + local_index);
+                    (fes[base]->n_dofs_per_vertex() * vertex_number +
+                     local_index);
 
-                  Assert(index_in_base < fes[base]->dofs_per_cell,
+                  Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
                   retval[total_index] =
                     fes[base]->restriction_is_additive(index_in_base);
@@ -261,7 +262,7 @@ namespace FETools
                     (fes[base]->dofs_per_line * line_number + local_index +
                      fes[base]->first_line_index);
 
-                  Assert(index_in_base < fes[base]->dofs_per_cell,
+                  Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
                   retval[total_index] =
                     fes[base]->restriction_is_additive(index_in_base);
@@ -283,7 +284,7 @@ namespace FETools
                     (fes[base]->dofs_per_quad * quad_number + local_index +
                      fes[base]->first_quad_index);
 
-                  Assert(index_in_base < fes[base]->dofs_per_cell,
+                  Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
                   retval[total_index] =
                     fes[base]->restriction_is_additive(index_in_base);
@@ -305,7 +306,7 @@ namespace FETools
                     (fes[base]->dofs_per_hex * hex_number + local_index +
                      fes[base]->first_hex_index);
 
-                  Assert(index_in_base < fes[base]->dofs_per_cell,
+                  Assert(index_in_base < fes[base]->n_dofs_per_cell(),
                          ExcInternalError());
                   retval[total_index] =
                     fes[base]->restriction_is_additive(index_in_base);
@@ -375,7 +376,7 @@ namespace FETools
       unsigned int n_shape_functions = 0;
       for (unsigned int i = 0; i < fes.size(); ++i)
         if (multiplicities[i] > 0) // needed because fe might be nullptr
-          n_shape_functions += fes[i]->dofs_per_cell * multiplicities[i];
+          n_shape_functions += fes[i]->n_dofs_per_cell() * multiplicities[i];
 
       unsigned int n_components = 0;
       if (do_tensor_product)
@@ -425,11 +426,12 @@ namespace FETools
                               comp_start +=
                               fes[base]->n_components() * do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fes[base]->dofs_per_vertex;
+                   local_index < fes[base]->n_dofs_per_vertex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fes[base]->dofs_per_vertex * vertex_number + local_index);
+                    (fes[base]->n_dofs_per_vertex() * vertex_number +
+                     local_index);
 
                   Assert(comp_start + fes[base]->n_components() <=
                            retval[total_index].size(),
@@ -666,11 +668,11 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_vertex;
+                   local_index < fe.base_element(base).n_dofs_per_vertex();
                    ++local_index, ++total_index)
                 {
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_vertex * vertex_number +
+                    (fe.base_element(base).n_dofs_per_vertex() * vertex_number +
                      local_index);
 
                   system_to_base_table[total_index] =
@@ -859,7 +861,7 @@ namespace FETools
                               fe.base_element(base).n_components() *
                               do_tensor_product)
               for (unsigned int local_index = 0;
-                   local_index < fe.base_element(base).dofs_per_vertex;
+                   local_index < fe.base_element(base).n_dofs_per_vertex();
                    ++local_index, ++total_index)
                 {
                   // get (cell) index of this shape function inside the base
@@ -871,11 +873,11 @@ namespace FETools
                   // taken as representative for all others located on the same
                   // type of object):
                   const unsigned int index_in_base =
-                    (fe.base_element(base).dofs_per_vertex * vertex_number +
+                    (fe.base_element(base).n_dofs_per_vertex() * vertex_number +
                      local_index);
 
                   const unsigned int face_index_in_base =
-                    (fe.base_element(base).dofs_per_vertex * vertex_number +
+                    (fe.base_element(base).n_dofs_per_vertex() * vertex_number +
                      local_index);
 
                   face_system_to_base_table[total_index] =
@@ -1349,8 +1351,8 @@ namespace FETools
                          std::vector<unsigned int> &             renumbering,
                          std::vector<std::vector<unsigned int>> &comp_start)
   {
-    Assert(renumbering.size() == element.dofs_per_cell,
-           ExcDimensionMismatch(renumbering.size(), element.dofs_per_cell));
+    Assert(renumbering.size() == element.n_dofs_per_cell(),
+           ExcDimensionMismatch(renumbering.size(), element.n_dofs_per_cell()));
 
     comp_start.resize(element.n_base_elements());
 
@@ -1358,7 +1360,8 @@ namespace FETools
     for (unsigned int i = 0; i < comp_start.size(); ++i)
       {
         comp_start[i].resize(element.element_multiplicity(i));
-        const unsigned int increment = element.base_element(i).dofs_per_cell;
+        const unsigned int increment =
+          element.base_element(i).n_dofs_per_cell();
 
         for (unsigned int &first_index_of_component : comp_start[i])
           {
@@ -1372,7 +1375,7 @@ namespace FETools
     // numbering, renumbering
     // contains the index of the
     // cell-block numbering
-    for (unsigned int i = 0; i < element.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < element.n_dofs_per_cell(); ++i)
       {
         std::pair<std::pair<unsigned int, unsigned int>, unsigned int> indices =
           element.system_to_base_index(i);
@@ -1390,8 +1393,8 @@ namespace FETools
                             std::vector<types::global_dof_index> &block_data,
                             bool return_start_indices)
   {
-    Assert(renumbering.size() == element.dofs_per_cell,
-           ExcDimensionMismatch(renumbering.size(), element.dofs_per_cell));
+    Assert(renumbering.size() == element.n_dofs_per_cell(),
+           ExcDimensionMismatch(renumbering.size(), element.n_dofs_per_cell()));
     Assert(block_data.size() == element.n_blocks(),
            ExcDimensionMismatch(block_data.size(), element.n_blocks()));
 
@@ -1418,7 +1421,7 @@ namespace FETools
           k += block_data[i];
         }
 
-    for (unsigned int i = 0; i < element.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < element.n_dofs_per_cell(); ++i)
       {
         std::pair<unsigned int, types::global_dof_index> indices =
           element.system_to_block_index(i);
@@ -1436,12 +1439,12 @@ namespace FETools
   {
     Assert(fe1.n_components() == fe2.n_components(),
            ExcDimensionMismatch(fe1.n_components(), fe2.n_components()));
-    Assert(interpolation_matrix.m() == fe2.dofs_per_cell &&
-             interpolation_matrix.n() == fe1.dofs_per_cell,
+    Assert(interpolation_matrix.m() == fe2.n_dofs_per_cell() &&
+             interpolation_matrix.n() == fe1.n_dofs_per_cell(),
            ExcMatrixDimensionMismatch(interpolation_matrix.m(),
                                       interpolation_matrix.n(),
-                                      fe2.dofs_per_cell,
-                                      fe1.dofs_per_cell));
+                                      fe2.n_dofs_per_cell(),
+                                      fe1.n_dofs_per_cell()));
 
     // first try the easy way: maybe the FE wants to implement things itself:
     try
@@ -1470,13 +1473,13 @@ namespace FETools
     const std::vector<Point<dim>> &fe2_support_points =
       fe2.get_unit_support_points();
 
-    Assert(fe2_support_points.size() == fe2.dofs_per_cell,
+    Assert(fe2_support_points.size() == fe2.n_dofs_per_cell(),
            (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints()));
 
-    for (unsigned int i = 0; i < fe2.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe2.n_dofs_per_cell(); ++i)
       {
         const unsigned int i1 = fe2.system_to_component_index(i).first;
-        for (unsigned int j = 0; j < fe1.dofs_per_cell; ++j)
+        for (unsigned int j = 0; j < fe1.n_dofs_per_cell(); ++j)
           {
             const unsigned int j1 = fe1.system_to_component_index(j).first;
             if (i1 == j1)
@@ -1498,15 +1501,17 @@ namespace FETools
   {
     Assert(fe1.n_components() == fe2.n_components(),
            ExcDimensionMismatch(fe1.n_components(), fe2.n_components()));
-    Assert(interpolation_matrix.m() == fe1.dofs_per_cell &&
-             interpolation_matrix.n() == fe1.dofs_per_cell,
+    Assert(interpolation_matrix.m() == fe1.n_dofs_per_cell() &&
+             interpolation_matrix.n() == fe1.n_dofs_per_cell(),
            ExcMatrixDimensionMismatch(interpolation_matrix.m(),
                                       interpolation_matrix.n(),
-                                      fe1.dofs_per_cell,
-                                      fe1.dofs_per_cell));
+                                      fe1.n_dofs_per_cell(),
+                                      fe1.n_dofs_per_cell()));
 
-    FullMatrix<number> first_matrix(fe2.dofs_per_cell, fe1.dofs_per_cell);
-    FullMatrix<number> second_matrix(fe1.dofs_per_cell, fe2.dofs_per_cell);
+    FullMatrix<number> first_matrix(fe2.n_dofs_per_cell(),
+                                    fe1.n_dofs_per_cell());
+    FullMatrix<number> second_matrix(fe1.n_dofs_per_cell(),
+                                     fe2.n_dofs_per_cell());
 
     get_interpolation_matrix(fe1, fe2, first_matrix);
     get_interpolation_matrix(fe2, fe1, second_matrix);
@@ -1525,18 +1530,18 @@ namespace FETools
   {
     Assert(fe1.n_components() == fe2.n_components(),
            ExcDimensionMismatch(fe1.n_components(), fe2.n_components()));
-    Assert(difference_matrix.m() == fe1.dofs_per_cell &&
-             difference_matrix.n() == fe1.dofs_per_cell,
+    Assert(difference_matrix.m() == fe1.n_dofs_per_cell() &&
+             difference_matrix.n() == fe1.n_dofs_per_cell(),
            ExcMatrixDimensionMismatch(difference_matrix.m(),
                                       difference_matrix.n(),
-                                      fe1.dofs_per_cell,
-                                      fe1.dofs_per_cell));
+                                      fe1.n_dofs_per_cell(),
+                                      fe1.n_dofs_per_cell()));
 
-    FullMatrix<number> interpolation_matrix(fe1.dofs_per_cell);
+    FullMatrix<number> interpolation_matrix(fe1.n_dofs_per_cell());
     get_back_interpolation_matrix(fe1, fe2, interpolation_matrix);
 
     // compute difference
-    difference_matrix = IdentityMatrix(fe1.dofs_per_cell);
+    difference_matrix = IdentityMatrix(fe1.n_dofs_per_cell());
     difference_matrix.add(-1, interpolation_matrix);
   }
 
@@ -1551,13 +1556,16 @@ namespace FETools
     Assert(fe1.n_components() == 1, ExcNotImplemented());
     Assert(fe1.n_components() == fe2.n_components(),
            ExcDimensionMismatch(fe1.n_components(), fe2.n_components()));
-    Assert(matrix.m() == fe2.dofs_per_cell && matrix.n() == fe1.dofs_per_cell,
-           ExcMatrixDimensionMismatch(
-             matrix.m(), matrix.n(), fe2.dofs_per_cell, fe1.dofs_per_cell));
+    Assert(matrix.m() == fe2.n_dofs_per_cell() &&
+             matrix.n() == fe1.n_dofs_per_cell(),
+           ExcMatrixDimensionMismatch(matrix.m(),
+                                      matrix.n(),
+                                      fe2.n_dofs_per_cell(),
+                                      fe1.n_dofs_per_cell()));
     matrix = 0;
 
-    const unsigned int n1 = fe1.dofs_per_cell;
-    const unsigned int n2 = fe2.dofs_per_cell;
+    const unsigned int n1 = fe1.n_dofs_per_cell();
+    const unsigned int n2 = fe2.n_dofs_per_cell();
 
     // First, create a local mass matrix for the unit cell
     Triangulation<dim, spacedim> tr;
@@ -1625,7 +1633,7 @@ namespace FETools
   FullMatrix<double>
   compute_node_matrix(const FiniteElement<dim, spacedim> &fe)
   {
-    const unsigned int n_dofs = fe.dofs_per_cell;
+    const unsigned int n_dofs = fe.n_dofs_per_cell();
 
     FullMatrix<double> N(n_dofs, n_dofs);
 
@@ -1691,7 +1699,7 @@ namespace FETools
         FullMatrix<number> &                this_matrix,
         const double                        threshold)
       {
-        const unsigned int n  = fe.dofs_per_cell;
+        const unsigned int n  = fe.n_dofs_per_cell();
         const unsigned int nd = fe.n_components();
         const unsigned int nq = coarse.n_quadrature_points;
 
@@ -1746,7 +1754,7 @@ namespace FETools
         const unsigned int                  ref_case,
         const double                        threshold)
       {
-        const unsigned int n = fe.dofs_per_cell;
+        const unsigned int n = fe.n_dofs_per_cell();
         const unsigned int nc =
           GeometryInfo<dim>::n_children(RefinementCase<dim>(ref_case));
         for (unsigned int i = 0; i < nc; ++i)
@@ -1937,11 +1945,11 @@ namespace FETools
         {
           const unsigned int offset_c =
             GeometryInfo<dim>::face_to_cell_vertices(face_coarse, i) *
-            fe.dofs_per_vertex;
+            fe.n_dofs_per_vertex();
           const unsigned int offset_f =
             GeometryInfo<dim>::face_to_cell_vertices(face_fine, i) *
-            fe.dofs_per_vertex;
-          for (unsigned int j = 0; j < fe.dofs_per_vertex; ++j)
+            fe.n_dofs_per_vertex();
+          for (unsigned int j = 0; j < fe.n_dofs_per_vertex(); ++j)
             {
               face_c_dofs[face_dof] = offset_c + j;
               face_f_dofs[face_dof] = offset_f + j;
@@ -2121,7 +2129,7 @@ namespace FETools
                                           > &                     matrices,
                               const bool isotropic_only)
   {
-    const unsigned int n      = fe.dofs_per_cell;
+    const unsigned int n      = fe.n_dofs_per_cell();
     const unsigned int nd     = fe.n_components();
     const unsigned int degree = fe.degree;
 
@@ -2270,9 +2278,9 @@ namespace FETools
             const std::vector<double> &JxW = fine.get_JxW_values();
 
             // Outer loop over all fine grid shape functions phi_j
-            for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+            for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
               {
-                for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
                   {
                     if (fe.
 
@@ -2302,7 +2310,7 @@ namespace FETools
 
                 // RHS ready. Solve system and enter row into matrix
                 inverse_mass_matrix.vmult(v_coarse, v_fine);
-                for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
                   this_matrix(i, j) = v_coarse(i);
               }
 
@@ -2724,30 +2732,30 @@ namespace FETools
 
     // first build the matrices M and Q
     // described in the documentation
-    FullMatrix<double> M(fe.dofs_per_cell, fe.dofs_per_cell);
-    FullMatrix<double> Q(fe.dofs_per_cell, rhs_quadrature.size());
+    FullMatrix<double> M(fe.n_dofs_per_cell(), fe.n_dofs_per_cell());
+    FullMatrix<double> Q(fe.n_dofs_per_cell(), rhs_quadrature.size());
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
-      for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+      for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
         for (unsigned int q = 0; q < lhs_quadrature.size(); ++q)
           M(i, j) += fe.shape_value(i, lhs_quadrature.point(q)) *
                      fe.shape_value(j, lhs_quadrature.point(q)) *
                      lhs_quadrature.weight(q);
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       for (unsigned int q = 0; q < rhs_quadrature.size(); ++q)
         Q(i, q) +=
           fe.shape_value(i, rhs_quadrature.point(q)) * rhs_quadrature.weight(q);
 
     // then invert M
-    FullMatrix<double> M_inverse(fe.dofs_per_cell, fe.dofs_per_cell);
+    FullMatrix<double> M_inverse(fe.n_dofs_per_cell(), fe.n_dofs_per_cell());
     M_inverse.invert(M);
 
     // finally compute the result
-    X.reinit(fe.dofs_per_cell, rhs_quadrature.size());
+    X.reinit(fe.n_dofs_per_cell(), rhs_quadrature.size());
     M_inverse.mmult(X, Q);
 
-    Assert(X.m() == fe.dofs_per_cell, ExcInternalError());
+    Assert(X.m() == fe.n_dofs_per_cell(), ExcInternalError());
     Assert(X.n() == rhs_quadrature.size(), ExcInternalError());
   }
 
@@ -2762,10 +2770,10 @@ namespace FETools
   {
     Assert(fe.n_components() == 1, ExcNotImplemented());
     Assert(I_q.m() == quadrature.size(), ExcMessage("Wrong matrix size"));
-    Assert(I_q.n() == fe.dofs_per_cell, ExcMessage("Wrong matrix size"));
+    Assert(I_q.n() == fe.n_dofs_per_cell(), ExcMessage("Wrong matrix size"));
 
     for (unsigned int q = 0; q < quadrature.size(); ++q)
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         I_q(q, i) = fe.shape_value(i, quadrature.point(q));
   }
 
@@ -2919,8 +2927,8 @@ namespace FETools
 
     // build the matrices M and Q
     // described in the documentation
-    FullMatrix<double> M(fe.dofs_per_cell, fe.dofs_per_cell);
-    FullMatrix<double> Q(fe.dofs_per_cell, rhs_quadrature.size());
+    FullMatrix<double> M(fe.n_dofs_per_cell(), fe.n_dofs_per_cell());
+    FullMatrix<double> Q(fe.n_dofs_per_cell(), rhs_quadrature.size());
 
     {
       // need an FEFaceValues object to evaluate shape function
@@ -2928,13 +2936,13 @@ namespace FETools
       FEFaceValues<dim> fe_face_values(fe, lhs_quadrature, update_values);
       fe_face_values.reinit(cell, face); // setup shape_value on this face.
 
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
-        for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+        for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
           for (unsigned int q = 0; q < lhs_quadrature.size(); ++q)
             M(i, j) += fe_face_values.shape_value(i, q) *
                        fe_face_values.shape_value(j, q) *
                        lhs_quadrature.weight(q);
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         {
           M(i, i) = (M(i, i) == 0 ? 1 : M(i, i));
         }
@@ -2944,20 +2952,20 @@ namespace FETools
       FEFaceValues<dim> fe_face_values(fe, rhs_quadrature, update_values);
       fe_face_values.reinit(cell, face); // setup shape_value on this face.
 
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         for (unsigned int q = 0; q < rhs_quadrature.size(); ++q)
           Q(i, q) +=
             fe_face_values.shape_value(i, q) * rhs_quadrature.weight(q);
     }
     // then invert M
-    FullMatrix<double> M_inverse(fe.dofs_per_cell, fe.dofs_per_cell);
+    FullMatrix<double> M_inverse(fe.n_dofs_per_cell(), fe.n_dofs_per_cell());
     M_inverse.invert(M);
 
     // finally compute the result
-    X.reinit(fe.dofs_per_cell, rhs_quadrature.size());
+    X.reinit(fe.n_dofs_per_cell(), rhs_quadrature.size());
     M_inverse.mmult(X, Q);
 
-    Assert(X.m() == fe.dofs_per_cell, ExcInternalError());
+    Assert(X.m() == fe.n_dofs_per_cell(), ExcInternalError());
     Assert(X.n() == rhs_quadrature.size(), ExcInternalError());
   }
 
@@ -3084,7 +3092,7 @@ namespace FETools
   {
     AssertDimension(support_point_values.size(),
                     finite_element.get_generalized_support_points().size());
-    AssertDimension(dof_values.size(), finite_element.dofs_per_cell);
+    AssertDimension(dof_values.size(), finite_element.n_dofs_per_cell());
 
     internal::FEToolsConvertHelper::convert_helper<dim, spacedim>(
       finite_element, support_point_values, dof_values);
@@ -3279,8 +3287,8 @@ namespace FETools
   hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe,
                                         std::vector<unsigned int> &   h2l)
   {
-    Assert(h2l.size() == fe.dofs_per_cell,
-           ExcDimensionMismatch(h2l.size(), fe.dofs_per_cell));
+    Assert(h2l.size() == fe.n_dofs_per_cell(),
+           ExcDimensionMismatch(h2l.size(), fe.n_dofs_per_cell()));
     hierarchic_to_lexicographic_numbering<dim>(fe.dofs_per_line + 1, h2l);
   }
 

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -546,7 +546,7 @@ namespace FETools
         {
           const FiniteElement<dim, spacedim> &fe =
             dealii_cell->get_dof_handler().get_fe();
-          const unsigned int dofs_per_cell = fe.dofs_per_cell;
+          const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
           Vector<typename OutVector::value_type> interpolated_values(
             dofs_per_cell);
@@ -608,7 +608,7 @@ namespace FETools
         {
           const FiniteElement<dim, spacedim> &fe =
             dealii_cell->get_dof_handler().get_fe();
-          const unsigned int dofs_per_cell = fe.dofs_per_cell;
+          const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
           Assert(interpolated_values.size() == dofs_per_cell,
                  ExcDimensionMismatch(interpolated_values.size(),
@@ -728,7 +728,7 @@ namespace FETools
     {
       const FiniteElement<dim, spacedim> &fe =
         dealii_cell->get_dof_handler().get_fe();
-      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
       if (dealii_cell->is_active())
         {
@@ -1242,7 +1242,7 @@ namespace FETools
     {
       const FiniteElement<dim, spacedim> &fe =
         dealii_cell->get_dof_handler().get_fe();
-      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
       CellData cell_data(dofs_per_cell);
       cell_data.quadrant   = p4est_cell;
@@ -1416,7 +1416,7 @@ namespace FETools
       const unsigned int                  dofs_per_face = fe.dofs_per_face;
       if (dofs_per_face > 0)
         {
-          const unsigned int                   dofs_per_cell = fe.dofs_per_cell;
+          const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
           std::vector<types::global_dof_index> indices(dofs_per_cell);
           typename DoFHandler<dim, spacedim>::active_cell_iterator
             cell = dof2.begin_active(),
@@ -1715,7 +1715,7 @@ namespace FETools
                        const DoFHandler<dim, spacedim> &dof2,
                        OutVector &                      u2)
     {
-      const unsigned int dofs_per_cell = dof2.get_fe().dofs_per_cell;
+      const unsigned int dofs_per_cell = dof2.get_fe().n_dofs_per_cell();
       Vector<typename OutVector::value_type> dof_values(dofs_per_cell);
 
       // then traverse grid bottom up

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1413,7 +1413,7 @@ namespace FETools
 
       // exclude dofs on more refined ghosted cells
       const FiniteElement<dim, spacedim> &fe            = dof2.get_fe();
-      const unsigned int                  dofs_per_face = fe.dofs_per_face;
+      const unsigned int                  dofs_per_face = fe.n_dofs_per_face();
       if (dofs_per_face > 0)
         {
           const unsigned int dofs_per_cell = fe.n_dofs_per_cell();

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -158,7 +158,7 @@ namespace FETools
           // hanging node constraints. Consequently, when the elements are
           // continuous no hanging node constraints are allowed.
           const bool hanging_nodes_not_allowed =
-            ((cell2->get_fe().dofs_per_vertex != 0) &&
+            ((cell2->get_fe().n_dofs_per_vertex() != 0) &&
              (constraints.n_constraints() == 0));
 
           if (hanging_nodes_not_allowed)
@@ -168,8 +168,8 @@ namespace FETools
                      ExcHangingNodesNotAllowed());
 #endif
 
-          const unsigned int dofs_per_cell1 = cell1->get_fe().dofs_per_cell;
-          const unsigned int dofs_per_cell2 = cell2->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell1 = cell1->get_fe().n_dofs_per_cell();
+          const unsigned int dofs_per_cell2 = cell2->get_fe().n_dofs_per_cell();
           u1_local.reinit(dofs_per_cell1);
           u2_local.reinit(dofs_per_cell2);
 
@@ -312,7 +312,8 @@ namespace FETools
           // hanging node constraints. Consequently, when the elements are
           // continuous no hanging node constraints are allowed.
           const bool hanging_nodes_not_allowed =
-            (cell->get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
+            (cell->get_fe().n_dofs_per_vertex() != 0) ||
+            (fe2.n_dofs_per_vertex() != 0);
 
           if (hanging_nodes_not_allowed)
             for (const unsigned int face : cell->face_indices())
@@ -321,7 +322,7 @@ namespace FETools
                      ExcHangingNodesNotAllowed());
 #endif
 
-          const unsigned int dofs_per_cell1 = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell1 = cell->get_fe().n_dofs_per_cell();
 
           // make sure back_interpolation matrix is available
           if (interpolation_matrices[&cell->get_fe()] == nullptr)
@@ -569,8 +570,8 @@ namespace FETools
   {
     // For discontinuous elements without constraints take the simpler version
     // of the back_interpolate function.
-    if (dof1.get_fe().dofs_per_vertex == 0 &&
-        dof2.get_fe().dofs_per_vertex == 0 &&
+    if (dof1.get_fe().n_dofs_per_vertex() == 0 &&
+        dof2.get_fe().n_dofs_per_vertex() == 0 &&
         constraints1.n_constraints() == 0 && constraints2.n_constraints() == 0)
       back_interpolate(dof1, u1, dof2.get_fe(), u1_interpolated);
     else
@@ -621,7 +622,7 @@ namespace FETools
                       " index sets."));
 #endif
 
-    const unsigned int dofs_per_cell = dof1.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof1.get_fe().n_dofs_per_cell();
 
     Vector<typename OutVector::value_type> u1_local(dofs_per_cell);
     Vector<typename OutVector::value_type> u1_diff_local(dofs_per_cell);
@@ -645,7 +646,8 @@ namespace FETools
           // hanging node constraints. Consequently, when the elements are
           // continuous no hanging node constraints are allowed.
           const bool hanging_nodes_not_allowed =
-            (dof1.get_fe().dofs_per_vertex != 0) || (fe2.dofs_per_vertex != 0);
+            (dof1.get_fe().n_dofs_per_vertex() != 0) ||
+            (fe2.n_dofs_per_vertex() != 0);
 
           if (hanging_nodes_not_allowed)
             for (const unsigned int face : cell->face_indices())
@@ -730,8 +732,8 @@ namespace FETools
     // without constraints take the
     // cheaper version of the
     // interpolation_difference function.
-    if (dof1.get_fe().dofs_per_vertex == 0 &&
-        dof2.get_fe().dofs_per_vertex == 0 &&
+    if (dof1.get_fe().n_dofs_per_vertex() == 0 &&
+        dof2.get_fe().n_dofs_per_vertex() == 0 &&
         constraints1.n_constraints() == 0 && constraints2.n_constraints() == 0)
       interpolation_difference(dof1, u1, dof2.get_fe(), u1_difference);
     else
@@ -766,8 +768,8 @@ namespace FETools
       dof2.begin_active();
     typename DoFHandler<dim, spacedim>::active_cell_iterator end = dof2.end();
 
-    const unsigned int n1 = dof1.get_fe().dofs_per_cell;
-    const unsigned int n2 = dof2.get_fe().dofs_per_cell;
+    const unsigned int n1 = dof1.get_fe().n_dofs_per_cell();
+    const unsigned int n2 = dof2.get_fe().n_dofs_per_cell();
 
     Vector<typename OutVector::value_type> u1_local(n1);
     Vector<typename OutVector::value_type> u2_local(n2);

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -361,12 +361,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution,
      *                      local_dof_values.begin(),
      *                      local_dof_values.end());
@@ -929,12 +929,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution,
      *                      local_dof_values.begin(),
      *                      local_dof_values.end());
@@ -1440,12 +1440,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution,
      *                      local_dof_values.begin(),
      *                      local_dof_values.end());
@@ -1750,12 +1750,12 @@ namespace FEValuesViews
      *
      * The DoF values typically would be obtained in the following way:
      * @code
-     * Vector<double> local_dof_values(cell->get_fe().dofs_per_cell);
+     * Vector<double> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution, local_dof_values);
      * @endcode
      * or, for a generic @p Number type,
      * @code
-     * std::vector<Number> local_dof_values(cell->get_fe().dofs_per_cell);
+     * std::vector<Number> local_dof_values(cell->get_fe().n_dofs_per_cell());
      * cell->get_dof_values(solution,
      *                      local_dof_values.begin(),
      *                      local_dof_values.end());
@@ -2015,8 +2015,8 @@ namespace FEValuesViews
  *   {
  *     values.reinit(cell);
  *     for (unsigned int q=0; q<quadrature.size(); ++q)
- *       for (unsigned int i=0; i<finite_element.dofs_per_cell; ++i)
- *         for (unsigned int j=0; j<finite_element.dofs_per_cell; ++j)
+ *       for (unsigned int i=0; i<finite_element.n_dofs_per_cell(); ++i)
+ *         for (unsigned int j=0; j<finite_element.n_dofs_per_cell(); ++j)
  *           A(i,j) += fe_values.shape_value(i,q) *
  *                     fe_values.shape_value(j,q) *
  *                     fe_values.JxW(q);
@@ -4122,7 +4122,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::value(const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(
       fe_values->update_flags & update_values,
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -4145,7 +4145,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::gradient(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4168,7 +4168,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::hessian(const unsigned int shape_function,
                                  const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
@@ -4190,7 +4190,7 @@ namespace FEValuesViews
   Scalar<dim, spacedim>::third_derivative(const unsigned int shape_function,
                                           const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
@@ -4213,7 +4213,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::value(const unsigned int shape_function,
                                const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4251,7 +4251,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::gradient(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4291,7 +4291,7 @@ namespace FEValuesViews
                                     const unsigned int q_point) const
   {
     // this function works like in the case above
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4328,7 +4328,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
 
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4500,7 +4500,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     // this function works like in the case above
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_hessians,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
@@ -4540,7 +4540,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     // this function works like in the case above
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
@@ -4647,7 +4647,7 @@ namespace FEValuesViews
   Vector<dim, spacedim>::symmetric_gradient(const unsigned int shape_function,
                                             const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4682,7 +4682,7 @@ namespace FEValuesViews
   SymmetricTensor<2, dim, spacedim>::value(const unsigned int shape_function,
                                            const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4727,7 +4727,7 @@ namespace FEValuesViews
     const unsigned int shape_function,
     const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4805,7 +4805,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::value(const unsigned int shape_function,
                                   const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
@@ -4855,7 +4855,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::divergence(const unsigned int shape_function,
                                        const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -4911,7 +4911,7 @@ namespace FEValuesViews
   Tensor<2, dim, spacedim>::gradient(const unsigned int shape_function,
                                      const unsigned int q_point) const
   {
-    AssertIndexRange(shape_function, fe_values->fe->dofs_per_cell);
+    AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
@@ -5027,7 +5027,7 @@ inline const double &
 FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5064,7 +5064,7 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_values,
          ExcAccessToUninitializedField("update_values"));
   AssertIndexRange(component, fe->n_components());
@@ -5093,7 +5093,7 @@ inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_gradients,
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5130,7 +5130,7 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_gradients,
          ExcAccessToUninitializedField("update_gradients"));
   AssertIndexRange(component, fe->n_components());
@@ -5158,7 +5158,7 @@ inline const Tensor<2, spacedim> &
 FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5195,7 +5195,7 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_hessians,
          ExcAccessToUninitializedField("update_hessians"));
   AssertIndexRange(component, fe->n_components());
@@ -5223,7 +5223,7 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
@@ -5260,7 +5260,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int j,
   const unsigned int component) const
 {
-  AssertIndexRange(i, fe->dofs_per_cell);
+  AssertIndexRange(i, fe->n_dofs_per_cell());
   Assert(this->update_flags & update_3rd_derivatives,
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertIndexRange(component, fe->n_components());

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -884,8 +884,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_vertex > max)
-        max = finite_elements[i]->dofs_per_vertex;
+      if (finite_elements[i]->n_dofs_per_vertex() > max)
+        max = finite_elements[i]->n_dofs_per_vertex();
 
     return max;
   }
@@ -964,8 +964,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_cell > max)
-        max = finite_elements[i]->dofs_per_cell;
+      if (finite_elements[i]->n_dofs_per_cell() > max)
+        max = finite_elements[i]->n_dofs_per_cell();
 
     return max;
   }

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -900,8 +900,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_line > max)
-        max = finite_elements[i]->dofs_per_line;
+      if (finite_elements[i]->n_dofs_per_line() > max)
+        max = finite_elements[i]->n_dofs_per_line();
 
     return max;
   }
@@ -916,8 +916,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_quad > max)
-        max = finite_elements[i]->dofs_per_quad;
+      if (finite_elements[i]->n_dofs_per_quad() > max)
+        max = finite_elements[i]->n_dofs_per_quad();
 
     return max;
   }
@@ -932,8 +932,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_hex > max)
-        max = finite_elements[i]->dofs_per_hex;
+      if (finite_elements[i]->n_dofs_per_hex() > max)
+        max = finite_elements[i]->n_dofs_per_hex();
 
     return max;
   }
@@ -948,8 +948,8 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->dofs_per_face > max)
-        max = finite_elements[i]->dofs_per_face;
+      if (finite_elements[i]->n_dofs_per_face() > max)
+        max = finite_elements[i]->n_dofs_per_face();
 
     return max;
   }

--- a/include/deal.II/integrators/l2.h
+++ b/include/deal.II/integrators/l2.h
@@ -244,8 +244,8 @@ namespace LocalIntegrators
                 const double             factor1 = 1.,
                 const double             factor2 = 1.)
     {
-      const unsigned int n1_dofs      = fe1.dofs_per_cell;
-      const unsigned int n2_dofs      = fe2.dofs_per_cell;
+      const unsigned int n1_dofs      = fe1.n_dofs_per_cell();
+      const unsigned int n2_dofs      = fe2.n_dofs_per_cell();
       const unsigned int n_components = fe1.get_fe().n_components();
 
       Assert(n1_dofs == n2_dofs, ExcNotImplemented());

--- a/include/deal.II/integrators/maxwell.h
+++ b/include/deal.II/integrators/maxwell.h
@@ -392,7 +392,7 @@ namespace LocalIntegrators
                    const double             factor1 = 1.,
                    const double             factor2 = -1.)
     {
-      const unsigned int n_dofs = fe1.dofs_per_cell;
+      const unsigned int n_dofs = fe1.n_dofs_per_cell();
 
       AssertDimension(fe1.get_fe().n_components(), dim);
       AssertDimension(fe2.get_fe().n_components(), dim);

--- a/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/cuda_hanging_nodes_internal.h
@@ -141,24 +141,24 @@ namespace CUDAWrappers
       setup_constraint_weigths(unsigned int fe_degree)
       {
         FE_Q<2>            fe_q(fe_degree);
-        FullMatrix<double> interpolation_matrix(fe_q.dofs_per_face,
-                                                fe_q.dofs_per_face);
+        FullMatrix<double> interpolation_matrix(fe_q.n_dofs_per_face(),
+                                                fe_q.n_dofs_per_face());
         fe_q.get_subface_interpolation_matrix(fe_q, 0, interpolation_matrix);
 
         std::vector<unsigned int> mapping =
           FETools::lexicographic_to_hierarchic_numbering<1>(fe_degree);
 
-        FullMatrix<double> mapped_matrix(fe_q.dofs_per_face,
-                                         fe_q.dofs_per_face);
-        for (unsigned int i = 0; i < fe_q.dofs_per_face; ++i)
-          for (unsigned int j = 0; j < fe_q.dofs_per_face; ++j)
+        FullMatrix<double> mapped_matrix(fe_q.n_dofs_per_face(),
+                                         fe_q.n_dofs_per_face());
+        for (unsigned int i = 0; i < fe_q.n_dofs_per_face(); ++i)
+          for (unsigned int j = 0; j < fe_q.n_dofs_per_face(); ++j)
             mapped_matrix(i, j) = interpolation_matrix(mapping[i], mapping[j]);
 
         cudaError_t error_code =
           cudaMemcpyToSymbol(internal::constraint_weights,
                              &mapped_matrix[0][0],
-                             sizeof(double) * fe_q.dofs_per_face *
-                               fe_q.dofs_per_face);
+                             sizeof(double) * fe_q.n_dofs_per_face() *
+                               fe_q.n_dofs_per_face());
         AssertCuda(error_code);
       }
     } // namespace internal

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -261,7 +261,7 @@ namespace CUDAWrappers
       const UpdateFlags &    update_flags)
       : data(data)
       , fe_degree(data->fe_degree)
-      , dofs_per_cell(data->dofs_per_cell)
+      , dofs_per_cell(data->n_dofs_per_cell())
       , q_points_per_cell(data->q_points_per_cell)
       , fe_values(mapping,
                   fe,
@@ -273,7 +273,7 @@ namespace CUDAWrappers
       , padding_length(data->get_padding_length())
       , hanging_nodes(fe_degree, dof_handler, lexicographic_inv)
     {
-      local_dof_indices.resize(data->dofs_per_cell);
+      local_dof_indices.resize(data->n_dofs_per_cell());
       lexicographic_dof_indices.resize(dofs_per_cell);
     }
 
@@ -503,7 +503,7 @@ namespace CUDAWrappers
       const AffineConstraints<number> &constraints)
     {
       std::vector<types::global_dof_index> local_dof_indices(
-        cell->get_fe().dofs_per_cell);
+        cell->get_fe().n_dofs_per_cell());
       cell->get_dof_indices(local_dof_indices);
       constraints.resolve_indices(local_dof_indices);
 
@@ -888,7 +888,7 @@ namespace CUDAWrappers
     padding_length = 1 << static_cast<unsigned int>(
                        std::ceil(dim * std::log2(fe_degree + 1.)));
 
-    dofs_per_cell     = fe.dofs_per_cell;
+    dofs_per_cell     = fe.n_dofs_per_cell();
     q_points_per_cell = std::pow(n_q_points_1d, dim);
 
     const ::dealii::internal::MatrixFreeFunctions::ShapeInfo<Number> shape_info(

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7068,7 +7068,7 @@ FEEvaluation<dim,
   Assert(this->mapped_geometry.get() != nullptr, ExcNotInitialized());
   this->mapped_geometry->reinit(
     static_cast<typename Triangulation<dim>::cell_iterator>(cell));
-  this->local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+  this->local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
   if (level_dof_access)
     cell->get_mg_dof_indices(this->local_dof_indices);
   else

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -760,7 +760,7 @@ namespace internal
             const FiniteElement<dim> &fe = fes[fe_index];
             // cache number of finite elements and dofs_per_cell
             dof_info[no].dofs_per_cell.push_back(fe.n_dofs_per_cell());
-            dof_info[no].dofs_per_face.push_back(fe.dofs_per_face);
+            dof_info[no].dofs_per_face.push_back(fe.n_dofs_per_face());
             dof_info[no].dimension       = dim;
             dof_info[no].n_base_elements = fe.n_base_elements();
             dof_info[no].n_components.resize(dof_info[no].n_base_elements);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -408,7 +408,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
                 dof_info[i].start_components[c] + dof_info[i].n_components[c];
             }
           dof_info[i].dofs_per_cell.push_back(
-            dof_handler[i]->get_fe(0).dofs_per_cell);
+            dof_handler[i]->get_fe(0).n_dofs_per_cell());
 
           // if indices are not initialized, the cell_level_index might not be
           // divisible by the vectorization length. But it must be for
@@ -746,7 +746,7 @@ namespace internal
           dof_info[no].cell_active_fe_index.resize(
             n_active_cells, numbers::invalid_unsigned_int);
 
-        is_fe_dg[no] = fes[0].dofs_per_vertex == 0;
+        is_fe_dg[no] = fes[0].n_dofs_per_vertex() == 0;
 
         lexicographic[no].resize(fes.size());
 
@@ -759,7 +759,7 @@ namespace internal
           {
             const FiniteElement<dim> &fe = fes[fe_index];
             // cache number of finite elements and dofs_per_cell
-            dof_info[no].dofs_per_cell.push_back(fe.dofs_per_cell);
+            dof_info[no].dofs_per_cell.push_back(fe.n_dofs_per_cell());
             dof_info[no].dofs_per_face.push_back(fe.dofs_per_face);
             dof_info[no].dimension       = dim;
             dof_info[no].n_base_elements = fe.n_base_elements();
@@ -780,7 +780,7 @@ namespace internal
                       .push_back(dof_info[no]
                                    .component_dof_indices_offset[fe_index]
                                    .back() +
-                                 fe.base_element(c).dofs_per_cell);
+                                 fe.base_element(c).n_dofs_per_cell());
                     dof_info[no].fe_index_conversion[fe_index].push_back(
                       fe.base_element(c).degree);
                   }
@@ -942,7 +942,7 @@ namespace internal
                           dof_indices.resize(
                             cell->neighbor_or_periodic_neighbor(f)
                               ->get_fe()
-                              .dofs_per_cell);
+                              .n_dofs_per_cell());
                           cell->neighbor_or_periodic_neighbor(f)
                             ->get_mg_dof_indices(dof_indices);
                           for (const auto dof_index : dof_indices)

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -124,7 +124,8 @@ namespace internal
 
       const unsigned int fe_degree     = fe->degree;
       const unsigned int n_q_points_1d = quad.size();
-      const unsigned int n_dofs_1d = std::min(fe->dofs_per_cell, fe_degree + 1);
+      const unsigned int n_dofs_1d =
+        std::min(fe->n_dofs_per_cell(), fe_degree + 1);
 
       // renumber (this is necessary for FE_Q, for example, since there the
       // vertex DoFs come first, which is incompatible with the lexicographic
@@ -154,8 +155,8 @@ namespace internal
           scalar_lexicographic = fe_poly->get_poly_space_numbering_inverse();
         else if (fe_dgp != nullptr)
           {
-            scalar_lexicographic.resize(fe_dgp->dofs_per_cell);
-            for (unsigned int i = 0; i < fe_dgp->dofs_per_cell; ++i)
+            scalar_lexicographic.resize(fe_dgp->n_dofs_per_cell());
+            for (unsigned int i = 0; i < fe_dgp->n_dofs_per_cell(); ++i)
               scalar_lexicographic[i] = i;
             element_type = truncated_tensor;
           }
@@ -164,7 +165,7 @@ namespace internal
             scalar_lexicographic = fe_q_dg0->get_poly_space_numbering_inverse();
             element_type         = tensor_symmetric_plus_dg0;
           }
-        else if (fe->dofs_per_cell == 0)
+        else if (fe->n_dofs_per_cell() == 0)
           {
             // FE_Nothing case -> nothing to do here
           }
@@ -183,7 +184,7 @@ namespace internal
             std::vector<unsigned int> scalar_inv =
               Utilities::invert_permutation(scalar_lexicographic);
             std::vector<unsigned int> lexicographic(
-              fe_in.dofs_per_cell, numbers::invalid_unsigned_int);
+              fe_in.n_dofs_per_cell(), numbers::invalid_unsigned_int);
             unsigned int components_before = 0;
             for (unsigned int e = 0; e < base_element_number; ++e)
               components_before += fe_in.element_multiplicity(e);
@@ -199,7 +200,7 @@ namespace internal
             // have undefined blocks
             lexicographic_numbering.resize(fe_in.element_multiplicity(
                                              base_element_number) *
-                                             fe->dofs_per_cell,
+                                             fe->n_dofs_per_cell(),
                                            numbers::invalid_unsigned_int);
             for (unsigned int i = 0; i < lexicographic.size(); ++i)
               if (lexicographic[i] != numbers::invalid_unsigned_int)
@@ -216,7 +217,7 @@ namespace internal
         // by reading the name, as done before r29356)
         if (fe->has_support_points())
           unit_point = fe->get_unit_support_points()[scalar_lexicographic[0]];
-        Assert(fe->dofs_per_cell == 0 ||
+        Assert(fe->n_dofs_per_cell() == 0 ||
                  std::abs(fe->shape_value(scalar_lexicographic[0], unit_point) -
                           1) < 1e-13,
                ExcInternalError("Could not decode 1D shape functions for the "
@@ -227,7 +228,7 @@ namespace internal
       n_q_points = Utilities::fixed_power<dim>(n_q_points_1d);
       n_q_points_face =
         dim > 1 ? Utilities::fixed_power<dim - 1>(n_q_points_1d) : 1;
-      dofs_per_component_on_cell = fe->dofs_per_cell;
+      dofs_per_component_on_cell = fe->n_dofs_per_cell();
       dofs_per_component_on_face =
         dim > 1 ? Utilities::fixed_power<dim - 1>(fe_degree + 1) : 1;
 

--- a/include/deal.II/meshworker/dof_info.h
+++ b/include/deal.II/meshworker/dof_info.h
@@ -304,7 +304,7 @@ namespace MeshWorker
     , level_cell(false)
   {
     std::vector<types::global_dof_index> aux(1);
-    aux[0] = dof_handler.get_fe().dofs_per_cell;
+    aux[0] = dof_handler.get_fe().n_dofs_per_cell();
     aux_local_indices.reinit(aux);
   }
 
@@ -314,12 +314,12 @@ namespace MeshWorker
   inline void
   DoFInfo<dim, spacedim, number>::get_indices(const DHCellIterator &c)
   {
-    indices.resize(c->get_fe().dofs_per_cell);
+    indices.resize(c->get_fe().n_dofs_per_cell());
     if (block_info == nullptr || block_info->local().size() == 0)
       c->get_active_or_mg_dof_indices(indices);
     else
       {
-        indices_org.resize(c->get_fe().dofs_per_cell);
+        indices_org.resize(c->get_fe().n_dofs_per_cell());
         c->get_active_or_mg_dof_indices(indices_org);
         set_block_indices();
       }

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -998,7 +998,8 @@ namespace MeshWorker
     const std::string &global_vector_name,
     Number             dummy) const
   {
-    const unsigned int n_dofs = get_current_fe_values().get_fe().dofs_per_cell;
+    const unsigned int n_dofs =
+      get_current_fe_values().get_fe().n_dofs_per_cell();
 
     const std::string dofs_name =
       get_unique_dofs_name(global_vector_name, n_dofs, dummy);

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -290,7 +290,7 @@ MGConstrainedDoFs::initialize(const DoFHandler<dim, spacedim> &dof)
                     }
 
                   const unsigned int dofs_per_face =
-                    cell->face(f)->get_fe(0).dofs_per_face;
+                    cell->face(f)->get_fe(0).n_dofs_per_face();
                   std::vector<types::global_dof_index> dofs_1(dofs_per_face);
                   std::vector<types::global_dof_index> dofs_2(dofs_per_face);
 

--- a/include/deal.II/multigrid/mg_transfer_internal.h
+++ b/include/deal.II/multigrid/mg_transfer_internal.h
@@ -97,7 +97,7 @@ namespace internal
 
       /**
        * A variable storing the number of degrees of freedom on all child cells.
-       * It is <tt>2<sup>dim</sup>*fe.dofs_per_cell</tt> for DG elements and
+       * It is <tt>2<sup>dim</sup>*fe.n_dofs_per_cell()</tt> for DG elements and
        * somewhat less for continuous elements.
        */
       unsigned int n_child_cell_dofs;

--- a/include/deal.II/multigrid/mg_transfer_matrix_free.h
+++ b/include/deal.II/multigrid/mg_transfer_matrix_free.h
@@ -199,8 +199,8 @@ private:
 
   /**
    * A variable storing the number of degrees of freedom on all child cells. It
-   * is <tt>2<sup>dim</sup>*fe.dofs_per_cell</tt> for DG elements and somewhat
-   * less for continuous elements.
+   * is <tt>2<sup>dim</sup>*fe.n_dofs_per_cell()</tt> for DG elements and
+   * somewhat less for continuous elements.
    */
   unsigned int n_child_cell_dofs;
 
@@ -545,10 +545,10 @@ MGTransferMatrixFree<dim, Number>::interpolate_to_mg(
       ghosted_vector = dst[level];
       ghosted_vector.update_ghost_values();
 
-      std::vector<Number>                  dof_values_coarse(fe.dofs_per_cell);
-      Vector<Number>                       dof_values_fine(fe.dofs_per_cell);
-      Vector<Number>                       tmp(fe.dofs_per_cell);
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      std::vector<Number> dof_values_coarse(fe.n_dofs_per_cell());
+      Vector<Number>      dof_values_fine(fe.n_dofs_per_cell());
+      Vector<Number>      tmp(fe.n_dofs_per_cell());
+      std::vector<types::global_dof_index>    dof_indices(fe.n_dofs_per_cell());
       typename DoFHandler<dim>::cell_iterator cell =
         dof_handler.begin(level - 1);
       typename DoFHandler<dim>::cell_iterator endc = dof_handler.end(level - 1);
@@ -565,18 +565,18 @@ MGTransferMatrixFree<dim, Number>::interpolate_to_mg(
             for (unsigned int child = 0; child < cell->n_children(); ++child)
               {
                 cell->child(child)->get_mg_dof_indices(dof_indices);
-                for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
                   dof_values_fine(i) = ghosted_vector(dof_indices[i]);
                 fe.get_restriction_matrix(child, cell->refinement_case())
                   .vmult(tmp, dof_values_fine);
-                for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
                   if (fe.restriction_is_additive(i))
                     dof_values_coarse[i] += tmp[i];
                   else if (tmp(i) != 0.)
                     dof_values_coarse[i] = tmp[i];
               }
             cell->get_mg_dof_indices(dof_indices);
-            for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+            for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
               dst[level - 1](dof_indices[i]) = dof_values_coarse[i];
           }
 

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -1251,7 +1251,7 @@ namespace internal
       const VectorType *vector = &((*vectors)[dof_cell->level()]);
 
       const unsigned int dofs_per_cell =
-        this->dof_handler->get_fe(0).dofs_per_cell;
+        this->dof_handler->get_fe(0).n_dofs_per_cell();
 
       std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
       dof_cell->get_mg_dof_indices(dof_indices);
@@ -1290,7 +1290,7 @@ namespace internal
       const VectorType *vector = &((*vectors)[dof_cell->level()]);
 
       const unsigned int dofs_per_cell =
-        this->dof_handler->get_fe(0).dofs_per_cell;
+        this->dof_handler->get_fe(0).n_dofs_per_cell();
 
       std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
       dof_cell->get_mg_dof_indices(dof_indices);

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -951,7 +951,7 @@ namespace MatrixCreator
       const unsigned int dofs_per_face = fe.dofs_per_face;
 
       copy_data.cell          = cell;
-      copy_data.dofs_per_cell = fe.dofs_per_cell;
+      copy_data.dofs_per_cell = fe.n_dofs_per_cell();
 
       UpdateFlags update_flags =
         UpdateFlags(update_values | update_JxW_values | update_normal_vectors |
@@ -1382,7 +1382,7 @@ namespace MatrixCreator
       const unsigned int                  dofs_per_face   = fe.dofs_per_face;
 
       copy_data.cell          = cell;
-      copy_data.dofs_per_cell = fe.dofs_per_cell;
+      copy_data.dofs_per_cell = fe.n_dofs_per_cell();
       copy_data.dofs.resize(copy_data.dofs_per_cell);
       cell->get_dof_indices(copy_data.dofs);
 

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -948,7 +948,7 @@ namespace MatrixCreator
       const bool fe_is_system    = (n_components != 1);
       const bool fe_is_primitive = fe.is_primitive();
 
-      const unsigned int dofs_per_face = fe.dofs_per_face;
+      const unsigned int dofs_per_face = fe.n_dofs_per_face();
 
       copy_data.cell          = cell;
       copy_data.dofs_per_cell = fe.n_dofs_per_cell();
@@ -1379,7 +1379,7 @@ namespace MatrixCreator
       const FiniteElement<dim, spacedim> &fe              = cell->get_fe();
       const bool                          fe_is_system    = (n_components != 1);
       const bool                          fe_is_primitive = fe.is_primitive();
-      const unsigned int                  dofs_per_face   = fe.dofs_per_face;
+      const unsigned int                  dofs_per_face = fe.n_dofs_per_face();
 
       copy_data.cell          = cell;
       copy_data.dofs_per_cell = fe.n_dofs_per_cell();

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -130,7 +130,7 @@ namespace VectorTools
                     boundary_function.vector_value(cell->vertex(direction),
                                                    function_values);
 
-                  for (unsigned int i = 0; i < fe.dofs_per_vertex; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_vertex(); ++i)
                     if (component_mask[fe.face_system_to_component_index(i)
                                          .first])
                       boundary_values[cell->vertex_dof_index(
@@ -229,7 +229,7 @@ namespace VectorTools
                   // interested in, however. make sure that all shape functions
                   // that are non-zero for the components we are interested in,
                   // are in fact primitive
-                  for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell;
+                  for (unsigned int i = 0; i < cell->get_fe().n_dofs_per_cell();
                        ++i)
                     {
                       const ComponentMask &nonzero_component_array =
@@ -310,19 +310,23 @@ namespace VectorTools
                                     (dim == 1 ?
                                        i :
                                        (dim == 2 ?
-                                          (i < 2 * fe.dofs_per_vertex ?
+                                          (i < 2 * fe.n_dofs_per_vertex() ?
                                              i :
-                                             i + 2 * fe.dofs_per_vertex) :
+                                             i + 2 * fe.n_dofs_per_vertex()) :
                                           (dim == 3 ?
-                                             (i < 4 * fe.dofs_per_vertex ?
+                                             (i < 4 * fe.n_dofs_per_vertex() ?
                                                 i :
-                                                (i < 4 * fe.dofs_per_vertex +
+                                                (i < 4 * fe.n_dofs_per_vertex() +
                                                        4 * fe.dofs_per_line ?
-                                                   i + 4 * fe.dofs_per_vertex :
-                                                   i + 4 * fe.dofs_per_vertex +
+                                                   i +
+                                                     4 *
+                                                       fe.n_dofs_per_vertex() :
+                                                   i +
+                                                     4 *
+                                                       fe.n_dofs_per_vertex() +
                                                      8 * fe.dofs_per_line)) :
                                              numbers::invalid_unsigned_int)));
-                                  Assert(cell_i < fe.dofs_per_cell,
+                                  Assert(cell_i < fe.n_dofs_per_cell(),
                                          ExcInternalError());
 
                                   // make sure that if this is not a primitive
@@ -2150,7 +2154,7 @@ namespace VectorTools
           //      and so on.
 
           const unsigned int face_dof_idx =
-            GeometryInfo<dim>::vertices_per_face * fe.dofs_per_vertex +
+            GeometryInfo<dim>::vertices_per_face * fe.n_dofs_per_vertex() +
             line * fe.dofs_per_line + line_dof_idx;
 
           // Note, assuming that the edge orientations are "standard"
@@ -2586,7 +2590,7 @@ namespace VectorTools
                       //      (degree+1),..,2*(degree+1) and so on.
                       const unsigned int face_dof_idx =
                         GeometryInfo<dim>::vertices_per_face *
-                          fe.dofs_per_vertex +
+                          fe.n_dofs_per_vertex() +
                         line * fe.dofs_per_line + line_dof_idx;
 
                       // Next, translate from face to cell. Note, this might be
@@ -2661,7 +2665,8 @@ namespace VectorTools
                    ++quad_dof_idx)
                 {
                   const unsigned int face_idx =
-                    GeometryInfo<dim>::vertices_per_face * fe.dofs_per_vertex +
+                    GeometryInfo<dim>::vertices_per_face *
+                      fe.n_dofs_per_vertex() +
                     lines_per_face * fe.dofs_per_line + quad_dof_idx;
                   const unsigned int cell_idx =
                     fe.face_to_cell_index(face_idx, face);

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -194,9 +194,9 @@ namespace VectorTools
                   // components we are interested in are primitive (by the above
                   // check), we can safely put such a check in front
                   std::vector<Point<dim - 1>> unit_support_points(
-                    fe.dofs_per_face);
+                    fe.n_dofs_per_face());
 
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (fe.is_primitive(fe.face_to_cell_index(i, 0)))
                       if (component_mask[fe.face_system_to_component_index(i)
                                            .first] == true)
@@ -260,7 +260,7 @@ namespace VectorTools
                   // element in use here has DoFs on the face at all
                   if ((function_map.find(boundary_component) !=
                        function_map.end()) &&
-                      (cell->get_fe().dofs_per_face > 0))
+                      (cell->get_fe().n_dofs_per_face() > 0))
                     {
                       // face is of the right component
                       x_fe_values.reinit(cell, face_no);
@@ -269,7 +269,7 @@ namespace VectorTools
 
                       // get indices, physical location and boundary values of
                       // dofs on this face
-                      face_dofs.resize(fe.dofs_per_face);
+                      face_dofs.resize(fe.n_dofs_per_face());
                       face->get_dof_indices(face_dofs, cell->active_fe_index());
                       const std::vector<Point<spacedim>> &dof_locations =
                         fe_values.get_quadrature_points();
@@ -278,12 +278,12 @@ namespace VectorTools
                         {
                           // resize array. avoid construction of a memory
                           // allocating temporary if possible
-                          if (dof_values_system.size() < fe.dofs_per_face)
-                            dof_values_system.resize(fe.dofs_per_face,
+                          if (dof_values_system.size() < fe.n_dofs_per_face())
+                            dof_values_system.resize(fe.n_dofs_per_face(),
                                                      Vector<number>(
                                                        fe.n_components()));
                           else
-                            dof_values_system.resize(fe.dofs_per_face);
+                            dof_values_system.resize(fe.n_dofs_per_face());
 
                           function_map.find(boundary_component)
                             ->second->vector_value_list(dof_locations,
@@ -317,14 +317,16 @@ namespace VectorTools
                                              (i < 4 * fe.n_dofs_per_vertex() ?
                                                 i :
                                                 (i < 4 * fe.n_dofs_per_vertex() +
-                                                       4 * fe.dofs_per_line ?
+                                                       4 *
+                                                         fe.n_dofs_per_line() ?
                                                    i +
                                                      4 *
                                                        fe.n_dofs_per_vertex() :
                                                    i +
                                                      4 *
                                                        fe.n_dofs_per_vertex() +
-                                                     8 * fe.dofs_per_line)) :
+                                                     8 *
+                                                       fe.n_dofs_per_line())) :
                                              numbers::invalid_unsigned_int)));
                                   Assert(cell_i < fe.n_dofs_per_cell(),
                                          ExcInternalError());
@@ -358,7 +360,7 @@ namespace VectorTools
                         // fe has only one component, so save some computations
                         {
                           // get only the one component that this function has
-                          dof_values_scalar.resize(fe.dofs_per_face);
+                          dof_values_scalar.resize(fe.n_dofs_per_face());
                           function_map.find(boundary_component)
                             ->second->value_list(dof_locations,
                                                  dof_values_scalar,
@@ -1024,7 +1026,7 @@ namespace VectorTools
 
           // Compute the degrees of
           // freedom.
-          for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
             if (((dynamic_cast<const FESystem<dim> *>(&fe) != nullptr) &&
                  (fe.system_to_base_index(fe.face_to_cell_index(i, face))
                     .first == base_indices) &&
@@ -1199,7 +1201,7 @@ namespace VectorTools
 
                   // Compute the degrees
                   // of freedom.
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (((dynamic_cast<const FESystem<dim> *>(&fe) !=
                           nullptr) &&
                          (fe.system_to_base_index(
@@ -1269,7 +1271,7 @@ namespace VectorTools
                   for (unsigned int d = 0; d < dim; ++d)
                     tmp[d] = values[q_point](first_vector_component + d);
 
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (((dynamic_cast<const FESystem<dim> *>(&fe) !=
                           nullptr) &&
                          (fe.system_to_base_index(
@@ -1335,7 +1337,7 @@ namespace VectorTools
 
                   unsigned int index = 0;
 
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (((dynamic_cast<const FESystem<dim> *>(&fe) !=
                           nullptr) &&
                          (fe.system_to_base_index(
@@ -1389,7 +1391,7 @@ namespace VectorTools
               {
                 unsigned int index = 0;
 
-                for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                   if (((dynamic_cast<const FESystem<dim> *>(&fe) != nullptr) &&
                        (fe.system_to_base_index(fe.face_to_cell_index(i, face))
                           .first == base_indices) &&
@@ -1429,7 +1431,7 @@ namespace VectorTools
                   for (unsigned int d = 0; d < dim; ++d)
                     tmp[d] = values[q_point](first_vector_component + d);
 
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (((dynamic_cast<const FESystem<dim> *>(&fe) !=
                           nullptr) &&
                          (fe.system_to_base_index(
@@ -1485,7 +1487,7 @@ namespace VectorTools
 
                   unsigned int index = 0;
 
-                  for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                  for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                     if (((dynamic_cast<const FESystem<dim> *>(&fe) !=
                           nullptr) &&
                          (fe.system_to_base_index(
@@ -1525,7 +1527,7 @@ namespace VectorTools
 
               unsigned int index = 0;
 
-              for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+              for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                 if (((dynamic_cast<const FESystem<dim> *>(&fe) != nullptr) &&
                      (fe.system_to_base_index(fe.face_to_cell_index(i, face))
                         .first == base_indices) &&
@@ -1581,7 +1583,7 @@ namespace VectorTools
     // corresponding degrees of freedom.
     const unsigned int    superdegree = dof_handler.get_fe().degree;
     const QGauss<dim - 1> reference_face_quadrature(2 * superdegree);
-    const unsigned int    dofs_per_face = dof_handler.get_fe().dofs_per_face;
+    const unsigned int dofs_per_face = dof_handler.get_fe().n_dofs_per_face();
     const hp::FECollection<dim> &fe_collection(dof_handler.get_fe_collection());
     const hp::MappingCollection<dim> mapping_collection(mapping);
     hp::QCollection<dim>             face_quadrature_collection;
@@ -1858,7 +1860,7 @@ namespace VectorTools
                         }
 
                       const unsigned int dofs_per_face =
-                        cell->get_fe().dofs_per_face;
+                        cell->get_fe().n_dofs_per_face();
 
                       dofs_processed.resize(dofs_per_face);
                       dof_values.resize(dofs_per_face);
@@ -1951,7 +1953,7 @@ namespace VectorTools
                       const unsigned int superdegree = cell->get_fe().degree;
                       const unsigned int degree      = superdegree - 1;
                       const unsigned int dofs_per_face =
-                        cell->get_fe().dofs_per_face;
+                        cell->get_fe().n_dofs_per_face();
 
                       dofs_processed.resize(dofs_per_face);
                       dof_values.resize(dofs_per_face);
@@ -2137,7 +2139,7 @@ namespace VectorTools
           .face_to_cell_index((line + 1) * (degree + 1) - 1, face);
 
       unsigned int associated_edge_dof_index = 0;
-      for (unsigned int line_dof_idx = 0; line_dof_idx < fe.dofs_per_line;
+      for (unsigned int line_dof_idx = 0; line_dof_idx < fe.n_dofs_per_line();
            ++line_dof_idx)
         {
           // For each DoF associated with the (interior of) the line, we need
@@ -2155,7 +2157,7 @@ namespace VectorTools
 
           const unsigned int face_dof_idx =
             GeometryInfo<dim>::vertices_per_face * fe.n_dofs_per_vertex() +
-            line * fe.dofs_per_line + line_dof_idx;
+            line * fe.n_dofs_per_line() + line_dof_idx;
 
           // Note, assuming that the edge orientations are "standard"
           //       i.e. cell->line_orientation(line) = true.
@@ -2426,7 +2428,7 @@ namespace VectorTools
                                                                         1);
 
               unsigned int associated_edge_dof_index = 0;
-              for (unsigned int face_idx = 0; face_idx < fe.dofs_per_face;
+              for (unsigned int face_idx = 0; face_idx < fe.n_dofs_per_face();
                    ++face_idx)
                 {
                   const unsigned int cell_idx =
@@ -2572,7 +2574,7 @@ namespace VectorTools
                   unsigned int associated_edge_dof_index = 0;
 
                   for (unsigned int line_dof_idx = 0;
-                       line_dof_idx < fe.dofs_per_line;
+                       line_dof_idx < fe.n_dofs_per_line();
                        ++line_dof_idx)
                     {
                       // For each DoF associated with the (interior of) the
@@ -2591,7 +2593,7 @@ namespace VectorTools
                       const unsigned int face_dof_idx =
                         GeometryInfo<dim>::vertices_per_face *
                           fe.n_dofs_per_vertex() +
-                        line * fe.dofs_per_line + line_dof_idx;
+                        line * fe.n_dofs_per_line() + line_dof_idx;
 
                       // Next, translate from face to cell. Note, this might be
                       // assuming that the edge orientations are "standard" (not
@@ -2661,13 +2663,13 @@ namespace VectorTools
               // Loop over these quad-interior dofs.
               unsigned int associated_face_dof_index = 0;
               for (unsigned int quad_dof_idx = 0;
-                   quad_dof_idx < fe.dofs_per_quad;
+                   quad_dof_idx < fe.n_dofs_per_quad();
                    ++quad_dof_idx)
                 {
                   const unsigned int face_idx =
                     GeometryInfo<dim>::vertices_per_face *
                       fe.n_dofs_per_vertex() +
-                    lines_per_face * fe.dofs_per_line + quad_dof_idx;
+                    lines_per_face * fe.n_dofs_per_line() + quad_dof_idx;
                   const unsigned int cell_idx =
                     fe.face_to_cell_index(face_idx, face);
                   if (((dynamic_cast<const FESystem<dim> *>(&fe) != nullptr) &&
@@ -2923,7 +2925,7 @@ namespace VectorTools
                                 }
 
                               const unsigned int dofs_per_face =
-                                cell->get_fe().dofs_per_face;
+                                cell->get_fe().n_dofs_per_face();
 
                               dofs_processed.resize(dofs_per_face);
                               dof_values.resize(dofs_per_face);
@@ -3049,7 +3051,7 @@ namespace VectorTools
                                 cell->get_fe().degree;
                               const unsigned int degree = superdegree - 1;
                               const unsigned int dofs_per_face =
-                                cell->get_fe().dofs_per_face;
+                                cell->get_fe().n_dofs_per_face();
 
                               dofs_processed.resize(dofs_per_face);
                               dof_values.resize(dofs_per_face);
@@ -3204,7 +3206,7 @@ namespace VectorTools
                                                                       0};
       std::vector<Vector<double>> values(fe_values.n_quadrature_points,
                                          Vector<double>(2));
-      Vector<double>              dof_values(fe.dofs_per_face);
+      Vector<double>              dof_values(fe.n_dofs_per_face());
 
       // Get the values of the boundary function at the quadrature points.
       {
@@ -3229,7 +3231,7 @@ namespace VectorTools
                       jacobians[q_point][1][face_coordinate_direction[face]] *
                         jacobians[q_point][1][face_coordinate_direction[face]]);
 
-          for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
             dof_values(i) +=
               tmp * (normals[q_point] *
                      fe_values[vec].value(
@@ -3241,14 +3243,15 @@ namespace VectorTools
                        q_point));
         }
 
-      std::vector<types::global_dof_index> face_dof_indices(fe.dofs_per_face);
+      std::vector<types::global_dof_index> face_dof_indices(
+        fe.n_dofs_per_face());
 
       cell->face(face)->get_dof_indices(face_dof_indices,
                                         cell->active_fe_index());
 
       // Copy the computed values in the AffineConstraints only, if the degree
       // of freedom is not already constrained.
-      for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
         if (!(constraints.is_constrained(face_dof_indices[i])) &&
             fe.get_nonzero_components(fe.face_to_cell_index(
               i,
@@ -3304,7 +3307,7 @@ namespace VectorTools
           {1, 2}, {1, 2}, {2, 0}, {2, 0}, {0, 1}, {0, 1}};
       std::vector<Vector<double>> values(fe_values.n_quadrature_points,
                                          Vector<double>(3));
-      Vector<double>              dof_values_local(fe.dofs_per_face);
+      Vector<double>              dof_values_local(fe.n_dofs_per_face());
 
       {
         const std::vector<Point<3>> &quadrature_points =
@@ -3337,7 +3340,7 @@ namespace VectorTools
                jacobians[q_point][2][face_coordinate_directions[face][1]] *
                  jacobians[q_point][2][face_coordinate_directions[face][1]]));
 
-          for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
             dof_values_local(i) +=
               tmp * (normals[q_point] *
                      fe_values[vec].value(
@@ -3349,12 +3352,13 @@ namespace VectorTools
                        q_point));
         }
 
-      std::vector<types::global_dof_index> face_dof_indices(fe.dofs_per_face);
+      std::vector<types::global_dof_index> face_dof_indices(
+        fe.n_dofs_per_face());
 
       cell->face(face)->get_dof_indices(face_dof_indices,
                                         cell->active_fe_index());
 
-      for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
         if (projected_dofs[face_dof_indices[i]] < fe.degree &&
             fe.get_nonzero_components(fe.face_to_cell_index(
               i,

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -499,7 +499,7 @@ namespace VectorTools
         const std::vector<Point<dim - 1>> &unit_support_points =
           fe_collection[i].get_unit_face_support_points();
 
-        Assert(unit_support_points.size() == fe_collection[i].dofs_per_face,
+        Assert(unit_support_points.size() == fe_collection[i].n_dofs_per_face(),
                ExcInternalError());
 
         face_quadrature_collection.push_back(
@@ -549,7 +549,7 @@ namespace VectorTools
                 cell->face(face_no);
 
               // get the indices of the dofs on this cell...
-              face_dofs.resize(fe.dofs_per_face);
+              face_dofs.resize(fe.n_dofs_per_face());
               face->get_dof_indices(face_dofs, cell->active_fe_index());
 
               x_fe_face_values.reinit(cell, face_no);
@@ -572,7 +572,7 @@ namespace VectorTools
                         "Error: the finite element does not have enough components "
                         "to define a normal direction."));
 
-                    for (unsigned int k = 0; k < fe.dofs_per_face; ++k)
+                    for (unsigned int k = 0; k < fe.n_dofs_per_face(); ++k)
                       if ((k != i) &&
                           (face_quadrature_collection[cell->active_fe_index()]
                              .point(k) ==
@@ -1085,7 +1085,7 @@ namespace VectorTools
         const std::vector<Point<dim - 1>> &unit_support_points =
           fe_collection[i].get_unit_face_support_points();
 
-        Assert(unit_support_points.size() == fe_collection[i].dofs_per_face,
+        Assert(unit_support_points.size() == fe_collection[i].n_dofs_per_face(),
                ExcInternalError());
 
         face_quadrature_collection.push_back(
@@ -1123,7 +1123,7 @@ namespace VectorTools
                 cell->face(face_no);
 
               // get the indices of the dofs on this cell...
-              face_dofs.resize(fe.dofs_per_face);
+              face_dofs.resize(fe.n_dofs_per_face());
               face->get_dof_indices(face_dofs, cell->active_fe_index());
 
               x_fe_face_values.reinit(cell, face_no);
@@ -1133,8 +1133,8 @@ namespace VectorTools
               std::map<types::global_dof_index, double> dof_to_b_value;
 
               unsigned int n_scalar_indices = 0;
-              cell_vector_dofs.resize(fe.dofs_per_face);
-              for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+              cell_vector_dofs.resize(fe.n_dofs_per_face());
+              for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                 {
                   if (fe.face_system_to_component_index(i).first >=
                         first_vector_component &&

--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -299,7 +299,7 @@ namespace VectorTools
                                       UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     cell_point.first->get_dof_indices(local_dof_indices);
@@ -358,7 +358,8 @@ namespace VectorTools
                             UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = cell_point.first->get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell =
+      cell_point.first->get_fe().n_dofs_per_cell();
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     cell_point.first->get_dof_indices(local_dof_indices);
@@ -400,7 +401,7 @@ namespace VectorTools
                                       UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     cell_point.first->get_dof_indices(local_dof_indices);
@@ -466,7 +467,8 @@ namespace VectorTools
                             UpdateFlags(update_values));
     fe_values.reinit(cell_point.first);
 
-    const unsigned int dofs_per_cell = cell_point.first->get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell =
+      cell_point.first->get_fe().n_dofs_per_cell();
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     cell_point.first->get_dof_indices(local_dof_indices);

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -639,7 +639,7 @@ namespace VectorTools
                                 quadrature,
                                 update_values | update_JxW_values);
 
-        const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
         const unsigned int n_q_points    = quadrature.size();
         Vector<Number>     cell_rhs(dofs_per_cell);
         std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -83,10 +83,11 @@ namespace VectorTools
         for (auto f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f))
             {
-              face_dof_indices.resize(cell->get_fe().dofs_per_face);
+              face_dof_indices.resize(cell->get_fe().n_dofs_per_face());
               cell->face(f)->get_dof_indices(face_dof_indices,
                                              cell->active_fe_index());
-              for (unsigned int i = 0; i < cell->get_fe().dofs_per_face; ++i)
+              for (unsigned int i = 0; i < cell->get_fe().n_dofs_per_face();
+                   ++i)
                 // enter zero boundary values
                 // for all boundary nodes
                 //

--- a/include/deal.II/particles/utilities.h
+++ b/include/deal.II/particles/utilities.h
@@ -220,7 +220,7 @@ namespace Particles
         if (comps[i])
           space_gtl[i] = j++;
 
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      std::vector<types::global_dof_index> dof_indices(fe.n_dofs_per_cell());
 
       while (particle != particle_handler.end())
         {
@@ -238,7 +238,7 @@ namespace Particles
 
               const auto id = particle->get_id();
 
-              for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+              for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
                 {
                   const auto comp_j =
                     space_gtl[fe.system_to_component_index(j).first];

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -82,7 +82,7 @@ namespace parallel
              const FiniteElement<dim, spacedim> &future_fe) -> unsigned int {
       const float result =
         std::trunc(coefficients.first *
-                   std::pow(future_fe.dofs_per_cell, coefficients.second));
+                   std::pow(future_fe.n_dofs_per_cell(), coefficients.second));
 
       Assert(result >= 0. &&
                result <=
@@ -106,7 +106,8 @@ namespace parallel
              const FiniteElement<dim, spacedim> &future_fe) -> unsigned int {
       float result = 0;
       for (const auto &pair : coefficients)
-        result += pair.first * std::pow(future_fe.dofs_per_cell, pair.second);
+        result +=
+          pair.first * std::pow(future_fe.n_dofs_per_cell(), pair.second);
       result = std::trunc(result);
 
       Assert(result >= 0. &&

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -343,7 +343,7 @@ namespace parallel
         }
 
       const unsigned int dofs_per_cell =
-        dof_handler->get_fe(fe_index).dofs_per_cell;
+        dof_handler->get_fe(fe_index).n_dofs_per_cell();
 
       if (dofs_per_cell == 0)
         return std::vector<char>(); // nothing to do for FE_Nothing
@@ -418,7 +418,7 @@ namespace parallel
         }
 
       const unsigned int dofs_per_cell =
-        dof_handler->get_fe(fe_index).dofs_per_cell;
+        dof_handler->get_fe(fe_index).n_dofs_per_cell();
 
       if (dofs_per_cell == 0)
         return; // nothing to do for FE_Nothing

--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -130,7 +130,7 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_indices(
 
   Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
-  AssertDimension(local_dof_indices.size(), this->get_fe().dofs_per_cell);
+  AssertDimension(local_dof_indices.size(), this->get_fe().n_dofs_per_cell());
 
   internal::DoFAccessorImplementation::Implementation::
     template set_dof_indices<dim, spacedim, lda, dim>(*this,

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -73,7 +73,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
           // well, here we need to first get the values from the current
           // cell and then interpolate it to the element requested. this
           // can clearly only happen for hp::DoFHandler objects
-          const unsigned int dofs_per_cell = this->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = this->get_fe().n_dofs_per_cell();
           if (dofs_per_cell == 0)
             {
               interpolated_values = 0;
@@ -84,8 +84,8 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
               this->get_dof_values(values, tmp);
 
               FullMatrix<double> interpolation(
-                this->dof_handler->get_fe(fe_index).dofs_per_cell,
-                this->get_fe().dofs_per_cell);
+                this->dof_handler->get_fe(fe_index).n_dofs_per_cell(),
+                this->get_fe().n_dofs_per_cell());
               this->dof_handler->get_fe(fe_index).get_interpolation_matrix(
                 this->get_fe(), interpolation);
               interpolation.vmult(interpolated_values, tmp);
@@ -115,7 +115,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
 
       const FiniteElement<dim, spacedim> &fe =
         this->get_dof_handler().get_fe(fe_index);
-      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
       Assert(this->dof_handler != nullptr,
              typename BaseClass::ExcInvalidObject());
@@ -130,7 +130,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
       // interpolating FE_Nothing), then simply skip all of the
       // following since the output vector would be of size zero
       // anyway (and in fact is of size zero, see the assertion above)
-      if (fe.dofs_per_cell > 0)
+      if (fe.n_dofs_per_cell() > 0)
         {
           Vector<number> tmp1(dofs_per_cell);
           Vector<number> tmp2(dofs_per_cell);

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -69,12 +69,12 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_values_by_interpolation(
       else
         {
           Assert(local_values.size() ==
-                   this->dof_handler->get_fe(fe_index).dofs_per_cell,
+                   this->dof_handler->get_fe(fe_index).n_dofs_per_cell(),
                  ExcMessage("Incorrect size of local_values vector."));
 
           FullMatrix<double> interpolation(
-            this->get_fe().dofs_per_cell,
-            this->dof_handler->get_fe(fe_index).dofs_per_cell);
+            this->get_fe().n_dofs_per_cell(),
+            this->dof_handler->get_fe(fe_index).n_dofs_per_cell());
 
           this->get_fe().get_interpolation_matrix(
             this->dof_handler->get_fe(fe_index), interpolation);
@@ -82,7 +82,7 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_values_by_interpolation(
           // do the interpolation to the target space. for historical
           // reasons, matrices are set to size 0x0 internally even
           // we reinit as 4x0, so we have to treat this case specially
-          Vector<number> tmp(this->get_fe().dofs_per_cell);
+          Vector<number> tmp(this->get_fe().n_dofs_per_cell());
           if ((tmp.size() > 0) && (local_values.size() > 0))
             interpolation.vmult(tmp, local_values);
 
@@ -105,7 +105,7 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_values_by_interpolation(
 
       const FiniteElement<dim, spacedim> &fe =
         this->get_dof_handler().get_fe(fe_index);
-      const unsigned int dofs_per_cell = fe.dofs_per_cell;
+      const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
 
       Assert(this->dof_handler != nullptr,
              typename BaseClass::ExcInvalidObject());

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -268,7 +268,7 @@ namespace internal
           {
             dof_handler.object_dof_indices[i][1].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_line,
+                dof_handler.get_fe().n_dofs_per_line(),
               numbers::invalid_dof_index);
 
             dof_handler.object_dof_ptr[i][1].reserve(
@@ -276,7 +276,7 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.object_dof_ptr[i][1].push_back(
-                j * dof_handler.get_fe().dofs_per_line);
+                j * dof_handler.get_fe().n_dofs_per_line());
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
@@ -309,7 +309,7 @@ namespace internal
           {
             dof_handler.object_dof_indices[i][2].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_quad,
+                dof_handler.get_fe().n_dofs_per_quad(),
               numbers::invalid_dof_index);
 
             dof_handler.object_dof_ptr[i][2].reserve(
@@ -317,7 +317,7 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.object_dof_ptr[i][2].push_back(
-                j * dof_handler.get_fe().dofs_per_quad);
+                j * dof_handler.get_fe().n_dofs_per_quad());
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
@@ -345,11 +345,11 @@ namespace internal
             for (unsigned int i = 0; i < dof_handler.tria->n_raw_lines() + 1;
                  i++)
               dof_handler.object_dof_ptr[0][1].push_back(
-                i * dof_handler.get_fe().dofs_per_line);
+                i * dof_handler.get_fe().n_dofs_per_line());
 
             dof_handler.object_dof_indices[0][1].resize(
               dof_handler.tria->n_raw_lines() *
-                dof_handler.get_fe().dofs_per_line,
+                dof_handler.get_fe().n_dofs_per_line(),
               numbers::invalid_dof_index);
           }
       }
@@ -366,7 +366,7 @@ namespace internal
           {
             dof_handler.object_dof_indices[i][3].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_hex,
+                dof_handler.get_fe().n_dofs_per_hex(),
               numbers::invalid_dof_index);
 
             dof_handler.object_dof_ptr[i][3].reserve(
@@ -374,7 +374,7 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.object_dof_ptr[i][3].push_back(
-                j * dof_handler.get_fe().dofs_per_hex);
+                j * dof_handler.get_fe().n_dofs_per_hex());
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
@@ -402,11 +402,11 @@ namespace internal
             for (unsigned int i = 0; i < dof_handler.tria->n_raw_lines() + 1;
                  i++)
               dof_handler.object_dof_ptr[0][1].push_back(
-                i * dof_handler.get_fe().dofs_per_line);
+                i * dof_handler.get_fe().n_dofs_per_line());
 
             dof_handler.object_dof_indices[0][1].resize(
               dof_handler.tria->n_raw_lines() *
-                dof_handler.get_fe().dofs_per_line,
+                dof_handler.get_fe().n_dofs_per_line(),
               numbers::invalid_dof_index);
 
             // faces
@@ -415,11 +415,11 @@ namespace internal
             for (unsigned int i = 0; i < dof_handler.tria->n_raw_quads() + 1;
                  i++)
               dof_handler.object_dof_ptr[0][2].push_back(
-                i * dof_handler.get_fe().dofs_per_quad);
+                i * dof_handler.get_fe().n_dofs_per_quad());
 
             dof_handler.object_dof_indices[0][2].resize(
               dof_handler.tria->n_raw_quads() *
-                dof_handler.get_fe().dofs_per_quad,
+                dof_handler.get_fe().n_dofs_per_quad(),
               numbers::invalid_dof_index);
           }
       }
@@ -433,8 +433,9 @@ namespace internal
 
         const dealii::Triangulation<1, spacedim> &tria =
           dof_handler.get_triangulation();
-        const unsigned int dofs_per_line = dof_handler.get_fe().dofs_per_line;
-        const unsigned int n_levels      = tria.n_levels();
+        const unsigned int dofs_per_line =
+          dof_handler.get_fe().n_dofs_per_line();
+        const unsigned int n_levels = tria.n_levels();
 
         for (unsigned int i = 0; i < n_levels; ++i)
           {
@@ -511,14 +512,16 @@ namespace internal
                 internal::DoFHandlerImplementation::DoFLevel<2>>());
             dof_handler.mg_levels.back()->dof_object.dofs =
               std::vector<types::global_dof_index>(tria.n_raw_quads(i) *
-                                                     fe.dofs_per_quad,
+                                                     fe.n_dofs_per_quad(),
                                                    numbers::invalid_dof_index);
           }
 
         dof_handler.mg_faces =
           std::make_unique<internal::DoFHandlerImplementation::DoFFaces<2>>();
-        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index>(
-          tria.n_raw_lines() * fe.dofs_per_line, numbers::invalid_dof_index);
+        dof_handler.mg_faces->lines.dofs =
+          std::vector<types::global_dof_index>(tria.n_raw_lines() *
+                                                 fe.n_dofs_per_line(),
+                                               numbers::invalid_dof_index);
 
         const unsigned int n_vertices = tria.n_vertices();
 
@@ -584,16 +587,20 @@ namespace internal
                 internal::DoFHandlerImplementation::DoFLevel<3>>());
             dof_handler.mg_levels.back()->dof_object.dofs =
               std::vector<types::global_dof_index>(tria.n_raw_hexs(i) *
-                                                     fe.dofs_per_hex,
+                                                     fe.n_dofs_per_hex(),
                                                    numbers::invalid_dof_index);
           }
 
         dof_handler.mg_faces =
           std::make_unique<internal::DoFHandlerImplementation::DoFFaces<3>>();
-        dof_handler.mg_faces->lines.dofs = std::vector<types::global_dof_index>(
-          tria.n_raw_lines() * fe.dofs_per_line, numbers::invalid_dof_index);
-        dof_handler.mg_faces->quads.dofs = std::vector<types::global_dof_index>(
-          tria.n_raw_quads() * fe.dofs_per_quad, numbers::invalid_dof_index);
+        dof_handler.mg_faces->lines.dofs =
+          std::vector<types::global_dof_index>(tria.n_raw_lines() *
+                                                 fe.n_dofs_per_line(),
+                                               numbers::invalid_dof_index);
+        dof_handler.mg_faces->quads.dofs =
+          std::vector<types::global_dof_index>(tria.n_raw_quads() *
+                                                 fe.n_dofs_per_quad(),
+                                               numbers::invalid_dof_index);
 
         const unsigned int n_vertices = tria.n_vertices();
 
@@ -1615,7 +1622,7 @@ namespace internal
                         {
                           fe_slots_needed++;
                           line_slots_needed +=
-                            dof_handler.get_fe(fe).dofs_per_line;
+                            dof_handler.get_fe(fe).n_dofs_per_line();
                         }
                   }
               }
@@ -1641,7 +1648,7 @@ namespace internal
                           dof_handler.object_dof_indices[l][d].size());
 
                         for (unsigned int i = 0;
-                             i < dof_handler.get_fe(fe).dofs_per_line;
+                             i < dof_handler.get_fe(fe).n_dofs_per_line();
                              i++)
                           dof_handler.object_dof_indices[l][d].push_back(
                             numbers::invalid_dof_index);
@@ -2267,7 +2274,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs() const
             const auto face = cell->face(iface);
             if (face->at_boundary())
               {
-                const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+                const unsigned int dofs_per_face =
+                  cell->get_fe().n_dofs_per_face();
                 dofs_on_face.resize(dofs_per_face);
 
                 face->get_dof_indices(dofs_on_face, cell->active_fe_index());
@@ -2318,7 +2326,8 @@ DoFHandler<dim, spacedim>::n_boundary_dofs(
             if (face->at_boundary() &&
                 (boundary_ids.find(boundary_id) != boundary_ids.end()))
               {
-                const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+                const unsigned int dofs_per_face =
+                  cell->get_fe().n_dofs_per_face();
                 dofs_on_face.resize(dofs_per_face);
 
                 face->get_dof_indices(dofs_on_face, cell->active_fe_index());

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -160,8 +160,8 @@ namespace internal
 
             // the following numbers are not based on actual counting but by
             // extrapolating the number sequences from the previous ones (for
-            // example, for dofs_per_vertex, the sequence above is 19, 21, 28,
-            // 30, 37, and is continued as follows):
+            // example, for n_dofs_per_vertex(), the sequence above is 19, 21,
+            // 28, 30, 37, and is continued as follows):
             case 9:
               max_couplings =
                 39 * dof_handler.fe_collection.max_dofs_per_vertex() +
@@ -260,7 +260,8 @@ namespace internal
       static void reserve_space(DoFHandler<1, spacedim> &dof_handler)
       {
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
 
         for (unsigned int i = 0; i < dof_handler.tria->n_levels(); ++i)
@@ -279,7 +280,7 @@ namespace internal
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_cell,
+                dof_handler.get_fe().n_dofs_per_cell(),
               numbers::invalid_dof_index);
 
             dof_handler.cell_dof_cache_ptr[i].reserve(
@@ -287,11 +288,12 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.cell_dof_cache_ptr[i].push_back(
-                j * dof_handler.get_fe().dofs_per_cell);
+                j * dof_handler.get_fe().n_dofs_per_cell());
           }
 
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
       }
 
@@ -299,7 +301,8 @@ namespace internal
       static void reserve_space(DoFHandler<2, spacedim> &dof_handler)
       {
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
 
         for (unsigned int i = 0; i < dof_handler.tria->n_levels(); ++i)
@@ -318,7 +321,7 @@ namespace internal
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_cell,
+                dof_handler.get_fe().n_dofs_per_cell(),
               numbers::invalid_dof_index);
 
             dof_handler.cell_dof_cache_ptr[i].reserve(
@@ -326,11 +329,12 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.cell_dof_cache_ptr[i].push_back(
-                j * dof_handler.get_fe().dofs_per_cell);
+                j * dof_handler.get_fe().n_dofs_per_cell());
           }
 
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
 
         if (dof_handler.tria->n_cells() > 0)
@@ -354,7 +358,8 @@ namespace internal
       static void reserve_space(DoFHandler<3, spacedim> &dof_handler)
       {
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
 
         for (unsigned int i = 0; i < dof_handler.tria->n_levels(); ++i)
@@ -373,7 +378,7 @@ namespace internal
 
             dof_handler.cell_dof_cache_indices[i].resize(
               dof_handler.tria->n_raw_cells(i) *
-                dof_handler.get_fe().dofs_per_cell,
+                dof_handler.get_fe().n_dofs_per_cell(),
               numbers::invalid_dof_index);
 
             dof_handler.cell_dof_cache_ptr[i].reserve(
@@ -381,11 +386,12 @@ namespace internal
             for (unsigned int j = 0; j < dof_handler.tria->n_raw_cells(i) + 1;
                  j++)
               dof_handler.cell_dof_cache_ptr[i].push_back(
-                j * dof_handler.get_fe().dofs_per_cell);
+                j * dof_handler.get_fe().n_dofs_per_cell());
           }
 
         dof_handler.object_dof_indices[0][0].resize(
-          dof_handler.tria->n_vertices() * dof_handler.get_fe().dofs_per_vertex,
+          dof_handler.tria->n_vertices() *
+            dof_handler.get_fe().n_dofs_per_vertex(),
           numbers::invalid_dof_index);
 
         if (dof_handler.tria->n_cells() > 0)
@@ -475,7 +481,7 @@ namespace internal
               dof_handler.mg_vertex_dofs[vertex].init(
                 min_level[vertex],
                 max_level[vertex],
-                dof_handler.get_fe().dofs_per_vertex);
+                dof_handler.get_fe().n_dofs_per_vertex());
             }
 
           else
@@ -548,7 +554,7 @@ namespace internal
                      ExcInternalError());
               dof_handler.mg_vertex_dofs[vertex].init(min_level[vertex],
                                                       max_level[vertex],
-                                                      fe.dofs_per_vertex);
+                                                      fe.n_dofs_per_vertex());
             }
 
           else
@@ -623,7 +629,7 @@ namespace internal
                      ExcInternalError());
               dof_handler.mg_vertex_dofs[vertex].init(min_level[vertex],
                                                       max_level[vertex],
-                                                      fe.dofs_per_vertex);
+                                                      fe.n_dofs_per_vertex());
             }
 
           else
@@ -1078,7 +1084,7 @@ namespace internal
                       {
                         fe_slots_needed++;
                         vertex_slots_needed +=
-                          dof_handler.get_fe(fe).dofs_per_vertex;
+                          dof_handler.get_fe(fe).n_dofs_per_vertex();
                       }
                 }
             }
@@ -1102,7 +1108,7 @@ namespace internal
                         dof_handler.object_dof_indices[l][d].size());
 
                       for (unsigned int i = 0;
-                           i < dof_handler.get_fe(fe).dofs_per_vertex;
+                           i < dof_handler.get_fe(fe).n_dofs_per_vertex();
                            i++)
                         dof_handler.object_dof_indices[l][d].push_back(
                           numbers::invalid_dof_index);
@@ -1173,7 +1179,7 @@ namespace internal
 
                     dof_handler.cell_dof_cache_ptr[level][cell->index()] =
                       cache_size;
-                    cache_size += cell->get_fe().dofs_per_cell;
+                    cache_size += cell->get_fe().n_dofs_per_cell();
                   }
 
               dof_handler.object_dof_indices[level][dim] =

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1702,7 +1702,7 @@ namespace internal
               if ((subdomain_id == numbers::invalid_subdomain_id) ||
                   (cell->subdomain_id() == subdomain_id))
                 {
-                  dof_indices.resize(cell->get_fe().dofs_per_cell);
+                  dof_indices.resize(cell->get_fe().n_dofs_per_cell());
 
                   // circumvent cache
                   internal::DoFAccessorImplementation::Implementation::
@@ -1755,7 +1755,7 @@ namespace internal
                 // delete all dofs that live there and that we have
                 // previously assigned a number to (i.e. the ones on
                 // the interface)
-                local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_indices(local_dof_indices);
                 for (const auto &local_dof_index : local_dof_indices)
                   if (local_dof_index != numbers::invalid_dof_index)
@@ -1792,7 +1792,7 @@ namespace internal
             if ((level_subdomain_id == numbers::invalid_subdomain_id) ||
                 (cell->level_subdomain_id() == level_subdomain_id))
               {
-                dof_indices.resize(cell->get_fe().dofs_per_cell);
+                dof_indices.resize(cell->get_fe().n_dofs_per_cell());
 
                 cell->get_mg_dof_indices(dof_indices);
 
@@ -1865,7 +1865,7 @@ namespace internal
                   // really is unused
                   Assert(dof_handler.get_triangulation().vertex_used(
                            (i - dof_handler.object_dof_indices[0][0].begin()) /
-                           dof_handler.get_fe().dofs_per_vertex) == false,
+                           dof_handler.get_fe().n_dofs_per_vertex()) == false,
                          ExcInternalError());
               return;
             }
@@ -1906,7 +1906,7 @@ namespace internal
                         std::integral_constant<int, 0>());
 
                   for (unsigned int d = 0;
-                       d < dof_handler.get_fe(fe_index).dofs_per_vertex;
+                       d < dof_handler.get_fe(fe_index).n_dofs_per_vertex();
                        ++d)
                     {
                       const types::global_dof_index old_dof_index =
@@ -2457,13 +2457,14 @@ namespace internal
             // if the present vertex lives on the current level
             if ((i->get_coarsest_level() <= level) &&
                 (i->get_finest_level() >= level))
-              for (unsigned int d = 0; d < dof_handler.get_fe().dofs_per_vertex;
+              for (unsigned int d = 0;
+                   d < dof_handler.get_fe().n_dofs_per_vertex();
                    ++d)
                 {
                   const dealii::types::global_dof_index idx =
                     i->get_index(level,
                                  d,
-                                 dof_handler.get_fe().dofs_per_vertex);
+                                 dof_handler.get_fe().n_dofs_per_vertex());
 
                   if (idx != numbers::invalid_dof_index)
                     {
@@ -2474,7 +2475,7 @@ namespace internal
                              ExcInternalError());
                       i->set_index(level,
                                    d,
-                                   dof_handler.get_fe().dofs_per_vertex,
+                                   dof_handler.get_fe().n_dofs_per_vertex(),
                                    (indices_we_care_about.size() == 0) ?
                                      (new_numbers[idx]) :
                                      (new_numbers[indices_we_care_about
@@ -2908,7 +2909,8 @@ namespace internal
               // that all cells are either locally owned or ghosts (not
               // artificial), so this call will always yield the true owner
               const types::subdomain_id subdomain_id = cell->subdomain_id();
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int        dofs_per_cell =
+                cell->get_fe().n_dofs_per_cell();
               local_dof_indices.resize(dofs_per_cell);
               cell->get_dof_indices(local_dof_indices);
 
@@ -2970,7 +2972,8 @@ namespace internal
               // artificial), so this call will always yield the true owner
               const types::subdomain_id level_subdomain_id =
                 cell->level_subdomain_id();
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell =
+                cell->get_fe().n_dofs_per_cell();
               local_dof_indices.resize(dofs_per_cell);
               cell->get_mg_dof_indices(local_dof_indices);
 
@@ -3554,14 +3557,14 @@ namespace internal
                    ExcInternalError());
 
             std::vector<dealii::types::global_dof_index> data(
-              cell->get_fe().dofs_per_cell);
+              cell->get_fe().n_dofs_per_cell());
             cell->get_mg_dof_indices(data);
 
             return data;
           };
 
           const auto unpack = [](const auto &cell, const auto &dofs) {
-            Assert(cell->get_fe().dofs_per_cell == dofs.size(),
+            Assert(cell->get_fe().n_dofs_per_cell() == dofs.size(),
                    ExcInternalError());
 
             Assert(cell->level_subdomain_id() !=
@@ -3569,7 +3572,7 @@ namespace internal
                    ExcInternalError());
 
             std::vector<dealii::types::global_dof_index> dof_indices(
-              cell->get_fe().dofs_per_cell);
+              cell->get_fe().n_dofs_per_cell());
             cell->get_mg_dof_indices(dof_indices);
 
             bool complete = true;
@@ -3655,20 +3658,20 @@ namespace internal
             Assert(cell->is_locally_owned(), ExcInternalError());
 
             std::vector<dealii::types::global_dof_index> data(
-              cell->get_fe().dofs_per_cell);
+              cell->get_fe().n_dofs_per_cell());
             cell->get_dof_indices(data);
 
             return data;
           };
 
           const auto unpack = [](const auto &cell, const auto &dofs) {
-            Assert(cell->get_fe().dofs_per_cell == dofs.size(),
+            Assert(cell->get_fe().n_dofs_per_cell() == dofs.size(),
                    ExcInternalError());
 
             Assert(cell->is_ghost(), ExcInternalError());
 
             std::vector<dealii::types::global_dof_index> dof_indices(
-              cell->get_fe().dofs_per_cell);
+              cell->get_fe().n_dofs_per_cell());
             cell->update_cell_dof_indices_cache();
             cell->get_dof_indices(dof_indices);
 
@@ -3941,7 +3944,7 @@ namespace internal
           for (const auto &cell : dof_handler->active_cell_iterators())
             if (!cell->is_artificial())
               {
-                local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_indices(local_dof_indices);
                 if (local_dof_indices.end() !=
                     std::find(local_dof_indices.begin(),
@@ -4041,9 +4044,11 @@ namespace internal
                       // delete all dofs that live there and that we
                       // have previously assigned a number to
                       // (i.e. the ones on the interface)
-                      local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+                      local_dof_indices.resize(
+                        cell->get_fe().n_dofs_per_cell());
                       cell->get_mg_dof_indices(local_dof_indices);
-                      for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell;
+                      for (unsigned int i = 0;
+                           i < cell->get_fe().n_dofs_per_cell();
                            ++i)
                         if (local_dof_indices[i] != numbers::invalid_dof_index)
                           renumbering[local_dof_indices[i]] =
@@ -4176,7 +4181,7 @@ namespace internal
             if (cell->level_subdomain_id() !=
                 dealii::numbers::artificial_subdomain_id)
               {
-                local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+                local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
                 cell->get_mg_dof_indices(local_dof_indices);
                 if (local_dof_indices.end() !=
                     std::find(local_dof_indices.begin(),
@@ -4369,10 +4374,11 @@ namespace internal
               for (auto cell : dof_handler->active_cell_iterators())
                 if (cell->is_ghost())
                   {
-                    local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+                    local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
                     cell->get_dof_indices(local_dof_indices);
 
-                    for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell;
+                    for (unsigned int i = 0;
+                         i < cell->get_fe().n_dofs_per_cell();
                          ++i)
                       // delete a DoF index if it has not already been deleted
                       // (e.g., by visiting a neighboring cell, if it is on the

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -458,13 +458,15 @@ namespace internal
                         // FE_Q objects of the same order, from which one is
                         // enhanced by a bubble function that is zero on the
                         // boundary.
-                        if ((dof_handler.get_fe(fe_index_1).dofs_per_line ==
-                             dof_handler.get_fe(fe_index_2).dofs_per_line) &&
-                            (dof_handler.get_fe(fe_index_1).dofs_per_line > 0))
+                        if ((dof_handler.get_fe(fe_index_1).n_dofs_per_line() ==
+                             dof_handler.get_fe(fe_index_2)
+                               .n_dofs_per_line()) &&
+                            (dof_handler.get_fe(fe_index_1).n_dofs_per_line() >
+                             0))
                           {
                             // the number of dofs per line is identical
                             const unsigned int dofs_per_line =
-                              dof_handler.get_fe(fe_index_1).dofs_per_line;
+                              dof_handler.get_fe(fe_index_1).n_dofs_per_line();
 
                             ensure_existence_of_dof_identities<1>(
                               dof_handler.get_fe(fe_index_1),
@@ -1290,13 +1292,15 @@ namespace internal
                                            fe_index_2 =
                                              line->nth_active_fe_index(g);
 
-                        if ((dof_handler.get_fe(fe_index_1).dofs_per_line ==
-                             dof_handler.get_fe(fe_index_2).dofs_per_line) &&
-                            (dof_handler.get_fe(fe_index_1).dofs_per_line > 0))
+                        if ((dof_handler.get_fe(fe_index_1).n_dofs_per_line() ==
+                             dof_handler.get_fe(fe_index_2)
+                               .n_dofs_per_line()) &&
+                            (dof_handler.get_fe(fe_index_1).n_dofs_per_line() >
+                             0))
                           {
                             // the number of dofs per line is identical
                             const unsigned int dofs_per_line =
-                              dof_handler.get_fe(fe_index_1).dofs_per_line;
+                              dof_handler.get_fe(fe_index_1).n_dofs_per_line();
 
                             ensure_existence_of_dof_identities<1>(
                               dof_handler.get_fe(fe_index_1),
@@ -2129,7 +2133,8 @@ namespace internal
                             line->nth_active_fe_index(f);
 
                           for (unsigned int d = 0;
-                               d < dof_handler.get_fe(fe_index).dofs_per_line;
+                               d <
+                               dof_handler.get_fe(fe_index).n_dofs_per_line();
                                ++d)
                             {
                               const types::global_dof_index old_dof_index =
@@ -2238,7 +2243,8 @@ namespace internal
                             line->nth_active_fe_index(f);
 
                           for (unsigned int d = 0;
-                               d < dof_handler.get_fe(fe_index).dofs_per_line;
+                               d <
+                               dof_handler.get_fe(fe_index).n_dofs_per_line();
                                ++d)
                             {
                               const types::global_dof_index old_dof_index =
@@ -2316,7 +2322,8 @@ namespace internal
                             quad->nth_active_fe_index(f);
 
                           for (unsigned int d = 0;
-                               d < dof_handler.get_fe(fe_index).dofs_per_quad;
+                               d <
+                               dof_handler.get_fe(fe_index).n_dofs_per_quad();
                                ++d)
                             {
                               const types::global_dof_index old_dof_index =
@@ -2552,7 +2559,7 @@ namespace internal
           const unsigned int       level,
           const bool               check_validity)
         {
-          if (dof_handler.get_fe().dofs_per_line > 0)
+          if (dof_handler.get_fe().n_dofs_per_line() > 0)
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
@@ -2580,7 +2587,7 @@ namespace internal
                   if (cell->line(l)->user_flag_set())
                     {
                       for (unsigned int d = 0;
-                           d < dof_handler.get_fe().dofs_per_line;
+                           d < dof_handler.get_fe().n_dofs_per_line();
                            ++d)
                         {
                           const dealii::types::global_dof_index idx =
@@ -2618,8 +2625,8 @@ namespace internal
           const unsigned int       level,
           const bool               check_validity)
         {
-          if (dof_handler.get_fe().dofs_per_line > 0 ||
-              dof_handler.get_fe().dofs_per_quad > 0)
+          if (dof_handler.get_fe().n_dofs_per_line() > 0 ||
+              dof_handler.get_fe().n_dofs_per_quad() > 0)
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;
@@ -2647,7 +2654,7 @@ namespace internal
                   if (cell->line(l)->user_flag_set())
                     {
                       for (unsigned int d = 0;
-                           d < dof_handler.get_fe().dofs_per_line;
+                           d < dof_handler.get_fe().n_dofs_per_line();
                            ++d)
                         {
                           const dealii::types::global_dof_index idx =
@@ -2686,7 +2693,7 @@ namespace internal
                   if (cell->quad(l)->user_flag_set())
                     {
                       for (unsigned int d = 0;
-                           d < dof_handler.get_fe().dofs_per_quad;
+                           d < dof_handler.get_fe().n_dofs_per_quad();
                            ++d)
                         {
                           const dealii::types::global_dof_index idx =

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -293,7 +293,7 @@ namespace DoFRenumbering
 
       for (const auto &cell : dof_handler.active_cell_iterators())
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
 
           dofs_on_this_cell.resize(dofs_per_cell);
 
@@ -756,8 +756,8 @@ namespace DoFRenumbering
     std::vector<std::vector<unsigned int>> component_list(fe_collection.size());
     for (unsigned int f = 0; f < fe_collection.size(); ++f)
       {
-        const FiniteElement<dim, spacedim> &fe            = fe_collection[f];
-        const unsigned int                  dofs_per_cell = fe.dofs_per_cell;
+        const FiniteElement<dim, spacedim> &fe = fe_collection[f];
+        const unsigned int dofs_per_cell       = fe.n_dofs_per_cell();
         component_list[f].resize(dofs_per_cell);
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           if (fe.is_primitive(i))
@@ -815,7 +815,7 @@ namespace DoFRenumbering
         // list using their component
         const unsigned int fe_index = cell->active_fe_index();
         const unsigned int dofs_per_cell =
-          fe_collection[fe_index].dofs_per_cell;
+          fe_collection[fe_index].n_dofs_per_cell();
         local_dof_indices.resize(dofs_per_cell);
         cell->get_active_or_mg_dof_indices(local_dof_indices);
 
@@ -1047,8 +1047,8 @@ namespace DoFRenumbering
     for (unsigned int f = 0; f < fe_collection.size(); ++f)
       {
         const FiniteElement<dim, spacedim> &fe = fe_collection[f];
-        block_list[f].resize(fe.dofs_per_cell);
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        block_list[f].resize(fe.n_dofs_per_cell());
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           block_list[f][i] = fe.system_to_block_index(i).first;
       }
 
@@ -1092,7 +1092,7 @@ namespace DoFRenumbering
         // list using their component
         const unsigned int fe_index = cell->active_fe_index();
         const unsigned int dofs_per_cell =
-          fe_collection[fe_index].dofs_per_cell;
+          fe_collection[fe_index].n_dofs_per_cell();
         local_dof_indices.resize(dofs_per_cell);
         cell->get_active_or_mg_dof_indices(local_dof_indices);
 
@@ -1255,7 +1255,8 @@ namespace DoFRenumbering
           if (cell->is_locally_owned())
             {
               // first get the existing DoF indices
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell =
+                cell->get_fe().n_dofs_per_cell();
               std::vector<types::global_dof_index> local_dof_indices(
                 dofs_per_cell);
               cell->get_dof_indices(local_dof_indices);
@@ -1760,7 +1761,7 @@ namespace DoFRenumbering
 
         for (const auto &cell : dof.active_cell_iterators())
           {
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
             local_dof_indices.resize(dofs_per_cell);
             hp_fe_values.reinit(cell);
             const FEValues<dim> &fe_values =
@@ -1854,7 +1855,7 @@ namespace DoFRenumbering
 
         std::vector<bool> already_touched(dof.n_dofs(), false);
 
-        const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
         std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
         typename DoFHandler<dim, spacedim>::level_cell_iterator begin =
           dof.begin(level);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -712,12 +712,12 @@ namespace DoFTools
               {
                 const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
-                const unsigned int dofs_per_face = fe.dofs_per_face;
+                const unsigned int dofs_per_face = fe.n_dofs_per_face();
                 face_dof_indices.resize(dofs_per_face);
                 cell->face(face)->get_dof_indices(face_dof_indices,
                                                   cell->active_fe_index());
 
-                for (unsigned int i = 0; i < fe.dofs_per_face; ++i)
+                for (unsigned int i = 0; i < fe.n_dofs_per_face(); ++i)
                   if (!check_vector_component)
                     selected_dofs.add_index(face_dof_indices[i]);
                   else
@@ -737,10 +737,10 @@ namespace DoFTools
                               (dim == 3 ? (i < 4 * fe.n_dofs_per_vertex() ?
                                              i :
                                              (i < 4 * fe.n_dofs_per_vertex() +
-                                                    4 * fe.dofs_per_line ?
+                                                    4 * fe.n_dofs_per_line() ?
                                                 i + 4 * fe.n_dofs_per_vertex() :
                                                 i + 4 * fe.n_dofs_per_vertex() +
-                                                  8 * fe.dofs_per_line)) :
+                                                  8 * fe.n_dofs_per_line())) :
                                           numbers::invalid_unsigned_int)));
                       if (fe.is_primitive(cell_index))
                         {
@@ -1002,7 +1002,7 @@ namespace DoFTools
                         if (cell->neighbor_child_on_subface(face, child)
                               ->is_artificial())
                           continue;
-                        for (unsigned int dof = 0; dof != fe.dofs_per_line;
+                        for (unsigned int dof = 0; dof != fe.n_dofs_per_line();
                              ++dof)
                           selected_dofs.add_index(
                             line->child(child)->dof_index(dof));
@@ -1041,7 +1041,7 @@ namespace DoFTools
                         {
                           // simply take all DoFs that live on this subface
                           std::vector<types::global_dof_index> ldi(
-                            fe.dofs_per_face);
+                            fe.n_dofs_per_face());
                           face->child(child)->get_dof_indices(ldi);
                           selected_dofs.add_indices(ldi.begin(), ldi.end());
                         }
@@ -2111,7 +2111,7 @@ namespace DoFTools
       for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_fe().n_dofs_per_face();
             dofs_on_face.resize(dofs_per_face);
             cell->face(f)->get_dof_indices(dofs_on_face,
                                            cell->active_fe_index());
@@ -2156,7 +2156,7 @@ namespace DoFTools
         if (boundary_ids.find(cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_fe().n_dofs_per_face();
             dofs_on_face.resize(dofs_per_face);
             cell->face(f)->get_dof_indices(dofs_on_face,
                                            cell->active_fe_index());
@@ -2533,7 +2533,7 @@ namespace DoFTools
             // Exclude degrees of freedom on faces opposite to the vertex
             exclude.resize(fe.n_dofs_per_cell());
             std::fill(exclude.begin(), exclude.end(), false);
-            const unsigned int dpf = fe.dofs_per_face;
+            const unsigned int dpf = fe.n_dofs_per_face();
 
             for (const unsigned int face : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face) ||
@@ -2594,7 +2594,7 @@ namespace DoFTools
               {
                 // Eliminate dofs on faces of the child which are on faces
                 // of the parent
-                const unsigned int dpf = fe.dofs_per_face;
+                const unsigned int dpf = fe.n_dofs_per_face();
 
                 for (unsigned int d = 0; d < dim; ++d)
                   {
@@ -2750,7 +2750,7 @@ namespace DoFTools
                 // vertex
                 exclude.resize(fe.n_dofs_per_cell());
                 std::fill(exclude.begin(), exclude.end(), false);
-                const unsigned int dpf = fe.dofs_per_face;
+                const unsigned int dpf = fe.n_dofs_per_face();
 
                 for (unsigned int d = 0; d < dim; ++d)
                   {

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -128,13 +128,13 @@ namespace DoFTools
                                     const ComponentMask &component_mask)
     {
       std::vector<unsigned char> local_component_association(
-        fe.dofs_per_cell, static_cast<unsigned char>(-1));
+        fe.n_dofs_per_cell(), static_cast<unsigned char>(-1));
 
       // compute the component each local dof belongs to.
       // if the shape function is primitive, then this
       // is simple and we can just associate it with
       // what system_to_component_index gives us
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         if (fe.is_primitive(i))
           local_component_association[i] =
             fe.system_to_component_index(i).first;
@@ -228,7 +228,7 @@ namespace DoFTools
         if (c->is_locally_owned())
           {
             const unsigned int fe_index      = c->active_fe_index();
-            const unsigned int dofs_per_cell = c->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = c->get_fe().n_dofs_per_cell();
             indices.resize(dofs_per_cell);
             c->get_dof_indices(indices);
             for (unsigned int i = 0; i < dofs_per_cell; ++i)
@@ -270,9 +270,9 @@ namespace DoFTools
       for (unsigned int f = 0; f < fe_collection.size(); ++f)
         {
           const FiniteElement<dim, spacedim> &fe = fe_collection[f];
-          local_block_association[f].resize(fe.dofs_per_cell,
+          local_block_association[f].resize(fe.n_dofs_per_cell(),
                                             static_cast<unsigned char>(-1));
-          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
             local_block_association[f][i] = fe.system_to_block_index(i).first;
 
           Assert(std::find(local_block_association[f].begin(),
@@ -288,7 +288,7 @@ namespace DoFTools
         if (cell->is_locally_owned())
           {
             const unsigned int fe_index      = cell->active_fe_index();
-            const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
             indices.resize(dofs_per_cell);
             cell->get_dof_indices(indices);
             for (unsigned int i = 0; i < dofs_per_cell; ++i)
@@ -355,7 +355,7 @@ namespace DoFTools
 
     for (unsigned int present_cell = 0; cell != endc; ++cell, ++present_cell)
       {
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
         dof_indices.resize(dofs_per_cell);
         cell->get_dof_indices(dof_indices);
 
@@ -471,8 +471,9 @@ namespace DoFTools
                                                     component_mask);
 
         // Check which dofs were selected
-        std::vector<bool> this_selected_dofs(fe_collection[f].dofs_per_cell);
-        for (unsigned int i = 0; i < fe_collection[f].dofs_per_cell; ++i)
+        std::vector<bool> this_selected_dofs(
+          fe_collection[f].n_dofs_per_cell());
+        for (unsigned int i = 0; i < fe_collection[f].n_dofs_per_cell(); ++i)
           this_selected_dofs[i] =
             component_mask[local_component_association[i]];
 
@@ -486,7 +487,7 @@ namespace DoFTools
       if (c->is_locally_owned())
         {
           const unsigned int fe_index      = c->active_fe_index();
-          const unsigned int dofs_per_cell = c->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = c->get_fe().n_dofs_per_cell();
           local_dof_indices.resize(dofs_per_cell);
           c->get_dof_indices(local_dof_indices);
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
@@ -599,17 +600,17 @@ namespace DoFTools
     // whether it is something interesting or not
     std::vector<unsigned char> local_component_asssociation =
       internal::get_local_component_association(fe, component_mask);
-    std::vector<bool> local_selected_dofs(fe.dofs_per_cell);
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    std::vector<bool> local_selected_dofs(fe.n_dofs_per_cell());
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       local_selected_dofs[i] = component_mask[local_component_asssociation[i]];
 
     // then loop over all cells and do work
-    std::vector<types::global_dof_index> indices(fe.dofs_per_cell);
+    std::vector<types::global_dof_index> indices(fe.n_dofs_per_cell());
     typename DoFHandler<dim, spacedim>::level_cell_iterator c;
     for (c = dof.begin(level); c != dof.end(level); ++c)
       {
         c->get_mg_dof_indices(indices);
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           selected_dofs[indices[i]] = local_selected_dofs[i];
       }
   }
@@ -730,15 +731,15 @@ namespace DoFTools
                         (dim == 1 ?
                            i :
                            (dim == 2 ?
-                              (i < 2 * fe.dofs_per_vertex ?
+                              (i < 2 * fe.n_dofs_per_vertex() ?
                                  i :
-                                 i + 2 * fe.dofs_per_vertex) :
-                              (dim == 3 ? (i < 4 * fe.dofs_per_vertex ?
+                                 i + 2 * fe.n_dofs_per_vertex()) :
+                              (dim == 3 ? (i < 4 * fe.n_dofs_per_vertex() ?
                                              i :
-                                             (i < 4 * fe.dofs_per_vertex +
+                                             (i < 4 * fe.n_dofs_per_vertex() +
                                                     4 * fe.dofs_per_line ?
-                                                i + 4 * fe.dofs_per_vertex :
-                                                i + 4 * fe.dofs_per_vertex +
+                                                i + 4 * fe.n_dofs_per_vertex() :
+                                                i + 4 * fe.n_dofs_per_vertex() +
                                                   8 * fe.dofs_per_line)) :
                                           numbers::invalid_unsigned_int)));
                       if (fe.is_primitive(cell_index))
@@ -811,11 +812,11 @@ namespace DoFTools
             {
               const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
-              const unsigned int dofs_per_cell = fe.dofs_per_cell;
+              const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
               cell_dof_indices.resize(dofs_per_cell);
               cell->get_dof_indices(cell_dof_indices);
 
-              for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+              for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
                 if (fe.has_support_on_face(i, face))
                   {
                     if (!check_vector_component)
@@ -876,7 +877,7 @@ namespace DoFTools
     for (; cell != endc; ++cell)
       if (!cell->is_artificial() && predicate(cell))
         {
-          local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+          local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
           cell->get_dof_indices(local_dof_indices);
           predicate_dofs.insert(local_dof_indices.begin(),
                                 local_dof_indices.end());
@@ -903,7 +904,7 @@ namespace DoFTools
             continue;
           }
 
-        const unsigned int dofs_per_cell = (*it)->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = (*it)->get_fe().n_dofs_per_cell();
         local_dof_indices.resize(dofs_per_cell);
         (*it)->get_dof_indices(local_dof_indices);
         dofs_with_support_on_halo_cells.insert(local_dof_indices.begin(),
@@ -991,7 +992,8 @@ namespace DoFTools
                                                       spacedim>::line_iterator
                       line = cell->face(face);
 
-                    for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                    for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex();
+                         ++dof)
                       selected_dofs.add_index(
                         line->child(0)->vertex_dof_index(1, dof));
 
@@ -1047,7 +1049,7 @@ namespace DoFTools
                     // and subtract (in the end) all the indices which a shared
                     // between this face and its subfaces
                     for (unsigned int vertex = 0; vertex < 4; ++vertex)
-                      for (unsigned int dof = 0; dof != fe.dofs_per_vertex;
+                      for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex();
                            ++dof)
                         unconstrained_dofs.add_index(
                           face->vertex_dof_index(vertex, dof));
@@ -1111,7 +1113,7 @@ namespace DoFTools
     for (; cell != endc; ++cell)
       if (cell->subdomain_id() == subdomain_id)
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
           local_dof_indices.resize(dofs_per_cell);
           cell->get_dof_indices(local_dof_indices);
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
@@ -1141,7 +1143,7 @@ namespace DoFTools
     for (; cell != endc; ++cell)
       if (cell->is_locally_owned())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_fe().n_dofs_per_cell());
           cell->get_dof_indices(dof_indices);
 
           for (const types::global_dof_index dof_index : dof_indices)
@@ -1181,7 +1183,7 @@ namespace DoFTools
     for (; cell != endc; ++cell)
       if (cell->is_ghost())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_fe().n_dofs_per_cell());
           cell->get_dof_indices(dof_indices);
           for (const auto dof_index : dof_indices)
             if (!dof_set.is_element(dof_index))
@@ -1232,7 +1234,7 @@ namespace DoFTools
             id == numbers::artificial_subdomain_id)
           continue;
 
-        dof_indices.resize(cell->get_fe().dofs_per_cell);
+        dof_indices.resize(cell->get_fe().n_dofs_per_cell());
         cell->get_mg_dof_indices(dof_indices);
         for (const auto dof_index : dof_indices)
           if (!dof_set.is_element(dof_index))
@@ -1323,7 +1325,7 @@ namespace DoFTools
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
         {
-          dof_indices.resize(cell->get_fe().dofs_per_cell);
+          dof_indices.resize(cell->get_fe().n_dofs_per_cell());
           cell->get_dof_indices(dof_indices);
 
           for (unsigned int i = 0; i < dof_indices.size(); ++i)
@@ -1513,7 +1515,7 @@ namespace DoFTools
               ExcMessage(
                 "The subdomain ID of the halo cell should not match that of the vector entry."));
 
-            local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+            local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
             cell->get_dof_indices(local_dof_indices);
 
             for (const types::global_dof_index local_dof_index :
@@ -1600,7 +1602,7 @@ namespace DoFTools
       {
         const types::subdomain_id subdomain_id =
           cell_owners[cell->active_cell_index()];
-        const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+        const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
         local_dof_indices.resize(dofs_per_cell);
         cell->get_dof_indices(local_dof_indices);
 
@@ -1681,7 +1683,7 @@ namespace DoFTools
       if ((cell->is_artificial() == false) &&
           (cell->subdomain_id() == subdomain))
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
           local_dof_indices.resize(dofs_per_cell);
           cell->get_dof_indices(local_dof_indices);
           subdomain_indices.insert(subdomain_indices.end(),
@@ -2223,12 +2225,13 @@ namespace DoFTools
               const FEValues<dim, spacedim> &fe_values =
                 hp_fe_values.get_present_fe_values();
 
-              local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+              local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
               cell->get_dof_indices(local_dof_indices);
 
               const std::vector<Point<spacedim>> &points =
                 fe_values.get_quadrature_points();
-              for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell; ++i)
+              for (unsigned int i = 0; i < cell->get_fe().n_dofs_per_cell();
+                   ++i)
                 {
                   const unsigned int dof_comp =
                     cell->get_fe().system_to_component_index(i).first;
@@ -2478,12 +2481,12 @@ namespace DoFTools
         ++i;
     block_list.reinit(i,
                       dof_handler.n_dofs(),
-                      dof_handler.get_fe().dofs_per_cell);
+                      dof_handler.get_fe().n_dofs_per_cell());
     i = 0;
     for (cell = dof_handler.begin(level); cell != endc; ++cell)
       if (cell->is_locally_owned_on_level())
         {
-          indices.resize(cell->get_fe().dofs_per_cell);
+          indices.resize(cell->get_fe().n_dofs_per_cell());
           cell->get_mg_dof_indices(indices);
 
           if (selected_dofs.size() != 0)
@@ -2522,13 +2525,13 @@ namespace DoFTools
 
     for (cell = dof_handler.begin(level); cell != endc; ++cell)
       {
-        indices.resize(cell->get_fe().dofs_per_cell);
+        indices.resize(cell->get_fe().n_dofs_per_cell());
         cell->get_mg_dof_indices(indices);
 
         if (interior_only)
           {
             // Exclude degrees of freedom on faces opposite to the vertex
-            exclude.resize(fe.dofs_per_cell);
+            exclude.resize(fe.n_dofs_per_cell());
             std::fill(exclude.begin(), exclude.end(), false);
             const unsigned int dpf = fe.dofs_per_face;
 
@@ -2581,7 +2584,7 @@ namespace DoFTools
 
             // For hp, only this line here would have to be replaced.
             const FiniteElement<dim> &fe     = dof_handler.get_fe();
-            const unsigned int        n_dofs = fe.dofs_per_cell;
+            const unsigned int        n_dofs = fe.n_dofs_per_cell();
             indices.resize(n_dofs);
             exclude.resize(n_dofs);
             std::fill(exclude.begin(), exclude.end(), false);
@@ -2680,7 +2683,7 @@ namespace DoFTools
       for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         {
           const unsigned int vg = cell->vertex_index(v);
-          vertex_dof_count[vg] += cell->get_fe().dofs_per_cell;
+          vertex_dof_count[vg] += cell->get_fe().n_dofs_per_cell();
           ++vertex_cell_count[vg];
           for (unsigned int d = 0; d < dim; ++d)
             {
@@ -2728,7 +2731,7 @@ namespace DoFTools
     for (cell = dof_handler.begin(level); cell != endc; ++cell)
       {
         const FiniteElement<dim> &fe = cell->get_fe();
-        indices.resize(fe.dofs_per_cell);
+        indices.resize(fe.n_dofs_per_cell());
         cell->get_mg_dof_indices(indices);
 
         for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
@@ -2745,7 +2748,7 @@ namespace DoFTools
               {
                 // Exclude degrees of freedom on faces opposite to the
                 // vertex
-                exclude.resize(fe.dofs_per_cell);
+                exclude.resize(fe.n_dofs_per_cell());
                 std::fill(exclude.begin(), exclude.end(), false);
                 const unsigned int dpf = fe.dofs_per_face;
 
@@ -2813,7 +2816,7 @@ namespace DoFTools
         Assert(cell->is_artificial() == false,
                ExcMessage("This function can not be called with cells that are "
                           "not either locally owned or ghost cells."));
-        local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
         cell->get_dof_indices(local_dof_indices);
         dofs_on_patch.insert(local_dof_indices.begin(),
                              local_dof_indices.end());
@@ -2844,7 +2847,7 @@ namespace DoFTools
         Assert(cell->is_artificial() == false,
                ExcMessage("This function can not be called with cells that are "
                           "not either locally owned or ghost cells."));
-        local_dof_indices.resize(cell->get_fe().dofs_per_cell);
+        local_dof_indices.resize(cell->get_fe().n_dofs_per_cell());
         cell->get_dof_indices(local_dof_indices);
         dofs_on_patch.insert(local_dof_indices.begin(),
                              local_dof_indices.end());

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -178,7 +178,8 @@ namespace DoFTools
         Assert(fe1.dofs_per_face >= fe2.dofs_per_face, ExcInternalError());
         AssertDimension(primary_dof_mask.size(), fe1.dofs_per_face);
 
-        Assert(fe2.dofs_per_vertex <= fe1.dofs_per_vertex, ExcInternalError());
+        Assert(fe2.n_dofs_per_vertex() <= fe1.n_dofs_per_vertex(),
+               ExcInternalError());
         Assert(fe2.dofs_per_line <= fe1.dofs_per_line, ExcInternalError());
         Assert((dim < 3) || (fe2.dofs_per_quad <= fe1.dofs_per_quad),
                ExcInternalError());
@@ -211,11 +212,11 @@ namespace DoFTools
           {
             unsigned int dofs_added = 0;
             unsigned int i          = 0;
-            while (dofs_added < fe2.dofs_per_vertex)
+            while (dofs_added < fe2.n_dofs_per_vertex())
               {
                 // make sure that we were able to find a set of primary dofs and
                 // that the code down below didn't just reject all our efforts
-                Assert(i < fe1.dofs_per_vertex, ExcInternalError());
+                Assert(i < fe1.n_dofs_per_vertex(), ExcInternalError());
 
                 // tentatively push this vertex dof
                 primary_dof_list.push_back(index + i);
@@ -232,7 +233,7 @@ namespace DoFTools
                 // forward counter by one
                 ++i;
               }
-            index += fe1.dofs_per_vertex;
+            index += fe1.n_dofs_per_vertex();
           }
 
         for (int l = 0;
@@ -646,9 +647,10 @@ namespace DoFTools
                 const unsigned int fe_index = cell->active_fe_index();
 
                 const unsigned int n_dofs_on_mother =
-                                     2 * fe.dofs_per_vertex + fe.dofs_per_line,
-                                   n_dofs_on_children =
-                                     fe.dofs_per_vertex + 2 * fe.dofs_per_line;
+                                     2 * fe.n_dofs_per_vertex() +
+                                     fe.dofs_per_line,
+                                   n_dofs_on_children = fe.n_dofs_per_vertex() +
+                                                        2 * fe.dofs_per_line;
 
                 dofs_on_mother.resize(n_dofs_on_mother);
                 // we might not use all of those in case of artificial cells, so
@@ -670,7 +672,8 @@ namespace DoFTools
                 // @p{FiniteElement::constraints()}
                 unsigned int next_index = 0;
                 for (unsigned int vertex = 0; vertex < 2; ++vertex)
-                  for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                  for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex();
+                       ++dof)
                     dofs_on_mother[next_index++] =
                       this_face->vertex_dof_index(vertex, dof, fe_index);
                 for (unsigned int dof = 0; dof != fe.dofs_per_line; ++dof)
@@ -678,7 +681,7 @@ namespace DoFTools
                     this_face->dof_index(dof, fe_index);
                 AssertDimension(next_index, dofs_on_mother.size());
 
-                for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex(); ++dof)
                   dofs_on_children.push_back(
                     this_face->child(0)->vertex_dof_index(1, dof, fe_index));
                 for (unsigned int child = 0; child < 2; ++child)
@@ -829,7 +832,7 @@ namespace DoFTools
 
                 const unsigned int n_dofs_on_mother = fe.dofs_per_face;
                 const unsigned int n_dofs_on_children =
-                  (5 * fe.dofs_per_vertex + 12 * fe.dofs_per_line +
+                  (5 * fe.n_dofs_per_vertex() + 12 * fe.dofs_per_line +
                    4 * fe.dofs_per_quad);
 
                 // TODO[TL]: think about this and the following in case of
@@ -855,7 +858,8 @@ namespace DoFTools
                 // @p{FiniteElement::constraints()}
                 unsigned int next_index = 0;
                 for (unsigned int vertex = 0; vertex < 4; ++vertex)
-                  for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                  for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex();
+                       ++dof)
                     dofs_on_mother[next_index++] =
                       this_face->vertex_dof_index(vertex, dof, fe_index);
                 for (unsigned int line = 0; line < 4; ++line)
@@ -881,13 +885,14 @@ namespace DoFTools
                            this_face->child(3)->vertex_index(0))),
                        ExcInternalError());
 
-                for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex(); ++dof)
                   dofs_on_children.push_back(
                     this_face->child(0)->vertex_dof_index(3, dof));
 
                 // dof numbers on the centers of the lines bounding this face
                 for (unsigned int line = 0; line < 4; ++line)
-                  for (unsigned int dof = 0; dof != fe.dofs_per_vertex; ++dof)
+                  for (unsigned int dof = 0; dof != fe.n_dofs_per_vertex();
+                       ++dof)
                     dofs_on_children.push_back(
                       this_face->line(line)->child(0)->vertex_dof_index(
                         1, dof, fe_index));
@@ -2617,7 +2622,7 @@ namespace DoFTools
         // vector to hold the representation of a single degree of freedom on
         // the coarse grid (for the selected fe) on the fine grid
 
-        copy_data.dofs_per_cell = coarse_fe.dofs_per_cell;
+        copy_data.dofs_per_cell = coarse_fe.n_dofs_per_cell();
         copy_data.parameter_dof_indices.resize(copy_data.dofs_per_cell);
 
         // get the global indices of the parameter dofs on this parameter grid
@@ -2744,7 +2749,7 @@ namespace DoFTools
 
         unsigned int n_interesting_dofs = 0;
         for (unsigned int local_dof = 0;
-             local_dof < coarse_grid.get_fe().dofs_per_cell;
+             local_dof < coarse_grid.get_fe().n_dofs_per_cell();
              ++local_dof)
           if (coarse_grid.get_fe().system_to_component_index(local_dof).first ==
               coarse_component)
@@ -2866,7 +2871,7 @@ namespace DoFTools
                                       n_fine_dofs   = fine_grid.n_dofs();
 
         // local numbers of dofs
-        const unsigned int fine_dofs_per_cell = fine_fe.dofs_per_cell;
+        const unsigned int fine_dofs_per_cell = fine_fe.n_dofs_per_cell();
 
         // alias the number of dofs per cell belonging to the coarse_component
         // which is to be the restriction of the fine grid:
@@ -2874,7 +2879,7 @@ namespace DoFTools
           coarse_fe
             .base_element(
               coarse_fe.component_to_base_index(coarse_component).first)
-            .dofs_per_cell;
+            .n_dofs_per_cell();
 
 
         // Try to find out whether the grids stem from the same coarse grid.
@@ -2939,7 +2944,7 @@ namespace DoFTools
         for (unsigned int local_coarse_dof = 0;
              local_coarse_dof < coarse_dofs_per_cell_component;
              ++local_coarse_dof)
-          for (unsigned int fine_dof = 0; fine_dof < fine_fe.dofs_per_cell;
+          for (unsigned int fine_dof = 0; fine_dof < fine_fe.n_dofs_per_cell();
                ++fine_dof)
             if (fine_fe.system_to_component_index(fine_dof) ==
                 std::make_pair(fine_component, local_coarse_dof))
@@ -2957,13 +2962,13 @@ namespace DoFTools
           // this is an interesting dof. finally count how many true's there
           std::vector<bool> dof_is_interesting(fine_grid.n_dofs(), false);
           std::vector<types::global_dof_index> local_dof_indices(
-            fine_fe.dofs_per_cell);
+            fine_fe.n_dofs_per_cell());
 
           for (const auto &cell : fine_grid.active_cell_iterators())
             if (cell->is_locally_owned())
               {
                 cell->get_dof_indices(local_dof_indices);
-                for (unsigned int i = 0; i < fine_fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fine_fe.n_dofs_per_cell(); ++i)
                   if (fine_fe.system_to_component_index(i).first ==
                       fine_component)
                     dof_is_interesting[local_dof_indices[i]] = true;
@@ -2984,13 +2989,13 @@ namespace DoFTools
 
         {
           std::vector<types::global_dof_index> local_dof_indices(
-            fine_fe.dofs_per_cell);
+            fine_fe.n_dofs_per_cell());
           unsigned int next_free_index = 0;
           for (const auto &cell : fine_grid.active_cell_iterators())
             if (cell->is_locally_owned())
               {
                 cell->get_dof_indices(local_dof_indices);
-                for (unsigned int i = 0; i < fine_fe.dofs_per_cell; ++i)
+                for (unsigned int i = 0; i < fine_fe.n_dofs_per_cell(); ++i)
                   // if this DoF is a parameter dof and has not yet been
                   // numbered, then do so
                   if ((fine_fe.system_to_component_index(i).first ==
@@ -3376,7 +3381,7 @@ namespace DoFTools
           const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
           // get global indices of dofs on the cell
-          cell_dofs.resize(fe.dofs_per_cell);
+          cell_dofs.resize(fe.n_dofs_per_cell());
           cell->get_dof_indices(cell_dofs);
 
           for (const auto face_no : cell->face_indices())

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -407,7 +407,7 @@ namespace DoFTools
       for (const unsigned int f : GeometryInfo<dim>::face_indices())
         if (cell->at_boundary(f))
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_fe().n_dofs_per_face();
             dofs_on_this_face.resize(dofs_per_face);
             cell->face(f)->get_dof_indices(dofs_on_this_face,
                                            cell->active_fe_index());
@@ -504,7 +504,7 @@ namespace DoFTools
         if (boundary_ids.find(cell->face(f)->boundary_id()) !=
             boundary_ids.end())
           {
-            const unsigned int dofs_per_face = cell->get_fe().dofs_per_face;
+            const unsigned int dofs_per_face = cell->get_fe().n_dofs_per_face();
             dofs_on_this_face.resize(dofs_per_face);
             cell->face(f)->get_dof_indices(dofs_on_this_face,
                                            cell->active_fe_index());

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -102,7 +102,7 @@ namespace DoFTools
            (subdomain_id == cell->subdomain_id())) &&
           cell->is_locally_owned())
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
           dofs_on_this_cell.resize(dofs_per_cell);
           cell->get_dof_indices(dofs_on_this_cell);
 
@@ -168,11 +168,11 @@ namespace DoFTools
     for (unsigned int f = 0; f < fe_collection.size(); ++f)
       {
         bool_dof_mask[f].reinit(
-          TableIndices<2>(fe_collection[f].dofs_per_cell,
-                          fe_collection[f].dofs_per_cell));
+          TableIndices<2>(fe_collection[f].n_dofs_per_cell(),
+                          fe_collection[f].n_dofs_per_cell()));
         bool_dof_mask[f].fill(false);
-        for (unsigned int i = 0; i < fe_collection[f].dofs_per_cell; ++i)
-          for (unsigned int j = 0; j < fe_collection[f].dofs_per_cell; ++j)
+        for (unsigned int i = 0; i < fe_collection[f].n_dofs_per_cell(); ++i)
+          for (unsigned int j = 0; j < fe_collection[f].n_dofs_per_cell(); ++j)
             if (dof_mask[f](i, j) != none)
               bool_dof_mask[f](i, j) = true;
       }
@@ -193,7 +193,7 @@ namespace DoFTools
         {
           const unsigned int fe_index = cell->active_fe_index();
           const unsigned int dofs_per_cell =
-            fe_collection[fe_index].dofs_per_cell;
+            fe_collection[fe_index].n_dofs_per_cell();
 
           dofs_on_this_cell.resize(dofs_per_cell);
           cell->get_dof_indices(dofs_on_this_cell);
@@ -282,9 +282,9 @@ namespace DoFTools
         if (cell_row->is_active() && cell_col->is_active())
           {
             const unsigned int dofs_per_cell_row =
-              cell_row->get_fe().dofs_per_cell;
+              cell_row->get_fe().n_dofs_per_cell();
             const unsigned int dofs_per_cell_col =
-              cell_col->get_fe().dofs_per_cell;
+              cell_col->get_fe().n_dofs_per_cell();
             std::vector<types::global_dof_index> local_dof_indices_row(
               dofs_per_cell_row);
             std::vector<types::global_dof_index> local_dof_indices_col(
@@ -308,9 +308,9 @@ namespace DoFTools
                 const typename DoFHandler<dim, spacedim>::cell_iterator
                                    cell_row_child = child_cells[i];
                 const unsigned int dofs_per_cell_row =
-                  cell_row_child->get_fe().dofs_per_cell;
+                  cell_row_child->get_fe().n_dofs_per_cell();
                 const unsigned int dofs_per_cell_col =
-                  cell_col->get_fe().dofs_per_cell;
+                  cell_col->get_fe().n_dofs_per_cell();
                 std::vector<types::global_dof_index> local_dof_indices_row(
                   dofs_per_cell_row);
                 std::vector<types::global_dof_index> local_dof_indices_col(
@@ -335,9 +335,9 @@ namespace DoFTools
                 const typename DoFHandler<dim, spacedim>::active_cell_iterator
                                    cell_col_child = child_cells[i];
                 const unsigned int dofs_per_cell_row =
-                  cell_row->get_fe().dofs_per_cell;
+                  cell_row->get_fe().n_dofs_per_cell();
                 const unsigned int dofs_per_cell_col =
-                  cell_col_child->get_fe().dofs_per_cell;
+                  cell_col_child->get_fe().n_dofs_per_cell();
                 std::vector<types::global_dof_index> local_dof_indices_row(
                   dofs_per_cell_row);
                 std::vector<types::global_dof_index> local_dof_indices_col(
@@ -452,7 +452,8 @@ namespace DoFTools
             while (!cell->is_active())
               cell = cell->child(direction);
 
-            const unsigned int dofs_per_vertex = cell->get_fe().dofs_per_vertex;
+            const unsigned int dofs_per_vertex =
+              cell->get_fe().n_dofs_per_vertex();
             std::vector<types::global_dof_index> boundary_dof_boundary_indices(
               dofs_per_vertex);
 
@@ -572,7 +573,8 @@ namespace DoFTools
            (subdomain_id == cell->subdomain_id())) &&
           cell->is_locally_owned())
         {
-          const unsigned int n_dofs_on_this_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int n_dofs_on_this_cell =
+            cell->get_fe().n_dofs_per_cell();
           dofs_on_this_cell.resize(n_dofs_on_this_cell);
           cell->get_dof_indices(dofs_on_this_cell);
 
@@ -615,7 +617,7 @@ namespace DoFTools
                                 cell->neighbor_child_on_subface(face, sub_nr);
 
                           const unsigned int n_dofs_on_neighbor =
-                            sub_neighbor->get_fe().dofs_per_cell;
+                            sub_neighbor->get_fe().n_dofs_per_cell();
                           dofs_on_other_cell.resize(n_dofs_on_neighbor);
                           sub_neighbor->get_dof_indices(dofs_on_other_cell);
 
@@ -652,7 +654,7 @@ namespace DoFTools
                           continue;
 
                       const unsigned int n_dofs_on_neighbor =
-                        neighbor->get_fe().dofs_per_cell;
+                        neighbor->get_fe().n_dofs_per_cell();
                       dofs_on_other_cell.resize(n_dofs_on_neighbor);
 
                       neighbor->get_dof_indices(dofs_on_other_cell);
@@ -712,7 +714,7 @@ namespace DoFTools
            ExcDimensionMismatch(component_couplings.n_cols(),
                                 fe.n_components()));
 
-    const unsigned int n_dofs = fe.dofs_per_cell;
+    const unsigned int n_dofs = fe.n_dofs_per_cell();
 
     Table<2, Coupling> dof_couplings(n_dofs, n_dofs);
 
@@ -784,9 +786,9 @@ namespace DoFTools
             const FiniteElement<dim, spacedim> &fe = dof.get_fe();
 
             std::vector<types::global_dof_index> dofs_on_this_cell(
-              fe.dofs_per_cell);
+              fe.n_dofs_per_cell());
             std::vector<types::global_dof_index> dofs_on_other_cell(
-              fe.dofs_per_cell);
+              fe.n_dofs_per_cell());
 
             const Table<2, Coupling>
               int_dof_mask =
@@ -794,19 +796,19 @@ namespace DoFTools
               flux_dof_mask =
                 dof_couplings_from_component_couplings(fe, flux_mask);
 
-            Table<2, bool> support_on_face(fe.dofs_per_cell,
+            Table<2, bool> support_on_face(fe.n_dofs_per_cell(),
                                            GeometryInfo<dim>::faces_per_cell);
-            for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+            for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
               for (const unsigned int f : GeometryInfo<dim>::face_indices())
                 support_on_face(i, f) = fe.has_support_on_face(i, f);
 
             // Convert the int_dof_mask to bool_int_dof_mask so we can pass it
             // to constraints.add_entries_local_to_global()
-            Table<2, bool> bool_int_dof_mask(fe.dofs_per_cell,
-                                             fe.dofs_per_cell);
+            Table<2, bool> bool_int_dof_mask(fe.n_dofs_per_cell(),
+                                             fe.n_dofs_per_cell());
             bool_int_dof_mask.fill(false);
-            for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
-              for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+            for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+              for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
                 if (int_dof_mask(i, j) != none)
                   bool_int_dof_mask(i, j) = true;
 
@@ -836,11 +838,12 @@ namespace DoFTools
 
                       if (cell->at_boundary(face_n) && (!periodic_neighbor))
                         {
-                          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+                          for (unsigned int i = 0; i < fe.n_dofs_per_cell();
+                               ++i)
                             {
                               const bool i_non_zero_i =
                                 support_on_face(i, face_n);
-                              for (unsigned int j = 0; j < fe.dofs_per_cell;
+                              for (unsigned int j = 0; j < fe.n_dofs_per_cell();
                                    ++j)
                                 {
                                   const bool j_non_zero_i =
@@ -925,7 +928,8 @@ namespace DoFTools
 
                                   sub_neighbor->get_dof_indices(
                                     dofs_on_other_cell);
-                                  for (unsigned int i = 0; i < fe.dofs_per_cell;
+                                  for (unsigned int i = 0;
+                                       i < fe.n_dofs_per_cell();
                                        ++i)
                                     {
                                       const bool i_non_zero_i =
@@ -933,7 +937,7 @@ namespace DoFTools
                                       const bool i_non_zero_e =
                                         support_on_face(i, neighbor_face_n);
                                       for (unsigned int j = 0;
-                                           j < fe.dofs_per_cell;
+                                           j < fe.n_dofs_per_cell();
                                            ++j)
                                         {
                                           const bool j_non_zero_i =
@@ -1019,14 +1023,15 @@ namespace DoFTools
                           else
                             {
                               neighbor->get_dof_indices(dofs_on_other_cell);
-                              for (unsigned int i = 0; i < fe.dofs_per_cell;
+                              for (unsigned int i = 0; i < fe.n_dofs_per_cell();
                                    ++i)
                                 {
                                   const bool i_non_zero_i =
                                     support_on_face(i, face_n);
                                   const bool i_non_zero_e =
                                     support_on_face(i, neighbor_face_n);
-                                  for (unsigned int j = 0; j < fe.dofs_per_cell;
+                                  for (unsigned int j = 0;
+                                       j < fe.n_dofs_per_cell();
                                        ++j)
                                     {
                                       const bool j_non_zero_i =
@@ -1134,10 +1139,11 @@ namespace DoFTools
             for (unsigned int f = 0; f < fe.size(); ++f)
               {
                 bool_int_and_flux_dof_mask[f].reinit(
-                  TableIndices<2>(fe[f].dofs_per_cell, fe[f].dofs_per_cell));
+                  TableIndices<2>(fe[f].n_dofs_per_cell(),
+                                  fe[f].n_dofs_per_cell()));
                 bool_int_and_flux_dof_mask[f].fill(false);
-                for (unsigned int i = 0; i < fe[f].dofs_per_cell; ++i)
-                  for (unsigned int j = 0; j < fe[f].dofs_per_cell; ++j)
+                for (unsigned int i = 0; i < fe[f].n_dofs_per_cell(); ++i)
+                  for (unsigned int j = 0; j < fe[f].n_dofs_per_cell(); ++j)
                     if (int_and_flux_dof_mask[f](i, j) != none)
                       bool_int_and_flux_dof_mask[f](i, j) = true;
               }
@@ -1151,7 +1157,7 @@ namespace DoFTools
                    (subdomain_id == cell->subdomain_id())) &&
                   cell->is_locally_owned())
                 {
-                  dofs_on_this_cell.resize(cell->get_fe().dofs_per_cell);
+                  dofs_on_this_cell.resize(cell->get_fe().n_dofs_per_cell());
                   cell->get_dof_indices(dofs_on_this_cell);
 
                   // make sparsity pattern for this cell also taking into
@@ -1239,11 +1245,11 @@ namespace DoFTools
                                                                         sub_nr);
 
                                   dofs_on_other_cell.resize(
-                                    sub_neighbor->get_fe().dofs_per_cell);
+                                    sub_neighbor->get_fe().n_dofs_per_cell());
                                   sub_neighbor->get_dof_indices(
                                     dofs_on_other_cell);
                                   for (unsigned int i = 0;
-                                       i < cell->get_fe().dofs_per_cell;
+                                       i < cell->get_fe().n_dofs_per_cell();
                                        ++i)
                                     {
                                       const unsigned int ii =
@@ -1259,8 +1265,8 @@ namespace DoFTools
                                              ExcInternalError());
 
                                       for (unsigned int j = 0;
-                                           j <
-                                           sub_neighbor->get_fe().dofs_per_cell;
+                                           j < sub_neighbor->get_fe()
+                                                 .n_dofs_per_cell();
                                            ++j)
                                         {
                                           const unsigned int jj =
@@ -1299,10 +1305,10 @@ namespace DoFTools
                           else
                             {
                               dofs_on_other_cell.resize(
-                                neighbor->get_fe().dofs_per_cell);
+                                neighbor->get_fe().n_dofs_per_cell());
                               neighbor->get_dof_indices(dofs_on_other_cell);
                               for (unsigned int i = 0;
-                                   i < cell->get_fe().dofs_per_cell;
+                                   i < cell->get_fe().n_dofs_per_cell();
                                    ++i)
                                 {
                                   const unsigned int ii =
@@ -1318,7 +1324,7 @@ namespace DoFTools
                                          ExcInternalError());
 
                                   for (unsigned int j = 0;
-                                       j < neighbor->get_fe().dofs_per_cell;
+                                       j < neighbor->get_fe().n_dofs_per_cell();
                                        ++j)
                                     {
                                       const unsigned int jj =

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -92,13 +92,13 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
   // submatrices with an array for each refine case
   std::vector<FullMatrix<double>> face_embeddings(
     1 << (dim - 1),
-    FullMatrix<double>(this->dofs_per_face, this->dofs_per_face));
+    FullMatrix<double>(this->n_dofs_per_face(), this->n_dofs_per_face()));
   // TODO: Something goes wrong there. The error of the least squares fit
   // is to large ...
   // FETools::compute_face_embedding_matrices(*this, face_embeddings.data(), 0,
   // 0);
-  this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
-                                     this->dofs_per_face);
+  this->interface_constraints.reinit((1 << (dim - 1)) * this->n_dofs_per_face(),
+                                     this->n_dofs_per_face());
   unsigned int target_row = 0;
   for (const auto &face_embedding : face_embeddings)
     for (unsigned int i = 0; i < face_embedding.m(); ++i)
@@ -189,7 +189,7 @@ FE_ABF<dim>::initialize_support_points(const unsigned int deg)
 
       boundary_weights.reinit(n_face_points, legendre.n());
 
-      //       Assert (face_points.size() == this->dofs_per_face,
+      //       Assert (face_points.size() == this->n_dofs_per_face(),
       //            ExcInternalError());
 
       for (unsigned int k = 0; k < n_face_points; ++k)
@@ -377,7 +377,7 @@ FE_ABF<dim>::initialize_restriction()
           for (unsigned int k = 0; k < n_face_points; ++k)
             for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
                  ++i_child)
-              for (unsigned int i_face = 0; i_face < this->dofs_per_face;
+              for (unsigned int i_face = 0; i_face < this->n_dofs_per_face();
                    ++i_face)
                 {
                   // The quadrature
@@ -385,13 +385,13 @@ FE_ABF<dim>::initialize_restriction()
                   // subcell are NOT
                   // transformed, so we
                   // have to do it here.
-                  this->restriction[iso][child](face * this->dofs_per_face +
+                  this->restriction[iso][child](face * this->n_dofs_per_face() +
                                                   i_face,
                                                 i_child) +=
                     Utilities::fixed_power<dim - 1>(.5) * q_sub.weight(k) *
                     cached_values_face(i_child, k) *
                     this->shape_value_component(
-                      face * this->dofs_per_face + i_face,
+                      face * this->n_dofs_per_face() + i_face,
                       q_sub.point(k),
                       GeometryInfo<dim>::unit_normal_direction[face]);
                 }
@@ -417,7 +417,7 @@ FE_ABF<dim>::initialize_restriction()
 
   QGauss<dim>        q_cell(rt_order + 1);
   const unsigned int start_cell_dofs =
-    GeometryInfo<dim>::faces_per_cell * this->dofs_per_face;
+    GeometryInfo<dim>::faces_per_cell * this->n_dofs_per_face();
 
   // Store shape values, since the
   // evaluation suffers if not
@@ -554,14 +554,14 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
     for (unsigned int k = 0; k < n_face_points; ++k)
       for (unsigned int i = 0; i < boundary_weights.size(1); ++i)
         {
-          nodal_values[i + face * this->dofs_per_face] +=
+          nodal_values[i + face * this->n_dofs_per_face()] +=
             boundary_weights(k, i) *
             support_point_values[face * n_face_points + k][GeometryInfo<
               dim>::unit_normal_direction[face]];
         }
 
   const unsigned int start_cell_dofs =
-    GeometryInfo<dim>::faces_per_cell * this->dofs_per_face;
+    GeometryInfo<dim>::faces_per_cell * this->n_dofs_per_face();
   const unsigned int start_cell_points =
     GeometryInfo<dim>::faces_per_cell * n_face_points;
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -58,7 +58,7 @@ FE_ABF<dim>::FE_ABF(const unsigned int deg)
   , rt_order(deg)
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
@@ -343,9 +343,10 @@ FE_ABF<dim>::initialize_restriction()
       // Store shape values, since the
       // evaluation suffers if not
       // ordered by point
-      Table<2, double> cached_values_face(this->dofs_per_cell, q_face.size());
+      Table<2, double> cached_values_face(this->n_dofs_per_cell(),
+                                          q_face.size());
       for (unsigned int k = 0; k < q_face.size(); ++k)
-        for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
           cached_values_face(i, k) = this->shape_value_component(
             i, q_face.point(k), GeometryInfo<dim>::unit_normal_direction[face]);
 
@@ -374,7 +375,7 @@ FE_ABF<dim>::initialize_restriction()
           // corresponding shape
           // functions.
           for (unsigned int k = 0; k < n_face_points; ++k)
-            for (unsigned int i_child = 0; i_child < this->dofs_per_cell;
+            for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
                  ++i_child)
               for (unsigned int i_face = 0; i_face < this->dofs_per_face;
                    ++i_face)
@@ -421,9 +422,11 @@ FE_ABF<dim>::initialize_restriction()
   // Store shape values, since the
   // evaluation suffers if not
   // ordered by point
-  Table<3, double> cached_values_cell(this->dofs_per_cell, q_cell.size(), dim);
+  Table<3, double> cached_values_cell(this->n_dofs_per_cell(),
+                                      q_cell.size(),
+                                      dim);
   for (unsigned int k = 0; k < q_cell.size(); ++k)
-    for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       for (unsigned int d = 0; d < dim; ++d)
         cached_values_cell(i, k, d) =
           this->shape_value_component(i, q_cell.point(k), d);
@@ -434,7 +437,8 @@ FE_ABF<dim>::initialize_restriction()
       Quadrature<dim> q_sub = QProjector<dim>::project_to_child(q_cell, child);
 
       for (unsigned int k = 0; k < q_sub.size(); ++k)
-        for (unsigned int i_child = 0; i_child < this->dofs_per_cell; ++i_child)
+        for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
+             ++i_child)
           for (unsigned int d = 0; d < dim; ++d)
             for (unsigned int i_weight = 0; i_weight < polynomials[d]->n();
                  ++i_weight)
@@ -491,7 +495,7 @@ bool
 FE_ABF<dim>::has_support_on_face(const unsigned int shape_index,
                                  const unsigned int face_index) const
 {
-  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(shape_index, this->n_dofs_per_cell());
   AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // Return computed values if we
@@ -540,8 +544,8 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
 
   std::fill(nodal_values.begin(), nodal_values.end(), 0.);
 

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -82,10 +82,10 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
 
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->dofs_per_face, this->dofs_per_face);
+    face_embeddings[i].reinit(this->n_dofs_per_face(), this->n_dofs_per_face());
   FETools::compute_face_embedding_matrices(*this, face_embeddings, 0, 0, 1.);
-  this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
-                                     this->dofs_per_face);
+  this->interface_constraints.reinit((1 << (dim - 1)) * this->n_dofs_per_face(),
+                                     this->n_dofs_per_face());
   unsigned int target_row = 0;
   for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face; ++d)
     for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
@@ -155,15 +155,15 @@ FE_BDM<dim>::convert_generalized_support_point_values_to_dof_values(
       // initialize_support_points()
       if (test_values_face.size() == 0)
         {
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             nodal_values[dbase + i] =
               support_point_values[pbase + i]
                                   [GeometryInfo<dim>::unit_normal_direction[f]];
-          pbase += this->dofs_per_face;
+          pbase += this->n_dofs_per_face();
         }
       else
         {
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             {
               double s = 0.;
               for (unsigned int k = 0; k < test_values_face.size(); ++k)
@@ -175,11 +175,11 @@ FE_BDM<dim>::convert_generalized_support_point_values_to_dof_values(
             }
           pbase += test_values_face.size();
         }
-      dbase += this->dofs_per_face;
+      dbase += this->n_dofs_per_face();
     }
 
   AssertDimension(dbase,
-                  this->dofs_per_face * GeometryInfo<dim>::faces_per_cell);
+                  this->n_dofs_per_face() * GeometryInfo<dim>::faces_per_cell);
   AssertDimension(pbase,
                   this->generalized_support_points.size() -
                     test_values_cell.size());
@@ -355,7 +355,7 @@ FE_BDM<dim>::initialize_support_points(const unsigned int deg)
        ++k)
     this->generalized_support_points[k] =
       faces.point(k + QProjector<dim>::DataSetDescriptor::face(
-                        0, true, false, false, this->dofs_per_face));
+                        0, true, false, false, this->n_dofs_per_face()));
 
   // Currently, for backward compatibility, we do not use moments, but
   // point values on faces in 2D. In 3D, this is impossible, since the

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -54,7 +54,7 @@ FE_BDM<dim>::FE_BDM(const unsigned int deg)
     ExcMessage(
       "Lowest order BDM element are degree 1, but you asked for degree 0"));
 
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_bdm};
   // These must be done first, since
@@ -139,8 +139,8 @@ FE_BDM<dim>::convert_generalized_support_point_values_to_dof_values(
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
   AssertDimension(support_point_values[0].size(), dim);
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
 
   // First do interpolation on faces. There, the component evaluated
   // depends on the face direction and orientation.
@@ -185,14 +185,14 @@ FE_BDM<dim>::convert_generalized_support_point_values_to_dof_values(
                     test_values_cell.size());
 
   // Done for BDM1
-  if (dbase == this->dofs_per_cell)
+  if (dbase == this->n_dofs_per_cell())
     return;
 
   // What's missing are the interior
   // degrees of freedom. In each
   // point, we take all components of
   // the solution.
-  Assert((this->dofs_per_cell - dbase) % dim == 0, ExcInternalError());
+  Assert((this->n_dofs_per_cell() - dbase) % dim == 0, ExcInternalError());
 
   for (unsigned int d = 0; d < dim; ++d, dbase += test_values_cell[0].size())
     {
@@ -205,7 +205,7 @@ FE_BDM<dim>::convert_generalized_support_point_values_to_dof_values(
         }
     }
 
-  Assert(dbase == this->dofs_per_cell, ExcInternalError());
+  Assert(dbase == this->n_dofs_per_cell(), ExcInternalError());
 }
 
 

--- a/source/fe/fe_bernardi_raugel.cc
+++ b/source/fe/fe_bernardi_raugel.cc
@@ -52,7 +52,7 @@ FE_BernardiRaugel<dim>::FE_BernardiRaugel(const unsigned int p)
   Assert(dim == 2 || dim == 3, ExcImpossibleInDim(dim));
   Assert(p == 1, ExcMessage("Only BR1 elements are available"));
 
-  // const unsigned int n_dofs = this->dofs_per_cell;
+  // const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_none};
   // These must be done first, since
@@ -97,8 +97,8 @@ FE_BernardiRaugel<dim>::convert_generalized_support_point_values_to_dof_values(
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
   AssertDimension(support_point_values[0].size(), dim);
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
 
   std::vector<Tensor<1, dim>> normals;
   for (unsigned int i : GeometryInfo<dim>::face_indices())
@@ -150,7 +150,7 @@ FE_BernardiRaugel<dim>::initialize_support_points()
 {
   // The support points for our shape functions are the vertices and
   // the face midpoints, for a total of #vertices + #faces points
-  this->generalized_support_points.resize(this->dofs_per_cell);
+  this->generalized_support_points.resize(this->n_dofs_per_cell());
 
   // We need dim copies of each vertex for the first dim*vertices_per_cell
   // generalized support points

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -111,9 +111,9 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
   const unsigned int                  subface,
   FullMatrix<double> &                interpolation_matrix) const
 {
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // see if source is a Bernstein element
   if (const FE_Bernstein<dim, spacedim> *source_fe =
@@ -121,9 +121,9 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
     {
       // have this test in here since a table of size 2x0 reports its size as
       // 0x0
-      Assert(interpolation_matrix.n() == this->dofs_per_face,
+      Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
              ExcDimensionMismatch(interpolation_matrix.n(),
-                                  this->dofs_per_face));
+                                  this->n_dofs_per_face()));
 
       // Make sure that the element for which the DoFs should be constrained
       // is the one with the higher polynomial degree.  Actually the procedure
@@ -131,7 +131,7 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
       // produced in that case might lead to problems in the hp procedures,
       // which use this method.
       Assert(
-        this->dofs_per_face <= source_fe->dofs_per_face,
+        this->n_dofs_per_face() <= source_fe->n_dofs_per_face(),
         (typename FiniteElement<dim,
                                 spacedim>::ExcInterpolationNotImplemented()));
 
@@ -155,10 +155,10 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
           QProjector<dim>::project_to_face(quad_face_support, 0) :
           QProjector<dim>::project_to_subface(quad_face_support, 0, subface);
 
-      for (unsigned int i = 0; i < source_fe->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < source_fe->n_dofs_per_face(); ++i)
         {
           const Point<dim> &p = subface_quadrature.point(i);
-          for (unsigned int j = 0; j < this->dofs_per_face; ++j)
+          for (unsigned int j = 0; j < this->n_dofs_per_face(); ++j)
             {
               double matrix_entry =
                 this->shape_value(this->face_to_cell_index(j, 0), p);
@@ -177,11 +177,11 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
 
       // make sure that the row sum of each of the matrices is 1 at this
       // point. this must be so since the shape functions sum up to 1
-      for (unsigned int j = 0; j < source_fe->dofs_per_face; ++j)
+      for (unsigned int j = 0; j < source_fe->n_dofs_per_face(); ++j)
         {
           double sum = 0.;
 
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             sum += interpolation_matrix(j, i);
 
           Assert(std::fabs(sum - 1) < eps, ExcInternalError());
@@ -228,7 +228,7 @@ FE_Bernstein<dim, spacedim>::hp_vertex_dof_identities(
       // equivalencies to be recorded
       return std::vector<std::pair<unsigned int, unsigned int>>();
     }
-  else if (fe_other.dofs_per_face == 0)
+  else if (fe_other.n_dofs_per_face() == 0)
     {
       // if the other element has no elements on faces at all,
       // then it would be impossible to enforce any kind of

--- a/source/fe/fe_dgp.cc
+++ b/source/fe/fe_dgp.cc
@@ -34,10 +34,12 @@ FE_DGP<dim, spacedim>::FE_DGP(const unsigned int degree)
                              degree,
                              FiniteElementData<dim>::L2),
       std::vector<bool>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
         true),
       std::vector<ComponentMask>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
         std::vector<bool>(1, true)))
 {
   // Reinit the vectors of restriction and prolongation matrices to the right
@@ -272,7 +274,7 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_DGP<dim, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(1, this->dofs_per_cell);
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
   constant_modes(0, 0) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));

--- a/source/fe/fe_dgp_monomial.cc
+++ b/source/fe/fe_dgp_monomial.cc
@@ -130,20 +130,21 @@ namespace internal
 
 template <int dim>
 FE_DGPMonomial<dim>::FE_DGPMonomial(const unsigned int degree)
-  : FE_Poly<dim>(
-      PolynomialsP<dim>(degree),
-      FiniteElementData<dim>(get_dpo_vector(degree),
-                             1,
-                             degree,
-                             FiniteElementData<dim>::L2),
-      std::vector<bool>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
-        true),
-      std::vector<ComponentMask>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
-        std::vector<bool>(1, true)))
+  : FE_Poly<dim>(PolynomialsP<dim>(degree),
+                 FiniteElementData<dim>(get_dpo_vector(degree),
+                                        1,
+                                        degree,
+                                        FiniteElementData<dim>::L2),
+                 std::vector<bool>(
+                   FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+                     .n_dofs_per_cell(),
+                   true),
+                 std::vector<ComponentMask>(
+                   FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+                     .n_dofs_per_cell(),
+                   std::vector<bool>(1, true)))
 {
-  Assert(this->poly_space->n() == this->dofs_per_cell, ExcInternalError());
+  Assert(this->poly_space->n() == this->n_dofs_per_cell(), ExcInternalError());
   Assert(this->poly_space->degree() == this->degree, ExcInternalError());
 
   // DG doesn't have constraints, so
@@ -208,10 +209,10 @@ FE_DGPMonomial<dim>::get_interpolation_matrix(
       const unsigned int n = interpolation_matrix.n();
       (void)m;
       (void)n;
-      Assert(m == this->dofs_per_cell,
-             ExcDimensionMismatch(m, this->dofs_per_cell));
-      Assert(n == source_dgp_monomial->dofs_per_cell,
-             ExcDimensionMismatch(n, source_dgp_monomial->dofs_per_cell));
+      Assert(m == this->n_dofs_per_cell(),
+             ExcDimensionMismatch(m, this->n_dofs_per_cell()));
+      Assert(n == source_dgp_monomial->n_dofs_per_cell(),
+             ExcDimensionMismatch(n, source_dgp_monomial->n_dofs_per_cell()));
 
       const unsigned int min_mn =
         interpolation_matrix.m() < interpolation_matrix.n() ?
@@ -223,17 +224,18 @@ FE_DGPMonomial<dim>::get_interpolation_matrix(
     }
   else
     {
-      std::vector<Point<dim>> unit_points(this->dofs_per_cell);
+      std::vector<Point<dim>> unit_points(this->n_dofs_per_cell());
       internal::FE_DGPMonomial::generate_unit_points(this->degree, unit_points);
 
       FullMatrix<double> source_fe_matrix(unit_points.size(),
-                                          source_fe.dofs_per_cell);
-      for (unsigned int j = 0; j < source_fe.dofs_per_cell; ++j)
+                                          source_fe.n_dofs_per_cell());
+      for (unsigned int j = 0; j < source_fe.n_dofs_per_cell(); ++j)
         for (unsigned int k = 0; k < unit_points.size(); ++k)
           source_fe_matrix(k, j) = source_fe.shape_value(j, unit_points[k]);
 
-      FullMatrix<double> this_matrix(this->dofs_per_cell, this->dofs_per_cell);
-      for (unsigned int j = 0; j < this->dofs_per_cell; ++j)
+      FullMatrix<double> this_matrix(this->n_dofs_per_cell(),
+                                     this->n_dofs_per_cell());
+      for (unsigned int j = 0; j < this->n_dofs_per_cell(); ++j)
         for (unsigned int k = 0; k < unit_points.size(); ++k)
           this_matrix(k, j) =
             this->poly_space->compute_value(j, unit_points[k]);

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -42,14 +42,16 @@ FE_DGPNonparametric<dim, spacedim>::FE_DGPNonparametric(
                              degree,
                              FiniteElementData<dim>::L2),
       std::vector<bool>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
         true),
       std::vector<ComponentMask>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree).dofs_per_cell,
+        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+          .n_dofs_per_cell(),
         std::vector<bool>(1, true)))
   , polynomial_space(Polynomials::Legendre::generate_complete_basis(degree))
 {
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
   for (unsigned int ref_case = RefinementCase<dim>::cut_x;
        ref_case < RefinementCase<dim>::isotropic_refinement + 1;
        ++ref_case)
@@ -139,7 +141,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_value(const unsigned int i,
 {
   (void)i;
   (void)p;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return 0;
@@ -157,7 +159,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_value_component(
   (void)i;
   (void)p;
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
@@ -173,7 +175,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad(const unsigned int i,
 {
   (void)i;
   (void)p;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<1, dim>();
@@ -190,7 +192,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_component(
   (void)i;
   (void)p;
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
@@ -206,7 +208,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_grad(const unsigned int i,
 {
   (void)i;
   (void)p;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
   return Tensor<2, dim>();
@@ -224,7 +226,7 @@ FE_DGPNonparametric<dim, spacedim>::shape_grad_grad_component(
   (void)i;
   (void)p;
   (void)component;
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, 1);
   AssertThrow(false,
               (typename FiniteElement<dim>::ExcUnitShapeValuesDoNotExist()));
@@ -321,11 +323,11 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
@@ -340,15 +342,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                   empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
         if (fe_internal.update_each & update_gradients)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
         if (fe_internal.update_each & update_hessians)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }
@@ -377,11 +379,11 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
@@ -396,15 +398,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                   empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
         if (fe_internal.update_each & update_gradients)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
         if (fe_internal.update_each & update_hessians)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }
@@ -434,11 +436,11 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->dofs_per_cell : 0);
+    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
@@ -453,15 +455,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                   empty_vector_of_4th_order_tensors);
 
         if (fe_internal.update_each & update_values)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
         if (fe_internal.update_each & update_gradients)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
         if (fe_internal.update_each & update_hessians)
-          for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+          for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
 }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -440,7 +440,7 @@ FE_Enriched<dim, spacedim>::initialize(
     // If the system is not primitive, these have not been initialized by
     // FiniteElement
     this->system_to_component_table.resize(this->n_dofs_per_cell());
-    this->face_system_to_component_table.resize(this->dofs_per_face);
+    this->face_system_to_component_table.resize(this->n_dofs_per_face());
 
     FETools::Compositing::build_cell_tables(this->system_to_base_table,
                                             this->system_to_component_table,

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -211,7 +211,7 @@ FE_Enriched<dim, spacedim>::FE_Enriched(
                               this->n_base_elements()));
 
   // build the map: (base_no, base_m) -> vector of local element DoFs
-  for (unsigned int system_index = 0; system_index < this->dofs_per_cell;
+  for (unsigned int system_index = 0; system_index < this->n_dofs_per_cell();
        ++system_index)
     {
       const unsigned int base_no =
@@ -248,10 +248,10 @@ FE_Enriched<dim, spacedim>::FE_Enriched(
            m < base_no_mult_local_enriched_dofs[base_no].size();
            m++)
         Assert(base_no_mult_local_enriched_dofs[base_no][m].size() ==
-                 fes[base_no]->dofs_per_cell,
+                 fes[base_no]->n_dofs_per_cell(),
                ExcDimensionMismatch(
                  base_no_mult_local_enriched_dofs[base_no][m].size(),
-                 fes[base_no]->dofs_per_cell));
+                 fes[base_no]->n_dofs_per_cell()));
     }
 }
 
@@ -439,7 +439,7 @@ FE_Enriched<dim, spacedim>::initialize(
   {
     // If the system is not primitive, these have not been initialized by
     // FiniteElement
-    this->system_to_component_table.resize(this->dofs_per_cell);
+    this->system_to_component_table.resize(this->n_dofs_per_cell());
     this->face_system_to_component_table.resize(this->dofs_per_face);
 
     FETools::Compositing::build_cell_tables(this->system_to_base_table,
@@ -659,13 +659,15 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
 
         const UpdateFlags base_flags = base_fe_data.update_each;
 
-        for (unsigned int system_index = 0; system_index < this->dofs_per_cell;
+        for (unsigned int system_index = 0;
+             system_index < this->n_dofs_per_cell();
              ++system_index)
           if (this->system_to_base_table[system_index].first.first == base_no)
             {
               const unsigned int base_index =
                 this->system_to_base_table[system_index].second;
-              Assert(base_index < base_fe.dofs_per_cell, ExcInternalError());
+              Assert(base_index < base_fe.n_dofs_per_cell(),
+                     ExcInternalError());
 
               // now copy. if the shape function is primitive, then there
               // is only one value to be copied, but for non-primitive

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -475,8 +475,8 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_FaceQ<dim, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(1, this->dofs_per_cell);
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     constant_modes(0, i) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));
@@ -491,9 +491,9 @@ FE_FaceQ<dim, spacedim>::convert_generalized_support_point_values_to_dof_values(
   AssertDimension(support_point_values.size(),
                   this->get_unit_support_points().size());
   AssertDimension(support_point_values.size(), nodal_values.size());
-  AssertDimension(this->dofs_per_cell, nodal_values.size());
+  AssertDimension(this->n_dofs_per_cell(), nodal_values.size());
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       AssertDimension(support_point_values[i].size(), 1);
 
@@ -647,8 +647,8 @@ template <int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_FaceQ<1, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(1, this->dofs_per_cell);
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     constant_modes(0, i) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));
@@ -712,7 +712,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
   const unsigned int foffset = face;
   if (fe_internal.update_each & update_values)
     {
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;
       output_data.shape_values(foffset, 0) = 1;
     }
@@ -978,7 +978,7 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_FaceP<dim, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(1, this->dofs_per_cell);
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
   for (unsigned int face : GeometryInfo<dim>::face_indices())
     constant_modes(0, face * this->dofs_per_face) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -164,11 +164,12 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
 {
   // this function is similar to the respective method in FE_Q
 
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // see if source is a FaceQ element
   if (const FE_FaceQ<dim, spacedim> *source_fe =
@@ -180,7 +181,7 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
       // produced in that case might lead to problems in the hp procedures,
       // which use this method.
       Assert(
-        this->dofs_per_face <= source_fe->dofs_per_face,
+        this->n_dofs_per_face() <= source_fe->n_dofs_per_face(),
         (typename FiniteElement<dim,
                                 spacedim>::ExcInterpolationNotImplemented()));
 
@@ -195,7 +196,7 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
 
       // compute the interpolation matrix by simply taking the value at the
       // support points.
-      for (unsigned int i = 0; i < source_fe->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < source_fe->n_dofs_per_face(); ++i)
         {
           const Point<dim - 1> p =
             subface == numbers::invalid_unsigned_int ?
@@ -203,7 +204,7 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
               GeometryInfo<dim - 1>::child_to_cell_coordinates(
                 face_quadrature.point(i), subface);
 
-          for (unsigned int j = 0; j < this->dofs_per_face; ++j)
+          for (unsigned int j = 0; j < this->n_dofs_per_face(); ++j)
             {
               double matrix_entry = this->poly_space.compute_value(j, p);
 
@@ -221,11 +222,11 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
 
       // make sure that the row sum of each of the matrices is 1 at this
       // point. this must be so since the shape functions sum up to 1
-      for (unsigned int j = 0; j < source_fe->dofs_per_face; ++j)
+      for (unsigned int j = 0; j < source_fe->n_dofs_per_face(); ++j)
         {
           double sum = 0.;
 
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             sum += interpolation_matrix(j, i);
 
           Assert(std::fabs(sum - 1) < eps, ExcInternalError());
@@ -250,7 +251,7 @@ FE_FaceQ<dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  return (face_index == (shape_index / this->dofs_per_face));
+  return (face_index == (shape_index / this->n_dofs_per_face()));
 }
 
 
@@ -336,7 +337,7 @@ FE_FaceQ<dim, spacedim>::hp_line_dof_identities(
           // equivalencies to be recorded
           return std::vector<std::pair<unsigned int, unsigned int>>();
         }
-      else if (fe_other.dofs_per_face == 0)
+      else if (fe_other.n_dofs_per_face() == 0)
         {
           // if the other element has no elements on faces at all,
           // then it would be impossible to enforce any kind of
@@ -413,7 +414,7 @@ FE_FaceQ<dim, spacedim>::hp_quad_dof_identities(
           // equivalencies to be recorded
           return std::vector<std::pair<unsigned int, unsigned int>>();
         }
-      else if (fe_other.dofs_per_face == 0)
+      else if (fe_other.n_dofs_per_face() == 0)
         {
           // if the other element has no elements on faces at all,
           // then it would be impossible to enforce any kind of
@@ -569,11 +570,12 @@ FE_FaceQ<1, spacedim>::get_subface_interpolation_matrix(
   FullMatrix<double> &interpolation_matrix) const
 {
   (void)x_source_fe;
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
   interpolation_matrix(0, 0) = 1.;
 }
 
@@ -788,7 +790,7 @@ FE_FaceP<dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  return (face_index == (shape_index / this->dofs_per_face));
+  return (face_index == (shape_index / this->n_dofs_per_face()));
 }
 
 
@@ -879,11 +881,12 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
 {
   // this function is similar to the respective method in FE_Q
 
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // see if source is a FaceP element
   if (const FE_FaceP<dim, spacedim> *source_fe =
@@ -895,7 +898,7 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
       // produced in that case might lead to problems in the hp procedures,
       // which use this method.
       Assert(
-        this->dofs_per_face <= source_fe->dofs_per_face,
+        this->n_dofs_per_face() <= source_fe->n_dofs_per_face(),
         (typename FiniteElement<dim,
                                 spacedim>::ExcInterpolationNotImplemented()));
 
@@ -909,7 +912,8 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
       // zero.
       const double eps = 2e-13 * (this->degree + 1) * (dim - 1);
 
-      FullMatrix<double> mass(face_quadrature.size(), source_fe->dofs_per_face);
+      FullMatrix<double> mass(face_quadrature.size(),
+                              source_fe->n_dofs_per_face());
 
       for (unsigned int k = 0; k < face_quadrature.size(); ++k)
         {
@@ -919,18 +923,18 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
               GeometryInfo<dim - 1>::child_to_cell_coordinates(
                 face_quadrature.point(k), subface);
 
-          for (unsigned int j = 0; j < source_fe->dofs_per_face; ++j)
+          for (unsigned int j = 0; j < source_fe->n_dofs_per_face(); ++j)
             mass(k, j) = source_fe->poly_space.compute_value(j, p);
         }
 
       Householder<double> H(mass);
       Vector<double>      v_in(face_quadrature.size());
-      Vector<double>      v_out(source_fe->dofs_per_face);
+      Vector<double>      v_out(source_fe->n_dofs_per_face());
 
 
       // compute the interpolation matrix by evaluating on the fine side and
       // then solving the least squares problem
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         {
           for (unsigned int k = 0; k < face_quadrature.size(); ++k)
             {
@@ -945,7 +949,7 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
           (void)result;
           Assert(result < 1e-12, FETools::ExcLeastSquaresError(result));
 
-          for (unsigned int j = 0; j < source_fe->dofs_per_face; ++j)
+          for (unsigned int j = 0; j < source_fe->n_dofs_per_face(); ++j)
             {
               double matrix_entry = v_out(j);
 
@@ -980,7 +984,7 @@ FE_FaceP<dim, spacedim>::get_constant_modes() const
 {
   Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
   for (unsigned int face : GeometryInfo<dim>::face_indices())
-    constant_modes(0, face * this->dofs_per_face) = true;
+    constant_modes(0, face * this->n_dofs_per_face()) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));
 }

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -85,7 +85,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
 
   Assert(dim >= 2, ExcImpossibleInDim(dim));
 
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_nedelec};
   // First, initialize the
@@ -534,7 +534,7 @@ FE_Nedelec<dim>::initialize_restriction()
           // functions of the child cells
           // to the lowest order shape
           // functions of the parent cell.
-          for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+          for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
             for (unsigned int q_point = 0; q_point < n_edge_quadrature_points;
                  ++q_point)
               {
@@ -626,7 +626,7 @@ FE_Nedelec<dim>::initialize_restriction()
               FullMatrix<double> system_rhs(this->degree - 1, 4);
               Vector<double>     tmp(4);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
                 for (unsigned int i = 0; i < 2; ++i)
                   {
                     system_rhs = 0.0;
@@ -801,7 +801,7 @@ FE_Nedelec<dim>::initialize_restriction()
               system_rhs.reinit(system_matrix_inv.m(), 8);
               tmp.reinit(8);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
                 {
                   system_rhs = 0.0;
 
@@ -963,7 +963,7 @@ FE_Nedelec<dim>::initialize_restriction()
           // functions of the child cells
           // to the lowest order shape
           // functions of the parent cell.
-          for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+          for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
             for (unsigned int q_point = 0; q_point < n_edge_quadrature_points;
                  ++q_point)
               {
@@ -1068,7 +1068,8 @@ FE_Nedelec<dim>::initialize_restriction()
 
               for (unsigned int i = 0; i < 2; ++i)
                 for (unsigned int j = 0; j < 2; ++j)
-                  for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+                  for (unsigned int dof = 0; dof < this->n_dofs_per_cell();
+                       ++dof)
                     {
                       system_rhs = 0.0;
 
@@ -1300,7 +1301,7 @@ FE_Nedelec<dim>::initialize_restriction()
               tmp.reinit(24);
 
               for (unsigned int i = 0; i < 2; ++i)
-                for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+                for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
                   {
                     system_rhs = 0.0;
 
@@ -1641,7 +1642,7 @@ FE_Nedelec<dim>::initialize_restriction()
               system_rhs.reinit(system_matrix_inv.m(), 24);
               tmp.reinit(24);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
                 {
                   system_rhs = 0.0;
 
@@ -2035,7 +2036,7 @@ bool
 FE_Nedelec<dim>::has_support_on_face(const unsigned int shape_index,
                                      const unsigned int face_index) const
 {
-  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(shape_index, this->n_dofs_per_cell());
   AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   const unsigned int deg = this->degree - 1;
@@ -2970,7 +2971,7 @@ FE_Nedelec<dim>::get_prolongation_matrix(
 
       // if matrix got updated while waiting for the lock
       if (this->prolongation[refinement_case - 1][child].n() ==
-          this->dofs_per_cell)
+          this->n_dofs_per_cell())
         return this->prolongation[refinement_case - 1][child];
 
       // now do the work. need to get a non-const version of data in order to
@@ -3026,7 +3027,7 @@ FE_Nedelec<dim>::get_restriction_matrix(
 
       // if matrix got updated while waiting for the lock...
       if (this->restriction[refinement_case - 1][child].n() ==
-          this->dofs_per_cell)
+          this->n_dofs_per_cell())
         return this->restriction[refinement_case - 1][child];
 
       // now do the work. need to get a non-const version of data in order to
@@ -3081,8 +3082,8 @@ FE_Nedelec<dim>::convert_generalized_support_point_values_to_dof_values(
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
   std::fill(nodal_values.begin(), nodal_values.end(), 0.0);
 
   switch (dim)
@@ -4018,9 +4019,9 @@ template <int dim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_Nedelec<dim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(dim, this->dofs_per_cell);
+  Table<2, bool> constant_modes(dim, this->n_dofs_per_cell());
   for (unsigned int d = 0; d < dim; ++d)
-    for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       constant_modes(d, i) = true;
   std::vector<unsigned int> components;
   for (unsigned int d = 0; d < dim; ++d)

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -109,7 +109,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
 
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->dofs_per_face, this->dofs_per_face);
+    face_embeddings[i].reinit(this->n_dofs_per_face(), this->n_dofs_per_face());
 
   FETools::compute_face_embedding_matrices<dim, double>(
     *this,
@@ -128,31 +128,31 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
 
       case 2:
         {
-          this->interface_constraints.reinit(2 * this->dofs_per_face,
-                                             this->dofs_per_face);
+          this->interface_constraints.reinit(2 * this->n_dofs_per_face(),
+                                             this->n_dofs_per_face());
 
           for (unsigned int i = 0; i < GeometryInfo<2>::max_children_per_face;
                ++i)
-            for (unsigned int j = 0; j < this->dofs_per_face; ++j)
-              for (unsigned int k = 0; k < this->dofs_per_face; ++k)
-                this->interface_constraints(i * this->dofs_per_face + j, k) =
-                  face_embeddings[i](j, k);
+            for (unsigned int j = 0; j < this->n_dofs_per_face(); ++j)
+              for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
+                this->interface_constraints(i * this->n_dofs_per_face() + j,
+                                            k) = face_embeddings[i](j, k);
 
           break;
         }
 
       case 3:
         {
-          this->interface_constraints.reinit(4 * (this->dofs_per_face -
+          this->interface_constraints.reinit(4 * (this->n_dofs_per_face() -
                                                   this->degree),
-                                             this->dofs_per_face);
+                                             this->n_dofs_per_face());
 
           unsigned int target_row = 0;
 
           for (unsigned int i = 0; i < 2; ++i)
             for (unsigned int j = this->degree; j < 2 * this->degree;
                  ++j, ++target_row)
-              for (unsigned int k = 0; k < this->dofs_per_face; ++k)
+              for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
                 this->interface_constraints(target_row, k) =
                   face_embeddings[2 * i](j, k);
 
@@ -160,7 +160,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
             for (unsigned int j = 3 * this->degree;
                  j < GeometryInfo<3>::lines_per_face * this->degree;
                  ++j, ++target_row)
-              for (unsigned int k = 0; k < this->dofs_per_face; ++k)
+              for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
                 this->interface_constraints(target_row, k) =
                   face_embeddings[i](j, k);
 
@@ -169,7 +169,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
               for (unsigned int k = i * this->degree;
                    k < (i + 1) * this->degree;
                    ++k, ++target_row)
-                for (unsigned int l = 0; l < this->dofs_per_face; ++l)
+                for (unsigned int l = 0; l < this->n_dofs_per_face(); ++l)
                   this->interface_constraints(target_row, l) =
                     face_embeddings[i + 2 * j](k, l);
 
@@ -178,7 +178,7 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
               for (unsigned int k = (i + 2) * this->degree;
                    k < (i + 3) * this->degree;
                    ++k, ++target_row)
-                for (unsigned int l = 0; l < this->dofs_per_face; ++l)
+                for (unsigned int l = 0; l < this->n_dofs_per_face(); ++l)
                   this->interface_constraints(target_row, l) =
                     face_embeddings[2 * i + j](k, l);
 
@@ -186,9 +186,9 @@ FE_Nedelec<dim>::FE_Nedelec(const unsigned int order)
                ++i)
             for (unsigned int j =
                    GeometryInfo<3>::lines_per_face * this->degree;
-                 j < this->dofs_per_face;
+                 j < this->n_dofs_per_face();
                  ++j, ++target_row)
-              for (unsigned int k = 0; k < this->dofs_per_face; ++k)
+              for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
                 this->interface_constraints(target_row, k) =
                   face_embeddings[i](j, k);
 
@@ -2430,10 +2430,12 @@ FE_Nedelec<dim>::get_face_interpolation_matrix(
   AssertThrow((source.get_name().find("FE_Nedelec<") == 0) ||
                 (dynamic_cast<const FE_Nedelec<dim> *>(&source) != nullptr),
               (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));
-  Assert(interpolation_matrix.m() == source.dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.m(), source.dofs_per_face));
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
+  Assert(interpolation_matrix.m() == source.n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.m(),
+                              source.n_dofs_per_face()));
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
 
   // ok, source is a Nedelec element, so
   // we will be able to do the work
@@ -2451,7 +2453,7 @@ FE_Nedelec<dim>::get_face_interpolation_matrix(
   // lead to problems in the
   // hp procedures, which use this
   // method.
-  Assert(this->dofs_per_face <= source_fe.dofs_per_face,
+  Assert(this->n_dofs_per_face() <= source_fe.n_dofs_per_face(),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));
   interpolation_matrix = 0;
 
@@ -2533,10 +2535,12 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
   AssertThrow((source.get_name().find("FE_Nedelec<") == 0) ||
                 (dynamic_cast<const FE_Nedelec<dim> *>(&source) != nullptr),
               typename FiniteElement<dim>::ExcInterpolationNotImplemented());
-  Assert(interpolation_matrix.m() == source.dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.m(), source.dofs_per_face));
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
+  Assert(interpolation_matrix.m() == source.n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.m(),
+                              source.n_dofs_per_face()));
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
 
   // ok, source is a Nedelec element, so
   // we will be able to do the work
@@ -2554,7 +2558,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
   // lead to problems in the
   // hp procedures, which use this
   // method.
-  Assert(this->dofs_per_face <= source_fe.dofs_per_face,
+  Assert(this->n_dofs_per_face() <= source_fe.n_dofs_per_face(),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));
   interpolation_matrix = 0.0;
   // Perform projection-based interpolation
@@ -2568,7 +2572,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
     {
       case 2:
         {
-          for (unsigned int dof = 0; dof < this->dofs_per_face; ++dof)
+          for (unsigned int dof = 0; dof < this->n_dofs_per_face(); ++dof)
             for (unsigned int q_point = 0; q_point < n_edge_quadrature_points;
                  ++q_point)
               {
@@ -2616,7 +2620,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
               Vector<double> solution(source_fe.degree - 1);
               Vector<double> system_rhs(source_fe.degree - 1);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_face; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_face(); ++dof)
                 {
                   system_rhs = 0.0;
 
@@ -2663,7 +2667,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
                                        {0.0, 1.0},
                                        {1.0, 1.0}};
 
-          for (unsigned int dof = 0; dof < this->dofs_per_face; ++dof)
+          for (unsigned int dof = 0; dof < this->n_dofs_per_face(); ++dof)
             for (unsigned int q_point = 0; q_point < n_edge_quadrature_points;
                  ++q_point)
               {
@@ -2732,7 +2736,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
                                             GeometryInfo<dim>::lines_per_face);
               Vector<double>     tmp(GeometryInfo<dim>::lines_per_face);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_face; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_face(); ++dof)
                 {
                   system_rhs = 0.0;
 
@@ -2855,7 +2859,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
               system_rhs.reinit(system_matrix_inv.m(), 2);
               tmp.reinit(2);
 
-              for (unsigned int dof = 0; dof < this->dofs_per_face; ++dof)
+              for (unsigned int dof = 0; dof < this->n_dofs_per_face(); ++dof)
                 {
                   system_rhs = 0.0;
 

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -146,8 +146,8 @@ FE_NedelecSZ<dim, spacedim>::get_data(
   const unsigned int lines_per_cell    = GeometryInfo<dim>::lines_per_cell;
   const unsigned int faces_per_cell    = GeometryInfo<dim>::faces_per_cell;
 
-  const unsigned int n_line_dofs = this->dofs_per_line * lines_per_cell;
-  const unsigned int n_face_dofs = this->dofs_per_quad * faces_per_cell;
+  const unsigned int n_line_dofs = this->n_dofs_per_line() * lines_per_cell;
+  const unsigned int n_face_dofs = this->n_dofs_per_quad() * faces_per_cell;
 
   const UpdateFlags  flags(data.update_each);
   const unsigned int n_q_points = quadrature.size();
@@ -1251,7 +1251,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
-                  const unsigned int shift_m(m * this->dofs_per_line);
+                  const unsigned int shift_m(m * this->n_dofs_per_line());
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
                       // Only compute 1d polynomials if degree>0.
@@ -1440,7 +1440,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
-                  const unsigned int shift_m(m * this->dofs_per_line);
+                  const unsigned int shift_m(m * this->n_dofs_per_line());
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
                       // precompute values of all 1d polynomials required:
@@ -1580,7 +1580,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
 
           // DoF info:
           const unsigned int n_line_dofs =
-            this->dofs_per_line * GeometryInfo<dim>::lines_per_cell;
+            this->n_dofs_per_line() * GeometryInfo<dim>::lines_per_cell;
 
           // First we find the global face orientations on the current cell.
           std::vector<std::vector<unsigned int>> face_orientation(
@@ -1695,7 +1695,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
           // Loop through quad points:
           for (unsigned int m = 0; m < faces_per_cell; ++m)
             {
-              const unsigned int shift_m(m * this->dofs_per_quad);
+              const unsigned int shift_m(m * this->n_dofs_per_quad());
               // Calculate the offsets for each face-based shape function:
               //
               // Type-1 (gradients)

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,13 +165,13 @@ FE_NedelecSZ<dim, spacedim>::get_data(
   // Resize shape function arrays according to update flags:
   if (flags & update_values)
     {
-      data.shape_values.resize(this->dofs_per_cell,
+      data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
   if (flags & update_gradients)
     {
-      data.shape_grads.resize(this->dofs_per_cell,
+      data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
@@ -1128,9 +1128,9 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
   const unsigned int n_q_points = quadrature.size();
 
   Assert(!(flags & update_values) ||
-           fe_data.shape_values.size() == this->dofs_per_cell,
+           fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
-                              this->dofs_per_cell));
+                              this->n_dofs_per_cell()));
   Assert(!(flags & update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
@@ -1565,9 +1565,9 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
           const unsigned int n_q_points = quadrature.size();
 
           Assert(!(flags & update_values) ||
-                   fe_data.shape_values.size() == this->dofs_per_cell,
+                   fe_data.shape_values.size() == this->n_dofs_per_cell(),
                  ExcDimensionMismatch(fe_data.shape_values.size(),
-                                      this->dofs_per_cell));
+                                      this->n_dofs_per_cell()));
           Assert(!(flags & update_values) ||
                    fe_data.shape_values[0].size() == n_q_points,
                  ExcDimensionMismatch(fe_data.shape_values[0].size(),
@@ -1939,9 +1939,9 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
   const unsigned int n_q_points = quadrature.size();
 
   Assert(!(flags & update_values) ||
-           fe_data.shape_values.size() == this->dofs_per_cell,
+           fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
-                              this->dofs_per_cell));
+                              this->n_dofs_per_cell()));
   Assert(!(flags & update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
@@ -1951,7 +1951,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
       std::vector<Tensor<1, dim>> transformed_shape_values(n_q_points);
-      for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+      for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
         {
           const unsigned int first =
             data.shape_function_to_row_table[dof * this->n_components() +
@@ -1978,7 +1978,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
       // Must now transform to the physical cell.
       std::vector<Tensor<2, dim>> input(n_q_points);
       std::vector<Tensor<2, dim>> transformed_shape_grads(n_q_points);
-      for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+      for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
         {
           for (unsigned int q = 0; q < n_q_points; ++q)
             {
@@ -2079,7 +2079,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
       std::vector<Tensor<1, dim>> transformed_shape_values(n_q_points);
-      for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+      for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
         {
           mapping.transform(make_array_view(fe_data.shape_values[dof],
                                             offset,
@@ -2109,7 +2109,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
       // Must now transform to the physical cell.
       std::vector<Tensor<2, dim>> input(n_q_points);
       std::vector<Tensor<2, dim>> transformed_shape_grads(n_q_points);
-      for (unsigned int dof = 0; dof < this->dofs_per_cell; ++dof)
+      for (unsigned int dof = 0; dof < this->n_dofs_per_cell(); ++dof)
         {
           for (unsigned int q = 0; q < n_q_points; ++q)
             {

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -228,14 +228,14 @@ FE_P1NC::fill_fe_values(
   // compute on the cell
   if (flags & update_values)
     for (unsigned int i = 0; i < n_q_points; ++i)
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
   if (flags & update_gradients)
     for (unsigned int i = 0; i < n_q_points; ++i)
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
           Point<2>(coeffs[k][0], coeffs[k][1]);
 }
@@ -266,7 +266,7 @@ FE_P1NC::fill_fe_face_values(
 
   if (flags & update_values)
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
           const Point<2> quadrature_point =
             mapping.transform_unit_to_real_cell(cell,
@@ -279,7 +279,7 @@ FE_P1NC::fill_fe_face_values(
 
   if (flags & update_gradients)
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
           Point<2>(coeffs[k][0], coeffs[k][1]);
 }
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   if (flags & update_values)
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
-        for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+        for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
           {
             const Point<2> quadrature_point =
               mapping.transform_unit_to_real_cell(
@@ -326,7 +326,7 @@ FE_P1NC::fill_fe_subface_values(
 
   if (flags & update_gradients)
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
-      for (unsigned int k = 0; k < this->dofs_per_cell; ++k)
+      for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
           Point<2>(coeffs[k][0], coeffs[k][1]);
 }

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -83,11 +83,11 @@ namespace internal
                 const unsigned int nn = cell->neighbor_face_no(f);
 
                 if (nn < GeometryInfo<dim>::faces_per_cell / 2)
-                  for (unsigned int j = 0; j < fe.dofs_per_face; ++j)
+                  for (unsigned int j = 0; j < fe.n_dofs_per_face(); ++j)
                     {
                       const unsigned int cell_j = fe.face_to_cell_index(j, f);
 
-                      Assert(f * fe.dofs_per_face + j < face_sign.size(),
+                      Assert(f * fe.n_dofs_per_face() + j < face_sign.size(),
                              ExcInternalError());
                       Assert(mapping_kind.size() == 1 ||
                                cell_j < mapping_kind.size(),
@@ -98,7 +98,7 @@ namespace internal
                       if ((mapping_kind.size() > 1 ?
                              mapping_kind[cell_j] :
                              mapping_kind[0]) == mapping_raviart_thomas)
-                        face_sign[f * fe.dofs_per_face + j] = -1.0;
+                        face_sign[f * fe.n_dofs_per_face() + j] = -1.0;
                     }
               }
           }

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -243,7 +243,7 @@ FE_PolyTensor<dim, spacedim>::shape_value_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
@@ -288,7 +288,7 @@ FE_PolyTensor<dim, spacedim>::shape_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
@@ -334,7 +334,7 @@ FE_PolyTensor<dim, spacedim>::shape_grad_grad_component(
   const Point<dim> & p,
   const unsigned int component) const
 {
-  AssertIndexRange(i, this->dofs_per_cell);
+  AssertIndexRange(i, this->n_dofs_per_cell());
   AssertIndexRange(component, dim);
 
   std::lock_guard<std::mutex> lock(cache_mutex);
@@ -392,9 +392,9 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
   const unsigned int n_q_points = quadrature.size();
 
   Assert(!(fe_data.update_each & update_values) ||
-           fe_data.shape_values.size()[0] == this->dofs_per_cell,
+           fe_data.shape_values.size()[0] == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size()[0],
-                              this->dofs_per_cell));
+                              this->n_dofs_per_cell()));
   Assert(!(fe_data.update_each & update_values) ||
            fe_data.shape_values.size()[1] == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values.size()[1], n_q_points));
@@ -418,7 +418,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
                                                         fe_data.sign_change);
 
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       const MappingKind mapping_kind = get_mapping_kind(i);
 
@@ -996,7 +996,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
                                                         this->mapping_kind,
                                                         fe_data.sign_change);
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       const MappingKind mapping_kind = get_mapping_kind(i);
 
@@ -1626,7 +1626,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
                                                         this->mapping_kind,
                                                         fe_data.sign_change);
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       const MappingKind mapping_kind = get_mapping_kind(i);
 
@@ -2190,7 +2190,7 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       const MappingKind mapping_kind = get_mapping_kind(i);
 

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -155,9 +155,9 @@ FE_Q<dim, spacedim>::convert_generalized_support_point_values_to_dof_values(
   AssertDimension(support_point_values.size(),
                   this->get_unit_support_points().size());
   AssertDimension(support_point_values.size(), nodal_values.size());
-  AssertDimension(this->dofs_per_cell, nodal_values.size());
+  AssertDimension(this->n_dofs_per_cell(), nodal_values.size());
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       AssertDimension(support_point_values[i].size(), 1);
 

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -52,7 +52,7 @@ namespace internal
         std::vector<std::vector<FullMatrix<double>>> &matrices,
         const bool                                    isotropic_only)
       {
-        const unsigned int dpc    = fe.dofs_per_cell;
+        const unsigned int dpc    = fe.n_dofs_per_cell();
         const unsigned int degree = fe.degree;
 
         // Initialize quadrature formula on fine cells
@@ -134,7 +134,7 @@ namespace internal
             FullMatrix<double> coarse_rhs_matrix(n_dofs, dpc);
 
             std::vector<std::vector<types::global_dof_index>> child_ldi(
-              nc, std::vector<types::global_dof_index>(fe.dofs_per_cell));
+              nc, std::vector<types::global_dof_index>(fe.n_dofs_per_cell()));
 
             // now create the mass matrix and all the right_hand sides
             unsigned int                                           child_no = 0;
@@ -210,7 +210,7 @@ FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const unsigned int q_degree)
     point[d] = 0.5;
   for (unsigned int i = 0; i < n_bubbles; ++i)
     this->unit_support_points.push_back(point);
-  AssertDimension(this->dofs_per_cell, this->unit_support_points.size());
+  AssertDimension(this->n_dofs_per_cell(), this->unit_support_points.size());
 
   this->reinit_restriction_and_prolongation_matrices();
   if (dim == spacedim)
@@ -249,7 +249,7 @@ FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const Quadrature<1> &points)
     point[d] = 0.5;
   for (unsigned int i = 0; i < n_bubbles; ++i)
     this->unit_support_points.push_back(point);
-  AssertDimension(this->dofs_per_cell, this->unit_support_points.size());
+  AssertDimension(this->n_dofs_per_cell(), this->unit_support_points.size());
 
   this->reinit_restriction_and_prolongation_matrices();
   if (dim == spacedim)
@@ -276,7 +276,7 @@ FE_Q_Bubbles<dim, spacedim>::get_name() const
   bool                           type     = true;
   const unsigned int             n_points = this->degree;
   std::vector<double>            points(n_points);
-  const unsigned int             dofs_per_cell = this->dofs_per_cell;
+  const unsigned int             dofs_per_cell = this->n_dofs_per_cell();
   const std::vector<Point<dim>> &unit_support_points =
     this->unit_support_points;
   unsigned int index = 0;
@@ -362,13 +362,13 @@ FE_Q_Bubbles<dim, spacedim>::
   Assert(support_point_values.size() == this->unit_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->unit_support_points.size()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
 
-  for (unsigned int i = 0; i < this->dofs_per_cell - 1; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell() - 1; ++i)
     {
       const std::pair<unsigned int, unsigned int> index =
         this->system_to_component_index(i);
@@ -397,11 +397,12 @@ FE_Q_Bubbles<dim, spacedim>::get_interpolation_matrix(
     (x_source_fe.get_name().find("FE_Q_Bubbles<") == 0) ||
       (dynamic_cast<const FEQBUBBLES *>(&x_source_fe) != nullptr),
     (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
-  Assert(interpolation_matrix.m() == this->dofs_per_cell,
-         ExcDimensionMismatch(interpolation_matrix.m(), this->dofs_per_cell));
-  Assert(interpolation_matrix.n() == x_source_fe.dofs_per_cell,
+  Assert(interpolation_matrix.m() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_cell));
+                              this->n_dofs_per_cell()));
+  Assert(interpolation_matrix.n() == x_source_fe.n_dofs_per_cell(),
+         ExcDimensionMismatch(interpolation_matrix.m(),
+                              x_source_fe.n_dofs_per_cell()));
 
   // Provide a short cut in case we are just inquiring the identity
   auto casted_fe = dynamic_cast<const FEQBUBBLES *>(&x_source_fe);

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -55,7 +55,7 @@ FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const unsigned int degree)
   for (unsigned int d = 0; d < dim; ++d)
     point[d] = 0.5;
   this->unit_support_points.push_back(point);
-  AssertDimension(this->dofs_per_cell, this->unit_support_points.size());
+  AssertDimension(this->n_dofs_per_cell(), this->unit_support_points.size());
 }
 
 
@@ -85,7 +85,7 @@ FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const Quadrature<1> &points)
   for (unsigned int d = 0; d < dim; ++d)
     point[d] = 0.5;
   this->unit_support_points.push_back(point);
-  AssertDimension(this->dofs_per_cell, this->unit_support_points.size());
+  AssertDimension(this->n_dofs_per_cell(), this->unit_support_points.size());
 }
 
 
@@ -102,7 +102,7 @@ FE_Q_DG0<dim, spacedim>::get_name() const
   bool                           type     = true;
   const unsigned int             n_points = this->degree + 1;
   std::vector<double>            points(n_points);
-  const unsigned int             dofs_per_cell = this->dofs_per_cell;
+  const unsigned int             dofs_per_cell = this->n_dofs_per_cell();
   const std::vector<Point<dim>> &unit_support_points =
     this->unit_support_points;
   unsigned int index = 0;
@@ -187,13 +187,13 @@ FE_Q_DG0<dim, spacedim>::convert_generalized_support_point_values_to_dof_values(
   Assert(support_point_values.size() == this->unit_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->unit_support_points.size()));
-  Assert(nodal_dofs.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_dofs.size(), this->dofs_per_cell));
+  Assert(nodal_dofs.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_dofs.size(), this->n_dofs_per_cell()));
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
 
-  for (unsigned int i = 0; i < this->dofs_per_cell - 1; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell() - 1; ++i)
     {
       const std::pair<unsigned int, unsigned int> index =
         this->system_to_component_index(i);
@@ -220,11 +220,12 @@ FE_Q_DG0<dim, spacedim>::get_interpolation_matrix(
       (dynamic_cast<const FEQDG0 *>(&x_source_fe) != nullptr),
     (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
-  Assert(interpolation_matrix.m() == this->dofs_per_cell,
-         ExcDimensionMismatch(interpolation_matrix.m(), this->dofs_per_cell));
-  Assert(interpolation_matrix.n() == x_source_fe.dofs_per_cell,
+  Assert(interpolation_matrix.m() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_cell));
+                              this->n_dofs_per_cell()));
+  Assert(interpolation_matrix.n() == x_source_fe.n_dofs_per_cell(),
+         ExcDimensionMismatch(interpolation_matrix.m(),
+                              x_source_fe.n_dofs_per_cell()));
 
   this->FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>::
     get_interpolation_matrix(x_source_fe, interpolation_matrix);
@@ -264,7 +265,7 @@ FE_Q_DG0<dim, spacedim>::has_support_on_face(
   const unsigned int face_index) const
 {
   // discontinuous function has support on all faces
-  if (shape_index == this->dofs_per_cell - 1)
+  if (shape_index == this->n_dofs_per_cell() - 1)
     return true;
   else
     return FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>::
@@ -277,14 +278,14 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_Q_DG0<dim, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(2, this->dofs_per_cell);
+  Table<2, bool> constant_modes(2, this->n_dofs_per_cell());
 
   // 1 represented by FE_Q part
-  for (unsigned int i = 0; i < this->dofs_per_cell - 1; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell() - 1; ++i)
     constant_modes(0, i) = true;
 
   // 1 represented by DG0 part
-  constant_modes(1, this->dofs_per_cell - 1) = true;
+  constant_modes(1, this->n_dofs_per_cell() - 1) = true;
 
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(2, 0));

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -84,9 +84,9 @@ FE_Q_iso_Q1<dim, spacedim>::
   AssertDimension(support_point_values.size(),
                   this->get_unit_support_points().size());
   AssertDimension(support_point_values.size(), nodal_values.size());
-  AssertDimension(this->dofs_per_cell, nodal_values.size());
+  AssertDimension(this->n_dofs_per_cell(), nodal_values.size());
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       AssertDimension(support_point_values[i].size(), 1);
 

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -115,7 +115,7 @@ FE_RannacherTurek<dim>::convert_generalized_support_point_values_to_dof_values(
 {
   AssertDimension(support_point_values.size(),
                   this->generalized_support_points.size());
-  AssertDimension(nodal_values.size(), this->dofs_per_cell);
+  AssertDimension(nodal_values.size(), this->n_dofs_per_cell());
 
   const unsigned int q_points_per_face = this->weights.size();
   std::fill(nodal_values.begin(), nodal_values.end(), 0.0);

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -91,13 +91,13 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
   // submatrices with an array for each refine case
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->dofs_per_face, this->dofs_per_face);
+    face_embeddings[i].reinit(this->n_dofs_per_face(), this->n_dofs_per_face());
   FETools::compute_face_embedding_matrices<dim, double>(*this,
                                                         face_embeddings,
                                                         0,
                                                         0);
-  this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
-                                     this->dofs_per_face);
+  this->interface_constraints.reinit((1 << (dim - 1)) * this->n_dofs_per_face(),
+                                     this->n_dofs_per_face());
   unsigned int target_row = 0;
   for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face; ++d)
     for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
@@ -173,7 +173,7 @@ FE_RaviartThomas<dim>::initialize_support_points(const unsigned int deg)
 
       boundary_weights.reinit(n_face_points, legendre.n());
 
-      //       Assert (face_points.size() == this->dofs_per_face,
+      //       Assert (face_points.size() == this->n_dofs_per_face(),
       //            ExcInternalError());
 
       for (unsigned int k = 0; k < n_face_points; ++k)
@@ -314,7 +314,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
           for (unsigned int k = 0; k < n_face_points; ++k)
             for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
                  ++i_child)
-              for (unsigned int i_face = 0; i_face < this->dofs_per_face;
+              for (unsigned int i_face = 0; i_face < this->n_dofs_per_face();
                    ++i_face)
                 {
                   // The quadrature
@@ -322,13 +322,13 @@ FE_RaviartThomas<dim>::initialize_restriction()
                   // subcell are NOT
                   // transformed, so we
                   // have to do it here.
-                  this->restriction[iso][child](face * this->dofs_per_face +
+                  this->restriction[iso][child](face * this->n_dofs_per_face() +
                                                   i_face,
                                                 i_child) +=
                     Utilities::fixed_power<dim - 1>(.5) * q_sub.weight(k) *
                     cached_values_on_face(i_child, k) *
                     this->shape_value_component(
-                      face * this->dofs_per_face + i_face,
+                      face * this->n_dofs_per_face() + i_face,
                       q_sub.point(k),
                       GeometryInfo<dim>::unit_normal_direction[face]);
                 }
@@ -355,7 +355,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
 
   QGauss<dim>        q_cell(this->degree);
   const unsigned int start_cell_dofs =
-    GeometryInfo<dim>::faces_per_cell * this->dofs_per_face;
+    GeometryInfo<dim>::faces_per_cell * this->n_dofs_per_face();
 
   // Store shape values, since the
   // evaluation suffers if not
@@ -500,14 +500,14 @@ FE_RaviartThomas<dim>::convert_generalized_support_point_values_to_dof_values(
     for (unsigned int k = 0; k < n_face_points; ++k)
       for (unsigned int i = 0; i < boundary_weights.size(1); ++i)
         {
-          nodal_values[i + face * this->dofs_per_face] +=
+          nodal_values[i + face * this->n_dofs_per_face()] +=
             boundary_weights(k, i) *
             support_point_values[face * n_face_points + k](
               GeometryInfo<dim>::unit_normal_direction[face]);
         }
 
   const unsigned int start_cell_dofs =
-    GeometryInfo<dim>::faces_per_cell * this->dofs_per_face;
+    GeometryInfo<dim>::faces_per_cell * this->n_dofs_per_face();
   const unsigned int start_cell_points =
     GeometryInfo<dim>::faces_per_cell * n_face_points;
 

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -58,7 +58,7 @@ FE_RaviartThomas<dim>::FE_RaviartThomas(const unsigned int deg)
                                  std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
@@ -280,10 +280,10 @@ FE_RaviartThomas<dim>::initialize_restriction()
       // Store shape values, since the
       // evaluation suffers if not
       // ordered by point
-      Table<2, double> cached_values_on_face(this->dofs_per_cell,
+      Table<2, double> cached_values_on_face(this->n_dofs_per_cell(),
                                              q_face.size());
       for (unsigned int k = 0; k < q_face.size(); ++k)
-        for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
           cached_values_on_face(i, k) = this->shape_value_component(
             i, q_face.point(k), GeometryInfo<dim>::unit_normal_direction[face]);
 
@@ -312,7 +312,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
           // corresponding shape
           // functions.
           for (unsigned int k = 0; k < n_face_points; ++k)
-            for (unsigned int i_child = 0; i_child < this->dofs_per_cell;
+            for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
                  ++i_child)
               for (unsigned int i_face = 0; i_face < this->dofs_per_face;
                    ++i_face)
@@ -360,11 +360,11 @@ FE_RaviartThomas<dim>::initialize_restriction()
   // Store shape values, since the
   // evaluation suffers if not
   // ordered by point
-  Table<3, double> cached_values_on_cell(this->dofs_per_cell,
+  Table<3, double> cached_values_on_cell(this->n_dofs_per_cell(),
                                          q_cell.size(),
                                          dim);
   for (unsigned int k = 0; k < q_cell.size(); ++k)
-    for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       for (unsigned int d = 0; d < dim; ++d)
         cached_values_on_cell(i, k, d) =
           this->shape_value_component(i, q_cell.point(k), d);
@@ -375,7 +375,8 @@ FE_RaviartThomas<dim>::initialize_restriction()
       Quadrature<dim> q_sub = QProjector<dim>::project_to_child(q_cell, child);
 
       for (unsigned int k = 0; k < q_sub.size(); ++k)
-        for (unsigned int i_child = 0; i_child < this->dofs_per_cell; ++i_child)
+        for (unsigned int i_child = 0; i_child < this->n_dofs_per_cell();
+             ++i_child)
           for (unsigned int d = 0; d < dim; ++d)
             for (unsigned int i_weight = 0; i_weight < polynomials[d]->n();
                  ++i_weight)
@@ -417,9 +418,9 @@ template <int dim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_RaviartThomas<dim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(dim, this->dofs_per_cell);
+  Table<2, bool> constant_modes(dim, this->n_dofs_per_cell());
   for (unsigned int d = 0; d < dim; ++d)
-    for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       constant_modes(d, i) = true;
   std::vector<unsigned int> components;
   for (unsigned int d = 0; d < dim; ++d)
@@ -440,7 +441,7 @@ bool
 FE_RaviartThomas<dim>::has_support_on_face(const unsigned int shape_index,
                                            const unsigned int face_index) const
 {
-  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(shape_index, this->n_dofs_per_cell());
   AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // Return computed values if we
@@ -486,8 +487,8 @@ FE_RaviartThomas<dim>::convert_generalized_support_point_values_to_dof_values(
   Assert(support_point_values.size() == this->generalized_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -49,7 +49,7 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
                          std::vector<bool>(dim, true)))
 {
   Assert(dim >= 2, ExcImpossibleInDim(dim));
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_raviart_thomas};
   // First, initialize the
@@ -147,7 +147,7 @@ template <int dim>
 void
 FE_RaviartThomasNodal<dim>::initialize_support_points(const unsigned int deg)
 {
-  this->generalized_support_points.resize(this->dofs_per_cell);
+  this->generalized_support_points.resize(this->n_dofs_per_cell());
   this->generalized_face_support_points.resize(this->dofs_per_face);
 
   // Number of the point being entered
@@ -211,7 +211,7 @@ FE_RaviartThomasNodal<dim>::initialize_support_points(const unsigned int deg)
       for (unsigned int k = 0; k < quadrature->size(); ++k)
         this->generalized_support_points[current++] = quadrature->point(k);
     }
-  Assert(current == this->dofs_per_cell, ExcInternalError());
+  Assert(current == this->n_dofs_per_cell(), ExcInternalError());
 }
 
 
@@ -278,7 +278,7 @@ FE_RaviartThomasNodal<dim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(shape_index, this->n_dofs_per_cell());
   AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // The first degrees of freedom are
@@ -310,8 +310,8 @@ FE_RaviartThomasNodal<dim>::
   Assert(support_point_values.size() == this->generalized_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
@@ -334,11 +334,11 @@ FE_RaviartThomasNodal<dim>::
 
   // The remaining points form dim
   // chunks, one for each component.
-  const unsigned int istep = (this->dofs_per_cell - fbase) / dim;
-  Assert((this->dofs_per_cell - fbase) % dim == 0, ExcInternalError());
+  const unsigned int istep = (this->n_dofs_per_cell() - fbase) / dim;
+  Assert((this->n_dofs_per_cell() - fbase) % dim == 0, ExcInternalError());
 
   f = 0;
-  while (fbase < this->dofs_per_cell)
+  while (fbase < this->n_dofs_per_cell())
     {
       for (unsigned int i = 0; i < istep; ++i)
         {
@@ -347,7 +347,7 @@ FE_RaviartThomasNodal<dim>::
       fbase += istep;
       ++f;
     }
-  Assert(fbase == this->dofs_per_cell, ExcInternalError());
+  Assert(fbase == this->n_dofs_per_cell(), ExcInternalError());
 }
 
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -88,13 +88,13 @@ FE_RaviartThomasNodal<dim>::FE_RaviartThomasNodal(const unsigned int deg)
   // submatrices with an array for each refine case
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->dofs_per_face, this->dofs_per_face);
+    face_embeddings[i].reinit(this->n_dofs_per_face(), this->n_dofs_per_face());
   FETools::compute_face_embedding_matrices<dim, double>(*this,
                                                         face_embeddings,
                                                         0,
                                                         0);
-  this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
-                                     this->dofs_per_face);
+  this->interface_constraints.reinit((1 << (dim - 1)) * this->n_dofs_per_face(),
+                                     this->n_dofs_per_face());
   unsigned int target_row = 0;
   for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face; ++d)
     for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
@@ -148,7 +148,7 @@ void
 FE_RaviartThomasNodal<dim>::initialize_support_points(const unsigned int deg)
 {
   this->generalized_support_points.resize(this->n_dofs_per_cell());
-  this->generalized_face_support_points.resize(this->dofs_per_face);
+  this->generalized_face_support_points.resize(this->n_dofs_per_face());
 
   // Number of the point being entered
   unsigned int current = 0;
@@ -162,19 +162,19 @@ FE_RaviartThomasNodal<dim>::initialize_support_points(const unsigned int deg)
   if (dim > 1)
     {
       QGauss<dim - 1> face_points(deg + 1);
-      Assert(face_points.size() == this->dofs_per_face, ExcInternalError());
-      for (unsigned int k = 0; k < this->dofs_per_face; ++k)
+      Assert(face_points.size() == this->n_dofs_per_face(), ExcInternalError());
+      for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
         this->generalized_face_support_points[k] = face_points.point(k);
       Quadrature<dim> faces =
         QProjector<dim>::project_to_all_faces(face_points);
       for (unsigned int k = 0;
-           k < this->dofs_per_face * GeometryInfo<dim>::faces_per_cell;
+           k < this->n_dofs_per_face() * GeometryInfo<dim>::faces_per_cell;
            ++k)
         this->generalized_support_points[k] =
           faces.point(k + QProjector<dim>::DataSetDescriptor::face(
-                            0, true, false, false, this->dofs_per_face));
+                            0, true, false, false, this->n_dofs_per_face()));
 
-      current = this->dofs_per_face * GeometryInfo<dim>::faces_per_cell;
+      current = this->n_dofs_per_face() * GeometryInfo<dim>::faces_per_cell;
     }
 
   if (deg == 0)
@@ -323,9 +323,9 @@ FE_RaviartThomasNodal<dim>::
   unsigned int fbase = 0;
   unsigned int f     = 0;
   for (; f < GeometryInfo<dim>::faces_per_cell;
-       ++f, fbase += this->dofs_per_face)
+       ++f, fbase += this->n_dofs_per_face())
     {
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         {
           nodal_values[fbase + i] = support_point_values[fbase + i](
             GeometryInfo<dim>::unit_normal_direction[f]);
@@ -472,8 +472,8 @@ FE_RaviartThomasNodal<dim>::hp_quad_dof_identities(
 
       // this works exactly like the line
       // case above
-      const unsigned int p = this->dofs_per_quad;
-      const unsigned int q = fe_q_other->dofs_per_quad;
+      const unsigned int p = this->n_dofs_per_quad();
+      const unsigned int q = fe_q_other->n_dofs_per_quad();
 
       std::vector<std::pair<unsigned int, unsigned int>> identities;
 
@@ -575,11 +575,12 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
                    &x_source_fe) != nullptr),
               typename FiniteElement<dim>::ExcInterpolationNotImplemented());
 
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // ok, source is a RaviartThomasNodal element, so
   // we will be able to do the work
@@ -597,7 +598,7 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
   // lead to problems in the
   // hp procedures, which use this
   // method.
-  Assert(this->dofs_per_face <= source_fe.dofs_per_face,
+  Assert(this->n_dofs_per_face() <= source_fe.n_dofs_per_face(),
          typename FiniteElement<dim>::ExcInterpolationNotImplemented());
 
   // generate a quadrature
@@ -622,11 +623,11 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
   const Quadrature<dim> face_projection =
     QProjector<dim>::project_to_face(quad_face_support, 0);
 
-  for (unsigned int i = 0; i < source_fe.dofs_per_face; ++i)
+  for (unsigned int i = 0; i < source_fe.n_dofs_per_face(); ++i)
     {
       const Point<dim> &p = face_projection.point(i);
 
-      for (unsigned int j = 0; j < this->dofs_per_face; ++j)
+      for (unsigned int j = 0; j < this->n_dofs_per_face(); ++j)
         {
           double matrix_entry =
             this->shape_value_component(this->face_to_cell_index(j, 0), p, 0);
@@ -651,11 +652,11 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
   // this point. this must be so
   // since the shape functions sum up
   // to 1
-  for (unsigned int j = 0; j < source_fe.dofs_per_face; ++j)
+  for (unsigned int j = 0; j < source_fe.n_dofs_per_face(); ++j)
     {
       double sum = 0.;
 
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         sum += interpolation_matrix(j, i);
 
       Assert(std::fabs(sum - 1) < 2e-13 * this->degree * (dim - 1),
@@ -679,11 +680,12 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
                    &x_source_fe) != nullptr),
               typename FiniteElement<dim>::ExcInterpolationNotImplemented());
 
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // ok, source is a RaviartThomasNodal element, so
   // we will be able to do the work
@@ -701,7 +703,7 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
   // lead to problems in the
   // hp procedures, which use this
   // method.
-  Assert(this->dofs_per_face <= source_fe.dofs_per_face,
+  Assert(this->n_dofs_per_face() <= source_fe.n_dofs_per_face(),
          typename FiniteElement<dim>::ExcInterpolationNotImplemented());
 
   // generate a quadrature
@@ -727,11 +729,11 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
   const Quadrature<dim> subface_projection =
     QProjector<dim>::project_to_subface(quad_face_support, 0, subface);
 
-  for (unsigned int i = 0; i < source_fe.dofs_per_face; ++i)
+  for (unsigned int i = 0; i < source_fe.n_dofs_per_face(); ++i)
     {
       const Point<dim> &p = subface_projection.point(i);
 
-      for (unsigned int j = 0; j < this->dofs_per_face; ++j)
+      for (unsigned int j = 0; j < this->n_dofs_per_face(); ++j)
         {
           double matrix_entry =
             this->shape_value_component(this->face_to_cell_index(j, 0), p, 0);
@@ -756,11 +758,11 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
   // this point. this must be so
   // since the shape functions sum up
   // to 1
-  for (unsigned int j = 0; j < source_fe.dofs_per_face; ++j)
+  for (unsigned int j = 0; j < source_fe.n_dofs_per_face(); ++j)
     {
       double sum = 0.;
 
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         sum += interpolation_matrix(j, i);
 
       Assert(std::fabs(sum - 1) < 2e-13 * this->degree * (dim - 1),

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -52,7 +52,7 @@ FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
     deg >= 1,
     ExcMessage(
       "Lowest order RT_Bubbles element is degree 1, but you requested for degree 0"));
-  const unsigned int n_dofs = this->dofs_per_cell;
+  const unsigned int n_dofs = this->n_dofs_per_cell();
 
   this->mapping_kind = {mapping_raviart_thomas};
   // Initialize support points and quadrature weights
@@ -131,7 +131,7 @@ template <int dim>
 void
 FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
 {
-  this->generalized_support_points.resize(this->dofs_per_cell);
+  this->generalized_support_points.resize(this->n_dofs_per_cell());
   this->generalized_face_support_points.resize(this->dofs_per_face);
 
   // Index of the point being entered
@@ -197,7 +197,7 @@ FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
       for (unsigned int k = 0; k < quadrature->size(); ++k)
         this->generalized_support_points[current++] = quadrature->point(k);
     }
-  Assert(current == this->dofs_per_cell, ExcInternalError());
+  Assert(current == this->n_dofs_per_cell(), ExcInternalError());
 }
 
 
@@ -266,8 +266,8 @@ FE_RT_Bubbles<dim>::convert_generalized_support_point_values_to_dof_values(
   Assert(support_point_values.size() == this->generalized_support_points.size(),
          ExcDimensionMismatch(support_point_values.size(),
                               this->generalized_support_points.size()));
-  Assert(nodal_values.size() == this->dofs_per_cell,
-         ExcDimensionMismatch(nodal_values.size(), this->dofs_per_cell));
+  Assert(nodal_values.size() == this->n_dofs_per_cell(),
+         ExcDimensionMismatch(nodal_values.size(), this->n_dofs_per_cell()));
   Assert(support_point_values[0].size() == this->n_components(),
          ExcDimensionMismatch(support_point_values[0].size(),
                               this->n_components()));
@@ -287,11 +287,11 @@ FE_RT_Bubbles<dim>::convert_generalized_support_point_values_to_dof_values(
     }
 
   // The remaining points form dim chunks, one for each component.
-  const unsigned int istep = (this->dofs_per_cell - fbase) / dim;
-  Assert((this->dofs_per_cell - fbase) % dim == 0, ExcInternalError());
+  const unsigned int istep = (this->n_dofs_per_cell() - fbase) / dim;
+  Assert((this->n_dofs_per_cell() - fbase) % dim == 0, ExcInternalError());
 
   f = 0;
-  while (fbase < this->dofs_per_cell)
+  while (fbase < this->n_dofs_per_cell())
     {
       for (unsigned int i = 0; i < istep; ++i)
         {
@@ -300,7 +300,7 @@ FE_RT_Bubbles<dim>::convert_generalized_support_point_values_to_dof_values(
       fbase += istep;
       ++f;
     }
-  Assert(fbase == this->dofs_per_cell, ExcInternalError());
+  Assert(fbase == this->n_dofs_per_cell(), ExcInternalError());
 }
 
 

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -80,13 +80,13 @@ FE_RT_Bubbles<dim>::FE_RT_Bubbles(const unsigned int deg)
   FETools::compute_embedding_matrices(*this, this->prolongation, true, 1.0);
   FullMatrix<double> face_embeddings[GeometryInfo<dim>::max_children_per_face];
   for (unsigned int i = 0; i < GeometryInfo<dim>::max_children_per_face; ++i)
-    face_embeddings[i].reinit(this->dofs_per_face, this->dofs_per_face);
+    face_embeddings[i].reinit(this->n_dofs_per_face(), this->n_dofs_per_face());
   FETools::compute_face_embedding_matrices<dim, double>(*this,
                                                         face_embeddings,
                                                         0,
                                                         0);
-  this->interface_constraints.reinit((1 << (dim - 1)) * this->dofs_per_face,
-                                     this->dofs_per_face);
+  this->interface_constraints.reinit((1 << (dim - 1)) * this->n_dofs_per_face(),
+                                     this->n_dofs_per_face());
   unsigned int target_row = 0;
   for (unsigned int d = 0; d < GeometryInfo<dim>::max_children_per_face; ++d)
     for (unsigned int i = 0; i < face_embeddings[d].m(); ++i)
@@ -132,7 +132,7 @@ void
 FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
 {
   this->generalized_support_points.resize(this->n_dofs_per_cell());
-  this->generalized_face_support_points.resize(this->dofs_per_face);
+  this->generalized_face_support_points.resize(this->n_dofs_per_face());
 
   // Index of the point being entered
   unsigned int current = 0;
@@ -143,19 +143,19 @@ FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
   if (dim > 1)
     {
       QGaussLobatto<dim - 1> face_points(deg + 1);
-      Assert(face_points.size() == this->dofs_per_face, ExcInternalError());
-      for (unsigned int k = 0; k < this->dofs_per_face; ++k)
+      Assert(face_points.size() == this->n_dofs_per_face(), ExcInternalError());
+      for (unsigned int k = 0; k < this->n_dofs_per_face(); ++k)
         this->generalized_face_support_points[k] = face_points.point(k);
       Quadrature<dim> faces =
         QProjector<dim>::project_to_all_faces(face_points);
       for (unsigned int k = 0;
-           k < this->dofs_per_face * GeometryInfo<dim>::faces_per_cell;
+           k < this->n_dofs_per_face() * GeometryInfo<dim>::faces_per_cell;
            ++k)
         this->generalized_support_points[k] =
           faces.point(k + QProjector<dim>::DataSetDescriptor::face(
-                            0, true, false, false, this->dofs_per_face));
+                            0, true, false, false, this->n_dofs_per_face()));
 
-      current = this->dofs_per_face * GeometryInfo<dim>::faces_per_cell;
+      current = this->n_dofs_per_face() * GeometryInfo<dim>::faces_per_cell;
     }
 
   if (deg == 1)
@@ -277,9 +277,9 @@ FE_RT_Bubbles<dim>::convert_generalized_support_point_values_to_dof_values(
   unsigned int fbase = 0;
   unsigned int f     = 0;
   for (; f < GeometryInfo<dim>::faces_per_cell;
-       ++f, fbase += this->dofs_per_face)
+       ++f, fbase += this->n_dofs_per_face())
     {
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         {
           nodal_values[fbase + i] = support_point_values[fbase + i](
             GeometryInfo<dim>::unit_normal_direction[f]);

--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -97,11 +97,12 @@ namespace
 
     if (fourier_transform_matrices[fe].m() == 0)
       {
-        fourier_transform_matrices[fe].reinit(n_coefficients_per_direction[fe],
-                                              fe_collection[fe].dofs_per_cell);
+        fourier_transform_matrices[fe].reinit(
+          n_coefficients_per_direction[fe],
+          fe_collection[fe].n_dofs_per_cell());
 
         for (unsigned int k = 0; k < n_coefficients_per_direction[fe]; ++k)
-          for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+          for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell(); ++j)
             fourier_transform_matrices[fe](k, j) =
               integrate(fe_collection[fe], q_collection[fe], k_vectors(k), j);
       }
@@ -123,13 +124,14 @@ namespace
       {
         fourier_transform_matrices[fe].reinit(
           Utilities::fixed_power<2>(n_coefficients_per_direction[fe]),
-          fe_collection[fe].dofs_per_cell);
+          fe_collection[fe].n_dofs_per_cell());
 
         unsigned int k = 0;
         for (unsigned int k1 = 0; k1 < n_coefficients_per_direction[fe]; ++k1)
           for (unsigned int k2 = 0; k2 < n_coefficients_per_direction[fe];
                ++k2, ++k)
-            for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+            for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell();
+                 ++j)
               fourier_transform_matrices[fe](k, j) = integrate(
                 fe_collection[fe], q_collection[fe], k_vectors(k1, k2), j);
       }
@@ -151,14 +153,15 @@ namespace
       {
         fourier_transform_matrices[fe].reinit(
           Utilities::fixed_power<3>(n_coefficients_per_direction[fe]),
-          fe_collection[fe].dofs_per_cell);
+          fe_collection[fe].n_dofs_per_cell());
 
         unsigned int k = 0;
         for (unsigned int k1 = 0; k1 < n_coefficients_per_direction[fe]; ++k1)
           for (unsigned int k2 = 0; k2 < n_coefficients_per_direction[fe]; ++k2)
             for (unsigned int k3 = 0; k3 < n_coefficients_per_direction[fe];
                  ++k3, ++k)
-              for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+              for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell();
+                   ++j)
                 fourier_transform_matrices[fe](k, j) =
                   integrate(fe_collection[fe],
                             q_collection[fe],

--- a/source/fe/fe_series_legendre.cc
+++ b/source/fe/fe_series_legendre.cc
@@ -118,11 +118,12 @@ namespace
 
     if (legendre_transform_matrices[fe].m() == 0)
       {
-        legendre_transform_matrices[fe].reinit(n_coefficients_per_direction[fe],
-                                               fe_collection[fe].dofs_per_cell);
+        legendre_transform_matrices[fe].reinit(
+          n_coefficients_per_direction[fe],
+          fe_collection[fe].n_dofs_per_cell());
 
         for (unsigned int k = 0; k < n_coefficients_per_direction[fe]; ++k)
-          for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+          for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell(); ++j)
             legendre_transform_matrices[fe](k, j) = integrate(
               fe_collection[fe], q_collection[fe], TableIndices<1>(k), j);
       }
@@ -143,13 +144,14 @@ namespace
       {
         legendre_transform_matrices[fe].reinit(
           Utilities::fixed_power<2>(n_coefficients_per_direction[fe]),
-          fe_collection[fe].dofs_per_cell);
+          fe_collection[fe].n_dofs_per_cell());
 
         unsigned int k = 0;
         for (unsigned int k1 = 0; k1 < n_coefficients_per_direction[fe]; ++k1)
           for (unsigned int k2 = 0; k2 < n_coefficients_per_direction[fe];
                ++k2, k++)
-            for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+            for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell();
+                 ++j)
               legendre_transform_matrices[fe](k, j) =
                 integrate(fe_collection[fe],
                           q_collection[fe],
@@ -173,14 +175,15 @@ namespace
       {
         legendre_transform_matrices[fe].reinit(
           Utilities::fixed_power<3>(n_coefficients_per_direction[fe]),
-          fe_collection[fe].dofs_per_cell);
+          fe_collection[fe].n_dofs_per_cell());
 
         unsigned int k = 0;
         for (unsigned int k1 = 0; k1 < n_coefficients_per_direction[fe]; ++k1)
           for (unsigned int k2 = 0; k2 < n_coefficients_per_direction[fe]; ++k2)
             for (unsigned int k3 = 0; k3 < n_coefficients_per_direction[fe];
                  ++k3, k++)
-              for (unsigned int j = 0; j < fe_collection[fe].dofs_per_cell; ++j)
+              for (unsigned int j = 0; j < fe_collection[fe].n_dofs_per_cell();
+                   ++j)
                 legendre_transform_matrices[fe](k, j) =
                   integrate(fe_collection[fe],
                             q_collection[fe],

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1450,9 +1450,9 @@ FESystem<dim, spacedim>::build_interface_constraints()
                   // then come the two sets of line indices
                   {
                     const unsigned int index_in_line =
-                      (m - this->n_dofs_per_vertex()) % this->dofs_per_line;
+                      (m - this->n_dofs_per_vertex()) % this->n_dofs_per_line();
                     const unsigned int sub_line =
-                      (m - this->n_dofs_per_vertex()) / this->dofs_per_line;
+                      (m - this->n_dofs_per_vertex()) / this->n_dofs_per_line();
                     Assert(sub_line < 2, ExcInternalError());
 
                     // from this information, try to get base element and
@@ -1479,12 +1479,12 @@ FESystem<dim, spacedim>::build_interface_constraints()
                     const unsigned int tmp2 =
                       this->face_system_to_base_table[tmp1].second -
                       2 * base_element(m_index.first.first).n_dofs_per_vertex();
-                    Assert(tmp2 <
-                             base_element(m_index.first.first).dofs_per_line,
+                    Assert(tmp2 < base_element(m_index.first.first)
+                                    .n_dofs_per_line(),
                            ExcInternalError());
                     m_index.second =
                       base_element(m_index.first.first).n_dofs_per_vertex() +
-                      base_element(m_index.first.first).dofs_per_line *
+                      base_element(m_index.first.first).n_dofs_per_line() *
                         sub_line +
                       tmp2;
                   }
@@ -1502,14 +1502,16 @@ FESystem<dim, spacedim>::build_interface_constraints()
                   m_index = this->system_to_base_table[m];
                 else
                   // then come the 12 sets of line indices
-                  if (m <
-                      5 * this->n_dofs_per_vertex() + 12 * this->dofs_per_line)
+                  if (m < 5 * this->n_dofs_per_vertex() +
+                            12 * this->n_dofs_per_line())
                   {
                     // for the meaning of all this, see the 2d part
                     const unsigned int index_in_line =
-                      (m - 5 * this->n_dofs_per_vertex()) % this->dofs_per_line;
+                      (m - 5 * this->n_dofs_per_vertex()) %
+                      this->n_dofs_per_line();
                     const unsigned int sub_line =
-                      (m - 5 * this->n_dofs_per_vertex()) / this->dofs_per_line;
+                      (m - 5 * this->n_dofs_per_vertex()) /
+                      this->n_dofs_per_line();
                     Assert(sub_line < 12, ExcInternalError());
 
                     const unsigned int tmp1 =
@@ -1523,13 +1525,13 @@ FESystem<dim, spacedim>::build_interface_constraints()
                     const unsigned int tmp2 =
                       this->face_system_to_base_table[tmp1].second -
                       4 * base_element(m_index.first.first).n_dofs_per_vertex();
-                    Assert(tmp2 <
-                             base_element(m_index.first.first).dofs_per_line,
+                    Assert(tmp2 < base_element(m_index.first.first)
+                                    .n_dofs_per_line(),
                            ExcInternalError());
                     m_index.second =
                       5 *
                         base_element(m_index.first.first).n_dofs_per_vertex() +
-                      base_element(m_index.first.first).dofs_per_line *
+                      base_element(m_index.first.first).n_dofs_per_line() *
                         sub_line +
                       tmp2;
                   }
@@ -1539,42 +1541,42 @@ FESystem<dim, spacedim>::build_interface_constraints()
                     // for the meaning of all this, see the 2d part
                     const unsigned int index_in_quad =
                       (m - 5 * this->n_dofs_per_vertex() -
-                       12 * this->dofs_per_line) %
-                      this->dofs_per_quad;
-                    Assert(index_in_quad < this->dofs_per_quad,
+                       12 * this->n_dofs_per_line()) %
+                      this->n_dofs_per_quad();
+                    Assert(index_in_quad < this->n_dofs_per_quad(),
                            ExcInternalError());
                     const unsigned int sub_quad =
                       ((m - 5 * this->n_dofs_per_vertex() -
-                        12 * this->dofs_per_line) /
-                       this->dofs_per_quad);
+                        12 * this->n_dofs_per_line()) /
+                       this->n_dofs_per_quad());
                     Assert(sub_quad < 4, ExcInternalError());
 
                     const unsigned int tmp1 = 4 * this->n_dofs_per_vertex() +
-                                              4 * this->dofs_per_line +
+                                              4 * this->n_dofs_per_line() +
                                               index_in_quad;
                     Assert(tmp1 < this->face_system_to_base_table.size(),
                            ExcInternalError());
                     m_index.first = this->face_system_to_base_table[tmp1].first;
 
-                    Assert(
-                      this->face_system_to_base_table[tmp1].second >=
-                        4 * base_element(m_index.first.first)
-                              .n_dofs_per_vertex() +
-                          4 * base_element(m_index.first.first).dofs_per_line,
-                      ExcInternalError());
+                    Assert(this->face_system_to_base_table[tmp1].second >=
+                             4 * base_element(m_index.first.first)
+                                   .n_dofs_per_vertex() +
+                               4 * base_element(m_index.first.first)
+                                     .n_dofs_per_line(),
+                           ExcInternalError());
                     const unsigned int tmp2 =
                       this->face_system_to_base_table[tmp1].second -
                       4 *
                         base_element(m_index.first.first).n_dofs_per_vertex() -
-                      4 * base_element(m_index.first.first).dofs_per_line;
-                    Assert(tmp2 <
-                             base_element(m_index.first.first).dofs_per_quad,
+                      4 * base_element(m_index.first.first).n_dofs_per_line();
+                    Assert(tmp2 < base_element(m_index.first.first)
+                                    .n_dofs_per_quad(),
                            ExcInternalError());
                     m_index.second =
                       5 *
                         base_element(m_index.first.first).n_dofs_per_vertex() +
-                      12 * base_element(m_index.first.first).dofs_per_line +
-                      base_element(m_index.first.first).dofs_per_quad *
+                      12 * base_element(m_index.first.first).n_dofs_per_line() +
+                      base_element(m_index.first.first).n_dofs_per_quad() *
                         sub_quad +
                       tmp2;
                   }
@@ -1643,7 +1645,7 @@ FESystem<dim, spacedim>::initialize(
     // If the system is not primitive, these have not been initialized by
     // FiniteElement
     this->system_to_component_table.resize(this->n_dofs_per_cell());
-    this->face_system_to_component_table.resize(this->dofs_per_face);
+    this->face_system_to_component_table.resize(this->n_dofs_per_face());
 
     FETools::Compositing::build_cell_tables(this->system_to_base_table,
                                             this->system_to_component_table,
@@ -1709,7 +1711,7 @@ FESystem<dim, spacedim>::initialize(
       for (unsigned int base_el = 0; base_el < this->n_base_elements();
            ++base_el)
         if (!base_element(base_el).has_support_points() &&
-            (base_element(base_el).dofs_per_face > 0))
+            (base_element(base_el).n_dofs_per_face() > 0))
           {
             this->unit_face_support_points.resize(0);
             return;
@@ -1718,9 +1720,9 @@ FESystem<dim, spacedim>::initialize(
 
       // generate unit face support points from unit support points of sub
       // elements
-      this->unit_face_support_points.resize(this->dofs_per_face);
+      this->unit_face_support_points.resize(this->n_dofs_per_face());
 
-      for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+      for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
         {
           const unsigned int base_i =
             this->face_system_to_base_table[i].first.first;
@@ -1810,7 +1812,7 @@ FESystem<dim, spacedim>::initialize(
       // the array into which we want to write should have the correct size
       // already.
       Assert(this->adjust_quad_dof_index_for_face_orientation_table
-                 .n_elements() == 8 * this->dofs_per_quad,
+                 .n_elements() == 8 * this->n_dofs_per_quad(),
              ExcInternalError());
 
       // to obtain the shifts for this composed element, copy the shift
@@ -1830,11 +1832,11 @@ FESystem<dim, spacedim>::initialize(
               index += temp.size(0);
             }
         }
-      Assert(index == this->dofs_per_quad, ExcInternalError());
+      Assert(index == this->n_dofs_per_quad(), ExcInternalError());
 
       // additionally compose the permutation information for lines
       Assert(this->adjust_line_dof_index_for_line_orientation_table.size() ==
-               this->dofs_per_line,
+               this->n_dofs_per_line(),
              ExcInternalError());
       index = 0;
       for (unsigned int b = 0; b < this->n_base_elements(); ++b)
@@ -1852,7 +1854,7 @@ FESystem<dim, spacedim>::initialize(
               index += temp2.size();
             }
         }
-      Assert(index == this->dofs_per_line, ExcInternalError());
+      Assert(index == this->n_dofs_per_line(), ExcInternalError());
     });
 
   // wait for all of this to finish
@@ -1880,11 +1882,12 @@ FESystem<dim, spacedim>::get_face_interpolation_matrix(
   const FiniteElement<dim, spacedim> &x_source_fe,
   FullMatrix<double> &                interpolation_matrix) const
 {
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // since dofs for each base are independent, we only have to stack things up
   // from base element to base element
@@ -1920,18 +1923,19 @@ FESystem<dim, spacedim>::get_face_interpolation_matrix(
                  ExcNotImplemented());
 
           // get the interpolation from the bases
-          base_to_base_interpolation.reinit(base_other.dofs_per_face,
-                                            base.dofs_per_face);
+          base_to_base_interpolation.reinit(base_other.n_dofs_per_face(),
+                                            base.n_dofs_per_face());
           base.get_face_interpolation_matrix(base_other,
                                              base_to_base_interpolation);
 
           // now translate entries. we'd like to have something like
           // face_base_to_system_index, but that doesn't exist. rather, all we
           // have is the reverse. well, use that then
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             if (this->face_system_to_base_index(i).first ==
                 std::make_pair(base_index, multiplicity))
-              for (unsigned int j = 0; j < fe_other_system->dofs_per_face; ++j)
+              for (unsigned int j = 0; j < fe_other_system->n_dofs_per_face();
+                   ++j)
                 if (fe_other_system->face_system_to_base_index(j).first ==
                     std::make_pair(base_index_other, multiplicity_other))
                   interpolation_matrix(j, i) = base_to_base_interpolation(
@@ -1995,11 +1999,12 @@ FESystem<dim, spacedim>::get_subface_interpolation_matrix(
       (dynamic_cast<const FESystem<dim, spacedim> *>(&x_source_fe) != nullptr),
     (typename FiniteElement<dim, spacedim>::ExcInterpolationNotImplemented()));
 
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // since dofs for each base are independent, we only have to stack things up
   // from base element to base element
@@ -2036,8 +2041,8 @@ FESystem<dim, spacedim>::get_subface_interpolation_matrix(
                  ExcNotImplemented());
 
           // get the interpolation from the bases
-          base_to_base_interpolation.reinit(base_other.dofs_per_face,
-                                            base.dofs_per_face);
+          base_to_base_interpolation.reinit(base_other.n_dofs_per_face(),
+                                            base.n_dofs_per_face());
           base.get_subface_interpolation_matrix(base_other,
                                                 subface,
                                                 base_to_base_interpolation);
@@ -2045,10 +2050,11 @@ FESystem<dim, spacedim>::get_subface_interpolation_matrix(
           // now translate entries. we'd like to have something like
           // face_base_to_system_index, but that doesn't exist. rather, all we
           // have is the reverse. well, use that then
-          for (unsigned int i = 0; i < this->dofs_per_face; ++i)
+          for (unsigned int i = 0; i < this->n_dofs_per_face(); ++i)
             if (this->face_system_to_base_index(i).first ==
                 std::make_pair(base_index, multiplicity))
-              for (unsigned int j = 0; j < fe_other_system->dofs_per_face; ++j)
+              for (unsigned int j = 0; j < fe_other_system->n_dofs_per_face();
+                   ++j)
                 if (fe_other_system->face_system_to_base_index(j).first ==
                     std::make_pair(base_index_other, multiplicity_other))
                   interpolation_matrix(j, i) = base_to_base_interpolation(
@@ -2337,8 +2343,8 @@ template <int dim, int spacedim>
 Point<dim - 1>
 FESystem<dim, spacedim>::unit_face_support_point(const unsigned int index) const
 {
-  AssertIndexRange(index, this->dofs_per_face);
-  Assert((this->unit_face_support_points.size() == this->dofs_per_face) ||
+  AssertIndexRange(index, this->n_dofs_per_face());
+  Assert((this->unit_face_support_points.size() == this->n_dofs_per_face()) ||
            (this->unit_face_support_points.size() == 0),
          (typename FiniteElement<dim, spacedim>::ExcFEHasNoSupportPoints()));
 

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -59,8 +59,8 @@ FE_TraceQ<dim, spacedim>::FE_TraceQ(const unsigned int degree)
   // initialize unit support points (this makes it possible to assign initial
   // values to FE_TraceQ). Note that we simply take the points of fe_q but
   // skip the last ones which are associated with the interior of FE_Q.
-  this->unit_support_points.resize(this->dofs_per_cell);
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  this->unit_support_points.resize(this->n_dofs_per_cell());
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     this->unit_support_points[i] = fe_q.get_unit_support_points()[i];
 
   // Initialize constraint matrices
@@ -101,14 +101,14 @@ FE_TraceQ<dim, spacedim>::has_support_on_face(
   const unsigned int shape_index,
   const unsigned int face_index) const
 {
-  AssertIndexRange(shape_index, this->dofs_per_cell);
+  AssertIndexRange(shape_index, this->n_dofs_per_cell());
   AssertIndexRange(face_index, GeometryInfo<dim>::faces_per_cell);
 
   // FE_TraceQ shares the numbering of elemental degrees of freedom with FE_Q
   // except for the missing interior ones (quad dofs in 2D and hex dofs in
   // 3D). Therefore, it is safe to ask fe_q for the corresponding
-  // information. The assertion 'shape_index < this->dofs_per_cell' will make
-  // sure that we only access the trace dofs.
+  // information. The assertion 'shape_index < this->n_dofs_per_cell()' will
+  // make sure that we only access the trace dofs.
   return fe_q.has_support_on_face(shape_index, face_index);
 }
 
@@ -118,8 +118,8 @@ template <int dim, int spacedim>
 std::pair<Table<2, bool>, std::vector<unsigned int>>
 FE_TraceQ<dim, spacedim>::get_constant_modes() const
 {
-  Table<2, bool> constant_modes(1, this->dofs_per_cell);
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  Table<2, bool> constant_modes(1, this->n_dofs_per_cell());
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     constant_modes(0, i) = true;
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(
     constant_modes, std::vector<unsigned int>(1, 0));
@@ -135,9 +135,9 @@ FE_TraceQ<dim, spacedim>::
   AssertDimension(support_point_values.size(),
                   this->get_unit_support_points().size());
   AssertDimension(support_point_values.size(), nodal_values.size());
-  AssertDimension(this->dofs_per_cell, nodal_values.size());
+  AssertDimension(this->n_dofs_per_cell(), nodal_values.size());
 
-  for (unsigned int i = 0; i < this->dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
     {
       AssertDimension(support_point_values[i].size(), 1);
 

--- a/source/fe/fe_trace.cc
+++ b/source/fe/fe_trace.cc
@@ -232,11 +232,12 @@ FE_TraceQ<dim, spacedim>::get_subface_interpolation_matrix(
   FullMatrix<double> &                interpolation_matrix) const
 {
   // this is the code from FE_FaceQ
-  Assert(interpolation_matrix.n() == this->dofs_per_face,
-         ExcDimensionMismatch(interpolation_matrix.n(), this->dofs_per_face));
-  Assert(interpolation_matrix.m() == x_source_fe.dofs_per_face,
+  Assert(interpolation_matrix.n() == this->n_dofs_per_face(),
+         ExcDimensionMismatch(interpolation_matrix.n(),
+                              this->n_dofs_per_face()));
+  Assert(interpolation_matrix.m() == x_source_fe.n_dofs_per_face(),
          ExcDimensionMismatch(interpolation_matrix.m(),
-                              x_source_fe.dofs_per_face));
+                              x_source_fe.n_dofs_per_face()));
 
   // see if source is a FaceQ element
   if (const FE_TraceQ<dim, spacedim> *source_fe =

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -79,9 +79,9 @@ namespace internal
   make_shape_function_to_row_table(const FiniteElement<dim, spacedim> &fe)
   {
     std::vector<unsigned int> shape_function_to_row_table(
-      fe.dofs_per_cell * fe.n_components(), numbers::invalid_unsigned_int);
+      fe.n_dofs_per_cell() * fe.n_components(), numbers::invalid_unsigned_int);
     unsigned int row = 0;
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       {
         // loop over all components that are nonzero for this particular
         // shape function. if a component is zero then we leave the
@@ -144,7 +144,7 @@ namespace FEValuesViews
                                 const unsigned int                 component)
     : fe_values(&fe_values)
     , component(component)
-    , shape_function_data(this->fe_values->fe->dofs_per_cell)
+    , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
     AssertIndexRange(component, fe.n_components());
@@ -155,7 +155,7 @@ namespace FEValuesViews
     const std::vector<unsigned int> shape_function_to_row_table =
       dealii::internal::make_shape_function_to_row_table(fe);
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       {
         const bool is_primitive = fe.is_primitive() || fe.is_primitive(i);
 
@@ -189,7 +189,7 @@ namespace FEValuesViews
                                 const unsigned int first_vector_component)
     : fe_values(&fe_values)
     , first_vector_component(first_vector_component)
-    , shape_function_data(this->fe_values->fe->dofs_per_cell)
+    , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
     AssertIndexRange(first_vector_component + spacedim - 1, fe.n_components());
@@ -204,7 +204,7 @@ namespace FEValuesViews
       {
         const unsigned int component = first_vector_component + d;
 
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             const bool is_primitive = fe.is_primitive() || fe.is_primitive(i);
 
@@ -225,7 +225,7 @@ namespace FEValuesViews
           }
       }
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       {
         unsigned int n_nonzero_components = 0;
         for (unsigned int d = 0; d < spacedim; ++d)
@@ -268,7 +268,7 @@ namespace FEValuesViews
     const unsigned int                 first_tensor_component)
     : fe_values(&fe_values)
     , first_tensor_component(first_tensor_component)
-    , shape_function_data(this->fe_values->fe->dofs_per_cell)
+    , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
     Assert(first_tensor_component + (dim * dim + dim) / 2 - 1 <
@@ -290,7 +290,7 @@ namespace FEValuesViews
       {
         const unsigned int component = first_tensor_component + d;
 
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             const bool is_primitive = fe.is_primitive() || fe.is_primitive(i);
 
@@ -311,7 +311,7 @@ namespace FEValuesViews
           }
       }
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       {
         unsigned int n_nonzero_components = 0;
         for (unsigned int d = 0;
@@ -357,7 +357,7 @@ namespace FEValuesViews
                                    const unsigned int first_tensor_component)
     : fe_values(&fe_values)
     , first_tensor_component(first_tensor_component)
-    , shape_function_data(this->fe_values->fe->dofs_per_cell)
+    , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
     AssertIndexRange(first_tensor_component + dim * dim - 1, fe.n_components());
@@ -371,7 +371,7 @@ namespace FEValuesViews
       {
         const unsigned int component = first_tensor_component + d;
 
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
           {
             const bool is_primitive = fe.is_primitive() || fe.is_primitive(i);
 
@@ -392,7 +392,7 @@ namespace FEValuesViews
           }
       }
 
-    for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+    for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
       {
         unsigned int n_nonzero_components = 0;
         for (unsigned int d = 0; d < dim * dim; ++d)
@@ -2839,10 +2839,10 @@ FEValuesBase<dim, spacedim>::CellIterator<CI>::get_interpolated_dof_values(
   Assert(cell->is_active(), ExcNotImplemented());
 
   std::vector<types::global_dof_index> dof_indices(
-    cell->get_fe().dofs_per_cell);
+    cell->get_fe().n_dofs_per_cell());
   cell->get_dof_indices(dof_indices);
 
-  for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell; ++i)
+  for (unsigned int i = 0; i < cell->get_fe().n_dofs_per_cell(); ++i)
     out[i] = (in.is_element(dof_indices[i]) ? 1 : 0);
 }
 
@@ -3008,9 +3008,9 @@ namespace internal
       // count the total number of non-zero components accumulated
       // over all shape functions
       unsigned int n_nonzero_shape_components = 0;
-      for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+      for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
         n_nonzero_shape_components += fe.n_nonzero_components(i);
-      Assert(n_nonzero_shape_components >= fe.dofs_per_cell,
+      Assert(n_nonzero_shape_components >= fe.n_dofs_per_cell(),
              ExcInternalError());
 
       // with the number of rows now known, initialize those fields
@@ -3171,7 +3171,7 @@ namespace internal
 
     // see if there the current cell has DoFs at all, and if not
     // then there is nothing else to do.
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     if (dofs_per_cell == 0)
       return;
 
@@ -3322,7 +3322,7 @@ namespace internal
 
     // see if there the current cell has DoFs at all, and if not
     // then there is nothing else to do.
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     if (dofs_per_cell == 0)
       return;
 
@@ -3467,7 +3467,7 @@ namespace internal
 
     // see if there the current cell has DoFs at all, and if not
     // then there is nothing else to do.
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     if (dofs_per_cell == 0)
       return;
 
@@ -4388,7 +4388,7 @@ FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping,
                                   const Quadrature<dim> &             q,
                                   const UpdateFlags update_flags)
   : FEValuesBase<dim, spacedim>(q.size(),
-                                fe.dofs_per_cell,
+                                fe.n_dofs_per_cell(),
                                 update_default,
                                 mapping,
                                 fe)
@@ -4404,7 +4404,7 @@ FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
                                   const Quadrature<dim> &             q,
                                   const UpdateFlags update_flags)
   : FEValuesBase<dim, spacedim>(q.size(),
-                                fe.dofs_per_cell,
+                                fe.n_dofs_per_cell(),
                                 update_default,
                                 StaticMappingQ1<dim, spacedim>::mapping,
                                 fe)
@@ -4656,7 +4656,7 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
   : FEFaceValuesBase<dim, spacedim>(quadrature.size(),
-                                    fe.dofs_per_cell,
+                                    fe.n_dofs_per_cell(),
                                     update_flags,
                                     mapping,
                                     fe,
@@ -4673,7 +4673,7 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
   : FEFaceValuesBase<dim, spacedim>(quadrature.size(),
-                                    fe.dofs_per_cell,
+                                    fe.n_dofs_per_cell(),
                                     update_flags,
                                     StaticMappingQ1<dim, spacedim>::mapping,
                                     fe,
@@ -4855,7 +4855,7 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
   : FEFaceValuesBase<dim, spacedim>(quadrature.size(),
-                                    fe.dofs_per_cell,
+                                    fe.n_dofs_per_cell(),
                                     update_flags,
                                     mapping,
                                     fe,
@@ -4872,7 +4872,7 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
   : FEFaceValuesBase<dim, spacedim>(quadrature.size(),
-                                    fe.dofs_per_cell,
+                                    fe.n_dofs_per_cell(),
                                     update_flags,
                                     StaticMappingQ1<dim, spacedim>::mapping,
                                     fe,

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -63,10 +63,10 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::InternalData::
   InternalData(const FiniteElement<dim, spacedim> &fe,
                const ComponentMask &               mask)
   : unit_tangentials()
-  , n_shape_functions(fe.dofs_per_cell)
+  , n_shape_functions(fe.n_dofs_per_cell())
   , mask(mask)
-  , local_dof_indices(fe.dofs_per_cell)
-  , local_dof_values(fe.dofs_per_cell)
+  , local_dof_indices(fe.n_dofs_per_cell())
+  , local_dof_values(fe.n_dofs_per_cell())
 {}
 
 
@@ -384,7 +384,8 @@ MappingFEField<dim, spacedim, VectorType, DoFHandlerType>::get_vertices(
     std::lock_guard<std::mutex> lock(fe_values_mutex);
     fe_values.reinit(dof_cell);
   }
-  const unsigned int dofs_per_cell = euler_dof_handler->get_fe().dofs_per_cell;
+  const unsigned int dofs_per_cell =
+    euler_dof_handler->get_fe().n_dofs_per_cell();
   std::vector<types::global_dof_index> dof_indices(dofs_per_cell);
   if (uses_level_dofs)
     dof_cell->get_mg_dof_indices(dof_indices);

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -78,7 +78,7 @@ MappingQ1Eulerian<dim, VectorType, spacedim>::get_vertices(
 
   // now get the values of the shift vectors at the vertices
   Vector<typename VectorType::value_type> mapping_values(
-    shiftmap_dof_handler->get_fe().dofs_per_cell);
+    shiftmap_dof_handler->get_fe().n_dofs_per_cell());
   dof_cell->get_dof_values(*euler_transform_vectors, mapping_values);
 
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -212,7 +212,7 @@ MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerianGeneric::
     n_support_pts, Vector<typename VectorType::value_type>(n_components));
 
   std::vector<types::global_dof_index> dof_indices(
-    mapping_q_eulerian.euler_dof_handler->get_fe(0).dofs_per_cell);
+    mapping_q_eulerian.euler_dof_handler->get_fe(0).n_dofs_per_cell());
   // fill shift vector for each support point using an fe_values object. make
   // sure that the fe_values variable isn't used simultaneously from different
   // threads

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -1830,7 +1830,7 @@ namespace GridTools
                                ExcInternalError());
 
                         const unsigned int n_dofs_per_face =
-                          cell->get_fe().dofs_per_face;
+                          cell->get_fe().n_dofs_per_face();
                         local_face_dof_indices.resize(n_dofs_per_face);
 
                         cell->face(f)->child(c)->get_dof_indices(
@@ -1865,7 +1865,7 @@ namespace GridTools
                     unsigned int subface = neighbor_face_no_subface_no.second;
 
                     const unsigned int n_dofs_per_face =
-                      cell->get_fe().dofs_per_face;
+                      cell->get_fe().n_dofs_per_face();
                     local_face_dof_indices.resize(n_dofs_per_face);
 
                     cell->neighbor(f)->face(face_no)->get_dof_indices(
@@ -1884,7 +1884,7 @@ namespace GridTools
                                           // original cell
                           {
                             const unsigned int n_dofs_per_face =
-                              cell->get_fe().dofs_per_face;
+                              cell->get_fe().n_dofs_per_face();
                             local_face_dof_indices.resize(n_dofs_per_face);
 
                             Assert(cell->neighbor(f)
@@ -1930,7 +1930,7 @@ namespace GridTools
                             // on line not including the vertices of the line.
                             const unsigned int n_dofs_per_line =
                               2 * cell->get_fe().n_dofs_per_vertex() +
-                              cell->get_fe().dofs_per_line;
+                              cell->get_fe().n_dofs_per_line();
                             local_line_dof_indices.resize(n_dofs_per_line);
 
                             cell->line(l)->child(c)->get_dof_indices(
@@ -1955,7 +1955,7 @@ namespace GridTools
                         // on line not including the vertices of the line.
                         const unsigned int n_dofs_per_line =
                           2 * cell->get_fe().n_dofs_per_vertex() +
-                          cell->get_fe().dofs_per_line;
+                          cell->get_fe().n_dofs_per_line();
                         local_line_dof_indices.resize(n_dofs_per_line);
 
                         parent_line->get_dof_indices(local_line_dof_indices);
@@ -1972,7 +1972,7 @@ namespace GridTools
 
                             const unsigned int n_dofs_per_line =
                               2 * cell->get_fe().n_dofs_per_vertex() +
-                              cell->get_fe().dofs_per_line;
+                              cell->get_fe().n_dofs_per_line();
                             local_line_dof_indices.resize(n_dofs_per_line);
 
                             parent_line->child(c)->get_dof_indices(

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -1789,7 +1789,8 @@ namespace GridTools
         // cells including ghost cells
         if (cell->is_artificial() == false)
           {
-            const unsigned int n_dofs_per_cell = cell->get_fe().dofs_per_cell;
+            const unsigned int n_dofs_per_cell =
+              cell->get_fe().n_dofs_per_cell();
             local_dof_indices.resize(n_dofs_per_cell);
 
             // Take care of adding cell pointer to each
@@ -1928,7 +1929,7 @@ namespace GridTools
                             // dofs_per_line returns number of dofs
                             // on line not including the vertices of the line.
                             const unsigned int n_dofs_per_line =
-                              2 * cell->get_fe().dofs_per_vertex +
+                              2 * cell->get_fe().n_dofs_per_vertex() +
                               cell->get_fe().dofs_per_line;
                             local_line_dof_indices.resize(n_dofs_per_line);
 
@@ -1953,7 +1954,7 @@ namespace GridTools
                         // dofs_per_line returns number of dofs
                         // on line not including the vertices of the line.
                         const unsigned int n_dofs_per_line =
-                          2 * cell->get_fe().dofs_per_vertex +
+                          2 * cell->get_fe().n_dofs_per_vertex() +
                           cell->get_fe().dofs_per_line;
                         local_line_dof_indices.resize(n_dofs_per_line);
 
@@ -1970,7 +1971,7 @@ namespace GridTools
                                    ExcInternalError());
 
                             const unsigned int n_dofs_per_line =
-                              2 * cell->get_fe().dofs_per_vertex +
+                              2 * cell->get_fe().n_dofs_per_vertex() +
                               cell->get_fe().dofs_per_line;
                             local_line_dof_indices.resize(n_dofs_per_line);
 

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -37,8 +37,8 @@ namespace MeshWorker
     , neighbor_cell_update_flags(update_flags)
     , face_update_flags(face_update_flags)
     , neighbor_face_update_flags(face_update_flags)
-    , local_dof_indices(fe.dofs_per_cell)
-    , neighbor_dof_indices(fe.dofs_per_cell)
+    , local_dof_indices(fe.n_dofs_per_cell())
+    , neighbor_dof_indices(fe.n_dofs_per_cell())
   {}
 
 
@@ -61,8 +61,8 @@ namespace MeshWorker
     , neighbor_cell_update_flags(neighbor_update_flags)
     , face_update_flags(face_update_flags)
     , neighbor_face_update_flags(neighbor_face_update_flags)
-    , local_dof_indices(fe.dofs_per_cell)
-    , neighbor_dof_indices(fe.dofs_per_cell)
+    , local_dof_indices(fe.n_dofs_per_cell())
+    , neighbor_dof_indices(fe.n_dofs_per_cell())
   {}
 
 
@@ -155,7 +155,7 @@ namespace MeshWorker
         *mapping, *fe, face_quadrature, face_update_flags);
 
     fe_face_values->reinit(cell, face_no);
-    local_dof_indices.resize(fe->dofs_per_cell);
+    local_dof_indices.resize(fe->n_dofs_per_cell());
     cell->get_dof_indices(local_dof_indices);
     current_fe_values = fe_face_values.get();
     return *fe_face_values;
@@ -176,7 +176,7 @@ namespace MeshWorker
           fe_subface_values = std::make_unique<FESubfaceValues<dim, spacedim>>(
             *mapping, *fe, face_quadrature, face_update_flags);
         fe_subface_values->reinit(cell, face_no, subface_no);
-        local_dof_indices.resize(fe->dofs_per_cell);
+        local_dof_indices.resize(fe->n_dofs_per_cell());
         cell->get_dof_indices(local_dof_indices);
 
         current_fe_values = fe_subface_values.get();

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -164,8 +164,9 @@ namespace MGTools
         // round.
         // TODO: This assumes that even in hp context, the dofs per face
         // coincide!
-        unsigned int increment = fe.n_dofs_per_cell() - dim * fe.dofs_per_face;
-        while (i < fe.first_line_index)
+        unsigned int increment =
+          fe.n_dofs_per_cell() - dim * fe.n_dofs_per_face();
+        while (i < fe.get_first_line_index())
           row_lengths[cell_indices[i++]] += increment;
         // From now on, if an object is
         // a cell, its dofs only couple
@@ -178,22 +179,22 @@ namespace MGTools
         // subtract adjacent faces to be
         // added in the loop below.
         increment = (dim > 1) ?
-                      fe.n_dofs_per_cell() - (dim - 1) * fe.dofs_per_face :
-                      fe.n_dofs_per_cell() -
-                        GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
-        while (i < fe.first_quad_index)
+                      fe.n_dofs_per_cell() - (dim - 1) * fe.n_dofs_per_face() :
+                      fe.n_dofs_per_cell() - GeometryInfo<dim>::faces_per_cell *
+                                               fe.n_dofs_per_face();
+        while (i < fe.get_first_quad_index())
           row_lengths[cell_indices[i++]] += increment;
 
         // Now quads in 2D and 3D
         increment = (dim > 2) ?
-                      fe.n_dofs_per_cell() - (dim - 2) * fe.dofs_per_face :
-                      fe.n_dofs_per_cell() -
-                        GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
-        while (i < fe.first_hex_index)
+                      fe.n_dofs_per_cell() - (dim - 2) * fe.n_dofs_per_face() :
+                      fe.n_dofs_per_cell() - GeometryInfo<dim>::faces_per_cell *
+                                               fe.n_dofs_per_face();
+        while (i < fe.get_first_hex_index())
           row_lengths[cell_indices[i++]] += increment;
         // Finally, cells in 3D
         increment = fe.n_dofs_per_cell() -
-                    GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
+                    GeometryInfo<dim>::faces_per_cell * fe.n_dofs_per_face();
         while (i < fe.n_dofs_per_cell())
           row_lengths[cell_indices[i++]] += increment;
 
@@ -224,7 +225,7 @@ namespace MGTools
                 for (unsigned int local_dof = 0;
                      local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
-                  row_lengths[cell_indices[local_dof]] += fe.dofs_per_face;
+                  row_lengths[cell_indices[local_dof]] += fe.n_dofs_per_face();
                 continue;
               }
 
@@ -243,7 +244,7 @@ namespace MGTools
             if (flux_coupling != DoFTools::none)
               {
                 const unsigned int dof_increment =
-                  nfe.n_dofs_per_cell() - nfe.dofs_per_face;
+                  nfe.n_dofs_per_cell() - nfe.n_dofs_per_face();
                 for (unsigned int local_dof = 0;
                      local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
@@ -271,10 +272,10 @@ namespace MGTools
             neighbor->get_mg_dof_indices(neighbor_indices);
             for (unsigned int local_dof = 0; local_dof < fe.n_dofs_per_cell();
                  ++local_dof)
-              row_lengths[cell_indices[local_dof]] += nfe.dofs_per_face;
+              row_lengths[cell_indices[local_dof]] += nfe.n_dofs_per_face();
             for (unsigned int local_dof = 0; local_dof < nfe.n_dofs_per_cell();
                  ++local_dof)
-              row_lengths[neighbor_indices[local_dof]] += fe.dofs_per_face;
+              row_lengths[neighbor_indices[local_dof]] += fe.n_dofs_per_face();
           }
       }
     user_flags_triangulation.load_user_flags(old_flags);
@@ -368,7 +369,7 @@ namespace MGTools
         // arbitrary, not the other way
         // round.
         unsigned int increment;
-        while (i < fe.first_line_index)
+        while (i < fe.get_first_line_index())
           {
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
@@ -378,7 +379,7 @@ namespace MGTools
                                             mult) != DoFTools::none)
                   {
                     increment = fe.base_element(base).n_dofs_per_cell() -
-                                dim * fe.base_element(base).dofs_per_face;
+                                dim * fe.base_element(base).n_dofs_per_face();
                     row_lengths[cell_indices[i]] += increment;
                   }
             ++i;
@@ -393,7 +394,7 @@ namespace MGTools
         // In all other cases we
         // subtract adjacent faces to be
         // added in the loop below.
-        while (i < fe.first_quad_index)
+        while (i < fe.get_first_quad_index())
           {
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
@@ -406,14 +407,14 @@ namespace MGTools
                       fe.base_element(base).n_dofs_per_cell() -
                       ((dim > 1) ? (dim - 1) :
                                    GeometryInfo<dim>::faces_per_cell) *
-                        fe.base_element(base).dofs_per_face;
+                        fe.base_element(base).n_dofs_per_face();
                     row_lengths[cell_indices[i]] += increment;
                   }
             ++i;
           }
 
         // Now quads in 2D and 3D
-        while (i < fe.first_hex_index)
+        while (i < fe.get_first_hex_index())
           {
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
@@ -426,7 +427,7 @@ namespace MGTools
                       fe.base_element(base).n_dofs_per_cell() -
                       ((dim > 2) ? (dim - 2) :
                                    GeometryInfo<dim>::faces_per_cell) *
-                        fe.base_element(base).dofs_per_face;
+                        fe.base_element(base).n_dofs_per_face();
                     row_lengths[cell_indices[i]] += increment;
                   }
             ++i;
@@ -444,7 +445,7 @@ namespace MGTools
                   {
                     increment = fe.base_element(base).n_dofs_per_cell() -
                                 GeometryInfo<dim>::faces_per_cell *
-                                  fe.base_element(base).dofs_per_face;
+                                  fe.base_element(base).n_dofs_per_face();
                     row_lengths[cell_indices[i]] += increment;
                   }
             ++i;
@@ -477,7 +478,7 @@ namespace MGTools
                 for (unsigned int local_dof = 0;
                      local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
-                  row_lengths[cell_indices[local_dof]] += fe.dofs_per_face;
+                  row_lengths[cell_indices[local_dof]] += fe.n_dofs_per_face();
                 continue;
               }
 
@@ -505,7 +506,7 @@ namespace MGTools
                     {
                       const unsigned int dof_increment =
                         nfe.base_element(base).n_dofs_per_cell() -
-                        nfe.base_element(base).dofs_per_face;
+                        nfe.base_element(base).n_dofs_per_face();
                       row_lengths[cell_indices[local_dof]] += dof_increment;
                     }
 
@@ -547,7 +548,7 @@ namespace MGTools
                         fe.system_to_component_index(local_dof).first,
                         nfe.first_block_of_base(base) + mult) != DoFTools::none)
                     row_lengths[cell_indices[local_dof]] +=
-                      nfe.base_element(base).dofs_per_face;
+                      nfe.base_element(base).n_dofs_per_face();
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
                    ++mult)
@@ -558,7 +559,7 @@ namespace MGTools
                         nfe.system_to_component_index(local_dof).first,
                         fe.first_block_of_base(base) + mult) != DoFTools::none)
                     row_lengths[neighbor_indices[local_dof]] +=
-                      fe.base_element(base).dofs_per_face;
+                      fe.base_element(base).n_dofs_per_face();
           }
       }
     user_flags_triangulation.load_user_flags(old_flags);
@@ -1327,7 +1328,7 @@ namespace MGTools
               continue;
             const FiniteElement<dim> &fe    = cell->get_fe();
             const unsigned int        level = cell->level();
-            local_dofs.resize(fe.dofs_per_face);
+            local_dofs.resize(fe.n_dofs_per_face());
 
             for (const unsigned int face_no : GeometryInfo<dim>::face_indices())
               if (cell->at_boundary(face_no) == true)
@@ -1400,7 +1401,7 @@ namespace MGTools
 
                     // get indices, physical location and boundary values of
                     // dofs on this face
-                    local_dofs.resize(fe.dofs_per_face);
+                    local_dofs.resize(fe.n_dofs_per_face());
                     face->get_mg_dof_indices(level, local_dofs);
                     if (fe_is_system)
                       {
@@ -1468,7 +1469,7 @@ namespace MGTools
     const FiniteElement<dim, spacedim> &fe = mg_dof_handler.get_fe();
 
     const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
-    const unsigned int dofs_per_face = fe.dofs_per_face;
+    const unsigned int dofs_per_face = fe.n_dofs_per_face();
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -138,7 +138,7 @@ namespace MGTools
     for (const auto &cell : dofs.cell_iterators_on_level(level))
       {
         const FiniteElement<dim> &fe = cell->get_fe();
-        cell_indices.resize(fe.dofs_per_cell);
+        cell_indices.resize(fe.n_dofs_per_cell());
         cell->get_mg_dof_indices(cell_indices);
         unsigned int i = 0;
         // First, dofs on
@@ -159,12 +159,12 @@ namespace MGTools
         // are identical. Nevertheless,
         // this will only work if
         // dofs_per_face is zero and
-        // dofs_per_vertex is
+        // n_dofs_per_vertex() is
         // arbitrary, not the other way
         // round.
         // TODO: This assumes that even in hp context, the dofs per face
         // coincide!
-        unsigned int increment = fe.dofs_per_cell - dim * fe.dofs_per_face;
+        unsigned int increment = fe.n_dofs_per_cell() - dim * fe.dofs_per_face;
         while (i < fe.first_line_index)
           row_lengths[cell_indices[i++]] += increment;
         // From now on, if an object is
@@ -178,23 +178,23 @@ namespace MGTools
         // subtract adjacent faces to be
         // added in the loop below.
         increment = (dim > 1) ?
-                      fe.dofs_per_cell - (dim - 1) * fe.dofs_per_face :
-                      fe.dofs_per_cell -
+                      fe.n_dofs_per_cell() - (dim - 1) * fe.dofs_per_face :
+                      fe.n_dofs_per_cell() -
                         GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
         while (i < fe.first_quad_index)
           row_lengths[cell_indices[i++]] += increment;
 
         // Now quads in 2D and 3D
         increment = (dim > 2) ?
-                      fe.dofs_per_cell - (dim - 2) * fe.dofs_per_face :
-                      fe.dofs_per_cell -
+                      fe.n_dofs_per_cell() - (dim - 2) * fe.dofs_per_face :
+                      fe.n_dofs_per_cell() -
                         GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
         while (i < fe.first_hex_index)
           row_lengths[cell_indices[i++]] += increment;
         // Finally, cells in 3D
-        increment = fe.dofs_per_cell -
+        increment = fe.n_dofs_per_cell() -
                     GeometryInfo<dim>::faces_per_cell * fe.dofs_per_face;
-        while (i < fe.dofs_per_cell)
+        while (i < fe.n_dofs_per_cell())
           row_lengths[cell_indices[i++]] += increment;
 
         // At this point, we have
@@ -221,7 +221,8 @@ namespace MGTools
 
             if (level_boundary)
               {
-                for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+                for (unsigned int local_dof = 0;
+                     local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
                   row_lengths[cell_indices[local_dof]] += fe.dofs_per_face;
                 continue;
@@ -242,8 +243,9 @@ namespace MGTools
             if (flux_coupling != DoFTools::none)
               {
                 const unsigned int dof_increment =
-                  nfe.dofs_per_cell - nfe.dofs_per_face;
-                for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+                  nfe.n_dofs_per_cell() - nfe.dofs_per_face;
+                for (unsigned int local_dof = 0;
+                     local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
                   row_lengths[cell_indices[local_dof]] += dof_increment;
               }
@@ -265,12 +267,12 @@ namespace MGTools
             // is refined, all the fine
             // face dofs couple with
             // the coarse one.
-            neighbor_indices.resize(nfe.dofs_per_cell);
+            neighbor_indices.resize(nfe.n_dofs_per_cell());
             neighbor->get_mg_dof_indices(neighbor_indices);
-            for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+            for (unsigned int local_dof = 0; local_dof < fe.n_dofs_per_cell();
                  ++local_dof)
               row_lengths[cell_indices[local_dof]] += nfe.dofs_per_face;
-            for (unsigned int local_dof = 0; local_dof < nfe.dofs_per_cell;
+            for (unsigned int local_dof = 0; local_dof < nfe.n_dofs_per_cell();
                  ++local_dof)
               row_lengths[neighbor_indices[local_dof]] += fe.dofs_per_face;
           }
@@ -341,7 +343,7 @@ namespace MGTools
                ExcDimensionMismatch(flux_couplings.n_cols(),
                                     fe.n_components()));
 
-        cell_indices.resize(fe.dofs_per_cell);
+        cell_indices.resize(fe.n_dofs_per_cell());
         cell->get_mg_dof_indices(cell_indices);
         unsigned int i = 0;
         // First, dofs on
@@ -362,7 +364,7 @@ namespace MGTools
         // are identical. Nevertheless,
         // this will only work if
         // dofs_per_face is zero and
-        // dofs_per_vertex is
+        // n_dofs_per_vertex() is
         // arbitrary, not the other way
         // round.
         unsigned int increment;
@@ -375,7 +377,7 @@ namespace MGTools
                                           fe.first_block_of_base(base) +
                                             mult) != DoFTools::none)
                   {
-                    increment = fe.base_element(base).dofs_per_cell -
+                    increment = fe.base_element(base).n_dofs_per_cell() -
                                 dim * fe.base_element(base).dofs_per_face;
                     row_lengths[cell_indices[i]] += increment;
                   }
@@ -401,7 +403,7 @@ namespace MGTools
                                             mult) != DoFTools::none)
                   {
                     increment =
-                      fe.base_element(base).dofs_per_cell -
+                      fe.base_element(base).n_dofs_per_cell() -
                       ((dim > 1) ? (dim - 1) :
                                    GeometryInfo<dim>::faces_per_cell) *
                         fe.base_element(base).dofs_per_face;
@@ -421,7 +423,7 @@ namespace MGTools
                                             mult) != DoFTools::none)
                   {
                     increment =
-                      fe.base_element(base).dofs_per_cell -
+                      fe.base_element(base).n_dofs_per_cell() -
                       ((dim > 2) ? (dim - 2) :
                                    GeometryInfo<dim>::faces_per_cell) *
                         fe.base_element(base).dofs_per_face;
@@ -431,7 +433,7 @@ namespace MGTools
           }
 
         // Finally, cells in 3D
-        while (i < fe.dofs_per_cell)
+        while (i < fe.n_dofs_per_cell())
           {
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
@@ -440,7 +442,7 @@ namespace MGTools
                                           fe.first_block_of_base(base) +
                                             mult) != DoFTools::none)
                   {
-                    increment = fe.base_element(base).dofs_per_cell -
+                    increment = fe.base_element(base).n_dofs_per_cell() -
                                 GeometryInfo<dim>::faces_per_cell *
                                   fe.base_element(base).dofs_per_face;
                     row_lengths[cell_indices[i]] += increment;
@@ -472,7 +474,8 @@ namespace MGTools
 
             if (level_boundary)
               {
-                for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+                for (unsigned int local_dof = 0;
+                     local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
                   row_lengths[cell_indices[local_dof]] += fe.dofs_per_face;
                 continue;
@@ -493,14 +496,15 @@ namespace MGTools
             for (unsigned int base = 0; base < nfe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < nfe.element_multiplicity(base);
                    ++mult)
-                for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+                for (unsigned int local_dof = 0;
+                     local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
                   if (couple_face[fe_index](
                         fe.system_to_block_index(local_dof).first,
                         nfe.first_block_of_base(base) + mult) != DoFTools::none)
                     {
                       const unsigned int dof_increment =
-                        nfe.base_element(base).dofs_per_cell -
+                        nfe.base_element(base).n_dofs_per_cell() -
                         nfe.base_element(base).dofs_per_face;
                       row_lengths[cell_indices[local_dof]] += dof_increment;
                     }
@@ -531,12 +535,13 @@ namespace MGTools
             // This will not work with
             // different couplings on
             // different cells.
-            neighbor_indices.resize(nfe.dofs_per_cell);
+            neighbor_indices.resize(nfe.n_dofs_per_cell());
             neighbor->get_mg_dof_indices(neighbor_indices);
             for (unsigned int base = 0; base < nfe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < nfe.element_multiplicity(base);
                    ++mult)
-                for (unsigned int local_dof = 0; local_dof < fe.dofs_per_cell;
+                for (unsigned int local_dof = 0;
+                     local_dof < fe.n_dofs_per_cell();
                      ++local_dof)
                   if (couple_cell[fe_index](
                         fe.system_to_component_index(local_dof).first,
@@ -546,7 +551,8 @@ namespace MGTools
             for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
               for (unsigned int mult = 0; mult < fe.element_multiplicity(base);
                    ++mult)
-                for (unsigned int local_dof = 0; local_dof < nfe.dofs_per_cell;
+                for (unsigned int local_dof = 0;
+                     local_dof < nfe.n_dofs_per_cell();
                      ++local_dof)
                   if (couple_cell[fe_index](
                         nfe.system_to_component_index(local_dof).first,
@@ -574,7 +580,7 @@ namespace MGTools
     Assert(sparsity.n_cols() == n_dofs,
            ExcDimensionMismatch(sparsity.n_cols(), n_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     typename DoFHandler<dim, spacedim>::cell_iterator cell = dof.begin(level),
                                                       endc = dof.end(level);
@@ -608,7 +614,7 @@ namespace MGTools
     Assert(sparsity.n_cols() == n_dofs,
            ExcDimensionMismatch(sparsity.n_cols(), n_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     typename DoFHandler<dim, spacedim>::cell_iterator cell = dof.begin(level),
@@ -690,7 +696,7 @@ namespace MGTools
     Assert(sparsity.n_cols() == fine_dofs,
            ExcDimensionMismatch(sparsity.n_cols(), fine_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     typename DoFHandler<dim, spacedim>::cell_iterator cell = dof.begin(level),
@@ -765,7 +771,7 @@ namespace MGTools
     Assert(flux_mask.n_cols() == n_comp,
            ExcDimensionMismatch(flux_mask.n_cols(), n_comp));
 
-    const unsigned int                   total_dofs = fe.dofs_per_cell;
+    const unsigned int                   total_dofs = fe.n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(total_dofs);
     std::vector<types::global_dof_index> dofs_on_other_cell(total_dofs);
     Table<2, bool>                       support_on_face(total_dofs,
@@ -956,7 +962,7 @@ namespace MGTools
     Assert(flux_mask.n_cols() == n_comp,
            ExcDimensionMismatch(flux_mask.n_cols(), n_comp));
 
-    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     std::vector<types::global_dof_index> dofs_on_other_cell(dofs_per_cell);
     Table<2, bool>                       support_on_face(dofs_per_cell,
@@ -1033,7 +1039,7 @@ namespace MGTools
     Assert(sparsity.n_cols() == n_dofs,
            ExcDimensionMismatch(sparsity.n_cols(), n_dofs));
 
-    const unsigned int dofs_per_cell = dof.get_fe().dofs_per_cell;
+    const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
     std::vector<types::global_dof_index> dofs_on_this_cell(dofs_per_cell);
     typename DoFHandler<dim, spacedim>::cell_iterator cell = dof.begin(level),
                                                       endc = dof.end(level);
@@ -1365,7 +1371,8 @@ namespace MGTools
                 if (boundary_ids.find(boundary_component) != boundary_ids.end())
                   // we want to constrain this boundary
                   {
-                    for (unsigned int i = 0; i < cell->get_fe().dofs_per_cell;
+                    for (unsigned int i = 0;
+                         i < cell->get_fe().n_dofs_per_cell();
                          ++i)
                       {
                         const ComponentMask &nonzero_component_array =
@@ -1460,7 +1467,7 @@ namespace MGTools
 
     const FiniteElement<dim, spacedim> &fe = mg_dof_handler.get_fe();
 
-    const unsigned int dofs_per_cell = fe.dofs_per_cell;
+    const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
     const unsigned int dofs_per_face = fe.dofs_per_face;
 
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -219,7 +219,7 @@ MGTransferBlockBase::build(const DoFHandler<dim, spacedim> &dof_handler)
 {
   const FiniteElement<dim> &fe            = dof_handler.get_fe();
   const unsigned int        n_blocks      = fe.n_blocks();
-  const unsigned int        dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int        dofs_per_cell = fe.n_dofs_per_cell();
   const unsigned int n_levels = dof_handler.get_triangulation().n_levels();
 
   Assert(selected.size() == n_blocks,
@@ -505,8 +505,8 @@ MGTransferBlockSelect<number>::build(
   MGTransferBlockBase::build(dof_handler);
 
   std::vector<types::global_dof_index> temp_copy_indices;
-  std::vector<types::global_dof_index> global_dof_indices(fe.dofs_per_cell);
-  std::vector<types::global_dof_index> level_dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> global_dof_indices(fe.n_dofs_per_cell());
+  std::vector<types::global_dof_index> level_dof_indices(fe.n_dofs_per_cell());
 
   for (int level = dof_handler.get_triangulation().n_levels() - 1; level >= 0;
        --level)
@@ -531,7 +531,7 @@ MGTransferBlockSelect<number>::build(
           level_cell->get_dof_indices(global_dof_indices);
           level_cell->get_mg_dof_indices(level_dof_indices);
 
-          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
             {
               const unsigned int block = fe.system_to_block_index(i).first;
               if (selected[block])
@@ -608,8 +608,8 @@ MGTransferBlock<number>::build(const DoFHandler<dim, spacedim> &dof_handler,
   MGTransferBlockBase::build(dof_handler);
 
   std::vector<std::vector<types::global_dof_index>> temp_copy_indices(n_blocks);
-  std::vector<types::global_dof_index> global_dof_indices(fe.dofs_per_cell);
-  std::vector<types::global_dof_index> level_dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> global_dof_indices(fe.n_dofs_per_cell());
+  std::vector<types::global_dof_index> level_dof_indices(fe.n_dofs_per_cell());
   for (int level = dof_handler.get_triangulation().n_levels() - 1; level >= 0;
        --level)
     {
@@ -637,7 +637,7 @@ MGTransferBlock<number>::build(const DoFHandler<dim, spacedim> &dof_handler,
           level_cell->get_dof_indices(global_dof_indices);
           level_cell->get_mg_dof_indices(level_dof_indices);
 
-          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
             {
               const unsigned int block = fe.system_to_block_index(i).first;
               if (selected[block])

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -318,7 +318,7 @@ MGTransferComponentBase::build(const DoFHandler<dim, spacedim> &mg_dof)
   const unsigned int n_components =
     *std::max_element(mg_target_component.begin(), mg_target_component.end()) +
     1;
-  const unsigned int dofs_per_cell = fe.dofs_per_cell;
+  const unsigned int dofs_per_cell = fe.n_dofs_per_cell();
   const unsigned int n_levels      = mg_dof.get_triangulation().n_levels();
 
   Assert(mg_component_mask.represents_n_components(fe.n_components()),
@@ -657,8 +657,8 @@ MGTransferSelect<number>::build(
   // use a temporary vector to create the
   // relation between global and level dofs
   std::vector<types::global_dof_index> temp_copy_indices;
-  std::vector<types::global_dof_index> global_dof_indices(fe.dofs_per_cell);
-  std::vector<types::global_dof_index> level_dof_indices(fe.dofs_per_cell);
+  std::vector<types::global_dof_index> global_dof_indices(fe.n_dofs_per_cell());
+  std::vector<types::global_dof_index> level_dof_indices(fe.n_dofs_per_cell());
   for (int level = mg_dof.get_triangulation().n_levels() - 1; level >= 0;
        --level)
     {
@@ -683,7 +683,7 @@ MGTransferSelect<number>::build(
           level_cell->get_dof_indices(global_dof_indices);
           level_cell->get_mg_dof_indices(level_dof_indices);
 
-          for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
+          for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
             {
               const unsigned int component =
                 fe.system_to_component_index(i).first;

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -602,7 +602,7 @@ namespace internal
       {
         AssertIndexRange(fe.n_dofs_per_vertex(), 2);
         renumbering[0] = 0;
-        for (unsigned int i = 0; i < fe.dofs_per_line; ++i)
+        for (unsigned int i = 0; i < fe.n_dofs_per_line(); ++i)
           renumbering[i + fe.n_dofs_per_vertex()] =
             GeometryInfo<1>::vertices_per_cell * fe.n_dofs_per_vertex() + i;
         if (fe.n_dofs_per_vertex() > 0)

--- a/source/multigrid/mg_transfer_internal.cc
+++ b/source/multigrid/mg_transfer_internal.cc
@@ -91,7 +91,7 @@ namespace internal
       IndexSet globally_relevant;
       DoFTools::extract_locally_relevant_dofs(dof_handler, globally_relevant);
 
-      const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+      const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
       std::vector<types::global_dof_index> global_dof_indices(dofs_per_cell);
       std::vector<types::global_dof_index> level_dof_indices(dofs_per_cell);
 
@@ -587,37 +587,37 @@ namespace internal
     {
       // currently, we have only FE_Q and FE_DGQ type elements implemented
       elem_info.n_components = dof_handler.get_fe().element_multiplicity(0);
-      AssertDimension(Utilities::fixed_power<dim>(fe.dofs_per_cell) *
+      AssertDimension(Utilities::fixed_power<dim>(fe.n_dofs_per_cell()) *
                         elem_info.n_components,
-                      dof_handler.get_fe().dofs_per_cell);
+                      dof_handler.get_fe().n_dofs_per_cell());
       AssertDimension(fe.degree, dof_handler.get_fe().degree);
       elem_info.fe_degree             = fe.degree;
-      elem_info.element_is_continuous = fe.dofs_per_vertex > 0;
-      Assert(fe.dofs_per_vertex < 2, ExcNotImplemented());
+      elem_info.element_is_continuous = fe.n_dofs_per_vertex() > 0;
+      Assert(fe.n_dofs_per_vertex() < 2, ExcNotImplemented());
 
       // step 1.2: get renumbering of 1D basis functions to lexicographic
-      // numbers. The distinction according to fe.dofs_per_vertex is to support
-      // both continuous and discontinuous bases.
-      std::vector<unsigned int> renumbering(fe.dofs_per_cell);
+      // numbers. The distinction according to fe.n_dofs_per_vertex() is to
+      // support both continuous and discontinuous bases.
+      std::vector<unsigned int> renumbering(fe.n_dofs_per_cell());
       {
-        AssertIndexRange(fe.dofs_per_vertex, 2);
+        AssertIndexRange(fe.n_dofs_per_vertex(), 2);
         renumbering[0] = 0;
         for (unsigned int i = 0; i < fe.dofs_per_line; ++i)
-          renumbering[i + fe.dofs_per_vertex] =
-            GeometryInfo<1>::vertices_per_cell * fe.dofs_per_vertex + i;
-        if (fe.dofs_per_vertex > 0)
-          renumbering[fe.dofs_per_cell - fe.dofs_per_vertex] =
-            fe.dofs_per_vertex;
+          renumbering[i + fe.n_dofs_per_vertex()] =
+            GeometryInfo<1>::vertices_per_cell * fe.n_dofs_per_vertex() + i;
+        if (fe.n_dofs_per_vertex() > 0)
+          renumbering[fe.n_dofs_per_cell() - fe.n_dofs_per_vertex()] =
+            fe.n_dofs_per_vertex();
       }
 
       // step 1.3: create a dummy 1D quadrature formula to extract the
       // lexicographic numbering for the elements
-      Assert(fe.dofs_per_vertex == 0 || fe.dofs_per_vertex == 1,
+      Assert(fe.n_dofs_per_vertex() == 0 || fe.n_dofs_per_vertex() == 1,
              ExcNotImplemented());
-      const unsigned int shift = fe.dofs_per_cell - fe.dofs_per_vertex;
+      const unsigned int shift = fe.n_dofs_per_cell() - fe.n_dofs_per_vertex();
       const unsigned int n_child_dofs_1d =
-        (fe.dofs_per_vertex > 0 ? (2 * fe.dofs_per_cell - 1) :
-                                  (2 * fe.dofs_per_cell));
+        (fe.n_dofs_per_vertex() > 0 ? (2 * fe.n_dofs_per_cell() - 1) :
+                                      (2 * fe.n_dofs_per_cell()));
 
       elem_info.n_child_cell_dofs =
         elem_info.n_components * Utilities::fixed_power<dim>(n_child_dofs_1d);
@@ -628,12 +628,12 @@ namespace internal
       elem_info.lexicographic_numbering = shape_info.lexicographic_numbering;
 
       // step 1.4: get the 1d prolongation matrix and combine from both children
-      elem_info.prolongation_matrix_1d.resize(fe.dofs_per_cell *
+      elem_info.prolongation_matrix_1d.resize(fe.n_dofs_per_cell() *
                                               n_child_dofs_1d);
 
       for (unsigned int c = 0; c < GeometryInfo<1>::max_children_per_cell; ++c)
-        for (unsigned int i = 0; i < fe.dofs_per_cell; ++i)
-          for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+        for (unsigned int i = 0; i < fe.n_dofs_per_cell(); ++i)
+          for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
             elem_info
               .prolongation_matrix_1d[i * n_child_dofs_1d + j + c * shift] =
               fe.get_prolongation_matrix(c)(renumbering[j], renumbering[i]);
@@ -737,7 +737,7 @@ namespace internal
         coarse_level_indices[level].resize(tria.n_raw_cells(level),
                                            numbers::invalid_unsigned_int);
       std::vector<types::global_dof_index> local_dof_indices(
-        dof_handler.get_fe().dofs_per_cell);
+        dof_handler.get_fe().n_dofs_per_cell());
       dirichlet_indices.resize(n_levels - 1);
 
       AssertDimension(target_partitioners.max_level(), n_levels - 1);
@@ -818,8 +818,8 @@ namespace internal
                       ghosted_level_dofs.push_back(local_dof_index);
 
                   add_child_indices<dim>(c,
-                                         fe->dofs_per_cell -
-                                           fe->dofs_per_vertex,
+                                         fe->n_dofs_per_cell() -
+                                           fe->n_dofs_per_vertex(),
                                          fe->degree,
                                          elem_info.lexicographic_numbering,
                                          local_dof_indices,
@@ -849,14 +849,14 @@ namespace internal
                           tria.n_cells(level);
                       parent_child_connect[level][child_index] =
                         std::make_pair(parent_index, c);
-                      AssertIndexRange(dof_handler.get_fe().dofs_per_cell,
+                      AssertIndexRange(dof_handler.get_fe().n_dofs_per_cell(),
                                        static_cast<unsigned short>(-1));
 
                       // set Dirichlet boundary conditions (as a list of
                       // constrained DoFs) for the child
                       if (mg_constrained_dofs != nullptr)
                         for (unsigned int i = 0;
-                             i < dof_handler.get_fe().dofs_per_cell;
+                             i < dof_handler.get_fe().n_dofs_per_cell();
                              ++i)
                           if (mg_constrained_dofs->is_boundary_index(
                                 level,
@@ -895,7 +895,7 @@ namespace internal
                     numbers::invalid_dof_index);
                   add_child_indices<dim>(
                     0,
-                    fe->dofs_per_cell - fe->dofs_per_vertex,
+                    fe->n_dofs_per_cell() - fe->n_dofs_per_vertex(),
                     fe->degree,
                     elem_info.lexicographic_numbering,
                     local_dof_indices,
@@ -904,7 +904,7 @@ namespace internal
                   dirichlet_indices[0].emplace_back();
                   if (mg_constrained_dofs != nullptr)
                     for (unsigned int i = 0;
-                         i < dof_handler.get_fe().dofs_per_cell;
+                         i < dof_handler.get_fe().n_dofs_per_cell();
                          ++i)
                       if (mg_constrained_dofs->is_boundary_index(
                             0,
@@ -991,7 +991,7 @@ namespace internal
       // ---------------------- 3. compute weights to make restriction additive
 
       const unsigned int n_child_dofs_1d =
-        fe->degree + 1 + fe->dofs_per_cell - fe->dofs_per_vertex;
+        fe->degree + 1 + fe->n_dofs_per_cell() - fe->n_dofs_per_vertex();
 
       // get the valence of the individual components and compute the weights as
       // the inverse of the valence

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -154,7 +154,7 @@ MGTransferPrebuilt<VectorType>::build(
 {
   const unsigned int n_levels =
     dof_handler.get_triangulation().n_global_levels();
-  const unsigned int dofs_per_cell = dof_handler.get_fe().dofs_per_cell;
+  const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();
 
   this->sizes.resize(n_levels);
   for (unsigned int l = 0; l < n_levels; ++l)

--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -231,8 +231,8 @@ namespace NonMatching
     const auto &immersed_fe = immersed_dh.get_fe();
 
     // Dof indices
-    std::vector<types::global_dof_index> dofs(immersed_fe.dofs_per_cell);
-    std::vector<types::global_dof_index> odofs(space_fe.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs(immersed_fe.n_dofs_per_cell());
+    std::vector<types::global_dof_index> odofs(space_fe.n_dofs_per_cell());
 
     // Take care of components
     const ComponentMask space_c =
@@ -275,14 +275,14 @@ namespace NonMatching
     // the version with the dof_mask, this should be uncommented.
     //
     // // Construct a dof_mask, used to distribute entries to the sparsity
-    // able< 2, bool > dof_mask(space_fe.dofs_per_cell,
-    //                          immersed_fe.dofs_per_cell);
+    // able< 2, bool > dof_mask(space_fe.n_dofs_per_cell(),
+    //                          immersed_fe.n_dofs_per_cell());
     // of_mask.fill(false);
-    // or (unsigned int i=0; i<space_fe.dofs_per_cell; ++i)
+    // or (unsigned int i=0; i<space_fe.n_dofs_per_cell(); ++i)
     //  {
     //    const auto comp_i = space_fe.system_to_component_index(i).first;
     //    if (space_gtl[comp_i] != numbers::invalid_unsigned_int)
-    //      for (unsigned int j=0; j<immersed_fe.dofs_per_cell; ++j)
+    //      for (unsigned int j=0; j<immersed_fe.n_dofs_per_cell(); ++j)
     //        {
     //          const auto comp_j =
     //          immersed_fe.system_to_component_index(j).first; if
@@ -416,8 +416,8 @@ namespace NonMatching
     const auto &immersed_fe = immersed_dh.get_fe();
 
     // Dof indices
-    std::vector<types::global_dof_index> dofs(immersed_fe.dofs_per_cell);
-    std::vector<types::global_dof_index> odofs(space_fe.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs(immersed_fe.n_dofs_per_cell());
+    std::vector<types::global_dof_index> odofs(space_fe.n_dofs_per_cell());
 
     // Take care of components
     const ComponentMask space_c =
@@ -446,7 +446,8 @@ namespace NonMatching
         immersed_gtl[i] = j++;
 
     FullMatrix<typename Matrix::value_type> cell_matrix(
-      space_dh.get_fe().dofs_per_cell, immersed_dh.get_fe().dofs_per_cell);
+      space_dh.get_fe().n_dofs_per_cell(),
+      immersed_dh.get_fe().n_dofs_per_cell());
 
     FEValues<dim1, spacedim> fe_v(immersed_mapping,
                                   immersed_dh.get_fe(),
@@ -576,14 +577,15 @@ namespace NonMatching
                 // Reset the matrices.
                 cell_matrix = typename Matrix::value_type();
 
-                for (unsigned int i = 0; i < space_dh.get_fe().dofs_per_cell;
+                for (unsigned int i = 0;
+                     i < space_dh.get_fe().n_dofs_per_cell();
                      ++i)
                   {
                     const auto comp_i =
                       space_dh.get_fe().system_to_component_index(i).first;
                     if (space_gtl[comp_i] != numbers::invalid_unsigned_int)
                       for (unsigned int j = 0;
-                           j < immersed_dh.get_fe().dofs_per_cell;
+                           j < immersed_dh.get_fe().n_dofs_per_cell();
                            ++j)
                         {
                           const auto comp_j = immersed_dh.get_fe()
@@ -676,8 +678,8 @@ namespace NonMatching
     const auto &fe1 = dh1.get_fe();
 
     // Dof indices
-    std::vector<types::global_dof_index> dofs0(fe0.dofs_per_cell);
-    std::vector<types::global_dof_index> dofs1(fe1.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs0(fe0.n_dofs_per_cell());
+    std::vector<types::global_dof_index> dofs1(fe1.n_dofs_per_cell());
 
     if (outer_loop_on_zero)
       {
@@ -829,12 +831,12 @@ namespace NonMatching
                                     update_quadrature_points);
 
     // Dof indices
-    std::vector<types::global_dof_index> dofs0(fe0.dofs_per_cell);
-    std::vector<types::global_dof_index> dofs1(fe1.dofs_per_cell);
+    std::vector<types::global_dof_index> dofs0(fe0.n_dofs_per_cell());
+    std::vector<types::global_dof_index> dofs1(fe1.n_dofs_per_cell());
 
     // Local Matrix
-    FullMatrix<typename Matrix::value_type> cell_matrix(fe0.dofs_per_cell,
-                                                        fe1.dofs_per_cell);
+    FullMatrix<typename Matrix::value_type> cell_matrix(fe0.n_dofs_per_cell(),
+                                                        fe1.n_dofs_per_cell());
 
     // Global to local indices
     const auto p =
@@ -851,7 +853,7 @@ namespace NonMatching
         {
           kernel.set_center(fev0.quadrature_point(q0));
           kernel.value_list(fev1.get_quadrature_points(), kernel_values);
-          for (unsigned int j = 0; j < fe1.dofs_per_cell; ++j)
+          for (unsigned int j = 0; j < fe1.n_dofs_per_cell(); ++j)
             {
               const auto comp_j = fe1.system_to_component_index(j).first;
 
@@ -866,7 +868,7 @@ namespace NonMatching
               // Now compute the main integral with the sum over q1 already
               // completed - this gives a cubic complexity as usual rather
               // than a quartic one with naive loops
-              for (unsigned int i = 0; i < fe0.dofs_per_cell; ++i)
+              for (unsigned int i = 0; i < fe0.n_dofs_per_cell(); ++i)
                 {
                   const auto comp_i = fe0.system_to_component_index(i).first;
                   if (gtl0[comp_i] != numbers::invalid_unsigned_int &&

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -270,7 +270,7 @@ PointValueHistory<dim>::add_point(const Point<dim> &location)
 
 
   std::vector<types::global_dof_index> local_dof_indices(
-    dof_handler->get_fe().dofs_per_cell);
+    dof_handler->get_fe().n_dofs_per_cell());
   std::vector<types::global_dof_index> new_solution_indices;
   current_cell->get_dof_indices(local_dof_indices);
   // there is an implicit assumption here
@@ -419,7 +419,7 @@ PointValueHistory<dim>::add_points(const std::vector<Point<dim>> &locations)
     }
 
   std::vector<types::global_dof_index> local_dof_indices(
-    dof_handler->get_fe().dofs_per_cell);
+    dof_handler->get_fe().n_dofs_per_cell());
   for (unsigned int point = 0; point < locations.size(); point++)
     {
       current_cell[point]->get_dof_indices(local_dof_indices);

--- a/source/numerics/smoothness_estimator.cc
+++ b/source/numerics/smoothness_estimator.cc
@@ -128,7 +128,7 @@ namespace SmoothnessEstimator
                   cell->active_fe_index());
                 resize(expansion_coefficients, n_modes);
 
-                local_dof_values.reinit(cell->get_fe().dofs_per_cell);
+                local_dof_values.reinit(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_values(solution, local_dof_values);
 
                 fe_legendre.calculate(local_dof_values,
@@ -229,7 +229,7 @@ namespace SmoothnessEstimator
                 // at least N=pe+1
                 AssertIndexRange(pe, n_modes);
 
-                local_dof_values.reinit(cell->get_fe().dofs_per_cell);
+                local_dof_values.reinit(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_values(solution, local_dof_values);
 
                 fe_legendre.calculate(local_dof_values,
@@ -396,7 +396,7 @@ namespace SmoothnessEstimator
                 // degrees of freedom and then need to compute the series
                 // expansion by multiplying this vector with the matrix ${\cal
                 // F}$ corresponding to this finite element.
-                local_dof_values.reinit(cell->get_fe().dofs_per_cell);
+                local_dof_values.reinit(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_values(solution, local_dof_values);
 
                 fe_fourier.calculate(local_dof_values,
@@ -510,7 +510,7 @@ namespace SmoothnessEstimator
                 // at least N=pe+1
                 AssertIndexRange(pe, n_modes);
 
-                local_dof_values.reinit(cell->get_fe().dofs_per_cell);
+                local_dof_values.reinit(cell->get_fe().n_dofs_per_cell());
                 cell->get_dof_values(solution, local_dof_values);
 
                 fe_fourier.calculate(local_dof_values,

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -106,7 +106,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_for_pure_refinement()
 
   for (unsigned int i = 0; cell != endc; ++cell, ++i)
     {
-      indices_on_cell[i].resize(cell->get_fe().dofs_per_cell);
+      indices_on_cell[i].resize(cell->get_fe().n_dofs_per_cell());
       // on each cell store the indices of the
       // dofs. after refining we get the values
       // on the children by taking these
@@ -161,7 +161,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::refine_interpolate(
           const unsigned int this_fe_index =
             pointerstruct->second.active_fe_index;
           const unsigned int dofs_per_cell =
-            cell->get_dof_handler().get_fe(this_fe_index).dofs_per_cell;
+            cell->get_dof_handler().get_fe(this_fe_index).n_dofs_per_cell();
           local_values.reinit(dofs_per_cell, true);
 
           // make sure that the size of the stored indices is the same as
@@ -210,7 +210,8 @@ namespace internal
       for (unsigned int j = 0; j < fe.size(); ++j)
         if (i != j)
           {
-            matrices(i, j).reinit(fe[i].dofs_per_cell, fe[j].dofs_per_cell);
+            matrices(i, j).reinit(fe[i].n_dofs_per_cell(),
+                                  fe[j].n_dofs_per_cell());
 
             // see if we can get the interpolation matrices for this
             // combination of elements. if not, reset the matrix sizes to zero
@@ -246,8 +247,8 @@ namespace internal
     restriction_is_additive.resize(fe.size());
     for (unsigned int f = 0; f < fe.size(); ++f)
       {
-        restriction_is_additive[f].resize(fe[f].dofs_per_cell);
-        for (unsigned int i = 0; i < fe[f].dofs_per_cell; ++i)
+        restriction_is_additive[f].resize(fe[f].n_dofs_per_cell());
+        for (unsigned int i = 0; i < fe[f].n_dofs_per_cell(); ++i)
           restriction_is_additive[f][i] = fe[f].restriction_is_additive(i);
       }
   }
@@ -334,7 +335,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
       // CASE 1: active cell that remains as it is
       if (cell->is_active() && !cell->coarsen_flag_set())
         {
-          const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+          const unsigned int dofs_per_cell = cell->get_fe().n_dofs_per_cell();
           indices_on_cell[n_sr].resize(dofs_per_cell);
           // cell will not be coarsened,
           // so we get away by storing the
@@ -377,7 +378,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
                    dim>::ExcNoDominatedFiniteElementAmongstChildren());
 
           const unsigned int dofs_per_cell =
-            dof_handler->get_fe(target_fe_index).dofs_per_cell;
+            dof_handler->get_fe(target_fe_index).n_dofs_per_cell();
 
           std::vector<Vector<typename VectorType::value_type>>(
             in_size, Vector<typename VectorType::value_type>(dofs_per_cell))
@@ -492,7 +493,8 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::interpolate(
               Assert(!cell->has_children(), ExcInternalError());
               Assert(indexptr == nullptr, ExcInternalError());
 
-              const unsigned int dofs_per_cell = cell->get_fe().dofs_per_cell;
+              const unsigned int dofs_per_cell =
+                cell->get_fe().n_dofs_per_cell();
               dofs.resize(dofs_per_cell);
               // get the local
               // indices

--- a/source/particles/utilities.cc
+++ b/source/particles/utilities.cc
@@ -63,9 +63,9 @@ namespace Particles
       // the version with the dof_mask, this should be uncommented.
       // // Construct a dof_mask, used to distribute entries to the sparsity
       // Table<2, bool> dof_mask(max_particles_per_cell * n_comps,
-      //                         fe.dofs_per_cell);
+      //                         fe.n_dofs_per_cell());
       // dof_mask.fill(false);
-      // for (unsigned int i = 0; i < space_fe.dofs_per_cell; ++i)
+      // for (unsigned int i = 0; i < space_fe.n_dofs_per_cell(); ++i)
       //   {
       //     const auto comp_i = space_fe.system_to_component_index(i).first;
       //     if (space_gtl[comp_i] != numbers::invalid_unsigned_int)
@@ -73,7 +73,7 @@ namespace Particles
       //         dof_mask(i, j * n_comps + space_gtl[comp_i]) = true;
       //   }
 
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      std::vector<types::global_dof_index> dof_indices(fe.n_dofs_per_cell());
       std::vector<types::particle_index>   particle_indices(
         max_particles_per_cell * n_comps);
 
@@ -91,7 +91,7 @@ namespace Particles
           for (unsigned int i = 0; particle != pic.end(); ++particle, ++i)
             {
               const auto p_id = particle->get_id();
-              for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+              for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
                 {
                   const auto comp_j =
                     space_gtl[fe.system_to_component_index(j).first];
@@ -154,9 +154,9 @@ namespace Particles
       // the version with the dof_mask, this should be uncommented.
       // // Construct a dof_mask, used to distribute entries to the sparsity
       // Table<2, bool> dof_mask(max_particles_per_cell * n_comps,
-      //                         fe.dofs_per_cell);
+      //                         fe.n_dofs_per_cell());
       // dof_mask.fill(false);
-      // for (unsigned int i = 0; i < space_fe.dofs_per_cell; ++i)
+      // for (unsigned int i = 0; i < space_fe.n_dofs_per_cell(); ++i)
       //   {
       //     const auto comp_i = space_fe.system_to_component_index(i).first;
       //     if (space_gtl[comp_i] != numbers::invalid_unsigned_int)
@@ -164,12 +164,12 @@ namespace Particles
       //         dof_mask(i, j * n_comps + space_gtl[comp_i]) = true;
       //   }
 
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
+      std::vector<types::global_dof_index> dof_indices(fe.n_dofs_per_cell());
       std::vector<types::particle_index>   particle_indices(
         max_particles_per_cell * n_comps);
 
       FullMatrix<typename MatrixType::value_type> local_matrix(
-        max_particles_per_cell * n_comps, fe.dofs_per_cell);
+        max_particles_per_cell * n_comps, fe.n_dofs_per_cell());
 
       auto particle = particle_handler.begin();
       while (particle != particle_handler.end())
@@ -181,7 +181,7 @@ namespace Particles
           const auto pic         = particle_handler.particles_in_cell(cell);
           const auto n_particles = particle_handler.n_particles_in_cell(cell);
           particle_indices.resize(n_particles * n_comps);
-          local_matrix.reinit({n_particles * n_comps, fe.dofs_per_cell});
+          local_matrix.reinit({n_particles * n_comps, fe.n_dofs_per_cell()});
           Assert(pic.begin() == particle, ExcInternalError());
           for (unsigned int i = 0; particle != pic.end(); ++particle, ++i)
             {
@@ -192,7 +192,7 @@ namespace Particles
                 particle_indices[i * n_comps + d] =
                   particle->get_id() * n_comps + d;
 
-              for (unsigned int j = 0; j < fe.dofs_per_cell; ++j)
+              for (unsigned int j = 0; j < fe.n_dofs_per_cell(); ++j)
                 {
                   const auto comp_j =
                     space_gtl[fe.system_to_component_index(j).first];


### PR DESCRIPTION
... and introduce `FiniteElementData::get_first_*`.

They key aspect is that internally the methods are used (and not the fields) such that asserts can be introduced depending on the reference cell type. 