### PR TITLE
work around gcc segfault in tensor.h

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -495,12 +495,10 @@ public:
    */
   constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
                                   Tensor()
-#ifdef DEAL_II_MSVC
+    // We would like to use =default, but this causes compile errors with some
+    // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
     : values{}
   {}
-#else
-    = default;
-#endif
 
   /**
    * A constructor where the data is copied from a C-style array.

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -494,11 +494,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                  Tensor()
-    // We would like to use =default, but this causes compile errors with some
-    // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
-    : values{}
-  {}
+                                  Tensor();
 
   /**
    * A constructor where the data is copied from a C-style array.
@@ -1161,6 +1157,17 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
   static_assert(sizeof...(indices) == dim,
                 "dim should match the number of indices");
 }
+
+
+
+template <int rank_, int dim, typename Number>
+constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
+                                Tensor<rank_, dim, Number>::Tensor()
+  // We would like to use =default, but this causes compile errors with some
+  // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
+  : values{}
+{}
+
 
 
 template <int rank_, int dim, typename Number>


### PR DESCRIPTION
gcc 5.4.0 with -O1 in debug mode segfaults with
```
In file included from ../include/deal.II/base/symmetric_tensor.h:25:0,
                 from ../include/deal.II/base/array_view.h:23,
                 from ../source/fe/fe_values.cc:16,
                 from ../source/fe/fe_values_inst4.cc:17:
../include/deal.II/base/tensor.h: In function ‘void
dealii::FEValuesViews::internal::do_function_symmetric_gradients(const
dealii::ArrayView<Number>&, const dealii::Table<2, dealii::Tensor<1,
spacedim> >&, const std::vector<typename
dealii::FEValuesViews::Vector<dim, spacedim>::ShapeFunctionData>&,
std::vector<typename dealii::ProductType<Number,
dealii::SymmetricTensor<2, spacedim> >::type>&) [with int dim = 1; int
spacedim = 1; Number = std::complex<double>; typename
dealii::FEValuesViews::Vector<dim, spacedim>::ShapeFunctionData =
dealii::FEValuesViews::Vector<1, 1>::ShapeFunctionData; typename
dealii::ProductType<Number, dealii::SymmetricTensor<2, spacedim> >::type
= dealii::SymmetricTensor<2, 1, std::complex<double> >]’:
../include/deal.II/base/tensor.h:497:35:   in constexpr expansion of
‘(long unsigned int)(__first + 16u)()’
../include/deal.II/base/tensor.h:497:35:   in constexpr expansion of
‘<expression error>()’
../include/deal.II/base/tensor.h:497:35:   in constexpr expansion of
‘dealii::Tensor<2, 1, double>()’
../include/deal.II/base/tensor.h:497:35:   in constexpr expansion of
‘(void*)__first()’

In file included from ../source/fe/fe_values_inst4.cc:17:0:
../source/fe/fe_values.cc:700:5: internal compiler error: Segmentation
fault
     do_function_symmetric_gradients(
```
Work around this by changing the constructor.

also see #9080