### PR TITLE
Replace __restrict by DEAL_II_RESTRICT

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2614,11 +2614,11 @@ namespace internal
     // `scratch_data` variable to not risk a stack overflow.
     constexpr unsigned int stack_array_size_threshold = 100;
 
+    VectorizedArrayType *DEAL_II_RESTRICT temp1;
     VectorizedArrayType
       temp_data[static_dofs_per_face < stack_array_size_threshold ?
                   2 * dofs_per_face :
                   1];
-    VectorizedArrayType *__restrict temp1;
     if (static_dofs_per_face < stack_array_size_threshold)
       temp1 = &temp_data[0];
     else


### PR DESCRIPTION
I didn't notice any problem with using `__restrict` directly but since it's non-standard and we use DEAL_II_RESTRICT in all the other places, we should just be consistent (and avoid possible future problems).

I changed the order of declarations to prevent `clang-tidy` from suggesting a weird indentation.