### PR TITLE
Rename Simplex::PGauss to Simplex::QGauss.

### DIFF
--- a/include/deal.II/simplex/quadrature_lib.h
+++ b/include/deal.II/simplex/quadrature_lib.h
@@ -38,13 +38,13 @@ namespace Simplex
    * @ingroup simplex
    */
   template <int dim>
-  class PGauss : public QSimplex<dim>
+  class QGauss : public QSimplex<dim>
   {
   public:
     /**
      * Constructor taking the number of quadrature points @p n_points.
      */
-    explicit PGauss(const unsigned int n_points);
+    explicit QGauss(const unsigned int n_points);
   };
 } // namespace Simplex
 

--- a/source/simplex/quadrature_lib.cc
+++ b/source/simplex/quadrature_lib.cc
@@ -29,7 +29,7 @@ DEAL_II_NAMESPACE_OPEN
 namespace Simplex
 {
   template <int dim>
-  PGauss<dim>::PGauss(const unsigned int n_points)
+  QGauss<dim>::QGauss(const unsigned int n_points)
     : QSimplex<dim>(Quadrature<dim>())
   {
     // fill quadrature points and quadrature weights
@@ -146,8 +146,8 @@ namespace Simplex
 } // namespace Simplex
 
 
-template class Simplex::PGauss<1>;
-template class Simplex::PGauss<2>;
-template class Simplex::PGauss<3>;
+template class Simplex::QGauss<1>;
+template class Simplex::QGauss<2>;
+template class Simplex::QGauss<3>;
 
 DEAL_II_NAMESPACE_CLOSE

--- a/tests/simplex/fe_lib_02.cc
+++ b/tests/simplex/fe_lib_02.cc
@@ -49,12 +49,12 @@ main()
 {
   initlog();
 
-  test(Simplex::FE_P<2>(1), Simplex::PGauss<2>(3));
-  test(Simplex::FE_P<2>(2), Simplex::PGauss<2>(7));
-  test(Simplex::FE_P<3>(1), Simplex::PGauss<3>(4));
-  test(Simplex::FE_P<3>(2), Simplex::PGauss<3>(10));
-  test(Simplex::FE_DGP<2>(1), Simplex::PGauss<2>(3));
-  test(Simplex::FE_DGP<2>(2), Simplex::PGauss<2>(7));
-  test(Simplex::FE_DGP<3>(1), Simplex::PGauss<3>(4));
-  test(Simplex::FE_DGP<3>(2), Simplex::PGauss<3>(10));
+  test(Simplex::FE_P<2>(1), Simplex::QGauss<2>(3));
+  test(Simplex::FE_P<2>(2), Simplex::QGauss<2>(7));
+  test(Simplex::FE_P<3>(1), Simplex::QGauss<3>(4));
+  test(Simplex::FE_P<3>(2), Simplex::QGauss<3>(10));
+  test(Simplex::FE_DGP<2>(1), Simplex::QGauss<2>(3));
+  test(Simplex::FE_DGP<2>(2), Simplex::QGauss<2>(7));
+  test(Simplex::FE_DGP<3>(1), Simplex::QGauss<3>(4));
+  test(Simplex::FE_DGP<3>(2), Simplex::QGauss<3>(10));
 }

--- a/tests/simplex/poisson_01.cc
+++ b/tests/simplex/poisson_01.cc
@@ -336,10 +336,10 @@ test_tet(const MPI_Comm &comm, const Parameters<dim> &params)
   // 3) Select components
   Simplex::FE_P<dim> fe(params.degree);
 
-  Simplex::PGauss<dim> quad(dim == 2 ? (params.degree == 1 ? 3 : 7) :
+  Simplex::QGauss<dim> quad(dim == 2 ? (params.degree == 1 ? 3 : 7) :
                                        (params.degree == 1 ? 4 : 10));
 
-  Simplex::PGauss<dim - 1> face_quad(dim == 2 ? (params.degree == 1 ? 2 : 3) :
+  Simplex::QGauss<dim - 1> face_quad(dim == 2 ? (params.degree == 1 ? 2 : 3) :
                                                 (params.degree == 1 ? 3 : 7));
 
   Simplex::FE_P<dim> fe_mapping(1);

--- a/tests/simplex/poisson_02.cc
+++ b/tests/simplex/poisson_02.cc
@@ -189,9 +189,9 @@ public:
       false,
       new Simplex::FE_DGP<dim>(degree),
       new MappingFE<dim>(Simplex::FE_P<dim>(1)),
-      new Simplex::PGauss<dim>(dim == 2 ? (degree == 1 ? 3 : 7) :
+      new Simplex::QGauss<dim>(dim == 2 ? (degree == 1 ? 3 : 7) :
                                           (degree == 1 ? 4 : 10)),
-      new Simplex::PGauss<dim - 1>(dim == 2 ? (degree == 1 ? 2 : 3) :
+      new Simplex::QGauss<dim - 1>(dim == 2 ? (degree == 1 ? 2 : 3) :
                                               (degree == 1 ? 3 : 7)),
       initial_refinement,
       number_refinement);

--- a/tests/simplex/q_projection_01.cc
+++ b/tests/simplex/q_projection_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// Test QProjection for Simplex::PGauss.
+// Test QProjection for Simplex::QGauss.
 
 
 #include <deal.II/base/qprojector.h>
@@ -38,7 +38,7 @@ test<2>(const unsigned int n_points)
 {
   const int dim = 2;
 
-  Simplex::PGauss<dim - 1> quad_ref(n_points);
+  Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
     QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Tri, quad_ref);
@@ -80,7 +80,7 @@ test<3>(const unsigned int n_points)
 {
   const int dim = 3;
 
-  Simplex::PGauss<dim - 1> quad_ref(n_points);
+  Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
     QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Tet, quad_ref);

--- a/tests/simplex/quadrature_lib_01.cc
+++ b/tests/simplex/quadrature_lib_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// Test Simplex::PGauss: output its quadrature points and weights.
+// Test Simplex::QGauss: output its quadrature points and weights.
 
 
 #include <deal.II/simplex/quadrature_lib.h>
@@ -27,7 +27,7 @@ template <int dim>
 void
 test(const unsigned int n_points)
 {
-  Simplex::PGauss<dim> quad(n_points);
+  Simplex::QGauss<dim> quad(n_points);
 
   for (unsigned int q = 0; q < quad.size(); ++q)
     {

--- a/tests/simplex/step-12.cc
+++ b/tests/simplex/step-12.cc
@@ -391,10 +391,10 @@ namespace Step12
 
     QGauss<dim - 1> face_quad(degree + 1);
 #else
-    Simplex::PGauss<dim> quad(dim == 2 ? (degree == 1 ? 3 : 7) :
+    Simplex::QGauss<dim> quad(dim == 2 ? (degree == 1 ? 3 : 7) :
                                          (degree == 1 ? 4 : 10));
 
-    Simplex::PGauss<dim - 1> face_quad(dim == 2 ? (degree == 1 ? 2 : 3) :
+    Simplex::QGauss<dim - 1> face_quad(dim == 2 ? (degree == 1 ? 2 : 3) :
                                                   (degree == 1 ? 3 : 7));
 #endif
 

--- a/tests/simplex/step-18.cc
+++ b/tests/simplex/step-18.cc
@@ -419,7 +419,7 @@ namespace Step18
     : triangulation()
     , fe(Simplex::FE_P<dim>(degree), dim)
     , dof_handler(triangulation)
-    , quadrature_formula(Simplex::PGauss<dim>(fe.degree == 1 ? 4 : 10))
+    , quadrature_formula(Simplex::QGauss<dim>(fe.degree == 1 ? 4 : 10))
     , mapping(Simplex::FE_P<dim>(1))
     , present_time(0.0)
     , present_timestep(1.0)


### PR DESCRIPTION
I mentioned this in #10797. I recognize that this is an incompatible change, but I'd rather change it now than when more people start to use it. The point is simply that the `Q` in `QGauss` never refered to the difference between "P" and "Q" spaces, but is just short for "Quadrature". 

Opinions welcome!

/rebuild