### PR TITLE
CI: change git depth for indent worker

### DIFF
--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: setup
       run: |
         ./contrib/utilities/download_clang_format

--- a/.github/workflows/indent.yml
+++ b/.github/workflows/indent.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        fetch-depth: 0
+        fetch-depth: 100
     - name: setup
       run: |
         ./contrib/utilities/download_clang_format


### PR DESCRIPTION
By default, github actions do a git clone with depth=1. That does not
allow our indent script to check the commits for authorship correctly.

more details: https://github.com/actions/checkout