### PR TITLE
Avoid hang by AssertThrow

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1514,7 +1514,8 @@ namespace deal_II_exceptions
     {                                                                  \
       if (__builtin_expect(!(cond), false))                            \
         ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception, \
+          ::dealii::deal_II_exceptions::internals::                    \
+            abort_or_throw_on_exception,                               \
           __FILE__,                                                    \
           __LINE__,                                                    \
           __PRETTY_FUNCTION__,                                         \
@@ -1527,7 +1528,8 @@ namespace deal_II_exceptions
     {                                                                  \
       if (!(cond))                                                     \
         ::dealii::deal_II_exceptions::internals::issue_error_noreturn( \
-          ::dealii::deal_II_exceptions::internals::throw_on_exception, \
+          ::dealii::deal_II_exceptions::internals::                    \
+            abort_or_throw_on_exception,                               \
           __FILE__,                                                    \
           __LINE__,                                                    \
           __PRETTY_FUNCTION__,                                         \


### PR DESCRIPTION
If I write the following code, I get the expected behaviour. The program terminates and I get the stacktrace
```
Assert(Utilities::MPI::this_mpi_process(mpi_communicator) == 0, ExcInternalError());
```
On the other hand, If I write the following code, the program hangs and does not provide any message.
```
AssertThrow(Utilities::MPI::this_mpi_process(mpi_communicator) == 0, ExcInternalError());
```
This behaviour makes some bugs difficult to debug. I wrote a solution in this PR, but I'm happy to hear your suggestions.

This behaviour might be related to my machine, therefore it might be useful if other developers check that the code above hangs deal.II programs.