### PR TITLE
Add CUDA 10.2 CI build check

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
     - name: build
       run: |
         make -j 2
-        
+
   linux-debug-parallel-simplex:
     # simple parallel debug build using g++ with simplex configuration enabled
 
@@ -75,4 +75,51 @@ jobs:
     - name: test
       run: |
         make -j 2 setup_tests_simplex
-        ctest --output-on-failure -j 2 
+        ctest --output-on-failure -j 2
+
+  linux-debug-cuda-10:
+    # simple parallel debug build using cuda-10
+
+    name: linux debug cuda-10
+    runs-on: [ubuntu-18.04]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: modules
+      run: |
+        wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+        sudo mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        wget http://developer.download.nvidia.com/compute/cuda/10.2/Prod/local_installers/cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+        sudo dpkg -i cuda-repo-ubuntu1804-10-2-local-10.2.89-440.33.01_1.0-1_amd64.deb
+        sudo apt-key add /var/cuda-repo-10-2-local-10.2.89-440.33.01/7fa2af80.pub
+        sudo apt-get install -y software-properties-common
+        sudo add-apt-repository ppa:ginggs/deal.ii-9.2.0-backports
+        sudo apt-get update
+        apt search cuda
+        sudo apt-get install -yq --no-install-recommends \
+            cuda-toolkit-10-2 \
+            libp4est-dev \
+            libopenmpi-dev \
+            openmpi-bin
+    - name: info
+      run: |
+        mpicc -v
+        cmake --version
+    - name: configure
+      run: |
+        cmake -D CMAKE_BUILD_TYPE=Debug \
+              -D DEAL_II_CUDA_FLAGS='-arch=sm_70' \
+              -D DEAL_II_CXX_FLAGS='-Werror -Wno-non-template-friend' \
+              -D DEAL_II_WITH_CUDA="ON" \
+              -D DEAL_II_WITH_MPI="ON" \
+              -D DEAL_II_WITH_P4EST="ON" \
+              -D DEAL_II_COMPONENT_EXAMPLES="ON" \
+              .
+    - name: archive
+      uses: actions/upload-artifact@v1
+      with:
+        name: linux-cuda-detailed.log
+        path: detailed.log
+    - name: build
+      run: |
+        make -j 2

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -256,8 +256,8 @@ namespace Step64
   // We can ask the parallel triangulation for the number of active, locally
   // owned cells but only have a DoFHandler object at hand. Since
   // DoFHandler::get_triangulation() returns a Triangulation object, not a
-  // parallel::Triangulation object, we have to downcast the return value. This
-  // is safe to do here because we know that the triangulation is a
+  // parallel::TriangulationBase object, we have to downcast the return value.
+  // This is safe to do here because we know that the triangulation is a
   // parallel:distributed::Triangulation object in fact.
   template <int dim, int fe_degree>
   HelmholtzOperator<dim, fe_degree>::HelmholtzOperator(
@@ -275,7 +275,7 @@ namespace Step64
 
 
     const unsigned int n_owned_cells =
-      dynamic_cast<const parallel::Triangulation<dim> *>(
+      dynamic_cast<const parallel::TriangulationBase<dim> *>(
         &dof_handler.get_triangulation())
         ->n_locally_owned_active_cells();
     coef.reinit(Utilities::pow(fe_degree + 1, dim) * n_owned_cells);

--- a/source/particles/generators.cc
+++ b/source/particles/generators.cc
@@ -120,7 +120,7 @@ namespace Particles
 
 #ifdef DEAL_II_WITH_MPI
       if (const auto tria =
-            dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+            dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
               &triangulation))
         {
           const types::particle_index n_particles_to_generate =
@@ -236,7 +236,7 @@ namespace Particles
     {
       unsigned int combined_seed = random_number_seed;
       if (const auto tria =
-            dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+            dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
               &triangulation))
         {
           const unsigned int my_rank =
@@ -264,7 +264,7 @@ namespace Particles
         double global_weight_integral;
 
         if (const auto tria =
-              dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+              dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
                 &triangulation))
           {
             global_weight_integral =
@@ -292,7 +292,7 @@ namespace Particles
 
 #ifdef DEAL_II_WITH_MPI
         if (const auto tria =
-              dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+              dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
                 &triangulation))
           {
             MPI_Exscan(&local_weight_integral,

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -195,7 +195,7 @@ namespace Particles
       }
 
     if (const auto parallel_triangulation =
-          dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+          dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &*triangulation))
       {
         global_number_of_particles = dealii::Utilities::MPI::sum(
@@ -439,7 +439,7 @@ namespace Particles
 
 #ifdef DEAL_II_WITH_MPI
     if (const auto parallel_triangulation =
-          dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+          dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &*triangulation))
       {
         types::particle_index particles_to_add_locally = positions.size();
@@ -1003,7 +1003,7 @@ namespace Particles
 
     std::set<types::subdomain_id> ghost_owners;
     if (const auto parallel_triangulation =
-          dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+          dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &*triangulation))
       ghost_owners = parallel_triangulation->ghost_owners();
 
@@ -1152,7 +1152,7 @@ namespace Particles
     // Exchange particles between processors if we have more than one process
 #ifdef DEAL_II_WITH_MPI
     if (const auto parallel_triangulation =
-          dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+          dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &*triangulation))
       {
         if (dealii::Utilities::MPI::n_mpi_processes(
@@ -1181,7 +1181,7 @@ namespace Particles
   {
     // Nothing to do in serial computations
     const auto parallel_triangulation =
-      dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
         &*triangulation);
     if (parallel_triangulation != nullptr)
       {
@@ -1266,12 +1266,12 @@ namespace Particles
       &send_cells)
   {
     const auto parallel_triangulation =
-      dynamic_cast<const parallel::Triangulation<dim, spacedim> *>(
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
         &*triangulation);
     Assert(
       parallel_triangulation,
       ExcMessage(
-        "This function is only implemented for parallel::Triangulation objects."));
+        "This function is only implemented for parallel::TriangulationBase objects."));
 
     // Determine the communication pattern
     const std::set<types::subdomain_id> ghost_owners =


### PR DESCRIPTION
After #10793, we at least need CUDA 10.2 to compile deal.II. We are already testing CUDA-11 in the regression tests. In my opinion, it makes sense to also test that the oldest version we claim to support compiles.