### PR TITLE
Add missing header

### DIFF
--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -17,6 +17,7 @@
 
 #include <boost/io/ios_state.hpp>
 
+#include <algorithm>
 #include <iomanip>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
We use `std::find` in algorithm. Updating boost broke deal.II