### PR TITLE
FEFaceEvaluation: Fix fast vector access case of gather_evaluate

### DIFF
--- a/tests/matrix_free/matrix_vector_faces_31.cc
+++ b/tests/matrix_free/matrix_vector_faces_31.cc
@@ -1,0 +1,275 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// similar to matrix_vector_faces_20 (Laplace, gather_evaluate and
+// integrate_scatter, vector-valued case in form of multiple components with
+// different vector entries, plain DG index numbering) but when not using the
+// polynomial degree as template argument
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_faces_common.h"
+
+
+
+template <int dim>
+void
+do_test(const unsigned int fe_degree)
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria, -1, 1);
+
+  for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
+       cell != tria.end();
+       ++cell)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_boundary_ids(f);
+  std::vector<
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+    periodic_faces;
+  for (unsigned int d = 0; d < dim; ++d)
+    GridTools::collect_periodic_faces(
+      tria, 2 * d, 2 * d + 1, d, periodic_faces);
+  tria.add_periodicity(periodic_faces);
+
+  tria.refine_global(3 - dim);
+
+  FE_DGQHermite<dim>        fe(fe_degree);
+  FESystem<dim>             fe_system(fe, dim);
+  DoFHandler<dim>           dof(tria);
+  DoFHandler<dim>           dof_system(tria);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  for (unsigned int test = 0; test < (dim == 3 && fe_degree > 3 ? 1 : 2);
+       ++test)
+    {
+      tria.refine_global(1);
+
+      dof.distribute_dofs(fe);
+      dof_system.distribute_dofs(fe_system);
+
+      deallog << "Testing " << dof_system.get_fe().get_name();
+      deallog << " on " << dof_system.n_dofs() << " DoFs";
+      deallog << std::endl;
+
+      // first build a vector-valued system that contains all components in
+      // analogy to matrix_vector_faces_14
+      LinearAlgebra::distributed::Vector<double> in, out, out_dist;
+
+      MatrixFree<dim, double> mf_data;
+      const QGauss<1>         quad(3 * fe_degree / 2 + 1);
+      typename MatrixFree<dim, double>::AdditionalData data;
+      data.tasks_parallel_scheme =
+        MatrixFree<dim, double>::AdditionalData::none;
+      data.mapping_update_flags_inner_faces =
+        (update_gradients | update_JxW_values);
+      data.mapping_update_flags_boundary_faces =
+        (update_gradients | update_JxW_values);
+      mf_data.reinit(dof_system, constraints, quad, data);
+
+      mf_data.initialize_dof_vector(in);
+      mf_data.initialize_dof_vector(out);
+      mf_data.initialize_dof_vector(out_dist);
+
+      // Set random seed for reproducibility
+      Testing::srand(42);
+      for (unsigned int i = 0; i < in.local_size(); ++i)
+        {
+          const double entry  = Testing::rand() / (double)RAND_MAX;
+          in.local_element(i) = entry;
+        }
+
+      MatrixFreeTest<dim,
+                     -1,
+                     0,
+                     double,
+                     LinearAlgebra::distributed::Vector<double>,
+                     dim>
+        mf(mf_data);
+      mf.vmult(out, in);
+
+      MatrixFreeVariant<dim,
+                        -1,
+                        0,
+                        double,
+                        LinearAlgebra::distributed::Vector<double>,
+                        dim>
+        mf2(mf_data, true);
+      mf2.vmult(out_dist, in);
+
+      out_dist -= out;
+
+      double diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+      deallog << "Norm of difference to no-gather:         " << diff_norm
+              << std::endl;
+
+      // now compare the result to a scalar implementation on each of the dim
+      // components, using vmult_add in subsequent steps
+      mf2.vmult(out, in);
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          MatrixFreeVariant<dim,
+                            -1,
+                            0,
+                            double,
+                            LinearAlgebra::distributed::Vector<double>,
+                            1>
+            mf3(mf_data, true, d);
+          if (d == 0)
+            mf3.vmult(out_dist, in);
+          else
+            mf3.vmult_add(out_dist, in);
+        }
+
+      out_dist -= out;
+      diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+      deallog << "Norm of difference to sum of scalar:     " << diff_norm
+              << std::endl;
+
+      if (dim == 3)
+        {
+          MatrixFreeVariant<dim,
+                            -1,
+                            0,
+                            double,
+                            LinearAlgebra::distributed::Vector<double>,
+                            2>
+            mf3(mf_data, true, 0);
+          mf3.vmult(out_dist, in);
+          MatrixFreeVariant<dim,
+                            -1,
+                            0,
+                            double,
+                            LinearAlgebra::distributed::Vector<double>,
+                            1>
+            mf4(mf_data, true, 2);
+          mf4.vmult_add(out_dist, in);
+
+          out_dist -= out;
+          diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to vector/scalar sum: " << diff_norm
+                  << std::endl;
+        }
+      if (dim == 3)
+        {
+          MatrixFreeVariant<dim,
+                            -1,
+                            0,
+                            double,
+                            LinearAlgebra::distributed::Vector<double>,
+                            1>
+            mf3(mf_data, true, 0);
+          mf3.vmult(out_dist, in);
+          MatrixFreeVariant<dim,
+                            -1,
+                            0,
+                            double,
+                            LinearAlgebra::distributed::Vector<double>,
+                            2>
+            mf4(mf_data, true, 1);
+          mf4.vmult_add(out_dist, in);
+
+          out_dist -= out;
+          diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to scalar/vector sum: " << diff_norm
+                  << std::endl;
+        }
+
+      // finally compare to a series of scalar problems
+      MatrixFree<dim, double> mf_data_scalar;
+      mf_data_scalar.reinit(dof, constraints, quad, data);
+
+      LinearAlgebra::distributed::Vector<double> in_small, out_small, ref_small;
+      mf_data_scalar.initialize_dof_vector(in_small);
+      mf_data_scalar.initialize_dof_vector(out_small);
+      mf_data_scalar.initialize_dof_vector(ref_small);
+
+      MatrixFreeVariant<dim,
+                        -1,
+                        0,
+                        double,
+                        LinearAlgebra::distributed::Vector<double>,
+                        1>
+        mf4(mf_data_scalar, true);
+
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          std::vector<types::global_dof_index> dof_indices_system(
+            fe_system.dofs_per_cell);
+          std::vector<types::global_dof_index> dof_indices_scalar(
+            fe.dofs_per_cell);
+          for (typename DoFHandler<dim>::active_cell_iterator
+                 cell_scalar = dof.begin_active(),
+                 cell_system = dof_system.begin_active();
+               cell_scalar != dof.end();
+               ++cell_scalar, ++cell_system)
+            if (cell_scalar->is_locally_owned())
+              {
+                cell_scalar->get_dof_indices(dof_indices_scalar);
+                cell_system->get_dof_indices(dof_indices_system);
+                for (unsigned int i = 0; i < fe_system.dofs_per_cell; ++i)
+                  if (fe_system.system_to_component_index(i).first == d)
+                    {
+                      in_small(
+                        dof_indices_scalar
+                          [fe_system.system_to_component_index(i).second]) =
+                        in(dof_indices_system[i]);
+                      out_small(
+                        dof_indices_scalar
+                          [fe_system.system_to_component_index(i).second]) =
+                        out(dof_indices_system[i]);
+                    }
+              }
+
+          mf4.vmult(ref_small, in_small);
+
+          out_small -= ref_small;
+          diff_norm = out_small.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to single scalar:     " << diff_norm
+                  << std::endl;
+        }
+    }
+}
+
+
+
+template <int dim, int degree>
+void
+test()
+{
+  if (degree == 1)
+    {
+      do_test<dim>(1);
+      do_test<dim>(3);
+      do_test<dim>(5);
+      do_test<dim>(7);
+    }
+}

