### PR TITLE
Properly sort #include <deal.II/simplex/*.h>

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -110,8 +110,10 @@ IncludeCategories:
     Priority: 290
   - Regex:    "deal.II/physics/.*\\.h"
     Priority: 300
-  - Regex:    "deal.II/sundials/.*\\.h"
+  - Regex:    "deal.II/simplex/.*\\.h"
     Priority: 310
+  - Regex:    "deal.II/sundials/.*\\.h"
+    Priority: 320
 # put boost right after deal:
   - Regex: "<boost.*>"
     Priority: 500


### PR DESCRIPTION
Add `simplex/` to the list of folders that are parsed by `clang-format`.