### PR TITLE
[WIP] Enable MPI-3 capabilities in MatrixFree

### DIFF
--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -75,6 +75,16 @@ namespace MemorySpace
      * Pointer to data on the device.
      */
     std::unique_ptr<Number[]> values_dev;
+
+    /**
+     * TODO
+     */
+    MPI_Win *values_win = nullptr;
+
+    /**
+     * TODO
+     */
+    std::vector<ArrayView<const Number>> others;
   };
 
 
@@ -125,6 +135,10 @@ namespace MemorySpace
     // This is not used but it allows to simplify the code until we start using
     // CUDA-aware MPI.
     std::unique_ptr<Number[]> values_dev;
+
+    MPI_Win *values_win = nullptr;
+
+    std::vector<ArrayView<const Number>> others;
   };
 
 
@@ -179,6 +193,8 @@ namespace MemorySpace
 
     std::unique_ptr<Number[], std::function<void(Number *)>> values;
     std::unique_ptr<Number[], void (*)(Number *)>            values_dev;
+    MPI_Win *                            values_win = nullptr;
+    std::vector<ArrayView<const Number>> others;
   };
 
 

--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -136,8 +136,6 @@ namespace MemorySpace
     // CUDA-aware MPI.
     std::unique_ptr<Number[]> values_dev;
 
-    MPI_Win *values_win = nullptr;
-
     std::vector<ArrayView<const Number>> others;
   };
 

--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -48,7 +48,7 @@ namespace MemorySpace
      * Copy the active data (values for Host and values_dev for CUDA) to @p begin.
      * If the data is on the device it is moved to the host.
      */
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       (void)begin;
@@ -59,7 +59,7 @@ namespace MemorySpace
      * Copy the data in @p begin to the active data of the structure (values for
      * Host and values_dev for CUDA). The pointer @p begin must be on the host.
      */
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       (void)begin;
@@ -75,11 +75,6 @@ namespace MemorySpace
      * Pointer to data on the device.
      */
     std::unique_ptr<Number[]> values_dev;
-
-    /**
-     * TODO
-     */
-    MPI_Win *values_win = nullptr;
 
     /**
      * TODO
@@ -111,20 +106,13 @@ namespace MemorySpace
       : values(nullptr, &std::free)
     {}
 
-    virtual ~MemorySpaceData() = default;
-
-    MemorySpaceData(MemorySpaceData &&) noexcept = default;
-
-    MemorySpaceData &
-    operator=(MemorySpaceData &&) noexcept = default;
-
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       std::copy(values.get(), values.get() + n_elements, begin);
     }
 
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       std::copy(begin, begin + n_elements, values.get());
@@ -160,14 +148,7 @@ namespace MemorySpace
       , values_dev(nullptr, Utilities::CUDA::delete_device_data<Number>)
     {}
 
-    virtual ~MemorySpaceData() = default;
-
-    MemorySpaceData(MemorySpaceData &&) noexcept = default;
-
-    MemorySpaceData &
-    operator=(MemorySpaceData &&) noexcept = default;
-
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       const cudaError_t cuda_error_code =
@@ -178,7 +159,7 @@ namespace MemorySpace
       AssertCuda(cuda_error_code);
     }
 
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       const cudaError_t cuda_error_code =
@@ -191,8 +172,7 @@ namespace MemorySpace
 
     std::unique_ptr<Number[], std::function<void(Number *)>> values;
     std::unique_ptr<Number[], void (*)(Number *)>            values_dev;
-    MPI_Win *                            values_win = nullptr;
-    std::vector<ArrayView<const Number>> others;
+    std::vector<ArrayView<const Number>>                     others;
   };
 
 

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -205,6 +205,13 @@ namespace Utilities
       Partitioner(const unsigned int size);
 
       /**
+       * TODO
+       */
+      Partitioner(const unsigned int size,
+                  const unsigned int ghost_size,
+                  const MPI_Comm     communicator);
+
+      /**
        * Constructor with index set arguments. This constructor creates a
        * distributed layout based on a given communicators, an IndexSet
        * describing the locally owned range and another one for describing

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -347,6 +347,15 @@ namespace LinearAlgebra
              const MPI_Comm  communicator);
 
       /**
+       * TODO
+       */
+      void
+      reinit(const size_type local_size,
+             const size_type ghost_size,
+             const MPI_Comm  comm,
+             const MPI_Comm  comm_sm);
+
+      /**
        * Same as above, but without ghost entries.
        */
       void

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1120,6 +1120,12 @@ namespace LinearAlgebra
       void
       set_ghost_state(const bool ghosted) const;
 
+      /**
+       * TODO
+       */
+      const std::vector<ArrayView<const Number>> &
+      shared_vector_data() const;
+
       //@}
 
       /**
@@ -1493,6 +1499,14 @@ namespace LinearAlgebra
     {
       return internal::Policy<Number, MemorySpace>::begin(data) +
              partitioner->local_size();
+    }
+
+
+    template <typename Number, typename MemorySpace>
+    const std::vector<ArrayView<const Number>> &
+    Vector<Number, MemorySpace>::shared_vector_data() const
+    {
+      return data.others;
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -360,7 +360,8 @@ namespace LinearAlgebra
        */
       void
       reinit(
-        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner,
+        const MPI_Comm &comm_sm = MPI_COMM_SELF);
 
       /**
        * Swap the contents of this vector and the other vector @p v. One could
@@ -1311,7 +1312,8 @@ namespace LinearAlgebra
        * A helper function that is used to resize the val array.
        */
       void
-      resize_val(const size_type new_allocated_size);
+      resize_val(const size_type new_allocated_size,
+                 const MPI_Comm &comm_sm = MPI_COMM_SELF);
 
       // Make all other vector types friends.
       template <typename Number2, typename MemorySpace2>

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1310,6 +1310,8 @@ namespace LinearAlgebra
        */
       mutable std::mutex mutex;
 
+      mutable MPI_Comm comm_sm = MPI_COMM_SELF;
+
       /**
        * A helper function that clears the compress_requests and
        * update_ghost_values_requests field. Used in reinit() functions.

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -161,9 +161,9 @@ namespace LinearAlgebra
           else
             {
               // TODO: is assert fine?
-              Assert(((allocated_size > 0 && data.values != nullptr) ||
-                      data.values == nullptr),
-                     ExcInternalError());
+              // Assert(((allocated_size > 0 && data.values != nullptr) ||
+              //        data.values == nullptr),
+              //       ExcInternalError());
 
               allocated_size = new_alloc_size;
 
@@ -252,6 +252,11 @@ namespace LinearAlgebra
               data.values_win = win;
 
 #ifdef DEBUG
+              for (unsigned int i = 0; i < new_alloc_size; ++i)
+                ptr_aligned[i] = 0.0;
+
+              MPI_Barrier(comm_shared);
+
               Number temp = 0;
 
               for (const auto &other : data.others)

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -150,6 +150,8 @@ namespace LinearAlgebra
               data.values.reset();
               allocated_size = 0;
             }
+          data.others = {
+            ArrayView<const Number>(data.values.get(), new_alloc_size)};
         }
 
         static void

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -160,6 +160,9 @@ namespace LinearAlgebra
             }
           else
             {
+#ifndef DEAL_II_WITH_MPI
+              Assert(false, ExcInternalError());
+#else
               // TODO: is assert fine?
               // Assert(((allocated_size > 0 && data.values != nullptr) ||
               //        data.values == nullptr),
@@ -248,7 +251,7 @@ namespace LinearAlgebra
               data.values = {ptr_aligned,
                              [win](Number *) { MPI_Win_free(win); }};
 
-#ifdef DEBUG
+#  ifdef DEBUG
               for (unsigned int i = 0; i < new_alloc_size; ++i)
                 ptr_aligned[i] = 0.0;
 
@@ -259,6 +262,7 @@ namespace LinearAlgebra
               for (const auto &other : data.others)
                 for (const auto &o : other)
                   temp += o;
+#  endif
 #endif
             }
         }

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -245,11 +245,11 @@ namespace LinearAlgebra
                 data.others[i] =
                   ArrayView<const Number>(others[i], new_alloc_sizes[i]);
 
-              data.values = {ptr_aligned, [&data](Number *) {
-                               MPI_Win_free(data.values_win);
+              data.values = {ptr_aligned, [win](Number *) {
+                              std::cout << "MPI_FREE" << std::endl; 
+                               MPI_Win_free(win);
+                              std::cout << "MPI_FREE_" << std::endl; 
                              }};
-
-              data.values_win = win;
 
 #ifdef DEBUG
               for (unsigned int i = 0; i < new_alloc_size; ++i)

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -240,6 +240,7 @@ namespace LinearAlgebra
                             MPI_UNSIGNED,
                             comm_shared);
 
+              data.others.resize(size_sm);
               for (unsigned int i = 0; i < size_sm; i++)
                 data.others[i] =
                   ArrayView<const Number>(others[i], new_alloc_sizes[i]);

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -94,7 +94,8 @@ namespace LinearAlgebra
           const types::global_dof_index /*new_alloc_size*/,
           types::global_dof_index & /*allocated_size*/,
           ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpaceType>
-            & /*data*/)
+            & /*data*/,
+          const MPI_Comm & /*comm_sm*/)
         {}
 
         static void
@@ -128,30 +129,126 @@ namespace LinearAlgebra
         resize_val(const types::global_dof_index new_alloc_size,
                    types::global_dof_index &     allocated_size,
                    ::dealii::MemorySpace::
-                     MemorySpaceData<Number, ::dealii::MemorySpace::Host> &data)
+                     MemorySpaceData<Number, ::dealii::MemorySpace::Host> &data,
+                   const MPI_Comm &comm_shared)
         {
-          if (new_alloc_size > allocated_size)
+          if (comm_shared == MPI_COMM_SELF)
             {
+              if (new_alloc_size > allocated_size)
+                {
+                  Assert(((allocated_size > 0 && data.values != nullptr) ||
+                          data.values == nullptr),
+                         ExcInternalError());
+
+                  Number *new_val;
+                  Utilities::System::posix_memalign(
+                    reinterpret_cast<void **>(&new_val),
+                    64,
+                    sizeof(Number) * new_alloc_size);
+                  data.values = {new_val,
+                                 [](Number *data) { std::free(data); }};
+
+                  allocated_size = new_alloc_size;
+                }
+              else if (new_alloc_size == 0)
+                {
+                  data.values.reset();
+                  allocated_size = 0;
+                }
+              data.others = {
+                ArrayView<const Number>(data.values.get(), new_alloc_size)};
+            }
+          else
+            {
+              // TODO: is assert fine?
               Assert(((allocated_size > 0 && data.values != nullptr) ||
                       data.values == nullptr),
                      ExcInternalError());
 
-              Number *new_val;
-              Utilities::System::posix_memalign(
-                reinterpret_cast<void **>(&new_val),
-                64,
-                sizeof(Number) * new_alloc_size);
-              data.values = {new_val, [](Number *data) { std::free(data); }};
-
               allocated_size = new_alloc_size;
+
+              const unsigned int size_sm =
+                Utilities::MPI::n_mpi_processes(comm_shared);
+              const unsigned int rank_sm =
+                Utilities::MPI::this_mpi_process(comm_shared);
+
+              MPI_Win *win = new MPI_Win;
+              Number * data_this;
+
+
+              std::vector<Number *> others(size_sm);
+
+              MPI_Info info;
+              MPI_Info_create(&info);
+
+              const bool contiguous_allocation_enabled = false; // TODO
+
+              if (contiguous_allocation_enabled)
+                MPI_Info_set(info, "alloc_shared_noncontig", "false");
+              else
+                MPI_Info_set(info, "alloc_shared_noncontig", "true");
+
+              const std::size_t align_by = 64;
+
+              std::size_t s =
+                ((new_alloc_size * sizeof(Number) + align_by - 1) /
+                 sizeof(Number)) *
+                sizeof(Number);
+
+              // data.memory_constumption_values = s; // TODO
+
+              MPI_Win_allocate_shared(
+                s, sizeof(Number), info, comm_shared, &data_this, win);
+
+              for (unsigned int i = 0; i < size_sm; i++)
+                {
+                  int      disp_unit;
+                  MPI_Aint ssize;
+                  MPI_Win_shared_query(*win, i, &ssize, &disp_unit, &others[i]);
+                }
+
+              Number *ptr_unaligned = others[rank_sm];
+              Number *ptr_aligned   = ptr_unaligned;
+
+              AssertThrow(std::align(align_by,
+                                     new_alloc_size * sizeof(Number),
+                                     reinterpret_cast<void *&>(ptr_aligned),
+                                     s) != nullptr,
+                          ExcNotImplemented());
+
+              unsigned int n_align_local = ptr_aligned - ptr_unaligned;
+              std::vector<unsigned int> n_align_sm(size_sm);
+
+              MPI_Allgather(&n_align_local,
+                            1,
+                            MPI_UNSIGNED,
+                            n_align_sm.data(),
+                            1,
+                            MPI_UNSIGNED,
+                            comm_shared);
+
+              for (unsigned int i = 0; i < size_sm; i++)
+                others[i] += n_align_sm[i];
+
+              std::vector<unsigned int> new_alloc_sizes(size_sm);
+
+              MPI_Allgather(&new_alloc_size,
+                            1,
+                            MPI_UNSIGNED,
+                            new_alloc_sizes.data(),
+                            1,
+                            MPI_UNSIGNED,
+                            comm_shared);
+
+              for (unsigned int i = 0; i < size_sm; i++)
+                data.others[i] =
+                  ArrayView<const Number>(others[i], new_alloc_sizes[i]);
+
+              data.values     = {ptr_aligned, [&data](Number *) {
+                               MPI_Win_free(data.values_win);
+                             }};
+              data.values_win = win;
             }
-          else if (new_alloc_size == 0)
-            {
-              data.values.reset();
-              allocated_size = 0;
-            }
-          data.others = {
-            ArrayView<const Number>(data.values.get(), new_alloc_size)};
         }
 
         static void
@@ -232,8 +329,11 @@ namespace LinearAlgebra
         resize_val(const types::global_dof_index new_alloc_size,
                    types::global_dof_index &     allocated_size,
                    ::dealii::MemorySpace::
-                     MemorySpaceData<Number, ::dealii::MemorySpace::CUDA> &data)
+                     MemorySpaceData<Number, ::dealii::MemorySpace::CUDA> &data,
+                   const MPI_Comm &comm_sm)
         {
+          (void)comm_sm;
+
           static_assert(
             std::is_same<Number, float>::value ||
               std::is_same<Number, double>::value,
@@ -403,11 +503,15 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     void
-    Vector<Number, MemorySpaceType>::resize_val(const size_type new_alloc_size)
+    Vector<Number, MemorySpaceType>::resize_val(const size_type new_alloc_size,
+                                                const MPI_Comm &comm_sm)
     {
       internal::la_parallel_vector_templates_functions<
         Number,
-        MemorySpaceType>::resize_val(new_alloc_size, allocated_size, data);
+        MemorySpaceType>::resize_val(new_alloc_size,
+                                     allocated_size,
+                                     data,
+                                     comm_sm);
 
       thread_loop_partitioner =
         std::make_shared<::dealii::parallel::internal::TBBPartitioner>();
@@ -511,7 +615,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::reinit(
-      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner_in)
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner_in,
+      const MPI_Comm &                                          comm_sm)
     {
       clear_mpi_requests();
       partitioner = partitioner_in;
@@ -519,7 +624,7 @@ namespace LinearAlgebra
       // set vector size and allocate memory
       const size_type new_allocated_size =
         partitioner->local_size() + partitioner->n_ghost_indices();
-      resize_val(new_allocated_size);
+      resize_val(new_allocated_size, comm_sm);
 
       // initialize to zero
       *this = Number();

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -546,6 +546,32 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number, MemorySpaceType>::reinit(const size_type local_size,
+                                            const size_type ghost_size,
+                                            const MPI_Comm  comm,
+                                            const MPI_Comm  comm_sm)
+    {
+      clear_mpi_requests();
+
+      // check whether we need to reallocate
+      resize_val(local_size + ghost_size, comm_sm);
+
+      // delete previous content in import data
+      import_data.values.reset();
+      import_data.values_dev.reset();
+
+      // set partitioner to serial version
+      partitioner = std::make_shared<Utilities::MPI::Partitioner>(local_size,
+                                                                  ghost_size,
+                                                                  comm);
+
+      this->operator=(Number());
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
     template <typename Number2>
     void
     Vector<Number, MemorySpaceType>::reinit(

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -245,11 +245,8 @@ namespace LinearAlgebra
                 data.others[i] =
                   ArrayView<const Number>(others[i], new_alloc_sizes[i]);
 
-              data.values = {ptr_aligned, [win](Number *) {
-                              std::cout << "MPI_FREE" << std::endl; 
-                               MPI_Win_free(win);
-                              std::cout << "MPI_FREE_" << std::endl; 
-                             }};
+              data.values = {ptr_aligned,
+                             [win](Number *) { MPI_Win_free(win); }};
 
 #ifdef DEBUG
               for (unsigned int i = 0; i < new_alloc_size; ++i)

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -327,9 +327,9 @@ SolverCG<VectorType>::solve(const MatrixType &        A,
   LogStream::Prefix prefix("cg");
 
   // Memory allocation
-  //typename VectorMemory<VectorType>::Pointer g_pointer(this->memory);
-  //typename VectorMemory<VectorType>::Pointer d_pointer(this->memory);
-  //typename VectorMemory<VectorType>::Pointer h_pointer(this->memory);
+  // typename VectorMemory<VectorType>::Pointer g_pointer(this->memory);
+  // typename VectorMemory<VectorType>::Pointer d_pointer(this->memory);
+  // typename VectorMemory<VectorType>::Pointer h_pointer(this->memory);
 
   // define some aliases for simpler access
   VectorType g;

--- a/include/deal.II/lac/solver_cg.h
+++ b/include/deal.II/lac/solver_cg.h
@@ -327,14 +327,14 @@ SolverCG<VectorType>::solve(const MatrixType &        A,
   LogStream::Prefix prefix("cg");
 
   // Memory allocation
-  typename VectorMemory<VectorType>::Pointer g_pointer(this->memory);
-  typename VectorMemory<VectorType>::Pointer d_pointer(this->memory);
-  typename VectorMemory<VectorType>::Pointer h_pointer(this->memory);
+  //typename VectorMemory<VectorType>::Pointer g_pointer(this->memory);
+  //typename VectorMemory<VectorType>::Pointer d_pointer(this->memory);
+  //typename VectorMemory<VectorType>::Pointer h_pointer(this->memory);
 
   // define some aliases for simpler access
-  VectorType &g = *g_pointer;
-  VectorType &d = *d_pointer;
-  VectorType &h = *h_pointer;
+  VectorType g;
+  VectorType d;
+  VectorType h;
 
   // Should we build the matrix for eigenvalue computations?
   const bool do_eigenvalues =

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -187,7 +187,8 @@ namespace internal
        * access to all vector entries.
        */
       void
-      assign_ghosts(const std::vector<unsigned int> &boundary_cells);
+      assign_ghosts(const std::vector<unsigned int> &boundary_cells,
+                    const MPI_Comm                   communicator_sm);
 
       /**
        * This method reorders the way cells are gone through based on a given
@@ -240,7 +241,8 @@ namespace internal
         const unsigned int                        n_lanes,
         const std::vector<FaceToCellTopology<1>> &inner_faces,
         const std::vector<FaceToCellTopology<1>> &ghosted_faces,
-        const bool                                fill_cell_centric);
+        const bool                                fill_cell_centric,
+        const MPI_Comm                            communicator_sm);
 
       /**
        * Compute a renumbering of the degrees of freedom to improve the data

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -33,6 +33,7 @@
 #include <deal.II/matrix_free/mapping_info.h>
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/task_info.h>
+#include <deal.II/matrix_free/vector_data_exchange.h>
 
 #include <array>
 #include <memory>
@@ -517,6 +518,13 @@ namespace internal
       std::shared_ptr<const Utilities::MPI::Partitioner> vector_partitioner;
 
       /**
+       * TODO
+       */
+      std::shared_ptr<
+        const internal::MatrixFreeFunctions::VectorDataExchange::Base>
+        vector_exchanger;
+
+      /**
        * This partitioning selects a subset of ghost indices to the full
        * vector partitioner stored in @p vector_partitioner. These
        * partitioners are used in specialized loops that only import parts of
@@ -534,7 +542,10 @@ namespace internal
        *   values and the gradients on all faces adjacent to the locally owned
        *   cells.
        */
-      std::array<std::shared_ptr<const Utilities::MPI::Partitioner>, 5>
+      std::array<
+        std::shared_ptr<
+          const internal::MatrixFreeFunctions::VectorDataExchange::Base>,
+        5>
         vector_partitioner_face_variants;
 
       /**

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -496,6 +496,9 @@ namespace internal
       Utilities::MPI::Partitioner *vec_part =
         const_cast<Utilities::MPI::Partitioner *>(vector_partitioner.get());
       vec_part->set_ghost_indices(ghost_indices);
+      vector_exchanger = std::make_shared<
+        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
+        vector_partitioner);
     }
 
 
@@ -1209,17 +1212,22 @@ namespace internal
           Utilities::MPI::min<int>(compressed_set.n_elements() ==
                                      part.ghost_indices().n_elements(),
                                    part.get_mpi_communicator()) != 0;
+
+        std::shared_ptr<const Utilities::MPI::Partitioner> temp_0;
+
         if (all_ghosts_equal)
-          vector_partitioner_face_variants[0] = vector_partitioner;
+          temp_0 = vector_partitioner;
         else
           {
-            vector_partitioner_face_variants[0] =
-              std::make_shared<Utilities::MPI::Partitioner>(
-                part.locally_owned_range(), part.get_mpi_communicator());
-            const_cast<Utilities::MPI::Partitioner *>(
-              vector_partitioner_face_variants[0].get())
+            temp_0 = std::make_shared<Utilities::MPI::Partitioner>(
+              part.locally_owned_range(), part.get_mpi_communicator());
+            const_cast<Utilities::MPI::Partitioner *>(temp_0.get())
               ->set_ghost_indices(compressed_set, part.ghost_indices());
           }
+
+        vector_partitioner_face_variants[0] =
+          std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                             PartitionerWrapper>(temp_0);
       }
 
       // construct a numbering of faces
@@ -1433,34 +1441,43 @@ namespace internal
             }
         };
 
+      std::shared_ptr<const Utilities::MPI::Partitioner> temp_1, temp_2, temp_3,
+        temp_4;
+
       // partitioner 1: values on faces
-      process_values(vector_partitioner_face_variants[1], loop_over_faces);
+      process_values(temp_1, loop_over_faces);
 
       // partitioner 2: values and gradients on faces
-      process_gradients(vector_partitioner_face_variants[1],
-                        vector_partitioner_face_variants[2],
-                        loop_over_faces);
+      process_gradients(temp_1, temp_2, loop_over_faces);
 
       if (fill_cell_centric)
         {
           ghost_indices.clear();
           // partitioner 3: values on all faces
-          process_values(vector_partitioner_face_variants[3],
-                         loop_over_all_faces);
+          process_values(temp_3, loop_over_all_faces);
           // partitioner 4: values and gradients on faces
-          process_gradients(vector_partitioner_face_variants[3],
-                            vector_partitioner_face_variants[4],
-                            loop_over_all_faces);
+          process_gradients(temp_3, temp_4, loop_over_all_faces);
         }
       else
         {
-          vector_partitioner_face_variants[3] =
-            std::make_shared<Utilities::MPI::Partitioner>(
-              part.locally_owned_range(), part.get_mpi_communicator());
-          vector_partitioner_face_variants[4] =
-            std::make_shared<Utilities::MPI::Partitioner>(
-              part.locally_owned_range(), part.get_mpi_communicator());
+          temp_3 = std::make_shared<Utilities::MPI::Partitioner>(
+            part.locally_owned_range(), part.get_mpi_communicator());
+          temp_4 = std::make_shared<Utilities::MPI::Partitioner>(
+            part.locally_owned_range(), part.get_mpi_communicator());
         }
+
+      vector_partitioner_face_variants[1] = std::make_shared<
+        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
+        temp_1);
+      vector_partitioner_face_variants[2] = std::make_shared<
+        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
+        temp_2);
+      vector_partitioner_face_variants[3] = std::make_shared<
+        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
+        temp_3);
+      vector_partitioner_face_variants[4] = std::make_shared<
+        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
+        temp_4);
     }
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -496,12 +496,18 @@ namespace internal
       Utilities::MPI::Partitioner *vec_part =
         const_cast<Utilities::MPI::Partitioner *>(vector_partitioner.get());
       vec_part->set_ghost_indices(ghost_indices);
-      vector_exchanger = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::Full>(
-        vector_partitioner->locally_owned_range(),
-        vector_partitioner->ghost_indices(),
-        vector_partitioner->get_mpi_communicator(),
-        MPI_COMM_SELF /*TODO*/);
+
+      if (false)
+        vector_exchanger =
+          std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                             PartitionerWrapper>(vector_partitioner);
+      else
+        vector_exchanger = std::make_shared<
+          internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+          vector_partitioner->locally_owned_range(),
+          vector_partitioner->ghost_indices(),
+          vector_partitioner->get_mpi_communicator(),
+          MPI_COMM_SELF /*TODO*/);
     }
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -382,7 +382,8 @@ namespace internal
 
 
     void
-    DoFInfo::assign_ghosts(const std::vector<unsigned int> &boundary_cells)
+    DoFInfo::assign_ghosts(const std::vector<unsigned int> &boundary_cells,
+                           const MPI_Comm                   communicator_sm)
     {
       Assert(boundary_cells.size() < row_starts.size(), ExcInternalError());
 
@@ -507,7 +508,7 @@ namespace internal
           vector_partitioner->locally_owned_range(),
           vector_partitioner->ghost_indices(),
           vector_partitioner->get_mpi_communicator(),
-          MPI_COMM_SELF /*TODO*/,
+          communicator_sm,
           vector_partitioner->ghost_indices_within_larger_ghost_set());
     }
 
@@ -1182,7 +1183,8 @@ namespace internal
       const unsigned int                        n_lanes,
       const std::vector<FaceToCellTopology<1>> &inner_faces,
       const std::vector<FaceToCellTopology<1>> &ghosted_faces,
-      const bool                                fill_cell_centric)
+      const bool                                fill_cell_centric,
+      const MPI_Comm                            communicator_sm)
     {
       const Utilities::MPI::Partitioner &part = *vector_partitioner;
 
@@ -1249,7 +1251,7 @@ namespace internal
               temp_0->locally_owned_range(),
               temp_0->ghost_indices(),
               temp_0->get_mpi_communicator(),
-              MPI_COMM_SELF /*TODO*/,
+              communicator_sm,
               temp_0->ghost_indices_within_larger_ghost_set());
           }
       }
