### PR TITLE
Improve MatrixFree::is_supported(FiniteElement)

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -464,38 +464,7 @@ bool
 MatrixFree<dim, Number, VectorizedArrayType>::is_supported(
   const FiniteElement<dim, spacedim> &fe)
 {
-  if (dim != spacedim)
-    return false;
-
-  // first check for degree, number of base_elemnt and number of its components
-  if (fe.degree == 0 || fe.n_base_elements() != 1)
-    return false;
-
-  const FiniteElement<dim, spacedim> *fe_ptr = &(fe.base_element(0));
-  if (fe_ptr->n_components() != 1)
-    return false;
-
-  // then check of the base element is supported
-  if (dynamic_cast<const FE_Poly<dim, spacedim> *>(fe_ptr) != nullptr)
-    {
-      const FE_Poly<dim, spacedim> *fe_poly_ptr =
-        dynamic_cast<const FE_Poly<dim, spacedim> *>(fe_ptr);
-      if (dynamic_cast<const TensorProductPolynomials<dim> *>(
-            &fe_poly_ptr->get_poly_space()) != nullptr)
-        return true;
-      if (dynamic_cast<const TensorProductPolynomials<
-            dim,
-            Polynomials::PiecewisePolynomial<double>> *>(
-            &fe_poly_ptr->get_poly_space()) != nullptr)
-        return true;
-    }
-  if (dynamic_cast<const FE_DGP<dim, spacedim> *>(fe_ptr) != nullptr)
-    return true;
-  if (dynamic_cast<const FE_Q_DG0<dim, spacedim> *>(fe_ptr) != nullptr)
-    return true;
-
-  // if the base element is not in the above list it is not supported
-  return false;
+  return internal::MatrixFreeFunctions::ShapeInfo<double>::is_supported(fe);
 }
 
 

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -332,6 +332,13 @@ namespace internal
              const unsigned int        base_element = 0);
 
       /**
+       * Return which kinds of elements are supported by MatrixFree.
+       */
+      template <int dim, int spacedim>
+      static bool
+      is_supported(const FiniteElement<dim, spacedim> &fe);
+
+      /**
        * Return data of univariate shape functions which defines the
        * dimension @p dimension of tensor product shape functions
        * regarding vector component @p component of the underlying

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -706,7 +706,8 @@ namespace VectorTools
       // If we can, use the matrix-free implementation
       bool use_matrix_free =
         MatrixFree<dim, typename VectorType::value_type>::is_supported(
-          dof.get_fe());
+          dof.get_fe()) &&
+        dof.get_fe().n_base_elements() == 1;
 
       // enforce_zero_boundary and project_to_boundary_first
       // are not yet supported.

--- a/source/matrix_free/shape_info.inst.in
+++ b/source/matrix_free/shape_info.inst.in
@@ -23,6 +23,15 @@ for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
         const unsigned int);
   }
 
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+#if deal_II_dimension <= deal_II_space_dimension
+    template bool
+    internal::MatrixFreeFunctions::ShapeInfo<double>::is_supported(
+      const FiniteElement<deal_II_dimension, deal_II_space_dimension> &);
+#endif
+  }
+
 
 
 for (deal_II_dimension : DIMENSIONS;


### PR DESCRIPTION
Since we merged the DG support for `MatrixFree` in 2018, we actually support `FiniteElement` objects with multiple base elements.

This also moves the function to `ShapeInfo` because the selection is primarily made in that function, so the code sits where it belongs. Related to #9544. Found while working on #11046.