### PR TITLE
Speed up DoFTools::extract_dofs

### DIFF
--- a/doc/news/changes/minor/20200903MartinKronbichler
+++ b/doc/news/changes/minor/20200903MartinKronbichler
@@ -1,0 +1,4 @@
+Fixed: DoFTools::extract_dofs() return an IndexSet as result used to have a
+quadratic complexity in the number of extracted indices. This is now fixed.
+<br>
+(Martin Kronbichler, 2020/08/11)


### PR DESCRIPTION
As reported on the mainling list, the function got really slow. It turned out that the function called IndexSet::add_index() for every index, which leads to frequent memory allocations and movements of indices that can lead to a quadratic complexity in the number of indices. This function was introduced in #9182. Luckily, we have a good implementation of that part almost there by an internal function, so we only need to go there.