### PR TITLE
Do not update ghost values in MGTransferMatrixFree::prolongate

### DIFF
--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -210,15 +210,14 @@ MGTransferMatrixFree<dim, Number>::prolongate(
           this->vector_partitioners[to_level]);
       AssertDimension(this->ghosted_level_vector[to_level].local_size(),
                       dst.local_size());
-      this->ghosted_level_vector[to_level] = 0.;
     }
-  else
-    dst = 0;
 
   const LinearAlgebra::distributed::Vector<Number> &src_vec =
     src_inplace ? src : this->ghosted_level_vector[to_level - 1];
   LinearAlgebra::distributed::Vector<Number> &dst_vec =
     dst_inplace ? dst : this->ghosted_level_vector[to_level];
+
+  dst_vec = 0.;
 
   src_vec.update_ghost_values();
   // the implementation in do_prolongate_add is templated in the degree of the
@@ -251,7 +250,7 @@ MGTransferMatrixFree<dim, Number>::prolongate(
 
   dst_vec.compress(VectorOperation::add);
   if (dst_inplace == false)
-    dst = dst_vec;
+    dst.copy_locally_owned_data_from(this->ghosted_level_vector[to_level]);
 
   if (src_inplace == true)
     src.zero_out_ghosts();

--- a/tests/multigrid/transfer_matrix_free_04.cc
+++ b/tests/multigrid/transfer_matrix_free_04.cc
@@ -87,7 +87,13 @@ check(const unsigned int fe_degree)
           LinearAlgebra::distributed::Vector<Number> v1, v2;
           LinearAlgebra::distributed::Vector<double> v1_cpy, v2_cpy, v3;
           v1.reinit(mgdof.locally_owned_mg_dofs(level - 1), MPI_COMM_WORLD);
-          v2.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
+          IndexSet relevant_set;
+          DoFTools::extract_locally_relevant_level_dofs(mgdof,
+                                                        level,
+                                                        relevant_set);
+          v2.reinit(mgdof.locally_owned_mg_dofs(level),
+                    relevant_set,
+                    MPI_COMM_WORLD);
           v3.reinit(mgdof.locally_owned_mg_dofs(level), MPI_COMM_WORLD);
           for (unsigned int i = 0; i < v1.local_size(); ++i)
             v1.local_element(i) = random_value<double>();
@@ -99,6 +105,8 @@ check(const unsigned int fe_degree)
           deallog << "Diff prolongate   l" << level << ": "
                   << filter_out_small_numbers(v3.l2_norm(), tolerance)
                   << std::endl;
+          deallog << "Vectors have ghosts: " << v2.has_ghost_elements() << " "
+                  << v3.has_ghost_elements() << std::endl;
         }
 
       // check restriction for all levels using random vector

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=1.output
@@ -2,7 +2,9 @@
 DEAL::FE: FE_DGQ<2>(1)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -10,8 +12,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -21,7 +26,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -29,9 +36,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -43,7 +54,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -51,8 +64,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -62,10 +78,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -80,12 +101,15 @@ DEAL::
 DEAL::FE: FE_DGQ<2>(3)
 DEAL::no. cells: 4
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -93,13 +117,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 36
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -109,12 +137,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 100
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -122,9 +153,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -137,12 +172,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(1)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -150,13 +188,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -166,12 +208,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -179,9 +224,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -196,6 +245,7 @@ DEAL::no. cells: 1
 DEAL::
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
@@ -203,7 +253,9 @@ DEAL::no. cells: 27
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -213,24 +265,30 @@ DEAL::no. cells: 125
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
 DEAL::Diff restrict add l2: 0.00000
-DEAL::Diff restrict     l3: 2.49702e-13
-DEAL::Diff restrict add l3: 2.50034e-13
+DEAL::Diff restrict     l3: 3.02285e-13
+DEAL::Diff restrict add l3: 3.02551e-13
 DEAL::
 DEAL::FE: FE_DGQ<2>(2)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -238,8 +296,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -249,7 +310,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -257,9 +320,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -271,7 +338,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -279,8 +348,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -290,10 +362,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -308,12 +385,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(2)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -321,13 +401,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -337,12 +421,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -350,9 +437,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=4.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=4.output
