### PR TITLE
ECL: Merge gather and adjust_for_face_orientation

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -467,6 +467,14 @@ namespace internal
        */
       dealii::Table<2, unsigned int> face_to_cell_index_hermite;
 
+      /**
+       * For degrees on faces, the basis functions are not
+       * in the correct order if a face is not in the standard orientation
+       * to a given element. This data structure is used to re-order the
+       * basis functions to represent the correct order.
+       */
+      dealii::Table<2, unsigned int> face_orientations;
+
     private:
       /**
        * Check whether we have symmetries in the shape values. In that case,

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -481,6 +481,46 @@ namespace internal
                       face_to_cell_index_nodal(f, l) = ind;
                     }
             }
+
+          // face orientation for faces in 3D
+          // (similar to MappingInfoStorage::QuadratureDescriptor::initialize)
+          if (dim == 3)
+            {
+              const unsigned int n = fe_degree + 1;
+              face_orientations.reinit(8, n * n);
+              for (unsigned int j = 0, i = 0; j < n; ++j)
+                for (unsigned int k = 0; k < n; ++k, ++i)
+                  {
+                    // face_orientation=true,  face_flip=false,
+                    // face_rotation=false
+                    face_orientations[0][i] = i;
+                    // face_orientation=false, face_flip=false,
+                    // face_rotation=false
+                    face_orientations[1][i] = j + k * n;
+                    // face_orientation=true,  face_flip=true,
+                    // face_rotation=false
+                    face_orientations[2][i] = (n - 1 - k) + (n - 1 - j) * n;
+                    // face_orientation=false, face_flip=true,
+                    // face_rotation=false
+                    face_orientations[3][i] = (n - 1 - j) + (n - 1 - k) * n;
+                    // face_orientation=true,  face_flip=false,
+                    // face_rotation=true
+                    face_orientations[4][i] = j + (n - 1 - k) * n;
+                    // face_orientation=false, face_flip=false,
+                    // face_rotation=true
+                    face_orientations[5][i] = k + (n - 1 - j) * n;
+                    // face_orientation=true,  face_flip=true,
+                    // face_rotation=true
+                    face_orientations[6][i] = (n - 1 - j) + k * n;
+                    // face_orientation=false, face_flip=true,
+                    // face_rotation=true
+                    face_orientations[7][i] = (n - 1 - k) + j * n;
+                  }
+            }
+          else
+            {
+              face_orientations.reinit(1, 1);
+            }
         }
 
       if (element_type == tensor_symmetric_hermite)


### PR DESCRIPTION
This PR enables, within `FEFaceEvaluation::gather_evaluate()`, re-orientation during reading for certain cases: no subfaces and no gradients in the case of Hermite basis.

In the next step I would like to make `face_no`, `face_orientation`, and `side` to `std::array<unsigned int, N>` to allow faces to have different numbers/orientations.

The fall-back case (`read_dof_values`/`evaluate`) is still not working.