### PR TITLE
Fix compiler warnings for old clang

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -162,7 +162,7 @@ namespace ReferenceCell
 
           (void)vertex;
 
-          return {0u, 0u};
+          return {{0u, 0u}};
         }
 
         /**
@@ -175,7 +175,7 @@ namespace ReferenceCell
 
           (void)line;
 
-          return {0, 0};
+          return {{0, 0}};
         }
 
         /**


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?type=1&buildid=8497.