--- a/tests/matrix_free/matrix_vector_faces_31.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/matrix_vector_faces_31.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,89 @@
+
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(1)^2] on 128 DoFs
+DEAL:2d::Norm of difference to no-gather:         0.00
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(1)^2] on 512 DoFs
+DEAL:2d::Norm of difference to no-gather:         0.00
+DEAL:2d::Norm of difference to sum of scalar:     2.27e-16
+DEAL:2d::Norm of difference to single scalar:     2.27e-16
+DEAL:2d::Norm of difference to single scalar:     1.70e-16
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(3)^2] on 512 DoFs
+DEAL:2d::Norm of difference to no-gather:         3.18e-16
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(3)^2] on 2048 DoFs
+DEAL:2d::Norm of difference to no-gather:         3.37e-16
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(5)^2] on 1152 DoFs
+DEAL:2d::Norm of difference to no-gather:         2.76e-16
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(5)^2] on 4608 DoFs
+DEAL:2d::Norm of difference to no-gather:         2.48e-16
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(7)^2] on 2048 DoFs
+DEAL:2d::Norm of difference to no-gather:         0.00
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQHermite<2>(7)^2] on 8192 DoFs
+DEAL:2d::Norm of difference to no-gather:         0.00
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(1)^3] on 192 DoFs
+DEAL:3d::Norm of difference to no-gather:         0.00
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(1)^3] on 1536 DoFs
+DEAL:3d::Norm of difference to no-gather:         0.00
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3] on 1536 DoFs
+DEAL:3d::Norm of difference to no-gather:         5.35e-16
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(3)^3] on 12288 DoFs
+DEAL:3d::Norm of difference to no-gather:         2.72e-16
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(5)^3] on 5184 DoFs
+DEAL:3d::Norm of difference to no-gather:         2.73e-16
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQHermite<3>(7)^3] on 12288 DoFs
+DEAL:3d::Norm of difference to no-gather:         0.00
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00

