### PR TITLE
Simplex HDF5 parallel testing

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -110,8 +110,10 @@ IncludeCategories:
     Priority: 290
   - Regex:    "deal.II/physics/.*\\.h"
     Priority: 300
-  - Regex:    "deal.II/sundials/.*\\.h"
+  - Regex:    "deal.II/simplex/.*\\.h"
     Priority: 310
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 320
 # put boost right after deal:
   - Regex: "<boost.*>"
     Priority: 500

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,6 +62,7 @@ jobs:
               -D DEAL_II_WITH_TRILINOS="ON" \
               -D DEAL_II_WITH_PETSC="ON" \
               -D DEAL_II_WITH_METIS="ON" \
+              -D DEAL_II_WITH_HDF5="ON" \
               -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
               .
     - name: archive

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -819,10 +819,7 @@ namespace
           }
         else
           {
-            Assert(patch.n_subdivisions == 1, ExcNotImplemented());
-            const auto &info = ReferenceCell::internal::Info::get_cell(
-              patch.reference_cell_type);
-            n_nodes += info.n_vertices();
+            n_nodes += patch.data.n_cols();
             n_cells += 1;
           }
       }


### PR DESCRIPTION
- Update the simplex test for exporting data in HDF5 file format to really work in parallel with a `parallel::fullydistributed::Triangulation`.
- Enable `-DWITH_HDF5=ON` in the simplex workflow.
- Remove a wrong assertion in the `compute_sizes()` function of `data_out_base.cc`.
- Adds `simplex/` to the list of folders that are parsed by `clang-format`.