### PR TITLE
MF mapping info: Avoid invalid access of some face-data-by-cells

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -3038,7 +3038,7 @@ namespace internal
                                     reorder_face_derivative_indices<dim>(face,
                                                                          e);
                                   face_data_by_cells[my_q]
-                                    .jacobians[1][offset + q][d][e][v] =
+                                    .jacobians[1][offset][d][e][v] =
                                     inv_jac[d][ee];
                                 }
                           }


### PR DESCRIPTION
I am a bit unsure about this PR but I think we should fix this at least temporarily. The problem is that the `face_data_by_cells` gets its array lengths from whether cells are affine or not on the current cell. For the outside value, we can thus only write data of a single quadrature point because that's the length of the arrays allocated here:
https://github.com/dealii/dealii/blob/96f909203c10bb998ae7953667669ca5aa06b512/include/deal.II/matrix_free/mapping_info.templates.h#L2918-L2919
We should switch to full storage if the neighbors turn out not the be affine, but I do not have the time to work on a proper fix that  checks all arrays and adjusts the outside storage length, so I temporarily only do the adjustments in terms of the index. We should fix this for the next release when we complete the element-centric loops.