--- a/tests/matrix_free/matrix_vector_faces_32.cc
+++ b/tests/matrix_free/matrix_vector_faces_32.cc
@@ -1,0 +1,259 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// similar to matrix_vector_faces_22 (advection, gather_evaluate and
+// integrate_scatter, vector-valued case in form of multiple components with
+// different vector entries, plain DG index numbering) but when not using the
+// polynomial degree as template argument
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_system.h>
+
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include "../tests.h"
+
+#include "matrix_vector_faces_common.h"
+
+
+
+template <int dim>
+void
+do_test(const unsigned int fe_degree)
+{
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria, -1, 1);
+
+  for (typename Triangulation<dim>::cell_iterator cell = tria.begin();
+       cell != tria.end();
+       ++cell)
+    for (const unsigned int f : GeometryInfo<dim>::face_indices())
+      if (cell->at_boundary(f))
+        cell->face(f)->set_all_boundary_ids(f);
+  std::vector<
+    GridTools::PeriodicFacePair<typename Triangulation<dim>::cell_iterator>>
+    periodic_faces;
+  for (unsigned int d = 0; d < dim; ++d)
+    GridTools::collect_periodic_faces(
+      tria, 2 * d, 2 * d + 1, d, periodic_faces);
+  tria.add_periodicity(periodic_faces);
+
+  tria.refine_global(3 - dim);
+
+  FE_DGQ<dim>               fe(fe_degree);
+  FESystem<dim>             fe_system(fe, dim);
+  DoFHandler<dim>           dof(tria);
+  DoFHandler<dim>           dof_system(tria);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  for (unsigned int test = 0; test < (dim == 3 && fe_degree > 3 ? 1 : 2);
+       ++test)
+    {
+      tria.refine_global(1);
+
+      dof.distribute_dofs(fe);
+      dof_system.distribute_dofs(fe_system);
+
+      deallog << "Testing " << dof_system.get_fe().get_name();
+      deallog << " on " << dof_system.n_dofs() << " DoFs";
+      deallog << std::endl;
+
+      // first build a vector-valued system that contains all components in
+      // analogy to matrix_vector_faces_14
+      LinearAlgebra::distributed::Vector<double> in, out, out_dist;
+
+      MatrixFree<dim, double> mf_data;
+      const QGauss<1>         quad(3 * fe_degree / 2 + 1);
+      typename MatrixFree<dim, double>::AdditionalData data;
+      data.tasks_parallel_scheme =
+        MatrixFree<dim, double>::AdditionalData::none;
+      data.mapping_update_flags_inner_faces =
+        (update_gradients | update_JxW_values);
+      data.mapping_update_flags_boundary_faces =
+        (update_gradients | update_JxW_values);
+      mf_data.reinit(dof_system, constraints, quad, data);
+
+      mf_data.initialize_dof_vector(in);
+      mf_data.initialize_dof_vector(out);
+      mf_data.initialize_dof_vector(out_dist);
+
+      // Set random seed for reproducibility
+      Testing::srand(42);
+      for (unsigned int i = 0; i < in.local_size(); ++i)
+        {
+          const double entry  = Testing::rand() / (double)RAND_MAX;
+          in.local_element(i) = entry;
+        }
+
+      MatrixFreeAdvection<dim,
+                          -1,
+                          0,
+                          double,
+                          LinearAlgebra::distributed::Vector<double>,
+                          dim>
+        mf2(mf_data, true);
+
+      // now compare the result to a scalar implementation on each of the dim
+      // components, using vmult_add in subsequent steps
+      mf2.vmult(out, in);
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          MatrixFreeAdvection<dim,
+                              -1,
+                              0,
+                              double,
+                              LinearAlgebra::distributed::Vector<double>,
+                              1>
+            mf3(mf_data, true, d);
+          if (d == 0)
+            mf3.vmult(out_dist, in);
+          else
+            mf3.vmult_add(out_dist, in);
+        }
+
+      out_dist -= out;
+      double diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+      deallog << "Norm of difference to sum of scalar:     " << diff_norm
+              << std::endl;
+
+      if (dim == 3)
+        {
+          MatrixFreeAdvection<dim,
+                              -1,
+                              0,
+                              double,
+                              LinearAlgebra::distributed::Vector<double>,
+                              2>
+            mf3(mf_data, true, 0);
+          mf3.vmult(out_dist, in);
+          MatrixFreeAdvection<dim,
+                              -1,
+                              0,
+                              double,
+                              LinearAlgebra::distributed::Vector<double>,
+                              1>
+            mf4(mf_data, true, 2);
+          mf4.vmult_add(out_dist, in);
+
+          out_dist -= out;
+          diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to vector/scalar sum: " << diff_norm
+                  << std::endl;
+        }
+      if (dim == 3)
+        {
+          MatrixFreeAdvection<dim,
+                              -1,
+                              0,
+                              double,
+                              LinearAlgebra::distributed::Vector<double>,
+                              1>
+            mf3(mf_data, true, 0);
+          mf3.vmult(out_dist, in);
+          MatrixFreeAdvection<dim,
+                              -1,
+                              0,
+                              double,
+                              LinearAlgebra::distributed::Vector<double>,
+                              2>
+            mf4(mf_data, true, 1);
+          mf4.vmult_add(out_dist, in);
+
+          out_dist -= out;
+          diff_norm = out_dist.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to scalar/vector sum: " << diff_norm
+                  << std::endl;
+        }
+
+      // finally compare to a series of scalar problems
+      MatrixFree<dim, double> mf_data_scalar;
+      mf_data_scalar.reinit(dof, constraints, quad, data);
+
+      LinearAlgebra::distributed::Vector<double> in_small, out_small, ref_small;
+      mf_data_scalar.initialize_dof_vector(in_small);
+      mf_data_scalar.initialize_dof_vector(out_small);
+      mf_data_scalar.initialize_dof_vector(ref_small);
+
+      MatrixFreeAdvection<dim,
+                          -1,
+                          0,
+                          double,
+                          LinearAlgebra::distributed::Vector<double>,
+                          1>
+        mf4(mf_data_scalar, true);
+
+      for (unsigned int d = 0; d < dim; ++d)
+        {
+          std::vector<types::global_dof_index> dof_indices_system(
+            fe_system.dofs_per_cell);
+          std::vector<types::global_dof_index> dof_indices_scalar(
+            fe.dofs_per_cell);
+          for (typename DoFHandler<dim>::active_cell_iterator
+                 cell_scalar = dof.begin_active(),
+                 cell_system = dof_system.begin_active();
+               cell_scalar != dof.end();
+               ++cell_scalar, ++cell_system)
+            if (cell_scalar->is_locally_owned())
+              {
+                cell_scalar->get_dof_indices(dof_indices_scalar);
+                cell_system->get_dof_indices(dof_indices_system);
+                for (unsigned int i = 0; i < fe_system.dofs_per_cell; ++i)
+                  if (fe_system.system_to_component_index(i).first == d)
+                    {
+                      in_small(
+                        dof_indices_scalar
+                          [fe_system.system_to_component_index(i).second]) =
+                        in(dof_indices_system[i]);
+                      out_small(
+                        dof_indices_scalar
+                          [fe_system.system_to_component_index(i).second]) =
+                        out(dof_indices_system[i]);
+                    }
+              }
+
+          mf4.vmult(ref_small, in_small);
+
+          out_small -= ref_small;
+          diff_norm = out_small.linfty_norm() / out.linfty_norm();
+          deallog << "Norm of difference to single scalar:     " << diff_norm
+                  << std::endl;
+        }
+    }
+}
+
+
+
+template <int dim, int degree>
+void
+test()
+{
+  if (degree == 1)
+    {
+      do_test<dim>(1);
+      do_test<dim>(3);
+      do_test<dim>(5);
+      do_test<dim>(7);
+    }
+}

