### PR TITLE
Use operator^ to create FESystem objects in the tutorials.

### DIFF
--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -225,7 +225,7 @@ namespace Step17
   // The first step in the actual implementation is the constructor of
   // the main class. Apart from initializing the same member variables
   // that we already had in step-8, we here initialize the MPI
-  // communicator variable we shall use with the global MPI
+  // communicator variable we want to use with the global MPI
   // communicator linking all processes together (in more complex
   // applications, one could here use a communicator object that only
   // links a subset of all processes), and call the Utilities::MPI
@@ -242,7 +242,7 @@ namespace Step17
     , n_mpi_processes(Utilities::MPI::n_mpi_processes(mpi_communicator))
     , this_mpi_process(Utilities::MPI::this_mpi_process(mpi_communicator))
     , pcout(std::cout, (this_mpi_process == 0))
-    , fe(FE_Q<dim>(1), dim)
+    , fe(FE_Q<dim>(1) ^ dim)
     , dof_handler(triangulation)
   {}
 

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -694,7 +694,7 @@ namespace Step18
   template <int dim>
   TopLevel<dim>::TopLevel()
     : triangulation(MPI_COMM_WORLD)
-    , fe(FE_Q<dim>(1), dim)
+    , fe(FE_Q<dim>(1) ^ dim)
     , dof_handler(triangulation)
     , quadrature_formula(fe.degree + 1)
     , present_time(0.0)

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -320,7 +320,7 @@ namespace Step20
   template <int dim>
   MixedLaplaceProblem<dim>::MixedLaplaceProblem(const unsigned int degree)
     : degree(degree)
-    , fe(FE_RaviartThomas<dim>(degree), 1, FE_DGQ<dim>(degree), 1)
+    , fe(FE_RaviartThomas<dim>(degree), FE_DGQ<dim>(degree))
     , dof_handler(triangulation)
   {}
 

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -509,11 +509,8 @@ namespace Step21
   TwoPhaseFlowProblem<dim>::TwoPhaseFlowProblem(const unsigned int degree)
     : degree(degree)
     , fe(FE_RaviartThomas<dim>(degree),
-         1,
          FE_DGQ<dim>(degree),
-         1,
-         FE_DGQ<dim>(degree),
-         1)
+         FE_DGQ<dim>(degree))
     , dof_handler(triangulation)
     , n_refinement_steps(5)
     , time(/*start time*/ 0., /*end time*/ 1.)

--- a/examples/step-22/step-22.cc
+++ b/examples/step-22/step-22.cc
@@ -405,7 +405,7 @@ namespace Step22
   StokesProblem<dim>::StokesProblem(const unsigned int degree)
     : degree(degree)
     , triangulation(Triangulation<dim>::maximum_smoothing)
-    , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
+    , fe(FE_Q<dim>(degree + 1) ^ dim, FE_Q<dim>(degree))
     , dof_handler(triangulation)
   {}
 

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -387,13 +387,16 @@ namespace Step29
 
   // The constructor takes the ParameterHandler object and stores it in a
   // reference. It also initializes the DoF-Handler and the finite element
-  // system, which consists of two copies of the scalar Q1 field, one for $v$
-  // and one for $w$:
+  // system, which consists of two copies of the scalar $Q_1$ field, one for
+  // $v$ and one for $w$. In other words, we want the finite element space
+  // $Q_1\times Q_1 = Q_1^2$, which is easily constructed and passed as the
+  // constructor argument to the FESystem class (i.e., the type of the `fe`
+  // member being initialized here):
   template <int dim>
   UltrasoundProblem<dim>::UltrasoundProblem(ParameterHandler &param)
     : prm(param)
     , dof_handler(triangulation)
-    , fe(FE_Q<dim>(1), 2)
+    , fe(FE_Q<dim>(1) ^ 2)
   {}
 
   // @sect4{<code>UltrasoundProblem::make_grid</code>}
@@ -590,7 +593,7 @@ namespace Step29
                 // compute from the given two shape functions.  Fortunately,
                 // the FESystem object can provide us with this information,
                 // namely it has a function
-                // FESystem::system_to_component_index, that for each local
+                // FESystem::system_to_component_index(), that for each local
                 // DoF index returns a pair of integers of which the first
                 // indicates to which component of the system the DoF
                 // belongs. The second integer of the pair indicates which

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -526,7 +526,7 @@ namespace Step31
   // The constructor of this class is an extension of the constructor in
   // step-22. We need to add the various variables that concern the
   // temperature. As discussed in the introduction, we are going to use
-  // $Q_2\times Q_1$ (Taylor-Hood) elements again for the Stokes part, and
+  // $Q_2^d\times Q_1$ (Taylor-Hood) elements again for the Stokes part, and
   // $Q_2$ elements for the temperature. However, by using variables that
   // store the polynomial degree of the Stokes and temperature finite
   // elements, it is easy to consistently modify the degree of the elements as
