### PR TITLE
Fix a changelog entry.

### DIFF
--- a/doc/news/changes/minor/20200627Bangerth
+++ b/doc/news/changes/minor/20200627Bangerth
@@ -1,4 +1,4 @@
 New: There is now a constructor for class Tensor that takes
 an initializer from an object of type ArrayView.
 <br>
-(Andrew Davis, Wolfgang Bangerth, 2020/06/27)
+(Wolfgang Bangerth, 2020/06/27)


### PR DESCRIPTION
Specifically, the patch to which this changelog entry was mine alone, but I had copy-pasted
from a previous changelog entry of mine.