### PR TITLE
Disable compression in MPI::some_to_some

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1160,7 +1160,8 @@ namespace Utilities
           if (rank_obj.first != my_proc)
             {
               const auto &rank   = rank_obj.first;
-              buffers_to_send[i] = Utilities::pack(rank_obj.second);
+              buffers_to_send[i] = Utilities::pack(rank_obj.second,
+                                                   /*allow_compression=*/false);
               const int ierr     = MPI_Isend(buffers_to_send[i].data(),
                                          buffers_to_send[i].size(),
                                          MPI_CHAR,
@@ -1205,7 +1206,9 @@ namespace Utilities
             Assert(received_objects.find(rank) == received_objects.end(),
                    ExcInternalError(
                      "I should not receive again from this rank"));
-            received_objects[rank] = Utilities::unpack<T>(buffer);
+            received_objects[rank] =
+              Utilities::unpack<T>(buffer,
+                                   /*allow_compression=*/false);
           }
       }
 


### PR DESCRIPTION
As we found out in #8513 and #8754, compressing stuff before sending over MPI is typically more expensive than just sending packed but uncompressed data. Thus, I change to that version here.

Found out while looking at a profile of step-68 in parallel.