### PR TITLE
Enable FE_Nothing in MatrixFree

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -975,9 +975,12 @@ namespace internal
       {
         const bool strict_categories =
           cell_vectorization_categories_strict || hp_functionality_enabled;
-        unsigned int dofs_per_cell = 0;
+        // Use max dofs per cell in create_blocks_serial. This is necessary
+        // to use FE_Nothing.
+        unsigned int max_dofs_per_cell = 0;
         for (const auto &info : dof_info)
-          dofs_per_cell = std::max(dofs_per_cell, info.dofs_per_cell[0]);
+          for (const auto &dofs : info.dofs_per_cell)
+            max_dofs_per_cell = std::max(max_dofs_per_cell, dofs);
 
         // Detect cells with the same parent to make sure they get scheduled
         // together in the loop, which increases data locality.
@@ -1004,7 +1007,7 @@ namespace internal
               ++position;
             }
         task_info.create_blocks_serial(subdomain_boundary_cells,
-                                       dofs_per_cell,
+                                       max_dofs_per_cell,
                                        hp_functionality_enabled,
                                        dof_info[0].cell_active_fe_index,
                                        strict_categories,

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -104,6 +104,9 @@ namespace internal
       univariate_shape_data.fe_degree     = fe->degree;
       univariate_shape_data.n_q_points_1d = quad.size();
 
+      if ((fe->n_dofs_per_cell() == 0) || (quad.size() == 0))
+        return;
+
       // grant write access to common univariate shape data
       auto &shape_values    = univariate_shape_data.shape_values;
       auto &shape_gradients = univariate_shape_data.shape_gradients;

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -784,6 +784,7 @@ namespace internal
       std::vector<unsigned int> &      renumbering,
       std::vector<unsigned char> &     incompletely_filled_vectorization)
     {
+      Assert(dofs_per_cell > 0, ExcInternalError());
       // This function is decomposed into several steps to determine a good
       // ordering that satisfies the following constraints:
       // a. Only cells belonging to the same category (or next higher if the

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -142,6 +142,9 @@ test()
   hp::QCollection<dim>  quadrature_collection;
   hp::QCollection<1>    quadrature_collection_mf;
 
+  fe_collection.push_back(FE_Nothing<dim>());
+  quadrature_collection.push_back(QGauss<dim>(1));
+  quadrature_collection_mf.push_back(QGauss<1>(1));
   for (unsigned int deg = 1; deg <= max_degree; ++deg)
     {
       fe_collection.push_back(FE_Q<dim>(QGaussLobatto<1>(deg + 1)));
@@ -158,8 +161,13 @@ test()
     for (; cell != endc; ++cell)
       {
         const unsigned int fe_index = Testing::rand() % max_degree;
-        cell->set_active_fe_index(fe_index);
+        cell->set_active_fe_index(fe_index + 1);
       }
+    // We cannot set random cells to FE_Nothing. We get the following error
+    // The violated condition was: dominating_fe.n_dofs_per_face(face) <=
+    // subface_fe.n_dofs_per_face(face)
+    cell = dof.begin_active();
+    cell->set_active_fe_index(0);
   }
 
   // setup DoFs


### PR DESCRIPTION
With this PR I can pass a simple test that uses` FE_Nothing` and `MatrixFree`. Before merging I want to test this more but I want to make sure that what I am doing make sense (@peterrum @kronbichler). The PR does two things: 
 1) when using `FE_Nothing` or a `Quadrature` with zero points, `ShapeInfo<Number>::reinit` does nothing
 2) I think that was a bug: `task_info.create_blocks_serial` requires the number of dofs per cell. We loop over the `dof_info` but in the `dof_info` we don't loop over `dofs_per_cell`, we would just take the first one. When `FE_Nothing` is first, we get `dofs_per_cell=0` and `task_info.create_blocks_serial` crashes.