### PR TITLE
Documentation: complete Enumerator tables

### DIFF
--- a/include/deal.II/base/time_stepping.h
+++ b/include/deal.II/base/time_stepping.h
@@ -46,25 +46,66 @@ namespace TimeStepping
    * - Embedded explicit methods (see EmbeddedExplicitRungeKutta::initialize):
    *   - HEUN_EULER (second order)
    *   - BOGACKI_SHAMPINE (third order)
-   *   - DOPRI: Dormand-Prince (fifth order; this is the method used by ode45
-   *     in MATLAB)
+   *   - DOPRI (Dormand-Prince method, fifth order; this is the method used by
+   * ode45 in MATLAB)
    *   - FEHLBERG (fifth order)
-   *   - CASH_KARP (firth order)
+   *   - CASH_KARP (fifth order)
    */
   enum runge_kutta_method
   {
+    /**
+     * Forward Euler method, first order.
+     */
     FORWARD_EULER,
+    /**
+     * Third order Runge-Kutta method.
+     */
     RK_THIRD_ORDER,
+    /**
+     * Classical fourth order Runge-Kutta method.
+     */
     RK_CLASSIC_FOURTH_ORDER,
+    /**
+     * Backward Euler method, first order.
+     */
     BACKWARD_EULER,
+    /**
+     * Implicit midpoint method, second order.
+     */
     IMPLICIT_MIDPOINT,
+    /**
+     * Crank-Nicolson method, second order.
+     */
     CRANK_NICOLSON,
+    /**
+     * Two stage SDIRK method (short for "singly diagonally implicit
+     * Runge-Kutta"), second order.
+     */
     SDIRK_TWO_STAGES,
+    /**
+     * Heun's method (improved Euler's method), second order.
+     */
     HEUN_EULER,
+    /**
+     * Bogacki–Shampine method, third-order.
+     */
     BOGACKI_SHAMPINE,
+    /**
+     * Dormand-Prince method, fifth order; this is the method used by
+     * ode45 in MATLAB.
+     */
     DOPRI,
+    /**
+     * Fehlberg method, fifth order.
+     */
     FEHLBERG,
+    /**
+     * Cash–Karp method, fifth order.
+     */
     CASH_KARP,
+    /**
+     * Invalid.
+     */
     invalid
   };
 
@@ -72,14 +113,21 @@ namespace TimeStepping
 
   /**
    * Reason for exiting evolve_one_time_step when using an embedded method:
-   * DELTA_T (the time step is in the valid range), MIN_DELTA_T (the time step
-   * was increased to the minimum acceptable time step), MAX_DELTA_T (the time
-   * step was reduced to the maximum acceptable time step).
+   * DELTA_T, MIN_DELTA_T, MAX_DELTA_T.
    */
   enum embedded_runge_kutta_time_step
   {
+    /**
+     * The time step is in the valid range.
+     */
     DELTA_T,
+    /**
+     * The time step was increased to the minimum acceptable time step.
+     */
     MIN_DELTA_T,
+    /**
+     * The time step was reduced to the maximum acceptable time step.
+     */
     MAX_DELTA_T
   };
 


### PR DESCRIPTION
Trying to complete the Enumerator tables here: 
https://www.dealii.org/developer/doxygen/deal.II/namespaceTimeStepping.html#abff97b5326e452552f108a379dd6cff4
Not sure if there is a better way to do it. 

This is what it looks like now: 
![Screenshot from 2020-09-23 17-43-51](https://user-images.githubusercontent.com/36655731/94073952-5afb6c00-fdc6-11ea-81fd-0a49cdd8d1ea.png)