@@ -1512,28 +1514,28 @@ namespace internal
             temp_1->locally_owned_range(),
             temp_1->ghost_indices(),
             temp_1->get_mpi_communicator(),
-            MPI_COMM_SELF /*TODO*/,
+            communicator_sm,
             temp_1->ghost_indices_within_larger_ghost_set());
           vector_partitioner_face_variants[2] = std::make_shared<
             internal::MatrixFreeFunctions::VectorDataExchange::Full>(
             temp_2->locally_owned_range(),
             temp_2->ghost_indices(),
             temp_2->get_mpi_communicator(),
-            MPI_COMM_SELF /*TODO*/,
+            communicator_sm,
             temp_2->ghost_indices_within_larger_ghost_set());
           vector_partitioner_face_variants[3] = std::make_shared<
             internal::MatrixFreeFunctions::VectorDataExchange::Full>(
             temp_3->locally_owned_range(),
             temp_3->ghost_indices(),
             temp_3->get_mpi_communicator(),
-            MPI_COMM_SELF /*TODO*/,
+            communicator_sm,
             temp_3->ghost_indices_within_larger_ghost_set());
           vector_partitioner_face_variants[4] = std::make_shared<
             internal::MatrixFreeFunctions::VectorDataExchange::Full>(
             temp_4->locally_owned_range(),
             temp_4->ghost_indices(),
             temp_4->get_mpi_communicator(),
-            MPI_COMM_SELF /*TODO*/,
+            communicator_sm,
             temp_4->ghost_indices_within_larger_ghost_set());
         }
     }

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1235,9 +1235,23 @@ namespace internal
               ->set_ghost_indices(compressed_set, part.ghost_indices());
           }
 
-        vector_partitioner_face_variants[0] =
-          std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
-                             PartitionerWrapper>(temp_0);
+        if (false)
+          {
+            vector_partitioner_face_variants[0] =
+              std::make_shared<internal::MatrixFreeFunctions::
+                                 VectorDataExchange::PartitionerWrapper>(
+                temp_0);
+          }
+        else
+          {
+            vector_partitioner_face_variants[0] = std::make_shared<
+              internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+              temp_0->locally_owned_range(),
+              temp_0->ghost_indices(),
+              temp_0->get_mpi_communicator(),
+              MPI_COMM_SELF /*TODO*/,
+              temp_0->ghost_indices_within_larger_ghost_set());
+          }
       }
 
       // construct a numbering of faces
@@ -1476,18 +1490,52 @@ namespace internal
             part.locally_owned_range(), part.get_mpi_communicator());
         }
 
-      vector_partitioner_face_variants[1] = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
-        temp_1);
-      vector_partitioner_face_variants[2] = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
-        temp_2);
-      vector_partitioner_face_variants[3] = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
-        temp_3);
-      vector_partitioner_face_variants[4] = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
-        temp_4);
+      if (false)
+        {
+          vector_partitioner_face_variants[1] =
+            std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                               PartitionerWrapper>(temp_1);
+          vector_partitioner_face_variants[2] =
+            std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                               PartitionerWrapper>(temp_2);
+          vector_partitioner_face_variants[3] =
+            std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                               PartitionerWrapper>(temp_3);
+          vector_partitioner_face_variants[4] =
+            std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                               PartitionerWrapper>(temp_4);
+        }
+      else
+        {
+          vector_partitioner_face_variants[1] = std::make_shared<
+            internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+            temp_1->locally_owned_range(),
+            temp_1->ghost_indices(),
+            temp_1->get_mpi_communicator(),
+            MPI_COMM_SELF /*TODO*/,
+            temp_1->ghost_indices_within_larger_ghost_set());
+          vector_partitioner_face_variants[2] = std::make_shared<
+            internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+            temp_2->locally_owned_range(),
+            temp_2->ghost_indices(),
+            temp_2->get_mpi_communicator(),
+            MPI_COMM_SELF /*TODO*/,
+            temp_2->ghost_indices_within_larger_ghost_set());
+          vector_partitioner_face_variants[3] = std::make_shared<
+            internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+            temp_3->locally_owned_range(),
+            temp_3->ghost_indices(),
+            temp_3->get_mpi_communicator(),
+            MPI_COMM_SELF /*TODO*/,
+            temp_3->ghost_indices_within_larger_ghost_set());
+          vector_partitioner_face_variants[4] = std::make_shared<
+            internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+            temp_4->locally_owned_range(),
+            temp_4->ghost_indices(),
+            temp_4->get_mpi_communicator(),
+            MPI_COMM_SELF /*TODO*/,
+            temp_4->ghost_indices_within_larger_ghost_set());
+        }
     }
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -497,8 +497,11 @@ namespace internal
         const_cast<Utilities::MPI::Partitioner *>(vector_partitioner.get());
       vec_part->set_ghost_indices(ghost_indices);
       vector_exchanger = std::make_shared<
-        internal::MatrixFreeFunctions::VectorDataExchange::PartitionerWrapper>(
-        vector_partitioner);
+        internal::MatrixFreeFunctions::VectorDataExchange::Full>(
+        vector_partitioner->locally_owned_range(),
+        vector_partitioner->ghost_indices(),
+        vector_partitioner->get_mpi_communicator(),
+        MPI_COMM_SELF /*TODO*/);
     }
 
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -507,7 +507,8 @@ namespace internal
           vector_partitioner->locally_owned_range(),
           vector_partitioner->ghost_indices(),
           vector_partitioner->get_mpi_communicator(),
-          MPI_COMM_SELF /*TODO*/);
+          MPI_COMM_SELF /*TODO*/,
+          vector_partitioner->ghost_indices_within_larger_ghost_set());
     }
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3591,8 +3591,8 @@ namespace internal
             ArrayView<Number>(vec.begin(), part.local_size()),
             vec.shared_vector_data(),
             ArrayView<Number>(vec.begin() + part.local_size(),
-                              matrix_free.get_dof_info(mf_component)
-                                .vector_partitioner->n_ghost_indices()),
+               matrix_free.get_dof_info(mf_component)
+                .vector_partitioner->n_ghost_indices()),
             ArrayView<const Number>(
               tmp_data[component_in_block_vector]->begin(),
               part.n_import_indices()),

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3670,19 +3670,26 @@ namespace internal
           AssertDimension(requests.size(), tmp_data.size());
 
           const unsigned int mf_component = find_vector_in_mf(vec);
-          const auto &       part         = get_partitioner(mf_component);
+
+          Assert(mf_component != numbers::invalid_unsigned_int,
+                 ExcNotImplemented());
+
+          const auto &part = get_partitioner(mf_component);
 
           if (part.n_ghost_indices() > 0)
             {
-              Number *array =
+              ArrayView<Number> array(
                 const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec)
-                  .begin();
+                    .begin() +
+                  part.local_size(),
+                matrix_free.get_dof_info(mf_component)
+                  .vector_partitioner->n_ghost_indices());
 
               for (const auto &my_ghosts :
                    part.ghost_indices_within_larger_ghost_set())
                 for (unsigned int j = my_ghosts.first; j < my_ghosts.second;
                      ++j)
-                  array[j + part.local_size()] = 0.;
+                  array[j] = 0.;
             }
 
 #  endif

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -227,7 +227,8 @@ public:
       const bool         initialize_mapping  = true,
       const bool         overlap_communication_computation    = true,
       const bool         hold_all_faces_to_owned_cells        = false,
-      const bool         cell_vectorization_categories_strict = false)
+      const bool         cell_vectorization_categories_strict = false,
+      const MPI_Comm     communicator_sm                      = MPI_COMM_SELF)
       : tasks_parallel_scheme(tasks_parallel_scheme)
       , tasks_block_size(tasks_block_size)
       , mapping_update_flags(mapping_update_flags)
@@ -268,6 +269,7 @@ public:
       , cell_vectorization_category(other.cell_vectorization_category)
       , cell_vectorization_categories_strict(
           other.cell_vectorization_categories_strict)
+      , communicator_sm(other.communicator_sm)
     {}
 
     // remove with level_mg_handler
@@ -297,6 +299,7 @@ public:
       cell_vectorization_category   = other.cell_vectorization_category;
       cell_vectorization_categories_strict =
         other.cell_vectorization_categories_strict;
+      communicator_sm = other.communicator_sm;
 
       return *this;
     }
@@ -529,6 +532,11 @@ public:
      * them in a single vectorized array.
      */
     bool cell_vectorization_categories_strict;
+
+    /**
+     * Shared-memory MPI communicator. Default: MPI_COMM_SELF.
+     */
+    MPI_Comm communicator_sm;
   };
 
   /**
@@ -3591,8 +3599,8 @@ namespace internal
             ArrayView<Number>(vec.begin(), part.local_size()),
             vec.shared_vector_data(),
             ArrayView<Number>(vec.begin() + part.local_size(),
-               matrix_free.get_dof_info(mf_component)
-                .vector_partitioner->n_ghost_indices()),
+                              matrix_free.get_dof_info(mf_component)
+                                .vector_partitioner->n_ghost_indices()),
             ArrayView<const Number>(
               tmp_data[component_in_block_vector]->begin(),
               part.n_import_indices()),

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3299,12 +3299,10 @@ namespace internal
             part.n_import_indices());
           AssertDimension(requests.size(), tmp_data.size());
 
-          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
-
           part.export_to_ghosted_array_start(
             component_in_block_vector + channel_shift,
             ArrayView<const Number>(vec.begin(), part.local_size()),
-            shared_arrays,
+            vec.shared_vector_data(),
             ArrayView<Number>(const_cast<Number *>(vec.begin()) +
                                 part.local_size(),
                               matrix_free.get_dof_info(mf_component)
@@ -3388,11 +3386,9 @@ namespace internal
 
           if (part.n_ghost_indices() != 0 || part.n_import_indices() != 0)
             {
-              const std::vector<ArrayView<const Number>> shared_arrays; // TODO
-
               part.export_to_ghosted_array_finish(
                 ArrayView<const Number>(vec.begin(), part.local_size()),
-                shared_arrays,
+                vec.shared_vector_data(),
                 ArrayView<Number>(const_cast<Number *>(vec.begin()) +
                                     part.local_size(),
                                   matrix_free.get_dof_info(mf_component)
@@ -3504,13 +3500,11 @@ namespace internal
             part.n_import_indices());
           AssertDimension(requests.size(), tmp_data.size());
 
-          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
-
           part.import_from_ghosted_array_start(
             dealii::VectorOperation::add,
             component_in_block_vector + channel_shift,
             ArrayView<Number>(vec.begin(), part.local_size()),
-            shared_arrays,
+            vec.shared_vector_data(),
             ArrayView<Number>(vec.begin() + part.local_size(),
                               matrix_free.get_dof_info(mf_component)
                                 .vector_partitioner->n_ghost_indices()),
@@ -3592,12 +3586,10 @@ namespace internal
           if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
             return;
 
-          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
-
           part.import_from_ghosted_array_finish(
             VectorOperation::add,
             ArrayView<Number>(vec.begin(), part.local_size()),
-            shared_arrays,
+            vec.shared_vector_data(),
             ArrayView<Number>(vec.begin() + part.local_size(),
                               matrix_free.get_dof_info(mf_component)
                                 .vector_partitioner->n_ghost_indices()),

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3299,7 +3299,8 @@ namespace internal
 
           const auto &part = get_partitioner(mf_component);
 
-          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
+          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0 &&
+              part.n_import_sm_procs() == 0)
             return;
 
           tmp_data[component_in_block_vector] =
@@ -3393,7 +3394,8 @@ namespace internal
 
           const auto &part = get_partitioner(mf_component);
 
-          if (part.n_ghost_indices() != 0 || part.n_import_indices() != 0)
+          if (true || part.n_ghost_indices() != 0 ||
+              part.n_import_indices() != 0 && part.n_import_sm_procs() != 0)
             {
               part.export_to_ghosted_array_finish(
                 ArrayView<const Number>(vec.begin(), part.local_size()),
@@ -3500,7 +3502,8 @@ namespace internal
 
           const auto &part = get_partitioner(mf_component);
 
-          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
+          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0 &&
+              part.n_import_sm_procs() == 0)
             return;
 
           tmp_data[component_in_block_vector] =
@@ -3592,7 +3595,8 @@ namespace internal
 
           const auto &part = get_partitioner(mf_component);
 
-          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
+          if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0 &&
+              part.n_import_sm_procs() == 0)
             return;
 
           part.import_from_ghosted_array_finish(

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -227,8 +227,7 @@ public:
       const bool         initialize_mapping  = true,
       const bool         overlap_communication_computation    = true,
       const bool         hold_all_faces_to_owned_cells        = false,
-      const bool         cell_vectorization_categories_strict = false,
-      const MPI_Comm     communicator_sm                      = MPI_COMM_SELF)
+      const bool         cell_vectorization_categories_strict = false)
       : tasks_parallel_scheme(tasks_parallel_scheme)
       , tasks_block_size(tasks_block_size)
       , mapping_update_flags(mapping_update_flags)
@@ -244,7 +243,9 @@ public:
       , hold_all_faces_to_owned_cells(hold_all_faces_to_owned_cells)
       , cell_vectorization_categories_strict(
           cell_vectorization_categories_strict)
-    {}
+    {
+      this->communicator_sm = MPI_COMM_SELF;
+    }
 
     /**
      * Copy constructor.
@@ -2178,7 +2179,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_dof_vector(
   const unsigned int                           comp) const
 {
   AssertIndexRange(comp, n_components());
-  vec.reinit(dof_info[comp].vector_partitioner);
+  vec.reinit(dof_info[comp].vector_partitioner, task_info.communicator_sm);
 }
 
 

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3299,15 +3299,18 @@ namespace internal
             part.n_import_indices());
           AssertDimension(requests.size(), tmp_data.size());
 
+          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
+
           part.export_to_ghosted_array_start(
             component_in_block_vector + channel_shift,
             ArrayView<const Number>(vec.begin(), part.local_size()),
-            ArrayView<Number>(tmp_data[component_in_block_vector]->begin(),
-                              part.n_import_indices()),
+            shared_arrays,
             ArrayView<Number>(const_cast<Number *>(vec.begin()) +
                                 part.local_size(),
                               matrix_free.get_dof_info(mf_component)
                                 .vector_partitioner->n_ghost_indices()),
+            ArrayView<Number>(tmp_data[component_in_block_vector]->begin(),
+                              part.n_import_indices()),
             this->requests[component_in_block_vector]);
 #  endif
         }
@@ -3385,7 +3388,11 @@ namespace internal
 
           if (part.n_ghost_indices() != 0 || part.n_import_indices() != 0)
             {
+              const std::vector<ArrayView<const Number>> shared_arrays; // TODO
+
               part.export_to_ghosted_array_finish(
+                ArrayView<const Number>(vec.begin(), part.local_size()),
+                shared_arrays,
                 ArrayView<Number>(const_cast<Number *>(vec.begin()) +
                                     part.local_size(),
                                   matrix_free.get_dof_info(mf_component)
@@ -3497,9 +3504,13 @@ namespace internal
             part.n_import_indices());
           AssertDimension(requests.size(), tmp_data.size());
 
+          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
+
           part.import_from_ghosted_array_start(
             dealii::VectorOperation::add,
             component_in_block_vector + channel_shift,
+            ArrayView<Number>(vec.begin(), part.local_size()),
+            shared_arrays,
             ArrayView<Number>(vec.begin() + part.local_size(),
                               matrix_free.get_dof_info(mf_component)
                                 .vector_partitioner->n_ghost_indices()),
@@ -3581,15 +3592,18 @@ namespace internal
           if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
             return;
 
+          const std::vector<ArrayView<const Number>> shared_arrays; // TODO
+
           part.import_from_ghosted_array_finish(
             VectorOperation::add,
-            ArrayView<const Number>(
-              tmp_data[component_in_block_vector]->begin(),
-              part.n_import_indices()),
             ArrayView<Number>(vec.begin(), part.local_size()),
+            shared_arrays,
             ArrayView<Number>(vec.begin() + part.local_size(),
                               matrix_free.get_dof_info(mf_component)
                                 .vector_partitioner->n_ghost_indices()),
+            ArrayView<const Number>(
+              tmp_data[component_in_block_vector]->begin(),
+              part.n_import_indices()),
             this->requests[component_in_block_vector]);
 
           matrix_free.release_scratch_data_non_threadsafe(

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3678,18 +3678,12 @@ namespace internal
 
           if (part.n_ghost_indices() > 0)
             {
-              ArrayView<Number> array(
+              part.reset_ghost_values(ArrayView<Number>(
                 const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec)
                     .begin() +
                   part.local_size(),
                 matrix_free.get_dof_info(mf_component)
-                  .vector_partitioner->n_ghost_indices());
-
-              for (const auto &my_ghosts :
-                   part.ghost_indices_within_larger_ghost_set())
-                for (unsigned int j = my_ghosts.first; j < my_ghosts.second;
-                     ++j)
-                  array[j] = 0.;
+                  .vector_partitioner->n_ghost_indices()));
             }
 
 #  endif

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -343,6 +343,15 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
             {
               task_info.communicator_sm = additional_data.communicator_sm;
             }
+          else if (true)
+            {
+              MPI_Comm comm_sm;
+              MPI_Comm_split(task_info.communicator,
+                             task_info.my_pid == 2,
+                             task_info.my_pid,
+                             &comm_sm);
+              task_info.communicator_sm = comm_sm;
+            }
           else
             {
               MPI_Comm comm_sm;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -811,6 +811,10 @@ namespace internal
         dof_info[no].vector_partitioner =
           std::make_shared<Utilities::MPI::Partitioner>(locally_owned_dofs[no],
                                                         task_info.communicator);
+        dof_info[no].vector_exchanger =
+          std::make_shared<internal::MatrixFreeFunctions::VectorDataExchange::
+                             PartitionerWrapper>(
+            dof_info[no].vector_partitioner);
 
         // initialize the arrays for indices
         const unsigned int n_components_total =

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -339,6 +339,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           task_info.n_procs =
             Utilities::MPI::n_mpi_processes(task_info.communicator);
 
+#ifndef DEAL_II_WITH_MPI
+          Assert(false, ExcInternalError());
+#else
           if (false)
             {
               task_info.communicator_sm = additional_data.communicator_sm;
@@ -362,6 +365,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
                                   &comm_sm);
               task_info.communicator_sm = comm_sm;
             }
+#endif
         }
       else
         {

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -333,6 +333,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           task_info.communicator = dist_tria != nullptr ?
                                      dist_tria->get_communicator() :
                                      MPI_COMM_SELF;
+          task_info.communicator_sm = additional_data.communicator_sm;
           task_info.my_pid =
             Utilities::MPI::this_mpi_process(task_info.communicator);
           task_info.n_procs =
@@ -340,9 +341,10 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
         }
       else
         {
-          task_info.communicator = MPI_COMM_SELF;
-          task_info.my_pid       = 0;
-          task_info.n_procs      = 1;
+          task_info.communicator    = MPI_COMM_SELF;
+          task_info.communicator_sm = MPI_COMM_SELF;
+          task_info.my_pid          = 0;
+          task_info.n_procs         = 1;
         }
 
       initialize_dof_handlers(dof_handler, additional_data);

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -333,11 +333,26 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           task_info.communicator = dist_tria != nullptr ?
                                      dist_tria->get_communicator() :
                                      MPI_COMM_SELF;
-          task_info.communicator_sm = additional_data.communicator_sm;
+
           task_info.my_pid =
             Utilities::MPI::this_mpi_process(task_info.communicator);
           task_info.n_procs =
             Utilities::MPI::n_mpi_processes(task_info.communicator);
+
+          if (false)
+            {
+              task_info.communicator_sm = additional_data.communicator_sm;
+            }
+          else
+            {
+              MPI_Comm comm_sm;
+              MPI_Comm_split_type(task_info.communicator,
+                                  MPI_COMM_TYPE_SHARED,
+                                  task_info.my_pid,
+                                  MPI_INFO_NULL,
+                                  &comm_sm);
+              task_info.communicator_sm = comm_sm;
+            }
         }
       else
         {

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1386,7 +1386,7 @@ namespace MatrixFreeOperators
         LinearAlgebra::distributed::Vector<Number> copy_vec(
           BlockHelper::subblock(src, i));
         BlockHelper::subblock(const_cast<VectorType &>(src), i)
-          .reinit(data->get_dof_info(mf_component).vector_partitioner);
+          .reinit(data->get_dof_info(mf_component).vector_partitioner, this->data->get_task_info().communicator_sm);
         BlockHelper::subblock(const_cast<VectorType &>(src), i)
           .copy_locally_owned_data_from(copy_vec);
       }

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1385,8 +1385,9 @@ namespace MatrixFreeOperators
         // lost
         LinearAlgebra::distributed::Vector<Number> copy_vec(
           BlockHelper::subblock(src, i));
-        BlockHelper::subblock(const_cast<VectorType &>(src), i)
-          .reinit(data->get_dof_info(mf_component).vector_partitioner, this->data->get_task_info().communicator_sm);
+        this->data->initialize_dof_vector(
+          BlockHelper::subblock(const_cast<VectorType &>(src), i),
+          mf_component);
         BlockHelper::subblock(const_cast<VectorType &>(src), i)
           .copy_locally_owned_data_from(copy_vec);
       }

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -566,6 +566,11 @@ namespace internal
       MPI_Comm communicator;
 
       /**
+       * Shared-memory MPI communicator
+       */
+      MPI_Comm communicator_sm;
+
+      /**
        * Rank of MPI process
        */
       unsigned int my_pid;

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -43,9 +43,6 @@ namespace internal
         virtual unsigned int
         n_import_indices() const = 0;
 
