### PR TITLE
Generalize p:d:SolutionTransfer for p:f:T [WIP]

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -231,6 +231,28 @@ namespace parallel
       virtual bool
       is_multilevel_hierarchy_constructed() const override;
 
+      void
+      save(const std::string &filename) const;
+
+
+      void
+      load(const std::string &filename, const bool autopartition = true);
+
+      virtual unsigned int
+      register_data_attach(
+        const std::function<std::vector<char>(const cell_iterator &,
+                                              const CellStatus)> &pack_callback,
+        const bool returns_variable_size_data) override;
+
+      virtual void
+      notify_ready_to_unpack(
+        const unsigned int handle,
+        const std::function<void(
+          const cell_iterator &,
+          const CellStatus,
+          const boost::iterator_range<std::vector<char>::const_iterator> &)>
+          &unpack_callback) override;
+
     private:
       virtual unsigned int
       coarse_cell_id_to_coarse_cell_index(

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -748,7 +748,7 @@ namespace parallel
       register_data_attach(
         const std::function<std::vector<char>(const cell_iterator &,
                                               const CellStatus)> &pack_callback,
-        const bool returns_variable_size_data);
+        const bool returns_variable_size_data) override;
 
       /**
        * This function is the opposite of register_data_attach(). It is called
@@ -805,7 +805,7 @@ namespace parallel
           const cell_iterator &,
           const CellStatus,
           const boost::iterator_range<std::vector<char>::const_iterator> &)>
-          &unpack_callback);
+          &unpack_callback) override;
 
       /**
        * Return a permutation vector for the order the coarse cells are handed
@@ -1330,7 +1330,7 @@ namespace parallel
           const typename dealii::Triangulation<1, spacedim>::cell_iterator &,
           const typename dealii::Triangulation<1, spacedim>::CellStatus)>
           &        pack_callback,
-        const bool returns_variable_size_data);
+        const bool returns_variable_size_data) override;
 
       /**
        * This function is not implemented, but needs to be present for the
@@ -1343,7 +1343,7 @@ namespace parallel
           const typename dealii::Triangulation<1, spacedim>::cell_iterator &,
           const typename dealii::Triangulation<1, spacedim>::CellStatus,
           const boost::iterator_range<std::vector<char>::const_iterator> &)>
-          &unpack_callback);
+          &unpack_callback) override;
 
       /**
        * Dummy arrays. This class isn't usable but the compiler wants to see

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -361,6 +361,23 @@ namespace parallel
       const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
                  smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
       const bool check_for_distorted_cells = false);
+
+    virtual unsigned int
+    register_data_attach(
+      const std::function<std::vector<char>(
+        const typename dealii::Triangulation<dim, spacedim>::cell_iterator &,
+        const typename dealii::Triangulation<dim, spacedim>::CellStatus)>
+        &        pack_callback,
+      const bool returns_variable_size_data) = 0;
+
+    virtual void
+    notify_ready_to_unpack(
+      const unsigned int handle,
+      const std::function<void(
+        const typename dealii::Triangulation<dim, spacedim>::cell_iterator &,
+        const typename dealii::Triangulation<dim, spacedim>::CellStatus,
+        const boost::iterator_range<std::vector<char>::const_iterator> &)>
+        &unpack_callback) = 0;
   };
 
 } // namespace parallel

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -391,6 +391,65 @@ namespace parallel
 
 
 
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::save(const std::string &filename) const
+    {
+      (void)filename;
+
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::load(const std::string &filename,
+                                       const bool         autopartition)
+    {
+      (void)filename;
+      (void)autopartition;
+
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+
+
+    template <int dim, int spacedim>
+    unsigned int
+    Triangulation<dim, spacedim>::register_data_attach(
+      const std::function<std::vector<char>(const cell_iterator &,
+                                            const CellStatus)> &pack_callback,
+      const bool returns_variable_size_data)
+    {
+      (void)pack_callback;
+      (void)returns_variable_size_data;
+
+      AssertThrow(false, ExcNotImplemented());
+
+      return 0;
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::notify_ready_to_unpack(
+      const unsigned int handle,
+      const std::function<
+        void(const cell_iterator &,
+             const CellStatus,
+             const boost::iterator_range<std::vector<char>::const_iterator> &)>
+        &unpack_callback)
+    {
+      (void)handle;
+      (void)unpack_callback;
+
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+
+
   } // namespace fullydistributed
 } // namespace parallel
 

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -121,8 +121,9 @@ namespace parallel
       , handle(numbers::invalid_unsigned_int)
     {
       Assert(
-        (dynamic_cast<const parallel::distributed::
-                        Triangulation<dim, DoFHandlerType::space_dimension> *>(
+        (dynamic_cast<const parallel::DistributedTriangulationBase<
+           dim,
+           DoFHandlerType::space_dimension> *>(
            &dof_handler->get_triangulation()) != nullptr),
         ExcMessage(
           "parallel::distributed::SolutionTransfer requires a parallel::distributed::Triangulation object."));
@@ -147,12 +148,11 @@ namespace parallel
     SolutionTransfer<dim, VectorType, DoFHandlerType>::register_data_attach()
     {
       // TODO: casting away constness is bad
-      parallel::distributed::Triangulation<dim, DoFHandlerType::space_dimension>
-        *tria = (dynamic_cast<parallel::distributed::Triangulation<
-                   dim,
-                   DoFHandlerType::space_dimension> *>(
-          const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
-                       *>(&dof_handler->get_triangulation())));
+      auto *tria = (dynamic_cast<parallel::DistributedTriangulationBase<
+                      dim,
+                      DoFHandlerType::space_dimension> *>(
+        const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
+                     *>(&dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
       handle = tria->register_data_attach(
@@ -232,12 +232,11 @@ namespace parallel
              ExcDimensionMismatch(input_vectors.size(), all_out.size()));
 
       // TODO: casting away constness is bad
-      parallel::distributed::Triangulation<dim, DoFHandlerType::space_dimension>
-        *tria = (dynamic_cast<parallel::distributed::Triangulation<
-                   dim,
-                   DoFHandlerType::space_dimension> *>(
-          const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
-                       *>(&dof_handler->get_triangulation())));
+      auto *tria = (dynamic_cast<parallel::DistributedTriangulationBase<
+                      dim,
+                      DoFHandlerType::space_dimension> *>(
+        const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
+                     *>(&dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
       tria->notify_ready_to_unpack(


### PR DESCRIPTION
The final goal of this PR is to register vectors to `p:f:T` and serialize/deserialize them together with the triangulation. 

The functions within `p:f:T` that have to be implemented are:
```cpp
void save(filename) const;

void load(filename, autopartition);

virtual unsigned int
register_data_attach(pack_callback, returns_variable_size_data) override;

virtual void
notify_ready_to_unpack(handle, unpack_callback) override;
```

For `load()` and `save()`, we could use the utility functions in `TriangulationDescription::Utilities`. The functions `register_data_attach` and `notify_ready_to_unpack` should look quite similar to the ones of `p:d:T`: if we for now assume that the is no AMR, we don't need any `DataTransfer` there and the code should significantly simpler than in `p:d:T`.

FYI @elauksap 