### PR TITLE
Let mapping transform multiple points from real to unit cell

### DIFF
--- a/doc/news/changes/minor/20201007MartinKronbichler
+++ b/doc/news/changes/minor/20201007MartinKronbichler
@@ -1,0 +1,6 @@
+New: Mapping::transform_points_real_to_unit_cell() can compute the operation
+of Mapping::transform_real_to_unit_cell() on many points simultaneously, which
+can be much faster for MappingQGeneric and derived classes that involve
+expensive operations to compute the support points of the mapping.
+<br>
+(Martin Kronbichler, 2020/10/07)

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -453,6 +453,23 @@ public:
     const Point<spacedim> &                                     p) const = 0;
 
   /**
+   * Map multiple points from the real point locations to points in reference
+   * locations. The functionality is essentially the same as looping over all
+   * points and calling the Mapping::transform_real_to_unit_cell() function
+   * for each point individually, but it can be much faster for certain
+   * mappings that implement a more specialized version such as
+   * MappingQGeneric. The only difference in behavior is that this function
+   * will never throw an ExcTransformationFailed() exception. If the
+   * transformation fails for `real_points[i]`, the returned `unit_points[i]`
+   * contains std::numeric_limits<double>::infinity() as the first entry.
+   */
+  virtual void
+  transform_points_real_to_unit_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const ArrayView<const Point<spacedim>> &                    real_points,
+    ArrayView<Point<dim>> &unit_points) const;
+
+  /**
    * Transform the point @p p on the real @p cell to the corresponding point
    * on the reference cell, and then project this point to a (dim-1)-dimensional
    * point in the coordinate system of the face with

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -181,6 +181,13 @@ public:
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const Point<spacedim> &p) const override;
 
+  // for documentation, see the Mapping base class
+  virtual void
+  transform_points_real_to_unit_cell(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const ArrayView<const Point<spacedim>> &                    real_points,
+    ArrayView<Point<dim>> &unit_points) const override;
+
   /**
    * @}
    */

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -77,6 +77,30 @@ Mapping<dim, spacedim>::get_bounding_box(
 
 
 template <int dim, int spacedim>
+void
+Mapping<dim, spacedim>::transform_points_real_to_unit_cell(
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+  const ArrayView<const Point<spacedim>> &                    real_points,
+  ArrayView<Point<dim>> &                                     unit_points) const
+{
+  AssertDimension(real_points.size(), unit_points.size());
+  for (unsigned int i = 0; i < real_points.size(); ++i)
+    {
+      try
+        {
+          unit_points[i] = transform_real_to_unit_cell(cell, real_points[i]);
+        }
+      catch (typename Mapping<dim>::ExcTransformationFailed &)
+        {
+          unit_points[i]    = Point<dim>();
+          unit_points[i][0] = std::numeric_limits<double>::infinity();
+        }
+    }
+}
+
+
+
+template <int dim, int spacedim>
 Point<dim - 1>
 Mapping<dim, spacedim>::project_real_point_to_unit_point_on_face(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,

--- a/tests/mappings/mapping_points_real_to_unit.cc
+++ b/tests/mappings/mapping_points_real_to_unit.cc
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// on a test case similar to mapping_real_to_unit_q4_curved, check the
+// implementation of the many-point interface
+// Mapping::transform_points_real_to_unit_cell for both a MappingQGeneric and
+// MappingFEField
+
+#include <deal.II/base/utilities.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_fe_field.h>
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/manifold_lib.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+
+template <int dim, int spacedim>
+void
+test_real_to_unit_cell(const Mapping<dim, spacedim> &mapping)
+{
+  // define a boundary that fits the the vertices of the hyper cube we're
+  // going to create below
+  SphericalManifold<dim, spacedim> boundary;
+
+  Triangulation<dim, spacedim> triangulation;
+  GridGenerator::hyper_cube(triangulation, -1, 1);
+
+  // set the boundary indicator for one face of the single cell
+  triangulation.set_manifold(1, boundary);
+  triangulation.begin_active()->face(0)->set_boundary_id(1);
+
+  const unsigned int      n_points = 5;
+  std::vector<Point<dim>> unit_points(Utilities::pow(n_points, dim));
+
+  switch (dim)
+    {
+      case 1:
+        for (unsigned int x = 0; x < n_points; ++x)
+          unit_points[x][0] = static_cast<double>(x) / n_points;
+        break;
+
+      case 2:
+        for (unsigned int x = 0; x < n_points; ++x)
+          for (unsigned int y = 0; y < n_points; ++y)
+            {
+              unit_points[y * n_points + x][0] =
+                static_cast<double>(x) / n_points;
+              unit_points[y * n_points + x][1] =
+                static_cast<double>(y) / n_points;
+            }
+        break;
+
+      case 3:
+        for (unsigned int x = 0; x < n_points; ++x)
+          for (unsigned int y = 0; y < n_points; ++y)
+            for (unsigned int z = 0; z < n_points; ++z)
+              {
+                unit_points[z * n_points * n_points + y * n_points + x][0] =
+                  static_cast<double>(x) / n_points;
+                unit_points[z * n_points * n_points + y * n_points + x][1] =
+                  static_cast<double>(y) / n_points;
+                unit_points[z * n_points * n_points + y * n_points + x][2] =
+                  static_cast<double>(z) / n_points;
+              }
+        break;
+    }
+
+  typename Triangulation<dim, spacedim>::active_cell_iterator cell =
+    triangulation.begin_active();
+  std::vector<Point<spacedim>> real_points(unit_points.size());
+  for (unsigned int i = 0; i < unit_points.size(); ++i)
+    real_points[i] = mapping.transform_unit_to_real_cell(cell, unit_points[i]);
+  std::vector<Point<dim>> new_points(unit_points.size());
+  ArrayView<Point<dim>>   points_view(new_points);
+  mapping.transform_points_real_to_unit_cell(cell, real_points, points_view);
+  for (unsigned int i = 0; i < unit_points.size(); ++i)
+    {
+      // for each of the points, verify that applying the forward map and
+      // then pull back get the same point again
+      AssertThrow(unit_points[i].distance(new_points[i]) < 1e-10,
+                  ExcInternalError());
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  deallog << "dim=" << dim << ", spacedim=" << spacedim << std::endl;
+  deallog << "MappingQ(1): ";
+  test_real_to_unit_cell(MappingQGeneric<dim, spacedim>(1));
+  deallog << "MappingQ(4): ";
+  test_real_to_unit_cell(MappingQGeneric<dim, spacedim>(4));
+
+  deallog << "MappingFEField(FESystem(FE_Q(4))): ";
+  Triangulation<dim, spacedim> triangulation;
+  GridGenerator::hyper_cube(triangulation, -1, 1);
+
+  FESystem<dim, spacedim>   fe(FE_Q<dim, spacedim>(4), spacedim);
+  DoFHandler<dim, spacedim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(fe);
+  const ComponentMask mask(spacedim, true);
+  Vector<double>      location_vector(dof_handler.n_dofs());
+  VectorTools::get_position_vector(dof_handler, location_vector, mask);
+  MappingFEField<dim, spacedim> mapping(dof_handler, location_vector, mask);
+  test_real_to_unit_cell(mapping);
+}
+
+
+
+int
+main()
+{
+  initlog();
+
+  test<1, 1>();
+  test<2, 2>();
+  test<3, 3>();
+
+  test<1, 2>();
+}

--- a/tests/mappings/mapping_points_real_to_unit.output
+++ b/tests/mappings/mapping_points_real_to_unit.output
@@ -1,0 +1,17 @@
+
+DEAL::dim=1, spacedim=1
+DEAL::MappingQ(1): OK
+DEAL::MappingQ(4): OK
+DEAL::MappingFEField(FESystem(FE_Q(4))): OK
+DEAL::dim=2, spacedim=2
+DEAL::MappingQ(1): OK
+DEAL::MappingQ(4): OK
+DEAL::MappingFEField(FESystem(FE_Q(4))): OK
+DEAL::dim=3, spacedim=3
+DEAL::MappingQ(1): OK
+DEAL::MappingQ(4): OK
+DEAL::MappingFEField(FESystem(FE_Q(4))): OK
+DEAL::dim=1, spacedim=2
+DEAL::MappingQ(1): OK
+DEAL::MappingQ(4): OK
+DEAL::MappingFEField(FESystem(FE_Q(4))): OK


### PR DESCRIPTION
Fixes #10969. As discussed in that issue, we can accelerate the `Mapping::transform_real_to_unit_cell` quite a bit if we compute multiple points at a time. The most important factor is `compute_mapping_support_points()` for higher order mappings. But we even gain when compared to the analytic inversion function for `MappingQ1` in 2d; partly because the collection of cell vertices is so slow, but also because the evaluation implemented in #10983 is so fast (unless we need more than 2 Newton iterations which is unlikely).

I implemented it within the `ParticleHandler::sort_particles_into_subdomains_and_cells()` and can confirm that it runs much faster in the case we have many particles per cell. The transformation indeed runs so fast that the other operations in that functions take much more time than the computation of reference positions. In fact, it can take more time to compute the individual positions of particles that left the cell and gets picked up in the surrounding cells (I tested in step-68 but it of course depends on the time step size and the fraction of particles leaving a cell in a time step). This latter part can surely be optimized as well to collect candidates from the cell.

~~This PR is right now based on #10983 and also some other function in `GridTools` that I want to break out into a separate PR, but I wanted to post this now already for discussion.~~