### PR TITLE
Enable python bindings in the docker image.

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -8,9 +8,10 @@ RUN cd /usr/src \
     && cd dealii && mkdir build && cd build \
     && cmake -GNinja \
     -DCMAKE_PREFIX_PATH="/usr/lib/x86_64-linux-gnu/hdf5/openmpi;/usr/include/hdf5/openmpi" \
+    -DDEAL_II_COMPILE_EXAMPLES=OFF \
+    -DDEAL_II_COMPONENT_PYTHON_BINDINGS=ON \
     -DDEAL_II_WITH_MPI=ON \
     -DDEAL_II_WITH_SIMPLEX_SUPPORT=ON \
-    -DDEAL_II_COMPILE_EXAMPLES=OFF \
     .. \  
     && ninja install \
     && cd ../ && rm -rf .git build


### PR DESCRIPTION
This requires the PR on [dealii/docker-files](https://github.com/dealii/docker-files/pull/29/files) to be merged first.