### PR TITLE
Fix compiling with CUDA 11

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -238,6 +238,22 @@
 #  define DEAL_II_GMSH_EXECUTABLE_PATH "@GMSH_EXECUTABLE@"
 #endif
 
+
+/*
+ * CUDA:
+ */
+
+#ifdef DEAL_II_WITH_CUDA
+#  define DEAL_II_CUDA_VERSION_MAJOR @CUDA_VERSION_MAJOR@
+#  define DEAL_II_CUDA_VERSION_MINOR @CUDA_VERSION_MINOR@
+
+#  define DEAL_II_CUDA_VERSION_GTE(major,minor) \
+ ((DEAL_II_CUDA_VERSION_MAJOR * 100 + DEAL_II_CUDA_VERSION_MINOR) \
+    >=  \
+    (major)*100 + (patch))
+#endif
+
+
 /*
  * p4est:
  */

--- a/source/lac/cuda_sparse_matrix.cu
+++ b/source/lac/cuda_sparse_matrix.cu
@@ -57,6 +57,21 @@ namespace CUDAWrappers
           bool                     add,
           float *                  y)
     {
+#  if DEAL_II_CUDA_VERSION_GTE(11, 0)
+      (void)handle;
+      (void)transpose;
+      (void)m;
+      (void)n;
+      (void)nnz;
+      (void)descr;
+      (void)A_val_dev;
+      (void)A_row_ptr_dev;
+      (void)A_column_index_dev;
+      (void)x;
+      (void)add;
+      (void)y;
+      AssertThrow(false, ExcNotImplemented());
+#  else
       float               alpha = 1.;
       float               beta  = add ? 1. : 0.;
       cusparseOperation_t cusparse_operation =
@@ -78,6 +93,7 @@ namespace CUDAWrappers
                                                    &beta,
                                                    y);
       AssertCusparse(error_code);
+#  endif
     }
 
 
@@ -96,6 +112,21 @@ namespace CUDAWrappers
           bool                     add,
           double *                 y)
     {
+#  if DEAL_II_CUDA_VERSION_GTE(11, 0)
+      (void)handle;
+      (void)transpose;
+      (void)m;
+      (void)n;
+      (void)nnz;
+      (void)descr;
+      (void)A_val_dev;
+      (void)A_row_ptr_dev;
+      (void)A_column_index_dev;
+      (void)x;
+      (void)add;
+      (void)y;
+      AssertThrow(false, ExcNotImplemented());
+#  else
       double              alpha = 1.;
       double              beta  = add ? 1. : 0.;
       cusparseOperation_t cusparse_operation =
@@ -117,6 +148,7 @@ namespace CUDAWrappers
                                                    &beta,
                                                    y);
       AssertCusparse(error_code);
+#  endif
     }
 
 


### PR DESCRIPTION
Simply error out if we try to use functionality removed in CUDA 11 for now.