### PR TITLE
Use min/max rather than if statements

### DIFF
--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -4705,12 +4705,9 @@ template <int dim>
 inline Point<dim>
 GeometryInfo<dim>::project_to_unit_cell(const Point<dim> &q)
 {
-  Point<dim> p = q;
+  Point<dim> p;
   for (unsigned int i = 0; i < dim; i++)
-    if (p[i] < 0.)
-      p[i] = 0.;
-    else if (p[i] > 1.)
-      p[i] = 1.;
+    p[i] = std::min(std::max(q[i], 0.), 1.);
 
   return p;
 }
@@ -4724,10 +4721,10 @@ GeometryInfo<dim>::distance_to_unit_cell(const Point<dim> &p)
   double result = 0.0;
 
   for (unsigned int i = 0; i < dim; i++)
-    if ((-p[i]) > result)
-      result = -p[i];
-    else if ((p[i] - 1.) > result)
-      result = (p[i] - 1.);
+    {
+      result = std::max(result, -p[i]);
+      result = std::max(result, p[i] - 1.);
+    }
 
   return result;
 }


### PR DESCRIPTION
`if` generally leads to conditional jumps in the code, whereas compilers can translate `std::min`/`std::max` into specific instructions on most architectures. The latter should be faster in essentially all circumstances, except the rare case being that the jump can be predicted well and the processor correctly speculates beyond it, whereas min/max take up execution resources otherwise free for floating point multiplications and additions. But that could also happen inside `min` or `max`, so better leave this to the compiler who knows more about the target hardware. Furthermore, this change would also allow to easily vectorize these two functions.