-        virtual const std::vector<std::pair<unsigned int, unsigned int>> &
-        ghost_indices_within_larger_ghost_set() const = 0;
-
         virtual void
         export_to_ghosted_array_start(
           const unsigned int                          communication_channel,
@@ -148,12 +145,6 @@ namespace internal
         n_import_indices() const override
         {
           return partitioner->n_import_indices();
-        }
-
-        const std::vector<std::pair<unsigned int, unsigned int>> &
-        ghost_indices_within_larger_ghost_set() const override
-        {
-          return partitioner->ghost_indices_within_larger_ghost_set();
         }
 
         void
@@ -327,16 +318,7 @@ namespace internal
         n_ghost_indices() const override;
 
         unsigned int
-        n_import_indices() const override
-        {
-          return 0; // TODO
-        }
-
-        const std::vector<std::pair<unsigned int, unsigned int>> &
-        ghost_indices_within_larger_ghost_set() const override
-        {
-          return dummy; // TODO
-        }
+        n_import_indices() const override;
 
         void
         export_to_ghosted_array_start(
@@ -374,11 +356,7 @@ namespace internal
           std::vector<MPI_Request> &                  requests) const override;
 
         void
-        reset_ghost_values(const ArrayView<double> &ghost_array) const override
-        {
-          (void)ghost_array;
-          // nothing to do
-        }
+        reset_ghost_values(const ArrayView<double> &ghost_array) const override;
 
         void
         export_to_ghosted_array_start(
@@ -416,11 +394,7 @@ namespace internal
           std::vector<MPI_Request> &                 requests) const override;
 
         void
-        reset_ghost_values(const ArrayView<float> &ghost_array) const override
-        {
-          (void)ghost_array;
-          // nothing to do
-        }
+        reset_ghost_values(const ArrayView<float> &ghost_array) const override;
 
       private:
         template <typename Number>
@@ -572,8 +546,6 @@ namespace internal
          * TODO
          */
         std::vector<unsigned int> send_sm_offset;
-
-        std::vector<std::pair<unsigned int, unsigned int>> dummy;
       };
 
     } // namespace VectorDataExchange

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -46,65 +46,75 @@ namespace internal
         virtual const std::vector<std::pair<unsigned int, unsigned int>> &
         ghost_indices_within_larger_ghost_set() const = 0;
 
-
-
         virtual void
         export_to_ghosted_array_start(
-          const unsigned int             communication_channel,
-          const ArrayView<const double> &locally_owned_array,
-          const ArrayView<double> &      temporary_storage,
-          const ArrayView<double> &      ghost_array,
-          std::vector<MPI_Request> &     requests) const = 0;
+          const unsigned int                          communication_channel,
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &                  requests) const = 0;
 
         virtual void
         export_to_ghosted_array_finish(
-          const ArrayView<double> & ghost_array,
-          std::vector<MPI_Request> &requests) const = 0;
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          std::vector<MPI_Request> &                  requests) const = 0;
 
         virtual void
         import_from_ghosted_array_start(
-          const VectorOperation::values vector_operation,
-          const unsigned int            communication_channel,
-          const ArrayView<double> &     ghost_array,
-          const ArrayView<double> &     temporary_storage,
-          std::vector<MPI_Request> &    requests) const = 0;
+          const VectorOperation::values               vector_operation,
+          const unsigned int                          communication_channel,
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &                  requests) const = 0;
 
         virtual void
         import_from_ghosted_array_finish(
-          const VectorOperation::values  vector_operation,
-          const ArrayView<const double> &temporary_storage,
-          const ArrayView<double> &      locally_owned_storage,
-          const ArrayView<double> &      ghost_array,
-          std::vector<MPI_Request> &     requests) const = 0;
+          const VectorOperation::values               vector_operation,
+          const ArrayView<double> &                   locally_owned_storage,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<const double> &             temporary_storage,
+          std::vector<MPI_Request> &                  requests) const = 0;
 
         virtual void
         export_to_ghosted_array_start(
-          const unsigned int            communication_channel,
-          const ArrayView<const float> &locally_owned_array,
-          const ArrayView<float> &      temporary_storage,
-          const ArrayView<float> &      ghost_array,
-          std::vector<MPI_Request> &    requests) const = 0;
+          const unsigned int                         communication_channel,
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &                 requests) const = 0;
 
         virtual void
         export_to_ghosted_array_finish(
-          const ArrayView<float> &  ghost_array,
-          std::vector<MPI_Request> &requests) const = 0;
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          std::vector<MPI_Request> &                 requests) const = 0;
 
         virtual void
         import_from_ghosted_array_start(
-          const VectorOperation::values vector_operation,
-          const unsigned int            communication_channel,
-          const ArrayView<float> &      ghost_array,
-          const ArrayView<float> &      temporary_storage,
-          std::vector<MPI_Request> &    requests) const = 0;
+          const VectorOperation::values              vector_operation,
+          const unsigned int                         communication_channel,
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &                 requests) const = 0;
 
         virtual void
         import_from_ghosted_array_finish(
-          const VectorOperation::values vector_operation,
-          const ArrayView<const float> &temporary_storage,
-          const ArrayView<float> &      locally_owned_storage,
-          const ArrayView<float> &      ghost_array,
-          std::vector<MPI_Request> &    requests) const = 0;
+          const VectorOperation::values              vector_operation,
+          const ArrayView<float> &                   locally_owned_storage,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<const float> &             temporary_storage,
+          std::vector<MPI_Request> &                 requests) const = 0;
       };
 
       class PartitionerWrapper : public Base
@@ -142,12 +152,14 @@ namespace internal
 
         void
         export_to_ghosted_array_start(
-          const unsigned int             communication_channel,
-          const ArrayView<const double> &locally_owned_array,
-          const ArrayView<double> &      temporary_storage,
-          const ArrayView<double> &      ghost_array,
-          std::vector<MPI_Request> &     requests) const override
+          const unsigned int                          communication_channel,
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &                  requests) const override
         {
+          (void)shared_arrays;
           partitioner->export_to_ghosted_array_start(communication_channel,
                                                      locally_owned_array,
                                                      temporary_storage,
@@ -157,20 +169,28 @@ namespace internal
 
         void
         export_to_ghosted_array_finish(
-          const ArrayView<double> & ghost_array,
-          std::vector<MPI_Request> &requests) const override
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          std::vector<MPI_Request> &                  requests) const override
         {
+          (void)locally_owned_array;
+          (void)shared_arrays;
           partitioner->export_to_ghosted_array_finish(ghost_array, requests);
         }
 
         void
         import_from_ghosted_array_start(
-          const VectorOperation::values vector_operation,
-          const unsigned int            communication_channel,
-          const ArrayView<double> &     ghost_array,
-          const ArrayView<double> &     temporary_storage,
-          std::vector<MPI_Request> &    requests) const override
+          const VectorOperation::values               vector_operation,
+          const unsigned int                          communication_channel,
+          const ArrayView<const double> &             locally_owned_array,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &                  requests) const override
         {
+          (void)locally_owned_array;
+          (void)shared_arrays;
           partitioner->import_from_ghosted_array_start(vector_operation,
                                                        communication_channel,
                                                        ghost_array,
@@ -180,12 +200,14 @@ namespace internal
 
         void
         import_from_ghosted_array_finish(
-          const VectorOperation::values  vector_operation,
-          const ArrayView<const double> &temporary_storage,
-          const ArrayView<double> &      locally_owned_storage,
-          const ArrayView<double> &      ghost_array,
-          std::vector<MPI_Request> &     requests) const override
+          const VectorOperation::values               vector_operation,
+          const ArrayView<double> &                   locally_owned_storage,
+          const std::vector<ArrayView<const double>> &shared_arrays,
+          const ArrayView<double> &                   ghost_array,
+          const ArrayView<const double> &             temporary_storage,
+          std::vector<MPI_Request> &                  requests) const override
         {
+          (void)shared_arrays;
           partitioner->import_from_ghosted_array_finish(vector_operation,
                                                         temporary_storage,
                                                         locally_owned_storage,
@@ -194,12 +216,14 @@ namespace internal
         }
         void
         export_to_ghosted_array_start(
-          const unsigned int            communication_channel,
-          const ArrayView<const float> &locally_owned_array,
-          const ArrayView<float> &      temporary_storage,
-          const ArrayView<float> &      ghost_array,
-          std::vector<MPI_Request> &    requests) const override
+          const unsigned int                         communication_channel,
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &                 requests) const override
         {
+          (void)shared_arrays;
           partitioner->export_to_ghosted_array_start(communication_channel,
                                                      locally_owned_array,
                                                      temporary_storage,
@@ -209,20 +233,28 @@ namespace internal
 
         void
         export_to_ghosted_array_finish(
-          const ArrayView<float> &  ghost_array,
-          std::vector<MPI_Request> &requests) const override
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          std::vector<MPI_Request> &                 requests) const override
         {
+          (void)locally_owned_array;
+          (void)shared_arrays;
           partitioner->export_to_ghosted_array_finish(ghost_array, requests);
         }
 
         void
         import_from_ghosted_array_start(
-          const VectorOperation::values vector_operation,
-          const unsigned int            communication_channel,
-          const ArrayView<float> &      ghost_array,
-          const ArrayView<float> &      temporary_storage,
-          std::vector<MPI_Request> &    requests) const override
+          const VectorOperation::values              vector_operation,
+          const unsigned int                         communication_channel,
+          const ArrayView<const float> &             locally_owned_array,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &                 requests) const override
         {
+          (void)locally_owned_array;
+          (void)shared_arrays;
           partitioner->import_from_ghosted_array_start(vector_operation,
                                                        communication_channel,
                                                        ghost_array,
@@ -232,12 +264,14 @@ namespace internal
 
         void
         import_from_ghosted_array_finish(
-          const VectorOperation::values vector_operation,
-          const ArrayView<const float> &temporary_storage,
-          const ArrayView<float> &      locally_owned_storage,
-          const ArrayView<float> &      ghost_array,
-          std::vector<MPI_Request> &    requests) const override
+          const VectorOperation::values              vector_operation,
+          const ArrayView<float> &                   locally_owned_storage,
+          const std::vector<ArrayView<const float>> &shared_arrays,
+          const ArrayView<float> &                   ghost_array,
+          const ArrayView<const float> &             temporary_storage,
+          std::vector<MPI_Request> &                 requests) const override
         {
+          (void)shared_arrays;
           partitioner->import_from_ghosted_array_finish(vector_operation,
                                                         temporary_storage,
                                                         locally_owned_storage,

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -174,11 +174,19 @@ namespace internal
           std::vector<MPI_Request> &                  requests) const override
         {
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)communication_channel;
+          (void)locally_owned_array;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->export_to_ghosted_array_start(communication_channel,
                                                      locally_owned_array,
                                                      temporary_storage,
                                                      ghost_array,
                                                      requests);
+#endif
         }
 
         void
@@ -190,7 +198,12 @@ namespace internal
         {
           (void)locally_owned_array;
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)ghost_array;
+          (void)requests;
+#else
           partitioner->export_to_ghosted_array_finish(ghost_array, requests);
+#endif
         }
 
         void
@@ -205,11 +218,19 @@ namespace internal
         {
           (void)locally_owned_array;
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)vector_operation;
+          (void)communication_channel;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->import_from_ghosted_array_start(vector_operation,
                                                        communication_channel,
                                                        ghost_array,
                                                        temporary_storage,
                                                        requests);
+#endif
         }
 
         void
@@ -222,11 +243,19 @@ namespace internal
           std::vector<MPI_Request> &                  requests) const override
         {
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)vector_operation;
+          (void)locally_owned_storage;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->import_from_ghosted_array_finish(vector_operation,
                                                         temporary_storage,
                                                         locally_owned_storage,
                                                         ghost_array,
                                                         requests);
+#endif
         }
 
         void
@@ -245,11 +274,19 @@ namespace internal
           std::vector<MPI_Request> &                 requests) const override
         {
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)communication_channel;
+          (void)locally_owned_array;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->export_to_ghosted_array_start(communication_channel,
                                                      locally_owned_array,
                                                      temporary_storage,
                                                      ghost_array,
                                                      requests);
+#endif
         }
 
         void
@@ -261,7 +298,12 @@ namespace internal
         {
           (void)locally_owned_array;
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)ghost_array;
+          (void)requests;
+#else
           partitioner->export_to_ghosted_array_finish(ghost_array, requests);
+#endif
         }
 
         void
@@ -276,11 +318,19 @@ namespace internal
         {
           (void)locally_owned_array;
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)vector_operation;
+          (void)communication_channel;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->import_from_ghosted_array_start(vector_operation,
                                                        communication_channel,
                                                        ghost_array,
                                                        temporary_storage,
                                                        requests);
+#endif
         }
 
         void
@@ -293,11 +343,19 @@ namespace internal
           std::vector<MPI_Request> &                 requests) const override
         {
           (void)shared_arrays;
+#ifndef DEAL_II_WITH_MPI
+          (void)vector_operation;
+          (void)locally_owned_storage;
+          (void)ghost_array;
+          (void)temporary_storage;
+          (void)requests;
+#else
           partitioner->import_from_ghosted_array_finish(vector_operation,
                                                         temporary_storage,
                                                         locally_owned_storage,
                                                         ghost_array,
                                                         requests);
+#endif
         }
 
         void

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -313,7 +313,9 @@ namespace internal
         Full(const IndexSet &is_locally_owned,
              const IndexSet &is_locally_ghost,
              const MPI_Comm &comm,
-             const MPI_Comm &comm_sm);
+             const MPI_Comm &comm_sm,
+             const std::vector<std::pair<unsigned int, unsigned int>>
+               &ghost_indices_within_larger_ghost_set);
 
         unsigned int
         local_size() const override;
@@ -478,7 +480,11 @@ namespace internal
         /**
          * TODO
          */
-        std::vector<types::global_dof_index> recv_remote_ptr = {0};
+        std::vector<std::pair<types::global_dof_index, types::global_dof_index>>
+          recv_remote_ptr;
+
+        std::vector<unsigned int> shifts;
+        std::vector<unsigned int> shifts_ptr;
 
         /**
          * TODO

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -120,6 +120,8 @@ namespace internal
         reset_ghost_values(const ArrayView<float> &ghost_array) const = 0;
       };
 
+
+
       class PartitionerWrapper : public Base
       {
       public:
@@ -303,6 +305,8 @@ namespace internal
         const std::shared_ptr<const Utilities::MPI::Partitioner> partitioner;
       };
 
+
+
       class Full : public Base
       {
       public:
@@ -438,8 +442,7 @@ namespace internal
 
         template <typename Number>
         void
-        reset_ghost_values_impl(
-          const ArrayView<Number> &ghost_array) const;
+        reset_ghost_values_impl(const ArrayView<Number> &ghost_array) const;
 
       private:
         /**
@@ -551,6 +554,331 @@ namespace internal
          * TODO
          */
         std::vector<unsigned int> send_sm_offset;
