### PR TITLE
Ignore differences in line endings on Windows and Linux.

### DIFF
--- a/cmake/scripts/run_test.sh
+++ b/cmake/scripts/run_test.sh
@@ -106,7 +106,7 @@ case $STAGE in
       #   - [space][tab][newline]=,:;<>[](){}^ as separators between
       #     numbers
       #
-      "${NUMDIFF_EXECUTABLE}" -a 1e-6 -r 1e-8 -s ' \t\n=,:;<>[](){}^' \
+      "${NUMDIFF_EXECUTABLE}" -a 1e-6 -r 1e-8 -s ' \t\r\n=,:;<>[](){}^' \
                               "${file}" output > diff${variant}
 
       if [ $? -eq 0 ]; then


### PR DESCRIPTION
In a different project, I've had problems where the test `.output` files were written on Linux but the tests run on Windows with its different line ending scheme. The test consequently failed, even though there was no reason for it. 

This patch teaches numdiff to ignore this difference.