### PR TITLE
Add constant to remove the need for macro usage

### DIFF
--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -371,6 +371,11 @@ OPTION(DEAL_II_WITH_64BIT_INDICES
   OFF
   )
 LIST(APPEND DEAL_II_FEATURES 64BIT_INDICES)
+IF(DEAL_II_WITH_64BIT_INDICES)
+    SET(DEAL_II_WITH_64BIT_INDICES_BOOL "true")
+ELSE()
+    SET(DEAL_II_WITH_64BIT_INDICES_BOOL "false")
+ENDIF()
 
 OPTION(DEAL_II_WITH_SIMPLEX_SUPPORT
   "If set to ON, triangulations with triangle and tetrahedron cells are supported in addition to quadrilateral- and hexahedra-only triangulations."

--- a/doc/news/changes/minor/20200807RezaRastak
+++ b/doc/news/changes/minor/20200807RezaRastak
@@ -1,0 +1,4 @@
+New: Namespace config and the constexpr parameter config::with_64bit_indices
+introduced to replace the DEAL_II_WITH_64BIT_INDICES macro.
+<br>
+(Reza Rastak, 2020/08/07)

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -363,6 +363,20 @@
 #define DEAL_II_NAMESPACE_CLOSE }
 
 /***********************************************************************
+ * Store the build configuration in a namespace called config to reduce the
+ * usage of macros in the codebase.
+ */
+DEAL_II_NAMESPACE_OPEN
+namespace config
+{
+  /**
+   * Specifies whether the code is compiled with 64 bit indices.
+   */
+  constexpr bool with_64bit_indices = @DEAL_II_WITH_64BIT_INDICES_BOOL@;
+} // namespace config
+DEAL_II_NAMESPACE_CLOSE
+
+/***********************************************************************
  * Two macros to guard external header includes.
  *
  * Selectively disable diagnostics set by "-Wextra" (and similar flags) for

--- a/include/deal.II/base/types.h
+++ b/include/deal.II/base/types.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <cstdint>
+#include <type_traits>
 
 
 DEAL_II_NAMESPACE_OPEN
@@ -70,11 +71,8 @@ namespace types
    * @ref GlobalDoFIndex
    * page for guidance on when this type should or should not be used.
    */
-#ifdef DEAL_II_WITH_64BIT_INDICES
-  using global_dof_index = uint64_t;
-#else
-  using global_dof_index  = unsigned int;
-#endif
+  using global_dof_index =
+    std::conditional_t<config::with_64bit_indices, uint64_t, unsigned int>;
 
   /**
    * An identifier that denotes the MPI type associated with
@@ -99,11 +97,8 @@ namespace types
    *
    * The data type always corresponds to an unsigned integer type.
    */
-#ifdef DEAL_II_WITH_64BIT_INDICES
-  using global_cell_index = uint64_t;
-#else
-  using global_cell_index = unsigned int;
-#endif
+  using global_cell_index =
+    std::conditional_t<config::with_64bit_indices, uint64_t, unsigned int>;
 
   /**
    * The type used for coarse-cell ids. See the glossary
@@ -167,17 +162,11 @@ namespace TrilinosWrappers
 {
   namespace types
   {
-#ifdef DEAL_II_WITH_64BIT_INDICES
     /**
      * Declare type of integer used in the Epetra package of Trilinos.
      */
-    using int_type = long long int;
-#else
-    /**
-     * Declare type of integer used in the Epetra package of Trilinos.
-     */
-    using int_type = int;
-#endif
+    using int_type =
+      std::conditional_t<config::with_64bit_indices, long long int, int>;
   } // namespace types
 } // namespace TrilinosWrappers
 

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -32,7 +32,6 @@ namespace types
 {
   /* Type definitions */
 
-#ifdef DEAL_II_WITH_64BIT_INDICES
   /**
    * The type used for indices of particles. While in
    * sequential computations the 4 billion indices of 32-bit unsigned integers
@@ -44,31 +43,17 @@ namespace types
    *
    * The data type always indicates an unsigned integer type.
    */
-  using particle_index = uint64_t;
+  using particle_index =
+    std::conditional_t<config::with_64bit_indices, uint64_t, unsigned int>;
 
-#  ifdef DEAL_II_WITH_MPI
+#ifdef DEAL_II_WITH_MPI
+#  ifdef DEAL_II_WITH_64BIT_INDICES
   /**
    * An identifier that denotes the MPI type associated with
    * types::global_dof_index.
    */
 #    define DEAL_II_PARTICLE_INDEX_MPI_TYPE MPI_UINT64_T
-#  endif
-
-#else
-  /**
-   * The type used for indices of particles. While in
-   * sequential computations the 4 billion indices of 32-bit unsigned integers
-   * is plenty, parallel computations using hundreds of processes can overflow
-   * this number and we need a bigger index space. We here utilize the same
-   * build variable that controls the dof indices because the number
-   * of degrees of freedom and the number of particles are typically on the same
-   * order of magnitude.
-   *
-   * The data type always indicates an unsigned integer type.
-   */
-  using particle_index = unsigned int;
-
-#  ifdef DEAL_II_WITH_MPI
+#  else
   /**
    * An identifier that denotes the MPI type associated with
    * types::global_dof_index.


### PR DESCRIPTION
With more C++ support for compile-time programming such as `constexpr` and `if constexpr`, we can redefine some of our macros as constants in order to reduce the number of `#ifdef`s in the dealii code and the user code.

In this PR, as a proof of concept, I redefined the macro `DEAL_II_WITH_64BIT_INDICES` as `config::with_64bit_indices` and replaced some of the `#ifdef`s in the codebase, which I think improves the code.

What do you think about following this approach for some other macros as well?

One downside of using `std::conditional_t` instead of `#ifdef` is that it might fail to compile if `uint64_t` is not defined on a given platform. I am not sure what types of systems do not support `uint64_t`.