### PR TITLE
Fix warning: declaration of dim hides template parameter when using CUDA

### DIFF
--- a/include/deal.II/base/tensor_product_polynomials.h
+++ b/include/deal.II/base/tensor_product_polynomials.h
@@ -665,8 +665,7 @@ Tensor<order, 0>
 TensorProductPolynomials<0, Polynomials::Polynomial<double>>::
   compute_derivative(const unsigned int, const Point<0> &) const
 {
-  constexpr int dim = 0;
-  AssertThrow(dim > 0, ExcNotImplemented());
+  AssertThrow(false, ExcNotImplemented());
 
   return {};
 }
@@ -843,8 +842,7 @@ Tensor<order, 0>
 AnisotropicPolynomials<0>::compute_derivative(const unsigned int,
                                               const Point<0> &) const
 {
-  constexpr int dim = 0;
-  AssertThrow(dim > 0, ExcNotImplemented());
+  AssertThrow(false, ExcNotImplemented());
 
   return {};
 }


### PR DESCRIPTION
Not sure why nvcc is not happy but since we are not supposed to get in these functions anyway, I think it's fine to set the condition to `false`.