### PR TITLE
Add a quick check for matching boost versions.

### DIFF
--- a/cmake/configure/configure_2_boost.cmake
+++ b/cmake/configure/configure_2_boost.cmake
@@ -92,6 +92,20 @@ MACRO(FEATURE_BOOST_CONFIGURE_BUNDLED)
   # We need to set this path before calling the configure function
   # to be able to use the include paths in the checks.
   SET(BOOST_BUNDLED_INCLUDE_DIRS ${BOOST_FOLDER}/include)
+  #
+  # We still need the version information, which is set up in the FindBoost
+  # module in the non-bundled case:
+  #
+  FILE(STRINGS "${BOOST_BUNDLED_INCLUDE_DIRS}/boost/version.hpp"
+    BOOST_VERSION_STRING
+    REGEX "#define.*BOOST_VERSION")
+
+  STRING(REGEX REPLACE "^.*BOOST_VERSION.* ([0-9]+).*" "\\1"
+    BOOST_VERSION_NUMBER "${BOOST_VERSION_STRING}"
+    )
+  MATH(EXPR Boost_MAJOR_VERSION "${BOOST_VERSION_NUMBER} / 100000")
+  MATH(EXPR Boost_MINOR_VERSION "${BOOST_VERSION_NUMBER} / 100 % 1000")
+  MATH(EXPR Boost_SUBMINOR_VERSION "${BOOST_VERSION_NUMBER} % 100")
 
   FEATURE_BOOST_CONFIGURE_COMMON()
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -230,6 +230,12 @@
     >=  \
     (major)*10000 + (minor)*100 + (subminor))
 
+/*
+ * boost:
+ */
+#define DEAL_II_BOOST_VERSION_MAJOR @Boost_MAJOR_VERSION@
+#define DEAL_II_BOOST_VERSION_MINOR @Boost_MINOR_VERSION@
+#define DEAL_II_BOOST_VERSION_SUBMINOR @Boost_SUBMINOR_VERSION@
 
 /*
  * Gmsh:
@@ -452,5 +458,22 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <deal.II/base/numbers.h>
 #include <deal.II/base/types.h>
+
+/*
+ * Include the boost version header to do a quick version check in case, by
+ * accident, we have configured with one version of boost but are compiling
+ * either the library or an external application with a different version of
+ * boost.
+ */
+#include <boost/version.hpp>
+static_assert(
+  BOOST_VERSION == 100000 * DEAL_II_BOOST_VERSION_MAJOR +
+                     100 * DEAL_II_BOOST_VERSION_MINOR +
+                     DEAL_II_BOOST_VERSION_SUBMINOR,
+  "The version number of boost that you are compiling with does not match the "
+  "version number of boost found during deal.II's configuration step. This "
+  "leads to difficult to understand bugs and is not supported. Please check "
+  "that you have set up your application with the same version of boost as "
+  "deal.II.");
 
 #endif


### PR DESCRIPTION
This addresses a problem a user had recently with inscrutable crashes caused by
mixed boost versions. Credit goes to @jodlbauer for reporting the issue.

I don't think boost is particularly strict on ABI stability even in patch versions so I went with the full version check.