### PR TITLE
Add change-log entry: parallel hp + MatrixFree

### DIFF
--- a/doc/news/changes/minor/20201020Munch
+++ b/doc/news/changes/minor/20201020Munch
@@ -1,0 +1,5 @@
+Improved: MatrixFree now also works for hp in MPI-parallelized
+programs.
+<br>
+(Marc Fehling, Katharina Kormann, Martin Kronbichler, Peter Munch, 2020/10/20)
+


### PR DESCRIPTION
Once #11060 is merged, parallel (distributed) hp with `MatrixFree` should work (at least a local Poisson test indicates this). This PR (and the change-log entry) is dedicated to the people who worked on the parallelization of the hp algorithms and those who worked on the hp-capabilities in `MatrixFree`. ~~Have I forgotten any names?~~

~TODO: add a test.~