+      };
+
+
+
+      /**
+       * Partitioner for discontinuous Galerkin discretizations, exploiting
+       * shared memory.
+       */
+      class Contiguous : public Base
+      {
+        const dealii::types::global_dof_index         dofs_per_cell;
+        const dealii::types::global_dof_index         dofs_per_face;
+        const std::vector<std::vector<unsigned int>> &face_to_cell_index_nodal;
+
+      public:
+        using RankType     = unsigned int;
+        using LocalDoFType = unsigned int;
+        using CellIdType   = dealii::types::global_dof_index;
+        using FaceIdType   = std::pair<CellIdType, unsigned int>;
+
+        /**
+         * Constructor.
+         */
+        template <typename ShapeInfo>
+        Contiguous(const ShapeInfo &shape_info)
+          : dofs_per_cell(shape_info.dofs_per_cell)
+          , dofs_per_face(shape_info.dofs_per_face)
+          , face_to_cell_index_nodal(shape_info.face_to_cell_index_nodal)
+        {}
+
+        /**
+         * Initialize partitioner with a list of locally owned cells and
+         * a list of ghost faces (cell and face no).
+         */
+        void
+        reinit(const std::vector<dealii::types::global_dof_index> local_cells,
+               const std::vector<std::pair<dealii::types::global_dof_index,
+                                           std::vector<unsigned int>>>
+                              local_ghost_faces,
+               const MPI_Comm comm,
+               const MPI_Comm comm_sm,
+               const bool     do_buffering);
+
+        unsigned int
+        local_size() const override;
+
+        unsigned int
+        n_ghost_indices() const override;
+
+        unsigned int
+        n_import_indices() const override;
+
+        void
+        reset_ghost_values(
+          const dealii::ArrayView<double> &ghost_array) const override;
+
+        void
+        reset_ghost_values(
+          const dealii::ArrayView<float> &ghost_array) const override;
+
+        /**
+         * Start to export to ghost array.
+         */
+        void
+        export_to_ghosted_array_start(
+          const unsigned int                     communication_channel,
+          const dealii::ArrayView<const double> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+          const dealii::ArrayView<double> &                   ghost_array,
+          const dealii::ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Finish to export to ghost array.
+         */
+        void
+        export_to_ghosted_array_finish(
+          const dealii::ArrayView<const double> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+          const dealii::ArrayView<double> &                   ghost_array,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Start to import from ghost array.
+         */
+        void
+        import_from_ghosted_array_start(
+          const dealii::VectorOperation::values  vector_operation,
+          const unsigned int                     communication_channel,
+          const dealii::ArrayView<const double> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+          const dealii::ArrayView<double> &                   ghost_array,
+          const dealii::ArrayView<double> &                   temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Finish to import from ghost array.
+         */
+        void
+        import_from_ghosted_array_finish(
+          const dealii::VectorOperation::values vector_operation,
+          const dealii::ArrayView<double> &     locally_owned_storage,
+          const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+          const dealii::ArrayView<double> &                   ghost_array,
+          const dealii::ArrayView<const double> &             temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Start to export to ghost array.
+         */
+        void
+        export_to_ghosted_array_start(
+          const unsigned int                    communication_channel,
+          const dealii::ArrayView<const float> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+          const dealii::ArrayView<float> &                   ghost_array,
+          const dealii::ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Finish to export to ghost array.
+         */
+        void
+        export_to_ghosted_array_finish(
+          const dealii::ArrayView<const float> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+          const dealii::ArrayView<float> &                   ghost_array,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Start to import from ghost array.
+         */
+        void
+        import_from_ghosted_array_start(
+          const dealii::VectorOperation::values vector_operation,
+          const unsigned int                    communication_channel,
+          const dealii::ArrayView<const float> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+          const dealii::ArrayView<float> &                   ghost_array,
+          const dealii::ArrayView<float> &                   temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * Finish to import from ghost array.
+         */
+        void
+        import_from_ghosted_array_finish(
+          const dealii::VectorOperation::values vector_operation,
+          const dealii::ArrayView<float> &      locally_owned_storage,
+          const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+          const dealii::ArrayView<float> &                   ghost_array,
+          const dealii::ArrayView<const float> &             temporary_storage,
+          std::vector<MPI_Request> &requests) const override;
+
+        /**
+         * TODO.
+         */
+        template <typename Number>
+        void
+        export_to_ghosted_array_finish_0(
+          const dealii::ArrayView<const Number> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          std::vector<MPI_Request> &                          requests) const;
+
+        /**
+         * TODO.
+         */
+        template <typename Number>
+        void
+        export_to_ghosted_array_finish_1(
+          const dealii::ArrayView<const Number> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          std::vector<MPI_Request> &                          requests) const;
+
+      private:
+        /**
+         * Actual type-independent implementation of
+         * export_to_ghosted_array_start().
+         */
+        template <typename Number>
+        void
+        export_to_ghosted_array_start_impl(
+          const unsigned int                     communication_channel,
+          const dealii::ArrayView<const Number> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          const dealii::ArrayView<Number> &                   temporary_storage,
+          std::vector<MPI_Request> &                          requests) const;
+
+        /**
+         * Actual type-independent implementation of
+         * export_to_ghosted_array_finish().
+         */
+        template <typename Number>
+        void
+        export_to_ghosted_array_finish_impl(
+          const dealii::ArrayView<const Number> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          std::vector<MPI_Request> &                          requests) const;
+
+        /**
+         * Actual type-independent implementation of
+         * import_from_ghosted_array_start().
+         */
+        template <typename Number>
+        void
+        import_from_ghosted_array_start_impl(
+          const dealii::VectorOperation::values  vector_operation,
+          const unsigned int                     communication_channel,
+          const dealii::ArrayView<const Number> &locally_owned_array,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          const dealii::ArrayView<Number> &                   temporary_storage,
+          std::vector<MPI_Request> &                          requests) const;
+
+        /**
+         * Actual type-independent implementation of
+         * import_from_ghosted_array_finish().
+         */
+        template <typename Number>
+        void
+        import_from_ghosted_array_finish_impl(
+          const dealii::VectorOperation::values vector_operation,
+          const dealii::ArrayView<Number> &     locally_owned_storage,
+          const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+          const dealii::ArrayView<Number> &                   ghost_array,
+          const dealii::ArrayView<const Number> &             temporary_storage,
+          std::vector<MPI_Request> &                          requests) const;
+
+      public:
+        /**
+         * Return position of shared cell: cell -> (owner, offset)
+         */
+        const std::map<dealii::types::global_dof_index,
+                       std::pair<unsigned int, unsigned int>> &
+        get_maps() const;
+
+
+        /**
+         * Return position of ghost face: (cell, no) -> (owner, offset)
+         */
+        const std::map<std::pair<dealii::types::global_dof_index, unsigned int>,
+                       std::pair<unsigned int, unsigned int>> &
+        get_maps_ghost() const;
+
+        /**
+         * Return memory consumption.
+         *
+         * @note: Only counts the buffers [TODO].
+         */
+        std::size_t
+        memory_consumption() const;
+
+        /**
+         * Synchronize.
+         */
+        void
+        sync(const unsigned int tag = 0) const;
+
+      private:
+        /**
+         * Global communicator.
+         */
+        MPI_Comm comm;
+
+        /**
+         * Shared-memory sub-communicator.
+         */
+        MPI_Comm comm_sm;
+
+        /**
+         * Number of processes in comm.
+         */
+        unsigned int n_mpi_processes_;
+
+        /**
+         * Number of locally-owned vector entries.
+         */
+        unsigned int n_local_elements;
+
+        /**
+         * Number of ghost vector entries.
+         */
+        unsigned int n_ghost_elements;
+
+        // I) configuration parameters
+        bool         do_buffering;   // buffering vs. non-buffering modus
+        unsigned int dofs_per_ghost; // ghost face or ghost cell
+
+        // II) MPI-communicator related stuff
+        unsigned int sm_size;
+        unsigned int sm_rank;
+
+        // III) access cells and ghost faces
+        std::map<CellIdType, std::pair<RankType, LocalDoFType>> maps;
+        std::map<FaceIdType, std::pair<RankType, LocalDoFType>> maps_ghost;
+
+        // III) information to pack/unpack buffers
+        std::vector<unsigned int>                    send_ranks;
+        std::vector<dealii::types::global_dof_index> send_ptr;
+        std::vector<dealii::types::global_dof_index> send_data_id;
+        std::vector<unsigned int>                    send_data_face_no;
+
+        std::vector<unsigned int>                    recv_ranks;
+        std::vector<dealii::types::global_dof_index> recv_ptr;
+        std::vector<dealii::types::global_dof_index> recv_size;
+
+        std::vector<unsigned int> sm_targets;
+        std::vector<unsigned int> sm_sources;
+
+
+        std::vector<dealii::types::global_dof_index> sm_send_ptr;
+        std::vector<unsigned int>                    sm_send_rank;
+        std::vector<unsigned int>                    sm_send_offset_1;
+        std::vector<unsigned int>                    sm_send_offset_2;
+        std::vector<unsigned int>                    sm_send_no;
+
+        std::vector<dealii::types::global_dof_index> sm_recv_ptr;
+        std::vector<unsigned int>                    sm_recv_rank;
+        std::vector<unsigned int>                    sm_recv_offset_1;
+        std::vector<unsigned int>                    sm_recv_offset_2;
+        std::vector<unsigned int>                    sm_recv_no;
       };
 
     } // namespace VectorDataExchange

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -493,7 +493,7 @@ namespace internal
          * Number of locally-owned vector entries.
          */
         unsigned int n_local_elements;
-        
+
         /**
          * Number of global vector entries.
          */
@@ -592,6 +592,36 @@ namespace internal
          * TODO
          */
         std::vector<unsigned int> send_sm_offset;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> recv_sm_indices_;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> recv_sm_ptr_;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> recv_sm_len_;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> send_sm_indices_;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> send_sm_ptr_;
+
+        /**
+         * TODO
+         */
+        std::vector<unsigned int> send_sm_len_;
       };
 
 

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -1,0 +1,258 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2011 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#ifndef dealii_matrix_free_vector_data_exchange_h
+#define dealii_matrix_free_vector_data_exchange_h
+
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/partitioner.h>
+
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  namespace MatrixFreeFunctions
+  {
+    namespace VectorDataExchange
+    {
+      class Base
+      {
+      public:
+        virtual unsigned int
+        local_size() const = 0;
+
+        virtual unsigned int
+        n_ghost_indices() const = 0;
+
+        virtual unsigned int
+        n_import_indices() const = 0;
+
+        virtual const std::vector<std::pair<unsigned int, unsigned int>> &
+        ghost_indices_within_larger_ghost_set() const = 0;
+
+
+
+        virtual void
+        export_to_ghosted_array_start(
+          const unsigned int             communication_channel,
+          const ArrayView<const double> &locally_owned_array,
+          const ArrayView<double> &      temporary_storage,
+          const ArrayView<double> &      ghost_array,
+          std::vector<MPI_Request> &     requests) const = 0;
+
+        virtual void
+        export_to_ghosted_array_finish(
+          const ArrayView<double> & ghost_array,
+          std::vector<MPI_Request> &requests) const = 0;
+
+        virtual void
+        import_from_ghosted_array_start(
+          const VectorOperation::values vector_operation,
+          const unsigned int            communication_channel,
+          const ArrayView<double> &     ghost_array,
+          const ArrayView<double> &     temporary_storage,
+          std::vector<MPI_Request> &    requests) const = 0;
+
+        virtual void
+        import_from_ghosted_array_finish(
+          const VectorOperation::values  vector_operation,
+          const ArrayView<const double> &temporary_storage,
+          const ArrayView<double> &      locally_owned_storage,
+          const ArrayView<double> &      ghost_array,
+          std::vector<MPI_Request> &     requests) const = 0;
+
+        virtual void
+        export_to_ghosted_array_start(
+          const unsigned int            communication_channel,
+          const ArrayView<const float> &locally_owned_array,
+          const ArrayView<float> &      temporary_storage,
+          const ArrayView<float> &      ghost_array,
+          std::vector<MPI_Request> &    requests) const = 0;
+
+        virtual void
+        export_to_ghosted_array_finish(
+          const ArrayView<float> &  ghost_array,
+          std::vector<MPI_Request> &requests) const = 0;
+
+        virtual void
+        import_from_ghosted_array_start(
+          const VectorOperation::values vector_operation,
+          const unsigned int            communication_channel,
+          const ArrayView<float> &      ghost_array,
+          const ArrayView<float> &      temporary_storage,
+          std::vector<MPI_Request> &    requests) const = 0;
+
+        virtual void
+        import_from_ghosted_array_finish(
+          const VectorOperation::values vector_operation,
+          const ArrayView<const float> &temporary_storage,
+          const ArrayView<float> &      locally_owned_storage,
+          const ArrayView<float> &      ghost_array,
+          std::vector<MPI_Request> &    requests) const = 0;
+      };
+
+      class PartitionerWrapper : public Base
+      {
+      public:
+        PartitionerWrapper(
+          const std::shared_ptr<const Utilities::MPI::Partitioner> partitioner)
+          : partitioner(partitioner)
+        {}
+
+
+        unsigned int
+        local_size() const override
+        {
+          return partitioner->local_size();
+        }
+
+        unsigned int
+        n_ghost_indices() const override
+        {
+          return partitioner->n_ghost_indices();
+        }
+
+        unsigned int
+        n_import_indices() const override
+        {
+          return partitioner->n_import_indices();
+        }
+
+        const std::vector<std::pair<unsigned int, unsigned int>> &
+        ghost_indices_within_larger_ghost_set() const override
+        {
+          return partitioner->ghost_indices_within_larger_ghost_set();
+        }
+
+        void
+        export_to_ghosted_array_start(
+          const unsigned int             communication_channel,
+          const ArrayView<const double> &locally_owned_array,
+          const ArrayView<double> &      temporary_storage,
+          const ArrayView<double> &      ghost_array,
+          std::vector<MPI_Request> &     requests) const override
+        {
+          partitioner->export_to_ghosted_array_start(communication_channel,
+                                                     locally_owned_array,
+                                                     temporary_storage,
+                                                     ghost_array,
+                                                     requests);
+        }
+
+        void
+        export_to_ghosted_array_finish(
+          const ArrayView<double> & ghost_array,
+          std::vector<MPI_Request> &requests) const override
+        {
+          partitioner->export_to_ghosted_array_finish(ghost_array, requests);
+        }
+
+        void
+        import_from_ghosted_array_start(
+          const VectorOperation::values vector_operation,
+          const unsigned int            communication_channel,
+          const ArrayView<double> &     ghost_array,
+          const ArrayView<double> &     temporary_storage,
+          std::vector<MPI_Request> &    requests) const override
+        {
+          partitioner->import_from_ghosted_array_start(vector_operation,
+                                                       communication_channel,
+                                                       ghost_array,
+                                                       temporary_storage,
+                                                       requests);
+        }
+
+        void
+        import_from_ghosted_array_finish(
+          const VectorOperation::values  vector_operation,
+          const ArrayView<const double> &temporary_storage,
+          const ArrayView<double> &      locally_owned_storage,
+          const ArrayView<double> &      ghost_array,
+          std::vector<MPI_Request> &     requests) const override
+        {
+          partitioner->import_from_ghosted_array_finish(vector_operation,
+                                                        temporary_storage,
+                                                        locally_owned_storage,
+                                                        ghost_array,
+                                                        requests);
+        }
+        void
+        export_to_ghosted_array_start(
+          const unsigned int            communication_channel,
+          const ArrayView<const float> &locally_owned_array,
+          const ArrayView<float> &      temporary_storage,
+          const ArrayView<float> &      ghost_array,
+          std::vector<MPI_Request> &    requests) const override
+        {
+          partitioner->export_to_ghosted_array_start(communication_channel,
+                                                     locally_owned_array,
+                                                     temporary_storage,
+                                                     ghost_array,
+                                                     requests);
+        }
+
+        void
+        export_to_ghosted_array_finish(
+          const ArrayView<float> &  ghost_array,
+          std::vector<MPI_Request> &requests) const override
+        {
+          partitioner->export_to_ghosted_array_finish(ghost_array, requests);
+        }
+
+        void
+        import_from_ghosted_array_start(
+          const VectorOperation::values vector_operation,
+          const unsigned int            communication_channel,
+          const ArrayView<float> &      ghost_array,
+          const ArrayView<float> &      temporary_storage,
+          std::vector<MPI_Request> &    requests) const override
+        {
+          partitioner->import_from_ghosted_array_start(vector_operation,
+                                                       communication_channel,
+                                                       ghost_array,
+                                                       temporary_storage,
+                                                       requests);
+        }
+
+        void
+        import_from_ghosted_array_finish(
+          const VectorOperation::values vector_operation,
+          const ArrayView<const float> &temporary_storage,
+          const ArrayView<float> &      locally_owned_storage,
+          const ArrayView<float> &      ghost_array,
+          std::vector<MPI_Request> &    requests) const override
+        {
+          partitioner->import_from_ghosted_array_finish(vector_operation,
+                                                        temporary_storage,
+                                                        locally_owned_storage,
+                                                        ghost_array,
+                                                        requests);
+        }
+
+      private:
+        const std::shared_ptr<const Utilities::MPI::Partitioner> partitioner;
+      };
+
+    } // namespace VectorDataExchange
+  }   // end of namespace MatrixFreeFunctions
+} // end of namespace internal
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -49,6 +49,9 @@ namespace internal
           return 0; // TODO
         }
 
+        virtual types::global_dof_index
+        size() const = 0;
+
         virtual void
         export_to_ghosted_array_start(
           const unsigned int                          communication_channel,
@@ -153,6 +156,12 @@ namespace internal
         n_import_indices() const override
         {
           return partitioner->n_import_indices();
+        }
+
+        virtual types::global_dof_index
+        size() const override
+        {
+          return partitioner->size();
         }
 
         void
@@ -338,6 +347,12 @@ namespace internal
           return send_sm_ranks.size() + recv_sm_ranks.size(); // TODO
         }
 
+        virtual types::global_dof_index
+        size() const override
+        {
+          return n_global_elements;
+        }
+
         void
         export_to_ghosted_array_start(
           const unsigned int                          communication_channel,
@@ -478,6 +493,11 @@ namespace internal
          * Number of locally-owned vector entries.
          */
         unsigned int n_local_elements;
+        
+        /**
+         * Number of global vector entries.
+         */
+        types::global_dof_index n_global_elements;
 
         /**
          * Number of ghost vector entries.

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -43,6 +43,12 @@ namespace internal
         virtual unsigned int
         n_import_indices() const = 0;
 
+        virtual unsigned int
+        n_import_sm_procs() const
+        {
+          return 0; // TODO
+        }
+
         virtual void
         export_to_ghosted_array_start(
           const unsigned int                          communication_channel,
@@ -325,6 +331,12 @@ namespace internal
 
         unsigned int
         n_import_indices() const override;
+
+        virtual unsigned int
+        n_import_sm_procs() const override
+        {
+          return send_sm_ranks.size(); // TODO
+        }
 
         void
         export_to_ghosted_array_start(

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -436,6 +436,11 @@ namespace internal
           const ArrayView<const Number> &             temporary_storage,
           std::vector<MPI_Request> &                  requests) const;
 
+        template <typename Number>
+        void
+        reset_ghost_values_impl(
+          const ArrayView<Number> &ghost_array) const;
+
       private:
         /**
          * Global communicator.
@@ -520,7 +525,7 @@ namespace internal
         /**
          * TODO
          */
-        std::vector<unsigned int> send_remote_offset;
+        std::vector<unsigned int> send_remote_offset = {0};
 
         /**
          * TODO

--- a/include/deal.II/matrix_free/vector_data_exchange.h
+++ b/include/deal.II/matrix_free/vector_data_exchange.h
@@ -335,7 +335,7 @@ namespace internal
         virtual unsigned int
         n_import_sm_procs() const override
         {
-          return send_sm_ranks.size(); // TODO
+          return send_sm_ranks.size() + recv_sm_ranks.size(); // TODO
         }
 
         void

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -359,9 +359,7 @@ namespace Utilities
       if (larger_ghost_index_set.size() == 0)
         {
           ghost_indices_subset_chunks_by_rank_data.clear();
-          ghost_indices_subset_data.emplace_back(local_size(),
-                                                 local_size() +
-                                                   n_ghost_indices());
+          ghost_indices_subset_data.emplace_back(0, n_ghost_indices());
           n_ghost_indices_in_larger_set = n_ghost_indices_data;
         }
       else

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -58,6 +58,28 @@ namespace Utilities
 
 
 
+    Partitioner::Partitioner(const unsigned int size,
+                             const unsigned int ghost_size,
+                             const MPI_Comm     communicator)
+      : global_size(
+          Utilities::MPI::sum<types::global_dof_index>(size, communicator))
+      , locally_owned_range_data(size)
+      , local_range_data(
+          std::pair<types::global_dof_index, types::global_dof_index>(0, size))
+      , n_ghost_indices_data(ghost_size)
+      , n_import_indices_data(0)
+      , n_ghost_indices_in_larger_set(0)
+      , my_pid(Utilities::MPI::this_mpi_process(communicator))
+      , n_procs(Utilities::MPI::n_mpi_processes(communicator))
+      , communicator(communicator)
+      , have_ghost_indices(true)
+    {
+      locally_owned_range_data.add_range(0, size);
+      locally_owned_range_data.compress();
+    }
+
+
+
     Partitioner::Partitioner(const IndexSet &locally_owned_indices,
                              const IndexSet &ghost_indices_in,
                              const MPI_Comm  communicator_in)

--- a/source/matrix_free/CMakeLists.txt
+++ b/source/matrix_free/CMakeLists.txt
@@ -29,6 +29,7 @@ SET(_src
   matrix_free.cc
   shape_info.cc
   task_info.cc
+  vector_data_exchange.cc
   )
 
 SET(_inst

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -631,7 +631,7 @@ namespace internal
         const ArrayView<const Number> &             temporary_storage,
         std::vector<MPI_Request> &                  requests) const
       {
-        (void)temporary_storage;
+        (void)buffer;
 
 #ifndef DEAL_II_WITH_MPI
         Assert(false, ExcNeedsMPI());
@@ -639,7 +639,7 @@ namespace internal
         (void)operation;
         (void)data_this;
         (void)data_others;
-        (void)buffer;
+        (void)temporary_storage;
         (void)requests;
 #else
         (void)operation;
@@ -716,12 +716,13 @@ namespace internal
                      j < send_remote_ptr[i + 1];
                      j++)
                   for (unsigned int l = 0; l < send_remote_len[j]; l++)
-                    data_this[send_remote_indices[j] + l] += buffer[k++];
+                    data_this[send_remote_indices[j] + l] +=
+                      temporary_storage[k++];
 #  else
                 for (unsigned int j = send_remote_ptr[i];
                      j < send_remote_ptr[i + 1];
                      j++)
-                  data_this[send_remote_indices[j]] += buffer[j];
+                  data_this[send_remote_indices[j]] += temporary_storage[j];
 #  endif
               }
             else /*if (s.first == 2)*/

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -13,9 +13,21 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/mpi.templates.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
+#include <deal.II/base/mpi_consensus_algorithms.h>
+#include <deal.II/base/timer.h>
 
 #include <deal.II/matrix_free/vector_data_exchange.h>
+
+#ifdef DEAL_II_WITH_64BIT_INDICES
+#  include <deal.II/base/mpi_consensus_algorithms.templates.h>
+#endif
+
+#include <map>
+#include <vector>
 
 #define DO_COMPRESS true
 
@@ -67,6 +79,33 @@ namespace internal
           recv_sm_len = recv_len;
           recv_sm_len.shrink_to_fit();
         }
+
+        std::vector<unsigned int>
+        procs_of_sm(const MPI_Comm &comm, const MPI_Comm &comm_shared)
+        {
+          // extract information from comm
+          int rank_;
+          MPI_Comm_rank(comm, &rank_);
+
+          const unsigned int rank = rank_;
+
+          // extract information from sm-comm
+          int size_shared;
+          MPI_Comm_size(comm_shared, &size_shared);
+
+          // gather ranks
+          std::vector<unsigned int> ranks_shared(size_shared);
+          MPI_Allgather(&rank,
+                        1,
+                        MPI_UNSIGNED,
+                        ranks_shared.data(),
+                        1,
+                        MPI_INT,
+                        comm_shared);
+
+          return ranks_shared;
+        }
+
       } // namespace internal
 
 
@@ -778,6 +817,1497 @@ namespace internal
                     0.0,
                     recv_remote_ptr.back() * sizeof(Number));
       }
