### PR TITLE
Remove n_components template argument from FEEvaluationImpl

### DIFF
--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef dealii_matrix_free_evaluation_flags_h
+#define dealii_matrix_free_evaluation_flags_h
+
+#include <deal.II/base/config.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+
+
+/**
+ * @brief The namespace for the EvaluationFlags enum
+ *
+ * This namespace contains the enum EvaluationFlags used in FEEvaluation
+ * to control evaluation and integration of values, gradients, etc..
+ */
+namespace EvaluationFlags
+{
+  /**
+   * @brief The EvaluationFlags enum
+   *
+   * This enum contains a set of flags used by FEEvaluation::integrate(),
+   * FEEvaluation::evaluate() and others to determine if values, gradients,
+   * hessians, or a combination of them is being used.
+   */
+  enum EvaluationFlags
+  {
+    /**
+     * Do not use or compute anything.
+     */
+    nothing = 0,
+    /**
+     * Use or evaluate values.
+     */
+    values = 0x1,
+    /**
+     * Use or evaluate gradients.
+     */
+    gradients = 0x2,
+    /**
+     * Use or evaluate hessians.
+     */
+    hessians = 0x4
+  };
+
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * either set in the first or the second argument. This operator exists since
+   * if it did not then the result of the bit-or <tt>operator |</tt> would be an
+   * integer which would in turn trigger a compiler warning when we tried to
+   * assign it to an object of type UpdateFlags.
+   *
+   * @ref EvaluationFlags
+   */
+  inline EvaluationFlags
+  operator|(const EvaluationFlags f1, const EvaluationFlags f2)
+  {
+    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) |
+                                        static_cast<unsigned int>(f2));
+  }
+
+
+
+  /**
+   * Global operator which sets the bits from the second argument also in the
+   * first one.
+   *
+   * @ref EvaluationFlags
+   */
+  inline EvaluationFlags &
+  operator|=(EvaluationFlags &f1, const EvaluationFlags f2)
+  {
+    f1 = f1 | f2;
+    return f1;
+  }
+
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * set in the first as well as the second argument. This operator exists since
+   * if it did not then the result of the bit-and <tt>operator &</tt> would be
+   * an integer which would in turn trigger a compiler warning when we tried to
+   * assign it to an object of type UpdateFlags.
+   *
+   * @ref EvaluationFlags
+   */
+  inline EvaluationFlags operator&(const EvaluationFlags f1,
+                                   const EvaluationFlags f2)
+  {
+    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) &
+                                        static_cast<unsigned int>(f2));
+  }
+
+
+  /**
+   * Global operator which clears all the bits in the first argument if they are
+   * not also set in the second argument.
+   *
+   * @ref EvaluationFlags
+   */
+  inline EvaluationFlags &
+  operator&=(EvaluationFlags &f1, const EvaluationFlags f2)
+  {
+    f1 = f1 & f2;
+    return f1;
+  }
+
+} // namespace EvaluationFlags
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1302,16 +1302,18 @@ namespace internal
                                                 start_indices,
                                                 cell_points.data());
 
-                  SelectEvaluator<dim, -1, 0, dim, VectorizedDouble>::evaluate(
+                  SelectEvaluator<dim, -1, 0, VectorizedDouble>::evaluate(
+                    dim,
+                    EvaluationFlags::values | EvaluationFlags::gradients |
+                      (update_flags_cells & update_jacobian_grads ?
+                         EvaluationFlags::hessians :
+                         EvaluationFlags::nothing),
                     shape_info,
                     cell_points.data(),
                     cell_quads.data(),
                     cell_grads.data(),
                     cell_grad_grads.data(),
-                    scratch_data.data(),
-                    true,
-                    true,
-                    update_flags_cells & update_jacobian_grads);
+                    scratch_data.data());
                 }
               if (update_flags_cells & update_quadrature_points)
                 {

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1016,11 +1016,9 @@ namespace MatrixFreeOperators
     VectorizedArrayType>::apply(const VectorizedArrayType *in_array,
                                 VectorizedArrayType *      out_array) const
   {
-    internal::CellwiseInverseMassMatrixImpl<
-      dim,
-      fe_degree,
-      n_components,
-      VectorizedArrayType>::apply(fe_eval, in_array, out_array);
+    internal::
+      CellwiseInverseMassMatrixImpl<dim, fe_degree, VectorizedArrayType>::apply(
+        n_components, fe_eval, in_array, out_array);
   }
 
 
@@ -1041,15 +1039,13 @@ namespace MatrixFreeOperators
           const VectorizedArrayType *               in_array,
           VectorizedArrayType *                     out_array) const
   {
-    internal::CellwiseInverseMassMatrixImpl<dim,
-                                            fe_degree,
-                                            n_components,
-                                            VectorizedArrayType>::
-      apply(fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
-            inverse_coefficients,
-            n_actual_components,
-            in_array,
-            out_array);
+    internal::
+      CellwiseInverseMassMatrixImpl<dim, fe_degree, VectorizedArrayType>::apply(
+        n_actual_components,
+        fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
+        inverse_coefficients,
+        in_array,
+        out_array);
   }
 
 
@@ -1069,15 +1065,13 @@ namespace MatrixFreeOperators
                                      const VectorizedArrayType *in_array,
                                      VectorizedArrayType *      out_array) const
   {
-    internal::CellwiseInverseMassMatrixImpl<dim,
-                                            fe_degree,
-                                            n_components,
-                                            VectorizedArrayType>::
-      transform_from_q_points_to_basis(
-        fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
-        n_actual_components,
-        in_array,
-        out_array);
+    internal::
+      CellwiseInverseMassMatrixImpl<dim, fe_degree, VectorizedArrayType>::
+        transform_from_q_points_to_basis(
+          n_actual_components,
+          fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
+          in_array,
+          out_array);
   }
 
 

