### PR TITLE
Don't even mention logstream in step-4.

### DIFF
--- a/examples/step-4/step-4.cc
+++ b/examples/step-4/step-4.cc
@@ -537,7 +537,6 @@ void Step4<dim>::run()
 // could actually use it.
 int main()
 {
-  deallog.depth_console(0);
   {
     Step4<2> laplace_problem_2d;
     laplace_problem_2d.run();

--- a/include/deal.II/base/logstream.h
+++ b/include/deal.II/base/logstream.h
@@ -129,8 +129,9 @@ public:
 
 
   /**
-   * Standard constructor. The standard output stream to
-   * <tt>std::cout</tt>.
+   * Standard constructor. The constructor sets the output stream to
+   * <tt>std::cout</tt> and the depth to zero. (Use attach() and
+   * depth_console() to change this.)
    */
   LogStream();
 


### PR DESCRIPTION
The only place where we do is to set the depth of output to zero, but that is already
the default.

While there, also clarify the documentation.