### PR TITLE
Make ArrayView argument const

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -467,7 +467,7 @@ public:
   transform_points_real_to_unit_cell(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const ArrayView<const Point<spacedim>> &                    real_points,
-    ArrayView<Point<dim>> &unit_points) const;
+    const ArrayView<Point<dim>> &unit_points) const;
 
   /**
    * Transform the point @p p on the real @p cell to the corresponding point

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -186,7 +186,7 @@ public:
   transform_points_real_to_unit_cell(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const ArrayView<const Point<spacedim>> &                    real_points,
-    ArrayView<Point<dim>> &unit_points) const override;
+    const ArrayView<Point<dim>> &unit_points) const override;
 
   /**
    * @}

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -81,7 +81,7 @@ void
 Mapping<dim, spacedim>::transform_points_real_to_unit_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const ArrayView<const Point<spacedim>> &                    real_points,
-  ArrayView<Point<dim>> &                                     unit_points) const
+  const ArrayView<Point<dim>> &                               unit_points) const
 {
   AssertDimension(real_points.size(), unit_points.size());
   for (unsigned int i = 0; i < real_points.size(); ++i)

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -892,7 +892,7 @@ namespace internal
 
 
       /**
-       * Implementation of transform_real_to_unit_cell for dim==spacedim
+       * Implementation of transform_real_to_unit_cell
        */
       template <int dim, int spacedim>
       Point<dim>
@@ -2307,7 +2307,7 @@ void
 MappingQGeneric<dim, spacedim>::transform_points_real_to_unit_cell(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const ArrayView<const Point<spacedim>> &                    real_points,
-  ArrayView<Point<dim>> &                                     unit_points) const
+  const ArrayView<Point<dim>> &                               unit_points) const
 {
   AssertDimension(real_points.size(), unit_points.size());
   const std::vector<Point<spacedim>> support_points =

--- a/tests/mappings/mapping_points_real_to_unit.cc
+++ b/tests/mappings/mapping_points_real_to_unit.cc
@@ -95,8 +95,7 @@ test_real_to_unit_cell(const Mapping<dim, spacedim> &mapping)
   for (unsigned int i = 0; i < unit_points.size(); ++i)
     real_points[i] = mapping.transform_unit_to_real_cell(cell, unit_points[i]);
   std::vector<Point<dim>> new_points(unit_points.size());
-  ArrayView<Point<dim>>   points_view(new_points);
-  mapping.transform_points_real_to_unit_cell(cell, real_points, points_view);
+  mapping.transform_points_real_to_unit_cell(cell, real_points, new_points);
   for (unsigned int i = 0; i < unit_points.size(); ++i)
     {
       // for each of the points, verify that applying the forward map and


### PR DESCRIPTION
Follow-up to #10991. We should make the `ArrayView` a `const` object also for data we write into, since we do not modify the view but the data behind it. I also used the opportunity to address https://github.com/dealii/dealii/pull/10991#discussion_r501434609 by @rezarastak 