### PR TITLE
MappingQGeneric: Remove redundant code for shape function evaluation

### DIFF
--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -295,7 +295,6 @@ public:
     void
     compute_shape_function_values(const std::vector<Point<dim>> &unit_points);
 
-
     /**
      * Shape function at quadrature point. Shape functions are in tensor
      * product order, so vertices must be reordered to obtain transformation.


### PR DESCRIPTION
With #10983, the only reason to have separate code for the shape functions of a `MappingQ1` will go away: The performance can only matter in case we have a single evaluation point, i.e., the `transform_real_to_unit_cell` function. All other cases were dominated by other effects already, so it makes no sense to keep almost 400 lines of additional code doing the same thing as the generic one around. This PR, intentionally kept separate from #10983, removes the code that is obsolete once performance is not an issue any more.

There is no change in code or functionality. The added 78 lines of code come from moving the code from `compute_shape_function_values_general` into the common implementation that is now used for all degrees, including the linear one.