+
+      unsigned int
+      Contiguous::local_size() const
+      {
+        return n_local_elements;
+      }
+
+      unsigned int
+      Contiguous::n_ghost_indices() const
+      {
+        return n_ghost_elements;
+      }
+
+      unsigned int
+      Contiguous::n_import_indices() const
+      {
+        return send_ptr.back() * dofs_per_ghost;
+      }
+
+      void
+      Contiguous::reset_ghost_values(
+        const dealii::ArrayView<double> &ghost_array) const
+      {
+        (void)ghost_array;
+
+        AssertThrow(false, ExcNotImplemented());
+      }
+
+      void
+      Contiguous::reset_ghost_values(
+        const dealii::ArrayView<float> &ghost_array) const
+      {
+        (void)ghost_array;
+
+        AssertThrow(false, ExcNotImplemented());
+      }
+
+      void
+      Contiguous::export_to_ghosted_array_start(
+        const unsigned int                     communication_channel,
+        const dealii::ArrayView<const double> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        const dealii::ArrayView<double> &                   temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        export_to_ghosted_array_start_impl(communication_channel,
+                                           locally_owned_array,
+                                           shared_arrays,
+                                           ghost_array,
+                                           temporary_storage,
+                                           requests);
+      }
+
+
+
+      void
+      Contiguous::export_to_ghosted_array_finish(
+        const dealii::ArrayView<const double> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        export_to_ghosted_array_finish_impl(locally_owned_array,
+                                            shared_arrays,
+                                            ghost_array,
+                                            requests);
+      }
+
+
+
+      void
+      Contiguous::import_from_ghosted_array_start(
+        const dealii::VectorOperation::values  vector_operation,
+        const unsigned int                     communication_channel,
+        const dealii::ArrayView<const double> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        const dealii::ArrayView<double> &                   temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        import_from_ghosted_array_start_impl(vector_operation,
+                                             communication_channel,
+                                             locally_owned_array,
+                                             shared_arrays,
+                                             ghost_array,
+                                             temporary_storage,
+                                             requests);
+      }
+
+
+
+      void
+      Contiguous::import_from_ghosted_array_finish(
+        const dealii::VectorOperation::values vector_operation,
+        const dealii::ArrayView<double> &     locally_owned_storage,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        const dealii::ArrayView<const double> &             temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        import_from_ghosted_array_finish_impl(vector_operation,
+                                              locally_owned_storage,
+                                              shared_arrays,
+                                              ghost_array,
+                                              temporary_storage,
+                                              requests);
+      }
+
+
+
+      void
+      Contiguous::export_to_ghosted_array_start(
+        const unsigned int                    communication_channel,
+        const dealii::ArrayView<const float> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+        const dealii::ArrayView<float> &                   ghost_array,
+        const dealii::ArrayView<float> &                   temporary_storage,
+        std::vector<MPI_Request> &                         requests) const
+      {
+        export_to_ghosted_array_start_impl(communication_channel,
+                                           locally_owned_array,
+                                           shared_arrays,
+                                           ghost_array,
+                                           temporary_storage,
+                                           requests);
+      }
+
+
+
+      void
+      Contiguous::export_to_ghosted_array_finish(
+        const dealii::ArrayView<const float> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+        const dealii::ArrayView<float> &                   ghost_array,
+        std::vector<MPI_Request> &                         requests) const
+      {
+        export_to_ghosted_array_finish_impl(locally_owned_array,
+                                            shared_arrays,
+                                            ghost_array,
+                                            requests);
+      }
+
+
+
+      void
+      Contiguous::import_from_ghosted_array_start(
+        const dealii::VectorOperation::values vector_operation,
+        const unsigned int                    communication_channel,
+        const dealii::ArrayView<const float> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+        const dealii::ArrayView<float> &                   ghost_array,
+        const dealii::ArrayView<float> &                   temporary_storage,
+        std::vector<MPI_Request> &                         requests) const
+      {
+        import_from_ghosted_array_start_impl(vector_operation,
+                                             communication_channel,
+                                             locally_owned_array,
+                                             shared_arrays,
+                                             ghost_array,
+                                             temporary_storage,
+                                             requests);
+      }
+
+
+
+      void
+      Contiguous::import_from_ghosted_array_finish(
+        const dealii::VectorOperation::values vector_operation,
+        const dealii::ArrayView<float> &      locally_owned_storage,
+        const std::vector<dealii::ArrayView<const float>> &shared_arrays,
+        const dealii::ArrayView<float> &                   ghost_array,
+        const dealii::ArrayView<const float> &             temporary_storage,
+        std::vector<MPI_Request> &                         requests) const
+      {
+        import_from_ghosted_array_finish_impl(vector_operation,
+                                              locally_owned_storage,
+                                              shared_arrays,
+                                              ghost_array,
+                                              temporary_storage,
+                                              requests);
+      }
+
+
+
+      void
+      Contiguous::sync(const unsigned int tag) const
+      {
+        std::vector<MPI_Request> req(sm_targets.size() + sm_sources.size());
+
+        for (unsigned int i = 0; i < sm_targets.size(); i++)
+          {
+            int dummy;
+            MPI_Isend(&dummy,
+                      0,
+                      MPI_INT,
+                      sm_targets[i],
+                      tag,
+                      this->comm_sm,
+                      req.data() + i);
+          }
+
+        for (unsigned int i = 0; i < sm_sources.size(); i++)
+          {
+            int dummy;
+            MPI_Irecv(&dummy,
+                      0,
+                      MPI_INT,
+                      sm_sources[i],
+                      tag,
+                      this->comm_sm,
+                      req.data() + i + sm_targets.size());
+          }
+
+        MPI_Waitall(req.size(), req.data(), MPI_STATUSES_IGNORE);
+      }
+
+
+
+      namespace internal
+      {
+        template <typename T, typename U>
+        std::vector<std::pair<T, U>>
+        MPI_Allgather_Pairs(const std::vector<std::pair<T, U>> &src,
+                            const MPI_Comm &                    comm)
+        {
+          int size;
+          MPI_Comm_size(comm, &size);
+
+          std::vector<T> src_1;
+          std::vector<U> src_2;
+
+          for (auto i : src)
+            {
+              src_1.push_back(i.first);
+              src_2.push_back(i.second);
+            }
+
+
+          unsigned int     len_local = src_1.size();
+          std::vector<int> len_global(
+            size); // actually unsigned int but MPI wants int
+          MPI_Allgather(&len_local,
+                        1,
+                        MPI_INT,
+                        &len_global[0],
+                        1,
+                        dealii::Utilities::MPI::internal::mpi_type_id(
+                          &len_local),
+                        comm);
+
+
+          std::vector<int> displs; // actually unsigned int but MPI wants int
+          displs.push_back(0);
+
+          int total_size = 0;
+
+          for (auto i : len_global)
+            {
+              displs.push_back(i + displs.back());
+              total_size += i;
+            }
+
+          std::vector<T> dst_1(total_size);
+          std::vector<U> dst_2(total_size);
+          MPI_Allgatherv(
+            &src_1[0],
+            len_local,
+            dealii::Utilities::MPI::internal::mpi_type_id(&src_1[0]),
+            &dst_1[0],
+            &len_global[0],
+            &displs[0],
+            dealii::Utilities::MPI::internal::mpi_type_id(&dst_1[0]),
+            comm);
+          MPI_Allgatherv(
+            &src_2[0],
+            len_local,
+            dealii::Utilities::MPI::internal::mpi_type_id(&src_2[0]),
+            &dst_2[0],
+            &len_global[0],
+            &displs[0],
+            dealii::Utilities::MPI::internal::mpi_type_id(&dst_2[0]),
+            comm);
+
+          std::vector<std::pair<T, U>> dst(total_size);
+
+          for (unsigned int i = 0; i < dst_1.size(); i++)
+            dst[i] = {dst_1[i], dst_2[i]};
+
+          return dst;
+        }
+      } // namespace internal
+
+
+
+      void
+      Contiguous::reinit(
+        const std::vector<dealii::types::global_dof_index> local_cells,
+        const std::vector<
+          std::pair<dealii::types::global_dof_index, std::vector<unsigned int>>>
+                       local_ghost_faces,
+        const MPI_Comm comm,
+        const MPI_Comm comm_sm,
+        const bool     do_buffering)
+      {
+        // fill some information needed by PartitionerBase
+        this->comm             = comm;
+        this->comm_sm          = comm_sm;
+        this->n_mpi_processes_ = dealii::Utilities::MPI::n_mpi_processes(comm);
+
+        this->do_buffering = do_buffering;
+
+        AssertThrow(local_cells.size() > 0,
+                    dealii::ExcMessage("No local cells!"));
+
+        this->n_local_elements = local_cells.size() * dofs_per_cell;
+
+        // 1) determine if ghost faces or ghost cells are needed
+        const dealii::types::global_dof_index dofs_per_ghost = [&]() {
+          unsigned int result = dofs_per_face;
+
+          for (const auto &ghost_faces : local_ghost_faces)
+            for (const auto ghost_face : ghost_faces.second)
+              if (ghost_face == dealii::numbers::invalid_unsigned_int)
+                result = dofs_per_cell;
+          return dealii::Utilities::MPI::max(result, comm);
+        }();
+
+        this->dofs_per_ghost = dofs_per_ghost;
+
+        // const auto this->comm_sm  = create_sm(comm);
+        const auto sm_procs = internal::procs_of_sm(comm, this->comm_sm);
+        const auto sm_rank  = [&]() {
+          const auto ptr =
+            std::find(sm_procs.begin(),
+                      sm_procs.end(),
+                      dealii::Utilities::MPI::this_mpi_process(comm));
+
+          AssertThrow(ptr != sm_procs.end(),
+                      dealii::ExcMessage("Proc not found!"));
+
+          return std::distance(sm_procs.begin(), ptr);
+        }();
+
+        this->sm_rank = sm_rank;
+        this->sm_size = sm_procs.size();
+
+
+        for (unsigned int i = 0; i < local_cells.size(); i++)
+          this->maps[local_cells[i]] = {sm_rank, i * dofs_per_cell};
+
+
+        // 2) determine which ghost face is shared or remote
+        std::vector<
+          std::pair<dealii::types::global_dof_index, std::vector<unsigned int>>>
+          local_ghost_faces_remote, local_ghost_faces_shared;
+        {
+          const auto n_total_cells = dealii::Utilities::MPI::sum(
+            static_cast<dealii::types::global_dof_index>(local_cells.size()),
+            comm);
+
+          dealii::IndexSet is_local_cells(n_total_cells);
+          is_local_cells.add_indices(local_cells.begin(), local_cells.end());
+
+          dealii::IndexSet is_ghost_cells(n_total_cells);
+          for (const auto &ghost_faces : local_ghost_faces)
+            is_ghost_cells.add_index(ghost_faces.first);
+
+          for (unsigned int i = 0; i < local_ghost_faces.size(); i++)
+            AssertThrow(local_ghost_faces[i].first ==
+                          is_ghost_cells.nth_index_in_set(i),
+                        dealii::ExcMessage("PROBLEM!"));
+
+          AssertThrow(
+            local_ghost_faces.size() == is_ghost_cells.n_elements(),
+            dealii::ExcMessage(
+              "Dimensions " + std::to_string(local_ghost_faces.size()) + " " +
+              std::to_string(is_ghost_cells.n_elements()) + " do not match!"));
+
+          std::vector<unsigned int> owning_ranks_of_ghosts(
+            is_ghost_cells.n_elements());
+
+          // set up dictionary
+          dealii::Utilities::MPI::internal::ComputeIndexOwner::
+            ConsensusAlgorithmsPayload process(is_local_cells,
+                                               is_ghost_cells,
+                                               comm,
+                                               owning_ranks_of_ghosts,
+                                               false);
+
+          dealii::Utilities::MPI::ConsensusAlgorithms::Selector<
+            std::pair<dealii::types::global_dof_index,
+                      dealii::types::global_dof_index>,
+            unsigned int>
+            consensus_algorithm(process, comm);
+          consensus_algorithm.run();
+
+          std::map<unsigned int, std::vector<dealii::types::global_dof_index>>
+            shared_procs_to_cells;
+
+          for (unsigned int i = 0; i < owning_ranks_of_ghosts.size(); i++)
+            {
+              AssertThrow(dealii::Utilities::MPI::this_mpi_process(comm) !=
+                            owning_ranks_of_ghosts[i],
+                          dealii::ExcMessage(
+                            "Locally owned cells should be not ghosted!"));
+
+              const auto ptr = std::find(sm_procs.begin(),
+                                         sm_procs.end(),
+                                         owning_ranks_of_ghosts[i]);
+
+              if (ptr == sm_procs.end())
+                local_ghost_faces_remote.push_back(local_ghost_faces[i]);
+              else
+                {
+                  local_ghost_faces_shared.push_back(local_ghost_faces[i]);
+                  shared_procs_to_cells[std::distance(sm_procs.begin(), ptr)]
+                    .emplace_back(local_ghost_faces[i].first);
+                }
+            }
+
+          // determine (ghost sm cell) -> (sm rank, offset)
+          dealii::Utilities::MPI::ConsensusAlgorithms::
+            AnonymousProcess<dealii::types::global_dof_index, unsigned int>
+              temp(
+                [&]() {
+                  std::vector<unsigned int> result;
+                  for (auto &i : shared_procs_to_cells)
+                    result.push_back(i.first);
+                  return result;
+                },
+                [&](const auto other_rank, auto &send_buffer) {
+                  send_buffer = shared_procs_to_cells[other_rank];
+                },
+                [&](const auto &other_rank,
+                    const auto &buffer_recv,
+                    auto &      request_buffer) {
+                  request_buffer.resize(buffer_recv.size());
+
+                  for (unsigned int i = 0; i < buffer_recv.size(); i++)
+                    {
+                      const auto value = buffer_recv[i];
+                      const auto ptr   = std::find(local_cells.begin(),
+                                                 local_cells.end(),
+                                                 value);
+
+                      AssertThrow(
+                        ptr != local_cells.end(),
+                        dealii::ExcMessage(
+                          "Cell " + std::to_string(value) + " at index " +
+                          std::to_string(i) + " on rank " +
+                          std::to_string(
+                            dealii::Utilities::MPI::this_mpi_process(comm)) +
+                          " requested by rank " + std::to_string(other_rank) +
+                          " not found!"));
+
+                      request_buffer[i] =
+                        std::distance(local_cells.begin(), ptr);
+                    }
+                },
+                [&](const auto other_rank, auto &recv_buffer) {
+                  recv_buffer.resize(shared_procs_to_cells[other_rank].size());
+                },
+                [&](const auto other_rank, const auto &recv_buffer) {
+                  for (unsigned int i = 0; i < recv_buffer.size(); i++)
+                    {
+                      const dealii::types::global_dof_index cell =
+                        shared_procs_to_cells[other_rank][i];
+                      const unsigned int offset = recv_buffer[i];
+
+                      Assert(maps.find(cell) == maps.end(),
+                             dealii::ExcMessage("Cell " + std::to_string(cell) +
+                                                " is already in maps!"));
+
+                      this->maps[cell] = {other_rank, offset * dofs_per_cell};
+                    }
+                });
+          dealii::Utilities::MPI::ConsensusAlgorithms::Selector<
+            dealii::types::global_dof_index,
+            unsigned int>(temp, this->comm_sm)
+            .run();
+        }
+
+
+        // 3) merge local_ghost_faces_remote and sort -> ghost_faces_remote
+        const auto local_ghost_faces_remote_pairs_global =
+          [&local_ghost_faces_remote, &comm, this]() {
+            std::vector<
+              std::pair<dealii::types::global_dof_index, unsigned int>>
+              local_ghost_faces_remote_pairs_local;
+
+            // convert vector<pair<U, std::vector<V>>> ->.vector<std::pair<U,
+            // V>>>
+            for (const auto &ghost_faces : local_ghost_faces_remote)
+              for (const auto ghost_face : ghost_faces.second)
+                local_ghost_faces_remote_pairs_local.emplace_back(
+                  ghost_faces.first, ghost_face);
+
+            // collect all on which are shared
+            std::vector<
+              std::pair<dealii::types::global_dof_index, unsigned int>>
+              local_ghost_faces_remote_pairs_global =
+                internal::MPI_Allgather_Pairs(
+                  local_ghost_faces_remote_pairs_local, this->comm_sm);
+
+            // sort
+            std::sort(local_ghost_faces_remote_pairs_global.begin(),
+                      local_ghost_faces_remote_pairs_global.end());
+
+            return local_ghost_faces_remote_pairs_global;
+          }();
+
+
+        // 4) distributed ghost_faces_remote,
+        auto distributed_local_ghost_faces_remote_pairs_global =
+          [&local_ghost_faces_remote_pairs_global, &sm_procs]() {
+            std::vector<std::vector<
+              std::pair<dealii::types::global_dof_index, unsigned int>>>
+              result(sm_procs.size());
+
+            unsigned int       counter = 0;
+            const unsigned int faces_per_process =
+              (local_ghost_faces_remote_pairs_global.size() + sm_procs.size() -
+               1) /
+              sm_procs.size();
+            for (auto p : local_ghost_faces_remote_pairs_global)
+              result[(counter++) / faces_per_process].push_back(p);
+
+            return result;
+          }();
+
+        // revert partitioning of ghost faces (TODO)
+        {
+          std::vector<std::pair<dealii::types::global_dof_index, unsigned int>>
+            local_ghost_faces_remote_pairs_local;
+
+          for (const auto &ghost_faces : local_ghost_faces_remote)
+            for (const auto ghost_face : ghost_faces.second)
+              local_ghost_faces_remote_pairs_local.emplace_back(
+                ghost_faces.first, ghost_face);
+
+          distributed_local_ghost_faces_remote_pairs_global.clear();
+          distributed_local_ghost_faces_remote_pairs_global.resize(
+            sm_procs.size());
+          distributed_local_ghost_faces_remote_pairs_global[sm_rank] =
+            local_ghost_faces_remote_pairs_local;
+        }
+
+
+        // ... update ghost size, and
+        this->n_ghost_elements =
+          (distributed_local_ghost_faces_remote_pairs_global[sm_rank].size() +
+           (do_buffering ?
+              std::accumulate(local_ghost_faces_shared.begin(),
+                              local_ghost_faces_shared.end(),
+                              std::size_t(0),
+                              [](const std::size_t &a, const auto &b) {
+                                return a + b.second.size();
+                              }) :
+              std::size_t(0))) *
+          dofs_per_ghost;
+
+
+        // ... update ghost map
+        this->maps_ghost = [&]() {
+          std::map<std::pair<dealii::types::global_dof_index, unsigned int>,
+                   std::pair<unsigned int, unsigned int>>
+            maps_ghost;
+
+          // counter for offset of ghost faces
+          unsigned int my_offset = local_cells.size() * dofs_per_cell;
+
+          // buffering-mode: insert shared faces into maps_ghost
+          if (do_buffering)
+            for (const auto &pair : local_ghost_faces_shared)
+              for (const auto &face : pair.second)
+                {
+                  maps_ghost[{pair.first, face}] = {sm_rank, my_offset};
+                  my_offset += dofs_per_ghost;
+                }
+
+          // create map (cell, face_no) -> (sm rank, offset)
+          const auto maps_ghost_inverse =
+            [&distributed_local_ghost_faces_remote_pairs_global,
+             &dofs_per_ghost,
+             &local_cells,
+             this,
+             &sm_procs,
+             &my_offset]() {
+              std::vector<unsigned int> offsets(sm_procs.size());
+
+              MPI_Allgather(
+                &my_offset,
+                1,
+                dealii::Utilities::MPI::internal::mpi_type_id(&my_offset),
+                offsets.data(),
+                1,
+                dealii::Utilities::MPI::internal::mpi_type_id(&my_offset),
+                this->comm_sm);
+
+              std::map<std::pair<unsigned int, unsigned int>,
+                       std::pair<dealii::types::global_dof_index, unsigned int>>
+                maps_ghost_inverse;
+
+              for (unsigned int i = 0; i < sm_procs.size(); i++)
+                for (unsigned int j = 0;
+                     j < distributed_local_ghost_faces_remote_pairs_global[i]
+                           .size();
+                     j++)
+                  maps_ghost_inverse
+                    [distributed_local_ghost_faces_remote_pairs_global[i][j]] =
+                      {i, offsets[i] + j * dofs_per_ghost};
+
+              return maps_ghost_inverse;
+            }();
+
+          // create map (cell, face_no) -> (sm rank, offset) with only
+          // ghost faces needed for evaluation
+          for (const auto &i : local_ghost_faces_remote)
+            for (const auto &j : i.second)
+              maps_ghost[{i.first, j}] = maps_ghost_inverse.at({i.first, j});
+
+          for (const auto &i :
+               distributed_local_ghost_faces_remote_pairs_global[sm_rank])
+            maps_ghost[i] = maps_ghost_inverse.at(i);
+
+          return maps_ghost;
+        }();
+
+        // buffering-mode: pre-compute information for memcopy of ghost faces
+        std::vector<std::array<LocalDoFType, 5>> ghost_list_shared_precomp;
+        std::vector<std::array<LocalDoFType, 5>> maps_ghost_inverse_precomp;
+
+        if (do_buffering)
+          {
+            std::map<unsigned int, std::vector<std::array<LocalDoFType, 5>>>
+              send_data;
+
+            for (const auto &pair : local_ghost_faces_shared)
+              for (const auto &face : pair.second)
+                {
+                  const auto ptr1 = maps.find(pair.first);
+                  AssertThrow(ptr1 != maps.end(),
+                              dealii::ExcMessage("Entry not found!"));
+
+                  const auto ptr2 = maps_ghost.find({pair.first, face});
+                  AssertThrow(ptr2 != maps_ghost.end(),
+                              dealii::ExcMessage("Entry not found!"));
+
+                  std::array<LocalDoFType, 5> v{{ptr1->second.first,
+                                                 ptr1->second.second,
+                                                 face,
+                                                 ptr2->second.first,
+                                                 ptr2->second.second}};
+
+                  ghost_list_shared_precomp.push_back(v);
+
+                  send_data[ptr1->second.first].push_back(v);
+                }
+
+            dealii::Utilities::MPI::ConsensusAlgorithms::
+              AnonymousProcess<LocalDoFType, LocalDoFType>
+                temp(
+                  [&]() {
+                    std::vector<unsigned int> result;
+                    for (auto &i : send_data)
+                      result.push_back(i.first);
+                    return result;
+                  },
+                  [&](const auto other_rank, auto &send_buffer) {
+                    for (const auto &i : send_data[other_rank])
+                      for (const auto &j : i)
+                        send_buffer.push_back(j);
+                  },
+                  [&](const auto & /*other_rank*/,
+                      const auto &buffer_recv,
+                      auto & /*request_buffer*/) {
+                    for (unsigned int i = 0; i < buffer_recv.size(); i += 5)
+                      maps_ghost_inverse_precomp.push_back(
+                        {{buffer_recv[i],
+                          buffer_recv[i + 1],
+                          buffer_recv[i + 2],
+                          buffer_recv[i + 3],
+                          buffer_recv[i + 4]}});
+                  });
+            dealii::Utilities::MPI::ConsensusAlgorithms::Selector<LocalDoFType,
+                                                                  LocalDoFType>(
+              temp, this->comm_sm)
+              .run();
+
+            std::sort(maps_ghost_inverse_precomp.begin(),
+                      maps_ghost_inverse_precomp.end());
+          }
+
+        // rank -> pair(offset, size)
+        std::map<unsigned int, std::pair<unsigned int, unsigned int>>
+          receive_info;
+        std::map<unsigned int, std::vector<std::array<unsigned int, 3>>>
+          requests_from_relevant_precomp;
+
+        // 5) setup communication patterns (during update_ghost_values &
+        // compress)
+        [&local_cells,
+         &distributed_local_ghost_faces_remote_pairs_global,
+         &sm_rank,
+         &comm,
+         &dofs_per_ghost,
+         this](auto &      requests_from_relevant_precomp,
+               auto &      receive_info,
+               const auto &maps,
+               const auto &maps_ghost) {
+          // determine of the owner of cells of remote ghost faces
+          const auto n_total_cells = dealii::Utilities::MPI::sum(
+            static_cast<dealii::types::global_dof_index>(local_cells.size()),
+            comm);
+
+          // owned cells (TODO: generalize so that local_cells is also
+          // partitioned)
+          dealii::IndexSet is_local_cells(n_total_cells);
+          is_local_cells.add_indices(local_cells.begin(), local_cells.end());
+
+          // needed (ghost) cell
+          dealii::IndexSet is_ghost_cells(n_total_cells);
+          for (const auto &ghost_faces :
+               distributed_local_ghost_faces_remote_pairs_global[sm_rank])
+            is_ghost_cells.add_index(ghost_faces.first);
+
+          // determine rank of (ghost) cells
+          const auto owning_ranks_of_ghosts = [&]() {
+            std::vector<unsigned int> owning_ranks_of_ghosts(
+              is_ghost_cells.n_elements());
+
+            dealii::Utilities::MPI::internal::ComputeIndexOwner::
+              ConsensusAlgorithmsPayload process(is_local_cells,
+                                                 is_ghost_cells,
+                                                 comm,
+                                                 owning_ranks_of_ghosts,
+                                                 false);
+
+            dealii::Utilities::MPI::ConsensusAlgorithms::Selector<
+              std::pair<dealii::types::global_dof_index,
+                        dealii::types::global_dof_index>,
+              unsigned int>
+              consensus_algorithm(process, comm);
+            consensus_algorithm.run();
+
+            return owning_ranks_of_ghosts;
+          }();
+
+          // determine targets
+          const auto send_ranks = [&]() {
+            std::set<unsigned int> send_ranks_set;
+
+            for (const auto &i : owning_ranks_of_ghosts)
+              send_ranks_set.insert(i);
+
+            const std::vector<unsigned int> send_ranks(send_ranks_set.begin(),
+                                                       send_ranks_set.end());
+
+            return send_ranks;
+          }();
+
+          // collect ghost faces (separated for each target)
+          const auto send_data = [&]() {
+            std::vector<std::vector<std::pair<dealii::types::global_dof_index,
+                                              dealii::types::global_dof_index>>>
+              send_data(send_ranks.size());
+
+            unsigned int index      = 0;
+            unsigned int index_cell = dealii::numbers::invalid_unsigned_int;
+
+            for (const auto &ghost_faces :
+                 distributed_local_ghost_faces_remote_pairs_global[sm_rank])
+              {
+                if (index_cell != ghost_faces.first)
+                  {
+                    index_cell = ghost_faces.first;
+                    const unsigned int index_rank =
+                      owning_ranks_of_ghosts[is_ghost_cells.index_within_set(
+                        ghost_faces.first)];
+                    index = std::distance(send_ranks.begin(),
+                                          std::find(send_ranks.begin(),
+                                                    send_ranks.end(),
+                                                    index_rank));
+                  }
+                send_data[index].emplace_back(ghost_faces.first,
+                                              ghost_faces.second);
+              }
+
+            return send_data;
+          }();
+
+          // send ghost faces to the owners
+          std::vector<MPI_Request> send_requests(send_ranks.size());
+
+          for (unsigned int i = 0; i < send_ranks.size(); i++)
+            {
+              dealii::types::global_dof_index dummy;
+              MPI_Isend(send_data[i].data(),
+                        2 * send_data[i].size(),
+                        dealii::Utilities::MPI::internal::mpi_type_id(&dummy),
+                        send_ranks[i],
+                        105,
+                        comm,
+                        send_requests.data() + i);
+
+              receive_info[send_ranks[i]] = {
+                send_data[i].size() * dofs_per_ghost,
+                maps_ghost.at(send_data[i][0]).second};
+            }
+
+          MPI_Barrier(comm);
+
+          const auto targets = dealii::Utilities::MPI::
+            compute_point_to_point_communication_pattern(comm, send_ranks);
+
+          // process requests
+          for (unsigned int i = 0; i < targets.size(); i++)
+            {
+              // wait for any request
+              MPI_Status status;
+              auto       ierr = MPI_Probe(MPI_ANY_SOURCE, 105, comm, &status);
+              AssertThrowMPI(ierr);
+
+              // determine number of ghost faces * 2 (since we are considering
+              // pairs)
+              int                             len;
+              dealii::types::global_dof_index dummy;
+              MPI_Get_count(&status,
+                            dealii::Utilities::MPI::internal::mpi_type_id(
+                              &dummy),
+                            &len);
+
+              AssertThrow(len % 2 == 0,
+                          dealii::ExcMessage("Length " + std::to_string(len) +
+                                             " is not a multiple of two!"));
+
+              // allocate memory for the incoming vector
+              std::vector<std::pair<dealii::types::global_dof_index,
+                                    dealii::types::global_dof_index>>
+                recv_data(len / 2);
+
+              // receive data
+              ierr =
+                MPI_Recv(recv_data.data(),
+                         len,
+                         dealii::Utilities::MPI::internal::mpi_type_id(&dummy),
+                         status.MPI_SOURCE,
+                         status.MPI_TAG,
+                         comm,
+                         &status);
+              AssertThrowMPI(ierr);
+
+              // setup pack and unpack info
+              requests_from_relevant_precomp[status.MPI_SOURCE] = [&]() {
+                std::vector<std::array<unsigned int, 3>> temp(len / 2);
+                for (unsigned int i = 0; i < static_cast<unsigned int>(len) / 2;
+                     i++)
+                  {
+                    const CellIdType   cell    = recv_data[i].first;
+                    const unsigned int face_no = recv_data[i].second;
+
+                    const auto ptr = maps.find(cell);
+                    AssertThrow(ptr != maps.end(),
+                                dealii::ExcMessage("Entry " +
+                                                   std::to_string(cell) +
+                                                   " not found!"));
+
+                    temp[i] = std::array<unsigned int, 3>{
+                      {ptr->second.first,
+                       (unsigned int)ptr->second.second,
+                       face_no}};
+                  }
+                return temp;
+              }();
+            }
+
+          // make sure requests have been sent away
+          MPI_Waitall(send_requests.size(),
+                      send_requests.data(),
+                      MPI_STATUSES_IGNORE);
+        }(requests_from_relevant_precomp,
+          receive_info,
+          this->maps,
+          this->maps_ghost);
+
+
+        {
+          recv_ptr.clear();
+          recv_size.clear();
+          recv_ranks.clear();
+
+          for (const auto i : receive_info)
+            {
+              recv_ranks.push_back(i.first);
+              recv_size.push_back(i.second.first);
+              recv_ptr.push_back(i.second.second -
+                                 local_cells.size() * dofs_per_cell);
+            }
+        }
+
+        {
+          // TODO: clear
+          send_ptr.push_back(0);
+
+          for (const auto &i : requests_from_relevant_precomp)
+            {
+              send_ranks.push_back(i.first);
+
+              for (const auto &j : i.second)
+                {
+                  AssertThrow(j[0] == sm_rank,
+                              dealii::StandardExceptions::ExcNotImplemented());
+                  send_data_id.push_back(j[1]);
+                  send_data_face_no.push_back(j[2]);
+                }
+
+              send_ptr.push_back(send_data_id.size());
+            }
+        }
+
+        {
+          std::set<unsigned int> temp;
+
+          for (const auto &i : maps)
+            if (i.second.first != sm_rank)
+              temp.insert(i.second.first);
+
+          for (const auto &i : temp)
+            this->sm_sources.push_back(i);
+
+          this->sm_targets = dealii::Utilities::MPI::
+            compute_point_to_point_communication_pattern(this->comm_sm,
+                                                         sm_sources);
+        }
+
+        if (do_buffering)
+          {
+            auto temp = ghost_list_shared_precomp;
+            std::sort(temp.begin(), temp.end());
+
+            std::vector<
+              std::vector<std::array<dealii::types::global_dof_index, 3>>>
+              temp_(sm_size);
+
+            for (auto t : temp)
+              {
+                AssertThrow(sm_rank == t[3],
+                            dealii::StandardExceptions::ExcNotImplemented());
+                temp_[t[0]].emplace_back(
+                  std::array<dealii::types::global_dof_index, 3>{
+                    {t[1], t[2], t[4]}});
+              }
+
+
+            sm_send_ptr.push_back(0);
+
+            for (unsigned int i = 0; i < temp_.size(); i++)
+              {
+                if (temp_[i].size() == 0)
+                  continue;
+
+                sm_send_rank.push_back(i);
+
+                for (const auto &v : temp_[i])
+                  {
+                    sm_send_offset_1.push_back(v[2] - local_cells.size() *
+                                                        dofs_per_cell);
+                    sm_send_offset_2.push_back(v[0]);
+                    sm_send_no.push_back(v[1]);
+                  }
+
+                sm_send_ptr.push_back(sm_send_no.size());
+              }
+
+            AssertThrow(sm_send_rank.size() == sm_sources.size(),
+                        dealii::StandardExceptions::ExcNotImplemented());
+          }
+
+        if (do_buffering)
+          {
+            auto temp = maps_ghost_inverse_precomp;
+            std::sort(temp.begin(), temp.end());
+
+            std::vector<
+              std::vector<std::array<dealii::types::global_dof_index, 3>>>
+              temp_(sm_size);
+
+            for (auto t : temp)
+              {
+                AssertThrow(sm_rank == t[0],
+                            dealii::StandardExceptions::ExcNotImplemented());
+                temp_[t[3]].emplace_back(
+                  std::array<dealii::types::global_dof_index, 3>{
+                    {t[4], t[2], t[1]}});
+              }
+
+
+            sm_recv_ptr.push_back(0);
+
+            for (unsigned int i = 0; i < temp_.size(); i++)
+              {
+                if (temp_[i].size() == 0)
+                  continue;
+
+                sm_recv_rank.push_back(i);
+
+                for (const auto &v : temp_[i])
+                  {
+                    sm_recv_offset_1.push_back(v[2]);
+                    sm_recv_offset_2.push_back(v[0]);
+                    sm_recv_no.push_back(v[1]);
+                  }
+
+                sm_recv_ptr.push_back(sm_recv_no.size());
+              }
+
+            AssertThrow(sm_recv_rank.size() == sm_targets.size(),
+                        dealii::StandardExceptions::ExcNotImplemented());
+          }
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::export_to_ghosted_array_start_impl(
+        const unsigned int                     communication_channel,
+        const dealii::ArrayView<const Number> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        const dealii::ArrayView<Number> &                   temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)shared_arrays;
+
+        AssertThrow(temporary_storage.size() ==
+                      send_ptr.back() * dofs_per_ghost,
+                    dealii::StandardExceptions::ExcDimensionMismatch(
+                      temporary_storage.size(),
+                      send_ptr.back() * dofs_per_ghost));
+
+        requests.resize(sm_sources.size() + sm_targets.size() +
+                        recv_ranks.size() + send_ranks.size());
+
+        // 1) notify relevant shared processes that local data is available
+        if (sm_size > 1)
+          {
+            int dummy;
+            for (unsigned int i = 0; i < sm_targets.size(); i++)
+              MPI_Isend(&dummy,
+                        0,
+                        MPI_INT,
+                        sm_targets[i],
+                        communication_channel + 21,
+                        this->comm_sm,
+                        requests.data() + i + sm_sources.size());
+
+            for (unsigned int i = 0; i < sm_sources.size(); i++)
+              MPI_Irecv(&dummy,
+                        0,
+                        MPI_INT,
+                        sm_sources[i],
+                        communication_channel + 21,
+                        this->comm_sm,
+                        requests.data() + i);
+          }
+
+        // 2) start receiving form (remote) processes
+        {
+          for (unsigned int i = 0; i < recv_ranks.size(); i++)
+            MPI_Irecv(ghost_array.data() + recv_ptr[i],
+                      recv_size[i],
+                      MPI_DOUBLE,
+                      recv_ranks[i],
+                      communication_channel + 22,
+                      comm,
+                      requests.data() + i + sm_sources.size() +
+                        sm_targets.size());
+        }
+
+        // 3) fill buffers and start sending to (remote) processes
+        for (unsigned int c = 0; c < send_ranks.size(); c++)
+          {
+            auto buffer =
+              temporary_storage.data() + send_ptr[c] * dofs_per_ghost;
+
+            for (unsigned int i = send_ptr[c]; i < send_ptr[c + 1];
+                 i++, buffer += dofs_per_ghost)
+              if (dofs_per_ghost == dofs_per_face)
+                {
+                  auto *__restrict dst = buffer;
+                  const auto *__restrict src =
+                    locally_owned_array.data() + send_data_id[i];
+                  const auto *__restrict idx =
+                    face_to_cell_index_nodal[send_data_face_no[i]].data();
+
+                  for (unsigned int i = 0; i < dofs_per_face; i++)
+                    dst[i] = src[idx[i]];
+                }
+              else if (dofs_per_ghost == dofs_per_cell)
+                {
+                  AssertThrow(false,
+                              dealii::StandardExceptions::ExcNotImplemented());
+                }
+
+            MPI_Issend(temporary_storage.data() + send_ptr[c] * dofs_per_ghost,
+                       (send_ptr[c + 1] - send_ptr[c]) * dofs_per_ghost,
+                       MPI_DOUBLE,
+                       send_ranks[c],
+                       communication_channel + 22,
+                       comm,
+                       requests.data() + c + sm_sources.size() +
+                         sm_targets.size() + recv_ranks.size());
+          }
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::export_to_ghosted_array_finish_impl(
+        const dealii::ArrayView<const Number> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)locally_owned_array;
+
+        AssertDimension(requests.size(),
+                        sm_sources.size() + sm_targets.size() +
+                          recv_ranks.size() + send_ranks.size());
+
+        if (do_buffering) // deal with shared faces if buffering is requested
+          {
+            // update ghost values of shared cells (if requested)
+            for (unsigned int c = 0; c < sm_sources.size(); c++)
+              {
+                int        i;
+                MPI_Status status;
+                const auto ierr =
+                  MPI_Waitany(sm_sources.size(), requests.data(), &i, &status);
+                AssertThrowMPI(ierr);
+
+                for (unsigned int j = sm_send_ptr[i]; j < sm_send_ptr[i + 1];
+                     j++)
+                  if (dofs_per_ghost == dofs_per_face)
+                    {
+                      auto *__restrict dst =
+                        ghost_array.data() + sm_send_offset_1[j];
+                      const auto *__restrict src =
+                        shared_arrays[sm_send_rank[i]].data() +
+                        sm_send_offset_2[j];
+                      const auto *__restrict idx =
+                        face_to_cell_index_nodal[sm_send_no[j]].data();
+
+                      for (unsigned int i = 0; i < dofs_per_face; i++)
+                        dst[i] = src[idx[i]];
+                    }
+                  else if (dofs_per_ghost == dofs_per_cell)
+                    {
+                      AssertThrow(
+                        false, dealii::StandardExceptions::ExcNotImplemented());
+                    }
+              }
+          }
+
+        MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::export_to_ghosted_array_finish_0(
+        const dealii::ArrayView<const Number> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)locally_owned_array;
+
+        AssertDimension(requests.size(),
+                        sm_sources.size() + sm_targets.size() +
+                          recv_ranks.size() + send_ranks.size());
+
+        if (do_buffering) // deal with shared faces if buffering is requested
+          {
+            // update ghost values of shared cells (if requested)
+            for (unsigned int c = 0; c < sm_sources.size(); c++)
+              {
+                int        i;
+                MPI_Status status;
+                const auto ierr =
+                  MPI_Waitany(sm_sources.size(), requests.data(), &i, &status);
+                AssertThrowMPI(ierr);
+
+                for (unsigned int j = sm_send_ptr[i]; j < sm_send_ptr[i + 1];
+                     j++)
+                  if (dofs_per_ghost == dofs_per_face)
+                    {
+                      auto *__restrict dst =
+                        ghost_array.data() + sm_send_offset_1[j];
+                      const auto *__restrict src =
+                        shared_arrays[sm_send_rank[i]].data() +
+                        sm_send_offset_2[j];
+                      const auto *__restrict idx =
+                        face_to_cell_index_nodal[sm_send_no[j]].data();
+
+                      for (unsigned int i = 0; i < dofs_per_face; i++)
+                        dst[i] = src[idx[i]];
+                    }
+                  else if (dofs_per_ghost == dofs_per_cell)
+                    {
+                      AssertThrow(
+                        false, dealii::StandardExceptions::ExcNotImplemented());
+                    }
+              }
+          }
+        else
+          {
+            MPI_Waitall(sm_sources.size(),
+                        requests.data(),
+                        MPI_STATUSES_IGNORE);
+          }
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::export_to_ghosted_array_finish_1(
+        const dealii::ArrayView<const Number> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)locally_owned_array;
+        (void)shared_arrays;
+        (void)ghost_array;
+
+        AssertDimension(requests.size(),
+                        sm_sources.size() + sm_targets.size() +
+                          recv_ranks.size() + send_ranks.size());
+
+        MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::import_from_ghosted_array_start_impl(
+        const dealii::VectorOperation::values  operation,
+        const unsigned int                     communication_channel,
+        const dealii::ArrayView<const Number> &locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        const dealii::ArrayView<Number> &                   temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)locally_owned_array;
+        (void)shared_arrays;
+        (void)communication_channel;
+        (void)ghost_array;
+
+        AssertThrow(operation == dealii::VectorOperation::add,
+                    dealii::ExcMessage("Not yet implemented."));
+
+        AssertThrow(temporary_storage.size() ==
+                      send_ptr.back() * dofs_per_ghost,
+                    dealii::StandardExceptions::ExcDimensionMismatch(
+                      temporary_storage.size(),
+                      send_ptr.back() * dofs_per_ghost));
+
+        requests.resize(sm_sources.size() + sm_targets.size() +
+                        recv_ranks.size() + send_ranks.size());
+
+        // 1) notify relevant shared processes that data is available
+        if (sm_size > 1)
+          {
+            int dummy;
+
+            for (unsigned int i = 0; i < sm_sources.size(); i++)
+              MPI_Isend(&dummy,
+                        0,
+                        MPI_INT,
+                        sm_sources[i],
+                        communication_channel + 21,
+                        this->comm_sm,
+                        requests.data() + i);
+
+            for (unsigned int i = 0; i < sm_targets.size(); i++)
+              MPI_Irecv(&dummy,
+                        0,
+                        MPI_INT,
+                        sm_targets[i],
+                        communication_channel + 21,
+                        this->comm_sm,
+                        requests.data() + i + sm_sources.size());
+          }
+
+        // request receive
+        {
+          for (unsigned int i = 0; i < recv_ranks.size(); i++)
+            MPI_Isend(ghost_array.data() + recv_ptr[i],
+                      recv_size[i],
+                      MPI_DOUBLE,
+                      recv_ranks[i],
+                      0,
+                      comm,
+                      requests.data() + i + sm_sources.size() +
+                        sm_targets.size());
+        }
+
+        // fill buffers and request send
+        for (unsigned int i = 0; i < send_ranks.size(); i++)
+          MPI_Irecv(temporary_storage.data() + send_ptr[i] * dofs_per_ghost,
+                    (send_ptr[i + 1] - send_ptr[i]) * dofs_per_ghost,
+                    MPI_DOUBLE,
+                    send_ranks[i],
+                    0,
+                    comm,
+                    requests.data() + i + sm_sources.size() +
+                      sm_targets.size() + recv_ranks.size());
+      }
+
+
+
+      template <typename Number>
+      void
+      Contiguous::import_from_ghosted_array_finish_impl(
+        const dealii::VectorOperation::values               operation,
+        const dealii::ArrayView<Number> &                   locally_owned_array,
+        const std::vector<dealii::ArrayView<const Number>> &shared_arrays,
+        const dealii::ArrayView<Number> &                   ghost_array,
+        const dealii::ArrayView<const Number> &             temporary_storage,
+        std::vector<MPI_Request> &                          requests) const
+      {
+        (void)ghost_array;
+
+        AssertThrow(operation == dealii::VectorOperation::add,
+                    dealii::ExcMessage("Not yet implemented."));
+
+        AssertThrow(temporary_storage.size() ==
+                      send_ptr.back() * dofs_per_ghost,
+                    dealii::StandardExceptions::ExcDimensionMismatch(
+                      temporary_storage.size(),
+                      send_ptr.back() * dofs_per_ghost));
+
+        AssertDimension(requests.size(),
+                        sm_sources.size() + sm_targets.size() +
+                          recv_ranks.size() + send_ranks.size());
+
+        // 1) compress for shared faces
+        if (do_buffering)
+          {
+            for (unsigned int c = 0; c < sm_targets.size(); c++)
+              {
+                int        i;
+                MPI_Status status;
+                const auto ierr =
+                  MPI_Waitany(sm_targets.size(),
+                              requests.data() + sm_sources.size(),
+                              &i,
+                              &status);
+                AssertThrowMPI(ierr);
+
+                for (unsigned int j = sm_recv_ptr[i]; j < sm_recv_ptr[i + 1];
+                     j++)
+                  if (dofs_per_ghost == dofs_per_face)
+                    {
+                      auto *__restrict dst =
+                        locally_owned_array.data() + sm_recv_offset_1[j];
+                      const auto *__restrict src =
+                        shared_arrays[sm_recv_rank[i]].data() +
+                        sm_recv_offset_2[j];
+                      const auto *__restrict idx =
+                        face_to_cell_index_nodal[sm_recv_no[j]].data();
+
+                      for (unsigned int i = 0; i < dofs_per_face; i++)
+                        dst[idx[i]] += src[i];
+                    }
+                  else if (dofs_per_ghost == dofs_per_cell)
+                    {
+                      AssertThrow(
+                        false, dealii::StandardExceptions::ExcNotImplemented());
+                    }
+              }
+          }
+
+        // 2) receive data and compress for remote faces
+        for (unsigned int c = 0; c < send_ranks.size(); c++)
+          {
+            int        r;
+            MPI_Status status;
+            const auto ierr =
+              MPI_Waitany(send_ranks.size(),
+                          requests.data() + sm_sources.size() +
+                            sm_targets.size() + recv_ranks.size(),
+                          &r,
+                          &status);
+            AssertThrowMPI(ierr);
+
+            auto buffer =
+              temporary_storage.data() + send_ptr[r] * dofs_per_ghost;
+
+            for (unsigned int i = send_ptr[r]; i < send_ptr[r + 1];
+                 i++, buffer += dofs_per_ghost)
+              if (dofs_per_ghost == dofs_per_face)
+                {
+                  auto *__restrict dst =
+                    locally_owned_array.data() + send_data_id[i];
+                  const auto *__restrict src = buffer;
+                  const auto *__restrict idx =
+                    face_to_cell_index_nodal[send_data_face_no[i]].data();
+
+                  for (unsigned int i = 0; i < dofs_per_face; i++)
+                    dst[idx[i]] += src[i];
+                }
+              else if (dofs_per_ghost == dofs_per_cell)
+                {
+                  AssertThrow(false,
+                              dealii::StandardExceptions::ExcNotImplemented());
+                }
+          }
+
+        MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+      }
+
+
+
+      const std::map<dealii::types::global_dof_index,
+                     std::pair<unsigned int, unsigned int>> &
+      Contiguous::get_maps() const
+      {
+        return maps;
+      }
+
+
+
+      const std::map<std::pair<dealii::types::global_dof_index, unsigned int>,
+                     std::pair<unsigned int, unsigned int>> &
+      Contiguous::get_maps_ghost() const
+      {
+        return maps_ghost;
+      }
+
+
+
+      std::size_t
+      Contiguous::memory_consumption() const
+      {
+        // [TODO] not counting maps and maps_ghost
+
+        return dealii::MemoryConsumption::memory_consumption(send_ranks) +
+               dealii::MemoryConsumption::memory_consumption(send_ptr) +
+               dealii::MemoryConsumption::memory_consumption(send_data_id) +
+               dealii::MemoryConsumption::memory_consumption(
+                 send_data_face_no) +
+               dealii::MemoryConsumption::memory_consumption(recv_ranks) +
+               dealii::MemoryConsumption::memory_consumption(recv_ptr) +
+               dealii::MemoryConsumption::memory_consumption(recv_size) +
+               dealii::MemoryConsumption::memory_consumption(sm_targets) +
+               dealii::MemoryConsumption::memory_consumption(sm_sources) +
+               dealii::MemoryConsumption::memory_consumption(sm_send_ptr) +
+               dealii::MemoryConsumption::memory_consumption(sm_send_rank) +
+               dealii::MemoryConsumption::memory_consumption(sm_send_offset_1) +
+               dealii::MemoryConsumption::memory_consumption(sm_send_offset_2) +
+               dealii::MemoryConsumption::memory_consumption(sm_send_no) +
+               dealii::MemoryConsumption::memory_consumption(sm_recv_ptr) +
+               dealii::MemoryConsumption::memory_consumption(sm_recv_rank) +
+               dealii::MemoryConsumption::memory_consumption(sm_recv_offset_1) +
+               dealii::MemoryConsumption::memory_consumption(sm_recv_offset_2) +
+               dealii::MemoryConsumption::memory_consumption(sm_recv_no);
+      }
+
+
+      template void
+      Contiguous::export_to_ghosted_array_finish_0(
+        const dealii::ArrayView<const double> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const;
+
+      template void
+      Contiguous::export_to_ghosted_array_finish_1(
+        const dealii::ArrayView<const double> &             locally_owned_array,
+        const std::vector<dealii::ArrayView<const double>> &shared_arrays,
+        const dealii::ArrayView<double> &                   ghost_array,
+        std::vector<MPI_Request> &                          requests) const;
 
     } // namespace VectorDataExchange
   }   // namespace MatrixFreeFunctions

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -1,0 +1,768 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/base/mpi_compute_index_owner_internal.h>
+
+#include <deal.II/matrix_free/vector_data_exchange.h>
+
+#define DO_COMPRESS true
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace internal
+{
+  namespace MatrixFreeFunctions
+  {
+    namespace VectorDataExchange
+    {
+      namespace internal
+      {
+        void
+        compress(std::vector<unsigned int> &recv_sm_ptr,
+                 std::vector<unsigned int> &recv_sm_indices,
+                 std::vector<unsigned int> &recv_sm_len)
+        {
+          std::vector<unsigned int> recv_ptr = {0};
+          std::vector<unsigned int> recv_indices;
+          std::vector<unsigned int> recv_len;
+
+          for (unsigned int i = 0; i + 1 < recv_sm_ptr.size(); i++)
+            {
+              if (recv_sm_ptr[i] != recv_sm_ptr[i + 1])
+                {
+                  recv_indices.push_back(recv_sm_indices[recv_sm_ptr[i]]);
+                  recv_len.push_back(1);
+
+                  for (unsigned int j = recv_sm_ptr[i] + 1;
+                       j < recv_sm_ptr[i + 1];
+                       j++)
+                    if (recv_indices.back() + recv_len.back() !=
+                        recv_sm_indices[j])
+                      {
+                        recv_indices.push_back(recv_sm_indices[j]);
+                        recv_len.push_back(1);
+                      }
+                    else
+                      recv_len.back()++;
+                }
+              recv_ptr.push_back(recv_indices.size());
+            }
+
+          recv_sm_ptr = recv_ptr;
+          recv_sm_ptr.shrink_to_fit();
+          recv_sm_indices = recv_indices;
+          recv_sm_indices.shrink_to_fit();
+          recv_sm_len = recv_len;
+          recv_sm_len.shrink_to_fit();
+        }
+      } // namespace internal
+
+
+      Full::Full(const IndexSet &is_locally_owned,
+                 const IndexSet &is_locally_ghost,
+                 const MPI_Comm &communicator,
+                 const MPI_Comm &communicator_sm)
+      {
+        this->comm    = communicator;
+        this->comm_sm = communicator_sm;
+
+#ifndef DEAL_II_WITH_MPI
+        Assert(false, ExcNeedsMPI());
+
+        (void)is_locally_owned;
+        (void)is_locally_ghost;
+#else
+        this->n_local_elements = is_locally_owned.n_elements();
+        this->n_ghost_elements = is_locally_ghost.n_elements();
+
+        this->n_mpi_processes_ = Utilities::MPI::n_mpi_processes(comm);
+
+        std::vector<unsigned int> sm_ranks(
+          Utilities::MPI::n_mpi_processes(comm_sm));
+
+        const unsigned int rank = Utilities::MPI::this_mpi_process(comm);
+
+        MPI_Allgather(
+          &rank, 1, MPI_UNSIGNED, sm_ranks.data(), 1, MPI_UNSIGNED, comm_sm);
+
+        std::vector<unsigned int> owning_ranks_of_ghosts(
+          is_locally_ghost.n_elements());
+
+        Utilities::MPI::internal::ComputeIndexOwner::ConsensusAlgorithmsPayload
+          process(is_locally_owned,
+                  is_locally_ghost,
+                  comm,
+                  owning_ranks_of_ghosts,
+                  true);
+
+        Utilities::MPI::ConsensusAlgorithms::Selector<
+          std::pair<types::global_dof_index, types::global_dof_index>,
+          unsigned int>
+          consensus_algorithm(process, comm);
+        consensus_algorithm.run();
+
+        std::vector<MPI_Request> recv_sm_req;
+        std::vector<MPI_Request> send_sm_req;
+
+        {
+          std::map<unsigned int, std::vector<types::global_dof_index>>
+            rank_to_local_indices;
+
+          for (unsigned int i = 0; i < owning_ranks_of_ghosts.size(); i++)
+            rank_to_local_indices[owning_ranks_of_ghosts[i]].push_back(i);
+
+          unsigned int offset = 0;
+
+
+          for (const auto &rank_and_local_indices : rank_to_local_indices)
+            {
+              const auto ptr = std::find(sm_ranks.begin(),
+                                         sm_ranks.end(),
+                                         rank_and_local_indices.first);
+
+              if (ptr == sm_ranks.end())
+                {
+                  // remote process
+                  recv_remote_ranks.push_back(rank_and_local_indices.first);
+                  recv_remote_ptr.push_back(
+                    recv_remote_ptr.back() +
+                    rank_and_local_indices.second.size());
+                }
+              else
+                {
+                  // shared process
+                  recv_sm_ranks.push_back(std::distance(sm_ranks.begin(), ptr));
+                  recv_sm_ptr.push_back(recv_sm_ptr.back() +
+                                        rank_and_local_indices.second.size());
+                  recv_sm_offset.push_back(is_locally_owned.n_elements() +
+                                           offset);
+                }
+              offset += rank_and_local_indices.second.size();
+            }
+          recv_sm_req.resize(recv_sm_ranks.size());
+
+          recv_sm_indices.resize(recv_sm_ptr.back());
+        }
+
+        {
+          const auto rank_to_global_indices = process.get_requesters();
+
+          for (const auto &rank_and_global_indices : rank_to_global_indices)
+            {
+              const auto ptr = std::find(sm_ranks.begin(),
+                                         sm_ranks.end(),
+                                         rank_and_global_indices.first);
+
+              if (ptr == sm_ranks.end())
+                {
+                  // remote process
+                  send_remote_ranks.push_back(rank_and_global_indices.first);
+
+                  for (const auto &i : rank_and_global_indices.second)
+                    send_remote_indices.push_back(
+                      is_locally_owned.index_within_set(i));
+
+                  send_remote_ptr.push_back(send_remote_indices.size());
+                }
+              else
+                {
+                  // shared process
+                  send_sm_ranks.push_back(std::distance(sm_ranks.begin(), ptr));
+
+                  for (const auto &i : rank_and_global_indices.second)
+                    send_sm_indices.push_back(
+                      is_locally_owned.index_within_set(i));
+
+                  send_sm_ptr.push_back(send_sm_indices.size());
+                }
+            }
+          send_sm_req.resize(send_sm_ranks.size());
+        }
+
+        {
+          for (unsigned int i = 0; i < send_sm_ranks.size(); i++)
+            MPI_Isend(send_sm_indices.data() + send_sm_ptr[i],
+                      send_sm_ptr[i + 1] - send_sm_ptr[i],
+                      MPI_UNSIGNED,
+                      send_sm_ranks[i],
+                      2,
+                      comm_sm,
+                      send_sm_req.data() + i);
+
+          for (unsigned int i = 0; i < recv_sm_ranks.size(); i++)
+            MPI_Irecv(recv_sm_indices.data() + recv_sm_ptr[i],
+                      recv_sm_ptr[i + 1] - recv_sm_ptr[i],
+                      MPI_UNSIGNED,
+                      recv_sm_ranks[i],
+                      2,
+                      comm_sm,
+                      recv_sm_req.data() + i);
+
+          MPI_Waitall(recv_sm_req.size(),
+                      recv_sm_req.data(),
+                      MPI_STATUSES_IGNORE);
+          MPI_Waitall(send_sm_req.size(),
+                      send_sm_req.data(),
+                      MPI_STATUSES_IGNORE);
+        }
+
+        {
+          send_sm_offset.resize(send_sm_ranks.size());
+
+          for (unsigned int i = 0; i < send_sm_ranks.size(); i++)
+            MPI_Irecv(send_sm_offset.data() + i,
+                      1,
+                      MPI_UNSIGNED,
+                      send_sm_ranks[i],
+                      3,
+                      comm_sm,
+                      send_sm_req.data() + i);
+
+          for (unsigned int i = 0; i < recv_sm_ranks.size(); i++)
+            MPI_Isend(recv_sm_offset.data() + i,
+                      1,
+                      MPI_UNSIGNED,
+                      recv_sm_ranks[i],
+                      3,
+                      comm_sm,
+                      recv_sm_req.data() + i);
+
+          MPI_Waitall(recv_sm_req.size(),
+                      recv_sm_req.data(),
+                      MPI_STATUSES_IGNORE);
+          MPI_Waitall(send_sm_req.size(),
+                      send_sm_req.data(),
+                      MPI_STATUSES_IGNORE);
+        }
+
+#  if DO_COMPRESS
+        internal::compress(recv_sm_ptr, recv_sm_indices, recv_sm_len);
+#  endif
+
+#  if DO_COMPRESS
+        internal::compress(send_remote_ptr,
+                           send_remote_indices,
+                           send_remote_len);
+        send_remote_offset.clear();
+        send_remote_offset.push_back(0);
+
+        for (unsigned int r = 0, c = 0; r < send_remote_ranks.size(); r++)
+          {
+            for (unsigned int i = send_remote_ptr[r];
+                 i < send_remote_ptr[r + 1];
+                 i++)
+              c += send_remote_len[i];
+            send_remote_offset.push_back(c);
+          }
+#  else
+        send_remote_offset = send_remote_ptr;
+#  endif
+
+#  if DO_COMPRESS
+        internal::compress(send_sm_ptr, send_sm_indices, send_sm_len);
+#  endif
+
+#endif
+      }
+
+      void
+      Full::export_to_ghosted_array_start(
+        const unsigned int                          communication_channel,
+        const ArrayView<const double> &             locally_owned_array,
+        const std::vector<ArrayView<const double>> &shared_arrays,
+        const ArrayView<double> &                   ghost_array,
+        const ArrayView<double> &                   temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        export_to_ghosted_array_start_impl(communication_channel,
+                                           locally_owned_array,
+                                           shared_arrays,
+                                           ghost_array,
+                                           temporary_storage,
+                                           requests);
+      }
+
+      void
+      Full::export_to_ghosted_array_finish(
+        const ArrayView<const double> &             locally_owned_array,
+        const std::vector<ArrayView<const double>> &shared_arrays,
+        const ArrayView<double> &                   ghost_array,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        export_to_ghosted_array_finish_impl(locally_owned_array,
+                                            shared_arrays,
+                                            ghost_array,
+                                            requests);
+      }
+
+      void
+      Full::import_from_ghosted_array_start(
+        const VectorOperation::values               vector_operation,
+        const unsigned int                          communication_channel,
+        const ArrayView<const double> &             locally_owned_array,
+        const std::vector<ArrayView<const double>> &shared_arrays,
+        const ArrayView<double> &                   ghost_array,
+        const ArrayView<double> &                   temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        import_from_ghosted_array_start_impl(vector_operation,
+                                             communication_channel,
+                                             locally_owned_array,
+                                             shared_arrays,
+                                             ghost_array,
+                                             temporary_storage,
+                                             requests);
+      }
+
+      void
+      Full::import_from_ghosted_array_finish(
+        const VectorOperation::values               vector_operation,
+        const ArrayView<double> &                   locally_owned_storage,
+        const std::vector<ArrayView<const double>> &shared_arrays,
+        const ArrayView<double> &                   ghost_array,
+        const ArrayView<const double> &             temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        import_from_ghosted_array_finish_impl(vector_operation,
+                                              locally_owned_storage,
+                                              shared_arrays,
+                                              ghost_array,
+                                              temporary_storage,
+                                              requests);
+      }
+
+      void
+      Full::export_to_ghosted_array_start(
+        const unsigned int                         communication_channel,
+        const ArrayView<const float> &             locally_owned_array,
+        const std::vector<ArrayView<const float>> &shared_arrays,
+        const ArrayView<float> &                   ghost_array,
+        const ArrayView<float> &                   temporary_storage,
+        std::vector<MPI_Request> &                 requests) const
+      {
+        export_to_ghosted_array_start_impl(communication_channel,
+                                           locally_owned_array,
+                                           shared_arrays,
+                                           ghost_array,
+                                           temporary_storage,
+                                           requests);
+      }
+
+      void
+      Full::export_to_ghosted_array_finish(
+        const ArrayView<const float> &             locally_owned_array,
+        const std::vector<ArrayView<const float>> &shared_arrays,
+        const ArrayView<float> &                   ghost_array,
+        std::vector<MPI_Request> &                 requests) const
+      {
+        export_to_ghosted_array_finish_impl(locally_owned_array,
+                                            shared_arrays,
+                                            ghost_array,
+                                            requests);
+      }
+
+      void
+      Full::import_from_ghosted_array_start(
+        const VectorOperation::values              vector_operation,
+        const unsigned int                         communication_channel,
+        const ArrayView<const float> &             locally_owned_array,
+        const std::vector<ArrayView<const float>> &shared_arrays,
+        const ArrayView<float> &                   ghost_array,
+        const ArrayView<float> &                   temporary_storage,
+        std::vector<MPI_Request> &                 requests) const
+      {
+        import_from_ghosted_array_start_impl(vector_operation,
+                                             communication_channel,
+                                             locally_owned_array,
+                                             shared_arrays,
+                                             ghost_array,
+                                             temporary_storage,
+                                             requests);
+      }
+
+      void
+      Full::import_from_ghosted_array_finish(
+        const VectorOperation::values              vector_operation,
+        const ArrayView<float> &                   locally_owned_storage,
+        const std::vector<ArrayView<const float>> &shared_arrays,
+        const ArrayView<float> &                   ghost_array,
+        const ArrayView<const float> &             temporary_storage,
+        std::vector<MPI_Request> &                 requests) const
+      {
+        import_from_ghosted_array_finish_impl(vector_operation,
+                                              locally_owned_storage,
+                                              shared_arrays,
+                                              ghost_array,
+                                              temporary_storage,
+                                              requests);
+      }
+
+      template <typename Number>
+      void
+      Full::export_to_ghosted_array_start_impl(
+        const unsigned int                          communication_channel,
+        const ArrayView<const Number> &             data_this,
+        const std::vector<ArrayView<const Number>> &data_others,
+        const ArrayView<Number> &                   buffer,
+        const ArrayView<Number> &                   temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        (void)data_this;
+
+#ifndef DEAL_II_WITH_MPI
+        Assert(false, ExcNeedsMPI());
+
+        (void)temporary_storage; // TODO
+        (void)communication_channel;
+        (void)data_others;
+        (void)buffer;
+        (void)requests;
+#else
+        (void)data_others;
+
+        // TODO!!!
+        // if (send_remote_offset.back() != buffer.size())
+        //  buffer.resize(send_remote_offset.back());
+
+        requests.resize(send_sm_ranks.size() + recv_sm_ranks.size() +
+                        recv_remote_ranks.size() + send_remote_ranks.size());
+
+        int dummy;
+        // receive a signal that relevant sm neighbors are ready
+        for (unsigned int i = 0; i < recv_sm_ranks.size(); i++)
+          MPI_Irecv(&dummy,
+                    0,
+                    MPI_INT,
+                    recv_sm_ranks[i],
+                    communication_channel + 2,
+                    comm_sm,
+                    requests.data() + send_sm_ranks.size() + i);
+
+        // signal to all relevant sm neighbors that this process is ready
+        for (unsigned int i = 0; i < send_sm_ranks.size(); i++)
+          MPI_Isend(&dummy,
+                    0,
+                    MPI_INT,
+                    send_sm_ranks[i],
+                    communication_channel + 2,
+                    comm_sm,
+                    requests.data() + i);
+
+        // receive data from remote processes
+        for (unsigned int i = 0; i < recv_remote_ranks.size(); i++)
+          MPI_Irecv(buffer.data() + recv_remote_ptr[i],
+                    recv_remote_ptr[i + 1] - recv_remote_ptr[i],
+                    Utilities::MPI::internal::mpi_type_id(data_this.data()),
+                    recv_remote_ranks[i],
+                    communication_channel + 3,
+                    comm,
+                    requests.data() + send_sm_ranks.size() +
+                      recv_sm_ranks.size() + i);
+
+          // send data to remote processes
+#  if DO_COMPRESS
+        for (unsigned int i = 0, k = 0; i < send_remote_ranks.size(); i++)
+          {
+            for (unsigned int j = send_remote_ptr[i];
+                 j < send_remote_ptr[i + 1];
+                 j++)
+              for (unsigned int l = 0; l < send_remote_len[j]; l++, k++)
+                temporary_storage[k] = data_this[send_remote_indices[j] + l];
+#  else
+        for (unsigned int i = 0; i < send_remote_ranks.size(); i++)
+          {
+            for (unsigned int j = send_remote_ptr[i];
+                 j < send_remote_ptr[i + 1];
+                 j++)
+              temporary_storage[j] = data_this[send_remote_indices[j]];
+#  endif
+
+            // send data away
+            MPI_Isend(temporary_storage.data() + send_remote_offset[i],
+                      send_remote_offset[i + 1] - send_remote_offset[i],
+                      Utilities::MPI::internal::mpi_type_id(data_this.data()),
+                      send_remote_ranks[i],
+                      communication_channel + 3,
+                      comm,
+                      requests.data() + send_sm_ranks.size() +
+                        recv_sm_ranks.size() + recv_remote_ranks.size() + i);
+          }
+#endif
+      }
+
+      template <typename Number>
+      void
+      Full::export_to_ghosted_array_finish_impl(
+        const ArrayView<const Number> &             data_this,
+        const std::vector<ArrayView<const Number>> &data_others,
+        const ArrayView<Number> &                   ghost_array,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        (void)data_this;
+
+#ifndef DEAL_II_WITH_MPI
+        Assert(false, ExcNeedsMPI());
+
+        (void)ghost_array;
+        (void)data_others;
+        (void)requests;
+#else
+        AssertDimension(requests.size(),
+                        send_sm_ranks.size() + recv_sm_ranks.size() +
+                          recv_remote_ranks.size() + send_remote_ranks.size());
+
+        for (unsigned int c = 0; c < recv_sm_ranks.size(); c++)
+          {
+            int i;
+            MPI_Waitany(recv_sm_ranks.size(),
+                        requests.data() + send_sm_ranks.size(),
+                        &i,
+                        MPI_STATUS_IGNORE);
+
+            const Number *__restrict__ data_others_ptr =
+              data_others[recv_sm_ranks[i]].data();
+            Number *__restrict__ data_this_ptr = ghost_array.data();
+
+#  if DO_COMPRESS
+            for (unsigned int j = recv_sm_ptr[i], k = recv_sm_offset[i];
+                 j < recv_sm_ptr[i + 1];
+                 j++)
+              for (unsigned int l = 0; l < recv_sm_len[j]; l++, k++)
+                data_this_ptr[k] =
+                  data_others_ptr[recv_sm_indices[j] + l]; // TODO!!!
+#  else
+            for (unsigned int j = recv_sm_ptr[i], k = recv_sm_offset[i];
+                 j < recv_sm_ptr[i + 1];
+                 j++, k++)
+              data_this_ptr[k] = data_others_ptr[recv_sm_indices[j]]; // TODO!!!
+#  endif
+          }
+
+        MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+#endif
+      }
+
+      template <typename Number>
+      void
+      Full::import_from_ghosted_array_start_impl(
+        const VectorOperation::values               operation,
+        const unsigned int                          communication_channel,
+        const ArrayView<const Number> &             data_this,
+        const std::vector<ArrayView<const Number>> &data_others,
+        const ArrayView<Number> &                   buffer,
+        const ArrayView<Number> &                   temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        (void)data_this;
+
+#ifndef DEAL_II_WITH_MPI
+        Assert(false, ExcNeedsMPI());
+
+        (void)operation;
+        (void)communication_channel;
+        (void)data_others;
+        (void)buffer;
+        (void)temporary_storage;
+        (void)requests;
+#else
+        (void)data_others;
+        (void)operation;
+
+        Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
+
+        requests.resize(recv_sm_ranks.size() + send_sm_ranks.size() +
+                        recv_remote_ranks.size() + send_remote_ranks.size());
+
+        // TODO!!!
+        // if (send_remote_offset.back() != temporary_storage.size())
+        //  temporary_storage.resize(send_remote_offset.back());
+
+        int dummy;
+        for (unsigned int i = 0; i < recv_sm_ranks.size(); i++)
+          MPI_Isend(&dummy,
+                    0,
+                    MPI_INT,
+                    recv_sm_ranks[i],
+                    communication_channel + 1,
+                    comm_sm,
+                    requests.data() + i);
+
+        for (unsigned int i = 0; i < send_sm_ranks.size(); i++)
+          MPI_Irecv(&dummy,
+                    0,
+                    MPI_INT,
+                    send_sm_ranks[i],
+                    communication_channel + 1,
+                    comm_sm,
+                    requests.data() + recv_sm_ranks.size() + i);
+
+        for (unsigned int i = 0; i < recv_remote_ranks.size(); i++)
+          MPI_Isend(buffer.data() + recv_remote_ptr[i],
+                    recv_remote_ptr[i + 1] - recv_remote_ptr[i],
+                    Utilities::MPI::internal::mpi_type_id(buffer.data()),
+                    recv_remote_ranks[i],
+                    communication_channel + 0,
+                    comm,
+                    requests.data() + recv_sm_ranks.size() +
+                      send_sm_ranks.size() + i);
+
+        for (unsigned int i = 0; i < send_remote_ranks.size(); i++)
+          MPI_Irecv(temporary_storage.data() + send_remote_offset[i],
+                    send_remote_offset[i + 1] - send_remote_offset[i],
+                    Utilities::MPI::internal::mpi_type_id(
+                      temporary_storage.data()),
+                    send_remote_ranks[i],
+                    communication_channel + 0,
+                    comm,
+                    requests.data() + recv_sm_ranks.size() +
+                      send_sm_ranks.size() + recv_remote_ranks.size() + i);
+#endif
+      }
+
+      template <typename Number>
+      void
+      Full::import_from_ghosted_array_finish_impl(
+        const VectorOperation::values               operation,
+        const ArrayView<Number> &                   data_this,
+        const std::vector<ArrayView<const Number>> &data_others,
+        const ArrayView<Number> &                   buffer,
+        const ArrayView<const Number> &             temporary_storage,
+        std::vector<MPI_Request> &                  requests) const
+      {
+        (void)temporary_storage;
+
+#ifndef DEAL_II_WITH_MPI
+        Assert(false, ExcNeedsMPI());
+
+        (void)operation;
+        (void)data_this;
+        (void)data_others;
+        (void)buffer;
+        (void)requests;
+#else
+        (void)operation;
+
+        Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
+
+        AssertDimension(requests.size(),
+                        recv_sm_ranks.size() + send_sm_ranks.size() +
+                          recv_remote_ranks.size() + send_remote_ranks.size());
+
+        const auto split = [&](const unsigned int i) {
+          AssertIndexRange(i,
+                           (send_sm_ranks.size() + recv_remote_ranks.size() +
+                            send_remote_ranks.size()));
+
+          if (i < send_sm_ranks.size())
+            return std::pair<unsigned int, unsigned int>{0, i};
+          else if (i < (send_sm_ranks.size() + recv_remote_ranks.size()))
+            return std::pair<unsigned int, unsigned int>{
+              2, i - send_sm_ranks.size()};
+          else
+            return std::pair<unsigned int, unsigned int>{
+              1, i - send_sm_ranks.size() - recv_remote_ranks.size()};
+        };
+
+        for (unsigned int c = 0;
+             c < send_sm_ranks.size() + send_remote_ranks.size() +
+                   recv_remote_ranks.size();
+             c++)
+          {
+            int i;
+            MPI_Waitany(send_sm_ranks.size() + send_remote_ranks.size() +
+                          recv_remote_ranks.size(),
+                        requests.data() + recv_sm_ranks.size(),
+                        &i,
+                        MPI_STATUS_IGNORE);
+
+            const auto &s = split(i);
+            i             = s.second;
+
+            if (s.first == 0)
+              {
+                Number *__restrict__ data_others_ptr =
+                  const_cast<Number *>(data_others[send_sm_ranks[i]].data());
+                Number *__restrict__ data_this_ptr = data_this.data();
+
+#  if DO_COMPRESS
+                for (unsigned int j = send_sm_ptr[i], k = send_sm_offset[i];
+                     j < send_sm_ptr[i + 1];
+                     j++)
+                  {
+                    for (unsigned int l = 0; l < send_sm_len[j]; l++, k++)
+                      {
+                        data_this_ptr[send_sm_indices[j] + l] +=
+                          data_others_ptr[k];
+                        data_others_ptr[k] = 0.0;
+                      }
+                  }
+#  else
+                for (unsigned int j = send_sm_ptr[i], k = send_sm_offset[i];
+                     j < send_sm_ptr[i + 1];
+                     j++, k++)
+                  {
+                    data_this_ptr[send_sm_indices[j]] += data_others_ptr[k];
+                    data_others_ptr[k] = 0.0;
+                  }
+#  endif
+              }
+            else if (s.first == 1)
+              {
+#  if DO_COMPRESS
+                for (unsigned int j = send_remote_ptr[i],
+                                  k = send_remote_offset[i];
+                     j < send_remote_ptr[i + 1];
+                     j++)
+                  for (unsigned int l = 0; l < send_remote_len[j]; l++)
+                    data_this[send_remote_indices[j] + l] += buffer[k++];
+#  else
+                for (unsigned int j = send_remote_ptr[i];
+                     j < send_remote_ptr[i + 1];
+                     j++)
+                  data_this[send_remote_indices[j]] += buffer[j];
+#  endif
+              }
+            else /*if (s.first == 2)*/
+              {
+                std::memset(data_this.data() + recv_remote_ptr[i] +
+                              n_local_elements,
+                            0,
+                            (recv_remote_ptr[i + 1] - recv_remote_ptr[i]) *
+                              sizeof(Number));
+              }
+          }
+
+        MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
+#endif
+      }
+
+      unsigned int
+      Full::local_size() const
+      {
+        return n_local_elements;
+      }
+
+      unsigned int
+      Full::n_ghost_indices() const
+      {
+        return n_ghost_elements;
+      }
+
+    } // namespace VectorDataExchange
+  }   // namespace MatrixFreeFunctions
+} // namespace internal
+
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -315,6 +315,16 @@ namespace internal
 
         internal::compress(send_sm_ptr, send_sm_indices, send_sm_len);
 
+        // std::cout << rank << std::endl;
+        //
+        // for(const auto i : recv_sm_ranks)
+        //    std::cout << i << " ";
+        // std::cout << std::endl;
+        //
+        // for(const auto i : send_sm_ranks)
+        //    std::cout << i << " ";
+        // std::cout << std::endl;
+
 #endif
       }
 
