### PR TITLE
Add more python wrappers for GridTools

### DIFF
--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -236,8 +236,13 @@ namespace python
     /*! @copydoc GridGenerator::merge_triangulations
      */
     void
-    merge_triangulations(TriangulationWrapper &triangulation_1,
-                         TriangulationWrapper &triangulation_2);
+    merge_triangulations(boost::python::list &triangulations);
+
+    /*! @copydoc GridGenerator::replicate_triangulation
+     */
+    void
+    replicate_triangulation(TriangulationWrapper &tria_in,
+                            boost::python::list & extents);
 
     /*! @copydoc GridGenerator::flatten_triangulation
      */

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -236,7 +236,9 @@ namespace python
     /*! @copydoc GridGenerator::merge_triangulations
      */
     void
-    merge_triangulations(boost::python::list &triangulations);
+    merge_triangulations(boost::python::list &triangulations,
+                         const double duplicated_vertex_tolerance = 1.0e-12,
+                         const bool   copy_manifold_ids           = false);
 
     /*! @copydoc GridGenerator::replicate_triangulation
      */

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -111,6 +111,10 @@ namespace python
     find_active_cell_around_point,
     1,
     2)
+  BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(merge_triangulations_overloads,
+                                         merge_triangulations,
+                                         1,
+                                         3)
 
   const char n_active_cells_docstring[] =
     "Return the number of active cells.                                     \n";
@@ -319,7 +323,7 @@ namespace python
 
 
 
-  const char merge_docstring[] =
+  const char merge_triangulations_docstring[] =
     "Given two or more triangulations, create the triangulation that        \n"
     "contains the cells of given triangulations.                            \n";
 
@@ -622,8 +626,10 @@ namespace python
            boost::python::args("self", "scaling_factor"))
       .def("merge_triangulations",
            &TriangulationWrapper::merge_triangulations,
-           merge_docstring,
-           boost::python::args("self", "triangulations"))
+           merge_triangulations_overloads(
+             boost::python::args(
+               "self", "triangulations", "vertex_tolerance", "copy_manifolds"),
+             merge_triangulations_docstring))
       .def("extrude_triangulation",
            &TriangulationWrapper::extrude_triangulation,
            extrude_docstring,

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -320,8 +320,8 @@ namespace python
 
 
   const char merge_docstring[] =
-    "Given two triangulations, create the triangulation that contains       \n"
-    "the cells of both triangulations.                                      \n";
+    "Given two or more triangulations, create the triangulation that        \n"
+    "contains the cells of given triangulations.                            \n";
 
 
 
@@ -354,6 +354,13 @@ namespace python
 
 
 
+  const char replicate_docstring[] =
+    "Replicate a given triangulation in multiple coordinate axes.          \n"
+    "This function creates a new Triangulation equal to a dim-dimensional  \n"
+    "array of copies of input.                                             \n";
+
+
+
   const char distort_random_docstring[] =
     "Distort the given triangulation by randomly moving around all the      \n"
     "vertices of the grid. The direction of movement of each vertex is      \n"
@@ -370,6 +377,7 @@ namespace python
 
   const char execute_coarsening_and_refinement_docstring[] =
     "Execute both refinement and coarsening of the Triangulation.           \n";
+
 
 
   const char active_cells_docstring[] =
@@ -615,7 +623,7 @@ namespace python
       .def("merge_triangulations",
            &TriangulationWrapper::merge_triangulations,
            merge_docstring,
-           boost::python::args("self", "triangulation_1", "triangulation_2"))
+           boost::python::args("self", "triangulations"))
       .def("extrude_triangulation",
            &TriangulationWrapper::extrude_triangulation,
            extrude_docstring,
@@ -624,6 +632,10 @@ namespace python
            &TriangulationWrapper::flatten_triangulation,
            flatten_triangulation_docstring,
            boost::python::args("self", "tria_out"))
+      .def("replicate_triangulation",
+           &TriangulationWrapper::replicate_triangulation,
+           replicate_docstring,
+           boost::python::args("self", "tria_in", "extents"))
       .def("distort_random",
            &TriangulationWrapper::distort_random,
            distort_random_overloads(

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -515,7 +515,9 @@ namespace python
     template <int dim, int spacedim>
     void
     merge_triangulations(boost::python::list &triangulations,
-                         void *               triangulation)
+                         void *               triangulation,
+                         const double         duplicated_vertex_tolerance,
+                         const bool           copy_manifold_ids)
     {
       Triangulation<dim, spacedim> *tria =
         static_cast<Triangulation<dim, spacedim> *>(triangulation);
@@ -531,7 +533,10 @@ namespace python
             tria_wrapper.get_triangulation()));
         }
 
