### PR TITLE
Matrix-free evaluation kernels: adjust check in assertion

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2549,7 +2549,7 @@ namespace internal
                MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
                  contiguous)))))
       {
-        AssertDimension(face_orientations.size(), 1);
+        AssertDimension(n_face_orientations, 1);
         adjust_for_face_orientation(dim,
                                     n_components,
                                     face_orientations[0],


### PR DESCRIPTION
In #10946 we cleaned up some of the interfaces in the internal evaluators. However, with that change we always pass `VectorizedArray::size()` options for the faces along, so we need to check for the template argument to actually know whether we have the same orientation in all SIMD lanes or whether they can differ.