### PR TITLE
Inform memory leak of sacado_rad_fad in doc.

### DIFF
--- a/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
+++ b/doc/doxygen/headers/automatic_and_symbolic_differentiation.h
@@ -300,7 +300,7 @@
  *  - Forward-mode Sacado with dynamic memory allocation using expression templates (once differentiable)
  *  - Nested forward-mode Sacado using expression templates (twice differentiable)
  *  - Reverse-mode Sacado (once differentiable)
- *  - Nested reverse and dynamically-allocated forward-mode Sacado (twice differentiable)
+ *  - Nested reverse and dynamically-allocated forward-mode Sacado (twice differentiable, but results memory leak described in Differentiation::AD::NumberTypes)
  *
  * Note that in the above, "dynamic memory allocation" refers to the fact that the number of
  * independent variables need not be specified at compile time.

--- a/include/deal.II/differentiation/ad/ad_number_types.h
+++ b/include/deal.II/differentiation/ad/ad_number_types.h
@@ -84,6 +84,11 @@ namespace Differentiation
        *
        * First derivatives will be computed using reverse mode, while the second
        * derivatives will be computed using forward mode.
+       *
+       * Note that the repeated use of the nested reverse-forward mode results
+       * in a memory leak described in this <a
+       * href="https://github.com/trilinos/Trilinos/issues/7741"> Trilinos
+       * issue.</a>
        */
       sacado_rad_dfad
     };


### PR DESCRIPTION
As per 

https://groups.google.com/g/dealii/c/BqtkaahE1NQ/m/1kOPQPXdBgAJ

and

https://github.com/trilinos/Trilinos/issues/7741

update the documentation about memory leak when using sacado_rad_fad.