### PR TITLE
Destroy tmp matrix in mmult.

### DIFF
--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -556,6 +556,8 @@ namespace PETScWrappers
                             PETSC_DEFAULT,
                             &result.petsc_matrix());
           AssertThrow(ierr == 0, ExcPETScError(ierr));
+          ierr = PETScWrappers::destroy_matrix(tmp);
+			    AssertThrow(ierr == 0, ExcPETScError(ierr));
         }
     }
   } // namespace internals

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -557,7 +557,7 @@ namespace PETScWrappers
                             &result.petsc_matrix());
           AssertThrow(ierr == 0, ExcPETScError(ierr));
           ierr = PETScWrappers::destroy_matrix(tmp);
-			    AssertThrow(ierr == 0, ExcPETScError(ierr));
+          AssertThrow(ierr == 0, ExcPETScError(ierr));
         }
     }
   } // namespace internals


### PR DESCRIPTION
When using a vector in the mmult, a tmp matrix with scaled rows is not destroyed, which leads to a memory leak.
This can be fixed using PETScWrappers::destroy_matrix(tmp).
-So, please verify!
Regards,
Richard