-      GridGenerator::merge_triangulations(tria_ptrs, *tria);
+      GridGenerator::merge_triangulations(tria_ptrs,
+                                          *tria,
+                                          duplicated_vertex_tolerance,
+                                          copy_manifold_ids);
     }
 
 
@@ -1436,7 +1441,9 @@ namespace python
 
   void
   TriangulationWrapper::merge_triangulations(
-    boost::python::list &triangulations)
+    boost::python::list &triangulations,
+    const double         duplicated_vertex_tolerance,
+    const bool           copy_manifold_ids)
   {
     AssertThrow(boost::python::len(triangulations) >= 2,
                 ExcMessage(
@@ -1457,11 +1464,20 @@ namespace python
       }
 
     if ((dim == 2) && (spacedim == 2))
-      internal::merge_triangulations<2, 2>(triangulations, triangulation);
+      internal::merge_triangulations<2, 2>(triangulations,
+                                           triangulation,
+                                           duplicated_vertex_tolerance,
+                                           copy_manifold_ids);
     else if ((dim == 2) && (spacedim == 3))
-      internal::merge_triangulations<2, 3>(triangulations, triangulation);
+      internal::merge_triangulations<2, 3>(triangulations,
+                                           triangulation,
+                                           duplicated_vertex_tolerance,
+                                           copy_manifold_ids);
     else
-      internal::merge_triangulations<3, 3>(triangulations, triangulation);
+      internal::merge_triangulations<3, 3>(triangulations,
+                                           triangulation,
+                                           duplicated_vertex_tolerance,
+                                           copy_manifold_ids);
   }
 
 

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -356,10 +356,21 @@ class TestTriangulationWrapper(unittest.TestCase):
             else:
                 triangulation_2.shift([1., 0., 0.])
             triangulation = Triangulation(dim[0], dim[1])
-            triangulation.merge_triangulations(triangulation_1,
-                                               triangulation_2)
+            triangulation.merge_triangulations([triangulation_1,
+                                                triangulation_2])
             n_cells = triangulation.n_active_cells()
             self.assertEqual(n_cells, 2)
+
+    def test_replicate(self):
+        for dim in self.restricted_dim:
+            triangulation_in = self.build_hyper_cube_triangulation(dim)
+            triangulation_out = Triangulation(dim[0])
+            if (dim[0] == '2D'):
+                triangulation_out.replicate_triangulation(triangulation_in, [3, 2]);
+            else:
+                triangulation_out.replicate_triangulation(triangulation_in, [3, 2, 1]);
+            n_cells = triangulation_out.n_active_cells()
+            self.assertEqual(n_cells, 6)
 
     def test_flatten(self):
         for dim in self.dim:

--- a/doc/news/changes/incompatibilities/20200901Grayver
+++ b/doc/news/changes/incompatibilities/20200901Grayver
@@ -1,0 +1,3 @@
+Replaced: Python wrapper for 'merge_triangulations' with a more generic equivalent.
+<br>
+(Alexander Grayver, 2020/09/01)

--- a/doc/news/changes/minor/20200901AlexanderGrayver
+++ b/doc/news/changes/minor/20200901AlexanderGrayver
@@ -1,0 +1,5 @@
+Added: python wrapper for GridTools::replicate_triangulation,
+more general version of the GridTools::merge_triangulations is
+implemented
+<br>
+(Alexander Grayver, 2020/09/01)

--- a/examples/step-49/step-49.ipynb
+++ b/examples/step-49/step-49.ipynb
@@ -575,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -625,7 +625,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -643,7 +643,7 @@
    ],
    "source": [
     "tria_merged = dealii.Triangulation('2D')\n",
-    "tria_merged.merge_triangulations(tria_1, tria_2)\n",
+    "tria_merged.merge_triangulations([tria_1, tria_2])\n",
     "plot_triangulation(tria_merged)"
    ]
   },


### PR DESCRIPTION
- Replace existing ```merge_triangulations``` wrapper that accepts only two triangulations with a more generic equivalent.
- Add python wrapper for GridTools::replicate_triangulation

Part of #9015