### PR TITLE
Fix Communication in TaskInfo::loop for partition_partition

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3135,9 +3135,8 @@ namespace internal
     template <typename VectorType>
     unsigned int
     find_vector_in_mf(const VectorType &vec,
-                      const bool check_global_compatibility = false) const
+                      const bool        check_global_compatibility = true) const
     {
-      unsigned int mf_component = numbers::invalid_unsigned_int;
       (void)check_global_compatibility;
       for (unsigned int c = 0; c < matrix_free.n_components(); ++c)
         if (
@@ -3148,11 +3147,11 @@ namespace internal
 #  endif
             vec.get_partitioner()->is_compatible(
               *matrix_free.get_dof_info(c).vector_partitioner))
-          {
-            mf_component = c;
-            break;
-          }
-      return mf_component;
+          return c;
+
+      Assert(false, ExcNotImplemented());
+
+      return numbers::invalid_unsigned_int;
     }
 
 
@@ -3285,9 +3284,6 @@ namespace internal
 #  ifdef DEAL_II_WITH_MPI
           const unsigned int mf_component = find_vector_in_mf(vec);
 
-          Assert(mf_component != numbers::invalid_unsigned_int,
-                 ExcNotImplemented());
-
           const auto &part = get_partitioner(mf_component);
 
           if (part.n_ghost_indices() == 0 && part.n_import_indices() == 0)
@@ -3377,9 +3373,6 @@ namespace internal
           AssertDimension(requests.size(), tmp_data.size());
 
           const unsigned int mf_component = find_vector_in_mf(vec);
-
-          Assert(mf_component != numbers::invalid_unsigned_int,
-                 ExcNotImplemented());
 
           const auto &part = get_partitioner(mf_component);
 
@@ -3483,8 +3476,6 @@ namespace internal
         {
 #  ifdef DEAL_II_WITH_MPI
           const unsigned int mf_component = find_vector_in_mf(vec);
-          Assert(mf_component != numbers::invalid_unsigned_int,
-                 ExcNotImplemented());
 
           const auto &part = get_partitioner(mf_component);
 
@@ -3572,9 +3563,6 @@ namespace internal
           AssertDimension(requests.size(), tmp_data.size());
 
           const unsigned int mf_component = find_vector_in_mf(vec);
-
-          Assert(mf_component != numbers::invalid_unsigned_int,
-                 ExcNotImplemented());
 
           const auto &part = get_partitioner(mf_component);
 


### PR DESCRIPTION
I had to disable in #11047 the flag `check_global_compatibility` because I got some weird errors; see also the discussion in https://github.com/dealii/dealii/pull/11047#discussion_r506610584.

I was able to pin point the problem to the treading implementation with `DoFInfo::TaskInfo::loop`. This PR enables the flag again and provides a very crude fix (disabling asyn communication). Alternative solutions are welcome.