### PR TITLE
step-68: A few updates to documentation + slight code cleanup

### DIFF
--- a/examples/step-68/doc/intro.dox
+++ b/examples/step-68/doc/intro.dox
@@ -130,11 +130,11 @@ also be different (non-matching) from the triangulation of the background grid,
 which is useful to generate particles in particular shapes (as in this
 example), or to transfer information between two different computational grids
 (as in step-70).  Furthermore, the Particles::ParticleHandler class provides the
-Particles::ParticleHandler::insert_global_particles function() which enables the
+Particles::ParticleHandler::insert_global_particles() function which enables the
 global insertion of particles from a vector of arbitrary points and a global
 vector of bounding boxes. In the present step, we use the
 Particles::Generators::quadrature_points() function on a non-matching triangulation to
-insert particle located at positions in the shape of a disk.
+insert particles located at positions in the shape of a disk.
 
 <h4>Particle exchange</h4>
 
@@ -183,7 +183,7 @@ finite-element problems already discussed in other examples.
 <h3>The testcase</h3>
 
 In the present step, we use particles as massless tracers to illustrate
-the dynamics of a particular vortical flow: the Rayleigh-Kothe Vortex. This flow pattern
+the dynamics of a particular vortical flow: the Rayleigh--Kothe vortex. This flow pattern
 is generally used as a complex test case for interface tracking methods
 (e.g., volume-of-fluid and level set approaches) since
 it leads to strong rotation and elongation of the fluid @cite Blais2013.
@@ -191,7 +191,7 @@ it leads to strong rotation and elongation of the fluid @cite Blais2013.
 The stream function $\Psi$ of this Rayleigh-Kothe vortex is defined as:
 
 @f[
-\Psi = \frac{1}{\pi} sin^2 (\pi x) \sin^2 (\pi y) \cos \left( \pi \frac{t}{T} \right)
+\Psi = \frac{1}{\pi} \sin^2 (\pi x) \sin^2 (\pi y) \cos \left( \pi \frac{t}{T} \right)
 @f]
 where $T$ is half the period of the flow. The velocity profile in 2D ($\textbf{u}=[u,v]^T$) is :
 @f{eqnarray*}

--- a/examples/step-68/doc/results.dox
+++ b/examples/step-68/doc/results.dox
@@ -78,7 +78,7 @@ This program highlights some of the main capabilities for handling particles in 
 capacity to be used in distributed parallel simulations. However, this step could
 be extended in numerous manners:
 - High-order time integration (for example using a Runge-Kutta 4 method) could be
-used to increase the accuracy and allow for an increased time-step size.
+used to increase the accuracy or allow for larger time-step sizes with the same accuracy.
 - The full equation of motion (with inertia) could be solved for the particles. In
 this case the particles would need to have additional properties such as their mass,
 as in step-19, and if one wanted to also consider interactions with the fluid, their diameter.


### PR DESCRIPTION
The code cleanup (which should deliver equivalent results) do the following:
- Consistently use mapping object of the class itself
- Use MappingQGeneric rather than MappingQ because the latter class is somewhat brittle
- Only set up background dofs for the case of interpolated_velocity
- Do not call Utilities::MPI::this_mpi_rank in inner loop because it shows up in profiles
