### PR TITLE
Generate error message with conflicting Qt macros

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -45,6 +45,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef signals
+#  error \
+    "The data type signals is already defined. You are most likely using the QT library \
+and using the signals keyword. You can either #include the Qt headers (or any conflicting headers) \
+after the deal.ii headers or you can define the QT_NO_KEYWORDS marco and use the Q_SIGNALS macro."
+#endif
+
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -36,6 +36,13 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+#ifdef signals
+#  error \
+    "The data type signals is already defined. You are most likely using the QT library \
+and using the signals keyword. You can either #include the Qt headers (or any conflicting headers) \
+after the deal.ii headers or you can define the QT_NO_KEYWORDS marco and use the Q_SIGNALS macro."
+#endif
+
 /*!@addtogroup mg */
 /*@{*/
 


### PR DESCRIPTION
Hello all,

Here is the pull request related to issue #7524 . In this, I created a build error to appear if "signals" is already defined. the message also lets the user know of a possible fix. 

On a side note, I tried to update my fork to the latest version but when I went to creating a pull request, it states that the branch can be auto merged.

If you have any feedback, please let me know.

Best