--- a/source/matrix_free/evaluation_selector.inst.in
+++ b/source/matrix_free/evaluation_selector.inst.in
@@ -14,37 +14,29 @@
 // ---------------------------------------------------------------------
 
 
-for (deal_II_dimension : DIMENSIONS; components : SPACE_DIMENSIONS;
-     scalar_type : REAL_SCALARS)
+for (deal_II_dimension : DIMENSIONS; scalar_type : REAL_SCALARS)
   {
-    template void SelectEvaluator<deal_II_dimension,
-                                  -1,
-                                  0,
-                                  components,
-                                  VectorizedArray<scalar_type>>::
-      integrate(const internal::MatrixFreeFunctions::ShapeInfo<
+    template void
+    SelectEvaluator<deal_II_dimension, -1, 0, VectorizedArray<scalar_type>>::
+      integrate(const unsigned int,
+                const EvaluationFlags::EvaluationFlags,
+                const internal::MatrixFreeFunctions::ShapeInfo<
                   VectorizedArray<scalar_type>> &shape_info,
                 VectorizedArray<scalar_type> *,
                 VectorizedArray<scalar_type> *,
                 VectorizedArray<scalar_type> *,
                 VectorizedArray<scalar_type> *,
-                const bool,
-                const bool,
                 const bool);
 
-    template void SelectEvaluator<deal_II_dimension,
-                                  -1,
-                                  0,
-                                  components,
-                                  VectorizedArray<scalar_type>>::
-      evaluate(const internal::MatrixFreeFunctions::ShapeInfo<
+    template void
+    SelectEvaluator<deal_II_dimension, -1, 0, VectorizedArray<scalar_type>>::
+      evaluate(const unsigned int,
+               const EvaluationFlags::EvaluationFlags,
+               const internal::MatrixFreeFunctions::ShapeInfo<
                  VectorizedArray<scalar_type>> &shape_info,
                VectorizedArray<scalar_type> *,
                VectorizedArray<scalar_type> *,
                VectorizedArray<scalar_type> *,
                VectorizedArray<scalar_type> *,
-               VectorizedArray<scalar_type> *,
-               const bool,
-               const bool,
-               const bool);
+               VectorizedArray<scalar_type> *);
   }

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -462,10 +462,10 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
                                                   dim,
                                                   degree + 1,
                                                   2 * degree + 1,
-                                                  1,
                                                   VectorizedArray<Number>,
                                                   VectorizedArray<Number>>::
-              do_forward(prolongation_matrix_1d,
+              do_forward(1,
+                         prolongation_matrix_1d,
                          evaluation_data.begin() +
                            c * Utilities::fixed_power<dim>(degree_size),
                          evaluation_data.begin() + c * n_scalar_cell_dofs,
@@ -484,10 +484,10 @@ MGTransferMatrixFree<dim, Number>::do_prolongate_add(
                                                   dim,
                                                   degree + 1,
                                                   2 * degree + 2,
-                                                  1,
                                                   VectorizedArray<Number>,
                                                   VectorizedArray<Number>>::
-              do_forward(prolongation_matrix_1d,
+              do_forward(1,
+                         prolongation_matrix_1d,
                          evaluation_data.begin() +
                            c * Utilities::fixed_power<dim>(degree_size),
                          evaluation_data.begin() + c * n_scalar_cell_dofs,
@@ -560,10 +560,10 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
                                                   dim,
                                                   degree + 1,
                                                   2 * degree + 1,
-                                                  1,
                                                   VectorizedArray<Number>,
                                                   VectorizedArray<Number>>::
-              do_backward(prolongation_matrix_1d,
+              do_backward(1,
+                          prolongation_matrix_1d,
                           false,
                           evaluation_data.begin() + c * n_scalar_cell_dofs,
                           evaluation_data.begin() +
@@ -578,10 +578,10 @@ MGTransferMatrixFree<dim, Number>::do_restrict_add(
                                                   dim,
                                                   degree + 1,
                                                   2 * degree + 2,
-                                                  1,
                                                   VectorizedArray<Number>,
                                                   VectorizedArray<Number>>::
-              do_backward(prolongation_matrix_1d,
+              do_backward(1,
+                          prolongation_matrix_1d,
                           false,
                           evaluation_data.begin() + c * n_scalar_cell_dofs,
                           evaluation_data.begin() +


### PR DESCRIPTION
This PR does two things:
- It cleans up some of the internal interfaces of `FEEvaluationImpl` as a follow-up to #10369 to only take an `EvaluationFlags::EvaluationFlags` argument rather than a list of bools
- It removes the `n_components` template argument from the internal `FEEvaluationImpl` classes. The components are only a variable to loop over with a lot of work done inside, so I see little value to have this a compile-time constant. This will help to keep the number of instantiations in a possible resolution of #9794 down because we do not need to compile by the number of components, but it should also generally help the compiler reduce the amount of code we generate.

I have not yet touched the implementation for face integrals because @peterrum is currently working on those parts and because the work is orthogonal to this anyway. In that part, we will also need to switch the order of some loops in `gather_evaluate` and `integrate_scatter`.

One thing we could think about is whether we need a changelog because the `SelectEvaluator` class sits in the general namespace, as opposed to the internal namespace for the `FEEvaluationImpl` class itself.