### PR TITLE
Generalize FiniteElementData s.t. faces can different nr. of dofs

### DIFF
--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -19,6 +19,107 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+namespace
+{
+  internal::GenericDoFsPerObject
+  expand(const unsigned int               dim,
+         const std::vector<unsigned int> &dofs_per_object,
+         const ReferenceCell::Type        cell_type)
+  {
+    internal::GenericDoFsPerObject result;
+
+    const unsigned int face_no = 0;
+
+    result.dofs_per_object_exclusive.resize(4, std::vector<unsigned int>(1));
+    result.dofs_per_object_inclusive.resize(4, std::vector<unsigned int>(1));
+    result.object_index.resize(4, std::vector<unsigned int>(1));
+    result.first_object_index_on_face.resize(3, std::vector<unsigned int>(1));
+
+    // dofs_per_vertex
+    const unsigned int dofs_per_vertex     = dofs_per_object[0];
+    result.dofs_per_object_exclusive[0][0] = dofs_per_vertex;
+
+    // dofs_per_line
+    const unsigned int dofs_per_line       = dofs_per_object[1];
+    result.dofs_per_object_exclusive[1][0] = dofs_per_line;
+
+    // dofs_per_quad
+    const unsigned int dofs_per_quad       = dim > 1 ? dofs_per_object[2] : 0;
+    result.dofs_per_object_exclusive[2][0] = dofs_per_quad;
+
+    // dofs_per_hex
+    const unsigned int dofs_per_hex        = dim > 2 ? dofs_per_object[3] : 0;
+    result.dofs_per_object_exclusive[3][0] = dofs_per_hex;
+
+
+    // first_line_index
+    const unsigned int first_line_index =
+      (ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
+       dofs_per_vertex);
+    result.object_index[1][0] = first_line_index;
+
+    // first_quad_index
+    const unsigned int first_quad_index =
+      (first_line_index +
+       ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
+         dofs_per_line);
+    result.object_index[2][0] = first_quad_index;
+
+    // first_hex_index
+    result.object_index[3][0] =
+      (first_quad_index +
+       (dim == 2 ?
+          1 :
+          (dim == 3 ?
+             ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
+             0)) *
+         dofs_per_quad);
+
+    // first_face_line_index
+    result.first_object_index_on_face[1][0] =
+      (ReferenceCell::internal::Info::get_face(cell_type, face_no)
+         .n_vertices() *
+       dofs_per_vertex);
+
+    // first_face_quad_index
+    result.first_object_index_on_face[2][0] =
+      ((dim == 3 ?
+          ReferenceCell::internal::Info::get_face(cell_type, face_no)
+              .n_vertices() *
+            dofs_per_vertex :
+          ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
+            dofs_per_vertex) +
+       ReferenceCell::internal::Info::get_face(cell_type, face_no).n_lines() *
+         dofs_per_line);
+
+    // dofs_per_face
+    result.dofs_per_object_inclusive[dim - 1][0] =
+      (ReferenceCell::internal::Info::get_face(cell_type, face_no)
+           .n_vertices() *
+         dofs_per_vertex +
+       ReferenceCell::internal::Info::get_face(cell_type, face_no).n_lines() *
+         dofs_per_line +
+       (dim == 3 ? 1 : 0) * dofs_per_quad);
+
+
+    // dofs_per_cell
+    result.dofs_per_object_inclusive[dim][0] =
+      (ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
+         dofs_per_vertex +
+       ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
+         dofs_per_line +
+       (dim == 2 ?
+          1 :
+          (dim == 3 ?
+             ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
+             0)) *
+         dofs_per_quad +
+       (dim == 3 ? 1 : 0) * dofs_per_hex);
+
+    return result;
+  }
+} // namespace
+
 template <int dim>
 FiniteElementData<dim>::FiniteElementData(
   const std::vector<unsigned int> &dofs_per_object,
@@ -46,67 +147,53 @@ FiniteElementData<dim>::FiniteElementData(
   const unsigned int               degree,
   const Conformity                 conformity,
   const BlockIndices &             block_indices)
+  : FiniteElementData(expand(dim, dofs_per_object, cell_type),
+                      cell_type,
+                      n_components,
+                      degree,
+                      conformity,
+                      block_indices)
+{}
+
+template <int dim>
+FiniteElementData<dim>::FiniteElementData(
+  const internal::GenericDoFsPerObject &data,
+  const ReferenceCell::Type             cell_type,
+  const unsigned int                    n_components,
+  const unsigned int                    degree,
+  const Conformity                      conformity,
+  const BlockIndices &                  block_indices)
   : cell_type(cell_type)
-  , dofs_per_vertex(dofs_per_object[0])
-  , dofs_per_line(dofs_per_object[1])
-  , dofs_per_quad(dim > 1 ? dofs_per_object[2] : 0)
-  , dofs_per_quad_max(dofs_per_quad)
-  , dofs_per_hex(dim > 2 ? dofs_per_object[3] : 0)
-  , first_line_index(
-      ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-      dofs_per_vertex)
-  , first_quad_index(
-      first_line_index +
-      ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
-        dofs_per_line)
-  , first_hex_index(
-      first_quad_index +
-      (dim == 2 ?
-         1 :
-         (dim == 3 ?
-            ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
-            0)) *
-        dofs_per_quad)
-  , first_face_line_index(
-      ReferenceCell::internal::Info::get_face(cell_type, 0).n_vertices() *
-      dofs_per_vertex)
-  , first_face_quad_index(
-      (dim == 3 ?
-         ReferenceCell::internal::Info::get_face(cell_type, 0).n_vertices() *
-           dofs_per_vertex :
-         ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-           dofs_per_vertex) +
-      ReferenceCell::internal::Info::get_face(cell_type, 0).n_lines() *
-        dofs_per_line)
-  , dofs_per_face(
-      ReferenceCell::internal::Info::get_face(cell_type, 0).n_vertices() *
-        dofs_per_vertex +
-      ReferenceCell::internal::Info::get_face(cell_type, 0).n_lines() *
-        dofs_per_line +
-      (dim == 3 ? 1 : 0) * dofs_per_quad)
-  , dofs_per_face_max(dofs_per_face)
-  , dofs_per_cell(
-      ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-        dofs_per_vertex +
-      ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
-        dofs_per_line +
-      (dim == 2 ?
-         1 :
-         (dim == 3 ?
-            ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
-            0)) *
-        dofs_per_quad +
-      (dim == 3 ? 1 : 0) * dofs_per_hex)
+  , number_unique_quads(data.dofs_per_object_inclusive[2].size())
+  , number_unique_faces(data.dofs_per_object_inclusive[dim - 1].size())
+  , dofs_per_vertex(data.dofs_per_object_exclusive[0][0])
+  , dofs_per_line(data.dofs_per_object_exclusive[1][0])
+  , n_dofs_on_quad(dim > 1 ? data.dofs_per_object_exclusive[2] :
+                             std::vector<unsigned int>{0})
+  , dofs_per_quad(n_dofs_on_quad[0])
+  , dofs_per_quad_max(
+      *max_element(n_dofs_on_quad.begin(), n_dofs_on_quad.end()))
+  , dofs_per_hex(dim > 2 ? data.dofs_per_object_exclusive[3][0] : 0)
+  , first_line_index(data.object_index[1][0])
+  , first_index_of_quads(data.object_index[2])
+  , first_quad_index(first_index_of_quads[0])
+  , first_hex_index(data.object_index[3][0])
+  , first_line_index_of_faces(data.first_object_index_on_face[1])
+  , first_face_line_index(first_line_index_of_faces[0])
+  , first_quad_index_of_faces(data.first_object_index_on_face[2])
+  , first_face_quad_index(first_quad_index_of_faces[0])
+  , n_dofs_on_face(data.dofs_per_object_inclusive[dim - 1])
+  , dofs_per_face(n_dofs_on_face[0])
+  , dofs_per_face_max(
+      *max_element(n_dofs_on_face.begin(), n_dofs_on_face.end()))
+  , dofs_per_cell(data.dofs_per_object_inclusive[dim][0])
   , components(n_components)
   , degree(degree)
   , conforming_space(conformity)
   , block_indices_data(block_indices.size() == 0 ?
                          BlockIndices(1, dofs_per_cell) :
                          block_indices)
-{
-  Assert(dofs_per_object.size() == dim + 1,
-         ExcDimensionMismatch(dofs_per_object.size() - 1, dim));
-}
+{}
 
 
 


### PR DESCRIPTION
This PR generalizes the notion of **dofs per objects**/**dpo** so that faces in 3D (objects) can have different number of dofs. This is in particular useful for wedges and pyramids. These are geometric entities whose faces consists of triangles and quadrilaterals. In the case of a quadratic elements, triangles have 6 dofs (1 per vertex and line, 0 inside) and quadrilaterals have 9 dofs (1 per vertex and line, and 1 inside).

Elements needing this kind of flexibility can fill a `PrecomputedFiniteElementData` and pass this to the constructor of `FiniteElementData`. As a consequence, all methods related to quad/face get an additional parameter: `quad_no`/`face_no`. Follow up PRs will explicitly pass a number to these functions.