### PR TITLE
Assign boundary ids

### DIFF
--- a/doc/news/changes/major/20200910Rastak
+++ b/doc/news/changes/major/20200910Rastak
@@ -1,0 +1,5 @@
+New: GridTools::assign_boundary_ids() allows quick assignment of boundary_id
+values to a triangulation using a number of geometrical predicate functions
+that could be provided as lambdas.
+<br>
+(Reza Rastak, 2020/09/10)

--- a/examples/step-52/step-52.cc
+++ b/examples/step-52/step-52.cc
@@ -29,6 +29,7 @@
 #include <deal.II/grid/tria_iterator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_accessor.h>
@@ -659,15 +660,10 @@ namespace Step52
     GridGenerator::hyper_cube(triangulation, 0., 5.);
     triangulation.refine_global(4);
 
-    for (const auto &cell : triangulation.active_cell_iterators())
-      for (const auto &face : cell->face_iterators())
-        if (face->at_boundary())
-          {
-            if ((face->center()[0] == 0.) || (face->center()[0] == 5.))
-              face->set_boundary_id(1);
-            else
-              face->set_boundary_id(0);
-          }
+    GridTools::assign_boundary_ids(triangulation, {{1, [](const auto &p) {
+                                                      return p[0] == 0. ||
+                                                             p[0] == 5.;
+                                                    }}});
 
     // Next, we set up the linear systems and fill them with content so that
     // they can be used throughout the time stepping process:

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2806,6 +2806,35 @@ namespace GridTools
           return numbers::flat_manifold_id;
       },
     bool overwrite_only_flat_manifold_ids = true);