@@ -472,6 +482,8 @@ namespace internal
 #else
         (void)data_others;
 
+        // std::cout << "AA1" << std::endl;
+
         requests.resize(send_sm_ranks.size() + recv_sm_ranks.size() +
                         recv_remote_ranks.size() + send_remote_ranks.size());
 
@@ -546,6 +558,8 @@ namespace internal
         (void)ghost_array;
         (void)requests;
 #else
+
+        // std::cout << "AA2" << std::endl;
         AssertDimension(requests.size(),
                         send_sm_ranks.size() + recv_sm_ranks.size() +
                           recv_remote_ranks.size() + send_remote_ranks.size());
@@ -558,6 +572,8 @@ namespace internal
                         &i,
                         MPI_STATUS_IGNORE);
 
+            continue;
+
             const Number *__restrict__ data_others_ptr =
               data_others[recv_sm_ranks[i]].data();
             Number *__restrict__ data_this_ptr = ghost_array.data();
@@ -568,6 +584,7 @@ namespace internal
               for (unsigned int l = 0; l < recv_sm_len[j]; l++, k++)
                 data_this_ptr[k] = data_others_ptr[recv_sm_indices[j] + l];
           }
+        // std::cout << "AA2_" << std::endl;
 
         for (unsigned int c = 0; c < recv_remote_ranks.size(); c++)
           {
@@ -594,6 +611,7 @@ namespace internal
                 ghost_array[idx_2] = 0.0;
               }
           }
