### PR TITLE
Add incompatibility change-log entry: L:d:V in MatrixFree

### DIFF
--- a/doc/news/changes/incompatibilities/20201021Munch
+++ b/doc/news/changes/incompatibilities/20201021Munch
@@ -1,0 +1,6 @@
+Changed: MatrixFree::loop() only accepts LinearAlgebra::distributed::Vector arguments
+that have been initialized via MatrixFree::initialize_dof_vector()
+and are as a consequence globally compatible with the 
+Utilities::MPI::Partitioner within internal::MatrixFreeFunctions::DoFInfo. 
+<br>
+(Peter Munch, Martin Kronbichler, 2020/10/21)


### PR DESCRIPTION
As pointed out in https://github.com/dealii/dealii/pull/11063#issuecomment-712875333.