### PR TITLE
Avoid use of deallog in step-29.

### DIFF
--- a/doc/news/changes/minor/20200923Bangerth
+++ b/doc/news/changes/minor/20200923Bangerth
@@ -1,0 +1,4 @@
+Changed: step-29 no longer uses the `deallog` variable to generate
+output, but instead directly writes to `std::cout`.
+<br>
+(Wolfgang Bangerth, 2020/09/23)

--- a/examples/step-29/doc/results.dox
+++ b/examples/step-29/doc/results.dox
@@ -46,13 +46,13 @@ Here's the console output of the program in debug mode:
 > make run
 [ 66%] Built target step-29
 [100%] Run step-29 with Debug configuration
-DEAL::Generating grid... done (0.832682s)
-DEAL::  Number of active cells:  25600
-DEAL::Setting up system... done (0.614761s)
-DEAL::  Number of degrees of freedom: 51842
-DEAL::Assembling system matrix... done (2.82536s)
-DEAL::Solving linear system... done (2.27971s)
-DEAL::Generating output... done (1.84418s)
+Generating grid... done (0.820449s)
+  Number of active cells:  25600
+Setting up system... done (1.18392s)
+  Number of degrees of freedom: 51842
+Assembling system matrix... done (2.33291s)
+Solving linear system... done (1.34837s)
+Generating output... done (2.05782s)
 [100%] Built target run
 @endcode
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -414,7 +414,7 @@ namespace Step29
   {
     // First we generate some logging output and start a timer so we can
     // compute execution time when this function is done:
-    deallog << "Generating grid... ";
+    std::cout << "Generating grid... ";
     Timer timer;
 
     // Then we query the values for the focal distance of the transducer lens
@@ -475,10 +475,10 @@ namespace Step29
     // query the number of CPU seconds elapsed since the beginning of the
     // function:
     timer.stop();
-    deallog << "done (" << timer.cpu_time() << "s)" << std::endl;
+    std::cout << "done (" << timer.cpu_time() << "s)" << std::endl;
 
-    deallog << "  Number of active cells:  " << triangulation.n_active_cells()
-            << std::endl;
+    std::cout << "  Number of active cells:  " << triangulation.n_active_cells()
+              << std::endl;
   }
 
 
@@ -491,7 +491,7 @@ namespace Step29
   template <int dim>
   void UltrasoundProblem<dim>::setup_system()
   {
-    deallog << "Setting up system... ";
+    std::cout << "Setting up system... ";
     Timer timer;
 
     dof_handler.distribute_dofs(fe);
@@ -505,10 +505,10 @@ namespace Step29
     solution.reinit(dof_handler.n_dofs());
 
     timer.stop();
-    deallog << "done (" << timer.cpu_time() << "s)" << std::endl;
+    std::cout << "done (" << timer.cpu_time() << "s)" << std::endl;
 
-    deallog << "  Number of degrees of freedom: " << dof_handler.n_dofs()
-            << std::endl;
+    std::cout << "  Number of degrees of freedom: " << dof_handler.n_dofs()
+              << std::endl;
   }
 
 
@@ -519,7 +519,7 @@ namespace Step29
   template <int dim>
   void UltrasoundProblem<dim>::assemble_system()
   {
-    deallog << "Assembling system matrix... ";
+    std::cout << "Assembling system matrix... ";
     Timer timer;
 
     // First we query wavespeed and frequency from the ParameterHandler object
@@ -734,7 +734,7 @@ namespace Step29
                                        system_rhs);
 
     timer.stop();
-    deallog << "done (" << timer.cpu_time() << "s)" << std::endl;
+    std::cout << "done (" << timer.cpu_time() << "s)" << std::endl;
   }
 
 
@@ -756,7 +756,7 @@ namespace Step29
   template <int dim>
   void UltrasoundProblem<dim>::solve()
   {
-    deallog << "Solving linear system... ";
+    std::cout << "Solving linear system... ";
     Timer timer;
 
     // The code to solve the linear system is short: First, we allocate an
@@ -774,7 +774,7 @@ namespace Step29
     A_direct.vmult(solution, system_rhs);
 
     timer.stop();
-    deallog << "done (" << timer.cpu_time() << "s)" << std::endl;
+    std::cout << "done (" << timer.cpu_time() << "s)" << std::endl;
   }
 
 
@@ -790,7 +790,7 @@ namespace Step29
   template <int dim>
   void UltrasoundProblem<dim>::output_results() const
   {
-    deallog << "Generating output... ";
+    std::cout << "Generating output... ";
     Timer timer;
 
     // Define objects of our <code>ComputeIntensity</code> class and a DataOut
@@ -841,7 +841,7 @@ namespace Step29
     data_out.write(output);
 
     timer.stop();
-    deallog << "done (" << timer.cpu_time() << "s)" << std::endl;
+    std::cout << "done (" << timer.cpu_time() << "s)" << std::endl;
   }
 
 
@@ -876,8 +876,6 @@ int main()
     {
       using namespace dealii;
       using namespace Step29;
-
-      deallog.depth_console(5);
 
       ParameterHandler prm;
       ParameterReader  param(prm);


### PR DESCRIPTION
In the process, make the output more readable since we can avoid the obscuring prefix that doesn't actually provide any kind of information. The program only outputs things explicitly written to `deallog`, so nothing that would have been generated in the bowels of deal.II is currently shown anyway.