+        // std::cout << "AA2__" << std::endl;
 
         MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
 #endif
@@ -622,6 +640,9 @@ namespace internal
         (void)temporary_storage;
         (void)requests;
 #else
+        // return;
+
+        // std::cout << "AA3" << std::endl;
         (void)data_others;
         (void)operation;
 
@@ -708,6 +729,9 @@ namespace internal
         (void)temporary_storage;
         (void)requests;
 #else
+        // return;
+
+        // std::cout << "AA4" << std::endl;
         (void)operation;
 
         Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
@@ -731,6 +755,8 @@ namespace internal
               1, i - send_sm_ranks.size() - recv_remote_ranks.size()};
         };
 
+        // std::cout << "AA4_" << std::endl;
+
         for (unsigned int c = 0;
              c < send_sm_ranks.size() + send_remote_ranks.size() +
                    recv_remote_ranks.size();
@@ -748,6 +774,9 @@ namespace internal
 
             if (s.first == 0)
               {
+                continue;
+
+                // std::cout << "AA4_a" << std::endl;
                 Number *__restrict__ data_others_ptr =
                   const_cast<Number *>(data_others[send_sm_ranks[i]].data());
                 Number *__restrict__ data_this_ptr = data_this.data();
@@ -763,9 +792,11 @@ namespace internal
                         data_others_ptr[k] = 0.0;
                       }
                   }
