### PR TITLE
Introduce FiniteElementData::max_dofs_per_quad() 

### DIFF
--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -243,6 +243,13 @@ public:
    */
   const unsigned int dofs_per_quad;
 
+private:
+  /**
+   * Maximum number of degrees of freedom on any quad.
+   */
+  const unsigned int dofs_per_quad_max;
+
+public:
   /**
    * Number of degrees of freedom in a hexahedron; not including the degrees
    * of freedom on the quadrilaterals, lines and vertices of the hexahedron.
@@ -281,6 +288,13 @@ public:
    */
   const unsigned int dofs_per_face;
 
+private:
+  /**
+   * Maximum number of degrees of freedom on any face.
+   */
+  const unsigned int dofs_per_face_max;
+
+public:
   /**
    * Total number of degrees of freedom on a cell. This is the accumulated
    * number of degrees of freedom on all the objects of dimension up to
@@ -396,6 +410,13 @@ public:
   n_dofs_per_quad() const;
 
   /**
+   * Maximum number of dofs per quad. Not including dofs on lower dimensional
+   * objects.
+   */
+  unsigned int
+  max_dofs_per_quad() const;
+
+  /**
    * Number of dofs per hex. Not including dofs on lower dimensional objects.
    */
   unsigned int
@@ -407,6 +428,13 @@ public:
    */
   unsigned int
   n_dofs_per_face() const;
+
+  /**
+   * Maximum number of dofs per face, accumulating degrees of freedom of all
+   * lower dimensional objects.
+   */
+  unsigned int
+  max_dofs_per_face() const;
 
   /**
    * Number of dofs per cell, accumulating degrees of freedom of all lower
@@ -596,6 +624,15 @@ FiniteElementData<dim>::n_dofs_per_quad() const
 
 template <int dim>
 inline unsigned int
+FiniteElementData<dim>::max_dofs_per_quad() const
+{
+  return dofs_per_quad_max;
+}
+
+
+
+template <int dim>
+inline unsigned int
 FiniteElementData<dim>::n_dofs_per_hex() const
 {
   return dofs_per_hex;
@@ -608,6 +645,15 @@ inline unsigned int
 FiniteElementData<dim>::n_dofs_per_face() const
 {
   return dofs_per_face;
+}
+
+
+
+template <int dim>
+inline unsigned int
+FiniteElementData<dim>::max_dofs_per_face() const
+{
+  return dofs_per_face_max;
 }
 
 

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -884,8 +884,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_vertex() > max)
-        max = finite_elements[i]->n_dofs_per_vertex();
+      max = std::max(max, finite_elements[i]->n_dofs_per_vertex());
 
     return max;
   }
@@ -900,8 +899,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_line() > max)
-        max = finite_elements[i]->n_dofs_per_line();
+      max = std::max(max, finite_elements[i]->n_dofs_per_line());
 
     return max;
   }
@@ -916,8 +914,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_quad() > max)
-        max = finite_elements[i]->n_dofs_per_quad();
+      max = std::max(max, finite_elements[i]->max_dofs_per_quad());
 
     return max;
   }
@@ -932,8 +929,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_hex() > max)
-        max = finite_elements[i]->n_dofs_per_hex();
+      max = std::max(max, finite_elements[i]->n_dofs_per_hex());
 
     return max;
   }
@@ -948,8 +944,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_face() > max)
-        max = finite_elements[i]->n_dofs_per_face();
+      max = std::max(max, finite_elements[i]->max_dofs_per_face());
 
     return max;
   }
@@ -964,8 +959,7 @@ namespace hp
 
     unsigned int max = 0;
     for (unsigned int i = 0; i < finite_elements.size(); ++i)
-      if (finite_elements[i]->n_dofs_per_cell() > max)
-        max = finite_elements[i]->n_dofs_per_cell();
+      max = std::max(max, finite_elements[i]->n_dofs_per_cell());
 
     return max;
   }

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2619,7 +2619,7 @@ namespace internal
           const bool               check_validity)
         {
           if (dof_handler.get_fe().n_dofs_per_line() > 0 ||
-              dof_handler.get_fe().n_dofs_per_quad() > 0)
+              dof_handler.get_fe().max_dofs_per_quad() > 0)
             {
               // save user flags as they will be modified
               std::vector<bool> user_flags;

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -50,6 +50,7 @@ FiniteElementData<dim>::FiniteElementData(
   , dofs_per_vertex(dofs_per_object[0])
   , dofs_per_line(dofs_per_object[1])
   , dofs_per_quad(dim > 1 ? dofs_per_object[2] : 0)
+  , dofs_per_quad_max(dofs_per_quad)
   , dofs_per_hex(dim > 2 ? dofs_per_object[3] : 0)
   , first_line_index(
       ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
@@ -83,6 +84,7 @@ FiniteElementData<dim>::FiniteElementData(
       ReferenceCell::internal::Info::get_face(cell_type, 0).n_lines() *
         dofs_per_line +
       (dim == 3 ? 1 : 0) * dofs_per_quad)
+  , dofs_per_face_max(dofs_per_face)
   , dofs_per_cell(
       ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
         dofs_per_vertex +


### PR DESCRIPTION
... and FiniteElementData::max_dofs_per_face().

Currently, the returned value is identical to `n_dofs_per_quad()`  and `n_dofs_per_face()`. However, I intend to introduce to the functions `n_dofs_per_quad()`  and `n_dofs_per_face()` an input argument `quad_no`/`face_no` to be query the number of each quad/face separately (since quads/faces might have different number of dofs e.g in the case of triangle/quadrilateral faces).