### PR TITLE
Fix another bug with DataPostprocessorTensor

### DIFF
--- a/source/numerics/data_postprocessor.cc
+++ b/source/numerics/data_postprocessor.cc
@@ -148,15 +148,7 @@ template <int dim>
 std::vector<std::string>
 DataPostprocessorTensor<dim>::get_names() const
 {
-  static_assert(dim <= 3,
-                "The following variable needs to be expanded for dim>3");
-  static const char suffixes[] = {'x', 'y', 'z'};
-
-  std::vector<std::string> names;
-  for (unsigned int d = 0; d < dim; ++d)
-    for (unsigned int e = 0; e < dim; ++e)
-      names.push_back(name + '_' + suffixes[d] + suffixes[e]);
-  return names;
+  return std::vector<std::string>(dim * dim, name);
 }
 
 

--- a/tests/data_out/data_out_postprocessor_tensor_01.output
+++ b/tests/data_out/data_out_postprocessor_tensor_01.output
@@ -10,7 +10,7 @@ DEAL:cg::Convergence step 11 value 3.55007e-13
 #
 # For a description of the GNUPLOT format see the GNUPLOT manual.
 #
-# <x> <y> <displacement> <displacement> <strain_xx> <strain_xy> <strain_yx> <strain_yy> 
+# <x> <y> <displacement> <displacement> <strain> <strain> <strain> <strain> 
 -1.00000 -1.00000 0.00000 0.00000 0.00000 0.00000 0.00000 0.00000 
 -0.500000 -1.00000 0.00000 0.00000 0.00000 0.0158134 0.0158134 0.0248929 
 

--- a/tests/data_out/data_out_postprocessor_tensor_02.output
+++ b/tests/data_out/data_out_postprocessor_tensor_02.output
@@ -32,7 +32,7 @@ AQAAABAAAAAQAAAACwAAAA==eNrj5EQFAATYAJE=
   <PointData Scalars="scalars">
     <DataArray type="Float32" Name="displacement" NumberOfComponents="3" format="binary">
 AQAAAAADAAAAAwAAegAAAA==eNpjYCAMWLsbbVTfeNsQqybya6eNCuNSG2LNaWI3tw3MsrbBZw6yGhl1ddttRba2+NyDrJeJ4ZX1fNm51vjU41KDyxxkNyC7DZc5yGpwAVxqkM3EFQ7IanCFP6nhgMscZIArHJD1IscpLj/iShu4zKEkrSIDAI4LYGU=    </DataArray>
-    <DataArray type="Float32" Name="strain_xx__strain_xy__strain_yx__strain_yy" NumberOfComponents="9" format="binary">
+    <DataArray type="Float32" Name="strain" NumberOfComponents="9" format="binary">
 AQAAAAAJAAAACQAAIgIAAA==eNqdVr8vREEQfufH0ZAoRCSu4golpbenQiQqhYR/gUgkGi0V0ZHoUGklChHebCIhBFEqqCUS0YlCI+Ybs42bzW1um+/lvW+/mdmZnXlZlrbat9ddwOrHg6v/XqpVP2bkfUCL07f+Jt+Alk6KLayFry0XcKhUrf3/PnFUzvv2Lv9sMVo64Cxld/IeaOmkxtVZG5a9wP3utuI/Z6PjrDa7mMv+gBZnd+DPB6ClA583b3uFA4xxvk9KwgFOv87VxTVf/il6ljfkPdDSAWfnekU4QEsnJRdYLdl7HvCwUqmL/+T9gG7Pr8bwDLR0wFlbLROegZZOiq2U1ZIt0s11v+gALR1wDiv7cm4BLZ8nx7tkL9A6Q3Cmnk6FA2w9W3BGLvL74xGJHRjJaf75NSo+Ay0d+Pw4WJa9wBinUVxcq/7l+Un2Ai0dcLjWSWueYjWfci/YBqktYltk+OzY11x9ziM5dRyz19i9pYOa57Mr9AyLGIdz4DQXyKk3cuo4l6Q5NX0Gh2uCtDbI0kmNi2u00FotuFYpa3LxnSkCWjrwme+e0zvoYhy+wxd6ly/4LvtmbGlPoYCWDmqee5PXHuWtMwSHe5zXXue51+VGzyy4V3rtmaYOONxzvfZeUwc1z73baw+PchrdC54pnmeJ15li6oDDM4l0Npk68JlnG+mMM88QHJ6RpLOSeFY2lQud2RTQ0oHPPPtJ/wGinEZxpdhKWb+GgHOA    </DataArray>
   </PointData>
  </Piece>


### PR DESCRIPTION
This is the promised follow-up to #10803: We spelled out the components of the tensor, which `DataOutBase` then helpfully collates into a very long string. What we should be doing is name all components the same because they're part of one whole. Do so here.

(Side note: This matches what we do in `DataPostprocessorVector`.)