@@ -2,7 +2,9 @@
 DEAL::FE: FE_DGQ<2>(1)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -10,8 +12,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -21,7 +26,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -29,9 +36,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -43,7 +54,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -51,8 +64,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -62,10 +78,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -80,12 +101,15 @@ DEAL::
 DEAL::FE: FE_DGQ<2>(3)
 DEAL::no. cells: 4
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -93,13 +117,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 36
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -109,12 +137,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 100
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -122,9 +153,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -137,12 +172,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(1)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -150,13 +188,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -166,12 +208,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -179,9 +224,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -196,6 +245,7 @@ DEAL::no. cells: 1
 DEAL::
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
@@ -203,7 +253,9 @@ DEAL::no. cells: 27
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -213,24 +265,30 @@ DEAL::no. cells: 125
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
 DEAL::Diff restrict add l2: 0.00000
-DEAL::Diff restrict     l3: 2.49702e-13
-DEAL::Diff restrict add l3: 2.50034e-13
+DEAL::Diff restrict     l3: 3.02285e-13
+DEAL::Diff restrict add l3: 3.02551e-13
 DEAL::
 DEAL::FE: FE_DGQ<2>(2)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -238,8 +296,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -249,7 +310,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -257,9 +320,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -271,7 +338,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -279,8 +348,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -290,10 +362,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -308,12 +385,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(2)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -321,13 +401,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -337,12 +421,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -350,9 +437,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000

--- a/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
+++ b/tests/multigrid/transfer_matrix_free_04.with_mpi=true.with_p4est=true.with_trilinos=true.mpirun=7.output
@@ -2,7 +2,9 @@
 DEAL::FE: FE_DGQ<2>(1)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -10,8 +12,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -21,7 +26,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -29,9 +36,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -43,7 +54,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -51,8 +64,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -62,10 +78,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -80,12 +101,15 @@ DEAL::
 DEAL::FE: FE_DGQ<2>(3)
 DEAL::no. cells: 4
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -93,13 +117,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 36
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -109,12 +137,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 100
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -122,9 +153,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -137,12 +172,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(1)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -150,13 +188,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -166,12 +208,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -179,9 +224,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -196,6 +245,7 @@ DEAL::no. cells: 1
 DEAL::
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
@@ -203,7 +253,9 @@ DEAL::no. cells: 27
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -213,24 +265,30 @@ DEAL::no. cells: 125
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
 DEAL::Diff restrict add l2: 0.00000
-DEAL::Diff restrict     l3: 2.49702e-13
-DEAL::Diff restrict add l3: 2.50034e-13
+DEAL::Diff restrict     l3: 3.02285e-13
+DEAL::Diff restrict add l3: 3.02551e-13
 DEAL::
 DEAL::FE: FE_DGQ<2>(2)
 DEAL::no. cells: 16
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -238,8 +296,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -249,7 +310,9 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 144
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -257,9 +320,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 256
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -271,7 +338,9 @@ DEAL::Diff restrict add l4: 0.00000
 DEAL::
 DEAL::no. cells: 400
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -279,8 +348,11 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 576
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -290,10 +362,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1024
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l5: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -308,12 +385,15 @@ DEAL::
 DEAL::FE: FE_DGQ<3>(2)
 DEAL::no. cells: 8
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 64
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -321,13 +401,17 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 216
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 512
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -337,12 +421,15 @@ DEAL::Diff restrict add l3: 0.00000
 DEAL::
 DEAL::no. cells: 1000
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::
 DEAL::no. cells: 1728
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000
@@ -350,9 +437,13 @@ DEAL::Diff restrict add l2: 0.00000
 DEAL::
 DEAL::no. cells: 4096
 DEAL::Diff prolongate   l1: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l2: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l3: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff prolongate   l4: 0.00000
+DEAL::Vectors have ghosts: 0 0
 DEAL::Diff restrict     l1: 0.00000
 DEAL::Diff restrict add l1: 0.00000
 DEAL::Diff restrict     l2: 0.00000


### PR DESCRIPTION
In `MGTransferMatrixFree::prolongate` we previously used the assignment `dst = ghosted_level_vector[to_level]`. However, if the ghosted level vector happens to have no ghost values (as in a DG scheme on the finest level) but the destination vector has ghost values (because it is used to compute face integrals for example), the `operator=` would call `update_ghost_values`, leaving the vector in an unintended state. For example, matrix-free loops using `dst` later would refuse to take ghosted destination vectors because the ghost state needs to be clean.

One could argue that the underlying problem is that `operator=` is defined in a strange way as it switches between ghosted and non-ghosted states depending on what the right hand side and left hand side vector can do, but this was a decision long ago for compatibility with ghosted Trilinos and other vectors.

That said, we have the right way to assign the local range, it is called `copy_locally_owned_data_from`.

[The tricky part about this PR was to find a good test, which I finally succeeded in by slightly augmenting an existing test.]