### PR TITLE
Extend GridOut::write_svg() for simplices

### DIFF
--- a/tests/simplex/grid_out_svg.cc
+++ b/tests/simplex/grid_out_svg.cc
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Write a file in the SVG format with (linear) triangular and tetrahedral
+// elements created by the GMSH program.
+
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include <fstream>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+check_file(const std::string &file_name)
+{
+  Triangulation<dim, spacedim> tria;
+
+  GridIn<dim, spacedim> grid_in;
+  grid_in.attach_triangulation(tria);
+  std::ifstream input_file(file_name);
+  grid_in.read_vtk(input_file);
+
+  GridOut grid_out;
+#if false
+  std::ofstream out("mesh-" + std::to_string(spacedim) + ".svg");
+  grid_out.write_svg(tria, out);
+#else
+  grid_out.write_svg(tria, deallog.get_file_stream());
+#endif
+
+  deallog << "OK!" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+  // TRIANGULAR ELEMENTS
+  // dim = spacedim = 2
+  deallog.push("triangluar_elements_dim2_spacedim2: ");
+  check_file<2, 2>(std::string(SOURCE_DIR "/grid_in_vtk/tri.vtk"));
+  deallog.pop();
+}

--- a/tests/simplex/grid_out_svg.with_simplex_support=on.output
+++ b/tests/simplex/grid_out_svg.with_simplex_support=on.output
@@ -1,0 +1,30 @@
+
+<svg width="1000" height="1000" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+
+<!-- internal style sheet -->
+<style type="text/css"><![CDATA[
+ rect.background{fill:white}
+ rect{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ text{font-family:Helvetica; text-anchor:middle; fill:rgb(25,25,25)}
+ line{stroke:rgb(25,25,25); stroke-width:4}
+ path{fill:none; stroke:rgb(25,25,25); stroke-width:2}
+ circle{fill:white; stroke:black; stroke-width:2}
+
+ path.p0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+ path.ps0{fill:rgb(0,77,191); stroke:rgb(20,20,20); stroke-width:2}
+ rect.r0{fill:rgb(0,102,255); stroke:rgb(25,25,25); stroke-width:2}
+]]></style>
+
+ <rect class="background" width="1000" height="1000"/>
+  <!-- cells -->
+  <path class="p0" d="M 80 920 L 920 920 L 500 500 L 80 920"/>
+  <line x1="80" y1="920" x2="920" y2="920"/>
+  <path class="p0" d="M 80 80 L 80 920 L 500 500 L 80 80"/>
+  <line x1="80" y1="80" x2="80" y2="920"/>
+  <path class="p0" d="M 920 920 L 920 80 L 500 500 L 920 920"/>
+  <line x1="920" y1="920" x2="920" y2="80"/>
+  <path class="p0" d="M 920 80 L 80 80 L 500 500 L 920 80"/>
+  <line x1="920" y1="80" x2="80" y2="80"/>
+
+</svg>DEAL:triangluar_elements_dim2_spacedim2: ::OK!


### PR DESCRIPTION
Hi everyone, 
I've adapted the write_svg() function in order to work with simplices as well.