@@ -538,7 +538,7 @@ namespace Step31
     : triangulation(Triangulation<dim>::maximum_smoothing)
     , global_Omega_diameter(std::numeric_limits<double>::quiet_NaN())
     , stokes_degree(1)
-    , stokes_fe(FE_Q<dim>(stokes_degree + 1), dim, FE_Q<dim>(stokes_degree), 1)
+    , stokes_fe(FE_Q<dim>(stokes_degree + 1) ^ dim, FE_Q<dim>(stokes_degree))
     , stokes_dof_handler(triangulation)
     ,
 

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1190,14 +1190,12 @@ namespace Step32
     mapping(4)
     ,
 
-    stokes_fe(FE_Q<dim>(parameters.stokes_velocity_degree),
-              dim,
+    stokes_fe(FE_Q<dim>(parameters.stokes_velocity_degree) ^ dim,
               (parameters.use_locally_conservative_discretization ?
                  static_cast<const FiniteElement<dim> &>(
                    FE_DGP<dim>(parameters.stokes_velocity_degree - 1)) :
                  static_cast<const FiniteElement<dim> &>(
-                   FE_Q<dim>(parameters.stokes_velocity_degree - 1))),
-              1)
+                   FE_Q<dim>(parameters.stokes_velocity_degree - 1))))
     ,
 
     stokes_dof_handler(triangulation)

--- a/examples/step-33/step-33.cc
+++ b/examples/step-33/step-33.cc
@@ -1377,7 +1377,7 @@ namespace Step33
   template <int dim>
   ConservationLaw<dim>::ConservationLaw(const char *input_filename)
     : mapping()
