### PR TITLE
Step-3, Step-7

### DIFF
--- a/examples/step-3/step-3.cc
+++ b/examples/step-3/step-3.cc
@@ -553,9 +553,10 @@ void Step3::solve()
   // which stops the iteration:
   SolverControl solver_control(1000, 1e-12);
   // Then we need the solver itself. The template parameter to the SolverCG
-  // class is the type of the vectors, but the empty angle brackets indicate
-  // that we simply take the default argument (which is
-  // <code>Vector@<double@></code>):
+  // class is the type of the vectors, and leaving the empty angle brackets
+  // would indicate that we are taking the default argument (which is
+  // <code>Vector@<double@></code>). However, we explicitly mention the template
+  // argument:
   SolverCG<Vector<double>> solver(solver_control);
 
   // Now solve the system of equations. The CG solver takes a preconditioner

--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -336,8 +336,6 @@ namespace Step7
     HelmholtzProblem(const FiniteElement<dim> &fe,
                      const RefinementMode      refinement_mode);
 
-    ~HelmholtzProblem();
-
     void run();
 
   private:
@@ -453,16 +451,6 @@ namespace Step7
     , fe(&fe)
     , refinement_mode(refinement_mode)
   {}
-
-
-  // @sect4{HelmholtzProblem::~HelmholtzProblem destructor}
-
-  // This is no different than before:
-  template <int dim>
-  HelmholtzProblem<dim>::~HelmholtzProblem()
-  {
-    dof_handler.clear();
-  }
 
 
   // @sect4{HelmholtzProblem::setup_system}
@@ -587,8 +575,8 @@ namespace Step7
     // Note that the operations we will do with the right hand side object are
     // only querying data, never changing the object. We can therefore declare
     // it <code>const</code>:
-    RightHandSide<dim>  right_hand_side;
-    std::vector<double> rhs_values(n_q_points);
+    const RightHandSide<dim> right_hand_side;
+    std::vector<double>      rhs_values(n_q_points);
 
     // Finally we define an object denoting the exact solution function. We
     // will use it to compute the Neumann values at the boundary from


### PR DESCRIPTION
Explained that template argument for `SolverCG` has been specified, even though it is the same as default argument(Step-3),  removed destructor and added `const` where the documentation indicated it(Step-7)

Linked to [this issue](https://github.com/dealii/dealii/issues/11019)