### PR TITLE
Enable VectorTools::interpolate for hp::MappingCollection

### DIFF
--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -37,6 +37,12 @@ class InterGridMap;
 template <int dim, int spacedim>
 class Mapping;
 
+namespace hp
+{
+  template <int dim, int spacedim>
+  class MappingCollection;
+}
+
 namespace VectorTools
 {
   /**
@@ -56,9 +62,6 @@ namespace VectorTools
    * continuous again.
    *
    * See the general documentation of this namespace for further information.
-   *
-   * @todo The @p mapping argument should be replaced by a
-   * hp::MappingCollection in case of a hp::DoFHandler.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -68,6 +71,19 @@ namespace VectorTools
     const Function<spacedim, typename VectorType::value_type> &function,
     VectorType &                                               vec,
     const ComponentMask &component_mask = ComponentMask());
+
+  /**
+   * Same as above but in an hp context.
+   */
+  template <int dim, int spacedim, typename VectorType>
+  void
+  interpolate(
+    const hp::MappingCollection<dim, spacedim> &               mapping,
+    const DoFHandler<dim, spacedim> &                          dof,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const ComponentMask &component_mask = ComponentMask());
+
 
   /**
    * Call the @p interpolate() function above with

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -215,11 +215,11 @@ namespace VectorTools
     // A given cell is skipped if function(cell) == nullptr
     template <int dim, int spacedim, typename VectorType, typename T>
     void
-    interpolate(const Mapping<dim, spacedim> &   mapping,
-                const DoFHandler<dim, spacedim> &dof_handler,
-                T &                              function,
-                VectorType &                     vec,
-                const ComponentMask &            component_mask)
+    interpolate(const hp::MappingCollection<dim, spacedim> &mapping_collection,
+                const DoFHandler<dim, spacedim> &           dof_handler,
+                T &                                         function,
+                VectorType &                                vec,
+                const ComponentMask &                       component_mask)
     {
       Assert(component_mask.represents_n_components(
                dof_handler.get_fe_collection().n_components()),
@@ -307,8 +307,6 @@ namespace VectorTools
           const auto &points = fe[fe_index].get_generalized_support_points();
           support_quadrature.push_back(Quadrature<dim>(points));
         }
-
-      const hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
 
       // An FEValues object to evaluate (generalized) support point
       // locations as well as Jacobians and their inverses.
@@ -481,7 +479,7 @@ namespace VectorTools
   template <int dim, int spacedim, typename VectorType>
   void
   interpolate(
-    const Mapping<dim, spacedim> &                             mapping,
+    const hp::MappingCollection<dim, spacedim> &               mapping,
     const DoFHandler<dim, spacedim> &                          dof_handler,
     const Function<spacedim, typename VectorType::value_type> &function,
     VectorType &                                               vec,
@@ -503,6 +501,24 @@ namespace VectorTools
 
     internal::interpolate(
       mapping, dof_handler, function_map, vec, component_mask);
+  }
+
+
+
+  template <int dim, int spacedim, typename VectorType>
+  void
+  interpolate(
+    const Mapping<dim, spacedim> &                             mapping,
+    const DoFHandler<dim, spacedim> &                          dof_handler,
+    const Function<spacedim, typename VectorType::value_type> &function,
+    VectorType &                                               vec,
+    const ComponentMask &                                      component_mask)
+  {
+    interpolate(hp::MappingCollection<dim, spacedim>(mapping),
+                dof_handler,
+                function,
+                vec,
+                component_mask);
   }
 
 
@@ -801,8 +817,11 @@ namespace VectorTools
         return nullptr;
     };
 
-    internal::interpolate(
-      mapping, dof_handler, function_map, vec, component_mask);
+    internal::interpolate(hp::MappingCollection<dim, spacedim>(mapping),
+                          dof_handler,
+                          function_map,
+                          vec,
+                          component_mask);
   }
 
   namespace internal

--- a/source/numerics/vector_tools_interpolate.inst.in
+++ b/source/numerics/vector_tools_interpolate.inst.in
@@ -24,6 +24,15 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
 
       template void
       interpolate(
+        const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
+          &,
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
+        const Function<deal_II_space_dimension, VEC::value_type> &,
+        VEC &,
+        const ComponentMask &);
+
+      template void
+      interpolate(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &,
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
         const Function<deal_II_space_dimension, VEC::value_type> &,


### PR DESCRIPTION
I guess no one can explain me why this was not already there. There was a `todo` but the implementation was already hp-ready ;)