### PR TITLE
doxygen: generate deprecated list

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -52,7 +52,7 @@ SORT_MEMBER_DOCS       = NO
 SORT_BRIEF_DOCS        = NO
 SORT_BY_SCOPE_NAME     = NO
 GENERATE_TODOLIST      = YES
-GENERATE_DEPRECATEDLIST= NO
+GENERATE_DEPRECATEDLIST= YES
 SHOW_USED_FILES        = YES
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
otherwise \deprecated paragraphs are being ignored.

Fixes #11017