### PR TITLE
allow the user to set the RNG seed in distort_random()

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -45,6 +45,7 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <boost/archive/binary_iarchive.hpp>
 #  include <boost/archive/binary_oarchive.hpp>
 #  include <boost/geometry/index/rtree.hpp>
+#  include <boost/random/mersenne_twister.hpp>
 #  include <boost/serialization/array.hpp>
 #  include <boost/serialization/vector.hpp>
 
@@ -628,12 +629,18 @@ namespace GridTools
    *
    * If @p keep_boundary is set to @p true (which is the default), then
    * boundary vertices are not moved.
+   *
+   * @p seed is used for the initialization of the random engine. Its
+   * default value initializes the engine with the same state as in
+   * previous versions of deal.II.
    */
   template <int dim, int spacedim>
   void
-  distort_random(const double                  factor,
-                 Triangulation<dim, spacedim> &triangulation,
-                 const bool                    keep_boundary = true);
+  distort_random(
+    const double                  factor,
+    Triangulation<dim, spacedim> &triangulation,
+    const bool                    keep_boundary = true,
+    const unsigned int            seed = boost::random::mt19937::default_seed);
 
   /**
    * Remove hanging nodes from a grid. If the @p isotropic parameter is set

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1125,7 +1125,8 @@ namespace GridTools
   void
   distort_random(const double                  factor,
                  Triangulation<dim, spacedim> &triangulation,
-                 const bool                    keep_boundary)
+                 const bool                    keep_boundary,
+                 const unsigned int            seed)
   {
     // if spacedim>dim we need to make sure that we perturb
     // points but keep them on
@@ -1201,14 +1202,8 @@ namespace GridTools
             }
         }
 
-    // create a random number generator for the interval [-1,1]. we use
-    // this to make sure the distribution we get is repeatable, i.e.,
-    // if you call the function twice on the same mesh, then you will
-    // get the same mesh. this would not be the case if you used
-    // the rand() function, which carries around some internal state
-    // we could use std::mt19937 but doing so results in compiler-dependent
-    // output.
-    boost::random::mt19937                     rng;
+    // create a random number generator for the interval [-1,1]
+    boost::random::mt19937                     rng(seed);
     boost::random::uniform_real_distribution<> uniform_distribution(-1, 1);
 
     // If the triangulation is distributed, we need to

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -254,7 +254,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       distort_random<deal_II_dimension>(
         const double,
         Triangulation<deal_II_dimension, deal_II_space_dimension> &,
-        const bool);
+        const bool,
+        const unsigned int);
 
       template void
       get_face_connectivity_of_cells(


### PR DESCRIPTION
The function distort_random induces a random distortion of the grid, using the default initialization of the std::mt19937 RNG used. Consequently, this function does not allow for different random distortions of the same mesh, which might be necessary for e.g. statistical averaging of the results over many different distortions. 

To solve this issue, a seed parameter is added to distort_random(). To not break the existing interface, the seed parameter has a default value. Moreover, the default seed is 5489u, which is the default value for std::mt19937 (see http://www.cplusplus.com/reference/random/mt19937/). Thus, when no seed is provided, the distortion will be numerically the same as in previous versions.