### PR TITLE
Fix gcc-10 warnings about unsigned int comparison < 0

### DIFF
--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -471,7 +471,7 @@ inline DEAL_II_CUDA_HOST_DEV Number
 Point<dim, Number>::operator()(const unsigned int index) const
 {
 #  ifndef __CUDA_ARCH__
-  AssertIndexRange(index, dim);
+  AssertIndexRange(static_cast<int>(index), dim);
 #  endif
   return this->values[index];
 }
@@ -483,7 +483,7 @@ inline DEAL_II_CUDA_HOST_DEV Number &
 Point<dim, Number>::operator()(const unsigned int index)
 {
 #  ifndef __CUDA_ARCH__
-  AssertIndexRange(index, dim);
+  AssertIndexRange(static_cast<int>(index), dim);
 #  endif
   return this->values[index];
 }

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -71,7 +71,7 @@ namespace internal
       for (unsigned int i = 0; i < n_q_points; ++i)
         quadrature_weights[i] = quadrature.weight(i);
 
-      for (unsigned int d = 0; d < structdim; ++d)
+      for (int d = 0; d < structdim; ++d)
         {
           tensor_quadrature_weights[d].resize(quadrature_1d.size());
           for (unsigned int i = 0; i < quadrature_1d.size(); ++i)
@@ -120,7 +120,7 @@ namespace internal
       std::size_t memory = sizeof(this) + quadrature.memory_consumption() +
                            quadrature_weights.memory_consumption() +
                            face_orientations.memory_consumption();
-      for (unsigned int d = 0; d < structdim; ++d)
+      for (int d = 0; d < structdim; ++d)
         memory += tensor_quadrature_weights[d].memory_consumption();
       return memory;
     }


### PR DESCRIPTION
This PR changes some counter variables from `unsigned int` to `int` to silence gcc-10 warnings of the kind
```
In file included from /home/kronbichler/deal/deal.II/source/base/polynomials_adini.cc:16:
/home/kronbichler/deal/deal.II/include/deal.II/base/point.h: In instantiation of ‘Number dealii::Point<dim, Number>::operator()(unsigned int) const [with int dim = 0; Number = double]’:
/home/kronbichler/deal/deal.II/source/base/polynomials_adini.cc:196:21:   required from ‘double dealii::PolynomialsAdini<dim>::compute_value(unsigned int, const dealii::Point<dim>&) const [with int dim = 0]’
/home/kronbichler/deal/deal.II/source/base/polynomials_adini.cc:269:16:   required from here
/home/kronbichler/deal/deal.II/include/deal.II/base/exceptions.h:1640:32: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
 1640 |                   type>(index) <                                               \
      |                                ^
/home/kronbichler/deal/deal.II/include/deal.II/base/exceptions.h:1413:32: note: in definition of macro ‘Assert’
 1413 |         if (__builtin_expect(!(cond), false))                            \
      |                                ^~~~
/home/kronbichler/deal/deal.II/include/deal.II/base/point.h:474:3: note: in expansion of macro ‘AssertIndexRange’
  474 |   AssertIndexRange(index, dim);
      |   ^~~~~~~~~~~~~~~~
```
The warnings come from loops we run up to but less than `dim` with `dim` getting 0 for some template instantiations. I tried a bit to work around in different ways but this seems to easiest way to do things. What do others think? If there is consensus, I will add a comment in the `point.h` file to explain why I make the static cast so it does not get accidentally deleted.