### PR TITLE
Avoid gcc-10 warning about deprecated parallel::Triangulation

### DIFF
--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -137,8 +137,8 @@ namespace parallel
      * Triangulation associated with the @p dof_handler.
      */
     static std::function<unsigned int(
-      const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-      const typename Triangulation<dim, spacedim>::CellStatus     status)>
+      const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+      const typename dealii::Triangulation<dim, spacedim>::CellStatus status)>
     make_weighting_callback(const DoFHandler<dim, spacedim> &dof_handler,
                             const WeightingFunction &weighting_function);
 

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -126,8 +126,8 @@ namespace parallel
 
   template <int dim, int spacedim>
   std::function<unsigned int(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    const typename Triangulation<dim, spacedim>::CellStatus     status)>
+    const typename dealii::Triangulation<dim, spacedim>::cell_iterator &cell,
+    const typename dealii::Triangulation<dim, spacedim>::CellStatus     status)>
   CellWeights<dim, spacedim>::make_weighting_callback(
     const DoFHandler<dim, spacedim> &dof_handler,
     const typename CellWeights<dim, spacedim>::WeightingFunction
@@ -142,17 +142,19 @@ namespace parallel
       ExcMessage(
         "parallel::CellWeights requires a parallel::TriangulationBase object."));
 
-    return [&dof_handler, tria, weighting_function](
-             const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-             const typename Triangulation<dim, spacedim>::CellStatus     status)
-             -> unsigned int {
-      return CellWeights<dim, spacedim>::weighting_callback(cell,
-                                                            status,
-                                                            std::cref(
-                                                              dof_handler),
-                                                            std::cref(*tria),
-                                                            weighting_function);
-    };
+    return
+      [&dof_handler, tria, weighting_function](
+        const typename dealii::Triangulation<dim, spacedim>::cell_iterator
+          &                                                             cell,
+        const typename dealii::Triangulation<dim, spacedim>::CellStatus status)
+        -> unsigned int {
+        return CellWeights<dim, spacedim>::weighting_callback(
+          cell,
+          status,
+          std::cref(dof_handler),
+          std::cref(*tria),
+          weighting_function);
+      };
   }
 
 


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=11070.