### PR TITLE
Make some more functions in ParticleHandler inline

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -949,11 +949,81 @@ namespace Particles
   /* ---------------------- inline and template functions ------------------
    */
 
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::begin() const
+  {
+    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->begin();
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::begin()
+  {
+    return particle_iterator(particles, particles.begin());
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::end() const
+  {
+    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->end();
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::end()
+  {
+    return particle_iterator(particles, particles.end());
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::begin_ghost() const
+  {
+    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->begin_ghost();
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::begin_ghost()
+  {
+    return particle_iterator(ghost_particles, ghost_particles.begin());
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::end_ghost() const
+  {
+    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->end_ghost();
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline typename ParticleHandler<dim, spacedim>::particle_iterator
+  ParticleHandler<dim, spacedim>::end_ghost()
+  {
+    return particle_iterator(ghost_particles, ghost_particles.end());
+  }
+
 
 
   template <int dim, int spacedim>
   template <class Archive>
-  void
+  inline void
   ParticleHandler<dim, spacedim>::serialize(Archive &ar, const unsigned int)
   {
     // Note that we do not serialize the particle data itself. Instead we
@@ -969,7 +1039,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   template <class VectorType>
-  typename std::enable_if<
+  inline typename std::enable_if<
     std::is_convertible<VectorType *, Function<spacedim> *>::value ==
     false>::type
   ParticleHandler<dim, spacedim>::set_particle_positions(
@@ -994,7 +1064,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   template <class VectorType>
-  void
+  inline void
   ParticleHandler<dim, spacedim>::get_particle_positions(
     VectorType &output_vector,
     const bool  add_to_output_vector)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -220,7 +220,8 @@ namespace Particles
     typename Triangulation<dim, spacedim>::active_cell_iterator current_cell =
       triangulation->begin_active();
 
-    for (particle_iterator particle = begin(); particle != end(); ++particle)
+    const particle_iterator end = this->end();
+    for (particle_iterator particle = begin(); particle != end; ++particle)
       {
         locally_highest_index =
           std::max(locally_highest_index, particle->get_id());
@@ -260,78 +261,6 @@ namespace Particles
           global_number_of_particles == 0 ? 0 : locally_highest_index + 1;
         global_max_particles_per_cell = local_max_particles_per_cell;
       }
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::begin() const
-  {
-    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->begin();
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::begin()
-  {
-    return particle_iterator(particles, particles.begin());
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::end() const
-  {
-    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->end();
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::end()
-  {
-    return particle_iterator(particles, particles.end());
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::begin_ghost() const
-  {
-    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->begin_ghost();
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::begin_ghost()
-  {
-    return particle_iterator(ghost_particles, ghost_particles.begin());
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::end_ghost() const
-  {
-    return (const_cast<ParticleHandler<dim, spacedim> *>(this))->end_ghost();
-  }
-
-
-
-  template <int dim, int spacedim>
-  typename ParticleHandler<dim, spacedim>::particle_iterator
-  ParticleHandler<dim, spacedim>::end_ghost()
-  {
-    return particle_iterator(ghost_particles, ghost_particles.end());
   }
 
 


### PR DESCRIPTION
These are all very light-weight functions (well, maybe apart from the cost of the access to `std::multimap`), so it should be cheaper to let the compiler inline things.
Follow-up to #10987.