### PR TITLE
Exchange ghost particles optimization by not rebuilding vertex_to_neighbor_subdomain 

### DIFF
--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -153,10 +153,11 @@ namespace GridTools
     get_locally_owned_cell_bounding_boxes_rtree() const;
 
 
-    /** Returns the vector of set of integer containing the subdomain id
+    /**
+     * Returns the vector of set of integer containing the subdomain id
      * to which each vertex is connected to. This feature is used extensively
      * in the particle_handler to detect on which processors ghost particles
-     * must be built
+     * must be built.
      */
     const std::vector<std::set<unsigned int>> &
     get_vertex_to_neighbor_subdomain() const;
@@ -281,7 +282,7 @@ namespace GridTools
 
     /**
      * Store an std::vector of std::set of integer containing the id of all
-     * subdomain to which a vertex is connected to
+     * subdomain to which a vertex is connected to.
      */
     mutable std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain;
 

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -152,6 +152,15 @@ namespace GridTools
                 typename Triangulation<dim, spacedim>::active_cell_iterator>> &
     get_locally_owned_cell_bounding_boxes_rtree() const;
 
+
+    /** Returns the vector of set of integer containing the subdomain id
+     * to which each vertex is connected to. This feature is used extensively
+     * in the particle_handler to detect on which processors ghost particles
+     * must be built
+     */
+    const std::vector<std::set<unsigned int>> &
+    get_vertex_to_neighbor_subdomain() const;
+
     /**
      * Return a reference to the stored triangulation.
      */
@@ -268,6 +277,13 @@ namespace GridTools
       std::pair<BoundingBox<spacedim>,
                 typename Triangulation<dim, spacedim>::active_cell_iterator>>
       locally_owned_cell_bounding_boxes_rtree;
+
+
+    /**
+     * Store an std::vector of std::set of integer containing the id of all
+     * subdomain to which a vertex is connected to
+     */
+    mutable std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain;
 
     /**
      * Storage for the status of the triangulation signal.

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -80,6 +80,11 @@ namespace GridTools
     update_locally_owned_cell_bounding_boxes_rtree = 0x080,
 
     /**
+     * Update vertex to neighbhor subdomain
+     */
+    update_vertex_to_neighbor_subdomain = 0x100,
+
+    /**
      * Update all objects.
      */
     update_all = 0x0FF,
@@ -163,8 +168,8 @@ namespace GridTools
    *
    * @ref CacheUpdateFlags
    */
-  inline CacheUpdateFlags operator&(const CacheUpdateFlags f1,
-                                    const CacheUpdateFlags f2)
+  inline CacheUpdateFlags
+  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
   {
     return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
                                          static_cast<unsigned int>(f2));

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -168,8 +168,8 @@ namespace GridTools
    *
    * @ref CacheUpdateFlags
    */
-  inline CacheUpdateFlags
-  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
+  inline CacheUpdateFlags operator&(const CacheUpdateFlags f1,
+                                    const CacheUpdateFlags f2)
   {
     return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
                                          static_cast<unsigned int>(f2));

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -87,7 +87,7 @@ namespace GridTools
     /**
      * Update all objects.
      */
-    update_all = 0x0FF,
+    update_all = 0xFFF,
   };
 
 

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -199,6 +199,25 @@ namespace GridTools
     return covering_rtree[level];
   }
 
+  template <int dim, int spacedim>
+  const std::vector<std::set<unsigned int>> &
+  Cache<dim, spacedim>::get_vertex_to_neighbor_subdomain() const
+  {
+    if (update_flags & update_vertex_to_neighbor_subdomain)
+      {
+        vertex_to_neighbor_subdomain.clear();
+        vertex_to_neighbor_subdomain.resize(tria->n_vertices());
+        for (const auto &cell : tria->active_cell_iterators())
+          {
+            if (cell->is_ghost())
+              for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
+                vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
+                  cell->subdomain_id());
+          }
+      }
+    return vertex_to_neighbor_subdomain;
+  }
+
 #include "grid_tools_cache.inst"
 
 } // namespace GridTools

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -214,6 +214,7 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
+        update_flags = update_flags & ~update_vertex_to_neighbor_subdomain;
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1679,8 +1679,8 @@ namespace Particles
 
     switch (status)
       {
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_PERSIST: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_PERSIST:
+          {
             auto position_hint = particles.end();
             for (const auto &particle : loaded_particles_on_cell)
               {
@@ -1699,8 +1699,8 @@ namespace Particles
           }
           break;
 
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_COARSEN: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_COARSEN:
+          {
             typename std::multimap<internal::LevelInd,
                                    Particle<dim, spacedim>>::iterator
               position_hint = particles.end();
@@ -1725,8 +1725,8 @@ namespace Particles
           }
           break;
 
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_REFINE: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
+          {
             std::vector<
               typename std::multimap<internal::LevelInd,
                                      Particle<dim, spacedim>>::iterator>

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1186,16 +1186,8 @@ namespace Particles
         static_cast<typename std::vector<particle_iterator>::size_type>(
           particles.size() * 0.25));
 
-    std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain(
-      triangulation->n_vertices());
-
-    for (const auto &cell : triangulation->active_cell_iterators())
-      {
-        if (cell->is_ghost())
-          for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
-            vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
-              cell->subdomain_id());
-      }
+    const std::vector<std::set<unsigned int>> vertex_to_neighbor_subdomain =
+      triangulation_cache->get_vertex_to_neighbor_subdomain();
 
     for (const auto &cell : triangulation->active_cell_iterators())
       {
@@ -1687,8 +1679,8 @@ namespace Particles
 
     switch (status)
       {
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_PERSIST:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_PERSIST: {
             auto position_hint = particles.end();
             for (const auto &particle : loaded_particles_on_cell)
               {
@@ -1707,8 +1699,8 @@ namespace Particles
           }
           break;
 
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_COARSEN:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_COARSEN: {
             typename std::multimap<internal::LevelInd,
                                    Particle<dim, spacedim>>::iterator
               position_hint = particles.end();
@@ -1733,8 +1725,8 @@ namespace Particles
           }
           break;
 
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_REFINE: {
             std::vector<
               typename std::multimap<internal::LevelInd,
                                      Particle<dim, spacedim>>::iterator>


### PR DESCRIPTION
This is related to Issue #11093
This PR adds the vertex_to_neighbor_subdomain data structure to the grid_tools_cache. This allows the exchange_ghost_particles() function of the particle_handler not to rebuild this structure when it is not needed.
This is still a WIP. Right now a lot of particles tests are failing because of  a recent PR, so I am having issues finding if I am introducing additional bugs or no.

I must admit my ignorance with respect to the update flags of the grid_tools_cache object. I think this part of my PR might have issues within it? Could somebody look at it and correct me if I am wrong?

As always, all comments are more than appreciated. I will do whatever needed to integrate your comments to the PR. :)!