### PR TITLE
Split out mapping-related part from FEEvaluationBase into base class

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -32,6 +32,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
+// forward declaration
+template <int, typename, bool, typename>
+class FEEvaluationBaseData;
+
+
 
 namespace internal
 {
@@ -3165,12 +3170,14 @@ namespace internal
   template <int dim, int fe_degree, typename Number>
   struct CellwiseInverseMassMatrixImpl
   {
-    template <typename FEEvaluationType>
     static void
-    apply(const unsigned int      n_components,
-          const FEEvaluationType &fe_eval,
-          const Number *          in_array,
-          Number *                out_array)
+    apply(const unsigned int                  n_components,
+          const FEEvaluationBaseData<dim,
+                                     typename Number::value_type,
+                                     false,
+                                     Number> &fe_eval,
+          const Number *                      in_array,
+          Number *                            out_array)
     {
       constexpr unsigned int dofs_per_component =
         Utilities::pow(fe_degree + 1, dim);


### PR DESCRIPTION
This PR splits the mapping-dependent part of `FEEvaluationBase` (a base class of `FEEvaluation`) into a separate base class which I called `FEEvaluationMappingRelated`. The advantage is that we skip the number of solution components in this base class, and that we better group the functionality such that `FEEvaluationBase` can concentrate on the functions related to reading vectors and to handle the solution data (values, gradients) at quadrature points.

If somebody has a suggestion for a better name (we cannot easily change the `FEEvaluationBase` name because it has been part of the public name before), I'd be happy to apply that.