### PR TITLE
Partitioner + L:d:V: new constructor

### DIFF
--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -205,6 +205,24 @@ namespace Utilities
       Partitioner(const unsigned int size);
 
       /**
+       * Constructor that takes the number of locally-owned degrees of freedom
+       * @p local_size and the number of ghost degrees of freedom @p ghost_size.
+       *
+       * The local index range is translated to global indices in an ascending
+       * and one-to-one fashion, i.e., the indices of process $p$ sit exactly
+       * between the indices of the processes $p-1$ and $p+1$, respectively.
+       *
+       * @note Setting the @p ghost_size variable to an appropriate value
+       *   provides memory space for the ghost data in a vector's memory
+       *   allocation as and allows access to it via local_element(). However,
+       *   the associated global indices must be handled externally in this
+       *   case.
+       */
+      Partitioner(const types::global_dof_index local_size,
+                  const types::global_dof_index ghost_size,
+                  const MPI_Comm                communicator);
+
+      /**
        * Constructor with index set arguments. This constructor creates a
        * distributed layout based on a given communicators, an IndexSet
        * describing the locally owned range and another one for describing

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -363,6 +363,24 @@ namespace LinearAlgebra
         const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
 
       /**
+       * Initialize vector with @p local_size locally-owned and @p ghost_size
+       * ghost degrees of freedoms.
+       *
+       * @note In the created underlying partitioner, the local index range is
+       *   translated to global indices in an ascending and one-to-one fashion,
+       *   i.e., the indices of process $p$ sit exactly between the indices of
+       *   the processes $p-1$ and $p+1$, respectively. Setting the
+       *   @p ghost_size variable to an appropriate value provides memory space
+       *   for the ghost data in a vector's memory allocation as and allows
+       *   access to it via local_element(). However, the associated global
+       *   indices must be handled externally in this case.
+       */
+      void
+      reinit(const types::global_dof_index local_size,
+             const types::global_dof_index ghost_size,
+             const MPI_Comm                comm);
+
+      /**
        * Swap the contents of this vector and the other vector @p v. One could
        * do this operation with a temporary variable and copying over the data
        * elements, but this function is significantly more efficient since it

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -440,6 +440,32 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number, MemorySpaceType>::reinit(
+      const types::global_dof_index local_size,
+      const types::global_dof_index ghost_size,
+      const MPI_Comm                comm)
+    {
+      clear_mpi_requests();
+
+      // check whether we need to reallocate
+      resize_val(local_size + ghost_size);
+
+      // delete previous content in import data
+      import_data.values.reset();
+      import_data.values_dev.reset();
+
+      // create partitioner
+      partitioner = std::make_shared<Utilities::MPI::Partitioner>(local_size,
+                                                                  ghost_size,
+                                                                  comm);
+
+      this->operator=(Number());
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
     template <typename Number2>
     void
     Vector<Number, MemorySpaceType>::reinit(


### PR DESCRIPTION
This PR adds new constructors that allow to explicitly specify the number of locally-owned degrees of freedom and the number of ghost degrees of freedom.