### PR TITLE
Add create-signal TransfiniteInterpolationManifold

### DIFF
--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -1138,6 +1138,7 @@ private:
    * this class goes out of scope.
    */
   boost::signals2::connection clear_signal;
+  boost::signals2::connection create_signal;
 };
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3938,6 +3938,11 @@ private:
   std::unique_ptr<std::map<unsigned int, types::manifold_id>>
     vertex_to_manifold_id_map_1d;
 
+  /**
+   * Flag to postpone sending the create signal.
+   */
+  bool currently_processing_create_triangulation_with_description;
+
   // make a couple of classes friends
   template <int, int, int>
   friend class TriaAccessorBase;


### PR DESCRIPTION
I had problems to run the following program:

```cpp
#include <deal.II/grid/grid_generator.h>
#include <deal.II/grid/grid_out.h>
#include <deal.II/grid/manifold_lib.h>
#include <deal.II/grid/tria.h>

using namespace dealii;


template <int dim>
void
test()
{
  dealii::Triangulation<dim> tria_0;
  dealii::Triangulation<dim> tria_1;

  dealii::GridGenerator::torus(tria_0, 2.0, 0.5);
  tria_0.refine_global(2);

  const auto manifold_ids = tria_0.get_manifold_ids();
  for (const auto manifold_id : manifold_ids)
    if (manifold_id != dealii::numbers::flat_manifold_id)
      {
        auto manifold = tria_0.get_manifold(manifold_id).clone();

  /*
        if (auto temp =
              dynamic_cast<const TransfiniteInterpolationManifold<dim> *>(
                manifold.get()))
          const_cast<TransfiniteInterpolationManifold<dim> *>(temp)->initialize(
            tria_1);
  */

        tria_1.set_manifold(manifold_id, *manifold);
      }

  const auto construction_data = dealii::TriangulationDescription::Utilities::
    create_description_from_triangulation(tria_0, MPI_COMM_SELF);
  tria_1.create_triangulation(construction_data);
  
  GridOut grid_out;
  grid_out.write_mesh_per_processor_as_vtu(tria_1, "mesh");
}

int
main(int argc, char **argv)
{
  dealii::Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
  test<3>();
}
```

I would like to create a (fully distributed) triangulation of a torus. The torus has multiple manifolds attached, including a `TransfiniteInterpolationManifold` which is initialized with a `Triangulation`. However, this is the wrong triangulation when I want to use the manifold in the new triangulation. So I need to reset the triangulation (as show by the commented lines). 

A further problem is that at that stage, the new triangulation is still empty (there is not even a coarse grid; it is created base on the construction data passe to `create_triangulation`), s.t., `TransfiniteInterpolationManifold::initialize()` will fail. The action of the function can be called once the coarse grid has been created. For this reason, I have attached it to a create signal.