### PR TITLE
There is no need to mark a declaration as 'inline'.

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1482,9 +1482,9 @@ public:
   /**
    * Return an array of iterators to all faces of this cell.
    */
-  inline boost::container::
-    small_vector<face_iterator, GeometryInfo<dimension_>::faces_per_cell>
-    face_iterators() const;
+  boost::container::small_vector<face_iterator,
+                                 GeometryInfo<dimension_>::faces_per_cell>
+  face_iterators() const;
 
   /**
    * Return the result of the @p neighbor_child_on_subface function of the


### PR DESCRIPTION
Only the definition needs to be marked so.