+
+  /**
+   * Assign a series of boundary ids to a triangulation based on a list of
+   * predicates.
+   * @param tria a triangulation object.
+   * @param boundary_specifiers describes which faces should be assigned to
+   *   specific boundary id values. It is a vector of pairs. The first
+   *   component is the desired boundary id for the faces. The second
+   *   component is the predicate that receives the coordinate of the face
+   *   center and decides whether that face is part of the boundary.
+   * @return a vector `V` where `V[i]` represents the number of faces that
+   *   matched the predicate
+   *   `boundary_specifiers[i].second(face->center()) == true` and have been
+   *   assigned the boundary id `boundary_specifiers[i].first`.
+   * @note In many cases, the return value is not needed and can be ignored,
+   *   but in some situations, it could extremely useful for error chacking,
+   *   debugging, and gathering statistics on the mesh faces.
+   * @note If a face matches more than one of the predicates, the earlier
+   *   predicate will determine the assigned boundary id.
+   * @post The size of the returned vector is the same as the size of
+   *   @boundary_specifiers.
+   */
+  template <int dim, int spacedim>
+  std::vector<types::global_cell_index>
+  assign_boundary_ids(
+    Triangulation<dim, spacedim> &tria,
+    const std::vector<std::pair<types::boundary_id,
+                                std::function<bool(const Point<spacedim> &)>>>
+      &boundary_specifiers);
   /*@}*/
 
   /**

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -403,6 +403,13 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
           types::manifold_id(const std::set<types::manifold_id> &)> &,
         bool);
 
+      template std::vector<types::global_cell_index>
+      assign_boundary_ids(
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const std::vector<std::pair<
+          types::boundary_id,
+          std::function<bool(const Point<deal_II_space_dimension> &)>>> &);
+
       template void
       regularize_corner_cells(
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,

--- a/tests/grid/grid_tools_assign_boundary_ids_01.cc
+++ b/tests/grid/grid_tools_assign_boundary_ids_01.cc
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test assign_boundary_ids by setting ids to two faces.
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria);
+  // assign b-id of 1 to (x == 0) and b-id of 2 to (x == 1)
+  // Two lambdas are passed. One of them accepts a Point<spacedim>
+  // however, the other one can accept anything. The function should
+  // work with either of these lambda definitions.
+  GridTools::assign_boundary_ids(
+    tria,
+    {{1, [](const Point<spacedim> &p) { return p[0] == 0.; }},
+     {2, [](const auto &p) { return p[0] == 1.; }}});
+  deallog << "hyper_cube<" << dim << ", " << spacedim << ">" << std::endl;
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      for (auto f : cell->face_indices())
+        if (cell->face(f)->at_boundary())
+          deallog << "face " << f << " B-id " << cell->face(f)->boundary_id()
+                  << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  test<1, 1>();
+  test<1, 2>();
+  test<2, 2>();
+  test<1, 3>();
+  test<2, 3>();
+  test<3, 3>();
+  deallog << "OK" << std::endl;
+  return 0;
+}

--- a/tests/grid/grid_tools_assign_boundary_ids_01.output
+++ b/tests/grid/grid_tools_assign_boundary_ids_01.output
@@ -1,0 +1,28 @@
+
+DEAL::hyper_cube<1, 1>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::hyper_cube<1, 2>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::hyper_cube<2, 2>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::face 2 B-id 0
+DEAL::face 3 B-id 0
+DEAL::hyper_cube<1, 3>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::hyper_cube<2, 3>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::face 2 B-id 0
+DEAL::face 3 B-id 0
+DEAL::hyper_cube<3, 3>
+DEAL::face 0 B-id 1
+DEAL::face 1 B-id 2
+DEAL::face 2 B-id 0
+DEAL::face 3 B-id 0
+DEAL::face 4 B-id 0
+DEAL::face 5 B-id 0
+DEAL::OK

--- a/tests/grid/grid_tools_assign_boundary_ids_02.cc
+++ b/tests/grid/grid_tools_assign_boundary_ids_02.cc
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test assign_boundary_ids when overlapping predicates are provided.
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  Triangulation<3> tria;
+  GridGenerator::hyper_cube(tria);
+  // assign b-id of 3 to four faces where face_center[x] == 0.5
+  // and b-id of 6 to two faces where
+  //   face_center[x] + face_center[y] == 1.5
+  // One of these faces already has b-id of 3, so we should not
+  // change it. Therefore, only once face will contain b-id of 6.
+  GridTools::assign_boundary_ids(
+    tria,
+    {{3, [](const auto &p) { return p[0] == 0.5; }},
+     {6, [](const auto &p) { return p[0] + p[1] == 1.5; }}});
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->is_locally_owned())
+      for (auto f : cell->face_indices())
+        if (cell->face(f)->at_boundary())
+          deallog << "face " << f << " B-id " << cell->face(f)->boundary_id()
+                  << std::endl;
+}
+
+int
+main()
+{
+  initlog();
+
+  test();
+  deallog << "OK" << std::endl;
+  return 0;
+}

--- a/tests/grid/grid_tools_assign_boundary_ids_02.output
+++ b/tests/grid/grid_tools_assign_boundary_ids_02.output
@@ -1,0 +1,8 @@
+
+DEAL::face 0 B-id 0
+DEAL::face 1 B-id 6
+DEAL::face 2 B-id 3
+DEAL::face 3 B-id 3
+DEAL::face 4 B-id 3
+DEAL::face 5 B-id 3
+DEAL::OK


### PR DESCRIPTION
I am introducing a new method to systematically assign boundary ids to faces of a triangulation. This follows more declarative and functional style of programming and requires the use of `std::function` and lambdas. I have modified a number of tutorials to use this new style. Let me know how you feel about it.

In short, when we assign boundary ids based on geometrical considerations, instead of:
```c++
for (const auto &cell : triangulation.active_cell_iterators())
  if (cell->is_locally_owned())
    for (const auto &face : cell->face_iterators())
      if (face->at_boundary())
        {
          const Point<dim> face_center = face->center();

          if (face_center[2] == 0)
            face->set_boundary_id(0);
          else if (face_center[2] == 3)
            face->set_boundary_id(1);
        }
```
we can write:
```c++
GridTools::assign_boundary_ids(triangulation,
      {{0, [](const auto &p) { return p[2] == 0.; }},
       {1, [](const auto &p) { return p[2] == 3.; }}});
```
The user might define helper classes to simplify this even more. For example, we can write:
```c++
GridTools::assign_boundary_ids(triangulation,
      {{0, OnPlane(2, 0.0)},
       {1, OnPlane(2, 3.0)}});
```
if we have pre-defined this helper class:
```c++
class OnPlane{
  int component;
  double location, tol;

  OnPlane(int component, double location, tol=1.-6) 
    : component{component}, location{location}, tol{tol}
  {}

  template <int dim>
  bool operator()(const Point<dim> &p){
    return std::abs(p[component] - location) < tol;
  }
};
```
Advantages:
* Functional and declarative style rather than procedural.
* Prevents users from making common mistakes such as forgetting to check if the face is on the boundary or forgetting to check if the cell is locally owned.
* Sometimes leads to shorter code especially when we have small number of boundary descriptions.
* More readable code (in my subjective opinion).

Disadvantages:
* Because of using std::function, there may be a small performance penalty but this function is not going to be run in performance-critical loops.
* Might seem less readable to some people because of the lambda syntax and heavy brace initializations.

Future improvements:
* User can provide an optional `Mapping` so that instead of `face->center()` we can check the location of the true center of face on a curved manifold.
* User can provide an optional `Quadrature` to ensure that boundary id is assigned only if all integration points match the predicate (not just the face center).