### PR TITLE
Revert changes to MemorySpaceData

### DIFF
--- a/include/deal.II/base/memory_space_data.h
+++ b/include/deal.II/base/memory_space_data.h
@@ -48,7 +48,7 @@ namespace MemorySpace
      * Copy the active data (values for Host and values_dev for CUDA) to @p begin.
      * If the data is on the device it is moved to the host.
      */
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       (void)begin;
@@ -59,7 +59,7 @@ namespace MemorySpace
      * Copy the data in @p begin to the active data of the structure (values for
      * Host and values_dev for CUDA). The pointer @p begin must be on the host.
      */
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       (void)begin;
@@ -101,20 +101,13 @@ namespace MemorySpace
       : values(nullptr, &std::free)
     {}
 
-    virtual ~MemorySpaceData() = default;
-
-    MemorySpaceData(MemorySpaceData &&) noexcept = default;
-
-    MemorySpaceData &
-    operator=(MemorySpaceData &&) noexcept = default;
-
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       std::copy(values.get(), values.get() + n_elements, begin);
     }
 
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       std::copy(begin, begin + n_elements, values.get());
@@ -148,14 +141,7 @@ namespace MemorySpace
       , values_dev(nullptr, Utilities::CUDA::delete_device_data<Number>)
     {}
 
-    virtual ~MemorySpaceData() = default;
-
-    MemorySpaceData(MemorySpaceData &&) noexcept = default;
-
-    MemorySpaceData &
-    operator=(MemorySpaceData &&) noexcept = default;
-
-    virtual void
+    void
     copy_to(Number *begin, std::size_t n_elements)
     {
       const cudaError_t cuda_error_code =
@@ -166,7 +152,7 @@ namespace MemorySpace
       AssertCuda(cuda_error_code);
     }
 
-    virtual void
+    void
     copy_from(Number *begin, std::size_t n_elements)
     {
       const cudaError_t cuda_error_code =


### PR DESCRIPTION
With the approach taken in #11053 to introduce MPI-3 features, the changes of PR #10873 and PR #10879 can be reverted. Closes #10986.

FYI @bangerth 