+                // std::cout << "AA4_aa" << std::endl;
               }
             else if (s.first == 1)
               {
+                // std::cout << "AA4_b" << std::endl;
                 for (unsigned int j = send_remote_ptr[i],
                                   k = send_remote_offset[i];
                      j < send_remote_ptr[i + 1];
@@ -776,11 +807,14 @@ namespace internal
               }
             else /*if (s.first == 2)*/
               {
+                // std::cout << "AA4_c" << std::endl;
                 std::memset(buffer.data() + recv_remote_ptr[i].first,
                             0.0,
                             (recv_remote_ptr[i].second) * sizeof(Number));
               }
           }
+
+        // std::cout << "AA4__" << std::endl;
 
         MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
 #endif
@@ -820,6 +854,8 @@ namespace internal
       void
       Full::reset_ghost_values_impl(const ArrayView<Number> &ghost_array) const
       {
+        // std::cout << "AA5" << std::endl;
+
         // TODO
         std::memset(ghost_array.data(),
                     0.0,

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -593,15 +593,15 @@ namespace internal
                         send_sm_ranks.size() + recv_sm_ranks.size() +
                           recv_remote_ranks.size() + send_remote_ranks.size());
 
-        const auto split = [&](const unsigned int i) {
+        const auto split =
+          [&](const unsigned int i) -> std::pair<unsigned int, unsigned int> {
           AssertIndexRange(i,
                            (recv_sm_ranks.size() + recv_remote_ranks.size()));
 
           if (i < recv_sm_ranks.size())
-            return std::pair<unsigned int, unsigned int>{0, i};
+            return {0, i};
           else
-            return std::pair<unsigned int, unsigned int>{
-              1, i - recv_sm_ranks.size()};
+            return {1, i - recv_sm_ranks.size()};
         };
 
         for (unsigned int c = 0;
@@ -792,19 +792,18 @@ namespace internal
                         recv_sm_ranks.size() + send_sm_ranks.size() +
                           recv_remote_ranks.size() + send_remote_ranks.size());
 
-        const auto split = [&](const unsigned int i) {
+        const auto split =
+          [&](const unsigned int i) -> std::pair<unsigned int, unsigned int> {
           AssertIndexRange(i,
                            (send_sm_ranks.size() + recv_remote_ranks.size() +
                             send_remote_ranks.size()));
 
           if (i < send_sm_ranks.size())
-            return std::pair<unsigned int, unsigned int>{0, i};
+            return {0, i};
           else if (i < (send_sm_ranks.size() + recv_remote_ranks.size()))
-            return std::pair<unsigned int, unsigned int>{
-              2, i - send_sm_ranks.size()};
+            return {2, i - send_sm_ranks.size()};
           else
-            return std::pair<unsigned int, unsigned int>{
-              1, i - send_sm_ranks.size() - recv_remote_ranks.size()};
+            return {1, i - send_sm_ranks.size() - recv_remote_ranks.size()};
         };
 
         for (unsigned int c = 0;

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -161,7 +161,7 @@ namespace internal
         std::vector<MPI_Request> send_sm_req;
 
         for (const auto &pair : ghost_indices_within_larger_ghost_set)
-          for (unsigned int c = 0, k = pair.first; c < pair.second; ++c, ++k)
+          for (unsigned int c = 0, k = pair.first; k < pair.second; ++c, ++k)
             shifts.push_back(k);
 
         {
@@ -588,6 +588,8 @@ namespace internal
                 if (idx_1 == idx_2)
                   continue;
 
+                AssertIndexRange(idx_2, idx_1);
+
                 ghost_array[idx_1] = ghost_array[idx_2];
                 ghost_array[idx_2] = 0.0;
               }
@@ -649,13 +651,15 @@ namespace internal
 
         for (unsigned int i = 0; i < recv_remote_ranks.size(); i++)
           {
-            for (unsigned int c = 0; c < recv_remote_ptr[i].second - 1; ++c)
+            for (unsigned int c = 0; c < recv_remote_ptr[i].second; ++c)
               {
                 const unsigned int idx_1 = shifts[shifts_ptr[i] + c];
                 const unsigned int idx_2 = recv_remote_ptr[i].first + c;
 
                 if (idx_1 == idx_2)
                   continue;
+
+                Assert(idx_2 < idx_1, ExcNotImplemented());
 
                 buffer[idx_2] = buffer[idx_1];
                 buffer[idx_1] = 0.0;

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -572,8 +572,6 @@ namespace internal
                         &i,
                         MPI_STATUS_IGNORE);
 
-            continue;
-
             const Number *__restrict__ data_others_ptr =
               data_others[recv_sm_ranks[i]].data();
             Number *__restrict__ data_this_ptr = ghost_array.data();
@@ -582,7 +580,8 @@ namespace internal
                  j < recv_sm_ptr[i + 1];
                  j++)
               for (unsigned int l = 0; l < recv_sm_len[j]; l++, k++)
-                data_this_ptr[k] = data_others_ptr[recv_sm_indices[j] + l];
+                data_this_ptr[k - n_local_elements] =
+                  data_others_ptr[recv_sm_indices[j] + l];
           }
         // std::cout << "AA2_" << std::endl;
 
@@ -774,8 +773,6 @@ namespace internal
 
             if (s.first == 0)
               {
-                continue;
-
                 // std::cout << "AA4_a" << std::endl;
                 Number *__restrict__ data_others_ptr =
                   const_cast<Number *>(data_others[send_sm_ranks[i]].data());

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -788,15 +788,22 @@ namespace internal
                   const_cast<Number *>(data_others[send_sm_ranks[i]].data());
                 Number *__restrict__ data_this_ptr = data_this.data();
 
-                for (unsigned int j = send_sm_ptr[i], k = send_sm_offset[i];
-                     j < send_sm_ptr[i + 1];
-                     j++)
+                for (unsigned int lo = send_sm_ptr[i],
+                                  k  = send_sm_offset[i],
+                                  li = 0;
+                     lo < send_sm_ptr[i + 1];)
                   {
-                    for (unsigned int l = 0; l < send_sm_len[j]; l++, k++)
+                    for (; li < send_sm_len[lo]; ++li, ++k)
                       {
-                        data_this_ptr[send_sm_indices[j] + l] +=
+                        data_this_ptr[send_sm_indices[lo] + li] +=
                           data_others_ptr[k];
                         data_others_ptr[k] = 0.0;
+                      }
+
+                    if (li == send_sm_len[lo])
+                      {
+                        lo++;   // increment outer counter
+                        li = 0; // reset inner counter
                       }
                   }
                 // std::cout << "AA4_aa" << std::endl;

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -127,6 +127,7 @@ namespace internal
 #else
         this->n_local_elements = is_locally_owned.n_elements();
         this->n_ghost_elements = is_locally_ghost.n_elements();
+        this->n_global_elements = is_locally_owned.size();
 
         if (Utilities::MPI::job_supports_mpi() == false)
           return; // nothing to do in serial case

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -357,16 +357,6 @@ namespace internal
         internal::compress(recv_sm_ptr_, recv_sm_indices_, recv_sm_len_);
         internal::compress(send_sm_ptr_, send_sm_indices_, send_sm_len_);
 
-        // std::cout << rank << std::endl;
-        //
-        // for(const auto i : recv_sm_ranks)
-        //    std::cout << i << " ";
-        // std::cout << std::endl;
-        //
-        // for(const auto i : send_sm_ranks)
-        //    std::cout << i << " ";
-        // std::cout << std::endl;
-
 #endif
       }
 
@@ -524,8 +514,6 @@ namespace internal
 #else
         (void)data_others;
 
-        // std::cout << "AA1" << std::endl;
-
         requests.resize(send_sm_ranks.size() + recv_sm_ranks.size() +
                         recv_remote_ranks.size() + send_remote_ranks.size());
 
@@ -601,7 +589,6 @@ namespace internal
         (void)requests;
 #else
 
-        // std::cout << "AA2" << std::endl;
         AssertDimension(requests.size(),
                         send_sm_ranks.size() + recv_sm_ranks.size() +
                           recv_remote_ranks.size() + send_remote_ranks.size());
@@ -642,7 +629,6 @@ namespace internal
                   }
               }
           }
-        // std::cout << "AA2_" << std::endl;
 
         for (unsigned int c = 0; c < recv_remote_ranks.size(); c++)
           {
@@ -669,7 +655,6 @@ namespace internal
                 ghost_array[idx_2] = 0.0;
               }
           }
-        // std::cout << "AA2__" << std::endl;
 
         MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
 #endif
@@ -700,7 +685,6 @@ namespace internal
 #else
         // return;
 
-        // std::cout << "AA3" << std::endl;
         (void)data_others;
         (void)operation;
 
@@ -787,9 +771,7 @@ namespace internal
         (void)temporary_storage;
         (void)requests;
 #else
-        // return;
 
-        // std::cout << "AA4" << std::endl;
         (void)operation;
 
         Assert(operation == dealii::VectorOperation::add, ExcNotImplemented());
@@ -813,8 +795,6 @@ namespace internal
               1, i - send_sm_ranks.size() - recv_remote_ranks.size()};
         };
 
-        // std::cout << "AA4_" << std::endl;
-
         for (unsigned int c = 0;
              c < send_sm_ranks.size() + send_remote_ranks.size() +
                    recv_remote_ranks.size();
@@ -832,7 +812,6 @@ namespace internal
 
             if (s.first == 0)
               {
-                // std::cout << "AA4_a" << std::endl;
                 Number *__restrict__ data_others_ptr =
                   const_cast<Number *>(data_others[send_sm_ranks[i]].data());
                 Number *__restrict__ data_this_ptr = data_this.data();
@@ -862,11 +841,9 @@ namespace internal
                         ki = 0; // reset inner counter
                       }
                   }
-                // std::cout << "AA4_aa" << std::endl;
               }
             else if (s.first == 1)
               {
-                // std::cout << "AA4_b" << std::endl;
                 for (unsigned int j = send_remote_ptr[i],
                                   k = send_remote_offset[i];
                      j < send_remote_ptr[i + 1];
@@ -877,14 +854,11 @@ namespace internal
               }
             else /*if (s.first == 2)*/
               {
-                // std::cout << "AA4_c" << std::endl;
                 std::memset(buffer.data() + recv_remote_ptr[i].first,
                             0.0,
                             (recv_remote_ptr[i].second) * sizeof(Number));
               }
           }
-
-        // std::cout << "AA4__" << std::endl;
 
         MPI_Waitall(requests.size(), requests.data(), MPI_STATUSES_IGNORE);
 #endif
@@ -924,8 +898,6 @@ namespace internal
       void
       Full::reset_ghost_values_impl(const ArrayView<Number> &ghost_array) const
       {
-        // std::cout << "AA5" << std::endl;
-
         // TODO
         std::memset(ghost_array.data(),
                     0.0,

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -424,17 +424,13 @@ namespace internal
 #ifndef DEAL_II_WITH_MPI
         Assert(false, ExcNeedsMPI());
 
-        (void)temporary_storage; // TODO
+        (void)temporary_storage;
         (void)communication_channel;
         (void)data_others;
         (void)buffer;
         (void)requests;
 #else
         (void)data_others;
-
-        // TODO!!!
-        // if (send_remote_offset.back() != buffer.size())
-        //  buffer.resize(send_remote_offset.back());
 
         requests.resize(send_sm_ranks.size() + recv_sm_ranks.size() +
                         recv_remote_ranks.size() + send_remote_ranks.size());
@@ -584,10 +580,6 @@ namespace internal
 
         requests.resize(recv_sm_ranks.size() + send_sm_ranks.size() +
                         recv_remote_ranks.size() + send_remote_ranks.size());
-
-        // TODO!!!
-        // if (send_remote_offset.back() != temporary_storage.size())
-        //  temporary_storage.resize(send_remote_offset.back());
 
         int dummy;
         for (unsigned int i = 0; i < recv_sm_ranks.size(); i++)
@@ -758,6 +750,26 @@ namespace internal
       Full::n_ghost_indices() const
       {
         return n_ghost_elements;
+      }
+
+      unsigned int
+      Full::n_import_indices() const
+      {
+        return send_remote_offset.back();
+      }
+
+      void
+      Full::reset_ghost_values(const ArrayView<double> &ghost_array) const
+      {
+        (void)ghost_array;
+        // nothing to do
+      }
+
+      void
+      Full::reset_ghost_values(const ArrayView<float> &ghost_array) const
+      {
+        (void)ghost_array;
+        // nothing to do
       }
 
     } // namespace VectorDataExchange

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -146,8 +146,7 @@ namespace internal
                   recv_sm_ranks.push_back(std::distance(sm_ranks.begin(), ptr));
                   recv_sm_ptr.push_back(recv_sm_ptr.back() +
                                         rank_and_local_indices.second.size());
-                  recv_sm_offset.push_back(is_locally_owned.n_elements() +
-                                           offset);
+                  recv_sm_offset.push_back(offset);
                 }
               offset += rank_and_local_indices.second.size();
             }
@@ -536,13 +535,12 @@ namespace internal
                  j < recv_sm_ptr[i + 1];
                  j++)
               for (unsigned int l = 0; l < recv_sm_len[j]; l++, k++)
-                data_this_ptr[k] =
-                  data_others_ptr[recv_sm_indices[j] + l]; // TODO!!!
+                data_this_ptr[k] = data_others_ptr[recv_sm_indices[j] + l];
 #  else
             for (unsigned int j = recv_sm_ptr[i], k = recv_sm_offset[i];
                  j < recv_sm_ptr[i + 1];
                  j++, k++)
-              data_this_ptr[k] = data_others_ptr[recv_sm_indices[j]]; // TODO!!!
+              data_this_ptr[k] = data_others_ptr[recv_sm_indices[j]];
 #  endif
           }
 

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -167,7 +167,8 @@ private:
                       "the correct size for compatibility with MatrixFree."));
     LinearAlgebra::distributed::Vector<Number> copy_vec(vec);
     const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec).reinit(
-      this->data->get_dof_info(0).vector_partitioner, this->data->get_task_info().communicator_sm);
+      this->data->get_dof_info(0).vector_partitioner,
+      this->data->get_task_info().communicator_sm);
     const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec)
       .copy_locally_owned_data_from(copy_vec);
   }

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -167,7 +167,7 @@ private:
                       "the correct size for compatibility with MatrixFree."));
     LinearAlgebra::distributed::Vector<Number> copy_vec(vec);
     const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec).reinit(
-      this->data->get_dof_info(0).vector_partitioner);
+      this->data->get_dof_info(0).vector_partitioner, this->data->get_task_info().communicator_sm);
     const_cast<LinearAlgebra::distributed::Vector<Number> &>(vec)
       .copy_locally_owned_data_from(copy_vec);
   }


### PR DESCRIPTION
In contrast to #10872, this PR takes a different approach:
- no additional vector class is added
- `L:p:V` is extended to that it can use MPI-3 functionalities to allocate shared memory
- efficient ghost-values update and compression is completely handled by `MatrixFree` and by so called `internal::MatrixFreeFunctions::VectorDataExchange` classes.

There is still a lot to do: extend `VectorDataExchange` so that it can work with two index sets (`Full`) and the capability to work with ghost cell (`Contiguous`).

I will probably extract parts of this PR in separate PRs. 

The next step will be to work on `FEEvaluation` so that it can work with the new sm-capabilities of `L:p:V` (in a non-buffer mode).