-    , fe(FE_Q<dim>(1), EulerEquations<dim>::n_components)
+    , fe(FE_Q<dim>(1) ^ EulerEquations<dim>::n_components)
     , dof_handler(triangulation)
     , quadrature(fe.degree + 1)
     , face_quadrature(fe.degree + 1)

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -1291,9 +1291,8 @@ namespace Step35
   void NavierStokesProjection<dim>::output_results(const unsigned int step)
   {
     assemble_vorticity((step == 1));
-    const FESystem<dim> joint_fe(
-      fe_velocity, dim, fe_pressure, 1, fe_velocity, 1);
-    DoFHandler<dim> joint_dof_handler(triangulation);
+    const FESystem<dim> joint_fe(fe_velocity ^ dim, fe_pressure, fe_velocity);
+    DoFHandler<dim>     joint_dof_handler(triangulation);
     joint_dof_handler.distribute_dofs(joint_fe);
     Assert(joint_dof_handler.n_dofs() ==
              ((dim + 1) * dof_handler_velocity.n_dofs() +

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -814,7 +814,7 @@ namespace Step42
         prm.get_integer("number of initial refinements"))
     , triangulation(mpi_communicator)
     , fe_degree(prm.get_integer("polynomial degree"))
-    , fe(FE_Q<dim>(QGaussLobatto<1>(fe_degree + 1)), dim)
+    , fe(FE_Q<dim>(QGaussLobatto<1>(fe_degree + 1)) ^ dim)
     , dof_handler(triangulation)
 
     , e_modulus(200000)

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -590,7 +590,7 @@ namespace Step43
     , global_Omega_diameter(std::numeric_limits<double>::quiet_NaN())
     , degree(degree)
     , darcy_degree(degree)
-    , darcy_fe(FE_Q<dim>(darcy_degree + 1), dim, FE_Q<dim>(darcy_degree), 1)
+    , darcy_fe(FE_Q<dim>(darcy_degree + 1) ^ dim, FE_Q<dim>(darcy_degree))
     , darcy_dof_handler(triangulation)
     ,
 

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -1042,12 +1042,9 @@ namespace Step44
     // condition, while $Q_1 \times DGP_0 \times DGP_0$ elements do
     // not. However, it has been shown that the latter demonstrate good
     // convergence characteristics nonetheless.
-    fe(FE_Q<dim>(parameters.poly_degree),
-       dim, // displacement
-       FE_DGP<dim>(parameters.poly_degree - 1),
-       1, // pressure
-       FE_DGP<dim>(parameters.poly_degree - 1),
-       1) // dilatation
+    fe(FE_Q<dim>(parameters.poly_degree) ^ dim, // displacement
+       FE_DGP<dim>(parameters.poly_degree - 1), // pressure
+       FE_DGP<dim>(parameters.poly_degree - 1)) // dilatation
     , dof_handler(triangulation)
     , dofs_per_cell(fe.n_dofs_per_cell())
     , u_fe(first_u_component)

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -291,7 +291,7 @@ namespace Step45
     : degree(degree)
     , mpi_communicator(MPI_COMM_WORLD)
     , triangulation(mpi_communicator)
-    , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
+    , fe(FE_Q<dim>(degree + 1) ^ dim, FE_Q<dim>(degree))
     , dof_handler(triangulation)
     , pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
     , mapping(degree + 1)

--- a/examples/step-46/step-46.cc
+++ b/examples/step-46/step-46.cc
@@ -220,18 +220,12 @@ namespace Step46
     : stokes_degree(stokes_degree)
     , elasticity_degree(elasticity_degree)
     , triangulation(Triangulation<dim>::maximum_smoothing)
-    , stokes_fe(FE_Q<dim>(stokes_degree + 1),
-                dim,
-                FE_Q<dim>(stokes_degree),
-                1,
-                FE_Nothing<dim>(),
-                dim)
-    , elasticity_fe(FE_Nothing<dim>(),
-                    dim,
-                    FE_Nothing<dim>(),
-                    1,
-                    FE_Q<dim>(elasticity_degree),
-                    dim)
+    , stokes_fe(FE_Q<dim>(stokes_degree + 1) ^ dim, // for the fluid velocity
+                FE_Q<dim>(stokes_degree),           // for the fluid pressure
+                FE_Nothing<dim>() ^ dim)          // for the solid displacement
+    , elasticity_fe(FE_Nothing<dim>() ^ dim,      // for the fluid velocity
+                    FE_Nothing<dim>(),            // for the fluid pressure
+                    FE_Q<dim>(elasticity_degree)) // for the solid displacement
     , dof_handler(triangulation)
     , viscosity(2)
     , lambda(1)

--- a/examples/step-51/step-51.cc
+++ b/examples/step-51/step-51.cc
@@ -383,7 +383,7 @@ namespace Step51
   // gradient/flux part and the scalar part.
   template <int dim>
   HDG<dim>::HDG(const unsigned int degree, const RefinementMode refinement_mode)
-    : fe_local(FE_DGQ<dim>(degree), dim, FE_DGQ<dim>(degree), 1)
+    : fe_local(FE_DGQ<dim>(degree) ^ dim, FE_DGQ<dim>(degree))
     , dof_handler_local(triangulation)
     , fe(degree)
     , dof_handler(triangulation)

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -328,7 +328,7 @@ namespace Step55
     : velocity_degree(velocity_degree)
     , viscosity(0.1)
     , mpi_communicator(MPI_COMM_WORLD)
-    , fe(FE_Q<dim>(velocity_degree), dim, FE_Q<dim>(velocity_degree - 1), 1)
+    , fe(FE_Q<dim>(velocity_degree) ^ dim, FE_Q<dim>(velocity_degree - 1))
     , triangulation(mpi_communicator,
                     typename Triangulation<dim>::MeshSmoothing(
                       Triangulation<dim>::smoothing_on_refinement |

--- a/examples/step-56/step-56.cc
+++ b/examples/step-56/step-56.cc
@@ -454,11 +454,12 @@ namespace Step56
     , solver_type(solver_type)
     , triangulation(Triangulation<dim>::maximum_smoothing)
     ,
-    // Finite element for the velocity only:
-    velocity_fe(FE_Q<dim>(pressure_degree + 1), dim)
+    // Finite element for the velocity only -- we choose the
+    // $Q_{\text{pressure_degree}}^d$ element:
+    velocity_fe(FE_Q<dim>(pressure_degree + 1) ^ dim)
     ,
     // Finite element for the whole system:
-    fe(velocity_fe, 1, FE_Q<dim>(pressure_degree), 1)
+    fe(velocity_fe, FE_Q<dim>(pressure_degree))
     , dof_handler(triangulation)
     , velocity_dof_handler(triangulation)
     , computing_timer(std::cout, TimerOutput::never, TimerOutput::wall_times)

--- a/examples/step-57/step-57.cc
+++ b/examples/step-57/step-57.cc
@@ -265,7 +265,7 @@ namespace Step57
     , gamma(1.0)
     , degree(degree)
     , triangulation(Triangulation<dim>::maximum_smoothing)
-    , fe(FE_Q<dim>(degree + 1), dim, FE_Q<dim>(degree), 1)
+    , fe(FE_Q<dim>(degree + 1) ^ dim, FE_Q<dim>(degree))
     , dof_handler(triangulation)
   {}
 

--- a/examples/step-60/step-60.cc
+++ b/examples/step-60/step-60.cc
@@ -647,7 +647,7 @@ namespace Step60
 
     embedded_configuration_fe = std::make_unique<FESystem<dim, spacedim>>(
       FE_Q<dim, spacedim>(
-        parameters.embedded_configuration_finite_element_degree),
+        parameters.embedded_configuration_finite_element_degree) ^
       spacedim);
 
     embedded_configuration_dh =

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -260,7 +260,7 @@ namespace Step61
   // interface pressures, $p^\circ$ and $p^\partial$.
   template <int dim>
   WGDarcyEquation<dim>::WGDarcyEquation(const unsigned int degree)
-    : fe(FE_DGQ<dim>(degree), 1, FE_FaceQ<dim>(degree), 1)
+    : fe(FE_DGQ<dim>(degree), FE_FaceQ<dim>(degree))
     , dof_handler(triangulation)
     , fe_dgrt(degree)
     , dof_handler_dgrt(triangulation)

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -710,7 +710,7 @@ namespace step62
                       Triangulation<dim>::smoothing_on_refinement |
                       Triangulation<dim>::smoothing_on_coarsening))
     , quadrature_formula(2)
-    , fe(FE_Q<dim>(1), dim)
+    , fe(FE_Q<dim>(1) ^ dim)
     , dof_handler(triangulation)
     , frequency(parameters.nb_frequency_points)
     , probe_positions(parameters.nb_probe_points, dim)

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1934,7 +1934,7 @@ namespace Euler_DG
 #ifdef DEAL_II_WITH_P4EST
     , triangulation(MPI_COMM_WORLD)
 #endif
-    , fe(FE_DGQ<dim>(fe_degree), dim + 2)
+    , fe(FE_DGQ<dim>(fe_degree) ^ (dim + 2))
     , mapping(fe_degree)
     , dof_handler(triangulation)
     , timer(pcout, TimerOutput::never, TimerOutput::wall_times)

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -305,7 +305,7 @@ namespace Step68
     , mpi_communicator(MPI_COMM_WORLD)
     , background_triangulation(mpi_communicator)
     , fluid_dh(background_triangulation)
-    , fluid_fe(FE_Q<dim>(par.velocity_degree), dim)
+    , fluid_fe(FE_Q<dim>(par.velocity_degree) ^ dim)
     , pcout(std::cout, Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
     , interpolated_velocity(interpolated_velocity)
 

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1191,12 +1191,9 @@ namespace Step70
   {
     TimerOutput::Scope t(computing_timer, "Initial setup");
 
-    fluid_fe =
-      std::make_unique<FESystem<spacedim>>(FE_Q<spacedim>(par.velocity_degree),
-                                           spacedim,
-                                           FE_Q<spacedim>(par.velocity_degree -
-                                                          1),
-                                           1);
+    fluid_fe = std::make_unique<FESystem<spacedim>>(
+      FE_Q<spacedim>(par.velocity_degree) ^ spacedim,
+      FE_Q<spacedim>(par.velocity_degree - 1));
 
 
     solid_fe = std::make_unique<FE_Nothing<dim, spacedim>>();

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -189,12 +189,26 @@ namespace Step8
   // the solution function has, which is <code>dim</code> since we consider
   // displacement in each space direction. The FESystem class can handle this:
   // we pass it the finite element of which we would like to compose the
-  // system of, and how often it shall be repeated:
-
+  // system of, and how often to repeat it. There are different ways to
+  // tell the FESystem constructor how to do this, but the one that is
+  // closest to mathematical notation is to write out what we want to do
+  // mathematically: We want to construct the finite element space
+  // $Q_1^d$ where the index 1 corresponds to the polynomial degree and
+  // the exponent $d$ to the space dimension -- because the *displacement*
+  // we try to simulate here is a vector with exactly $d$ components. The
+  // FESystem class then lets us create this space by initialization with
+  // `FE_Q<dim>(1)^dim`, emulating the mathematical notation.
+  //
+  // (We could also have written `fe(FE_Q<dim>(1), dim)`, which would simply
+  // have called a different constructor of the FESystem class that first
+  // takes the "base element" and then a "multiplicity", i.e., a number that
+  // indicates how many times the base element is to be repeated. The two
+  // ways of writing things are entirely equivalent; we choose the one that
+  // is closer to mathematical notation.)
   template <int dim>
   ElasticProblem<dim>::ElasticProblem()
     : dof_handler(triangulation)
-    , fe(FE_Q<dim>(1), dim)
+    , fe(FE_Q<dim>(1) ^ dim)
   {}
   // In fact, the FESystem class has several more constructors which can
   // perform more complex operations than just stacking together several


### PR DESCRIPTION
A student of mine (@juleoc02) showed me some code in which he created an `FESystem` object with a syntax I did not remember. But it is true that we have an `operator^`  (#5026 by @masterleinad plus follow-up #5090) that can be used in this context, and that moves the notation we use closer to what we write in mathematical notation. 

This patch whole-sale converts all of the tutorials to this notation. step-8 is the first example where we use this, so I added a bit of explanation there to what is happening.