### PR TITLE
Fix MPIEXEC detection again.

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -83,7 +83,8 @@ MACRO(DEAL_II_PICKUP_TESTS)
   # Necessary external interpreters and programs:
   #
   IF(${DEAL_II_WITH_MPI})
-    IF( "${MPIEXEC_EXECUTABLE}" STREQUAL "")
+    IF("${DEAL_II_MPIEXEC}" STREQUAL "" OR
+       "${DEAL_II_MPIEXEC}" STREQUAL "MPIEXEC_EXECUTABLE-NOTFOUND")
       MESSAGE(FATAL_ERROR "Could not find an MPI launcher program, which is required "
 "for running the testsuite. Please explicitly specify MPIEXEC_EXECUTABLE to CMake "
 "as a full path to the MPI launcher program.")


### PR DESCRIPTION
Fixes problems with #10734.

We should check the value deal.II finally stores - other MPI variables are not necessarily set at this point.

