### PR TITLE
Add a constructor to GridIn and extend read(std::string)

### DIFF
--- a/include/deal.II/grid/grid_in.h
+++ b/include/deal.II/grid/grid_in.h
@@ -342,6 +342,11 @@ public:
   GridIn();
 
   /**
+   * Constructor. Attach this triangulation to be fed with the grid data.
+   */
+  GridIn(Triangulation<dim, spacedim> &tria);
+
+  /**
    * Attach this triangulation to be fed with the grid data.
    */
   void

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -96,6 +96,15 @@ GridIn<dim, spacedim>::GridIn()
 {}
 
 
+
+template <int dim, int spacedim>
+GridIn<dim, spacedim>::GridIn(Triangulation<dim, spacedim> &t)
+  : tria(&t, typeid(*this).name())
+  , default_format(ucd)
+{}
+
+
+
 template <int dim, int spacedim>
 void
 GridIn<dim, spacedim>::attach_triangulation(Triangulation<dim, spacedim> &t)

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3036,7 +3036,6 @@ GridIn<dim, spacedim>::read(const std::string &filename, Format format)
   else
     name = search.find(filename, default_suffix(format));
 
-  std::ifstream in(name.c_str());
 
   if (format == Default)
     {
@@ -3049,7 +3048,16 @@ GridIn<dim, spacedim>::read(const std::string &filename, Format format)
           format          = parse_format(ext);
         }
     }
-  read(in, format);
+
+  if (format == assimp)
+    {
+      read_assimp(name);
+    }
+  else
+    {
+      std::ifstream in(name.c_str());
+      read(in, format);
+    }
 }
 
 


### PR DESCRIPTION
This PR does two things: add a new constructor to `GridIn` and add `read_assimp` to `read(std::string)`. The function `read(std::ifstream)` throws for the `assimp` format because `read_assimp` input is a `std::string` instead of a `std::ifstream`.