--- a/tests/matrix_free/matrix_vector_faces_32.with_mpi=true.with_p4est=true.mpirun=3.output
+++ b/tests/matrix_free/matrix_vector_faces_32.with_mpi=true.with_p4est=true.mpirun=3.output
@@ -1,0 +1,75 @@
+
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(1)^2] on 128 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(1)^2] on 512 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     5.99e-16
+DEAL:2d::Norm of difference to single scalar:     5.99e-16
+DEAL:2d::Norm of difference to single scalar:     5.99e-16
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(3)^2] on 512 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(3)^2] on 2048 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(5)^2] on 1152 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(5)^2] on 4608 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(7)^2] on 2048 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Testing FESystem<2>[FE_DGQ<2>(7)^2] on 8192 DoFs
+DEAL:2d::Norm of difference to sum of scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:2d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3] on 192 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(1)^3] on 1536 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(3)^3] on 1536 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(3)^3] on 12288 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(5)^3] on 5184 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Testing FESystem<3>[FE_DGQ<3>(7)^3] on 12288 DoFs
+DEAL:3d::Norm of difference to sum of scalar:     0.00
+DEAL:3d::Norm of difference to vector/scalar sum: 0.00
+DEAL:3d::Norm of difference to scalar/vector sum: 0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00
+DEAL:3d::Norm of difference to single scalar:     0.00


### PR DESCRIPTION
In the `gather_evaluate` and `integrate_scatter` functions, we assume in some places that we know the polynomial degree as a template parameter. However, for the case the user only requested the values on faces and we have nodal basis functions, we missed that check.

While there (and looking in the wrong place), I also converted all loops to compile-time constants when possible and switched some loops and `if` statements to help the compiler create better code.