### PR TITLE
Unitfy set/get_dof_indices() and set/get_mg_dof_indices()

### DIFF
--- a/source/dofs/dof_accessor.cc
+++ b/source/dofs/dof_accessor.cc
@@ -130,8 +130,6 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_indices(
 
   Assert(this->dof_handler != nullptr, typename BaseClass::ExcInvalidObject());
 
-  AssertDimension(local_dof_indices.size(), this->get_fe().n_dofs_per_cell());
-
   internal::DoFAccessorImplementation::Implementation::
     template set_dof_indices<dim, spacedim, lda, dim>(*this,
                                                       local_dof_indices,


### PR DESCRIPTION
Follow up to #10268, such that `set/get_mg_dof_indices()` uses the same infrastructure as `set/get_dof_indices()` does.