### PR TITLE
fix dof_accessor warning

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -281,29 +281,26 @@ namespace internal
         AssertIndexRange(obj_level, dof_handler.object_dof_indices.size());
         AssertIndexRange(d, dof_handler.object_dof_indices[obj_level].size());
 
-        unsigned int fe_index_;
         Assert(dof_handler.hp_capability_enabled, ExcInternalError());
 
-        {
-          AssertIndexRange(d, dof_handler.hp_object_fe_ptr.size());
-          AssertIndexRange(obj_index, dof_handler.hp_object_fe_ptr[d].size());
+        AssertIndexRange(d, dof_handler.hp_object_fe_ptr.size());
+        AssertIndexRange(obj_index, dof_handler.hp_object_fe_ptr[d].size());
 
-          const auto ptr =
-            std::find(dof_handler.hp_object_fe_indices[d].begin() +
-                        dof_handler.hp_object_fe_ptr[d][obj_index],
-                      dof_handler.hp_object_fe_indices[d].begin() +
+        const auto ptr =
+          std::find(dof_handler.hp_object_fe_indices[d].begin() +
+                      dof_handler.hp_object_fe_ptr[d][obj_index],
+                    dof_handler.hp_object_fe_indices[d].begin() +
+                      dof_handler.hp_object_fe_ptr[d][obj_index + 1],
+                    fe_index);
+
+        Assert(ptr != dof_handler.hp_object_fe_indices[d].begin() +
                         dof_handler.hp_object_fe_ptr[d][obj_index + 1],
-                      fe_index);
+               ExcNotImplemented());
 
-          Assert(ptr != dof_handler.hp_object_fe_indices[d].begin() +
-                          dof_handler.hp_object_fe_ptr[d][obj_index + 1],
-                 ExcNotImplemented());
-
-          fe_index_ =
-            std::distance(dof_handler.hp_object_fe_indices[d].begin() +
-                            dof_handler.hp_object_fe_ptr[d][obj_index],
-                          ptr);
-        }
+        const unsigned int fe_index_ =
+          std::distance(dof_handler.hp_object_fe_indices[d].begin() +
+                          dof_handler.hp_object_fe_ptr[d][obj_index],
+                        ptr);
 
         AssertIndexRange(dof_handler.hp_capability_enabled ?
                            (dof_handler.hp_object_fe_ptr[d][obj_index] +

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -282,28 +282,28 @@ namespace internal
         AssertIndexRange(d, dof_handler.object_dof_indices[obj_level].size());
 
         unsigned int fe_index_;
+        Assert(dof_handler.hp_capability_enabled, ExcInternalError());
 
-        if (dof_handler.hp_capability_enabled)
-          {
-            AssertIndexRange(d, dof_handler.hp_object_fe_ptr.size());
-            AssertIndexRange(obj_index, dof_handler.hp_object_fe_ptr[d].size());
+        {
+          AssertIndexRange(d, dof_handler.hp_object_fe_ptr.size());
+          AssertIndexRange(obj_index, dof_handler.hp_object_fe_ptr[d].size());
 
-            const auto ptr =
-              std::find(dof_handler.hp_object_fe_indices[d].begin() +
-                          dof_handler.hp_object_fe_ptr[d][obj_index],
-                        dof_handler.hp_object_fe_indices[d].begin() +
+          const auto ptr =
+            std::find(dof_handler.hp_object_fe_indices[d].begin() +
+                        dof_handler.hp_object_fe_ptr[d][obj_index],
+                      dof_handler.hp_object_fe_indices[d].begin() +
+                        dof_handler.hp_object_fe_ptr[d][obj_index + 1],
+                      fe_index);
+
+          Assert(ptr != dof_handler.hp_object_fe_indices[d].begin() +
                           dof_handler.hp_object_fe_ptr[d][obj_index + 1],
-                        fe_index);
+                 ExcNotImplemented());
 
-            Assert(ptr != dof_handler.hp_object_fe_indices[d].begin() +
-                            dof_handler.hp_object_fe_ptr[d][obj_index + 1],
-                   ExcNotImplemented());
-
-            fe_index_ =
-              std::distance(dof_handler.hp_object_fe_indices[d].begin() +
-                              dof_handler.hp_object_fe_ptr[d][obj_index],
-                            ptr);
-          }
+          fe_index_ =
+            std::distance(dof_handler.hp_object_fe_indices[d].begin() +
+                            dof_handler.hp_object_fe_ptr[d][obj_index],
+                          ptr);
+        }
 
         AssertIndexRange(dof_handler.hp_capability_enabled ?
                            (dof_handler.hp_object_fe_ptr[d][obj_index] +


### PR DESCRIPTION
fixes:
```
/jenkins/workspace/dealii_PR-10786/include/deal.II/base/exceptions.h:1414:72:
error: ‘fe_index_’ may be used uninitialized in this function [-Werror
=maybe-uninitialized]
/jenkins/workspace/dealii_PR-10786/include/deal.II/dofs/dof_accessor.templates.h:284:22:
note: ‘fe_index_’ was declared here
```

part of #10786