### PR TITLE
Enable tests with same name

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -240,13 +240,13 @@ MACRO(DEAL_II_ADD_TEST _category _test_name _comparison_file)
       # otherwise run the test with mpirun:
       IF("${_n_cpu}" STREQUAL "0")
 
-        SET(_diff_target ${_test_name}.${_build_lowercase}.diff) # diff target name
+        SET(_diff_target ${_category}.${_test_name}.${_build_lowercase}.diff) # diff target name
         SET(_test_full ${_category}/${_test_name}.${_build_lowercase}) # full test name
         SET(_test_directory ${CMAKE_CURRENT_BINARY_DIR}/${_test_name}.${_build_lowercase}) # directory to run the test in
 
       ELSE()
 
-        SET(_diff_target ${_test_name}.mpirun${_n_cpu}.${_build_lowercase}.diff) # diff target name
+        SET(_diff_target ${_category}.${_test_name}.mpirun${_n_cpu}.${_build_lowercase}.diff) # diff target name
         SET(_test_full ${_category}/${_test_name}.mpirun=${_n_cpu}.${_build_lowercase}) # full test name
         SET(_test_directory ${CMAKE_CURRENT_BINARY_DIR}/${_test_name}.${_build_lowercase}/mpirun=${_n_cpu}) # directory to run the test in
         SET(_run_args


### PR DESCRIPTION
In an application code, I had the issue that tests could not have had the same name even though they are separate folders. This PR fixes the issue by adding the prefix category/folder name at some places.