### PR TITLE
Mark two functions 'noexcept'.

### DIFF
--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -565,7 +565,8 @@ public:
   /**
    * Move constructor
    */
-  AffineConstraints(AffineConstraints &&affine_constraints) = default; // NOLINT
+  AffineConstraints(AffineConstraints &&affine_constraints) noexcept =
+    default; // NOLINT
 
   /**
    * Copy operator. Like for many other large objects, this operator
@@ -583,7 +584,8 @@ public:
    * Move assignment operator
    */
   AffineConstraints &
-  operator=(AffineConstraints &&affine_constraints) = default; // NOLINT
+  operator=(AffineConstraints &&affine_constraints) noexcept =
+    default; // NOLINT
 
   /**
    * Copy the given object to the current one.


### PR DESCRIPTION
With a newer compiler, I got a warning about missing `noexcept` on two functions. I have no idea what the `// NOLINT` comment on these lines referred to, but assume that it is unrelated. Let's see what the testers have to say.