### PR TITLE
Remove deprecated MGConstrainedDoFs::initialize overload

### DIFF
--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -70,23 +70,6 @@ public:
   initialize(const DoFHandler<dim, spacedim> &dof);
 
   /**
-   * Fill the internal data structures with values extracted from the dof
-   * handler object and apply the boundary values provided.
-   *
-   * This function internally calls the initialize() function above and the
-   * constrains degrees on the external boundary of the domain by calling
-   * MGTools::make_boundary_list() with the given second and third argument.
-   *
-   * @deprecated Use initialize() followed by make_zero_boundary_constraints() instead
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  initialize(const DoFHandler<dim, spacedim> &dof,
-             const std::map<types::boundary_id, const Function<spacedim> *>
-               &                  function_map,
-             const ComponentMask &component_mask = ComponentMask());
-
-  /**
    * Fill the internal data structures with information
    * about Dirichlet boundary dofs.
    *
@@ -325,27 +308,6 @@ MGConstrainedDoFs::initialize(const DoFHandler<dim, spacedim> &dof)
   MGTools::extract_inner_interface_dofs(dof, refinement_edge_indices);
 }
 
-
-template <int dim, int spacedim>
-inline void
-MGConstrainedDoFs::initialize(
-  const DoFHandler<dim, spacedim> &                               dof,
-  const std::map<types::boundary_id, const Function<spacedim> *> &function_map,
-  const ComponentMask &component_mask)
-{
-  initialize(dof);
-
-  // allocate an IndexSet for each global level. Contents will be
-  // overwritten inside make_boundary_list.
-  const unsigned int n_levels = dof.get_triangulation().n_global_levels();
-  // At this point boundary_indices is empty.
-  boundary_indices.resize(n_levels);
-
-  MGTools::make_boundary_list(dof,
-                              function_map,
-                              boundary_indices,
-                              component_mask);
-}
 
 
 template <int dim, int spacedim>

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -593,11 +593,9 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
     }
   mg_smoother.initialize(mg_matrices, smoother_data);
 
-  MGConstrainedDoFs                                   mg_constrained_dofs;
-  Functions::ZeroFunction<dim>                        zero_function;
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  MGConstrainedDoFs mg_constrained_dofs;
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MGTransferMF<dim, LevelMatrixType> mg_transfer(mg_matrices,
                                                  mg_constrained_dofs);

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -500,11 +500,9 @@ do_test(const DoFHandler<dim> &dof, const bool also_test_parallel = false)
     }
   mg_smoother.initialize(mg_matrices, smoother_data);
 
-  MGConstrainedDoFs                                   mg_constrained_dofs;
-  Functions::ZeroFunction<dim>                        zero_function;
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  MGConstrainedDoFs mg_constrained_dofs;
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MGTransferMF<dim, LevelMatrixType> mg_transfer(mg_matrices,
                                                  mg_constrained_dofs);

--- a/tests/matrix_free/parallel_multigrid_02.cc
+++ b/tests/matrix_free/parallel_multigrid_02.cc
@@ -116,7 +116,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_01.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_01.cc
@@ -517,7 +517,8 @@ do_test(const DoFHandler<dim> &dof)
   Functions::ZeroFunction<dim>                        zero_function;
   std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim>                                          mapping(fe_degree + 1);
   LaplaceOperator<dim, fe_degree, n_q_points_1d, number> fine_matrix;

--- a/tests/matrix_free/parallel_multigrid_adaptive_02.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_02.cc
@@ -154,7 +154,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_03.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_03.cc
@@ -525,7 +525,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   Functions::ZeroFunction<dim>                        zero_function;
   std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim>                                          mapping(fe_degree + 1);
   LaplaceOperator<dim, fe_degree, n_q_points_1d, double> fine_matrix;

--- a/tests/matrix_free/parallel_multigrid_adaptive_04.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_04.cc
@@ -154,7 +154,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_05.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_05.cc
@@ -522,7 +522,8 @@ do_test(const DoFHandler<dim> &dof, const bool threaded)
   Functions::ZeroFunction<dim>                        zero_function;
   std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
   dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim>                                          mapping(fe_degree + 1);
   LaplaceOperator<dim, fe_degree, n_q_points_1d, double> fine_matrix;

--- a/tests/matrix_free/parallel_multigrid_adaptive_06.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06.cc
@@ -239,7 +239,8 @@ do_test(const DoFHandler<dim> &dof, const unsigned int nb)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_06ref.cc
@@ -155,7 +155,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_07.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_07.cc
@@ -316,7 +316,10 @@ do_test(const std::vector<const DoFHandler<dim> *> &dof)
   // level constraints:
   std::vector<MGConstrainedDoFs> mg_constrained_dofs(dof.size());
   for (unsigned int i = 0; i < dof.size(); ++i)
-    mg_constrained_dofs[i].initialize(*dof[i], dirichlet_boundary);
+    {
+      mg_constrained_dofs[i].initialize(*dof[i]);
+      mg_constrained_dofs[i].make_zero_boundary_constraints(*dof[i], {0});
+    }
 
   // set up multigrid in analogy to step-37
   typedef BlockLaplace<dim,

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -236,7 +236,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // level constraints:
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MappingQ<dim> mapping(fe_degree + 1);
 

--- a/tests/matrix_free/parallel_multigrid_fullydistributed.cc
+++ b/tests/matrix_free/parallel_multigrid_fullydistributed.cc
@@ -377,11 +377,9 @@ do_test(const DoFHandler<dim> &dof)
       mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
     }
 
-  MGConstrainedDoFs                                   mg_constrained_dofs;
-  Functions::ZeroFunction<dim>                        zero_function;
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  MGConstrainedDoFs mg_constrained_dofs;
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MGTransferPrebuiltMF<dim, LevelMatrixType> mg_transfer(mg_matrices,
                                                          mg_constrained_dofs);

--- a/tests/matrix_free/parallel_multigrid_mf.cc
+++ b/tests/matrix_free/parallel_multigrid_mf.cc
@@ -373,11 +373,9 @@ do_test(const DoFHandler<dim> &dof)
       mg_matrices[level].initialize(mapping, dof, dirichlet_boundaries, level);
     }
 
-  MGConstrainedDoFs                                   mg_constrained_dofs;
-  Functions::ZeroFunction<dim>                        zero_function;
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  dirichlet_boundary[0] = &zero_function;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  MGConstrainedDoFs mg_constrained_dofs;
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   MGTransferPrebuiltMF<dim, LevelMatrixType> mg_transfer(mg_matrices,
                                                          mg_constrained_dofs);

--- a/tests/matrix_free/parallel_multigrid_mf_02.cc
+++ b/tests/matrix_free/parallel_multigrid_mf_02.cc
@@ -135,7 +135,8 @@ do_test(const DoFHandler<dim> &dof)
 
   // set up multigrid in analogy to step-37
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(dof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dof);
+  mg_constrained_dofs.make_zero_boundary_constraints(dof, {0});
 
   typedef MatrixFreeOperators::LaplaceOperator<
     dim,

--- a/tests/mpi/multigrid_adaptive.cc
+++ b/tests/mpi/multigrid_adaptive.cc
@@ -209,7 +209,8 @@ namespace Step50
                          true);
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/mpi/multigrid_uniform.cc
+++ b/tests/mpi/multigrid_uniform.cc
@@ -209,7 +209,8 @@ namespace Step50
                          true);
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -124,20 +124,16 @@ check_fe(FiniteElement<dim> &fe)
         cell->update_cell_dof_indices_cache();
       }
 
-    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-    dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-    mg_constrained_dofs_ref.initialize(dofhref, dirichlet_boundary);
+    mg_constrained_dofs_ref.initialize(dofhref);
+    mg_constrained_dofs_ref.make_zero_boundary_constraints(dofhref, {0});
   }
 
 
 
   MGConstrainedDoFs mg_constrained_dofs;
 
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-  dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-  mg_constrained_dofs.initialize(dofh, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dofh);
+  mg_constrained_dofs.make_zero_boundary_constraints(dofh, {0});
 
   const unsigned int n_levels = tr.n_global_levels();
   for (unsigned int level = 0; level < n_levels; ++level)

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -185,20 +185,15 @@ check_fe(FiniteElement<dim> &fe)
         cell->update_cell_dof_indices_cache();
       }
 
-    std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-    Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-    dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-    mg_constrained_dofs_ref.initialize(dofhref, dirichlet_boundary);
+    mg_constrained_dofs_ref.initialize(dofhref);
+    mg_constrained_dofs_ref.make_zero_boundary_constraints(dofhref, {0});
   }
 
 
 
   MGConstrainedDoFs mg_constrained_dofs;
-
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-  dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-  mg_constrained_dofs.initialize(dofh, dirichlet_boundary);
+  mg_constrained_dofs.initialize(dofh);
+  mg_constrained_dofs.make_zero_boundary_constraints(dofh, {0});
 
   const unsigned int n_levels = tr.n_global_levels();
   for (unsigned int level = 0; level < n_levels; ++level)

--- a/tests/multigrid/events_01.cc
+++ b/tests/multigrid/events_01.cc
@@ -170,7 +170,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/multigrid/mg_coarse_01.cc
+++ b/tests/multigrid/mg_coarse_01.cc
@@ -227,7 +227,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/multigrid/mg_output_dirichlet.cc
+++ b/tests/multigrid/mg_output_dirichlet.cc
@@ -204,10 +204,6 @@ check_simple(const FiniteElement<dim> &fe)
 
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1, 1);
-  std::map<types::boundary_id, const Function<dim> *>
-                               dirichlet_boundary_functions;
-  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-  dirichlet_boundary_functions[0] = &homogeneous_dirichlet_bc;
 
   tr.refine_global(1);
   refine_mesh(tr);
@@ -234,11 +230,13 @@ check_simple(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mgdof_renumbered, level, block_component);
 
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mgdof, dirichlet_boundary_functions);
+  mg_constrained_dofs.initialize(mgdof);
+  mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
   MGConstrainedDoFs mg_constrained_dofs_renumbered;
-  mg_constrained_dofs_renumbered.initialize(mgdof_renumbered,
-                                            dirichlet_boundary_functions);
+  mg_constrained_dofs_renumbered.initialize(mgdof_renumbered);
+  mg_constrained_dofs_renumbered.make_zero_boundary_constraints(
+    mgdof_renumbered, {0});
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
   transfer.build(mgdof);

--- a/tests/multigrid/mg_output_neumann.cc
+++ b/tests/multigrid/mg_output_neumann.cc
@@ -204,8 +204,6 @@ check_simple(const FiniteElement<dim> &fe)
 
   Triangulation<dim> tr(Triangulation<dim>::limit_level_difference_at_vertices);
   GridGenerator::hyper_cube(tr, -1, 1);
-  std::map<types::boundary_id, const Function<dim> *>
-    dirichlet_boundary_functions;
 
   tr.refine_global(1);
   refine_mesh(tr);
@@ -232,11 +230,10 @@ check_simple(const FiniteElement<dim> &fe)
     DoFRenumbering::component_wise(mgdof_renumbered, level, block_component);
 
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mgdof, dirichlet_boundary_functions);
+  mg_constrained_dofs.initialize(mgdof);
 
   MGConstrainedDoFs mg_constrained_dofs_renumbered;
-  mg_constrained_dofs_renumbered.initialize(mgdof_renumbered,
-                                            dirichlet_boundary_functions);
+  mg_constrained_dofs_renumbered.initialize(mgdof_renumbered);
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
   transfer.build(mgdof);

--- a/tests/multigrid/mg_renumbered_01.cc
+++ b/tests/multigrid/mg_renumbered_01.cc
@@ -339,10 +339,6 @@ template <int dim>
 void
 LaplaceProblem<dim>::test()
 {
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
-  dirichlet_boundary[0] = &dirichlet_bc;
-
   const unsigned int min_l = mg_matrices.min_level();
   const unsigned int max_l = mg_matrices.max_level();
   for (unsigned int l = min_l; l < max_l; ++l)
@@ -352,10 +348,12 @@ LaplaceProblem<dim>::test()
     }
 
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   MGConstrainedDoFs mg_constrained_dofs_renumbered;
-  mg_constrained_dofs_renumbered.initialize(mg_dof_handler_renumbered,
-                                            dirichlet_boundary);
+  mg_constrained_dofs_renumbered.initialize(mg_dof_handler_renumbered);
+  mg_constrained_dofs_renumbered.make_zero_boundary_constraints(
+    mg_dof_handler_renumbered, {0});
 
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
   mg_transfer.build(mg_dof_handler);

--- a/tests/multigrid/mg_renumbered_03.cc
+++ b/tests/multigrid/mg_renumbered_03.cc
@@ -348,15 +348,13 @@ template <int dim>
 void
 LaplaceProblem<dim>::test()
 {
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
-  dirichlet_boundary[0] = &dirichlet_bc;
-
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   MGConstrainedDoFs mg_constrained_dofs_renumbered;
-  mg_constrained_dofs_renumbered.initialize(mg_dof_handler_renumbered,
-                                            dirichlet_boundary);
+  mg_constrained_dofs_renumbered.initialize(mg_dof_handler_renumbered);
+  mg_constrained_dofs_renumbered.make_zero_boundary_constraints(
+    mg_dof_handler_renumbered, {0});
 
   MGTransferPrebuilt<Vector<double>> mg_transfer(mg_constrained_dofs);
   mg_transfer.build(mg_dof_handler);

--- a/tests/multigrid/step-16-02.cc
+++ b/tests/multigrid/step-16-02.cc
@@ -268,7 +268,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_in.resize(0, n_levels - 1);

--- a/tests/multigrid/step-16-03.cc
+++ b/tests/multigrid/step-16-03.cc
@@ -187,7 +187,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels - 1);

--- a/tests/multigrid/step-16-04.cc
+++ b/tests/multigrid/step-16-04.cc
@@ -191,7 +191,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels - 1);

--- a/tests/multigrid/step-16-05.cc
+++ b/tests/multigrid/step-16-05.cc
@@ -192,7 +192,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels - 1);

--- a/tests/multigrid/step-16-06.cc
+++ b/tests/multigrid/step-16-06.cc
@@ -192,7 +192,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(min_level, n_levels - 1);

--- a/tests/multigrid/step-16-07.cc
+++ b/tests/multigrid/step-16-07.cc
@@ -193,7 +193,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(0, n_levels - 1);

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -221,7 +221,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
 
     const unsigned int n_levels = triangulation.n_global_levels();

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -221,8 +221,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
-
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -221,7 +221,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
 
     const unsigned int n_levels = triangulation.n_global_levels();

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -191,7 +191,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(0, n_levels - 1);

--- a/tests/multigrid/step-16-bdry1.cc
+++ b/tests/multigrid/step-16-bdry1.cc
@@ -269,7 +269,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_in.resize(0, n_levels - 1);

--- a/tests/multigrid/step-16.cc
+++ b/tests/multigrid/step-16.cc
@@ -193,7 +193,8 @@ LaplaceProblem<dim>::setup_system()
   system_matrix.reinit(sparsity_pattern);
 
   mg_constrained_dofs.clear();
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
   const unsigned int n_levels = triangulation.n_levels();
 
   mg_interface_matrices.resize(0, n_levels - 1);

--- a/tests/multigrid/step-50_01.cc
+++ b/tests/multigrid/step-50_01.cc
@@ -224,7 +224,8 @@ namespace Step50
 
 
     mg_constrained_dofs.clear();
-    mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+    mg_constrained_dofs.initialize(mg_dof_handler);
+    mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {0});
 
     const unsigned int n_levels = triangulation.n_global_levels();
 

--- a/tests/multigrid/transfer_05.cc
+++ b/tests/multigrid/transfer_05.cc
@@ -105,11 +105,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference non-block
       MGTransferMatrixFree<dim, Number> transfer_ref(mg_constrained_dofs);

--- a/tests/multigrid/transfer_06.cc
+++ b/tests/multigrid/transfer_06.cc
@@ -118,12 +118,12 @@ check(const unsigned int fe_degree)
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 
       std::vector<MGConstrainedDoFs> mg_constrained_dofs_vector(2);
-      Functions::ZeroFunction<dim>   zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
       for (unsigned int i = 0; i < mgdof_ptr.size(); ++i)
-        mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i],
-                                                 dirichlet_boundary);
+        {
+          mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i]);
+          mg_constrained_dofs_vector[i].make_zero_boundary_constraints(
+            *mgdof_ptr[i], {0});
+        }
 
       // build reference non-block
       std::vector<MGTransferMatrixFree<dim, Number>> transfer_ref;

--- a/tests/multigrid/transfer_matrix_free_01.cc
+++ b/tests/multigrid/transfer_matrix_free_01.cc
@@ -67,11 +67,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02.cc
@@ -96,11 +96,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_02_block.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block.cc
@@ -100,11 +100,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference
       MGTransferMatrixFree<dim, Number> transfer_ref(mg_constrained_dofs);

--- a/tests/multigrid/transfer_matrix_free_02_block_02.cc
+++ b/tests/multigrid/transfer_matrix_free_02_block_02.cc
@@ -112,12 +112,12 @@ check(const unsigned int fe_degree)
       const std::vector<const DoFHandler<dim> *> mgdof_ptr{&mgdof_1, &mgdof_2};
 
       std::vector<MGConstrainedDoFs> mg_constrained_dofs_vector(2);
-      Functions::ZeroFunction<dim>   zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
       for (unsigned int i = 0; i < mgdof_ptr.size(); ++i)
-        mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i],
-                                                 dirichlet_boundary);
+        {
+          mg_constrained_dofs_vector[i].initialize(*mgdof_ptr[i]);
+          mg_constrained_dofs_vector[i].make_zero_boundary_constraints(
+            *mgdof_ptr[i], {0});
+        }
 
       // build reference
       std::vector<MGTransferMatrixFree<dim, Number>> transfer_ref;

--- a/tests/multigrid/transfer_matrix_free_03.cc
+++ b/tests/multigrid/transfer_matrix_free_03.cc
@@ -65,11 +65,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_matrix_free_06.cc
+++ b/tests/multigrid/transfer_matrix_free_06.cc
@@ -98,11 +98,9 @@ check(const unsigned int fe_degree)
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       // build reference
       MGTransferPrebuilt<LinearAlgebra::distributed::Vector<double>>

--- a/tests/multigrid/transfer_prebuilt_03.cc
+++ b/tests/multigrid/transfer_prebuilt_03.cc
@@ -63,12 +63,9 @@ check_simple(const FiniteElement<dim> &fe)
   mgdof.distribute_dofs(fe);
   mgdof.distribute_mg_dofs();
 
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> homogeneous_dirichlet_bc(1);
-  dirichlet_boundary[0] = &homogeneous_dirichlet_bc;
-
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mgdof);
+  mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
   transfer.build(mgdof);

--- a/tests/multigrid/transfer_prebuilt_04.cc
+++ b/tests/multigrid/transfer_prebuilt_04.cc
@@ -65,11 +65,9 @@ check()
       mgdof.distribute_dofs(fe);
       mgdof.distribute_mg_dofs();
 
-      MGConstrainedDoFs                                   mg_constrained_dofs;
-      Functions::ZeroFunction<dim>                        zero_function;
-      std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-      dirichlet_boundary[0] = &zero_function;
-      mg_constrained_dofs.initialize(mgdof, dirichlet_boundary);
+      MGConstrainedDoFs mg_constrained_dofs;
+      mg_constrained_dofs.initialize(mgdof);
+      mg_constrained_dofs.make_zero_boundary_constraints(mgdof, {0});
 
       unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 

--- a/tests/multigrid/transfer_system_adaptive_02.cc
+++ b/tests/multigrid/transfer_system_adaptive_02.cc
@@ -151,13 +151,9 @@ check(const FiniteElement<dim> &fe)
   for (unsigned int level = 0; level < tr.n_levels(); ++level)
     DoFRenumbering::component_wise(mg_dof_handler, level);
 
-  std::vector<std::set<unsigned int>> boundary_indices(tr.n_levels());
-  std::map<types::boundary_id, const Function<dim> *> dirichlet_boundary;
-  Functions::ZeroFunction<dim> dirichlet_bc(fe.n_components());
-  dirichlet_boundary[3] = &dirichlet_bc;
-
   MGConstrainedDoFs mg_constrained_dofs;
-  mg_constrained_dofs.initialize(mg_dof_handler, dirichlet_boundary);
+  mg_constrained_dofs.initialize(mg_dof_handler);
+  mg_constrained_dofs.make_zero_boundary_constraints(mg_dof_handler, {3});
 
   MGTransferPrebuilt<Vector<double>> transfer(mg_constrained_dofs);
   transfer.build(mg_dof_handler);


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/2847.