### PR TITLE
Remove many GeometryInfo usages from examples

### DIFF
--- a/examples/step-1/step-1.cc
+++ b/examples/step-1/step-1.cc
@@ -199,17 +199,13 @@ void second_grid()
           // classes used in deal.II, and @ref CPP11 for more information about
           // range-based for loops and the `auto` keyword.
           //
-          // Next, we want to loop over all vertices of the cells. Since we are
-          // in 2d, we know that each cell has exactly four vertices. However,
-          // instead of penning down a 4 in the loop bound, we make a first
-          // attempt at writing it in a dimension-independent way by which we
-          // find out about the number of vertices of a cell. Using the
-          // GeometryInfo class, we will later have an easier time getting the
-          // program to also run in 3d: we only have to change all occurrences
-          // of <code>&lt;2&gt;</code> to <code>&lt;3&gt;</code>, and do not
-          // have to audit our code for the hidden appearance of magic numbers
-          // like a 4 that needs to be replaced by an 8:
-          for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+          // Next, we loop over all vertices of the cells. For that purpose
+          // we query an iterator over indices from zero to four, which happens
+          // to be the number of vertices in 2d. Since the upper bound is
+          // automatically adjusted in all dimensions this enables us a
+          // dimension-independent programming. This will later enable us to
+          // get the program to also run in 3d.
+          for (const auto v : cell->vertex_indices())
             {
               // If this cell is at the inner boundary, then at least one of its
               // vertices must sit on the inner ring and therefore have a radial

--- a/examples/step-13/doc/results.dox
+++ b/examples/step-13/doc/results.dox
@@ -162,7 +162,7 @@ profit. Answer 2: this quick hack
 @code
   bool refinement_indicated = false;
   for (const auto &cell : triangulation.active_cell_iterators())
-    for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+    for (const auto v : cell->vertex_indices())
 	  if (cell->vertex(v) == Point<dim>(.5,.5))
 	    {
 	      cell->clear_coarsen_flag();
@@ -170,7 +170,7 @@ profit. Answer 2: this quick hack
 	    }
   if (refinement_indicated)
     for (const auto &cell : triangulation.active_cell_iterators())
-      for (unsigned int v=0; v<GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const auto v : cell->vertex_indices())
 	    if (cell->vertex(v) == Point<dim>(.5,.5))
 	      cell->set_refine_flag ();
 @endcode

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -221,9 +221,7 @@ namespace Step13
       bool evaluation_point_found = false;
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (!evaluation_point_found)
-          for (unsigned int vertex = 0;
-               vertex < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex)
+          for (const auto vertex : cell->vertex_indices())
             if (cell->vertex(vertex) == evaluation_point)
               {
                 // In order to extract the point value from the global solution

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -135,9 +135,7 @@ namespace Step14
       bool evaluation_point_found = false;
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (!evaluation_point_found)
-          for (unsigned int vertex = 0;
-               vertex < GeometryInfo<dim>::vertices_per_cell;
-               ++vertex)
+          for (const auto vertex : cell->vertex_indices())
             if (cell->vertex(vertex).distance(evaluation_point) <
                 cell->diameter() * 1e-8)
               {
@@ -218,9 +216,7 @@ namespace Step14
       // often the vertex has been found:
       unsigned int evaluation_point_hits = 0;
       for (const auto &cell : dof_handler.active_cell_iterators())
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex)
+        for (const auto vertex : cell->vertex_indices())
           if (cell->vertex(vertex) == evaluation_point)
             {
               // Things are now no more as simple, since we can't get the
@@ -1294,8 +1290,7 @@ namespace Step14
       std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
       for (unsigned int i = 0; i < n_cells; ++i)
         {
-          for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell;
-               ++j)
+          for (unsigned int j = 0; j < cell_vertices[i].size(); ++j)
             cells[i].vertices[j] = cell_vertices[i][j];
           cells[i].material_id = 0;
         }
@@ -1447,9 +1442,7 @@ namespace Step14
       // vertices (or very close to a vertex, which may happen due to floating
       // point round-off):
       for (const auto &cell : dof_handler.active_cell_iterators())
-        for (unsigned int vertex = 0;
-             vertex < GeometryInfo<dim>::vertices_per_cell;
-             ++vertex)
+        for (const auto vertex : cell->vertex_indices())
           if (cell->vertex(vertex).distance(evaluation_point) <
               cell->diameter() * 1e-8)
             {
@@ -2273,7 +2266,7 @@ namespace Step14
       // After computing the cell terms, turn to the face terms. For this,
       // loop over all faces of the present cell, and see whether
       // something needs to be computed on it:
-      for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+      for (const auto face_no : cell->face_indices())
         {
           // First, if this face is part of the boundary, then there is
           // nothing to do. However, to make things easier when summing up

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -1482,7 +1482,7 @@ namespace Step18
   // points, see @ref GlossSupport "support points"). For such a case, one
   // could construct a custom quadrature rule using
   // FiniteElement::get_unit_support_points(). The first
-  // <code>GeometryInfo@<dim@>::%vertices_per_cell*fe.dofs_per_vertex</code>
+  // <code>cell-&gt;n_vertices()*fe.dofs_per_vertex</code>
   // quadrature points will then correspond to the vertices of the cell and
   // are ordered consistent with <code>cell-@>vertex(i)</code>, taking into
   // account that support points for vector elements will be duplicated
@@ -1515,7 +1515,7 @@ namespace Step18
 
     std::vector<bool> vertex_touched(triangulation.n_vertices(), false);
     for (auto &cell : dof_handler.active_cell_iterators())
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const auto v : cell->vertex_indices())
         if (vertex_touched[cell->vertex_index(v)] == false)
           {
             vertex_touched[cell->vertex_index(v)] = true;

--- a/examples/step-2/step-2.cc
+++ b/examples/step-2/step-2.cc
@@ -75,7 +75,7 @@ void make_grid(Triangulation<2> &triangulation)
   for (unsigned int step = 0; step < 3; ++step)
     {
       for (auto &cell : triangulation.active_cell_iterators())
-        for (unsigned int v = 0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+        for (const auto v : cell->vertex_indices())
           {
             const double distance_from_center =
               center.distance(cell->vertex(v));

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -851,7 +851,7 @@ namespace Step21
         //
         // All this is a bit tricky, but has been explained in some detail
         // already in step-9. Take a look there how this is supposed to work!
-        for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+        for (const auto face_no : cell->face_indices())
           {
             fe_face_values.reinit(cell, face_no);
 

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -570,7 +570,7 @@ namespace Step27
     std::vector<CellData<dim>> cells(n_cells, CellData<dim>());
     for (unsigned int i = 0; i < n_cells; ++i)
       {
-        for (unsigned int j = 0; j < GeometryInfo<dim>::vertices_per_cell; ++j)
+        for (unsigned int j = 0; j < cell_vertices[i].size(); ++j)
           cells[i].vertices[j] = cell_vertices[i][j];
         cells[i].material_id = 0;
       }

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -651,7 +651,7 @@ namespace Step29
         // is at the boundary, and second has the correct boundary indicator
         // associated with $\Gamma_2$, the part of the boundary where we have
         // absorbing boundary conditions:
-        for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+        for (const auto face_no : cell->face_indices())
           if (cell->face(face_no)->at_boundary() &&
               (cell->face(face_no)->boundary_id() == 0))
             {

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -451,7 +451,7 @@ namespace Step30
 
         cell->get_dof_indices(dofs);
 
-        for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+        for (const auto face_no : cell->face_indices())
           {
             const auto face = cell->face(face_no);
 
@@ -724,7 +724,7 @@ namespace Step30
           Point<dim> jump;
           Point<dim> area;
 
-          for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+          for (const auto face_no : cell->face_indices())
             {
               const auto face = cell->face(face_no);
 
@@ -839,8 +839,7 @@ namespace Step30
                           std::pair<unsigned int, unsigned int>
                             neighbor_face_subface =
                               cell->neighbor_of_coarser_neighbor(face_no);
-                          Assert(neighbor_face_subface.first <
-                                   GeometryInfo<dim>::faces_per_cell,
+                          Assert(neighbor_face_subface.first < cell->n_faces(),
                                  ExcInternalError());
                           Assert(neighbor_face_subface.second <
                                    neighbor->face(neighbor_face_subface.first)

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1486,7 +1486,7 @@ namespace Step33
         // whether we are working on an external or internal face; if it is an
         // external face, the fourth argument denoting the degrees of freedom
         // indices of the neighbor is ignored, so we pass an empty vector):
-        for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+        for (const auto face_no : cell->face_indices())
           if (cell->at_boundary(face_no))
             {
               fe_v_face.reinit(cell, face_no);

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -443,10 +443,9 @@ namespace Step41
     std::vector<bool>   dof_touched(dof_handler.n_dofs(), false);
 
     for (const auto &cell : dof_handler.active_cell_iterators())
-      for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+      for (const auto v : cell->vertex_indices())
         {
-          Assert(dof_handler.get_fe().n_dofs_per_cell() ==
-                   GeometryInfo<dim>::vertices_per_cell,
+          Assert(dof_handler.get_fe().n_dofs_per_cell() == cell->n_vertices(),
                  ExcNotImplemented());
 
           const unsigned int dof_index = cell->vertex_dof_index(v, 0);

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -1929,7 +1929,7 @@ namespace Step42
 
     for (const auto &cell : dof_handler.active_cell_iterators())
       if (cell->is_locally_owned())
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const auto v : cell->vertex_indices())
           if (vertex_touched[cell->vertex_index(v)] == false)
             {
               vertex_touched[cell->vertex_index(v)] = true;

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -468,7 +468,7 @@ solid cell is refined, yielding the following code:
 std::vector<unsigned int> local_face_dof_indices (stokes_fe.dofs_per_face);
 for (const auto &cell: dof_handler.active_cell_iterators())
   if (cell_is_in_fluid_domain (cell))
-    for (unsigned int f : GeometryInfo<dim>::face_indices())
+    for (const auto f : cell->face_indices())
       if (!cell->at_boundary(f))
         {
           bool face_is_on_interface = false;

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -367,7 +367,7 @@ namespace Step46
         stokes_fe.n_dofs_per_face());
       for (const auto &cell : dof_handler.active_cell_iterators())
         if (cell_is_in_fluid_domain(cell))
-          for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+          for (const auto face_no : cell->face_indices())
             {
               bool face_is_on_interface = false;
 
@@ -641,7 +641,7 @@ namespace Step46
         // boundary and the potential neighbor behind it is part of the fluid
         // domain. Let's start with these conditions:
         if (cell_is_in_solid_domain(cell))
-          for (unsigned int f : GeometryInfo<dim>::face_indices())
+          for (const auto f : cell->face_indices())
             {
               // At this point we know that the current cell is a candidate
               // for integration and that a neighbor behind face
@@ -950,7 +950,7 @@ namespace Step46
     // encountered when assembling interface terms in
     // <code>assemble_system</code>.
     for (const auto &cell : dof_handler.active_cell_iterators())
-      for (unsigned int f : GeometryInfo<dim>::face_indices())
+      for (const auto f : cell->face_indices())
         if (cell_is_in_solid_domain(cell))
           {
             if ((cell->at_boundary(f) == false) &&

--- a/examples/step-49/doc/results.dox
+++ b/examples/step-49/doc/results.dox
@@ -91,7 +91,7 @@ void create_2d_grid(
   std::vector<CellData<2>> cells(vertex_indices.size());
   for (unsigned int i = 0; i < cells.size(); ++i)
     {
-      for (unsigned int j = 0; j < GeometryInfo<2>::vertices_per_cell; ++j)
+      for (unsigned int j = 0; j < vertex_indices[i].size(); ++j)
         cells[i].vertices[j] = vertex_indices[i][j];
     }
 

--- a/examples/step-49/step-49.cc
+++ b/examples/step-49/step-49.cc
@@ -168,7 +168,7 @@ void grid_3()
 
   for (const auto &cell : triangulation.active_cell_iterators())
     {
-      for (unsigned int i = 0; i < GeometryInfo<2>::vertices_per_cell; ++i)
+      for (const auto i : cell->vertex_indices())
         {
           Point<2> &v = cell->vertex(i);
           if (std::abs(v(1) - 1.0) < 1e-5)

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -766,7 +766,7 @@ namespace Step51
     // Face terms are assembled on all faces of all elements. This is in
     // contrast to more traditional DG methods, where each face is only visited
     // once in the assembly procedure.
-    for (unsigned int face_no : GeometryInfo<dim>::face_indices())
+    for (const auto face_no : cell->face_indices())
       {
         scratch.fe_face_values_local.reinit(loc_cell, face_no);
         scratch.fe_face_values.reinit(cell, face_no);

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -1339,7 +1339,9 @@ namespace Step59
             triangulation.begin_active()->face(0)->set_boundary_id(10);
             triangulation.begin_active()->face(1)->set_boundary_id(11);
             triangulation.begin_active()->face(2)->set_boundary_id(0);
-            for (unsigned int f = 3; f < GeometryInfo<dim>::faces_per_cell; ++f)
+            for (unsigned int f = 3;
+                 f < triangulation.begin_active()->n_faces();
+                 ++f)
               triangulation.begin_active()->face(f)->set_boundary_id(1);
 
             std::vector<GridTools::PeriodicFacePair<

--- a/examples/step-6/doc/results.dox
+++ b/examples/step-6/doc/results.dox
@@ -327,9 +327,7 @@ const double core_radius  = 1.0/5.0,
 for (const auto &cell : triangulation.active_cell_iterators())
   if (mesh_center.distance(cell->center()) < 1e-5)
     {
-      for (unsigned int v=0;
-           v < GeometryInfo<dim>::vertices_per_cell;
-           ++v)
+      for (const auto v : cell->vertex_indices())
         cell->vertex(v) *= core_radius/mesh_center.distance(cell->vertex(v));
     }
 
@@ -348,7 +346,7 @@ triangulation.execute_coarsening_and_refinement();
 // created in radial direction to a place where we need
 // them.
 for (const auto &cell : triangulation.active_cell_iterators())
-  for (unsigned int v=0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+  for (const auto v : cell->vertex_indices())
     {
       const double dist = mesh_center.distance(cell->vertex(v));
       if (dist > core_radius*1.0001 && dist < 0.9999)
@@ -369,7 +367,7 @@ for (const auto &cell : triangulation.active_cell_iterators())
 for (const auto &cell : triangulation.active_cell_iterators())
   {
     bool is_in_inner_circle = false;
-    for (unsigned int v=0; v < GeometryInfo<2>::vertices_per_cell; ++v)
+    for (const auto v : cell->vertex_indices())
       if (mesh_center.distance(cell->vertex(v)) < inner_radius)
         {
           is_in_inner_circle = true;

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -772,7 +772,7 @@ namespace Step60
         for (auto &cell : cells)
           {
             cell->set_refine_flag();
-            for (unsigned int face_no : GeometryInfo<spacedim>::face_indices())
+            for (const auto face_no : cell->face_indices())
               if (!cell->at_boundary(face_no))
                 cell->neighbor(face_no)->set_refine_flag();
           }

--- a/examples/step-65/step-65.cc
+++ b/examples/step-65/step-65.cc
@@ -230,9 +230,7 @@ namespace Step65
         for (const auto &face : cell->face_iterators())
           {
             bool face_at_sphere_boundary = true;
-            for (unsigned int v = 0;
-                 v < GeometryInfo<dim - 1>::vertices_per_cell;
-                 ++v)
+            for (const auto v : face->vertex_indices())
               {
                 if (std::abs(face->vertex(v).norm_square() - 0.25) > 1e-12)
                   face_at_sphere_boundary = false;

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -630,7 +630,7 @@ namespace Step69
 
     for (const auto &cell : triangulation.active_cell_iterators())
       {
-        for (unsigned int v = 0; v < GeometryInfo<dim>::vertices_per_cell; ++v)
+        for (const auto v : cell->vertex_indices())
           {
             if (cell->vertex(v)[0] <= -disk_diameter + 1.e-6)
               cell->vertex(v)[0] = -disk_position;
@@ -639,7 +639,7 @@ namespace Step69
 
     for (const auto &cell : triangulation.active_cell_iterators())
       {
-        for (auto f : GeometryInfo<dim>::face_indices())
+        for (const auto f : cell->face_indices())
           {
             const auto face = cell->face(f);
 
@@ -1090,7 +1090,7 @@ namespace Step69
           // Now we have to compute the boundary normals. Note that the
           // following loop does not do much unless the element has faces on
           // the boundary of the domain.
-          for (auto f : GeometryInfo<dim>::face_indices())
+          for (const auto f : cell->face_indices())
             {
               const auto face = cell->face(f);
               const auto id   = face->boundary_id();
@@ -1126,9 +1126,7 @@ namespace Step69
                   const auto index = copy.local_dof_indices[j];
 
                   Point<dim> position;
-                  for (unsigned int v = 0;
-                       v < GeometryInfo<dim>::vertices_per_cell;
-                       ++v)
+                  for (const auto v : cell->vertex_indices())
                     if (cell->vertex_dof_index(v, 0) ==
                         partitioner->local_to_global(index))
                       {
@@ -1351,7 +1349,7 @@ namespace Step69
           for (auto &matrix : copy.cell_cij_matrix)
             matrix = 0.;
 
-          for (auto f : GeometryInfo<dim>::face_indices())
+          for (const auto f : cell->face_indices())
             {
               const auto face = cell->face(f);
               const auto id   = face->boundary_id();

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -1043,7 +1043,7 @@ namespace Step9
     // have to clear the array storing the iterators to the active
     // neighbors, of course.
     scratch_data.active_neighbors.clear();
-    for (unsigned int face_n : GeometryInfo<dim>::face_indices())
+    for (const auto face_n : cell->face_indices())
       if (!cell->at_boundary(face_n))
         {
           // First define an abbreviation for the iterator to the face and


### PR DESCRIPTION
... from 63 to 21.

`GeometryInfo` is still used for following purposes:
- get the maximum number of faces/vertices to be able to create arrays with fixed sizes
- to get the face normals via `unit_normal_direction`
- to get the number of children via `max_children_per_cell` and `max_children_per_face`