### PR TITLE
[step-67] Fix typo in computation of speed of sound

### DIFF
--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -565,7 +565,7 @@ namespace Euler_DG
   // \frac{\lambda}{2}\left[\mathbf{w}^--\mathbf{w}^+\right]\otimes
   // \mathbf{n^-}$, where the factor $\lambda =
   // \max\left(\|\mathbf{u}^-\|+c^-, \|\mathbf{u}^+\|+c^+\right)$ gives the
-  // maximal wave speed and $c = \sqrt{\lambda p / \rho}$ is the speed of
+  // maximal wave speed and $c = \sqrt{\gamma p / \rho}$ is the speed of
   // sound. Here, we choose two modifications of that expression for reasons
   // of computational efficiency, given the small impact of the flux on the
   // solution. For the above definition of the factor $\lambda$, we would need


### PR DESCRIPTION
The symbol `lambda` is used for the estimation of wave speed for a Lax-Friedrichs-like flux. `gamma` is gas constant to be used for the speed of sound.