### PR TITLE
Indentation clang-format 11

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,8 +26,9 @@ BinPackArguments: false
 BinPackParameters: false
 
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum: true
   AfterExternBlock: true
   AfterFunction: true
@@ -36,6 +37,8 @@ BraceWrapping:
   AfterUnion: true
   BeforeCatch: true
   BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
   IndentBraces: true
   SplitEmptyFunction: false
   SplitEmptyRecord: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,34 +60,6 @@ pipeline
             githubNotify context: 'CI', description: 'running tests...',  status: 'PENDING'
           }
         }
-
-        stage("indent")
-        {
-          post {
-            failure {
-              githubNotify context: 'indent', description: 'failed',  status: 'FAILURE'
-            }
-          }
-
-          steps
-          {
-            // we are finally running, so we can mark the 'ready' context from Jenkinsfile.mark as success:
-            githubNotify context: 'ready', description: ':-)',  status: 'SUCCESS'
-
-            // We can not use 'indent' because we are missing the master branch:
-            // "fatal: ambiguous argument 'master': unknown revision or path"
-            sh '''
-               ./contrib/utilities/indent-all
-            '''
-            sh 'git diff > changes.diff'
-            archiveArtifacts artifacts: 'changes.diff', fingerprint: true
-            sh '''
-               git diff --exit-code || \
-               { echo "Please check indentation, see artifacts at the top right!"; exit 1; }
-            '''
-            githubNotify context: 'indent', description: '',  status: 'SUCCESS'
-          }
-        }
       }
     }
 

--- a/contrib/python-bindings/include/point_wrapper.h
+++ b/contrib/python-bindings/include/point_wrapper.h
@@ -100,7 +100,8 @@ namespace python
     /**
      * Return the scalar product of the vectors representing two points.
      */
-    double operator*(const PointWrapper &p) const;
+    double
+    operator*(const PointWrapper &p) const;
 
     /**
      * Add an offset to a point.
@@ -129,7 +130,8 @@ namespace python
     /**
      * Multiply the coordinates of the point by a factor.
      */
-    PointWrapper operator*(const double factor) const;
+    PointWrapper
+    operator*(const double factor) const;
 
     /**
      * Add another point.

--- a/contrib/python-bindings/source/point_wrapper.cc
+++ b/contrib/python-bindings/source/point_wrapper.cc
@@ -298,7 +298,8 @@ namespace python
 
 
 
-  double PointWrapper::operator*(const PointWrapper &p) const
+  double
+  PointWrapper::operator*(const PointWrapper &p) const
   {
     AssertThrow(p.get_dim() == dim,
                 ExcMessage("The points do not have the same dimension."));
@@ -378,7 +379,8 @@ namespace python
   }
 
 
-  PointWrapper PointWrapper::operator*(const double factor) const
+  PointWrapper
+  PointWrapper::operator*(const double factor) const
   {
     if (dim == 2)
       return PointWrapper(

--- a/contrib/utilities/compile_clang_format
+++ b/contrib/utilities/compile_clang_format
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## ---------------------------------------------------------------------
 ##
-## Copyright (C) 2018 by the deal.II authors
+## Copyright (C) 2018 - 2021 by the deal.II authors
 ##
 ## This file is part of the deal.II library.
 ##
@@ -29,14 +29,13 @@ set -u
 
 PRG="$(cd "$(dirname "$0")" && pwd)/programs"
 
-CLANG_PATH="${PRG}/clang-6"
+VERSION="11"
+RELEASE_DATE="2021-02-03"
+LLVM_COMMIT="1fdec59bffc11ae37eb51a1b9869f0696bfd5312"
 
-RELEASE_DATE="2018-04-06"
-RELEASE_BRANCH="release_60"
-LLVM_REPOSITORY="https://github.com/llvm-mirror/llvm"
-CLANG_REPOSITORY="https://github.com/llvm-mirror/clang"
-LLVM_COMMIT="1a0dddf879aadfcfea409b3c0a9aa3c9da306945"
-CLANG_COMMIT="d5f48a217f404c3462537527f4169bb45eed3904"
+CLANG_PATH="${PRG}/clang-${VERSION}"
+RELEASE_BRANCH="release/${VERSION}.x"
+LLVM_REPOSITORY="https://github.com/llvm/llvm-project"
 
 if [ ! -d "${PRG}" ]
 then
@@ -50,7 +49,7 @@ then
     exit 1
 fi
 
-echo "Downloading and compiling clang-format-6."
+echo "Downloading and compiling clang-format-${VERSION}."
 mkdir -p "${CLANG_PATH}/bin"
 
 tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"
@@ -80,23 +79,11 @@ else
 fi
 git reset --hard "${LLVM_COMMIT}"
 
-git init tools/clang
-cd tools/clang
-git remote add origin "${CLANG_REPOSITORY}"
-if [ "$GIT_SHALLOW_SINCE_AVAILABLE" = true ]; then
-  git fetch --shallow-since="${RELEASE_DATE}" origin "${RELEASE_BRANCH}"
-else
-  git fetch --depth=1 origin "${RELEASE_BRANCH}"
-  i=1;
-  while ! git cat-file -e ${CLANG_COMMIT} 2> /dev/null; do
-    git fetch --depth=$((i+=10)) origin "${RELEASE_BRANCH}";
-  done
-fi
-git reset --hard "${CLANG_COMMIT}"
+# move clang directory into right place for the build system
+mv clang llvm/tools
 
-cd ../../
-mkdir build
-cd build
+mkdir llvm/build
+cd llvm/build
 
 case "${OSTYPE}" in
   darwin*)

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -24,17 +24,23 @@
 # This can be done with the compile_clang_format script.
 #
 
+VERSION=11
 PRG="$(cd "$(dirname "$0")" && pwd)/programs"
-CLANG_PATH="${PRG}/clang-11"
+CLANG_PATH="${PRG}/clang-${VERSION}"
 
-URL="https://github.com/dealii/dealii/releases/download/v9.0.0"
+URL="https://github.com/dealii/dealii/releases/download/v9.3.0"
 
 # Find out which kind of OS we are running and set the appropriate settings
 case "${OSTYPE}" in
   linux*)
-    FILENAME="clang-format-11-linux.tar.gz"
+    FILENAME="clang-format-${VERSION}-linux.tar.gz"
     CHECKSUM_CMD="sha256sum"
-    CHECKSUM="a25874e0d5691aa6472061eb843890a8ad09094fb0ab2aab3f412d8762d494b3 $FILENAME"
+    CHECKSUM="9420c4ed80268500ef357eb42b2e77dc55e807e559d6d9851f4808a9939fa47b  $FILENAME"
+    ;;
+  darwin*)
+    FILENAME="clang-format-${VERSION}-darwin.tar.gz"
+    CHECKSUM_CMD="shasum"
+    CHECKSUM="8eaf852cc96947245de706f1059e764b7086a82e8bd769da2654936acb1d63e0  $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"
@@ -54,7 +60,7 @@ then
     exit 1
 fi
 
-echo "Downloading and installing clang-format-11 from ${URL}/${FILENAME}"
+echo "Downloading and installing clang-format-${VERSION} from ${URL}/${FILENAME}"
 mkdir "${CLANG_PATH}"
 
 tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -38,9 +38,9 @@ case "${OSTYPE}" in
     CHECKSUM="9420c4ed80268500ef357eb42b2e77dc55e807e559d6d9851f4808a9939fa47b  $FILENAME"
     ;;
   darwin*)
-    FILENAME="clang-format-${VERSION}-darwin.tar.gz"
+    FILENAME="clang-format-${VERSION}-darwin-intel.tar.gz"
     CHECKSUM_CMD="shasum"
-    CHECKSUM="8eaf852cc96947245de706f1059e764b7086a82e8bd769da2654936acb1d63e0  $FILENAME"
+    CHECKSUM="8b6eed46680d556c6ba9dcf971ad97d1c6a7a543c807dabd7931ea57830398ef  $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -25,21 +25,16 @@
 #
 
 PRG="$(cd "$(dirname "$0")" && pwd)/programs"
-CLANG_PATH="${PRG}/clang-6"
+CLANG_PATH="${PRG}/clang-11"
 
 URL="https://github.com/dealii/dealii/releases/download/v9.0.0"
 
 # Find out which kind of OS we are running and set the appropriate settings
 case "${OSTYPE}" in
   linux*)
-    FILENAME="clang-format-6-linux.tar.gz"
+    FILENAME="clang-format-11-linux.tar.gz"
     CHECKSUM_CMD="sha256sum"
-    CHECKSUM="26c046456d0a8c109df74e890f46bbe4ad50b035a9febc13ec41c22dabd005a5  $FILENAME"
-    ;;
-  darwin*)
-    FILENAME="clang-format-6-darwin.tar.gz"
-    CHECKSUM_CMD="shasum"
-    CHECKSUM="8eaf852cc96947245de706f1059e764b7086a82e8bd769da2654936acb1d63e0  $FILENAME"
+    CHECKSUM="a25874e0d5691aa6472061eb843890a8ad09094fb0ab2aab3f412d8762d494b3 $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"
@@ -59,7 +54,7 @@ then
     exit 1
 fi
 
-echo "Downloading and installing clang-format-6 from ${URL}/${FILENAME}"
+echo "Downloading and installing clang-format-11 from ${URL}/${FILENAME}"
 mkdir "${CLANG_PATH}"
 
 tmpdir="${TMPDIR:-/tmp}/dealiiclang${RANDOM}${RANDOM}"

--- a/contrib/utilities/download_clang_format
+++ b/contrib/utilities/download_clang_format
@@ -40,7 +40,7 @@ case "${OSTYPE}" in
   darwin*)
     FILENAME="clang-format-${VERSION}-darwin-intel.tar.gz"
     CHECKSUM_CMD="shasum"
-    CHECKSUM="8b6eed46680d556c6ba9dcf971ad97d1c6a7a543c807dabd7931ea57830398ef  $FILENAME"
+    CHECKSUM="5b8c310a660102a1aa46cc0242294fb14271797a4027883a698651411f8e51bf  $FILENAME"
     ;;
   *)
     echo "unknown: ${OSTYPE}"

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -27,9 +27,9 @@
 #
 # The script can be invoked with DEAL_II_CLANG_FORMAT to change
 # the default version of clang-format. For example:
-#   DEAL_II_CLANG_FORMAT=clang-format-6.0 ./contrib/utilities/indent
+#   DEAL_II_CLANG_FORMAT=clang-format-11.0 ./contrib/utilities/indent
 # or,
-#   make DEAL_II_CLANG_FORMAT="clang-format-6.0" indent
+#   make DEAL_II_CLANG_FORMAT="clang-format-11.0" indent
 #
 # Note: If the script is invoked with REPORT_ONLY=true set,
 #   REPORT_ONLY=true ./contrib/utilities/indent

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -31,9 +31,9 @@
 #
 # The script can be invoked with DEAL_II_CLANG_FORMAT to change
 # the default version of clang-format. For example:
-#   DEAL_II_CLANG_FORMAT=clang-format-6.0 ./contrib/utilities/indent
+#   DEAL_II_CLANG_FORMAT=clang-format-11.0 ./contrib/utilities/indent
 # or,
-#   make DEAL_II_CLANG_FORMAT="clang-format-6.0" indent
+#   make DEAL_II_CLANG_FORMAT="clang-format-11.0" indent
 #
 # Note: If the script is invoked with REPORT_ONLY=true set,
 #   REPORT_ONLY=true ./contrib/utilities/indent-all

--- a/contrib/utilities/indent.py
+++ b/contrib/utilities/indent.py
@@ -289,11 +289,11 @@ if __name__ == "__main__":
 
     #
     # If clang-format-binary is not found, search again in
-    # contrib/utlitlies/programs/clang-6/bin
+    # contrib/utlitlies/programs/clang-11/bin
     #
     if not PARSED_ARGUMENTS.clang_format_binary:
         os.environ["PATH"] += ':' + \
-            os.getcwd() + "/contrib/utilities/programs/clang-6/bin"
+            os.getcwd() + "/contrib/utilities/programs/clang-11/bin"
         PARSED_ARGUMENTS.clang_format_binary = distutils.spawn.find_executable(
             "clang-format")
 

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -39,7 +39,7 @@ checks() {
 
   # Add the location 'download_clang_format' or 'compile_clang_format'
   # installs clang-format to the local PATH.
-  CLANG_FORMAT_PATH="$(cd "$(dirname "$0")" && pwd)/programs/clang-6/bin"
+  CLANG_FORMAT_PATH="$(cd "$(dirname "$0")" && pwd)/programs/clang-11/bin"
   export PATH="${CLANG_FORMAT_PATH}:${PATH}"
 
   if ! [ -x "$(command -v "${DEAL_II_CLANG_FORMAT}")" ]; then
@@ -51,14 +51,13 @@ checks() {
     exit 1
   fi
 
-  # Make sure to have the right version. We know that clang-6.0.0
-  # and clang-6.0.1 work. Hence, test for clang-6.0.
+  # Make sure to have the right version.
   CLANG_FORMAT_VERSION="$(${DEAL_II_CLANG_FORMAT} --version)"
   CLANG_FORMAT_MAJOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
   CLANG_FORMAT_MINOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
 
-  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 11 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
-    echo "***   This indent script requires clang-format version 6.0,"
+  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 11 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 1 ]; then
+    echo "***   This indent script requires clang-format version 11.1,"
     echo "***   but version ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION} was found instead."
     echo "***"
     echo "***   You can run the './contrib/utilities/download_clang_format'"

--- a/contrib/utilities/indent_common.sh
+++ b/contrib/utilities/indent_common.sh
@@ -57,7 +57,7 @@ checks() {
   CLANG_FORMAT_MAJOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*\([0-9]*\).*$/\1/g')
   CLANG_FORMAT_MINOR_VERSION=$(echo "${CLANG_FORMAT_VERSION}" | sed 's/^[^0-9]*[0-9]*\.\([0-9]*\).*$/\1/g')
 
-  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 6 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
+  if [ "${CLANG_FORMAT_MAJOR_VERSION}" -ne 11 ] || [ "${CLANG_FORMAT_MINOR_VERSION}" -ne 0 ]; then
     echo "***   This indent script requires clang-format version 6.0,"
     echo "***   but version ${CLANG_FORMAT_MAJOR_VERSION}.${CLANG_FORMAT_MINOR_VERSION} was found instead."
     echo "***"

--- a/examples/.clang-format
+++ b/examples/.clang-format
@@ -28,8 +28,9 @@ BinPackArguments: false
 BinPackParameters: false
 
 BraceWrapping:
+  AfterCaseLabel: true
   AfterClass: true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum: true
   AfterExternBlock: true
   AfterFunction: true
@@ -38,6 +39,8 @@ BraceWrapping:
   AfterUnion: true
   BeforeCatch: true
   BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
   IndentBraces: true
   SplitEmptyFunction: false
   SplitEmptyRecord: false

--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -199,9 +199,9 @@ namespace Step13
     // Now for the function that is mainly of interest in this class, the
     // computation of the point value:
     template <int dim>
-    void PointValueEvaluation<dim>::
-         operator()(const DoFHandler<dim> &dof_handler,
-               const Vector<double> & solution) const
+    void
+    PointValueEvaluation<dim>::operator()(const DoFHandler<dim> &dof_handler,
+                                          const Vector<double> & solution) const
     {
       // First allocate a variable that will hold the point value. Initialize
       // it with a value that is clearly bogus, so that if we fail to set it

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -123,9 +123,9 @@ namespace Step14
 
 
     template <int dim>
-    void PointValueEvaluation<dim>::
-         operator()(const DoFHandler<dim> &dof_handler,
-               const Vector<double> & solution) const
+    void
+    PointValueEvaluation<dim>::operator()(const DoFHandler<dim> &dof_handler,
+                                          const Vector<double> & solution) const
     {
       double point_value = 1e20;
 
@@ -192,9 +192,9 @@ namespace Step14
     // The more interesting things happen inside the function doing the actual
     // evaluation:
     template <int dim>
-    void PointXDerivativeEvaluation<dim>::
-         operator()(const DoFHandler<dim> &dof_handler,
-               const Vector<double> & solution) const
+    void PointXDerivativeEvaluation<dim>::operator()(
+      const DoFHandler<dim> &dof_handler,
+      const Vector<double> & solution) const
     {
       // This time initialize the return value with something useful, since we
       // will have to add up a number of contributions and take the mean value

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -647,7 +647,7 @@ namespace Step21
     std::vector<Tensor<2, dim>> k_inverse_values(n_q_points);
 
     std::vector<Vector<double>>              old_solution_values(n_q_points,
-                                                                 Vector<double>(dim + 2));
+                                                    Vector<double>(dim + 2));
     std::vector<std::vector<Tensor<1, dim>>> old_solution_grads(
       n_q_points, std::vector<Tensor<1, dim>>(dim + 2));
 

--- a/examples/step-41/step-41.cc
+++ b/examples/step-41/step-41.cc
@@ -82,7 +82,7 @@ namespace Step41
     void setup_system();
     void assemble_system();
     void
-         assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
+    assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
     void update_solution_and_constraints();
     void solve();
     void output_results(const unsigned int iteration) const;

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -612,7 +612,7 @@ namespace Step42
     void compute_dirichlet_constraints();
     void update_solution_and_constraints();
     void
-         assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
+    assemble_mass_matrix_diagonal(TrilinosWrappers::SparseMatrix &mass_matrix);
     void assemble_newton_system(
       const TrilinosWrappers::MPI::Vector &linearization_point);
     void compute_nonlinear_residual(

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -149,8 +149,8 @@ namespace Step64
   // the two terms on the left-hand side correspond to the two function calls
   // here:
   template <int dim, int fe_degree>
-  __device__ void HelmholtzOperatorQuad<dim, fe_degree>::
-                  operator()(CUDAWrappers::FEEvaluation<dim, fe_degree> *fe_eval) const
+  __device__ void HelmholtzOperatorQuad<dim, fe_degree>::operator()(
+    CUDAWrappers::FEEvaluation<dim, fe_degree> *fe_eval) const
   {
     fe_eval->submit_value(coef * fe_eval->get_value());
     fe_eval->submit_gradient(fe_eval->get_gradient());
@@ -366,7 +366,7 @@ namespace Step64
     // In addition, we also keep a solution vector with CPU storage such that we
     // can view and display the solution as usual.
     LinearAlgebra::distributed::Vector<double, MemorySpace::Host>
-                                                                  ghost_solution_host;
+      ghost_solution_host;
     LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA> solution_dev;
     LinearAlgebra::distributed::Vector<double, MemorySpace::CUDA>
       system_rhs_dev;

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -282,7 +282,7 @@ namespace Step70
     std::string arguments_for_solid_grid = spacedim == 2 ?
                                              "-.5, -.1: .5, .1: false" :
                                              "-.5, -.1, -.1: .5, .1, .1: false";
-    std::string name_of_particle_grid = "hyper_ball";
+    std::string name_of_particle_grid    = "hyper_ball";
     std::string arguments_for_particle_grid =
       spacedim == 2 ? "0.3, 0.3: 0.1: false" : "0.3, 0.3, 0.3 : 0.1: false";
 

--- a/include/deal.II/algorithms/general_data_storage.h
+++ b/include/deal.II/algorithms/general_data_storage.h
@@ -246,7 +246,7 @@ public:
   Type &
   get_or_add_object_with_name(const std::string &name,
                               Arg &              argument,
-                              Args &... arguments);
+                              Args &...arguments);
 
   /**
    * Return a reference to the object with given name. If the object does
@@ -273,7 +273,7 @@ public:
   Type &
   get_or_add_object_with_name(const std::string &name,
                               Arg &&             argument,
-                              Args &&... arguments);
+                              Args &&...arguments);
 
   /**
    * Return a reference to the object with given name. If the object does
@@ -492,7 +492,7 @@ template <typename Type, typename Arg, typename... Args>
 Type &
 GeneralDataStorage::get_or_add_object_with_name(const std::string &name,
                                                 Arg &              argument,
-                                                Args &... arguments)
+                                                Args &...arguments)
 {
   if (!stores_object_with_name(name))
     add_unique_copy(name, Type(argument, arguments...));
@@ -519,7 +519,7 @@ template <typename Type, typename Arg, typename... Args>
 Type &
 GeneralDataStorage::get_or_add_object_with_name(const std::string &name,
                                                 Arg &&             argument,
-                                                Args &&... arguments)
+                                                Args &&...arguments)
 {
   if (!stores_object_with_name(name))
     add_unique_copy(name,

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -377,12 +377,14 @@ public:
   /**
    * Read-write access to entry @p index in the vector.
    */
-  reference operator[](const size_type index);
+  reference
+  operator[](const size_type index);
 
   /**
    * Read-only access to entry @p index in the vector.
    */
-  const_reference operator[](const size_type index) const;
+  const_reference
+  operator[](const size_type index) const;
 
   /**
    * Return a pointer to the underlying data buffer.
@@ -1683,8 +1685,8 @@ AlignedVector<T>::capacity() const
 
 
 template <class T>
-inline typename AlignedVector<T>::reference AlignedVector<T>::
-                                            operator[](const size_type index)
+inline typename AlignedVector<T>::reference
+AlignedVector<T>::operator[](const size_type index)
 {
   AssertIndexRange(index, size());
   return elements[index];
@@ -1693,8 +1695,8 @@ inline typename AlignedVector<T>::reference AlignedVector<T>::
 
 
 template <class T>
-inline typename AlignedVector<T>::const_reference AlignedVector<T>::
-                                                  operator[](const size_type index) const
+inline typename AlignedVector<T>::const_reference
+AlignedVector<T>::operator[](const size_type index) const
 {
   AssertIndexRange(index, size());
   return elements[index];

--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -322,7 +322,8 @@ public:
    * This function is only allowed to be called if the underlying data is indeed
    * stored in CPU memory.
    */
-  value_type &operator[](const std::size_t i) const;
+  value_type &
+  operator[](const std::size_t i) const;
 
 private:
   /**
@@ -515,8 +516,8 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
 
 template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType, MemorySpaceType>::
-operator==(const ArrayView<const value_type, MemorySpaceType> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::operator==(
+  const ArrayView<const value_type, MemorySpaceType> &other_view) const
 {
   return (other_view.data() == starting_element) &&
          (other_view.size() == n_elements);
@@ -526,9 +527,9 @@ operator==(const ArrayView<const value_type, MemorySpaceType> &other_view) const
 
 template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType, MemorySpaceType>::
-operator==(const ArrayView<typename std::remove_cv<value_type>::type,
-                           MemorySpaceType> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::operator==(
+  const ArrayView<typename std::remove_cv<value_type>::type, MemorySpaceType>
+    &other_view) const
 {
   return (other_view.data() == starting_element) &&
          (other_view.size() == n_elements);
@@ -538,8 +539,8 @@ operator==(const ArrayView<typename std::remove_cv<value_type>::type,
 
 template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType, MemorySpaceType>::
-operator!=(const ArrayView<const value_type, MemorySpaceType> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::operator!=(
+  const ArrayView<const value_type, MemorySpaceType> &other_view) const
 {
   return !(*this == other_view);
 }
@@ -560,9 +561,9 @@ ArrayView<ElementType, MemorySpaceType>::data() const noexcept
 
 template <typename ElementType, typename MemorySpaceType>
 inline bool
-ArrayView<ElementType, MemorySpaceType>::
-operator!=(const ArrayView<typename std::remove_cv<value_type>::type,
-                           MemorySpaceType> &other_view) const
+ArrayView<ElementType, MemorySpaceType>::operator!=(
+  const ArrayView<typename std::remove_cv<value_type>::type, MemorySpaceType>
+    &other_view) const
 {
   return !(*this == other_view);
 }
@@ -616,7 +617,7 @@ ArrayView<ElementType, MemorySpaceType>::cend() const
 
 template <typename ElementType, typename MemorySpaceType>
 inline typename ArrayView<ElementType, MemorySpaceType>::value_type &
-  ArrayView<ElementType, MemorySpaceType>::operator[](const std::size_t i) const
+ArrayView<ElementType, MemorySpaceType>::operator[](const std::size_t i) const
 {
   AssertIndexRange(i, n_elements);
   Assert(
@@ -1072,8 +1073,8 @@ make_array_view(const std::vector<ElementType> &vector,
  */
 template <typename ElementType>
 inline ArrayView<ElementType>
-  make_array_view(Table<2, ElementType> &                         table,
-                  const typename Table<2, ElementType>::size_type row)
+make_array_view(Table<2, ElementType> &                         table,
+                const typename Table<2, ElementType>::size_type row)
 {
   AssertIndexRange(row, table.size()[0]);
   return ArrayView<ElementType>(&table[row][0], table.size()[1]);
@@ -1098,7 +1099,8 @@ inline ArrayView<ElementType>
  * @relatesalso ArrayView
  */
 template <typename ElementType>
-inline ArrayView<ElementType> make_array_view(Table<2, ElementType> &table)
+inline ArrayView<ElementType>
+make_array_view(Table<2, ElementType> &table)
 {
   return ArrayView<ElementType>(&table[0][0], table.n_elements());
 }
@@ -1227,11 +1229,11 @@ make_array_view(const Table<2, ElementType> &                   table,
  * @relatesalso ArrayView
  */
 template <typename ElementType>
-inline ArrayView<ElementType> make_array_view(
-  Table<2, ElementType> &                         table,
-  const typename Table<2, ElementType>::size_type row,
-  const typename Table<2, ElementType>::size_type starting_column,
-  const std::size_t                               size_of_view)
+inline ArrayView<ElementType>
+make_array_view(Table<2, ElementType> &                         table,
+                const typename Table<2, ElementType>::size_type row,
+                const typename Table<2, ElementType>::size_type starting_column,
+                const std::size_t                               size_of_view)
 {
   AssertIndexRange(row, table.size()[0]);
   AssertIndexRange(starting_column, table.size()[1]);

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -467,8 +467,8 @@ BoundingBox<spacedim, Number>::get_boundary_points() const
 
 template <int spacedim, typename Number>
 inline bool
-BoundingBox<spacedim, Number>::
-operator==(const BoundingBox<spacedim, Number> &box) const
+BoundingBox<spacedim, Number>::operator==(
+  const BoundingBox<spacedim, Number> &box) const
 {
   return boundary_points == box.boundary_points;
 }
@@ -477,8 +477,8 @@ operator==(const BoundingBox<spacedim, Number> &box) const
 
 template <int spacedim, typename Number>
 inline bool
-BoundingBox<spacedim, Number>::
-operator!=(const BoundingBox<spacedim, Number> &box) const
+BoundingBox<spacedim, Number>::operator!=(
+  const BoundingBox<spacedim, Number> &box) const
 {
   return boundary_points != box.boundary_points;
 }

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -501,7 +501,8 @@ namespace DataOutBase
     /**
      * Swap the current object's contents with those of the given argument.
      */
-    void swap(Patch<0, spacedim> &other_patch);
+    void
+    swap(Patch<0, spacedim> &other_patch);
 
     /**
      * Value to be used if this patch has no neighbor on one side.

--- a/include/deal.II/base/derivative_form.h
+++ b/include/deal.II/base/derivative_form.h
@@ -76,12 +76,14 @@ public:
   /**
    * Read-Write access operator.
    */
-  Tensor<order, dim, Number> &operator[](const unsigned int i);
+  Tensor<order, dim, Number> &
+  operator[](const unsigned int i);
 
   /**
    * Read-only access operator.
    */
-  const Tensor<order, dim, Number> &operator[](const unsigned int i) const;
+  const Tensor<order, dim, Number> &
+  operator[](const unsigned int i) const;
 
   /**
    * Assignment operator.
@@ -207,8 +209,8 @@ inline DerivativeForm<order, dim, spacedim, Number>::DerivativeForm(
 
 template <int order, int dim, int spacedim, typename Number>
 inline DerivativeForm<order, dim, spacedim, Number> &
-DerivativeForm<order, dim, spacedim, Number>::
-operator=(const Tensor<order + 1, dim, Number> &ta)
+DerivativeForm<order, dim, spacedim, Number>::operator=(
+  const Tensor<order + 1, dim, Number> &ta)
 {
   Assert((dim == spacedim), ExcMessage("Only allowed when dim==spacedim."));
 
@@ -222,8 +224,8 @@ operator=(const Tensor<order + 1, dim, Number> &ta)
 
 template <int order, int dim, int spacedim, typename Number>
 inline DerivativeForm<order, dim, spacedim, Number> &
-DerivativeForm<order, dim, spacedim, Number>::
-operator=(const Tensor<order, spacedim, Tensor<1, dim, Number>> &T)
+DerivativeForm<order, dim, spacedim, Number>::operator=(
+  const Tensor<order, spacedim, Tensor<1, dim, Number>> &T)
 {
   for (unsigned int j = 0; j < spacedim; ++j)
     (*this)[j] = T[j];
@@ -234,8 +236,8 @@ operator=(const Tensor<order, spacedim, Tensor<1, dim, Number>> &T)
 
 template <int order, int dim, int spacedim, typename Number>
 inline DerivativeForm<order, dim, spacedim, Number> &
-DerivativeForm<order, dim, spacedim, Number>::
-operator=(const Tensor<1, dim, Number> &T)
+DerivativeForm<order, dim, spacedim, Number>::operator=(
+  const Tensor<1, dim, Number> &T)
 {
   Assert((1 == spacedim) && (order == 1),
          ExcMessage("Only allowed for spacedim==1 and order==1."));
@@ -249,7 +251,7 @@ operator=(const Tensor<1, dim, Number> &T)
 
 template <int order, int dim, int spacedim, typename Number>
 inline Tensor<order, dim, Number> &
-  DerivativeForm<order, dim, spacedim, Number>::operator[](const unsigned int i)
+DerivativeForm<order, dim, spacedim, Number>::operator[](const unsigned int i)
 {
   AssertIndexRange(i, spacedim);
 
@@ -260,8 +262,8 @@ inline Tensor<order, dim, Number> &
 
 template <int order, int dim, int spacedim, typename Number>
 inline const Tensor<order, dim, Number> &
-  DerivativeForm<order, dim, spacedim, Number>::
-  operator[](const unsigned int i) const
+DerivativeForm<order, dim, spacedim, Number>::operator[](
+  const unsigned int i) const
 {
   AssertIndexRange(i, spacedim);
 

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1355,7 +1355,8 @@ namespace deal_II_exceptions
                          const char *      function,
                          const char *      cond,
                          const char *      exc_name,
-                         ExceptionType     e) {
+                         ExceptionType     e)
+    {
       // Fill the fields of the exception object
       e.set_fields(file, line, function, cond, exc_name);
 
@@ -1385,7 +1386,8 @@ namespace deal_II_exceptions
     /**
      * Internal function that does the work of issue_error_nothrow.
      */
-    void do_issue_error_nothrow(const ExceptionBase &e) noexcept;
+    void
+    do_issue_error_nothrow(const ExceptionBase &e) noexcept;
 
     /**
      * Exception generation mechanism in case we must not throw.

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -832,7 +832,8 @@ public:
    * Return the intersection of the refinement flags represented by the
    * current object and the one given as argument.
    */
-  RefinementCase operator&(const RefinementCase &r) const;
+  RefinementCase
+  operator&(const RefinementCase &r) const;
 
   /**
    * Return the negation of the refinement flags represented by the current
@@ -2826,8 +2827,8 @@ RefinementCase<dim>::operator|(const RefinementCase<dim> &r) const
 
 
 template <int dim>
-inline RefinementCase<dim> RefinementCase<dim>::
-                           operator&(const RefinementCase<dim> &r) const
+inline RefinementCase<dim>
+RefinementCase<dim>::operator&(const RefinementCase<dim> &r) const
 {
   return RefinementCase<dim>(static_cast<std::uint8_t>(value & r.value));
 }

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -324,7 +324,8 @@ public:
    * sets must have the same size (though of course they do not have to have
    * the same number of indices).
    */
-  IndexSet operator&(const IndexSet &is) const;
+  IndexSet
+  operator&(const IndexSet &is) const;
 
   /**
    * This command takes an interval <tt>[begin, end)</tt> and returns the
@@ -658,12 +659,14 @@ public:
     /**
      * Dereferencing operator, returns an IntervalAccessor.
      */
-    const IntervalAccessor &operator*() const;
+    const IntervalAccessor &
+    operator*() const;
 
     /**
      * Dereferencing operator, returns a pointer to an IntervalAccessor.
      */
-    const IntervalAccessor *operator->() const;
+    const IntervalAccessor *
+    operator->() const;
 
     /**
      * Comparison.
@@ -734,7 +737,8 @@ public:
      * Dereferencing operator. The returned value is the index of the element
      * inside the IndexSet.
      */
-    size_type operator*() const;
+    size_type
+    operator*() const;
 
     /**
      * Does this iterator point to an existing element?
@@ -1116,8 +1120,8 @@ IndexSet::IntervalAccessor::operator=(const IndexSet::IntervalAccessor &other)
 
 
 inline bool
-IndexSet::IntervalAccessor::
-operator==(const IndexSet::IntervalAccessor &other) const
+IndexSet::IntervalAccessor::operator==(
+  const IndexSet::IntervalAccessor &other) const
 {
   Assert(index_set == other.index_set,
          ExcMessage(
@@ -1128,8 +1132,8 @@ operator==(const IndexSet::IntervalAccessor &other) const
 
 
 inline bool
-IndexSet::IntervalAccessor::
-operator<(const IndexSet::IntervalAccessor &other) const
+IndexSet::IntervalAccessor::operator<(
+  const IndexSet::IntervalAccessor &other) const
 {
   Assert(index_set == other.index_set,
          ExcMessage(
@@ -1195,16 +1199,16 @@ IndexSet::IntervalIterator::operator++(int)
 
 
 
-inline const IndexSet::IntervalAccessor &IndexSet::IntervalIterator::
-                                         operator*() const
+inline const IndexSet::IntervalAccessor &
+IndexSet::IntervalIterator::operator*() const
 {
   return accessor;
 }
 
 
 
-inline const IndexSet::IntervalAccessor *IndexSet::IntervalIterator::
-                                         operator->() const
+inline const IndexSet::IntervalAccessor *
+IndexSet::IntervalIterator::operator->() const
 {
   return &accessor;
 }
@@ -1212,8 +1216,8 @@ inline const IndexSet::IntervalAccessor *IndexSet::IntervalIterator::
 
 
 inline bool
-IndexSet::IntervalIterator::
-operator==(const IndexSet::IntervalIterator &other) const
+IndexSet::IntervalIterator::operator==(
+  const IndexSet::IntervalIterator &other) const
 {
   return accessor == other.accessor;
 }
@@ -1221,8 +1225,8 @@ operator==(const IndexSet::IntervalIterator &other) const
 
 
 inline bool
-IndexSet::IntervalIterator::
-operator!=(const IndexSet::IntervalIterator &other) const
+IndexSet::IntervalIterator::operator!=(
+  const IndexSet::IntervalIterator &other) const
 {
   return !(*this == other);
 }
@@ -1230,8 +1234,8 @@ operator!=(const IndexSet::IntervalIterator &other) const
 
 
 inline bool
-IndexSet::IntervalIterator::
-operator<(const IndexSet::IntervalIterator &other) const
+IndexSet::IntervalIterator::operator<(
+  const IndexSet::IntervalIterator &other) const
 {
   return accessor < other.accessor;
 }
@@ -1239,8 +1243,8 @@ operator<(const IndexSet::IntervalIterator &other) const
 
 
 inline int
-IndexSet::IntervalIterator::
-operator-(const IndexSet::IntervalIterator &other) const
+IndexSet::IntervalIterator::operator-(
+  const IndexSet::IntervalIterator &other) const
 {
   Assert(accessor.index_set == other.accessor.index_set,
          ExcMessage(
@@ -1307,7 +1311,8 @@ IndexSet::ElementIterator::is_valid() const
 
 
 
-inline IndexSet::size_type IndexSet::ElementIterator::operator*() const
+inline IndexSet::size_type
+IndexSet::ElementIterator::operator*() const
 {
   Assert(
     is_valid(),
@@ -1319,8 +1324,8 @@ inline IndexSet::size_type IndexSet::ElementIterator::operator*() const
 
 
 inline bool
-IndexSet::ElementIterator::
-operator==(const IndexSet::ElementIterator &other) const
+IndexSet::ElementIterator::operator==(
+  const IndexSet::ElementIterator &other) const
 {
   Assert(index_set == other.index_set,
          ExcMessage(
@@ -1379,8 +1384,8 @@ IndexSet::ElementIterator::operator++(int)
 
 
 inline bool
-IndexSet::ElementIterator::
-operator!=(const IndexSet::ElementIterator &other) const
+IndexSet::ElementIterator::operator!=(
+  const IndexSet::ElementIterator &other) const
 {
   return !(*this == other);
 }
@@ -1388,8 +1393,8 @@ operator!=(const IndexSet::ElementIterator &other) const
 
 
 inline bool
-IndexSet::ElementIterator::
-operator<(const IndexSet::ElementIterator &other) const
+IndexSet::ElementIterator::operator<(
+  const IndexSet::ElementIterator &other) const
 {
   Assert(index_set == other.index_set,
          ExcMessage(
@@ -1401,8 +1406,8 @@ operator<(const IndexSet::ElementIterator &other) const
 
 
 inline std::ptrdiff_t
-IndexSet::ElementIterator::
-operator-(const IndexSet::ElementIterator &other) const
+IndexSet::ElementIterator::operator-(
+  const IndexSet::ElementIterator &other) const
 {
   Assert(index_set == other.index_set,
          ExcMessage(

--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -217,13 +217,15 @@ public:
    * Dereferencing operator.
    * @return The iterator within the collection currently pointed to.
    */
-  const BaseIterator &operator*() const;
+  const BaseIterator &
+  operator*() const;
 
   /**
    * Dereferencing operator.
    * @return The iterator within the collection currently pointed to.
    */
-  const BaseIterator *operator->() const;
+  const BaseIterator *
+  operator->() const;
 
   /**
    * Prefix increment operator. Move the current iterator to the next
@@ -311,7 +313,7 @@ inline IteratorOverIterators<Iterator>::IteratorOverIterators(
 
 template <typename Iterator>
 inline const typename IteratorOverIterators<Iterator>::BaseIterator &
-  IteratorOverIterators<Iterator>::operator*() const
+IteratorOverIterators<Iterator>::operator*() const
 {
   return element_of_iterator_collection;
 }
@@ -320,7 +322,7 @@ inline const typename IteratorOverIterators<Iterator>::BaseIterator &
 
 template <typename Iterator>
 inline const typename IteratorOverIterators<Iterator>::BaseIterator *
-  IteratorOverIterators<Iterator>::operator->() const
+IteratorOverIterators<Iterator>::operator->() const
 {
   return &element_of_iterator_collection;
 }
@@ -350,8 +352,8 @@ IteratorOverIterators<Iterator>::operator++(int)
 
 template <typename Iterator>
 inline bool
-IteratorOverIterators<Iterator>::
-operator!=(const IteratorOverIterators &i_o_i) const
+IteratorOverIterators<Iterator>::operator!=(
+  const IteratorOverIterators &i_o_i) const
 {
   return element_of_iterator_collection != i_o_i.element_of_iterator_collection;
 }

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -236,12 +236,14 @@ public:
   /**
    * Dereferencing operator.
    */
-  reference operator*() const;
+  reference
+  operator*() const;
 
   /**
    * Dereferencing operator.
    */
-  pointer operator->() const;
+  pointer
+  operator->() const;
 
   /**
    * Comparison operator. Returns <code>true</code> if both iterators point to
@@ -328,8 +330,8 @@ protected:
 
 template <class DerivedIterator, class AccessorType>
 inline DerivedIterator &
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator=(const DerivedIterator &it)
+LinearIndexIterator<DerivedIterator, AccessorType>::operator=(
+  const DerivedIterator &it)
 {
   accessor.container    = it.container;
   accessor.linear_index = it.linear_index;
@@ -380,8 +382,8 @@ LinearIndexIterator<DerivedIterator, AccessorType>::operator--(int)
 
 template <class DerivedIterator, class AccessorType>
 inline DerivedIterator
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator+(const difference_type n) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator+(
+  const difference_type n) const
 {
   DerivedIterator copy(this->accessor);
   copy += n;
@@ -392,8 +394,8 @@ operator+(const difference_type n) const
 
 template <class DerivedIterator, class AccessorType>
 inline DerivedIterator
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator-(const difference_type n) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator-(
+  const difference_type n) const
 {
   DerivedIterator copy(this->accessor);
   copy += -n;
@@ -404,8 +406,8 @@ operator-(const difference_type n) const
 
 template <class DerivedIterator, class AccessorType>
 inline DerivedIterator &
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator+=(const difference_type n)
+LinearIndexIterator<DerivedIterator, AccessorType>::operator+=(
+  const difference_type n)
 {
   accessor.linear_index += n;
   return static_cast<DerivedIterator &>(*this);
@@ -415,8 +417,8 @@ operator+=(const difference_type n)
 
 template <class DerivedIterator, class AccessorType>
 inline DerivedIterator &
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator-=(const difference_type n)
+LinearIndexIterator<DerivedIterator, AccessorType>::operator-=(
+  const difference_type n)
 {
   return operator+=(-n);
 }
@@ -426,8 +428,8 @@ operator-=(const difference_type n)
 template <class DerivedIterator, class AccessorType>
 inline
   typename LinearIndexIterator<DerivedIterator, AccessorType>::difference_type
-  LinearIndexIterator<DerivedIterator, AccessorType>::
-  operator-(const DerivedIterator &other) const
+  LinearIndexIterator<DerivedIterator, AccessorType>::operator-(
+    const DerivedIterator &other) const
 {
   Assert(this->accessor.container == other.accessor.container,
          ExcMessage(
@@ -439,7 +441,7 @@ inline
 
 template <class DerivedIterator, class AccessorType>
 inline typename LinearIndexIterator<DerivedIterator, AccessorType>::reference
-  LinearIndexIterator<DerivedIterator, AccessorType>::operator*() const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator*() const
 {
   return accessor;
 }
@@ -448,7 +450,7 @@ inline typename LinearIndexIterator<DerivedIterator, AccessorType>::reference
 
 template <class DerivedIterator, class AccessorType>
 inline typename LinearIndexIterator<DerivedIterator, AccessorType>::pointer
-  LinearIndexIterator<DerivedIterator, AccessorType>::operator->() const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator->() const
 {
   return &accessor;
 }
@@ -457,8 +459,8 @@ inline typename LinearIndexIterator<DerivedIterator, AccessorType>::pointer
 
 template <class DerivedIterator, class AccessorType>
 inline bool
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator<=(const DerivedIterator &other) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator<=(
+  const DerivedIterator &other) const
 {
   return (*this == other) || (*this < other);
 }
@@ -467,8 +469,8 @@ operator<=(const DerivedIterator &other) const
 
 template <class DerivedIterator, class AccessorType>
 inline bool
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator>=(const DerivedIterator &other) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator>=(
+  const DerivedIterator &other) const
 {
   return !(*this < other);
 }
@@ -477,8 +479,8 @@ operator>=(const DerivedIterator &other) const
 
 template <class DerivedIterator, class AccessorType>
 inline bool
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator<(const DerivedIterator &other) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator<(
+  const DerivedIterator &other) const
 {
   Assert(this->accessor.container == other.accessor.container,
          ExcMessage(
@@ -490,8 +492,8 @@ operator<(const DerivedIterator &other) const
 
 template <class DerivedIterator, class AccessorType>
 inline bool
-LinearIndexIterator<DerivedIterator, AccessorType>::
-operator>(const DerivedIterator &other) const
+LinearIndexIterator<DerivedIterator, AccessorType>::operator>(
+  const DerivedIterator &other) const
 {
   return other < static_cast<const DerivedIterator &>(*this);
 }

--- a/include/deal.II/base/mg_level_object.h
+++ b/include/deal.II/base/mg_level_object.h
@@ -73,7 +73,7 @@ public:
   template <class... Args>
   MGLevelObject(const unsigned int minlevel,
                 const unsigned int maxlevel,
-                Args &&... args);
+                Args &&...args);
 
   /**
    * Constructor. Same as above but without arguments to be forwarded to the
@@ -85,7 +85,8 @@ public:
   /**
    * Access object on level @p level.
    */
-  Object &operator[](const unsigned int level);
+  Object &
+  operator[](const unsigned int level);
 
   /**
    * Access object on level @p level.
@@ -93,7 +94,8 @@ public:
    * This function can be called on a @p const object, and
    * consequently returns a @p const reference.
    */
-  const Object &operator[](const unsigned int level) const;
+  const Object &
+  operator[](const unsigned int level) const;
 
   /**
    * Delete all previous contents of this object and reset its size according
@@ -112,7 +114,7 @@ public:
   void
   resize(const unsigned int new_minlevel,
          const unsigned int new_maxlevel,
-         Args &&... args);
+         Args &&...args);
 
   /**
    * Call <tt>operator = (s)</tt> on all objects stored by this object.
@@ -186,7 +188,7 @@ template <class Object>
 template <class... Args>
 MGLevelObject<Object>::MGLevelObject(const unsigned int min,
                                      const unsigned int max,
-                                     Args &&... args)
+                                     Args &&...args)
   : minlevel(0)
 {
   resize(min, max, std::forward<Args>(args)...);
@@ -203,7 +205,8 @@ MGLevelObject<Object>::MGLevelObject(const unsigned int min,
 
 
 template <class Object>
-Object &MGLevelObject<Object>::operator[](const unsigned int i)
+Object &
+MGLevelObject<Object>::operator[](const unsigned int i)
 {
   Assert((i >= minlevel) && (i < minlevel + objects.size()),
          ExcIndexRange(i, minlevel, minlevel + objects.size()));
@@ -212,7 +215,8 @@ Object &MGLevelObject<Object>::operator[](const unsigned int i)
 
 
 template <class Object>
-const Object &MGLevelObject<Object>::operator[](const unsigned int i) const
+const Object &
+MGLevelObject<Object>::operator[](const unsigned int i) const
 {
   Assert((i >= minlevel) && (i < minlevel + objects.size()),
          ExcIndexRange(i, minlevel, minlevel + objects.size()));
@@ -225,7 +229,7 @@ template <class... Args>
 void
 MGLevelObject<Object>::resize(const unsigned int new_minlevel,
                               const unsigned int new_maxlevel,
-                              Args &&... args)
+                              Args &&...args)
 {
   Assert(new_minlevel <= new_maxlevel, ExcInternalError());
   // note that on clear(), the

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -285,7 +285,8 @@ namespace Utilities
       /**
        * Access the stored communicator.
        */
-      const MPI_Comm &operator*() const
+      const MPI_Comm &
+      operator*() const
       {
         return comm;
       }

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -268,7 +268,7 @@ namespace Utilities
                 // ranks. Here, we process the interval by breaking into
                 // smaller pieces in terms of the dictionary number.
                 std::pair<types::global_dof_index, types::global_dof_index>
-                                   index_range(*interval->begin(), interval->last() + 1);
+                  index_range(*interval->begin(), interval->last() + 1);
                 const unsigned int owner_last =
                   dof_to_dict_rank(interval->last());
                 unsigned int owner_first = numbers::invalid_unsigned_int;

--- a/include/deal.II/base/mutable_bind.h
+++ b/include/deal.II/base/mutable_bind.h
@@ -94,7 +94,7 @@ namespace Utilities
      * each arguments separately.
      */
     template <class FunctionType>
-    MutableBind(FunctionType function, FunctionArgs &&... arguments);
+    MutableBind(FunctionType function, FunctionArgs &&...arguments);
 
     /**
      * Construct a MutableBind object specifying the function, and
@@ -129,7 +129,7 @@ namespace Utilities
      * operator()() is called, using move semantic.
      */
     void
-    set_arguments(FunctionArgs &&... arguments);
+    set_arguments(FunctionArgs &&...arguments);
 
     /**
      * Parse the arguments to use in @p function from a string, for next time
@@ -186,7 +186,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(ReturnType (*function)(FunctionArgs...),
-               typename identity<FunctionArgs>::type &&... arguments);
+               typename identity<FunctionArgs>::type &&...arguments);
 
   /**
    * Same as above, using a std::function object.
@@ -194,7 +194,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(std::function<ReturnType(FunctionArgs...)>,
-               typename identity<FunctionArgs>::type &&... arguments);
+               typename identity<FunctionArgs>::type &&...arguments);
 
   /**
    * Create a MutableBind object from a function pointer, with uninitialized
@@ -224,7 +224,7 @@ namespace Utilities
   template <class FunctionType>
   MutableBind<ReturnType, FunctionArgs...>::MutableBind(
     FunctionType function,
-    FunctionArgs &&... arguments)
+    FunctionArgs &&...arguments)
     : function(function)
     , arguments(std::make_tuple(std::move(arguments)...))
   {}
@@ -261,7 +261,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   void
   MutableBind<ReturnType, FunctionArgs...>::set_arguments(
-    FunctionArgs &&... args)
+    FunctionArgs &&...args)
   {
     arguments = std::make_tuple(std::move(args)...);
   }
@@ -292,7 +292,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(ReturnType (*function)(FunctionArgs...),
-               typename identity<FunctionArgs>::type &&... arguments)
+               typename identity<FunctionArgs>::type &&...arguments)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function,
                                                     std::move(arguments)...);
@@ -312,7 +312,7 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   MutableBind<ReturnType, FunctionArgs...>
   mutable_bind(std::function<ReturnType(FunctionArgs...)> function,
-               typename identity<FunctionArgs>::type &&... arguments)
+               typename identity<FunctionArgs>::type &&...arguments)
   {
     return MutableBind<ReturnType, FunctionArgs...>(function,
                                                     std::move(arguments)...);

--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -571,7 +571,7 @@ namespace numbers
 
   template <typename number>
   constexpr DEAL_II_CUDA_HOST_DEV const number &
-                                        NumberTraits<number>::conjugate(const number &x)
+  NumberTraits<number>::conjugate(const number &x)
   {
     return x;
   }
@@ -700,7 +700,7 @@ namespace internal
   struct NumberType
   {
     static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV const T &
-                                                                       value(const T &t)
+    value(const T &t)
     {
       return t;
     }
@@ -715,8 +715,8 @@ namespace internal
     // Type T is constructible from F.
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV T
-                                                                 value(const F &f,
-                                                                       typename std::enable_if<
+    value(const F &f,
+          typename std::enable_if<
             !std::is_same<typename std::decay<T>::type,
                           typename std::decay<F>::type>::value &&
             std::is_constructible<T, F>::value>::type * = nullptr)
@@ -727,8 +727,8 @@ namespace internal
     // Type T is explicitly convertible (but not constructible) from F.
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE T
-                                           value(const F &f,
-                                                 typename std::enable_if<
+    value(const F &f,
+          typename std::enable_if<
             !std::is_same<typename std::decay<T>::type,
                           typename std::decay<F>::type>::value &&
             !std::is_constructible<T, F>::value &&

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -456,13 +456,13 @@ namespace parallel
 
     f(begin, end);
 #else
-    internal::parallel_for(begin,
-                           end,
-                           [&f](const tbb::blocked_range<RangeType> &range) {
-                             internal::apply_to_subranges<RangeType, Function>(
-                               range, f);
-                           },
-                           grainsize);
+    internal::parallel_for(
+      begin,
+      end,
+      [&f](const tbb::blocked_range<RangeType> &range) {
+        internal::apply_to_subranges<RangeType, Function>(range, f);
+      },
+      grainsize);
 #endif
   }
 

--- a/include/deal.II/base/parameter_acceptor.h
+++ b/include/deal.II/base/parameter_acceptor.h
@@ -401,7 +401,7 @@ public:
   initialize(const std::string &filename        = "",
              const std::string &output_filename = "",
              const ParameterHandler::OutputStyle
-                                                 output_style_for_output_filename = ParameterHandler::Short,
+               output_style_for_output_filename      = ParameterHandler::Short,
              ParameterHandler &                  prm = ParameterAcceptor::prm,
              const ParameterHandler::OutputStyle output_style_for_filename =
                ParameterHandler::DefaultStyle);

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -799,7 +799,7 @@ namespace Patterns
      * @param patterns The list of patterns to use
      */
     template <class... PatternTypes>
-    Tuple(const std::string &separator, const PatternTypes &... patterns);
+    Tuple(const std::string &separator, const PatternTypes &...patterns);
 
     /**
      * Constructor. This is needed to allow users to specify
@@ -809,7 +809,7 @@ namespace Patterns
      * specialization, the compiler will fail with cryptic errors.
      */
     template <class... PatternTypes>
-    Tuple(const char *separator, const PatternTypes &... patterns);
+    Tuple(const char *separator, const PatternTypes &...patterns);
 
     /**
      * Constructor. Same as above, using the default separator.
@@ -817,7 +817,7 @@ namespace Patterns
      * @param patterns The list of patterns to use
      */
     template <typename... Patterns>
-    Tuple(const Patterns &... patterns);
+    Tuple(const Patterns &...patterns);
 
     /**
      * Copy constructor.
@@ -1413,7 +1413,7 @@ namespace Patterns
 namespace Patterns
 {
   template <class... PatternTypes>
-  Tuple::Tuple(const char *separator, const PatternTypes &... ps)
+  Tuple::Tuple(const char *separator, const PatternTypes &...ps)
     : // forward to the version with std::string argument
     Tuple(std::string(separator), ps...)
   {}
@@ -1421,7 +1421,7 @@ namespace Patterns
 
 
   template <class... PatternTypes>
-  Tuple::Tuple(const std::string &separator, const PatternTypes &... ps)
+  Tuple::Tuple(const std::string &separator, const PatternTypes &...ps)
     : separator(separator)
   {
     static_assert(is_base_of_all<PatternBase, PatternTypes...>::value,
@@ -1437,7 +1437,7 @@ namespace Patterns
 
 
   template <class... PatternTypes>
-  Tuple::Tuple(const PatternTypes &... ps)
+  Tuple::Tuple(const PatternTypes &...ps)
     : // forward to the version with the separator argument
     Tuple(std::string(":"), ps...)
   {}

--- a/include/deal.II/base/point.h
+++ b/include/deal.II/base/point.h
@@ -185,7 +185,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   DEAL_II_CUDA_HOST_DEV Number
-                        operator()(const unsigned int index) const;
+  operator()(const unsigned int index) const;
 
   /**
    * Read and write access to the <tt>index</tt>th coordinate.
@@ -288,7 +288,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  DEAL_II_CUDA_HOST_DEV Number operator*(const Tensor<1, dim, Number> &p) const;
+  DEAL_II_CUDA_HOST_DEV Number
+  operator*(const Tensor<1, dim, Number> &p) const;
 
   /**
    * Return the scalar product of this point vector with itself, i.e. the
@@ -548,10 +549,10 @@ Point<dim, Number>::operator-() const
 template <int dim, typename Number>
 template <typename OtherNumber>
 inline DEAL_II_CUDA_HOST_DEV
-    Point<dim,
+  Point<dim,
         typename ProductType<Number,
                              typename EnableIfScalar<OtherNumber>::type>::type>
-    Point<dim, Number>::operator*(const OtherNumber factor) const
+  Point<dim, Number>::operator*(const OtherNumber factor) const
 {
   Point<dim, typename ProductType<Number, OtherNumber>::type> tmp;
   for (unsigned int i = 0; i < dim; ++i)
@@ -580,8 +581,8 @@ inline DEAL_II_CUDA_HOST_DEV
 
 
 template <int dim, typename Number>
-inline DEAL_II_CUDA_HOST_DEV Number Point<dim, Number>::
-                                    operator*(const Tensor<1, dim, Number> &p) const
+inline DEAL_II_CUDA_HOST_DEV Number
+Point<dim, Number>::operator*(const Tensor<1, dim, Number> &p) const
 {
   Number res = Number();
   for (unsigned int i = 0; i < dim; ++i)

--- a/include/deal.II/base/polynomials_barycentric.h
+++ b/include/deal.II/base/polynomials_barycentric.h
@@ -137,7 +137,8 @@ public:
    * Multiply by a scalar.
    */
   template <typename Number2>
-  BarycentricPolynomial<dim, Number> operator*(const Number2 &a) const;
+  BarycentricPolynomial<dim, Number>
+  operator*(const Number2 &a) const;
 
   /**
    * Divide by a scalar.
@@ -234,7 +235,8 @@ public:
   /**
    * Access operator.
    */
-  const BarycentricPolynomial<dim> &operator[](const std::size_t i) const;
+  const BarycentricPolynomial<dim> &
+  operator[](const std::size_t i) const;
 
   /**
    * @copydoc ScalarPolynomialsBase::evaluate()
@@ -489,8 +491,8 @@ BarycentricPolynomial<dim, Number>::operator-(const Number2 &a) const
 
 template <int dim, typename Number>
 template <typename Number2>
-BarycentricPolynomial<dim, Number> BarycentricPolynomial<dim, Number>::
-                                   operator*(const Number2 &a) const
+BarycentricPolynomial<dim, Number>
+BarycentricPolynomial<dim, Number>::operator*(const Number2 &a) const
 {
   if (a == Number2())
     {
@@ -522,8 +524,8 @@ BarycentricPolynomial<dim, Number>::operator/(const Number2 &a) const
 
 template <int dim, typename Number>
 BarycentricPolynomial<dim, Number>
-BarycentricPolynomial<dim, Number>::
-operator+(const BarycentricPolynomial<dim, Number> &augend) const
+BarycentricPolynomial<dim, Number>::operator+(
+  const BarycentricPolynomial<dim, Number> &augend) const
 {
   TableIndices<dim + 1> deg;
   for (unsigned int d = 0; d < dim + 1; ++d)
@@ -550,8 +552,8 @@ operator+(const BarycentricPolynomial<dim, Number> &augend) const
 
 template <int dim, typename Number>
 BarycentricPolynomial<dim, Number>
-BarycentricPolynomial<dim, Number>::
-operator-(const BarycentricPolynomial<dim, Number> &augend) const
+BarycentricPolynomial<dim, Number>::operator-(
+  const BarycentricPolynomial<dim, Number> &augend) const
 {
   return *this + (-augend);
 }
@@ -559,8 +561,9 @@ operator-(const BarycentricPolynomial<dim, Number> &augend) const
 
 
 template <int dim, typename Number>
-BarycentricPolynomial<dim, Number> BarycentricPolynomial<dim, Number>::
-                                   operator*(const BarycentricPolynomial<dim, Number> &multiplicand) const
+BarycentricPolynomial<dim, Number>
+BarycentricPolynomial<dim, Number>::operator*(
+  const BarycentricPolynomial<dim, Number> &multiplicand) const
 {
   TableIndices<dim + 1> deg;
   for (unsigned int d = 0; d < dim + 1; ++d)
@@ -697,8 +700,8 @@ BarycentricPolynomial<dim, Number>::index_to_indices(
 }
 
 template <int dim>
-const BarycentricPolynomial<dim> &BarycentricPolynomials<dim>::
-                                  operator[](const std::size_t i) const
+const BarycentricPolynomial<dim> &
+BarycentricPolynomials<dim>::operator[](const std::size_t i) const
 {
   AssertIndexRange(i, polys.size());
   return polys[i];

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -148,13 +148,15 @@ public:
    * Dereferencing operator. This operator throws an ExcNotInitialized() if the
    * pointer is a null pointer.
    */
-  T &operator*() const;
+  T &
+  operator*() const;
 
   /**
    * Dereferencing operator. This operator throws an ExcNotInitializedi() if the
    * pointer is a null pointer.
    */
-  T *operator->() const;
+  T *
+  operator->() const;
 
   /**
    * Exchange the pointers of this object and the argument. Since both the
@@ -363,7 +365,8 @@ inline SmartPointer<T, P>::operator T *() const
 
 
 template <typename T, typename P>
-inline T &SmartPointer<T, P>::operator*() const
+inline T &
+SmartPointer<T, P>::operator*() const
 {
   Assert(t != nullptr, ExcNotInitialized());
   Assert(pointed_to_object_is_alive,
@@ -374,7 +377,8 @@ inline T &SmartPointer<T, P>::operator*() const
 
 
 template <typename T, typename P>
-inline T *SmartPointer<T, P>::operator->() const
+inline T *
+SmartPointer<T, P>::operator->() const
 {
   Assert(t != nullptr, ExcNotInitialized());
   Assert(pointed_to_object_is_alive,

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -129,15 +129,15 @@ constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<4, dim, Number>
 
 template <int dim2, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       trace(const SymmetricTensor<2, dim2, Number> &);
+trace(const SymmetricTensor<2, dim2, Number> &);
 
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, Number>
-                                       deviator(const SymmetricTensor<2, dim, Number> &);
+deviator(const SymmetricTensor<2, dim, Number> &);
 
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       determinant(const SymmetricTensor<2, dim, Number> &);
+determinant(const SymmetricTensor<2, dim, Number> &);
 
 
 
@@ -213,9 +213,9 @@ namespace internal
      * invalid state.
      */
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE TableIndices<2>
-                                                   merge(const TableIndices<2> &previous_indices,
-                                                         const unsigned int     new_index,
-                                                         const unsigned int     position)
+    merge(const TableIndices<2> &previous_indices,
+          const unsigned int     new_index,
+          const unsigned int     position)
     {
       AssertIndexRange(position, 2);
 
@@ -234,9 +234,9 @@ namespace internal
      * invalid state.
      */
     DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE TableIndices<4>
-                                                   merge(const TableIndices<4> &previous_indices,
-                                                         const unsigned int     new_index,
-                                                         const unsigned int     position)
+    merge(const TableIndices<4> &previous_indices,
+          const unsigned int     new_index,
+          const unsigned int     position)
     {
       AssertIndexRange(position, 4);
 
@@ -563,12 +563,14 @@ namespace internal
       /**
        * Index operator.
        */
-      constexpr reference operator[](const unsigned int);
+      constexpr reference
+      operator[](const unsigned int);
 
       /**
        * Index operator.
        */
-      constexpr reference operator[](const unsigned int) const;
+      constexpr reference
+      operator[](const unsigned int) const;
 
     private:
       /**
@@ -912,14 +914,16 @@ public:
    *
    * Exactly the same as operator().
    */
-  constexpr const Number &operator[](const TableIndices<rank_> &indices) const;
+  constexpr const Number &
+  operator[](const TableIndices<rank_> &indices) const;
 
   /**
    * Return a read-write reference to the indicated element.
    *
    * Exactly the same as operator().
    */
-  constexpr Number &operator[](const TableIndices<rank_> &indices);
+  constexpr Number &
+  operator[](const TableIndices<rank_> &indices);
 
   /**
    * Access to an element according to unrolled index. The function
@@ -1086,9 +1090,9 @@ namespace internal
 
     template <int rank_, int dim, bool constness, int P, typename Number>
     constexpr inline DEAL_II_ALWAYS_INLINE
-        Accessor<rank_, dim, constness, P - 1, Number>
-        Accessor<rank_, dim, constness, P, Number>::
-        operator[](const unsigned int i)
+      Accessor<rank_, dim, constness, P - 1, Number>
+      Accessor<rank_, dim, constness, P, Number>::operator[](
+        const unsigned int i)
     {
       return Accessor<rank_, dim, constness, P - 1, Number>(
         tensor, merge(previous_indices, i, rank_ - P));
@@ -1098,9 +1102,9 @@ namespace internal
 
     template <int rank_, int dim, bool constness, int P, typename Number>
     constexpr DEAL_II_ALWAYS_INLINE
-        Accessor<rank_, dim, constness, P - 1, Number>
-        Accessor<rank_, dim, constness, P, Number>::
-        operator[](const unsigned int i) const
+      Accessor<rank_, dim, constness, P - 1, Number>
+      Accessor<rank_, dim, constness, P, Number>::operator[](
+        const unsigned int i) const
     {
       return Accessor<rank_, dim, constness, P - 1, Number>(
         tensor, merge(previous_indices, i, rank_ - P));
@@ -1122,8 +1126,8 @@ namespace internal
     template <int rank_, int dim, bool constness, typename Number>
     constexpr inline DEAL_II_ALWAYS_INLINE
       typename Accessor<rank_, dim, constness, 1, Number>::reference
-        Accessor<rank_, dim, constness, 1, Number>::
-        operator[](const unsigned int i)
+      Accessor<rank_, dim, constness, 1, Number>::operator[](
+        const unsigned int i)
     {
       return tensor(merge(previous_indices, i, rank_ - 1));
     }
@@ -1132,8 +1136,8 @@ namespace internal
     template <int rank_, int dim, bool constness, typename Number>
     constexpr DEAL_II_ALWAYS_INLINE
       typename Accessor<rank_, dim, constness, 1, Number>::reference
-        Accessor<rank_, dim, constness, 1, Number>::
-        operator[](const unsigned int i) const
+      Accessor<rank_, dim, constness, 1, Number>::operator[](
+        const unsigned int i) const
     {
       return tensor(merge(previous_indices, i, rank_ - 1));
     }
@@ -1191,8 +1195,8 @@ SymmetricTensor<rank_, dim, Number>::SymmetricTensor(
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number> &
-                                       SymmetricTensor<rank_, dim, Number>::
-                                       operator=(const SymmetricTensor<rank_, dim, OtherNumber> &t)
+SymmetricTensor<rank_, dim, Number>::operator=(
+  const SymmetricTensor<rank_, dim, OtherNumber> &t)
 {
   data = t.data;
   return *this;
@@ -1220,7 +1224,7 @@ namespace internal
   {
     template <int dim, typename Number>
     constexpr inline DEAL_II_ALWAYS_INLINE dealii::Tensor<2, dim, Number>
-                                           convert_to_tensor(const dealii::SymmetricTensor<2, dim, Number> &s)
+    convert_to_tensor(const dealii::SymmetricTensor<2, dim, Number> &s)
     {
       dealii::Tensor<2, dim, Number> t;
 
@@ -1563,8 +1567,9 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>::
-                                operator Tensor<rank_, dim, Number>() const
+constexpr DEAL_II_ALWAYS_INLINE
+  SymmetricTensor<rank_, dim, Number>::operator Tensor<rank_, dim, Number>()
+    const
 {
   return internal::SymmetricTensorImplementation::convert_to_tensor(*this);
 }
@@ -1573,8 +1578,8 @@ constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>::
 
 template <int rank_, int dim, typename Number>
 constexpr bool
-SymmetricTensor<rank_, dim, Number>::
-operator==(const SymmetricTensor<rank_, dim, Number> &t) const
+SymmetricTensor<rank_, dim, Number>::operator==(
+  const SymmetricTensor<rank_, dim, Number> &t) const
 {
   return data == t.data;
 }
@@ -1583,8 +1588,8 @@ operator==(const SymmetricTensor<rank_, dim, Number> &t) const
 
 template <int rank_, int dim, typename Number>
 constexpr bool
-SymmetricTensor<rank_, dim, Number>::
-operator!=(const SymmetricTensor<rank_, dim, Number> &t) const
+SymmetricTensor<rank_, dim, Number>::operator!=(
+  const SymmetricTensor<rank_, dim, Number> &t) const
 {
   return data != t.data;
 }
@@ -1594,8 +1599,8 @@ operator!=(const SymmetricTensor<rank_, dim, Number> &t) const
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number> &
-                                       SymmetricTensor<rank_, dim, Number>::
-                                       operator+=(const SymmetricTensor<rank_, dim, OtherNumber> &t)
+SymmetricTensor<rank_, dim, Number>::operator+=(
+  const SymmetricTensor<rank_, dim, OtherNumber> &t)
 {
   data += t.data;
   return *this;
@@ -1606,8 +1611,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number> &
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number> &
-                                       SymmetricTensor<rank_, dim, Number>::
-                                       operator-=(const SymmetricTensor<rank_, dim, OtherNumber> &t)
+SymmetricTensor<rank_, dim, Number>::operator-=(
+  const SymmetricTensor<rank_, dim, OtherNumber> &t)
 {
   data -= t.data;
   return *this;
@@ -1815,8 +1820,8 @@ template <typename OtherNumber>
 DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE
   typename internal::SymmetricTensorAccessors::
     double_contraction_result<rank_, 2, dim, Number, OtherNumber>::type
-      SymmetricTensor<rank_, dim, Number>::
-      operator*(const SymmetricTensor<2, dim, OtherNumber> &s) const
+    SymmetricTensor<rank_, dim, Number>::operator*(
+      const SymmetricTensor<2, dim, OtherNumber> &s) const
 {
   // need to have two different function calls
   // because a scalar and rank-2 tensor are not
@@ -1832,8 +1837,8 @@ template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 DEAL_II_CONSTEXPR inline typename internal::SymmetricTensorAccessors::
   double_contraction_result<rank_, 4, dim, Number, OtherNumber>::type
-    SymmetricTensor<rank_, dim, Number>::
-    operator*(const SymmetricTensor<4, dim, OtherNumber> &s) const
+  SymmetricTensor<rank_, dim, Number>::operator*(
+    const SymmetricTensor<4, dim, OtherNumber> &s) const
 {
   typename internal::SymmetricTensorAccessors::
     double_contraction_result<rank_, 4, dim, Number, OtherNumber>::type tmp;
@@ -1872,9 +1877,9 @@ namespace internal
 
   template <int dim, typename Number>
   constexpr inline DEAL_II_ALWAYS_INLINE Number &
-                                         symmetric_tensor_access(const TableIndices<2> &indices,
-                                                                 typename SymmetricTensorAccessors::
-                                                                   StorageType<2, dim, Number>::base_tensor_type &data)
+  symmetric_tensor_access(const TableIndices<2> &indices,
+                          typename SymmetricTensorAccessors::
+                            StorageType<2, dim, Number>::base_tensor_type &data)
   {
     // 1d is very simple and done first
     if (dim == 1)
@@ -1918,9 +1923,9 @@ namespace internal
 
   template <int dim, typename Number>
   constexpr inline DEAL_II_ALWAYS_INLINE const Number &
-                                               symmetric_tensor_access(const TableIndices<2> &indices,
-                                                                       const typename SymmetricTensorAccessors::
-                                                                         StorageType<2, dim, Number>::base_tensor_type &data)
+  symmetric_tensor_access(const TableIndices<2> &indices,
+                          const typename SymmetricTensorAccessors::
+                            StorageType<2, dim, Number>::base_tensor_type &data)
   {
     // 1d is very simple and done first
     if (dim == 1)
@@ -2011,9 +2016,9 @@ namespace internal
 
   template <int dim, typename Number>
   constexpr inline DEAL_II_ALWAYS_INLINE const Number &
-                                               symmetric_tensor_access(const TableIndices<4> &indices,
-                                                                       const typename SymmetricTensorAccessors::
-                                                                         StorageType<4, dim, Number>::base_tensor_type &data)
+  symmetric_tensor_access(const TableIndices<4> &indices,
+                          const typename SymmetricTensorAccessors::
+                            StorageType<4, dim, Number>::base_tensor_type &data)
   {
     switch (dim)
       {
@@ -2061,8 +2066,8 @@ namespace internal
 
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number &
-                                       SymmetricTensor<rank_, dim, Number>::
-                                       operator()(const TableIndices<rank_> &indices)
+SymmetricTensor<rank_, dim, Number>::operator()(
+  const TableIndices<rank_> &indices)
 {
   for (unsigned int r = 0; r < rank; ++r)
     AssertIndexRange(indices[r], dimension);
@@ -2073,8 +2078,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE Number &
 
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE const Number &
-                                             SymmetricTensor<rank_, dim, Number>::
-                                             operator()(const TableIndices<rank_> &indices) const
+SymmetricTensor<rank_, dim, Number>::operator()(
+  const TableIndices<rank_> &indices) const
 {
   for (unsigned int r = 0; r < rank; ++r)
     AssertIndexRange(indices[r], dimension);
@@ -2113,8 +2118,7 @@ namespace internal
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE internal::SymmetricTensorAccessors::
   Accessor<rank_, dim, true, rank_ - 1, Number>
-    SymmetricTensor<rank_, dim, Number>::
-    operator[](const unsigned int row) const
+  SymmetricTensor<rank_, dim, Number>::operator[](const unsigned int row) const
 {
   return internal::SymmetricTensorAccessors::
     Accessor<rank_, dim, true, rank_ - 1, Number>(
@@ -2128,7 +2132,7 @@ constexpr DEAL_II_ALWAYS_INLINE internal::SymmetricTensorAccessors::
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE internal::SymmetricTensorAccessors::
   Accessor<rank_, dim, false, rank_ - 1, Number>
-    SymmetricTensor<rank_, dim, Number>::operator[](const unsigned int row)
+  SymmetricTensor<rank_, dim, Number>::operator[](const unsigned int row)
 {
   return internal::SymmetricTensorAccessors::
     Accessor<rank_, dim, false, rank_ - 1, Number>(
@@ -2141,8 +2145,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE internal::SymmetricTensorAccessors::
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE const Number &
-                                      SymmetricTensor<rank_, dim, Number>::
-                                      operator[](const TableIndices<rank_> &indices) const
+SymmetricTensor<rank_, dim, Number>::operator[](
+  const TableIndices<rank_> &indices) const
 {
   return operator()(indices);
 }
@@ -2151,8 +2155,8 @@ constexpr DEAL_II_ALWAYS_INLINE const Number &
 
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number &
-                                       SymmetricTensor<rank_, dim, Number>::
-                                       operator[](const TableIndices<rank_> &indices)
+SymmetricTensor<rank_, dim, Number>::operator[](
+  const TableIndices<rank_> &indices)
 {
   return operator()(indices);
 }
@@ -2452,8 +2456,8 @@ namespace internal
     // this function is for rank-2 tensors
     template <int dim>
     constexpr inline DEAL_II_ALWAYS_INLINE TableIndices<2>
-                                           unrolled_to_component_indices(const unsigned int i,
-                                                                         const std::integral_constant<int, 2> &)
+    unrolled_to_component_indices(const unsigned int i,
+                                  const std::integral_constant<int, 2> &)
     {
       Assert(
         (i < dealii::SymmetricTensor<2, dim, double>::n_independent_components),
@@ -2533,7 +2537,7 @@ namespace internal
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE TableIndices<rank_>
-                                SymmetricTensor<rank_, dim, Number>::unrolled_to_component_indices(
+SymmetricTensor<rank_, dim, Number>::unrolled_to_component_indices(
   const unsigned int i)
 {
   return internal::SymmetricTensorImplementation::unrolled_to_component_indices<
@@ -2690,7 +2694,7 @@ constexpr DEAL_II_ALWAYS_INLINE
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       determinant(const SymmetricTensor<2, dim, Number> &t)
+determinant(const SymmetricTensor<2, dim, Number> &t)
 {
   switch (dim)
     {
@@ -2730,7 +2734,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE Number
  */
 template <int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                third_invariant(const SymmetricTensor<2, dim, Number> &t)
+third_invariant(const SymmetricTensor<2, dim, Number> &t)
 {
   return determinant(t);
 }
@@ -2748,7 +2752,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       trace(const SymmetricTensor<2, dim, Number> &d)
+trace(const SymmetricTensor<2, dim, Number> &d)
 {
   Number t = d.data[0];
   for (unsigned int i = 1; i < dim; ++i)
@@ -2789,7 +2793,7 @@ first_invariant(const SymmetricTensor<2, dim, Number> &t)
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                second_invariant(const SymmetricTensor<2, 1, Number> &)
+second_invariant(const SymmetricTensor<2, 1, Number> &)
 {
   return internal::NumberType<Number>::value(0.0);
 }
@@ -2816,7 +2820,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                second_invariant(const SymmetricTensor<2, 2, Number> &t)
+second_invariant(const SymmetricTensor<2, 2, Number> &t)
 {
   return t[0][0] * t[1][1] - t[0][1] * t[0][1];
 }
@@ -2833,7 +2837,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                second_invariant(const SymmetricTensor<2, 3, Number> &t)
+second_invariant(const SymmetricTensor<2, 3, Number> &t)
 {
   return (t[0][0] * t[1][1] + t[1][1] * t[2][2] + t[2][2] * t[0][0] -
           t[0][1] * t[0][1] - t[0][2] * t[0][2] - t[1][2] * t[1][2]);
@@ -3046,7 +3050,7 @@ namespace internal
      */
     template <int dim, typename Number>
     std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
-      jacobi(dealii::SymmetricTensor<2, dim, Number> A);
+    jacobi(dealii::SymmetricTensor<2, dim, Number> A);
 
 
 
@@ -3238,7 +3242,7 @@ eigenvectors(const SymmetricTensor<2, dim, Number> &T,
  */
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>
-                                transpose(const SymmetricTensor<rank_, dim, Number> &t)
+transpose(const SymmetricTensor<rank_, dim, Number> &t)
 {
   return t;
 }
@@ -3257,7 +3261,7 @@ constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, Number>
-                                       deviator(const SymmetricTensor<2, dim, Number> &t)
+deviator(const SymmetricTensor<2, dim, Number> &t)
 {
   SymmetricTensor<2, dim, Number> tmp = t;
 
@@ -3441,7 +3445,7 @@ outer_product(const SymmetricTensor<2, dim, Number> &t1,
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, Number>
-                                       symmetrize(const Tensor<2, dim, Number> &t)
+symmetrize(const Tensor<2, dim, Number> &t)
 {
   SymmetricTensor<2, dim, Number> result;
   for (unsigned int d = 0; d < dim; ++d)
@@ -3465,7 +3469,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, Number>
  */
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>
-                                       operator*(const SymmetricTensor<rank_, dim, Number> &t, const Number &factor)
+operator*(const SymmetricTensor<rank_, dim, Number> &t, const Number &factor)
 {
   SymmetricTensor<rank_, dim, Number> tt = t;
   tt *= factor;
@@ -3483,7 +3487,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>
  */
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim, Number>
-                                operator*(const Number &factor, const SymmetricTensor<rank_, dim, Number> &t)
+operator*(const Number &factor, const SymmetricTensor<rank_, dim, Number> &t)
 {
   // simply forward to the other operator
   return t * factor;
@@ -3591,7 +3595,7 @@ operator/(const SymmetricTensor<rank_, dim, Number> &t,
  */
 template <int rank_, int dim>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim>
-                                       operator*(const SymmetricTensor<rank_, dim> &t, const double factor)
+operator*(const SymmetricTensor<rank_, dim> &t, const double factor)
 {
   SymmetricTensor<rank_, dim> tt(t);
   tt *= factor;
@@ -3608,7 +3612,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim>
  */
 template <int rank_, int dim>
 constexpr inline DEAL_II_ALWAYS_INLINE SymmetricTensor<rank_, dim>
-                                       operator*(const double factor, const SymmetricTensor<rank_, dim> &t)
+operator*(const double factor, const SymmetricTensor<rank_, dim> &t)
 {
   SymmetricTensor<rank_, dim> tt(t);
   tt *= factor;
@@ -3714,7 +3718,8 @@ scalar_product(const Tensor<2, dim, Number> &              t1,
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline DEAL_II_ALWAYS_INLINE void double_contract(
+constexpr inline DEAL_II_ALWAYS_INLINE void
+double_contract(
   SymmetricTensor<2, 1, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<4, 1, Number> &                                   t,
   const SymmetricTensor<2, 1, OtherNumber> &                              s)
@@ -3739,7 +3744,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE void double_contract(
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline void double_contract(
+constexpr inline void
+double_contract(
   SymmetricTensor<2, 1, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<2, 1, Number> &                                   s,
   const SymmetricTensor<4, 1, OtherNumber> &                              t)
@@ -3764,7 +3770,8 @@ constexpr inline void double_contract(
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline void double_contract(
+constexpr inline void
+double_contract(
   SymmetricTensor<2, 2, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<4, 2, Number> &                                   t,
   const SymmetricTensor<2, 2, OtherNumber> &                              s)
@@ -3794,7 +3801,8 @@ constexpr inline void double_contract(
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline void double_contract(
+constexpr inline void
+double_contract(
   SymmetricTensor<2, 2, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<2, 2, Number> &                                   s,
   const SymmetricTensor<4, 2, OtherNumber> &                              t)
@@ -3824,7 +3832,8 @@ constexpr inline void double_contract(
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline void double_contract(
+constexpr inline void
+double_contract(
   SymmetricTensor<2, 3, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<4, 3, Number> &                                   t,
   const SymmetricTensor<2, 3, OtherNumber> &                              s)
@@ -3855,7 +3864,8 @@ constexpr inline void double_contract(
  * @relatesalso SymmetricTensor
  */
 template <typename Number, typename OtherNumber>
-constexpr inline void double_contract(
+constexpr inline void
+double_contract(
   SymmetricTensor<2, 3, typename ProductType<Number, OtherNumber>::type> &tmp,
   const SymmetricTensor<2, 3, Number> &                                   s,
   const SymmetricTensor<4, 3, OtherNumber> &                              t)

--- a/include/deal.II/base/symmetric_tensor.templates.h
+++ b/include/deal.II/base/symmetric_tensor.templates.h
@@ -376,7 +376,7 @@ namespace internal
 
     template <int dim, typename Number>
     std::array<std::pair<Number, Tensor<1, dim, Number>>, dim>
-      jacobi(dealii::SymmetricTensor<2, dim, Number> A)
+    jacobi(dealii::SymmetricTensor<2, dim, Number> A)
     {
       static_assert(numbers::NumberTraits<Number>::is_complex == false,
                     "This implementation of the Jacobi algorithm does "

--- a/include/deal.II/base/synchronous_iterator.h
+++ b/include/deal.II/base/synchronous_iterator.h
@@ -58,13 +58,15 @@ struct SynchronousIterators
    * Dereference const operator. Returns a const reference to the iterators
    * represented by the current class.
    */
-  const Iterators &operator*() const;
+  const Iterators &
+  operator*() const;
 
   /**
    * Dereference operator. Returns a reference to the iterators
    * represented by the current class.
    */
-  Iterators &operator*();
+  Iterators &
+  operator*();
 
 private:
   /**
@@ -83,7 +85,8 @@ inline SynchronousIterators<Iterators>::SynchronousIterators(const Iterators &i)
 
 
 template <typename Iterators>
-inline const Iterators &SynchronousIterators<Iterators>::operator*() const
+inline const Iterators &
+SynchronousIterators<Iterators>::operator*() const
 {
   return iterators;
 }
@@ -91,7 +94,8 @@ inline const Iterators &SynchronousIterators<Iterators>::operator*() const
 
 
 template <typename Iterators>
-inline Iterators &SynchronousIterators<Iterators>::operator*()
+inline Iterators &
+SynchronousIterators<Iterators>::operator*()
 {
   return iterators;
 }

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -189,7 +189,8 @@ namespace internal
       /**
        * Index operator. Performs a range check.
        */
-      Accessor<N, T, C, P - 1> operator[](const size_type i) const;
+      Accessor<N, T, C, P - 1>
+      operator[](const size_type i) const;
 
       /**
        * Exception for range check. Do not use global exception since this way
@@ -285,7 +286,8 @@ namespace internal
       /**
        * Index operator. Performs a range check.
        */
-      reference operator[](const size_type) const;
+      reference
+      operator[](const size_type) const;
 
       /**
        * Return the length of one row, i.e. the number of elements
@@ -893,7 +895,8 @@ public:
    * Access operator. Since this is a one-dimensional object, this simply
    * accesses the requested data element. Returns a read-write reference.
    */
-  typename AlignedVector<T>::reference operator[](const size_type i);
+  typename AlignedVector<T>::reference
+  operator[](const size_type i);
 
   /**
    * Access operator. Since this is a one-dimensional object, this simply
@@ -2208,8 +2211,8 @@ namespace internal
 
 
     template <int N, typename T, bool C, unsigned int P>
-    inline Accessor<N, T, C, P - 1> Accessor<N, T, C, P>::
-                                    operator[](const size_type i) const
+    inline Accessor<N, T, C, P - 1>
+    Accessor<N, T, C, P>::operator[](const size_type i) const
     {
       AssertIndexRange(i, table.size()[N - P]);
 
@@ -2251,8 +2254,8 @@ namespace internal
 
 
     template <int N, typename T, bool C>
-    inline typename Accessor<N, T, C, 1>::reference Accessor<N, T, C, 1>::
-                                                    operator[](const size_type i) const
+    inline typename Accessor<N, T, C, 1>::reference
+    Accessor<N, T, C, 1>::operator[](const size_type i) const
     {
       AssertIndexRange(i, table.size()[N - 1]);
       return *(data + i);
@@ -2635,8 +2638,8 @@ inline Table<1, T>::Table(const size_type size,
 
 
 template <typename T>
-inline typename AlignedVector<T>::const_reference Table<1, T>::
-                                                  operator[](const size_type i) const
+inline typename AlignedVector<T>::const_reference
+Table<1, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   return this->values[i];
@@ -2645,8 +2648,8 @@ inline typename AlignedVector<T>::const_reference Table<1, T>::
 
 
 template <typename T>
-inline typename AlignedVector<T>::reference Table<1, T>::
-                                            operator[](const size_type i)
+inline typename AlignedVector<T>::reference
+Table<1, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   return this->values[i];
@@ -2709,7 +2712,7 @@ Table<2, T>::reinit(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<2, T, true, 1>
-  Table<2, T>::operator[](const size_type i) const
+Table<2, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   return dealii::internal::TableBaseAccessors::Accessor<2, T, true, 1>(
@@ -2720,7 +2723,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<2, T, true, 1>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<2, T, false, 1>
-  Table<2, T>::operator[](const size_type i)
+Table<2, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   return dealii::internal::TableBaseAccessors::Accessor<2, T, false, 1>(
@@ -3222,7 +3225,7 @@ inline Table<3, T>::Table(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<3, T, true, 2>
-  Table<3, T>::operator[](const size_type i) const
+Table<3, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =
@@ -3235,7 +3238,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<3, T, true, 2>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<3, T, false, 2>
-  Table<3, T>::operator[](const size_type i)
+Table<3, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =
@@ -3248,8 +3251,9 @@ inline dealii::internal::TableBaseAccessors::Accessor<3, T, false, 2>
 
 template <typename T>
 inline typename AlignedVector<T>::const_reference
-Table<3, T>::
-operator()(const size_type i, const size_type j, const size_type k) const
+Table<3, T>::operator()(const size_type i,
+                        const size_type j,
+                        const size_type k) const
 {
   AssertIndexRange(i, this->table_size[0]);
   AssertIndexRange(j, this->table_size[1]);
@@ -3287,7 +3291,7 @@ inline Table<4, T>::Table(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<4, T, true, 3>
-  Table<4, T>::operator[](const size_type i) const
+Table<4, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =
@@ -3300,7 +3304,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<4, T, true, 3>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<4, T, false, 3>
-  Table<4, T>::operator[](const size_type i)
+Table<4, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =
@@ -3364,7 +3368,7 @@ inline Table<5, T>::Table(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<5, T, true, 4>
-  Table<5, T>::operator[](const size_type i) const
+Table<5, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
@@ -3378,7 +3382,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<5, T, true, 4>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<5, T, false, 4>
-  Table<5, T>::operator[](const size_type i)
+Table<5, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
@@ -3462,7 +3466,7 @@ inline Table<6, T>::Table(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<6, T, true, 5>
-  Table<6, T>::operator[](const size_type i) const
+Table<6, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
@@ -3476,7 +3480,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<6, T, true, 5>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<6, T, false, 5>
-  Table<6, T>::operator[](const size_type i)
+Table<6, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size = size_type(this->table_size[1]) *
@@ -3570,7 +3574,7 @@ inline Table<7, T>::Table(const size_type size1,
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<7, T, true, 6>
-  Table<7, T>::operator[](const size_type i) const
+Table<7, T>::operator[](const size_type i) const
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =
@@ -3584,7 +3588,7 @@ inline dealii::internal::TableBaseAccessors::Accessor<7, T, true, 6>
 
 template <typename T>
 inline dealii::internal::TableBaseAccessors::Accessor<7, T, false, 6>
-  Table<7, T>::operator[](const size_type i)
+Table<7, T>::operator[](const size_type i)
 {
   AssertIndexRange(i, this->table_size[0]);
   const size_type subobject_size =

--- a/include/deal.II/base/table_indices.h
+++ b/include/deal.II/base/table_indices.h
@@ -66,12 +66,14 @@ public:
   /**
    * Read-only access the value of the <tt>i</tt>th index.
    */
-  constexpr std::size_t operator[](const unsigned int i) const;
+  constexpr std::size_t
+  operator[](const unsigned int i) const;
 
   /**
    * Write access the value of the <tt>i</tt>th index.
    */
-  constexpr std::size_t &operator[](const unsigned int i);
+  constexpr std::size_t &
+  operator[](const unsigned int i);
 
   /**
    * Compare two index fields for equality.
@@ -125,8 +127,8 @@ constexpr TableIndices<N>::TableIndices(const T... args)
 
 
 template <int N>
-constexpr inline std::size_t TableIndices<N>::
-                             operator[](const unsigned int i) const
+constexpr inline std::size_t
+TableIndices<N>::operator[](const unsigned int i) const
 {
   AssertIndexRange(i, N);
   return indices[i];
@@ -134,7 +136,8 @@ constexpr inline std::size_t TableIndices<N>::
 
 
 template <int N>
-constexpr inline std::size_t &TableIndices<N>::operator[](const unsigned int i)
+constexpr inline std::size_t &
+TableIndices<N>::operator[](const unsigned int i)
 {
   AssertIndexRange(i, N);
   return indices[i];

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -177,7 +177,7 @@ public:
    * Move constructor
    */
   constexpr DEAL_II_CUDA_HOST_DEV
-    Tensor(Tensor<0, dim, Number> &&other) noexcept;
+  Tensor(Tensor<0, dim, Number> &&other) noexcept;
 #endif
 
   /**
@@ -214,7 +214,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_CUDA_HOST_DEV operator Number &();
+  constexpr DEAL_II_CUDA_HOST_DEV
+  operator Number &();
 
   /**
    * Return a reference to the encapsulated Number object. Since rank-0
@@ -235,7 +236,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator=(const Tensor<0, dim, OtherNumber> &rhs);
+  operator=(const Tensor<0, dim, OtherNumber> &rhs);
 
 #if defined(__INTEL_COMPILER) || defined(DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG)
   /**
@@ -255,7 +256,7 @@ public:
    * Move assignment operator
    */
   constexpr DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
-                                  operator=(Tensor<0, dim, Number> &&other) noexcept;
+  operator=(Tensor<0, dim, Number> &&other) noexcept;
 #endif
 
   /**
@@ -289,7 +290,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator+=(const Tensor<0, dim, OtherNumber> &rhs);
+  operator+=(const Tensor<0, dim, OtherNumber> &rhs);
 
   /**
    * Subtract another scalar.
@@ -298,7 +299,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator-=(const Tensor<0, dim, OtherNumber> &rhs);
+  operator-=(const Tensor<0, dim, OtherNumber> &rhs);
 
   /**
    * Multiply the scalar with a <tt>factor</tt>.
@@ -324,7 +325,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   constexpr DEAL_II_CUDA_HOST_DEV Tensor
-                                  operator-() const;
+  operator-() const;
 
   /**
    * Reset all values to zero.
@@ -356,7 +357,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   constexpr DEAL_II_CUDA_HOST_DEV real_type
-                                  norm_square() const;
+  norm_square() const;
 
   /**
    * Read or write the data of this object to or from a stream for the purpose
@@ -517,7 +518,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                  Tensor();
+  Tensor();
 
   /**
    * A constructor where the data is copied from a C-style array.
@@ -586,7 +587,8 @@ public:
    *
    * @note This function can also be used in CUDA device code.
    */
-  constexpr DEAL_II_CUDA_HOST_DEV value_type &operator[](const unsigned int i);
+  constexpr DEAL_II_CUDA_HOST_DEV value_type &
+                                  operator[](const unsigned int i);
 
   /**
    * Read-only access operator.
@@ -599,12 +601,14 @@ public:
   /**
    * Read access using TableIndices <tt>indices</tt>
    */
-  constexpr const Number &operator[](const TableIndices<rank_> &indices) const;
+  constexpr const Number &
+  operator[](const TableIndices<rank_> &indices) const;
 
   /**
    * Read and write access using TableIndices <tt>indices</tt>
    */
-  constexpr Number &operator[](const TableIndices<rank_> &indices);
+  constexpr Number &
+  operator[](const TableIndices<rank_> &indices);
 
   /**
    * Return a pointer to the first element of the underlying storage.
@@ -639,7 +643,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator=(const Tensor<rank_, dim, OtherNumber> &rhs);
+  operator=(const Tensor<rank_, dim, OtherNumber> &rhs);
 
   /**
    * This operator assigns a scalar to a tensor. To avoid confusion with what
@@ -685,7 +689,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator+=(const Tensor<rank_, dim, OtherNumber> &);
+  operator+=(const Tensor<rank_, dim, OtherNumber> &);
 
   /**
    * Subtract another tensor.
@@ -694,7 +698,7 @@ public:
    */
   template <typename OtherNumber>
   constexpr DEAL_II_CUDA_HOST_DEV Tensor &
-                                  operator-=(const Tensor<rank_, dim, OtherNumber> &);
+  operator-=(const Tensor<rank_, dim, OtherNumber> &);
 
   /**
    * Scale the tensor by <tt>factor</tt>, i.e. multiply all components by
@@ -721,7 +725,7 @@ public:
    * @note This function can also be used in CUDA device code.
    */
   constexpr DEAL_II_CUDA_HOST_DEV Tensor
-                                  operator-() const;
+  operator-() const;
 
   /**
    * Reset all values to zero.
@@ -887,7 +891,7 @@ namespace internal
   struct NumberType<Tensor<rank, dim, T>>
   {
     static constexpr DEAL_II_ALWAYS_INLINE const Tensor<rank, dim, T> &
-                                                 value(const Tensor<rank, dim, T> &t)
+    value(const Tensor<rank, dim, T> &t)
     {
       return t;
     }
@@ -908,7 +912,7 @@ namespace internal
 
 template <int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, Number>::Tensor()
+Tensor<0, dim, Number>::Tensor()
   // Some auto-differentiable numbers need explicit
   // zero initialization such as adtl::adouble.
   : Tensor{0.0}
@@ -919,7 +923,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 template <int dim, typename Number>
 template <typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
+Tensor<0, dim, Number>::Tensor(const OtherNumber &initializer)
   : value(internal::NumberType<Number>::value(initializer))
 {}
 
@@ -928,7 +932,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 template <int dim, typename Number>
 template <typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
+Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, OtherNumber> &p)
   : Tensor{p.value}
 {}
 
@@ -936,7 +940,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
+Tensor<0, dim, Number>::Tensor(const Tensor<0, dim, Number> &other)
   : value{other.value}
 {}
 
@@ -944,7 +948,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 
 template <int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, Number>::Tensor(Tensor<0, dim, Number> &&other) noexcept
+Tensor<0, dim, Number>::Tensor(Tensor<0, dim, Number> &&other) noexcept
   : value{std::move(other.value)}
 {}
 #  endif
@@ -987,8 +991,8 @@ Tensor<0, dim, Number>::end_raw() const
 
 
 template <int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE
-  DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number>::operator Number &()
+constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
+Tensor<0, dim, Number>::operator Number &()
 {
   // We cannot use Assert inside a CUDA kernel
 #  ifndef __CUDA_ARCH__
@@ -1037,7 +1041,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
 #  ifdef DEAL_II_DELETED_MOVE_CONSTRUCTOR_BUG
 template <int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV Tensor<0, dim, Number> &
-  Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
+Tensor<0, dim, Number>::operator=(Tensor<0, dim, Number> &&other) noexcept
 {
   value = std::move(other.value);
   return *this;
@@ -1112,7 +1116,7 @@ namespace internal
   {
     template <typename Number, typename OtherNumber>
     constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV void
-                                           multiply_assign_scalar(Number &val, const OtherNumber &s)
+    multiply_assign_scalar(Number &val, const OtherNumber &s)
     {
       val *= s;
     }
@@ -1120,7 +1124,7 @@ namespace internal
 #  ifdef __CUDA_ARCH__
     template <typename Number, typename OtherNumber>
     constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV void
-                                           multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
+    multiply_assign_scalar(std::complex<Number> &, const OtherNumber &)
     {
       printf("This function is not implemented for std::complex<Number>!\n");
       assert(false);
@@ -1225,7 +1229,7 @@ constexpr unsigned int Tensor<0, dim, Number>::n_independent_components;
 template <int rank_, int dim, typename Number>
 template <typename ArrayLike, std::size_t... indices>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
+Tensor<rank_, dim, Number>::Tensor(const ArrayLike &initializer,
                                    std::index_sequence<indices...>)
   : values{Tensor<rank_ - 1, dim, Number>(initializer[indices])...}
 {
@@ -1237,7 +1241,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<rank_, dim, Number>::Tensor()
+Tensor<rank_, dim, Number>::Tensor()
   // We would like to use =default, but this causes compile errors with some
   // MSVC versions and internal compiler errors with -O1 in gcc 5.4.
   : values{}
@@ -1247,7 +1251,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
+Tensor<rank_, dim, Number>::Tensor(const array_type &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
 {}
 
@@ -1256,7 +1260,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 template <int rank_, int dim, typename Number>
 template <typename ElementType, typename MemorySpace>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<rank_, dim, Number>::Tensor(
+Tensor<rank_, dim, Number>::Tensor(
   const ArrayView<ElementType, MemorySpace> &initializer)
 {
   AssertDimension(initializer.size(), n_independent_components);
@@ -1270,7 +1274,7 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<rank_, dim, Number>::Tensor(
+Tensor<rank_, dim, Number>::Tensor(
   const Tensor<rank_, dim, OtherNumber> &initializer)
   : Tensor(initializer, std::make_index_sequence<dim>{})
 {}
@@ -1290,7 +1294,7 @@ Tensor<rank_, dim, Number>::Tensor(
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE Tensor<rank_, dim, Number>::
-                                operator Tensor<1, dim, Tensor<rank_ - 1, dim, OtherNumber>>() const
+operator Tensor<1, dim, Tensor<rank_ - 1, dim, OtherNumber>>() const
 {
   return Tensor<1, dim, Tensor<rank_ - 1, dim, Number>>(values);
 }
@@ -1370,9 +1374,9 @@ namespace internal
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE             DEAL_II_CUDA_HOST_DEV
-  typename Tensor<rank_, dim, Number>::value_type &Tensor<rank_, dim, Number>::
-                                                   operator[](const unsigned int i)
+constexpr inline DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
+  typename Tensor<rank_, dim, Number>::value_type &
+  Tensor<rank_, dim, Number>::operator[](const unsigned int i)
 {
   return dealii::internal::TensorSubscriptor::subscript(
     values, i, std::integral_constant<int, dim>());
@@ -1381,8 +1385,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE             DEAL_II_CUDA_HOST_DEV
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE
-    DEAL_II_CUDA_HOST_DEV const typename Tensor<rank_, dim, Number>::value_type &
-    Tensor<rank_, dim, Number>::operator[](const unsigned int i) const
+  DEAL_II_CUDA_HOST_DEV const typename Tensor<rank_, dim, Number>::value_type &
+  Tensor<rank_, dim, Number>::operator[](const unsigned int i) const
 {
 #  ifndef DEAL_II_COMPILER_CUDA_AWARE
   AssertIndexRange(i, dim);
@@ -1394,8 +1398,7 @@ constexpr DEAL_II_ALWAYS_INLINE
 
 template <int rank_, int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE const Number &
-                                             Tensor<rank_, dim, Number>::
-                                             operator[](const TableIndices<rank_> &indices) const
+Tensor<rank_, dim, Number>::operator[](const TableIndices<rank_> &indices) const
 {
 #  ifndef DEAL_II_COMPILER_CUDA_AWARE
   Assert(dim != 0,
@@ -1408,8 +1411,8 @@ constexpr inline DEAL_II_ALWAYS_INLINE const Number &
 
 
 template <int rank_, int dim, typename Number>
-constexpr inline DEAL_II_ALWAYS_INLINE Number &Tensor<rank_, dim, Number>::
-                                               operator[](const TableIndices<rank_> &indices)
+constexpr inline DEAL_II_ALWAYS_INLINE Number &
+Tensor<rank_, dim, Number>::operator[](const TableIndices<rank_> &indices)
 {
 #  ifndef DEAL_II_COMPILER_CUDA_AWARE
   Assert(dim != 0,
@@ -1500,8 +1503,8 @@ Tensor<rank_, dim, Number>::operator=(const Tensor<rank_, dim, Number> &other)
 
 template <int rank_, int dim, typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Tensor<rank_, dim, Number> &
-                                Tensor<rank_, dim, Number>::
-                                operator=(Tensor<rank_, dim, Number> &&other) noexcept
+Tensor<rank_, dim, Number>::operator=(
+  Tensor<rank_, dim, Number> &&other) noexcept
 {
   for (unsigned int i = 0; i < dim; ++i)
     values[i] = other.values[i];
@@ -1513,8 +1516,8 @@ constexpr DEAL_II_ALWAYS_INLINE Tensor<rank_, dim, Number> &
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline bool
-Tensor<rank_, dim, Number>::
-operator==(const Tensor<rank_, dim, OtherNumber> &p) const
+Tensor<rank_, dim, Number>::operator==(
+  const Tensor<rank_, dim, OtherNumber> &p) const
 {
   for (unsigned int i = 0; i < dim; ++i)
     if (values[i] != p.values[i])
@@ -1540,8 +1543,8 @@ Tensor<1, 0, double>::operator==(const Tensor<1, 0, double> &) const
 template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr bool
-Tensor<rank_, dim, Number>::
-operator!=(const Tensor<rank_, dim, OtherNumber> &p) const
+Tensor<rank_, dim, Number>::operator!=(
+  const Tensor<rank_, dim, OtherNumber> &p) const
 {
   return !((*this) == p);
 }
@@ -1551,8 +1554,8 @@ template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
   DEAL_II_CUDA_HOST_DEV Tensor<rank_, dim, Number> &
-                        Tensor<rank_, dim, Number>::
-                        operator+=(const Tensor<rank_, dim, OtherNumber> &p)
+  Tensor<rank_, dim, Number>::operator+=(
+    const Tensor<rank_, dim, OtherNumber> &p)
 {
   for (unsigned int i = 0; i < dim; ++i)
     values[i] += p.values[i];
@@ -1564,8 +1567,8 @@ template <int rank_, int dim, typename Number>
 template <typename OtherNumber>
 constexpr inline DEAL_II_ALWAYS_INLINE
   DEAL_II_CUDA_HOST_DEV Tensor<rank_, dim, Number> &
-                        Tensor<rank_, dim, Number>::
-                        operator-=(const Tensor<rank_, dim, OtherNumber> &p)
+  Tensor<rank_, dim, Number>::operator-=(
+    const Tensor<rank_, dim, OtherNumber> &p)
 {
   for (unsigned int i = 0; i < dim; ++i)
     values[i] -= p.values[i];
@@ -1945,8 +1948,8 @@ DEAL_II_CUDA_HOST_DEV constexpr DEAL_II_ALWAYS_INLINE
  */
 template <int dim, typename Number, typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
-                                operator+(const Tensor<0, dim, Number> &     p,
+  Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
+  operator+(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)
 {
   return static_cast<const Number &>(p) + static_cast<const OtherNumber &>(q);
@@ -1962,8 +1965,8 @@ constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
  */
 template <int dim, typename Number, typename OtherNumber>
 constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV
-                                Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
-                                operator-(const Tensor<0, dim, Number> &     p,
+  Tensor<0, dim, typename ProductType<Number, OtherNumber>::type>
+  operator-(const Tensor<0, dim, Number> &     p,
             const Tensor<0, dim, OtherNumber> &q)
 {
   return static_cast<const Number &>(p) - static_cast<const OtherNumber &>(q);
@@ -2466,8 +2469,10 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  * @relatesalso Tensor
  */
 template <template <int, int, typename> class TensorT1,
-          template <int, int, typename> class TensorT2,
-          template <int, int, typename> class TensorT3,
+          template <int, int, typename>
+          class TensorT2,
+          template <int, int, typename>
+          class TensorT3,
           int rank_1,
           int rank_2,
           int dim,
@@ -2536,7 +2541,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, Number>
-                                       cross_product_2d(const Tensor<1, dim, Number> &src)
+cross_product_2d(const Tensor<1, dim, Number> &src)
 {
   Assert(dim == 2, ExcInternalError());
 
@@ -2595,7 +2600,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       determinant(const Tensor<2, dim, Number> &t)
+determinant(const Tensor<2, dim, Number> &t)
 {
   // Compute the determinant using the Laplace expansion of the
   // determinant. We expand along the last row.
@@ -2623,7 +2628,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE Number
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                determinant(const Tensor<2, 1, Number> &t)
+determinant(const Tensor<2, 1, Number> &t)
 {
   return t[0][0];
 }
@@ -2635,7 +2640,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                determinant(const Tensor<2, 2, Number> &t)
+determinant(const Tensor<2, 2, Number> &t)
 {
   // hard-coded for efficiency reasons
   return t[0][0] * t[1][1] - t[1][0] * t[0][1];
@@ -2648,7 +2653,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <typename Number>
 constexpr DEAL_II_ALWAYS_INLINE Number
-                                determinant(const Tensor<2, 3, Number> &t)
+determinant(const Tensor<2, 3, Number> &t)
 {
   // hard-coded for efficiency reasons
   const Number C0 = internal::NumberType<Number>::value(t[1][1] * t[2][2]) -
@@ -2669,7 +2674,7 @@ constexpr DEAL_II_ALWAYS_INLINE Number
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Number
-                                       trace(const Tensor<2, dim, Number> &d)
+trace(const Tensor<2, dim, Number> &d)
 {
   Number t = d[0][0];
   for (unsigned int i = 1; i < dim; ++i)
@@ -2775,7 +2780,7 @@ constexpr inline DEAL_II_ALWAYS_INLINE Tensor<2, 3, Number>
  */
 template <int dim, typename Number>
 constexpr inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, Number>
-                                       transpose(const Tensor<2, dim, Number> &t)
+transpose(const Tensor<2, dim, Number> &t)
 {
   Tensor<2, dim, Number> tt;
   for (unsigned int i = 0; i < dim; ++i)

--- a/include/deal.II/base/tensor_accessors.h
+++ b/include/deal.II/base/tensor_accessors.h
@@ -412,7 +412,7 @@ namespace TensorAccessors
 
       // Recurse by applying index j directly:
       constexpr DEAL_II_ALWAYS_INLINE value_type
-                                      operator[](unsigned int j) const
+      operator[](unsigned int j) const
       {
         return value_type(t_[j]);
       }
@@ -443,7 +443,7 @@ namespace TensorAccessors
       using value_type = StoreIndex<rank - 1, internal::Identity<T>>;
 
       constexpr DEAL_II_ALWAYS_INLINE value_type
-                                      operator[](unsigned int j) const
+      operator[](unsigned int j) const
       {
         return value_type(Identity<T>(t_), j);
       }
@@ -467,7 +467,7 @@ namespace TensorAccessors
         typename ReferenceType<typename ValueType<T>::value_type>::type;
 
       constexpr DEAL_II_ALWAYS_INLINE value_type
-                                      operator[](unsigned int j) const
+      operator[](unsigned int j) const
       {
         return t_[j];
       }
@@ -521,7 +521,7 @@ namespace TensorAccessors
       using value_type = StoreIndex<rank - 1, StoreIndex<rank, S>>;
 
       constexpr DEAL_II_ALWAYS_INLINE value_type
-                                      operator[](unsigned int j) const
+      operator[](unsigned int j) const
       {
         return value_type(*this, j);
       }

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -142,7 +142,8 @@ public:
    * Dereferencing operator (const version): returns the value of the current
    * lane.
    */
-  const typename T::value_type &operator*() const
+  const typename T::value_type &
+  operator*() const
   {
     AssertIndexRange(lane, T::size());
     return (*data)[lane];
@@ -428,7 +429,8 @@ public:
    * specialization).
    */
   DEAL_II_ALWAYS_INLINE
-  Number &operator[](const unsigned int comp)
+  Number &
+  operator[](const unsigned int comp)
   {
     (void)comp;
     AssertIndexRange(comp, 1);
@@ -440,7 +442,8 @@ public:
    * without specialization).
    */
   DEAL_II_ALWAYS_INLINE
-  const Number &operator[](const unsigned int comp) const
+  const Number &
+  operator[](const unsigned int comp) const
   {
     (void)comp;
     AssertIndexRange(comp, 1);
@@ -719,7 +722,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             make_vectorized_array(const typename VectorizedArrayType::value_type &u)
+make_vectorized_array(const typename VectorizedArrayType::value_type &u)
 {
   static_assert(
     std::is_same<VectorizedArrayType,
@@ -955,7 +958,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  double &operator[](const unsigned int comp)
+  double &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 8);
     return *(reinterpret_cast<double *>(&data) + comp);
@@ -965,7 +969,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const double &operator[](const unsigned int comp) const
+  const double &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 8);
     return *(reinterpret_cast<const double *>(&data) + comp);
@@ -1502,7 +1507,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  float &operator[](const unsigned int comp)
+  float &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 16);
     return *(reinterpret_cast<float *>(&data) + comp);
@@ -1512,7 +1518,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const float &operator[](const unsigned int comp) const
+  const float &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 16);
     return *(reinterpret_cast<const float *>(&data) + comp);
@@ -2145,7 +2152,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  double &operator[](const unsigned int comp)
+  double &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<double *>(&data) + comp);
@@ -2155,7 +2163,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const double &operator[](const unsigned int comp) const
+  const double &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<const double *>(&data) + comp);
@@ -2651,7 +2660,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  float &operator[](const unsigned int comp)
+  float &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 8);
     return *(reinterpret_cast<float *>(&data) + comp);
@@ -2661,7 +2671,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const float &operator[](const unsigned int comp) const
+  const float &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 8);
     return *(reinterpret_cast<const float *>(&data) + comp);
@@ -3191,7 +3202,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  double &operator[](const unsigned int comp)
+  double &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 2);
     return *(reinterpret_cast<double *>(&data) + comp);
@@ -3201,7 +3213,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const double &operator[](const unsigned int comp) const
+  const double &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 2);
     return *(reinterpret_cast<const double *>(&data) + comp);
@@ -3628,7 +3641,8 @@ public:
    * Access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  float &operator[](const unsigned int comp)
+  float &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<float *>(&data) + comp);
@@ -3638,7 +3652,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const float &operator[](const unsigned int comp) const
+  const float &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<const float *>(&data) + comp);
@@ -4106,7 +4121,8 @@ public:
    * Access operator. The component must be either 0 or 1.
    */
   DEAL_II_ALWAYS_INLINE
-  double &operator[](const unsigned int comp)
+  double &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 2);
     return *(reinterpret_cast<double *>(&data) + comp);
@@ -4116,7 +4132,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const double &operator[](const unsigned int comp) const
+  const double &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 2);
     return *(reinterpret_cast<const double *>(&data) + comp);
@@ -4340,7 +4357,8 @@ public:
    * Access operator. The component must be between 0 and 3.
    */
   DEAL_II_ALWAYS_INLINE
-  float &operator[](const unsigned int comp)
+  float &
+  operator[](const unsigned int comp)
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<float *>(&data) + comp);
@@ -4350,7 +4368,8 @@ public:
    * Constant access operator.
    */
   DEAL_II_ALWAYS_INLINE
-  const float &operator[](const unsigned int comp) const
+  const float &
+  operator[](const unsigned int comp) const
   {
     AssertIndexRange(comp, 4);
     return *(reinterpret_cast<const float *>(&data) + comp);
@@ -4621,7 +4640,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator+(const Number &u, const VectorizedArray<Number, width> &v)
+operator+(const Number &u, const VectorizedArray<Number, width> &v)
 {
   VectorizedArray<Number, width> tmp = u;
   return tmp += v;
@@ -4637,7 +4656,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator+(const double u, const VectorizedArray<float, width> &v)
+operator+(const double u, const VectorizedArray<float, width> &v)
 {
   VectorizedArray<float, width> tmp = u;
   return tmp += v;
@@ -4651,7 +4670,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator+(const VectorizedArray<Number, width> &v, const Number &u)
+operator+(const VectorizedArray<Number, width> &v, const Number &u)
 {
   return u + v;
 }
@@ -4666,7 +4685,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator+(const VectorizedArray<float, width> &v, const double u)
+operator+(const VectorizedArray<float, width> &v, const double u)
 {
   return u + v;
 }
@@ -4679,7 +4698,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator-(const Number &u, const VectorizedArray<Number, width> &v)
+operator-(const Number &u, const VectorizedArray<Number, width> &v)
 {
   VectorizedArray<Number, width> tmp = u;
   return tmp -= v;
@@ -4695,7 +4714,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator-(const double u, const VectorizedArray<float, width> &v)
+operator-(const double u, const VectorizedArray<float, width> &v)
 {
   VectorizedArray<float, width> tmp = static_cast<float>(u);
   return tmp -= v;
@@ -4709,7 +4728,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator-(const VectorizedArray<Number, width> &v, const Number &u)
+operator-(const VectorizedArray<Number, width> &v, const Number &u)
 {
   VectorizedArray<Number, width> tmp = u;
   return v - tmp;
@@ -4725,7 +4744,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator-(const VectorizedArray<float, width> &v, const double u)
+operator-(const VectorizedArray<float, width> &v, const double u)
 {
   VectorizedArray<float, width> tmp = static_cast<float>(u);
   return v - tmp;
@@ -4739,7 +4758,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator*(const Number &u, const VectorizedArray<Number, width> &v)
+operator*(const Number &u, const VectorizedArray<Number, width> &v)
 {
   VectorizedArray<Number, width> tmp = u;
   return tmp *= v;
@@ -4755,7 +4774,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator*(const double u, const VectorizedArray<float, width> &v)
+operator*(const double u, const VectorizedArray<float, width> &v)
 {
   VectorizedArray<float, width> tmp = static_cast<float>(u);
   return tmp *= v;
@@ -4769,7 +4788,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator*(const VectorizedArray<Number, width> &v, const Number &u)
+operator*(const VectorizedArray<Number, width> &v, const Number &u)
 {
   return u * v;
 }
@@ -4784,7 +4803,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator*(const VectorizedArray<float, width> &v, const double u)
+operator*(const VectorizedArray<float, width> &v, const double u)
 {
   return u * v;
 }
@@ -4797,7 +4816,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator/(const Number &u, const VectorizedArray<Number, width> &v)
+operator/(const Number &u, const VectorizedArray<Number, width> &v)
 {
   VectorizedArray<Number, width> tmp = u;
   return tmp /= v;
@@ -4813,7 +4832,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator/(const double u, const VectorizedArray<float, width> &v)
+operator/(const double u, const VectorizedArray<float, width> &v)
 {
   VectorizedArray<float, width> tmp = static_cast<float>(u);
   return tmp /= v;
@@ -4827,7 +4846,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
  */
 template <typename Number, std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
-                             operator/(const VectorizedArray<Number, width> &v, const Number &u)
+operator/(const VectorizedArray<Number, width> &v, const Number &u)
 {
   VectorizedArray<Number, width> tmp = u;
   return v / tmp;
@@ -4843,7 +4862,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArray<Number, width>
  */
 template <std::size_t width>
 inline DEAL_II_ALWAYS_INLINE VectorizedArray<float, width>
-                             operator/(const VectorizedArray<float, width> &v, const double u)
+operator/(const VectorizedArray<float, width> &v, const double u)
 {
   VectorizedArray<float, width> tmp = static_cast<float>(u);
   return v / tmp;

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -1434,20 +1434,21 @@ namespace WorkStream
       const unsigned int chunk_size   = 8)
   {
     // forward to the other function
-    run(begin,
-        end,
-        [&main_object, worker](const Iterator &iterator,
-                               ScratchData &   scratch_data,
-                               CopyData &      copy_data) {
-          (main_object.*worker)(iterator, scratch_data, copy_data);
-        },
-        [&main_object, copier](const CopyData &copy_data) {
-          (main_object.*copier)(copy_data);
-        },
-        sample_scratch_data,
-        sample_copy_data,
-        queue_length,
-        chunk_size);
+    run(
+      begin,
+      end,
+      [&main_object, worker](const Iterator &iterator,
+                             ScratchData &   scratch_data,
+                             CopyData &      copy_data) {
+        (main_object.*worker)(iterator, scratch_data, copy_data);
+      },
+      [&main_object, copier](const CopyData &copy_data) {
+        (main_object.*copier)(copy_data);
+      },
+      sample_scratch_data,
+      sample_copy_data,
+      queue_length,
+      chunk_size);
   }
 
 
@@ -1467,20 +1468,21 @@ namespace WorkStream
       const unsigned int chunk_size   = 8)
   {
     // forward to the other function
-    run(begin,
-        end,
-        [&main_object, worker](const Iterator &iterator,
-                               ScratchData &   scratch_data,
-                               CopyData &      copy_data) {
-          (main_object.*worker)(iterator, scratch_data, copy_data);
-        },
-        [&main_object, copier](const CopyData &copy_data) {
-          (main_object.*copier)(copy_data);
-        },
-        sample_scratch_data,
-        sample_copy_data,
-        queue_length,
-        chunk_size);
+    run(
+      begin,
+      end,
+      [&main_object, worker](const Iterator &iterator,
+                             ScratchData &   scratch_data,
+                             CopyData &      copy_data) {
+        (main_object.*worker)(iterator, scratch_data, copy_data);
+      },
+      [&main_object, copier](const CopyData &copy_data) {
+        (main_object.*copier)(copy_data);
+      },
+      sample_scratch_data,
+      sample_copy_data,
+      queue_length,
+      chunk_size);
   }
 
 

--- a/include/deal.II/differentiation/ad/ad_helpers.h
+++ b/include/deal.II/differentiation/ad/ad_helpers.h
@@ -2449,9 +2449,10 @@ namespace Differentiation
        * @p t to the given @p value.
        */
       template <int dim, typename NumberType>
-      inline void set_tensor_entry(Tensor<0, dim, NumberType> &t,
-                                   const unsigned int          unrolled_index,
-                                   const NumberType &          value)
+      inline void
+      set_tensor_entry(Tensor<0, dim, NumberType> &t,
+                       const unsigned int          unrolled_index,
+                       const NumberType &          value)
       {
         AssertIndexRange(unrolled_index, 1);
         (void)unrolled_index;
@@ -2482,10 +2483,11 @@ namespace Differentiation
        * @p t to the given @p value.
        */
       template <int dim, typename NumberType>
-      inline void set_tensor_entry(SymmetricTensor<4, dim, NumberType> &t,
-                                   const unsigned int unrolled_index_row,
-                                   const unsigned int unrolled_index_col,
-                                   const NumberType & value)
+      inline void
+      set_tensor_entry(SymmetricTensor<4, dim, NumberType> &t,
+                       const unsigned int                   unrolled_index_row,
+                       const unsigned int                   unrolled_index_col,
+                       const NumberType &                   value)
       {
         // Fourth order symmetric tensors require a specialized interface
         // to extract values.
@@ -2510,7 +2512,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename NumberType,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       inline NumberType
       get_tensor_entry(const TensorType<rank, dim, NumberType> &t,
                        const unsigned int                       unrolled_index)
@@ -2528,7 +2531,8 @@ namespace Differentiation
        */
       template <int dim,
                 typename NumberType,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       inline NumberType
       get_tensor_entry(const TensorType<0, dim, NumberType> &t,
                        const unsigned int                    unrolled_index)
@@ -2561,7 +2565,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename NumberType,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       inline NumberType &
       get_tensor_entry(TensorType<rank, dim, NumberType> &t,
                        const unsigned int                 unrolled_index)
@@ -2579,9 +2584,11 @@ namespace Differentiation
        */
       template <int dim,
                 typename NumberType,
-                template <int, int, typename> class TensorType>
-      NumberType &get_tensor_entry(TensorType<0, dim, NumberType> &t,
-                                   const unsigned int              index)
+                template <int, int, typename>
+                class TensorType>
+      NumberType &
+      get_tensor_entry(TensorType<0, dim, NumberType> &t,
+                       const unsigned int              index)
       {
         AssertIndexRange(index, 1);
         (void)index;

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -986,7 +986,8 @@ namespace Differentiation
      * @note This operator can only be applied on boolean and conditional
      * expressions.
      */
-    Expression operator!(const Expression &expression);
+    Expression
+    operator!(const Expression &expression);
 
     /**
      * Logical and operator.
@@ -994,7 +995,8 @@ namespace Differentiation
      * @note This operator can only be applied on boolean and conditional
      * expressions.
      */
-    Expression operator&(const Expression &lhs, const Expression &rhs);
+    Expression
+    operator&(const Expression &lhs, const Expression &rhs);
 
     /**
      * Logical inclusive or operator.
@@ -1062,7 +1064,8 @@ namespace Differentiation
      *
      * Return the result of multiplying the @p lhs by the @p rhs.
      */
-    Expression operator*(Expression lhs, const Expression &rhs);
+    Expression
+    operator*(Expression lhs, const Expression &rhs);
 
     /**
      * Division operator.
@@ -1151,7 +1154,8 @@ namespace Differentiation
     template <typename NumberType,
               typename = typename std::enable_if<
                 std::is_constructible<Expression, NumberType>::value>::type>
-    inline Expression operator*(const NumberType &lhs, const Expression &rhs)
+    inline Expression
+    operator*(const NumberType &lhs, const Expression &rhs)
     {
       return Expression(lhs) * rhs;
     }
@@ -1167,7 +1171,8 @@ namespace Differentiation
     template <typename NumberType,
               typename = typename std::enable_if<
                 std::is_constructible<Expression, NumberType>::value>::type>
-    inline Expression operator*(const Expression &lhs, const NumberType &rhs)
+    inline Expression
+    operator*(const Expression &lhs, const NumberType &rhs)
     {
       return lhs * Expression(rhs);
     }

--- a/include/deal.II/differentiation/sd/symengine_optimizer.h
+++ b/include/deal.II/differentiation/sd/symengine_optimizer.h
@@ -208,8 +208,8 @@ namespace Differentiation
     // <tt>operator |</tt> would be an integer which would in turn trigger a
     // compiler warning when we tried to assign it to an object of type
     // OptimizationFlags.
-    inline OptimizationFlags operator&(const OptimizationFlags f1,
-                                       const OptimizationFlags f2)
+    inline OptimizationFlags
+    operator&(const OptimizationFlags f1, const OptimizationFlags f2)
     {
       return static_cast<OptimizationFlags>(static_cast<unsigned int>(f1) &
                                             static_cast<unsigned int>(f2));
@@ -1137,7 +1137,8 @@ namespace Differentiation
       template <typename NumberType,
                 int rank,
                 int dim,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, NumberType>
       tensor_evaluate_optimized(
         const TensorType<rank, dim, Expression> &symbol_tensor,
@@ -1278,7 +1279,7 @@ namespace Differentiation
       void
       register_functions(BatchOptimizer<NumberType> &optimizer,
                          const T &                   function,
-                         const Args &... other_functions)
+                         const Args &...other_functions)
       {
         register_functions(optimizer, function);
         register_functions(optimizer, other_functions...);
@@ -1298,7 +1299,8 @@ namespace Differentiation
        */
       template <int rank,
                 int dim,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       types::symbol_vector
       unroll_to_expression_vector(
         const TensorType<rank, dim, Expression> &symbol_tensor)
@@ -1704,7 +1706,7 @@ namespace Differentiation
        */
       template <typename T, typename... Args>
       void
-      register_functions(const T &functions, const Args &... other_functions);
+      register_functions(const T &functions, const Args &...other_functions);
 
       /**
        * Return a vector of expressions that have been registered as dependent
@@ -2489,7 +2491,7 @@ namespace Differentiation
     void
     BatchOptimizer<ReturnType>::register_functions(
       const T &functions,
-      const Args &... other_functions)
+      const Args &...other_functions)
     {
       internal::register_functions(*this, functions);
       internal::register_functions(*this, other_functions...);

--- a/include/deal.II/differentiation/sd/symengine_scalar_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_scalar_operations.h
@@ -229,7 +229,7 @@ namespace Differentiation
               typename SymbolicType,
               typename... Args>
     types::substitution_map
-    make_symbol_map(const SymbolicType &symbol, const Args &... other_symbols);
+    make_symbol_map(const SymbolicType &symbol, const Args &...other_symbols);
 
     /**
      * A convenience function for adding an empty entry, with the key value
@@ -417,7 +417,7 @@ namespace Differentiation
     void
     add_to_symbol_map(types::substitution_map &symbol_map,
                       const SymbolicType &     symbol,
-                      const Args &... other_symbols);
+                      const Args &...other_symbols);
 
     /**
      * Find the entry for @p symbol in the @p substitution_map and set its
@@ -551,7 +551,7 @@ namespace Differentiation
     set_value_in_symbol_map(
       types::substitution_map &                 substitution_map,
       const std::pair<SymbolicType, ValueType> &symbol_value,
-      const Args &... other_symbol_values);
+      const Args &...other_symbol_values);
 
     /**
      * Find the entries for @p symbols in the @p substitution_map and set their
@@ -780,7 +780,7 @@ namespace Differentiation
     types::substitution_map
     make_substitution_map(
       const std::pair<ExpressionType, ValueType> &symbol_value,
-      const Args &... other_symbol_values);
+      const Args &...other_symbol_values);
 
     //@}
 
@@ -1121,7 +1121,7 @@ namespace Differentiation
     add_to_substitution_map(
       types::substitution_map &                   substitution_map,
       const std::pair<ExpressionType, ValueType> &symbol_value,
-      const Args &... other_symbol_values);
+      const Args &...other_symbol_values);
 
     /**
      * Concatenate two symbolic maps, merging a second map @p substitution_map_in
@@ -1148,7 +1148,7 @@ namespace Differentiation
     void
     merge_substitution_maps(types::substitution_map &      substitution_map_out,
                             const types::substitution_map &substitution_map_in,
-                            const Args &... other_substitution_maps_in);
+                            const Args &...other_substitution_maps_in);
 
     /**
      * Concatenate multiple symbolic maps, merging the maps @p substitution_map_in
@@ -1160,7 +1160,7 @@ namespace Differentiation
     template <typename... Args>
     types::substitution_map
     merge_substitution_maps(const types::substitution_map &substitution_map_in,
-                            const Args &... other_substitution_maps_in);
+                            const Args &...other_substitution_maps_in);
 
     //@}
 
@@ -1355,7 +1355,7 @@ namespace Differentiation
      */
     template <typename ExpressionType, typename... Args>
     ExpressionType
-    substitute(const ExpressionType &expression, const Args &... symbol_values);
+    substitute(const ExpressionType &expression, const Args &...symbol_values);
 
     /**
      * Perform a single substitution sweep of a set of symbols into the given
@@ -1421,7 +1421,7 @@ namespace Differentiation
     template <typename ValueType, typename... Args>
     ValueType
     substitute_and_evaluate(const Expression &expression,
-                            const Args &... symbol_values);
+                            const Args &...symbol_values);
 
     //@}
 
@@ -1459,7 +1459,7 @@ namespace Differentiation
               typename SymbolicType,
               typename... Args>
     types::substitution_map
-    make_symbol_map(const SymbolicType &symbol, const Args &... other_symbols)
+    make_symbol_map(const SymbolicType &symbol, const Args &...other_symbols)
     {
       types::substitution_map symbol_map;
       add_to_symbol_map<ignore_invalid_symbols, ValueType>(symbol_map,
@@ -1541,7 +1541,7 @@ namespace Differentiation
     void
     add_to_symbol_map(types::substitution_map &symbol_map,
                       const SymbolicType &     symbol,
-                      const Args &... other_symbols)
+                      const Args &...other_symbols)
     {
       add_to_symbol_map<ignore_invalid_symbols, ValueType>(symbol_map, symbol);
       add_to_symbol_map<ignore_invalid_symbols, ValueType>(symbol_map,
@@ -1601,7 +1601,7 @@ namespace Differentiation
     set_value_in_symbol_map(
       types::substitution_map &                 substitution_map,
       const std::pair<SymbolicType, ValueType> &symbol_value,
-      const Args &... other_symbol_values)
+      const Args &...other_symbol_values)
     {
       set_value_in_symbol_map(substitution_map, symbol_value);
       set_value_in_symbol_map(substitution_map, other_symbol_values...);
@@ -1670,7 +1670,7 @@ namespace Differentiation
     types::substitution_map
     make_substitution_map(
       const std::pair<ExpressionType, ValueType> &symbol_value,
-      const Args &... other_symbol_values)
+      const Args &...other_symbol_values)
     {
       types::substitution_map substitution_map;
       add_to_substitution_map(substitution_map,
@@ -1834,7 +1834,7 @@ namespace Differentiation
     add_to_substitution_map(
       types::substitution_map &                   substitution_map,
       const std::pair<ExpressionType, ValueType> &symbol_value,
-      const Args &... other_symbol_values)
+      const Args &...other_symbol_values)
     {
       add_to_substitution_map<ignore_invalid_symbols>(substitution_map,
                                                       symbol_value);
@@ -1847,7 +1847,7 @@ namespace Differentiation
     types::substitution_map
     merge_substitution_maps(
       const types::substitution_map &substitution_map_in_1,
-      const Args &... other_substitution_maps_in)
+      const Args &...other_substitution_maps_in)
     {
       types::substitution_map substitution_map_out = substitution_map_in_1;
       merge_substitution_maps(substitution_map_out,
@@ -1861,7 +1861,7 @@ namespace Differentiation
     merge_substitution_maps(
       types::substitution_map &      substitution_map_out,
       const types::substitution_map &substitution_map_in_1,
-      const Args &... other_substitution_maps_in)
+      const Args &...other_substitution_maps_in)
     {
       merge_substitution_maps(substitution_map_out, substitution_map_in_1);
       merge_substitution_maps(substitution_map_out,
@@ -1895,7 +1895,7 @@ namespace Differentiation
 
     template <typename ExpressionType, typename... Args>
     ExpressionType
-    substitute(const ExpressionType &expression, const Args &... symbol_values)
+    substitute(const ExpressionType &expression, const Args &...symbol_values)
     {
       // Call other function
       return substitute(expression, make_substitution_map(symbol_values...));
@@ -1914,7 +1914,7 @@ namespace Differentiation
     template <typename ValueType, typename... Args>
     ValueType
     substitute_and_evaluate(const Expression &expression,
-                            const Args &... symbol_values)
+                            const Args &...symbol_values)
     {
       // Call other function
       return substitute_and_evaluate<ValueType>(

--- a/include/deal.II/differentiation/sd/symengine_tensor_operations.h
+++ b/include/deal.II/differentiation/sd/symengine_tensor_operations.h
@@ -853,7 +853,8 @@ namespace Differentiation
 
       template <int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<0, dim, ValueType>
       scalar_diff_tensor(const ValueType &                    func,
                          const TensorType<0, dim, ValueType> &op)
@@ -865,7 +866,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, ValueType>
       scalar_diff_tensor(const ValueType &                       func,
                          const TensorType<rank, dim, ValueType> &op)
@@ -888,7 +890,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, ValueType>
       tensor_diff_tensor(const TensorType<0, dim, ValueType> &   func,
                          const TensorType<rank, dim, ValueType> &op)
@@ -910,7 +913,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, ValueType>
       tensor_diff_scalar(const TensorType<rank, dim, ValueType> &funcs,
                          const ValueType &                       op)
@@ -930,7 +934,8 @@ namespace Differentiation
       template <int rank,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, ValueType>
       tensor_diff_tensor(const TensorType<rank, dim, ValueType> &funcs,
                          const TensorType<0, dim, ValueType> &   op)
@@ -951,7 +956,8 @@ namespace Differentiation
                 int rank_2,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank_1 + rank_2, dim, ValueType>
       tensor_diff_tensor(const TensorType<rank_1, dim, ValueType> &funcs,
                          const TensorType<rank_2, dim, ValueType> &op)
@@ -987,8 +993,10 @@ namespace Differentiation
                 int rank_2,
                 int dim,
                 typename ValueType = Expression,
-                template <int, int, typename> class TensorType_1,
-                template <int, int, typename> class TensorType_2>
+                template <int, int, typename>
+                class TensorType_1,
+                template <int, int, typename>
+                class TensorType_2>
       Tensor<rank_1 + rank_2, dim, ValueType>
       tensor_diff_tensor(const TensorType_1<rank_1, dim, ValueType> &funcs,
                          const TensorType_2<rank_2, dim, ValueType> &op)
@@ -1166,7 +1174,8 @@ namespace Differentiation
                 typename ValueType,
                 int rank,
                 int dim,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       void
       set_tensor_value_in_symbol_map(
         types::substitution_map &                  substitution_map,
@@ -1303,7 +1312,8 @@ namespace Differentiation
                 int dim,
                 typename ExpressionType,
                 typename ValueType,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       std::vector<std::pair<ExpressionType, ValueType>>
       make_tensor_entries_for_substitution_map(
         const TensorType<rank, dim, ExpressionType> &symbol_tensor,
@@ -1401,7 +1411,8 @@ namespace Differentiation
     {
       template <int rank,
                 int dim,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, Expression>
       substitute_tensor(
         const TensorType<rank, dim, Expression> &expression_tensor,
@@ -1455,7 +1466,8 @@ namespace Differentiation
       template <typename ValueType,
                 int rank,
                 int dim,
-                template <int, int, typename> class TensorType>
+                template <int, int, typename>
+                class TensorType>
       TensorType<rank, dim, ValueType>
       substitute_and_evaluate_tensor(
         const TensorType<rank, dim, Expression> &expression_tensor,

--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -261,9 +261,9 @@ namespace internal
 
       template <int spacedim>
       static void
-        iterate(dealii::internal::p4est::types<2>::forest *parallel_forest,
-                dealii::internal::p4est::types<2>::ghost * parallel_ghost,
-                void *                                     user_data);
+      iterate(dealii::internal::p4est::types<2>::forest *parallel_forest,
+              dealii::internal::p4est::types<2>::ghost * parallel_ghost,
+              void *                                     user_data);
 
       static constexpr unsigned int max_level = P4EST_MAXLEVEL;
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -363,8 +363,8 @@ namespace parallel
       explicit Triangulation(
         const MPI_Comm &mpi_communicator,
         const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
-                       smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
-        const Settings settings    = default_setting);
+          smooth_grid           = (dealii::Triangulation<dim, spacedim>::none),
+        const Settings settings = default_setting);
 
       /**
        * Destructor.
@@ -762,10 +762,8 @@ namespace parallel
        *
        * This function exists in 2d and 3d variants.
        */
-      void
-      copy_new_triangulation_to_p4est(std::integral_constant<int, 2>);
-      void
-      copy_new_triangulation_to_p4est(std::integral_constant<int, 3>);
+      void copy_new_triangulation_to_p4est(std::integral_constant<int, 2>);
+      void copy_new_triangulation_to_p4est(std::integral_constant<int, 3>);
 
       /**
        * Copy the local part of the refined forest from p4est into the

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -912,8 +912,9 @@ public:
   /**
    * Move assignment operator.
    */
-  DoFAccessor<0, 1, spacedim, level_dof_access> &operator      =(
-    DoFAccessor<0, 1, spacedim, level_dof_access> &&) noexcept = default;
+  DoFAccessor<0, 1, spacedim, level_dof_access> &
+  operator=(DoFAccessor<0, 1, spacedim, level_dof_access> &&) noexcept =
+    default;
 
   /**
    * @}
@@ -1199,7 +1200,8 @@ protected:
   /**
    * Reset the DoF handler pointer.
    */
-  void set_dof_handler(DoFHandler<1, spacedim> *dh);
+  void
+  set_dof_handler(DoFHandler<1, spacedim> *dh);
 
   /**
    * Set the index of the <i>i</i>th degree of freedom of this object to @p

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -1009,12 +1009,13 @@ namespace internal
               dof_processor);
 
         // 4) INNER dofs
-        dof_operation.process_dofs(accessor,
-                                   [&](const auto d) { return d; },
-                                   index,
-                                   dof_indices,
-                                   fe_index,
-                                   dof_processor);
+        dof_operation.process_dofs(
+          accessor,
+          [&](const auto d) { return d; },
+          index,
+          dof_indices,
+          fe_index,
+          dof_processor);
 
         AssertDimension(n_dof_indices(accessor, fe_index, count_level_dofs),
                         index);
@@ -1059,18 +1060,19 @@ namespace internal
               DoFHandler<dim, spacedim>::default_fe_index :
               fe_index_;
 
-          process_object(accessor.get_dof_handler(),
-                         0,
-                         accessor.vertex_index(vertex),
-                         fe_index,
-                         [](const auto d) {
-                           Assert(false, ExcInternalError());
-                           return d;
-                         },
-                         std::integral_constant<int, 0>(),
-                         index_value,
-                         index,
-                         dof_processor);
+          process_object(
+            accessor.get_dof_handler(),
+            0,
+            accessor.vertex_index(vertex),
+            fe_index,
+            [](const auto d) {
+              Assert(false, ExcInternalError());
+              return d;
+            },
+            std::integral_constant<int, 0>(),
+            index_value,
+            index,
+            dof_processor);
         }
 
         /**
@@ -1868,7 +1870,8 @@ inline DoFAccessor<0, 1, spacedim, level_dof_access>::DoFAccessor(
 
 
 template <int spacedim, bool level_dof_access>
-inline void DoFAccessor<0, 1, spacedim, level_dof_access>::set_dof_handler(
+inline void
+DoFAccessor<0, 1, spacedim, level_dof_access>::set_dof_handler(
   DoFHandler<1, spacedim> *dh)
 {
   Assert(dh != nullptr, ExcInvalidObject());

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -2018,14 +2018,14 @@ DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 {
   if (this->hp_capability_enabled)
     {
-      ar & this->object_dof_indices;
-      ar & this->object_dof_ptr;
+      ar &this->object_dof_indices;
+      ar &this->object_dof_ptr;
 
-      ar & this->cell_dof_cache_indices;
-      ar & this->cell_dof_cache_ptr;
+      ar &this->cell_dof_cache_indices;
+      ar &this->cell_dof_cache_ptr;
 
-      ar & this->hp_cell_active_fe_indices;
-      ar & this->hp_cell_future_fe_indices;
+      ar &this->hp_cell_active_fe_indices;
+      ar &this->hp_cell_future_fe_indices;
 
       ar &hp_object_fe_ptr;
       ar &hp_object_fe_indices;
@@ -2045,14 +2045,14 @@ DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
     }
   else
     {
-      ar & this->block_info_object;
+      ar &this->block_info_object;
       ar &number_cache;
 
-      ar & this->object_dof_indices;
-      ar & this->object_dof_ptr;
+      ar &this->object_dof_indices;
+      ar &this->object_dof_ptr;
 
-      ar & this->cell_dof_cache_indices;
-      ar & this->cell_dof_cache_ptr;
+      ar &this->cell_dof_cache_indices;
+      ar &this->cell_dof_cache_ptr;
 
       // write out the number of triangulation cells and later check during
       // loading that this number is indeed correct; same with something that
@@ -2074,14 +2074,14 @@ DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 {
   if (this->hp_capability_enabled)
     {
-      ar & this->object_dof_indices;
-      ar & this->object_dof_ptr;
+      ar &this->object_dof_indices;
+      ar &this->object_dof_ptr;
 
-      ar & this->cell_dof_cache_indices;
-      ar & this->cell_dof_cache_ptr;
+      ar &this->cell_dof_cache_indices;
+      ar &this->cell_dof_cache_ptr;
 
-      ar & this->hp_cell_active_fe_indices;
-      ar & this->hp_cell_future_fe_indices;
+      ar &this->hp_cell_active_fe_indices;
+      ar &this->hp_cell_future_fe_indices;
 
       ar &hp_object_fe_ptr;
       ar &hp_object_fe_indices;
@@ -2112,18 +2112,18 @@ DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
     }
   else
     {
-      ar & this->block_info_object;
+      ar &this->block_info_object;
       ar &number_cache;
 
       object_dof_indices.clear();
 
       object_dof_ptr.clear();
 
-      ar & this->object_dof_indices;
-      ar & this->object_dof_ptr;
+      ar &this->object_dof_indices;
+      ar &this->object_dof_ptr;
 
-      ar & this->cell_dof_cache_indices;
-      ar & this->cell_dof_cache_ptr;
+      ar &this->cell_dof_cache_indices;
+      ar &this->cell_dof_cache_ptr;
 
       // these are the checks that correspond to the last block in the save()
       // function

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -125,7 +125,8 @@ public:
    * given index needs to be between zero and the number of blocks that this
    * mask represents.
    */
-  bool operator[](const unsigned int block_index) const;
+  bool
+  operator[](const unsigned int block_index) const;
 
   /**
    * Return whether this block mask represents a mask with exactly
@@ -185,7 +186,8 @@ public:
    * Return a block mask that has only those elements set that are set both in
    * the current object as well as the one passed as an argument.
    */
-  BlockMask operator&(const BlockMask &mask) const;
+  BlockMask
+  operator&(const BlockMask &mask) const;
 
   /**
    * Return whether this object and the argument are identical.
@@ -253,7 +255,8 @@ BlockMask::size() const
 }
 
 
-inline bool BlockMask::operator[](const unsigned int block_index) const
+inline bool
+BlockMask::operator[](const unsigned int block_index) const
 {
   // if the mask represents the all-block mask
   // then always return true
@@ -347,7 +350,8 @@ BlockMask::operator|(const BlockMask &mask) const
 }
 
 
-inline BlockMask BlockMask::operator&(const BlockMask &mask) const
+inline BlockMask
+BlockMask::operator&(const BlockMask &mask) const
 {
   // if one of the two masks denotes the all-block mask,
   // then return the other one

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -140,7 +140,8 @@ public:
    * Otherwise, the given index needs to be between zero and the number of
    * components that this mask represents.
    */
-  bool operator[](const unsigned int component_index) const;
+  bool
+  operator[](const unsigned int component_index) const;
 
   /**
    * Return whether this component mask represents a mask with exactly
@@ -200,7 +201,8 @@ public:
    * Return a component mask that has only those elements set that are set
    * both in the current object as well as the one passed as an argument.
    */
-  ComponentMask operator&(const ComponentMask &mask) const;
+  ComponentMask
+  operator&(const ComponentMask &mask) const;
 
   /**
    * Return whether this object and the argument are identical.
@@ -283,7 +285,8 @@ ComponentMask::set(const unsigned int index, const bool value)
 }
 
 
-inline bool ComponentMask::operator[](const unsigned int component_index) const
+inline bool
+ComponentMask::operator[](const unsigned int component_index) const
 {
   // if the mask represents the all-component mask
   // then always return true
@@ -377,7 +380,8 @@ ComponentMask::operator|(const ComponentMask &mask) const
 }
 
 
-inline ComponentMask ComponentMask::operator&(const ComponentMask &mask) const
+inline ComponentMask
+ComponentMask::operator&(const ComponentMask &mask) const
 {
   // if one of the two masks denotes the all-component mask,
   // then return the other one

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -3084,8 +3084,8 @@ protected:
 
 
 template <int dim, int spacedim>
-inline const FiniteElement<dim, spacedim> &FiniteElement<dim, spacedim>::
-                                           operator[](const unsigned int fe_index) const
+inline const FiniteElement<dim, spacedim> &
+FiniteElement<dim, spacedim>::operator[](const unsigned int fe_index) const
 {
   (void)fe_index;
   Assert(fe_index == 0,

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -125,7 +125,8 @@ namespace FiniteElementDomination
    * <code>other_element_dominates</code>, then the returned value is
    * <code>neither_element_dominates</code>.
    */
-  inline Domination operator&(const Domination d1, const Domination d2);
+  inline Domination
+  operator&(const Domination d1, const Domination d2);
 } // namespace FiniteElementDomination
 
 namespace internal
@@ -698,7 +699,8 @@ namespace internal
 
 namespace FiniteElementDomination
 {
-  inline Domination operator&(const Domination d1, const Domination d2)
+  inline Domination
+  operator&(const Domination d1, const Domination d2)
   {
     // go through the entire list of possibilities. note that if we were into
     // speed, obfuscation and cared enough, we could implement this operator

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1399,8 +1399,8 @@ FEInterfaceValues<dim, spacedim>::jump_3rd_derivative(
 /*------------ Inline functions: FEInterfaceValues------------*/
 template <int dim, int spacedim>
 inline const FEInterfaceViews::Scalar<dim, spacedim>
-  FEInterfaceValues<dim, spacedim>::
-  operator[](const FEValuesExtractors::Scalar &scalar) const
+FEInterfaceValues<dim, spacedim>::operator[](
+  const FEValuesExtractors::Scalar &scalar) const
 {
   AssertIndexRange(scalar.component, this->get_fe().n_components());
   return FEInterfaceViews::Scalar<dim, spacedim>(*this, scalar.component);
@@ -1410,8 +1410,8 @@ inline const FEInterfaceViews::Scalar<dim, spacedim>
 
 template <int dim, int spacedim>
 inline const FEInterfaceViews::Vector<dim, spacedim>
-  FEInterfaceValues<dim, spacedim>::
-  operator[](const FEValuesExtractors::Vector &vector) const
+FEInterfaceValues<dim, spacedim>::operator[](
+  const FEValuesExtractors::Vector &vector) const
 {
   const FiniteElement<dim, spacedim> &fe = this->get_fe();
   const unsigned int                  n_vectors =

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -549,7 +549,7 @@ public:
                               unsigned int>>::value ||
        std::is_base_of<FiniteElement<dim, spacedim>,
                        typename std::decay<FEPairs>::type>::value)...>::type>
-  FESystem(FEPairs &&... fe_pairs);
+  FESystem(FEPairs &&...fe_pairs);
 
   /**
    * Same as above allowing the following syntax:
@@ -1358,7 +1358,7 @@ namespace internal
 // of the std::enable_if.
 template <int dim, int spacedim>
 template <class... FEPairs, typename>
-FESystem<dim, spacedim>::FESystem(FEPairs &&... fe_pairs)
+FESystem<dim, spacedim>::FESystem(FEPairs &&...fe_pairs)
   : FESystem<dim, spacedim>(
       {internal::FESystemImplementation::promote_to_fe_pair<dim, spacedim>(
         std::forward<FEPairs>(fe_pairs))...})

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2216,8 +2216,8 @@ namespace FETools
     // finally loop over all possible refinement cases
     Threads::TaskGroup<> tasks;
     unsigned int         ref_case = (isotropic_only) ?
-                              RefinementCase<dim>::isotropic_refinement :
-                              RefinementCase<dim>::cut_x;
+                                      RefinementCase<dim>::isotropic_refinement :
+                                      RefinementCase<dim>::cut_x;
     for (; ref_case <= RefinementCase<dim>::isotropic_refinement; ++ref_case)
       tasks += Threads::new_task([&, ref_case]() {
         compute_one_case(ref_case, mass, matrices[ref_case - 1]);

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -325,7 +325,8 @@ operator|=(UpdateFlags &f1, const UpdateFlags f2)
  *
  * @ref UpdateFlags
  */
-inline UpdateFlags operator&(const UpdateFlags f1, const UpdateFlags f2)
+inline UpdateFlags
+operator&(const UpdateFlags f1, const UpdateFlags f2)
 {
   return static_cast<UpdateFlags>(static_cast<unsigned int>(f1) &
                                   static_cast<unsigned int>(f2));

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -1984,8 +1984,8 @@ namespace FEValuesViews
     /**
      * Move assignment operator.
      */
-    // NOLINTNEXTLINE
-    Tensor &operator=(Tensor<2, dim, spacedim> &&) = default;
+    Tensor &
+    operator=(Tensor<2, dim, spacedim> &&) = default; // NOLINT
 
     /**
      * Return the value of the vector components selected by this view, for

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -5439,8 +5439,9 @@ namespace FEValuesViews
 
 
 template <int dim, int spacedim>
-inline const FEValuesViews::Scalar<dim, spacedim> &FEValuesBase<dim, spacedim>::
-                                                   operator[](const FEValuesExtractors::Scalar &scalar) const
+inline const FEValuesViews::Scalar<dim, spacedim> &
+FEValuesBase<dim, spacedim>::operator[](
+  const FEValuesExtractors::Scalar &scalar) const
 {
   AssertIndexRange(scalar.component, fe_values_views_cache.scalars.size());
 
@@ -5450,8 +5451,9 @@ inline const FEValuesViews::Scalar<dim, spacedim> &FEValuesBase<dim, spacedim>::
 
 
 template <int dim, int spacedim>
-inline const FEValuesViews::Vector<dim, spacedim> &FEValuesBase<dim, spacedim>::
-                                                   operator[](const FEValuesExtractors::Vector &vector) const
+inline const FEValuesViews::Vector<dim, spacedim> &
+FEValuesBase<dim, spacedim>::operator[](
+  const FEValuesExtractors::Vector &vector) const
 {
   AssertIndexRange(vector.first_vector_component,
                    fe_values_views_cache.vectors.size());
@@ -5463,8 +5465,8 @@ inline const FEValuesViews::Vector<dim, spacedim> &FEValuesBase<dim, spacedim>::
 
 template <int dim, int spacedim>
 inline const FEValuesViews::SymmetricTensor<2, dim, spacedim> &
-  FEValuesBase<dim, spacedim>::
-  operator[](const FEValuesExtractors::SymmetricTensor<2> &tensor) const
+FEValuesBase<dim, spacedim>::operator[](
+  const FEValuesExtractors::SymmetricTensor<2> &tensor) const
 {
   Assert(
     tensor.first_tensor_component <
@@ -5481,8 +5483,8 @@ inline const FEValuesViews::SymmetricTensor<2, dim, spacedim> &
 
 template <int dim, int spacedim>
 inline const FEValuesViews::Tensor<2, dim, spacedim> &
-  FEValuesBase<dim, spacedim>::
-  operator[](const FEValuesExtractors::Tensor<2> &tensor) const
+FEValuesBase<dim, spacedim>::operator[](
+  const FEValuesExtractors::Tensor<2> &tensor) const
 {
   AssertIndexRange(tensor.first_tensor_component,
                    fe_values_views_cache.second_order_tensors.size());

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -1131,8 +1131,8 @@ inline FilteredIterator<BaseIterator>::PredicateTemplate<
 template <typename BaseIterator>
 template <typename Predicate>
 bool
-FilteredIterator<BaseIterator>::PredicateTemplate<Predicate>::
-operator()(const BaseIterator &bi) const
+FilteredIterator<BaseIterator>::PredicateTemplate<Predicate>::operator()(
+  const BaseIterator &bi) const
 {
   return predicate(bi);
 }

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -798,9 +798,10 @@ namespace GridGenerator
    * @param[in] rotate_right_square <code>true</code> if the right square is
    * rotated by $\pi/2$.
    */
-  void non_standard_orientation_mesh(Triangulation<2> &tria,
-                                     const bool        rotate_left_square,
-                                     const bool        rotate_right_square);
+  void
+  non_standard_orientation_mesh(Triangulation<2> &tria,
+                                const bool        rotate_left_square,
+                                const bool        rotate_right_square);
 
   /**
    * Generate a 3D mesh consisting of the unit cube joined with a copy shifted
@@ -823,11 +824,12 @@ namespace GridGenerator
    * @param[in] manipulate_left_cube <code>true</code> if the left cube is
    * to be re-ordered. If `false`, it is the right cube.
    */
-  void non_standard_orientation_mesh(Triangulation<3> &tria,
-                                     const bool        face_orientation,
-                                     const bool        face_flip,
-                                     const bool        face_rotation,
-                                     const bool        manipulate_left_cube);
+  void
+  non_standard_orientation_mesh(Triangulation<3> &tria,
+                                const bool        face_orientation,
+                                const bool        face_flip,
+                                const bool        face_rotation,
+                                const bool        manipulate_left_cube);
 
 
   /**
@@ -856,9 +858,10 @@ namespace GridGenerator
    * this function.
    */
   template <int spacedim>
-  void hyper_sphere(Triangulation<spacedim - 1, spacedim> &tria,
-                    const Point<spacedim> &center = Point<spacedim>(),
-                    const double           radius = 1.);
+  void
+  hyper_sphere(Triangulation<spacedim - 1, spacedim> &tria,
+               const Point<spacedim> &center = Point<spacedim>(),
+               const double           radius = 1.);
 
   /**
    * This function produces a hyper-ball intersected with the positive orthant
@@ -1569,11 +1572,12 @@ namespace GridGenerator
    * of the torus containing the loop of cells. Must be greater than @p r.
    * @param r           The radius of the cylinder bent together as a loop.
    */
-  void moebius(Triangulation<3, 3> &tria,
-               const unsigned int   n_cells,
-               const unsigned int   n_rotations,
-               const double         R,
-               const double         r);
+  void
+  moebius(Triangulation<3, 3> &tria,
+          const unsigned int   n_cells,
+          const unsigned int   n_rotations,
+          const double         R,
+          const double         r);
 
   /**
    * Call one of the other GridGenerator functions, parsing the name of the
@@ -2464,49 +2468,55 @@ namespace GridGenerator
   // These functions are only implemented with specializations; declare them
   // here
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<1> &,
-                                        const double,
-                                        const double,
-                                        const double,
-                                        const unsigned int,
-                                        const bool);
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<1> &,
+                                   const double,
+                                   const double,
+                                   const double,
+                                   const unsigned int,
+                                   const bool);
 
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<2> &,
-                                        const double,
-                                        const double,
-                                        const double,
-                                        const unsigned int,
-                                        const bool);
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<2> &,
+                                   const double,
+                                   const double,
+                                   const double,
+                                   const unsigned int,
+                                   const bool);
 
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<3> &,
-                                        const double,
-                                        const double,
-                                        const double,
-                                        const unsigned int,
-                                        const bool);
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<3> &,
+                                   const double,
+                                   const double,
+                                   const double,
+                                   const unsigned int,
+                                   const bool);
 
   template <>
-  void channel_with_cylinder(Triangulation<1> &,
-                             const double,
-                             const unsigned int,
-                             const double,
-                             const bool);
+  void
+  channel_with_cylinder(Triangulation<1> &,
+                        const double,
+                        const unsigned int,
+                        const double,
+                        const bool);
 
   template <>
-  void channel_with_cylinder(Triangulation<2> &,
-                             const double,
-                             const unsigned int,
-                             const double,
-                             const bool);
+  void
+  channel_with_cylinder(Triangulation<2> &,
+                        const double,
+                        const unsigned int,
+                        const double,
+                        const bool);
 
   template <>
-  void channel_with_cylinder(Triangulation<3> &,
-                             const double,
-                             const unsigned int,
-                             const double,
-                             const bool);
+  void
+  channel_with_cylinder(Triangulation<3> &,
+                        const double,
+                        const unsigned int,
+                        const double,
+                        const bool);
 #endif
 } // namespace GridGenerator
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1463,7 +1463,7 @@ namespace GridTools
     const Cache<dim, spacedim> &cache,
     const Point<spacedim> &     p,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &
-                             cell_hint = typename Triangulation<dim, spacedim>::active_cell_iterator(),
+      cell_hint = typename Triangulation<dim, spacedim>::active_cell_iterator(),
     const std::vector<bool> &marked_vertices = {},
     const double             tolerance       = 1.e-10);
 
@@ -2737,7 +2737,8 @@ namespace GridTools
    * article.
    */
   template <typename FaceIterator>
-  bool orthogonal_equality(
+  bool
+  orthogonal_equality(
     std::bitset<3> &                                              orientation,
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,
@@ -4352,7 +4353,7 @@ namespace GridTools
       std::vector<std::vector<typename CellId::binary_type>> cell_data_to_send(
         ghost_owners.size());
       std::vector<std::vector<types::global_dof_index>>
-                                     send_dof_numbers_and_indices(ghost_owners.size());
+        send_dof_numbers_and_indices(ghost_owners.size());
       std::vector<MPI_Request>       reply_requests(ghost_owners.size());
       std::vector<std::vector<char>> sendbuffers(ghost_owners.size());
 

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -168,8 +168,8 @@ namespace GridTools
    *
    * @ref CacheUpdateFlags
    */
-  inline CacheUpdateFlags operator&(const CacheUpdateFlags f1,
-                                    const CacheUpdateFlags f2)
+  inline CacheUpdateFlags
+  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
   {
     return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
                                          static_cast<unsigned int>(f2));

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -136,7 +136,8 @@ public:
    * refined cell of which the source cell would be created if it were further
    * refined.
    */
-  cell_iterator operator[](const cell_iterator &source_cell) const;
+  cell_iterator
+  operator[](const cell_iterator &source_cell) const;
 
   /**
    * Delete all data of this class.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -569,7 +569,7 @@ private:
    * called by anyone, but at least hidden in an internal namespace.
    */
   friend DEAL_II_CONSTEXPR ReferenceCell
-                           internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
+  internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
 };
 
 
@@ -608,7 +608,7 @@ namespace internal
   namespace ReferenceCell
   {
     inline DEAL_II_CONSTEXPR dealii::ReferenceCell
-                             make_reference_cell_from_int(const std::uint8_t kind)
+    make_reference_cell_from_int(const std::uint8_t kind)
     {
       // Make sure these are the only indices from which objects can be
       // created.

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -176,8 +176,8 @@ TriaAccessorBase<structdim, dim, spacedim>::copy_from(
 
 template <int structdim, int dim, int spacedim>
 inline TriaAccessorBase<structdim, dim, spacedim> &
-TriaAccessorBase<structdim, dim, spacedim>::
-operator=(const TriaAccessorBase<structdim, dim, spacedim> &a)
+TriaAccessorBase<structdim, dim, spacedim>::operator=(
+  const TriaAccessorBase<structdim, dim, spacedim> &a)
 {
   present_level = a.present_level;
   present_index = a.present_index;
@@ -196,8 +196,8 @@ operator=(const TriaAccessorBase<structdim, dim, spacedim> &a)
 
 template <int structdim, int dim, int spacedim>
 inline bool
-TriaAccessorBase<structdim, dim, spacedim>::
-operator==(const TriaAccessorBase<structdim, dim, spacedim> &a) const
+TriaAccessorBase<structdim, dim, spacedim>::operator==(
+  const TriaAccessorBase<structdim, dim, spacedim> &a) const
 {
   Assert(tria == a.tria || tria == nullptr || a.tria == nullptr,
          TriaAccessorExceptions::ExcCantCompareIterators());
@@ -209,8 +209,8 @@ operator==(const TriaAccessorBase<structdim, dim, spacedim> &a) const
 
 template <int structdim, int dim, int spacedim>
 inline bool
-TriaAccessorBase<structdim, dim, spacedim>::
-operator!=(const TriaAccessorBase<structdim, dim, spacedim> &a) const
+TriaAccessorBase<structdim, dim, spacedim>::operator!=(
+  const TriaAccessorBase<structdim, dim, spacedim> &a) const
 {
   Assert(tria == a.tria || tria == nullptr || a.tria == nullptr,
          TriaAccessorExceptions::ExcCantCompareIterators());
@@ -222,8 +222,8 @@ operator!=(const TriaAccessorBase<structdim, dim, spacedim> &a) const
 
 template <int structdim, int dim, int spacedim>
 inline bool
-TriaAccessorBase<structdim, dim, spacedim>::
-operator<(const TriaAccessorBase<structdim, dim, spacedim> &other) const
+TriaAccessorBase<structdim, dim, spacedim>::operator<(
+  const TriaAccessorBase<structdim, dim, spacedim> &other) const
 {
   Assert(tria == other.tria, TriaAccessorExceptions::ExcCantCompareIterators());
 
@@ -423,8 +423,8 @@ InvalidAccessor<structdim, dim, spacedim>::copy_from(const InvalidAccessor &)
 
 template <int structdim, int dim, int spacedim>
 bool
-InvalidAccessor<structdim, dim, spacedim>::
-operator==(const InvalidAccessor &) const
+InvalidAccessor<structdim, dim, spacedim>::operator==(
+  const InvalidAccessor &) const
 {
   // nothing to do here. we could
   // throw an exception but we can't
@@ -438,8 +438,8 @@ operator==(const InvalidAccessor &) const
 
 template <int structdim, int dim, int spacedim>
 bool
-InvalidAccessor<structdim, dim, spacedim>::
-operator!=(const InvalidAccessor &) const
+InvalidAccessor<structdim, dim, spacedim>::operator!=(
+  const InvalidAccessor &) const
 {
   // nothing to do here. we could
   // throw an exception but we can't
@@ -2334,8 +2334,8 @@ TriaAccessor<0, dim, spacedim>::copy_from(const TriaAccessor &t)
 
 template <int dim, int spacedim>
 inline bool
-TriaAccessor<0, dim, spacedim>::
-operator<(const TriaAccessor<0, dim, spacedim> &other) const
+TriaAccessor<0, dim, spacedim>::operator<(
+  const TriaAccessor<0, dim, spacedim> &other) const
 {
   Assert(tria == other.tria, TriaAccessorExceptions::ExcCantCompareIterators());
 
@@ -2749,8 +2749,8 @@ TriaAccessor<0, 1, spacedim>::copy_from(const TriaAccessor &t)
 
 template <int spacedim>
 inline bool
-TriaAccessor<0, 1, spacedim>::
-operator<(const TriaAccessor<0, 1, spacedim> &other) const
+TriaAccessor<0, 1, spacedim>::operator<(
+  const TriaAccessor<0, 1, spacedim> &other) const
 {
   Assert(tria == other.tria, TriaAccessorExceptions::ExcCantCompareIterators());
 

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -582,8 +582,8 @@ namespace TriangulationDescription
 
   template <int dim, int spacedim>
   bool
-  Description<dim, spacedim>::
-  operator==(const Description<dim, spacedim> &other) const
+  Description<dim, spacedim>::operator==(
+    const Description<dim, spacedim> &other) const
   {
     if (this->coarse_cells != other.coarse_cells)
       return false;

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -332,12 +332,14 @@ public:
    *
    * You must not dereference invalid or past the end iterators.
    */
-  const Accessor &operator*() const;
+  const Accessor &
+  operator*() const;
 
   /**
    * Dereferencing operator, non-@p const version.
    */
-  Accessor &operator*();
+  Accessor &
+  operator*();
 
   /**
    * Dereferencing operator, returns a reference of the cell pointed to. Usage
@@ -345,12 +347,14 @@ public:
    *
    * There is a @p const and a non-@p const version.
    */
-  const Accessor *operator->() const;
+  const Accessor *
+  operator->() const;
 
   /**
    * Dereferencing operator, non-@p const version.
    */
-  Accessor *operator->();
+  Accessor *
+  operator->();
 
 
   /**
@@ -991,7 +995,8 @@ inline TriaRawIterator<Accessor>::TriaRawIterator(
 
 
 template <typename Accessor>
-inline const Accessor &TriaRawIterator<Accessor>::operator*() const
+inline const Accessor &
+TriaRawIterator<Accessor>::operator*() const
 {
   Assert(Accessor::structure_dimension != Accessor::dimension ||
            state() == IteratorState::valid,
@@ -1006,7 +1011,8 @@ inline const Accessor &TriaRawIterator<Accessor>::operator*() const
 
 
 template <typename Accessor>
-inline Accessor &TriaRawIterator<Accessor>::operator*()
+inline Accessor &
+TriaRawIterator<Accessor>::operator*()
 {
   Assert(Accessor::structure_dimension != Accessor::dimension ||
            state() == IteratorState::valid,
@@ -1030,7 +1036,8 @@ TriaRawIterator<Accessor>::access_any() const
 
 
 template <typename Accessor>
-inline const Accessor *TriaRawIterator<Accessor>::operator->() const
+inline const Accessor *
+TriaRawIterator<Accessor>::operator->() const
 {
   return &(this->operator*());
 }
@@ -1038,7 +1045,8 @@ inline const Accessor *TriaRawIterator<Accessor>::operator->() const
 
 
 template <typename Accessor>
-inline Accessor *TriaRawIterator<Accessor>::operator->()
+inline Accessor *
+TriaRawIterator<Accessor>::operator->()
 {
   return &(this->operator*());
 }
@@ -1056,8 +1064,8 @@ TriaRawIterator<Accessor>::state() const
 
 template <typename Accessor>
 inline bool
-TriaRawIterator<Accessor>::
-operator<(const TriaRawIterator<Accessor> &other) const
+TriaRawIterator<Accessor>::operator<(
+  const TriaRawIterator<Accessor> &other) const
 {
   Assert(state() != IteratorState::invalid,
          ExcDereferenceInvalidObject(accessor));
@@ -1080,8 +1088,8 @@ operator<(const TriaRawIterator<Accessor> &other) const
 
 template <typename Accessor>
 inline bool
-TriaRawIterator<Accessor>::
-operator>(const TriaRawIterator<Accessor> &other) const
+TriaRawIterator<Accessor>::operator>(
+  const TriaRawIterator<Accessor> &other) const
 {
   return (other < *this);
 }

--- a/include/deal.II/grid/tria_iterator.templates.h
+++ b/include/deal.II/grid/tria_iterator.templates.h
@@ -86,8 +86,8 @@ template <typename OtherAccessor>
 inline
   typename std::enable_if<std::is_convertible<OtherAccessor, Accessor>::value,
                           bool>::type
-  TriaRawIterator<Accessor>::
-  operator==(const TriaRawIterator<OtherAccessor> &other) const
+  TriaRawIterator<Accessor>::operator==(
+    const TriaRawIterator<OtherAccessor> &other) const
 {
   return accessor == other.accessor;
 }
@@ -95,8 +95,8 @@ inline
 
 template <typename Accessor>
 inline bool
-TriaRawIterator<Accessor>::
-operator!=(const TriaRawIterator<Accessor> &other) const
+TriaRawIterator<Accessor>::operator!=(
+  const TriaRawIterator<Accessor> &other) const
 {
   return !(*this == other);
 }
@@ -412,8 +412,8 @@ TriaActiveIterator<Accessor>::operator=(const TriaActiveIterator<Accessor> &i)
 template <typename Accessor>
 template <class OtherAccessor>
 inline TriaActiveIterator<Accessor> &
-TriaActiveIterator<Accessor>::
-operator=(const TriaActiveIterator<OtherAccessor> &i)
+TriaActiveIterator<Accessor>::operator=(
+  const TriaActiveIterator<OtherAccessor> &i)
 {
   this->accessor.copy_from(i.accessor);
   return *this;

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -59,7 +59,8 @@ namespace hp
      * @pre @p index must be between zero and the number of elements of the
      * collection.
      */
-    const T &operator[](const unsigned int index) const;
+    const T &
+    operator[](const unsigned int index) const;
 
     /**
      * Return the number of objects stored in this container.
@@ -114,7 +115,8 @@ namespace hp
 
 
   template <typename T>
-  inline const T &Collection<T>::operator[](const unsigned int index) const
+  inline const T &
+  Collection<T>::operator[](const unsigned int index) const
   {
     AssertIndexRange(index, entries.size());
     return *entries[index];

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -116,7 +116,7 @@ namespace hp
      * from class FiniteElement<dim,spacedim>.
      */
     template <class... FETypes>
-    explicit FECollection(const FETypes &... fes);
+    explicit FECollection(const FETypes &...fes);
 
     /**
      * Constructor. Same as above but for any number of elements. Pointers to
@@ -765,7 +765,7 @@ namespace hp
 
   template <int dim, int spacedim>
   template <class... FETypes>
-  FECollection<dim, spacedim>::FECollection(const FETypes &... fes)
+  FECollection<dim, spacedim>::FECollection(const FETypes &...fes)
   {
     static_assert(
       is_base_of_all<FiniteElement<dim, spacedim>, FETypes...>::value,
@@ -804,8 +804,8 @@ namespace hp
 
   template <int dim, int spacedim>
   inline bool
-  FECollection<dim, spacedim>::
-  operator==(const FECollection<dim, spacedim> &fe_collection) const
+  FECollection<dim, spacedim>::operator==(
+    const FECollection<dim, spacedim> &fe_collection) const
   {
     const unsigned int n_elements = this->size();
     if (n_elements != fe_collection.size())
@@ -822,8 +822,8 @@ namespace hp
 
   template <int dim, int spacedim>
   inline bool
-  FECollection<dim, spacedim>::
-  operator!=(const FECollection<dim, spacedim> &fe_collection) const
+  FECollection<dim, spacedim>::operator!=(
+    const FECollection<dim, spacedim> &fe_collection) const
   {
     return !(*this == fe_collection);
   }

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -83,7 +83,7 @@ namespace hp
      * from class Mapping<dim,spacedim>.
      */
     template <class... MappingTypes>
-    explicit MappingCollection(const MappingTypes &... mappings);
+    explicit MappingCollection(const MappingTypes &...mappings);
 
     /**
      * Add a new mapping to the MappingCollection. Generally, you will
@@ -134,7 +134,7 @@ namespace hp
   template <int dim, int spacedim>
   template <class... MappingTypes>
   MappingCollection<dim, spacedim>::MappingCollection(
-    const MappingTypes &... mappings)
+    const MappingTypes &...mappings)
   {
     static_assert(
       is_base_of_all<Mapping<dim, spacedim>, MappingTypes...>::value,

--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -74,7 +74,7 @@ namespace hp
      * from class Quadrature<dim>.
      */
     template <class... QTypes>
-    explicit QCollection(const QTypes &... quadrature_objects);
+    explicit QCollection(const QTypes &...quadrature_objects);
 
     /**
      * Add a new quadrature rule to the QCollection. In most cases, you will
@@ -149,7 +149,7 @@ namespace hp
 
   template <int dim>
   template <class... QTypes>
-  QCollection<dim>::QCollection(const QTypes &... quadrature_objects)
+  QCollection<dim>::QCollection(const QTypes &...quadrature_objects)
   {
     // loop over all of the given arguments and add the quadrature objects to
     // this collection. Inlining the definition of q_pointers causes internal

--- a/include/deal.II/integrators/patches.h
+++ b/include/deal.II/integrators/patches.h
@@ -38,9 +38,9 @@ namespace LocalIntegrators
   {
     template <int dim>
     inline void
-      points_and_values(Table<2, double> &                          result,
-                        const FEValuesBase<dim> &                   fe,
-                        const ArrayView<const std::vector<double>> &input)
+    points_and_values(Table<2, double> &                          result,
+                      const FEValuesBase<dim> &                   fe,
+                      const ArrayView<const std::vector<double>> &input)
     {
       const unsigned int n_comp = fe.get_fe().n_components();
       AssertVectorVectorDimension(input, n_comp, fe.n_quadrature_points);

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2549,8 +2549,8 @@ inline AffineConstraints<number>::ConstraintLine::ConstraintLine(
 template <typename number>
 template <typename ConstraintLineType>
 inline typename AffineConstraints<number>::ConstraintLine &
-AffineConstraints<number>::ConstraintLine::
-operator=(const ConstraintLineType &other)
+AffineConstraints<number>::ConstraintLine::operator=(
+  const ConstraintLineType &other)
 {
   this->index = other.index;
 

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -65,8 +65,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <typename number>
 bool
-AffineConstraints<number>::ConstraintLine::
-operator<(const ConstraintLine &a) const
+AffineConstraints<number>::ConstraintLine::operator<(
+  const ConstraintLine &a) const
 {
   return index < a.index;
 }
@@ -75,8 +75,8 @@ operator<(const ConstraintLine &a) const
 
 template <typename number>
 bool
-AffineConstraints<number>::ConstraintLine::
-operator==(const ConstraintLine &a) const
+AffineConstraints<number>::ConstraintLine::operator==(
+  const ConstraintLine &a) const
 {
   return index == a.index;
 }
@@ -3117,7 +3117,8 @@ namespace internal
       /**
        * Dereferencing operator.
        */
-      ScratchData<number> &operator*()
+      ScratchData<number> &
+      operator*()
       {
         return *my_scratch_data;
       }
@@ -3125,7 +3126,8 @@ namespace internal
       /**
        * Dereferencing operator.
        */
-      ScratchData<number> *operator->()
+      ScratchData<number> *
+      operator->()
       {
         return my_scratch_data;
       }

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -211,13 +211,15 @@ namespace internal
        * is <tt>true</tt>, then no writing to the result is possible, making
        * this a const_iterator.
        */
-      dereference_type operator*() const;
+      dereference_type
+      operator*() const;
 
       /**
        * Random access operator, grant access to arbitrary elements relative
        * to the one presently pointed to.
        */
-      dereference_type operator[](const difference_type d) const;
+      dereference_type
+      operator[](const difference_type d) const;
 
       /**
        * Prefix increment operator. This operator advances the iterator to the
@@ -614,14 +616,16 @@ public:
    *
    * Exactly the same as operator().
    */
-  value_type operator[](const size_type i) const;
+  value_type
+  operator[](const size_type i) const;
 
   /**
    * Access components, returns U(i) as a writeable reference.
    *
    * Exactly the same as operator().
    */
-  reference operator[](const size_type i);
+  reference
+  operator[](const size_type i);
 
   /**
    * Instead of getting individual elements of a vector via operator(),
@@ -721,7 +725,8 @@ public:
   /**
    * $U = U * V$: scalar product.
    */
-  value_type operator*(const BlockVectorBase &V) const;
+  value_type
+  operator*(const BlockVectorBase &V) const;
 
   /**
    * Return the square of the $l_2$-norm.
@@ -1042,7 +1047,7 @@ namespace internal
 
     template <class BlockVectorType, bool Constness>
     inline typename Iterator<BlockVectorType, Constness>::dereference_type
-      Iterator<BlockVectorType, Constness>::operator*() const
+    Iterator<BlockVectorType, Constness>::operator*() const
     {
       return parent->block(current_block)(index_within_block);
     }
@@ -1051,8 +1056,8 @@ namespace internal
 
     template <class BlockVectorType, bool Constness>
     inline typename Iterator<BlockVectorType, Constness>::dereference_type
-      Iterator<BlockVectorType, Constness>::
-      operator[](const difference_type d) const
+    Iterator<BlockVectorType, Constness>::operator[](
+      const difference_type d) const
     {
       // if the index pointed to is
       // still within the block we
@@ -1120,8 +1125,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator==(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator==(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1133,8 +1138,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator!=(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator!=(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1146,8 +1151,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator<(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator<(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1159,8 +1164,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator<=(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator<=(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1172,8 +1177,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator>(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator>(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1185,8 +1190,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline bool
-    Iterator<BlockVectorType, Constness>::
-    operator>=(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator>=(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1198,8 +1203,8 @@ namespace internal
     template <class BlockVectorType, bool Constness>
     template <bool OtherConstness>
     inline typename Iterator<BlockVectorType, Constness>::difference_type
-    Iterator<BlockVectorType, Constness>::
-    operator-(const Iterator<BlockVectorType, OtherConstness> &i) const
+    Iterator<BlockVectorType, Constness>::operator-(
+      const Iterator<BlockVectorType, OtherConstness> &i) const
     {
       Assert(parent == i.parent, ExcPointerToDifferentVectors());
 
@@ -1211,8 +1216,8 @@ namespace internal
 
     template <class BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
-    Iterator<BlockVectorType, Constness>::
-    operator+(const difference_type &d) const
+    Iterator<BlockVectorType, Constness>::operator+(
+      const difference_type &d) const
     {
       // if the index pointed to is
       // still within the block we
@@ -1238,8 +1243,8 @@ namespace internal
 
     template <class BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>
-    Iterator<BlockVectorType, Constness>::
-    operator-(const difference_type &d) const
+    Iterator<BlockVectorType, Constness>::operator-(
+      const difference_type &d) const
     {
       // if the index pointed to is
       // still within the block we
@@ -1606,8 +1611,9 @@ BlockVectorBase<VectorType>::is_non_negative() const
 
 
 template <class VectorType>
-typename BlockVectorBase<VectorType>::value_type BlockVectorBase<VectorType>::
-                                                 operator*(const BlockVectorBase<VectorType> &v) const
+typename BlockVectorBase<VectorType>::value_type
+BlockVectorBase<VectorType>::operator*(
+  const BlockVectorBase<VectorType> &v) const
 {
   Assert(n_blocks() == v.n_blocks(),
          ExcDimensionMismatch(n_blocks(), v.n_blocks()));
@@ -2040,8 +2046,8 @@ BlockVectorBase<VectorType>::operator=(const VectorType &v)
 template <class VectorType>
 template <class VectorType2>
 inline bool
-BlockVectorBase<VectorType>::
-operator==(const BlockVectorBase<VectorType2> &v) const
+BlockVectorBase<VectorType>::operator==(
+  const BlockVectorBase<VectorType2> &v) const
 {
   Assert(block_indices == v.block_indices, ExcDifferentBlockIndices());
 
@@ -2108,7 +2114,7 @@ BlockVectorBase<VectorType>::operator()(const size_type i)
 
 template <class VectorType>
 inline typename BlockVectorBase<VectorType>::value_type
-  BlockVectorBase<VectorType>::operator[](const size_type i) const
+BlockVectorBase<VectorType>::operator[](const size_type i) const
 {
   return operator()(i);
 }
@@ -2117,7 +2123,7 @@ inline typename BlockVectorBase<VectorType>::value_type
 
 template <class VectorType>
 inline typename BlockVectorBase<VectorType>::reference
-  BlockVectorBase<VectorType>::operator[](const size_type i)
+BlockVectorBase<VectorType>::operator[](const size_type i)
 {
   return operator()(i);
 }

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -339,12 +339,14 @@ namespace ChunkSparseMatrixIterators
     /**
      * Dereferencing operator.
      */
-    const Accessor<number, Constness> &operator*() const;
+    const Accessor<number, Constness> &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor<number, Constness> *operator->() const;
+    const Accessor<number, Constness> *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -1874,16 +1876,16 @@ namespace ChunkSparseMatrixIterators
 
 
   template <typename number, bool Constness>
-  inline const Accessor<number, Constness> &Iterator<number, Constness>::
-                                            operator*() const
+  inline const Accessor<number, Constness> &
+  Iterator<number, Constness>::operator*() const
   {
     return accessor;
   }
 
 
   template <typename number, bool Constness>
-  inline const Accessor<number, Constness> *Iterator<number, Constness>::
-                                            operator->() const
+  inline const Accessor<number, Constness> *
+  Iterator<number, Constness>::operator->() const
   {
     return &accessor;
   }

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -192,12 +192,14 @@ namespace ChunkSparsityPatternIterators
     /**
      * Dereferencing operator.
      */
-    const Accessor &operator*() const;
+    const Accessor &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor *operator->() const;
+    const Accessor *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -1062,14 +1064,16 @@ namespace ChunkSparsityPatternIterators
 
 
 
-  inline const Accessor &Iterator::operator*() const
+  inline const Accessor &
+  Iterator::operator*() const
   {
     return accessor;
   }
 
 
 
-  inline const Accessor *Iterator::operator->() const
+  inline const Accessor *
+  Iterator::operator->() const
   {
     return &accessor;
   }

--- a/include/deal.II/lac/cuda_kernels.templates.h
+++ b/include/deal.II/lac/cuda_kernels.templates.h
@@ -82,7 +82,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 ElemSum<Number>::reduction_op(const Number a, const Number b)
+      ElemSum<Number>::reduction_op(const Number a, const Number b)
       {
         return (a + b);
       }
@@ -91,7 +91,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 ElemSum<Number>::atomic_op(Number *dst, const Number a)
+      ElemSum<Number>::atomic_op(Number *dst, const Number a)
       {
         return atomicAdd(dst, a);
       }
@@ -100,7 +100,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 ElemSum<Number>::element_wise_op(const Number a)
+      ElemSum<Number>::element_wise_op(const Number a)
       {
         return a;
       }
@@ -109,7 +109,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 ElemSum<Number>::null_value()
+      ElemSum<Number>::null_value()
       {
         return Number();
       }
@@ -118,7 +118,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 L1Norm<Number>::reduction_op(const Number a, const Number b)
+      L1Norm<Number>::reduction_op(const Number a, const Number b)
       {
         return (a + b);
       }
@@ -127,7 +127,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 L1Norm<Number>::atomic_op(Number *dst, const Number a)
+      L1Norm<Number>::atomic_op(Number *dst, const Number a)
       {
         return atomicAdd(dst, a);
       }
@@ -136,7 +136,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 L1Norm<Number>::element_wise_op(const Number a)
+      L1Norm<Number>::element_wise_op(const Number a)
       {
         return std::fabs(a);
       }
@@ -145,7 +145,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 L1Norm<Number>::null_value()
+      L1Norm<Number>::null_value()
       {
         return Number();
       }
@@ -154,7 +154,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 LInfty<Number>::reduction_op(const Number a, const Number b)
+      LInfty<Number>::reduction_op(const Number a, const Number b)
       {
         if (a > b)
           return a;
@@ -166,7 +166,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 LInfty<Number>::atomic_op(Number *dst, const Number a)
+      LInfty<Number>::atomic_op(Number *dst, const Number a)
       {
         return atomicMax_wrapper(dst, a);
       }
@@ -175,7 +175,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 LInfty<Number>::element_wise_op(const Number a)
+      LInfty<Number>::element_wise_op(const Number a)
       {
         return std::fabs(a);
       }
@@ -184,7 +184,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 LInfty<Number>::null_value()
+      LInfty<Number>::null_value()
       {
         return Number();
       }
@@ -249,7 +249,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 DotProduct<Number>::binary_op(const Number a, const Number b)
+      DotProduct<Number>::binary_op(const Number a, const Number b)
       {
         return a * b;
       }
@@ -258,7 +258,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 DotProduct<Number>::reduction_op(const Number a, const Number b)
+      DotProduct<Number>::reduction_op(const Number a, const Number b)
       {
         return a + b;
       }
@@ -267,7 +267,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 DotProduct<Number>::atomic_op(Number *dst, const Number a)
+      DotProduct<Number>::atomic_op(Number *dst, const Number a)
       {
         return atomicAdd(dst, a);
       }
@@ -276,7 +276,7 @@ namespace LinearAlgebra
 
       template <typename Number>
       __device__ Number
-                 DotProduct<Number>::null_value()
+      DotProduct<Number>::null_value()
       {
         return Number();
       }

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -225,12 +225,14 @@ namespace DynamicSparsityPatternIterators
     /**
      * Dereferencing operator.
      */
-    const Accessor &operator*() const;
+    const Accessor &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor *operator->() const;
+    const Accessor *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -934,14 +936,16 @@ namespace DynamicSparsityPatternIterators
 
 
 
-  inline const Accessor &Iterator::operator*() const
+  inline const Accessor &
+  Iterator::operator*() const
   {
     return accessor;
   }
 
 
 
-  inline const Accessor *Iterator::operator->() const
+  inline const Accessor *
+  Iterator::operator->() const
   {
     return &accessor;
   }

--- a/include/deal.II/lac/full_matrix.h
+++ b/include/deal.II/lac/full_matrix.h
@@ -244,13 +244,14 @@ public:
    * matrix coincide.
    */
   template <int dim>
-  void copy_to(Tensor<2, dim> &   T,
-               const size_type    src_r_i = 0,
-               const size_type    src_r_j = dim - 1,
-               const size_type    src_c_i = 0,
-               const size_type    src_c_j = dim - 1,
-               const unsigned int dst_r   = 0,
-               const unsigned int dst_c   = 0) const;
+  void
+  copy_to(Tensor<2, dim> &   T,
+          const size_type    src_r_i = 0,
+          const size_type    src_r_j = dim - 1,
+          const size_type    src_c_i = 0,
+          const size_type    src_c_j = dim - 1,
+          const unsigned int dst_r   = 0,
+          const unsigned int dst_c   = 0) const;
 
   /**
    * Copy a subset of the rows and columns of another matrix into the current

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1697,13 +1697,14 @@ FullMatrix<number>::copy_from(const Tensor<2, dim> &T,
 
 template <typename number>
 template <int dim>
-void FullMatrix<number>::copy_to(Tensor<2, dim> &   T,
-                                 const size_type    src_r_i,
-                                 const size_type    src_r_j,
-                                 const size_type    src_c_i,
-                                 const size_type    src_c_j,
-                                 const unsigned int dst_r,
-                                 const unsigned int dst_c) const
+void
+FullMatrix<number>::copy_to(Tensor<2, dim> &   T,
+                            const size_type    src_r_i,
+                            const size_type    src_r_j,
+                            const size_type    src_c_i,
+                            const size_type    src_c_j,
+                            const unsigned int dst_r,
+                            const unsigned int dst_c) const
 {
   Assert(!this->empty(), ExcEmptyMatrix());
   AssertIndexRange(src_r_j - src_r_i, dim - dst_r);

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -247,8 +247,8 @@ namespace LinearAlgebra
 
     template <typename Number>
     BlockVector<Number> &
-    BlockVector<Number>::
-    operator=(const PETScWrappers::MPI::BlockVector &petsc_vec)
+    BlockVector<Number>::operator=(
+      const PETScWrappers::MPI::BlockVector &petsc_vec)
     {
       AssertDimension(this->n_blocks(), petsc_vec.n_blocks());
       for (unsigned int i = 0; i < this->n_blocks(); ++i)
@@ -296,8 +296,8 @@ namespace LinearAlgebra
 
     template <typename Number>
     BlockVector<Number> &
-    BlockVector<Number>::
-    operator=(const TrilinosWrappers::MPI::BlockVector &trilinos_vec)
+    BlockVector<Number>::operator=(
+      const TrilinosWrappers::MPI::BlockVector &trilinos_vec)
     {
       AssertDimension(this->n_blocks(), trilinos_vec.n_blocks());
       for (unsigned int i = 0; i < this->n_blocks(); ++i)
@@ -641,8 +641,8 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    Number BlockVector<Number>::
-           operator*(const VectorSpaceVector<Number> &vv) const
+    Number
+    BlockVector<Number>::operator*(const VectorSpaceVector<Number> &vv) const
     {
       Assert(this->n_blocks() > 0, ExcEmptyObject());
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1033,7 +1033,8 @@ namespace LinearAlgebra
        *
        * This function does the same thing as operator().
        */
-      Number operator[](const size_type global_index) const;
+      Number
+      operator[](const size_type global_index) const;
       /**
        * Read and write access to the data in the position corresponding to @p
        * global_index. The index must be either in the local range of the
@@ -1041,7 +1042,8 @@ namespace LinearAlgebra
        *
        * This function does the same thing as operator().
        */
-      Number &operator[](const size_type global_index);
+      Number &
+      operator[](const size_type global_index);
 
       /**
        * Read access to the data field specified by @p local_index. Locally
@@ -1676,8 +1678,8 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline Number Vector<Number, MemorySpace>::
-                  operator[](const size_type global_index) const
+    inline Number
+    Vector<Number, MemorySpace>::operator[](const size_type global_index) const
     {
       return operator()(global_index);
     }
@@ -1685,8 +1687,8 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpace>
-    inline Number &Vector<Number, MemorySpace>::
-                   operator[](const size_type global_index)
+    inline Number &
+    Vector<Number, MemorySpace>::operator[](const size_type global_index)
     {
       return operator()(global_index);
     }

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -785,8 +785,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     inline Vector<Number, MemorySpaceType> &
-    Vector<Number, MemorySpaceType>::
-    operator=(const Vector<Number, MemorySpaceType> &c)
+    Vector<Number, MemorySpaceType>::operator=(
+      const Vector<Number, MemorySpaceType> &c)
     {
 #ifdef _MSC_VER
       return this->operator=<Number>(c);
@@ -800,8 +800,8 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     template <typename Number2>
     inline Vector<Number, MemorySpaceType> &
-    Vector<Number, MemorySpaceType>::
-    operator=(const Vector<Number2, MemorySpaceType> &c)
+    Vector<Number, MemorySpaceType>::operator=(
+      const Vector<Number2, MemorySpaceType> &c)
     {
       Assert(c.partitioner.get() != nullptr, ExcNotInitialized());
 
@@ -1475,8 +1475,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType> &
-    Vector<Number, MemorySpaceType>::
-    operator+=(const VectorSpaceVector<Number> &vv)
+    Vector<Number, MemorySpaceType>::operator+=(
+      const VectorSpaceVector<Number> &vv)
     {
       // Downcast. Throws an exception if invalid.
       using VectorType = Vector<Number, MemorySpaceType>;
@@ -1503,8 +1503,8 @@ namespace LinearAlgebra
 
     template <typename Number, typename MemorySpaceType>
     Vector<Number, MemorySpaceType> &
-    Vector<Number, MemorySpaceType>::
-    operator-=(const VectorSpaceVector<Number> &vv)
+    Vector<Number, MemorySpaceType>::operator-=(
+      const VectorSpaceVector<Number> &vv)
     {
       // Downcast. Throws an exception if invalid.
       using VectorType = Vector<Number, MemorySpaceType>;
@@ -1819,8 +1819,9 @@ namespace LinearAlgebra
 
 
     template <typename Number, typename MemorySpaceType>
-    Number Vector<Number, MemorySpaceType>::
-           operator*(const VectorSpaceVector<Number> &vv) const
+    Number
+    Vector<Number, MemorySpaceType>::operator*(
+      const VectorSpaceVector<Number> &vv) const
     {
       // Downcast. Throws an exception if invalid.
       using VectorType = Vector<Number, MemorySpaceType>;

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -214,7 +214,8 @@ namespace LinearAlgebra
     /**
      * Return the scalar product of two vectors.
      */
-    virtual Number operator*(const VectorSpaceVector<Number> &V) const override;
+    virtual Number
+    operator*(const VectorSpaceVector<Number> &V) const override;
 
     /**
      * This function is not implemented and will throw an exception.
@@ -485,7 +486,7 @@ namespace LinearAlgebra
   {
     size_type current_size = this->size();
     ar &static_cast<Subscriptor &>(*this);
-    ar & this->stored_elements;
+    ar &this->stored_elements;
     // If necessary, resize the vector during a read operation
     if (this->size() != current_size)
       this->reinit(this->size());

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -226,7 +226,8 @@ namespace LinearAlgebra
 
 
   template <typename Number>
-  Number Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
+  Number
+  Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
   {
     // Check that casting will work.
     Assert(dynamic_cast<const Vector<Number> *>(&V) != nullptr,

--- a/include/deal.II/lac/linear_operator.h
+++ b/include/deal.II/lac/linear_operator.h
@@ -1146,7 +1146,8 @@ namespace internal
      * Operator that returns a payload configured to support the
      * multiplication of two LinearOperators
      */
-    inline EmptyPayload operator*(const EmptyPayload &, const EmptyPayload &)
+    inline EmptyPayload
+    operator*(const EmptyPayload &, const EmptyPayload &)
     {
       return {};
     }

--- a/include/deal.II/lac/matrix_iterator.h
+++ b/include/deal.II/lac/matrix_iterator.h
@@ -75,12 +75,14 @@ public:
   /**
    * Dereferencing operator.
    */
-  const ACCESSOR &operator*() const;
+  const ACCESSOR &
+  operator*() const;
 
   /**
    * Dereferencing operator.
    */
-  const ACCESSOR *operator->() const;
+  const ACCESSOR *
+  operator->() const;
 
   /**
    * Comparison. True, if both accessors are equal.
@@ -160,14 +162,16 @@ MatrixIterator<ACCESSOR>::operator++(int)
 
 
 template <class ACCESSOR>
-inline const ACCESSOR &MatrixIterator<ACCESSOR>::operator*() const
+inline const ACCESSOR &
+MatrixIterator<ACCESSOR>::operator*() const
 {
   return accessor;
 }
 
 
 template <class ACCESSOR>
-inline const ACCESSOR *MatrixIterator<ACCESSOR>::operator->() const
+inline const ACCESSOR *
+MatrixIterator<ACCESSOR>::operator->() const
 {
   return &accessor;
 }

--- a/include/deal.II/lac/packaged_operation.h
+++ b/include/deal.II/lac/packaged_operation.h
@@ -360,8 +360,9 @@ operator-(const PackagedOperation<Range> &first_comp,
  * @ingroup LAOperators
  */
 template <typename Range>
-PackagedOperation<Range> operator*(const PackagedOperation<Range> &comp,
-                                   typename Range::value_type      number)
+PackagedOperation<Range>
+operator*(const PackagedOperation<Range> &comp,
+          typename Range::value_type      number)
 {
   PackagedOperation<Range> return_comp;
 
@@ -400,8 +401,9 @@ PackagedOperation<Range> operator*(const PackagedOperation<Range> &comp,
  * @ingroup LAOperators
  */
 template <typename Range>
-PackagedOperation<Range> operator*(typename Range::value_type      number,
-                                   const PackagedOperation<Range> &comp)
+PackagedOperation<Range>
+operator*(typename Range::value_type      number,
+          const PackagedOperation<Range> &comp)
 {
   return comp * number;
 }
@@ -614,8 +616,8 @@ template <typename Range,
           typename = typename std::enable_if<
             internal::PackagedOperationImplementation::has_vector_interface<
               Range>::type::value>::type>
-PackagedOperation<Range> operator*(const Range &              u,
-                                   typename Range::value_type number)
+PackagedOperation<Range>
+operator*(const Range &u, typename Range::value_type number)
 {
   return PackagedOperation<Range>(u) * number;
 }
@@ -639,8 +641,8 @@ template <typename Range,
           typename = typename std::enable_if<
             internal::PackagedOperationImplementation::has_vector_interface<
               Range>::type::value>::type>
-PackagedOperation<Range> operator*(typename Range::value_type number,
-                                   const Range &              u)
+PackagedOperation<Range>
+operator*(typename Range::value_type number, const Range &u)
 {
   return number * PackagedOperation<Range>(u);
 }

--- a/include/deal.II/lac/petsc_matrix_base.h
+++ b/include/deal.II/lac/petsc_matrix_base.h
@@ -202,12 +202,14 @@ namespace PETScWrappers
       /**
        * Dereferencing operator.
        */
-      const Accessor &operator*() const;
+      const Accessor &
+      operator*() const;
 
       /**
        * Dereferencing operator.
        */
-      const Accessor *operator->() const;
+      const Accessor *
+      operator->() const;
 
       /**
        * Comparison. True, if both iterators point to the same matrix
@@ -1160,13 +1162,15 @@ namespace PETScWrappers
     }
 
 
-    inline const const_iterator::Accessor &const_iterator::operator*() const
+    inline const const_iterator::Accessor &
+    const_iterator::operator*() const
     {
       return accessor;
     }
 
 
-    inline const const_iterator::Accessor *const_iterator::operator->() const
+    inline const const_iterator::Accessor *
+    const_iterator::operator->() const
     {
       return &accessor;
     }

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -444,14 +444,16 @@ namespace PETScWrappers
      *
      * Exactly the same as operator().
      */
-    reference operator[](const size_type index);
+    reference
+    operator[](const size_type index);
 
     /**
      * Provide read-only access to an element.
      *
      * Exactly the same as operator().
      */
-    PetscScalar operator[](const size_type index) const;
+    PetscScalar
+    operator[](const size_type index) const;
 
     /**
      * A collective set operation: instead of setting individual elements of a
@@ -547,7 +549,8 @@ namespace PETScWrappers
      *
      * For complex valued vector, this gives$\left(v^\ast,vec\right)$.
      */
-    PetscScalar operator*(const VectorBase &vec) const;
+    PetscScalar
+    operator*(const VectorBase &vec) const;
 
     /**
      * Return the square of the $l_2$-norm.
@@ -1128,14 +1131,16 @@ namespace PETScWrappers
 
 
 
-  inline internal::VectorReference VectorBase::operator[](const size_type index)
+  inline internal::VectorReference
+  VectorBase::operator[](const size_type index)
   {
     return operator()(index);
   }
 
 
 
-  inline PetscScalar VectorBase::operator[](const size_type index) const
+  inline PetscScalar
+  VectorBase::operator[](const size_type index) const
   {
     return operator()(index);
   }

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -2196,7 +2196,7 @@ template <typename MatrixType, class VectorType, typename PreconditionerType>
 inline typename PreconditionChebyshev<MatrixType,
                                       VectorType,
                                       PreconditionerType>::AdditionalData &
-                  PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
+PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
   AdditionalData::operator=(const AdditionalData &other_data)
 {
   degree              = other_data.degree;

--- a/include/deal.II/lac/precondition_block.h
+++ b/include/deal.II/lac/precondition_block.h
@@ -475,12 +475,14 @@ public:
     /**
      * Dereferencing operator.
      */
-    const Accessor &operator*() const;
+    const Accessor &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor *operator->() const;
+    const Accessor *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -993,10 +995,9 @@ inline PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
 
 
 template <typename MatrixType, typename inverse_type>
-inline
-  typename PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator &
-  PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-  operator++()
+inline typename PreconditionBlockJacobi<MatrixType,
+                                        inverse_type>::const_iterator &
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator++()
 {
   Assert(*this != accessor.matrix->end(), ExcIteratorPastEnd());
 
@@ -1019,8 +1020,8 @@ inline
 template <typename MatrixType, typename inverse_type>
 inline const typename PreconditionBlockJacobi<MatrixType, inverse_type>::
   const_iterator::Accessor &
-    PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-    operator*() const
+  PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator*()
+    const
 {
   return accessor;
 }
@@ -1029,8 +1030,8 @@ inline const typename PreconditionBlockJacobi<MatrixType, inverse_type>::
 template <typename MatrixType, typename inverse_type>
 inline const typename PreconditionBlockJacobi<MatrixType, inverse_type>::
   const_iterator::Accessor *
-    PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-    operator->() const
+  PreconditionBlockJacobi<MatrixType,
+                          inverse_type>::const_iterator::operator->() const
 {
   return &accessor;
 }
@@ -1038,8 +1039,8 @@ inline const typename PreconditionBlockJacobi<MatrixType, inverse_type>::
 
 template <typename MatrixType, typename inverse_type>
 inline bool
-PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-operator==(const const_iterator &other) const
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator==(
+  const const_iterator &other) const
 {
   if (accessor.a_block == accessor.matrix->size() &&
       accessor.a_block == other.accessor.a_block)
@@ -1055,8 +1056,8 @@ operator==(const const_iterator &other) const
 
 template <typename MatrixType, typename inverse_type>
 inline bool
-PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-operator!=(const const_iterator &other) const
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator!=(
+  const const_iterator &other) const
 {
   return !(*this == other);
 }
@@ -1064,8 +1065,8 @@ operator!=(const const_iterator &other) const
 
 template <typename MatrixType, typename inverse_type>
 inline bool
-PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::
-operator<(const const_iterator &other) const
+PreconditionBlockJacobi<MatrixType, inverse_type>::const_iterator::operator<(
+  const const_iterator &other) const
 {
   return (accessor.row() < other.accessor.row() ||
           (accessor.row() == other.accessor.row() &&

--- a/include/deal.II/lac/qr.h
+++ b/include/deal.II/lac/qr.h
@@ -623,7 +623,7 @@ ImplicitQR<VectorType>::append_column(const VectorType &column)
       const Number rho2            = column_norm_sqr - u.norm_sqr();
       const bool   linearly_independent =
         column_signal.empty() ? rho2 > 0 :
-                                column_signal(u, rho2, column_norm_sqr).get();
+                                  column_signal(u, rho2, column_norm_sqr).get();
 
       // bail out if it turns out to be linearly dependent
       if (!linearly_independent)

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -502,7 +502,8 @@ namespace LinearAlgebra
      *
      * This function does the same thing as operator().
      */
-    Number operator[](const size_type global_index) const;
+    Number
+    operator[](const size_type global_index) const;
 
     /**
      * Read and write access to the data in the position corresponding to @p
@@ -511,7 +512,8 @@ namespace LinearAlgebra
      *
      * This function does the same thing as operator().
      */
-    Number &operator[](const size_type global_index);
+    Number &
+    operator[](const size_type global_index);
 
     /**
      * Instead of getting individual elements of a vector via operator(),
@@ -928,8 +930,8 @@ namespace LinearAlgebra
 
 
   template <typename Number>
-  inline Number ReadWriteVector<Number>::
-                operator[](const size_type global_index) const
+  inline Number
+  ReadWriteVector<Number>::operator[](const size_type global_index) const
   {
     return operator()(global_index);
   }
@@ -937,8 +939,8 @@ namespace LinearAlgebra
 
 
   template <typename Number>
-  inline Number &ReadWriteVector<Number>::
-                 operator[](const size_type global_index)
+  inline Number &
+  ReadWriteVector<Number>::operator[](const size_type global_index)
   {
     return operator()(global_index);
   }
@@ -1062,8 +1064,9 @@ namespace LinearAlgebra
   template <typename Number>
   template <typename Functor>
   void
-  ReadWriteVector<Number>::FunctorTemplate<Functor>::
-  operator()(const size_type begin, const size_type end)
+  ReadWriteVector<Number>::FunctorTemplate<Functor>::operator()(
+    const size_type begin,
+    const size_type end)
   {
     for (size_type i = begin; i < end; ++i)
       functor(parent.values[i]);

--- a/include/deal.II/lac/relaxation_block.h
+++ b/include/deal.II/lac/relaxation_block.h
@@ -90,7 +90,7 @@ public:
       const bool   invert_diagonal = true,
       const bool   same_diagonal   = false,
       const typename PreconditionBlockBase<InverseNumberType>::Inversion
-                   inversion = PreconditionBlockBase<InverseNumberType>::gauss_jordan,
+        inversion = PreconditionBlockBase<InverseNumberType>::gauss_jordan,
       const double threshold         = 0.,
       VectorType * temp_ghost_vector = nullptr);
 

--- a/include/deal.II/lac/relaxation_block.templates.h
+++ b/include/deal.II/lac/relaxation_block.templates.h
@@ -99,13 +99,13 @@ RelaxationBlock<MatrixType, InverseNumberType, VectorType>::invert_diagblocks()
   else
     {
       // compute blocks in parallel
-      parallel::apply_to_subranges(0,
-                                   this->additional_data->block_list.n_rows(),
-                                   [this](const size_type block_begin,
-                                          const size_type block_end) {
-                                     this->block_kernel(block_begin, block_end);
-                                   },
-                                   16);
+      parallel::apply_to_subranges(
+        0,
+        this->additional_data->block_list.n_rows(),
+        [this](const size_type block_begin, const size_type block_end) {
+          this->block_kernel(block_begin, block_end);
+        },
+        16);
     }
   this->inverses_computed(true);
 }

--- a/include/deal.II/lac/solver.h
+++ b/include/deal.II/lac/solver.h
@@ -478,9 +478,9 @@ protected:
 
 template <class VectorType>
 inline SolverControl::State
-SolverBase<VectorType>::StateCombiner::
-operator()(const SolverControl::State state1,
-           const SolverControl::State state2) const
+SolverBase<VectorType>::StateCombiner::operator()(
+  const SolverControl::State state1,
+  const SolverControl::State state2) const
 {
   if ((state1 == SolverControl::failure) || (state2 == SolverControl::failure))
     return SolverControl::failure;

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -74,7 +74,8 @@ namespace internal
        * Get vector number @p i. If this vector was unused before, an error
        * occurs.
        */
-      VectorType &operator[](const unsigned int i) const;
+      VectorType &
+      operator[](const unsigned int i) const;
 
       /**
        * Get vector number @p i. Allocate it if necessary.
@@ -537,8 +538,8 @@ namespace internal
 
 
     template <class VectorType>
-    inline VectorType &TmpVectors<VectorType>::
-                       operator[](const unsigned int i) const
+    inline VectorType &
+    TmpVectors<VectorType>::operator[](const unsigned int i) const
     {
       AssertIndexRange(i, data.size());
 

--- a/include/deal.II/lac/solver_idr.h
+++ b/include/deal.II/lac/solver_idr.h
@@ -65,7 +65,8 @@ namespace internal
        * Get vector number @p i. If this vector was unused before, an error
        * occurs.
        */
-      VectorType &operator[](const unsigned int i) const;
+      VectorType &
+      operator[](const unsigned int i) const;
 
       /**
        * Get vector number @p i. Allocate it if necessary.
@@ -199,8 +200,8 @@ namespace internal
 
 
     template <class VectorType>
-    inline VectorType &TmpVectors<VectorType>::
-                       operator[](const unsigned int i) const
+    inline VectorType &
+    TmpVectors<VectorType>::operator[](const unsigned int i) const
     {
       AssertIndexRange(i, data.size());
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -398,12 +398,14 @@ namespace SparseMatrixIterators
     /**
      * Dereferencing operator.
      */
-    const Accessor<number, Constness> &operator*() const;
+    const Accessor<number, Constness> &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor<number, Constness> *operator->() const;
+    const Accessor<number, Constness> *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -2277,8 +2279,8 @@ namespace SparseMatrixIterators
 
   template <typename number, bool Constness>
   inline const Iterator<number, Constness> &
-  Iterator<number, Constness>::
-  operator=(const SparseMatrixIterators::Iterator<number, false> &i)
+  Iterator<number, Constness>::operator=(
+    const SparseMatrixIterators::Iterator<number, false> &i)
   {
     accessor = *i;
     return *this;
@@ -2306,16 +2308,16 @@ namespace SparseMatrixIterators
 
 
   template <typename number, bool Constness>
-  inline const Accessor<number, Constness> &Iterator<number, Constness>::
-                                            operator*() const
+  inline const Accessor<number, Constness> &
+  Iterator<number, Constness>::operator*() const
   {
     return accessor;
   }
 
 
   template <typename number, bool Constness>
-  inline const Accessor<number, Constness> *Iterator<number, Constness>::
-                                            operator->() const
+  inline const Accessor<number, Constness> *
+  Iterator<number, Constness>::operator->() const
   {
     return &accessor;
   }

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -253,12 +253,14 @@ public:
     /**
      * Dereferencing operator.
      */
-    const Accessor &operator*() const;
+    const Accessor &
+    operator*() const;
 
     /**
      * Dereferencing operator.
      */
-    const Accessor *operator->() const;
+    const Accessor *
+    operator->() const;
 
     /**
      * Comparison. True, if both iterators point to the same matrix position.
@@ -1042,7 +1044,7 @@ SparseMatrixEZ<number>::const_iterator::operator++()
 
 template <typename number>
 inline const typename SparseMatrixEZ<number>::const_iterator::Accessor &
-  SparseMatrixEZ<number>::const_iterator::operator*() const
+SparseMatrixEZ<number>::const_iterator::operator*() const
 {
   return accessor;
 }
@@ -1050,7 +1052,7 @@ inline const typename SparseMatrixEZ<number>::const_iterator::Accessor &
 
 template <typename number>
 inline const typename SparseMatrixEZ<number>::const_iterator::Accessor *
-  SparseMatrixEZ<number>::const_iterator::operator->() const
+SparseMatrixEZ<number>::const_iterator::operator->() const
 {
   return &accessor;
 }
@@ -1058,8 +1060,8 @@ inline const typename SparseMatrixEZ<number>::const_iterator::Accessor *
 
 template <typename number>
 inline bool
-SparseMatrixEZ<number>::const_iterator::
-operator==(const const_iterator &other) const
+SparseMatrixEZ<number>::const_iterator::operator==(
+  const const_iterator &other) const
 {
   return (accessor.row() == other.accessor.row() &&
           accessor.index() == other.accessor.index());
@@ -1068,8 +1070,8 @@ operator==(const const_iterator &other) const
 
 template <typename number>
 inline bool
-SparseMatrixEZ<number>::const_iterator::
-operator!=(const const_iterator &other) const
+SparseMatrixEZ<number>::const_iterator::operator!=(
+  const const_iterator &other) const
 {
   return !(*this == other);
 }
@@ -1077,8 +1079,8 @@ operator!=(const const_iterator &other) const
 
 template <typename number>
 inline bool
-SparseMatrixEZ<number>::const_iterator::
-operator<(const const_iterator &other) const
+SparseMatrixEZ<number>::const_iterator::operator<(
+  const const_iterator &other) const
 {
   return (accessor.row() < other.accessor.row() ||
           (accessor.row() == other.accessor.row() &&

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -387,12 +387,14 @@ namespace TrilinosWrappers
       /**
        * Dereferencing operator.
        */
-      const Accessor<Constness> &operator*() const;
+      const Accessor<Constness> &
+      operator*() const;
 
       /**
        * Dereferencing operator.
        */
-      const Accessor<Constness> *operator->() const;
+      const Accessor<Constness> *
+      operator->() const;
 
       /**
        * Comparison. True, if both iterators point to the same matrix
@@ -2392,8 +2394,9 @@ namespace TrilinosWrappers
        * Return an operator that returns a payload configured to support the
        * multiplication of two LinearOperators
        */
-      TrilinosPayload operator*(const TrilinosPayload &first_op,
-                                const TrilinosPayload &second_op);
+      TrilinosPayload
+      operator*(const TrilinosPayload &first_op,
+                const TrilinosPayload &second_op);
 
     } // namespace LinearOperatorImplementation
   }   /* namespace internal */
@@ -2598,7 +2601,8 @@ namespace TrilinosWrappers
 
 
     template <bool Constness>
-    inline const Accessor<Constness> &Iterator<Constness>::operator*() const
+    inline const Accessor<Constness> &
+    Iterator<Constness>::operator*() const
     {
       return accessor;
     }
@@ -2606,7 +2610,8 @@ namespace TrilinosWrappers
 
 
     template <bool Constness>
-    inline const Accessor<Constness> *Iterator<Constness>::operator->() const
+    inline const Accessor<Constness> *
+    Iterator<Constness>::operator->() const
     {
       return &accessor;
     }

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -203,12 +203,14 @@ namespace TrilinosWrappers
       /**
        * Dereferencing operator.
        */
-      const Accessor &operator*() const;
+      const Accessor &
+      operator*() const;
 
       /**
        * Dereferencing operator.
        */
-      const Accessor *operator->() const;
+      const Accessor *
+      operator->() const;
 
       /**
        * Comparison. True, if both iterators point to the same matrix
@@ -1114,14 +1116,16 @@ namespace TrilinosWrappers
 
 
 
-    inline const Accessor &Iterator::operator*() const
+    inline const Accessor &
+    Iterator::operator*() const
     {
       return accessor;
     }
 
 
 
-    inline const Accessor *Iterator::operator->() const
+    inline const Accessor *
+    Iterator::operator->() const
     {
       return &accessor;
     }

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -300,7 +300,8 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    Number Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
+    Number
+    Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
     {
       // Check that casting will work.
       Assert(dynamic_cast<const Vector<Number> *>(&V) != nullptr,

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -821,7 +821,8 @@ namespace TrilinosWrappers
        * Return the scalar (inner) product of two vectors. The vectors must have
        * the same size.
        */
-      TrilinosScalar operator*(const Vector &vec) const;
+      TrilinosScalar
+      operator*(const Vector &vec) const;
 
       /**
        * Return the square of the $l_2$-norm.
@@ -943,14 +944,16 @@ namespace TrilinosWrappers
        *
        * Exactly the same as operator().
        */
-      reference operator[](const size_type index);
+      reference
+      operator[](const size_type index);
 
       /**
        * Provide read-only access to an element.
        *
        * Exactly the same as operator().
        */
-      TrilinosScalar operator[](const size_type index) const;
+      TrilinosScalar
+      operator[](const size_type index) const;
 
       /**
        * Instead of getting individual elements of a vector via operator(),
@@ -1494,14 +1497,16 @@ namespace TrilinosWrappers
 
 
 
-    inline internal::VectorReference Vector::operator[](const size_type index)
+    inline internal::VectorReference
+    Vector::operator[](const size_type index)
     {
       return operator()(index);
     }
 
 
 
-    inline TrilinosScalar Vector::operator[](const size_type index) const
+    inline TrilinosScalar
+    Vector::operator[](const size_type index) const
     {
       return operator()(index);
     }
@@ -1775,7 +1780,8 @@ namespace TrilinosWrappers
 
 
 
-    inline TrilinosScalar Vector::operator*(const Vector &vec) const
+    inline TrilinosScalar
+    Vector::operator*(const Vector &vec) const
     {
       Assert(vector->Map().SameAs(vec.vector->Map()),
              ExcDifferentParallelPartitioning());

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -474,7 +474,8 @@ public:
    * repeatable results from one run to another.
    */
   template <typename Number2>
-  Number operator*(const Vector<Number2> &V) const;
+  Number
+  operator*(const Vector<Number2> &V) const;
 
   /**
    * Return the square of the $l_2$-norm.
@@ -625,14 +626,16 @@ public:
    *
    * Exactly the same as operator().
    */
-  Number operator[](const size_type i) const;
+  Number
+  operator[](const size_type i) const;
 
   /**
    * Access the @p ith component as a writeable reference.
    *
    * Exactly the same as operator().
    */
-  Number &operator[](const size_type i);
+  Number &
+  operator[](const size_type i);
 
   /**
    * Instead of getting individual elements of a vector via operator(),
@@ -1192,7 +1195,8 @@ Vector<Number>::operator()(const size_type i)
 
 
 template <typename Number>
-inline Number Vector<Number>::operator[](const size_type i) const
+inline Number
+Vector<Number>::operator[](const size_type i) const
 {
   return operator()(i);
 }
@@ -1200,7 +1204,8 @@ inline Number Vector<Number>::operator[](const size_type i) const
 
 
 template <typename Number>
-inline Number &Vector<Number>::operator[](const size_type i)
+inline Number &
+Vector<Number>::operator[](const size_type i)
 {
   return operator()(i);
 }

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -367,7 +367,8 @@ Vector<Number>::sadd(const Number x, const Number a, const Vector<Number> &v)
 
 template <typename Number>
 template <typename Number2>
-Number Vector<Number>::operator*(const Vector<Number2> &v) const
+Number
+Vector<Number>::operator*(const Vector<Number2> &v) const
 {
   Assert(size() != 0, ExcEmptyObject());
 

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -115,7 +115,8 @@ namespace LinearAlgebra
     /**
      * Return the scalar product of two vectors.
      */
-    virtual Number operator*(const VectorSpaceVector<Number> &V) const = 0;
+    virtual Number
+    operator*(const VectorSpaceVector<Number> &V) const = 0;
 
     /**
      * Add @p a to all components. Note that @p a is a scalar not a vector.

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -48,12 +48,11 @@ namespace CUDAWrappers
     __device__ inline unsigned int
     compute_index()
     {
-      return (dim == 1 ?
-                threadIdx.x % n_points_1d :
-                dim == 2 ?
-                threadIdx.x % n_points_1d + n_points_1d * threadIdx.y :
-                threadIdx.x % n_points_1d +
-                    n_points_1d * (threadIdx.y + n_points_1d * threadIdx.z));
+      return (dim == 1 ? threadIdx.x % n_points_1d :
+              dim == 2 ? threadIdx.x % n_points_1d + n_points_1d * threadIdx.y :
+                         threadIdx.x % n_points_1d +
+                           n_points_1d *
+                             (threadIdx.y + n_points_1d * threadIdx.z));
     }
   } // namespace internal
 
@@ -180,14 +179,14 @@ namespace CUDAWrappers
      * id.
      */
     __device__ value_type
-               get_value() const;
+    get_value() const;
 
     /**
      * Same as above, except that the local dof index is computed from the
      * thread id.
      */
     __device__ value_type
-               get_dof_value() const;
+    get_dof_value() const;
 
     /**
      * Same as above, except that the quadrature point is computed from the
@@ -208,7 +207,7 @@ namespace CUDAWrappers
      * thread id.
      */
     __device__ gradient_type
-               get_gradient() const;
+    get_gradient() const;
 
     /**
      * Same as above, except that the quadrature point is computed from the

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -690,7 +690,7 @@ namespace CUDAWrappers
   // time (by virtue of being 'constexpr')
   // TODO this function should be rewritten using meta-programming
   __host__ __device__ constexpr unsigned int
-           cells_per_block_shmem(int dim, int fe_degree)
+  cells_per_block_shmem(int dim, int fe_degree)
   {
     /* clang-format off */
     // We are limiting the number of threads according to the
@@ -719,12 +719,11 @@ namespace CUDAWrappers
   __device__ inline unsigned int
   q_point_id_in_cell(const unsigned int n_q_points_1d)
   {
-    return (dim == 1 ?
-              threadIdx.x % n_q_points_1d :
-              dim == 2 ?
-              threadIdx.x % n_q_points_1d + n_q_points_1d * threadIdx.y :
-              threadIdx.x % n_q_points_1d +
-                  n_q_points_1d * (threadIdx.y + n_q_points_1d * threadIdx.z));
+    return (
+      dim == 1 ? threadIdx.x % n_q_points_1d :
+      dim == 2 ? threadIdx.x % n_q_points_1d + n_q_points_1d * threadIdx.y :
+                 threadIdx.x % n_q_points_1d +
+                   n_q_points_1d * (threadIdx.y + n_q_points_1d * threadIdx.z));
   }
 
 

--- a/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/cuda_tensor_product_kernels.h
@@ -212,9 +212,9 @@ namespace CUDAWrappers
     {
       const unsigned int i = (dim == 1) ? 0 : threadIdx.x % n_q_points_1d;
       const unsigned int j = (dim == 3) ? threadIdx.y : 0;
-      const unsigned int q = (dim == 1) ?
-                               (threadIdx.x % n_q_points_1d) :
-                               (dim == 2) ? threadIdx.y : threadIdx.z;
+      const unsigned int q = (dim == 1) ? (threadIdx.x % n_q_points_1d) :
+                             (dim == 2) ? threadIdx.y :
+                                          threadIdx.z;
 
       // This loop simply multiply the shape function at the quadrature point by
       // the value finite element coefficient.
@@ -224,10 +224,9 @@ namespace CUDAWrappers
           const unsigned int shape_idx =
             dof_to_quad ? (q + k * n_q_points_1d) : (k + q * n_q_points_1d);
           const unsigned int source_idx =
-            (direction == 0) ?
-              (k + n_q_points_1d * (i + n_q_points_1d * j)) :
-              (direction == 1) ? (i + n_q_points_1d * (k + n_q_points_1d * j)) :
-                                 (i + n_q_points_1d * (j + n_q_points_1d * k));
+            (direction == 0) ? (k + n_q_points_1d * (i + n_q_points_1d * j)) :
+            (direction == 1) ? (i + n_q_points_1d * (k + n_q_points_1d * j)) :
+                               (i + n_q_points_1d * (j + n_q_points_1d * k));
           t += shape_data[shape_idx] *
                (in_place ? out[source_idx] : in[source_idx]);
         }
@@ -236,10 +235,9 @@ namespace CUDAWrappers
         __syncthreads();
 
       const unsigned int destination_idx =
-        (direction == 0) ?
-          (q + n_q_points_1d * (i + n_q_points_1d * j)) :
-          (direction == 1) ? (i + n_q_points_1d * (q + n_q_points_1d * j)) :
-                             (i + n_q_points_1d * (j + n_q_points_1d * q));
+        (direction == 0) ? (q + n_q_points_1d * (i + n_q_points_1d * j)) :
+        (direction == 1) ? (i + n_q_points_1d * (q + n_q_points_1d * j)) :
+                           (i + n_q_points_1d * (j + n_q_points_1d * q));
 
       if (add)
         out[destination_idx] += t;

--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -101,8 +101,8 @@ namespace EvaluationFlags
    *
    * @ref EvaluationFlags
    */
-  inline EvaluationFlags operator&(const EvaluationFlags f1,
-                                   const EvaluationFlags f2)
+  inline EvaluationFlags
+  operator&(const EvaluationFlags f1, const EvaluationFlags f2)
   {
     return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) &
                                         static_cast<unsigned int>(f2));

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2330,9 +2330,9 @@ namespace internal
                   n_points_1d,
                   0);
 
-          const unsigned int in_stride = do_evaluate ?
-                                           dofs_per_component_on_cell :
-                                           dofs_per_component_on_face;
+          const unsigned int in_stride  = do_evaluate ?
+                                            dofs_per_component_on_cell :
+                                            dofs_per_component_on_face;
           const unsigned int out_stride = do_evaluate ?
                                             dofs_per_component_on_face :
                                             dofs_per_component_on_cell;

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -37,7 +37,7 @@ namespace internal
   bool
   instantiation_helper_run(const unsigned int given_degree,
                            const unsigned int n_q_points_1d,
-                           Args &... args)
+                           Args &...args)
   {
     if (given_degree == degree)
       {

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -3724,7 +3724,7 @@ FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::get_dof_info()
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, VectorizedArrayType>
-                             FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
   get_normal_vector(const unsigned int q_point) const
 {
   AssertIndexRange(q_point, n_quadrature_points);
@@ -3741,7 +3741,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, VectorizedArrayType>
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::JxW(
+FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::JxW(
   const unsigned int q_point) const
 {
   AssertIndexRange(q_point, n_quadrature_points);
@@ -3761,7 +3761,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, VectorizedArrayType>
-                             FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
   inverse_jacobian(const unsigned int q_point) const
 {
   AssertIndexRange(q_point, n_quadrature_points);
@@ -5580,7 +5580,7 @@ template <int dim,
           bool is_face,
           typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, n_components_, VectorizedArrayType>
-                             FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
+FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   get_dof_value(const unsigned int dof) const
 {
   AssertIndexRange(dof, this->data->dofs_per_component_on_cell);
@@ -5598,7 +5598,7 @@ template <int dim,
           bool is_face,
           typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, n_components_, VectorizedArrayType>
-                             FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
+FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   get_value(const unsigned int q_point) const
 {
 #  ifdef DEBUG
@@ -5674,7 +5674,7 @@ template <int dim,
           bool is_face,
           typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, n_components_, VectorizedArrayType>
-                             FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
+FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>::
   get_normal_derivative(const unsigned int q_point) const
 {
   AssertIndexRange(q_point, this->n_quadrature_points);
@@ -6403,8 +6403,9 @@ inline FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType> &
 FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::operator=(
   const FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType> &other)
 {
-  this->FEEvaluationBase<dim, 1, Number, is_face, VectorizedArrayType>::
-  operator=(other);
+  this
+    ->FEEvaluationBase<dim, 1, Number, is_face, VectorizedArrayType>::operator=(
+      other);
   return *this;
 }
 
@@ -6412,7 +6413,7 @@ FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::operator=(
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_dof_value(
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_dof_value(
   const unsigned int dof) const
 {
   AssertIndexRange(dof, this->data->dofs_per_component_on_cell);
@@ -6423,7 +6424,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_value(
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_value(
   const unsigned int q_point) const
 {
 #  ifdef DEBUG
@@ -6438,7 +6439,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
   get_normal_derivative(const unsigned int q_point) const
 {
   return BaseClass::get_normal_derivative(q_point)[0];
@@ -6448,7 +6449,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, dim, VectorizedArrayType>
-                             FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_gradient(
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_gradient(
   const unsigned int q_point) const
 {
   // could use the base class gradient, but that involves too many expensive
@@ -6524,7 +6525,7 @@ FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::get_laplacian(
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline void DEAL_II_ALWAYS_INLINE
-            FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
   submit_dof_value(const VectorizedArrayType val_in, const unsigned int dof)
 {
 #  ifdef DEBUG
@@ -6538,7 +6539,7 @@ inline void DEAL_II_ALWAYS_INLINE
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline void DEAL_II_ALWAYS_INLINE
-            FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::submit_value(
+FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::submit_value(
   const VectorizedArrayType val_in,
   const unsigned int        q_point)
 {
@@ -6726,7 +6727,7 @@ FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::operator=(
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, VectorizedArrayType>
-                             FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
   get_gradient(const unsigned int q_point) const
 {
   return BaseClass::get_gradient(q_point);
@@ -6736,7 +6737,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, VectorizedArrayType>
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
   get_divergence(const unsigned int q_point) const
 {
 #  ifdef DEBUG
@@ -6781,7 +6782,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE SymmetricTensor<2, dim, VectorizedArrayType>
-                             FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
   get_symmetric_gradient(const unsigned int q_point) const
 {
   // copy from generic function into dim-specialization function
@@ -6848,7 +6849,7 @@ inline DEAL_II_ALWAYS_INLINE
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, VectorizedArrayType>
-                             FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
   get_hessian_diagonal(const unsigned int q_point) const
 {
   return BaseClass::get_hessian_diagonal(q_point);
@@ -6858,7 +6859,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<2, dim, VectorizedArrayType>
 
 template <int dim, typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<3, dim, VectorizedArrayType>
-                             FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::get_hessian(
+FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::get_hessian(
   const unsigned int q_point) const
 {
 #  ifdef DEBUG
@@ -7134,7 +7135,7 @@ FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::operator=(
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_dof_value(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_dof_value(
   const unsigned int dof) const
 {
   AssertIndexRange(dof, this->data->dofs_per_component_on_cell);
@@ -7145,7 +7146,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_value(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_value(
   const unsigned int q_point) const
 {
 #  ifdef DEBUG
@@ -7160,7 +7161,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, 1, VectorizedArrayType>
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_gradient(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_gradient(
   const unsigned int q_point) const
 {
   // could use the base class gradient, but that involves too many inefficient
@@ -7187,7 +7188,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<1, 1, VectorizedArrayType>
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_divergence(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_divergence(
   const unsigned int q_point) const
 {
   return get_gradient(q_point)[0];
@@ -7197,7 +7198,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
   get_normal_derivative(const unsigned int q_point) const
 {
   return BaseClass::get_normal_derivative(q_point)[0];
@@ -7207,7 +7208,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<2, 1, VectorizedArrayType>
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_hessian(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_hessian(
   const unsigned int q_point) const
 {
   return BaseClass::get_hessian(q_point)[0];
@@ -7217,7 +7218,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<2, 1, VectorizedArrayType>
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE Tensor<1, 1, VectorizedArrayType>
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
   get_hessian_diagonal(const unsigned int q_point) const
 {
   return BaseClass::get_hessian_diagonal(q_point)[0];
@@ -7227,7 +7228,7 @@ inline DEAL_II_ALWAYS_INLINE Tensor<1, 1, VectorizedArrayType>
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
-                             FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_laplacian(
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::get_laplacian(
   const unsigned int q_point) const
 {
   return BaseClass::get_laplacian(q_point)[0];
@@ -7237,7 +7238,7 @@ inline DEAL_II_ALWAYS_INLINE VectorizedArrayType
 
 template <typename Number, bool is_face, typename VectorizedArrayType>
 inline DEAL_II_ALWAYS_INLINE void DEAL_II_ALWAYS_INLINE
-                                  FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
+FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
   submit_dof_value(const VectorizedArrayType val_in, const unsigned int dof)
 {
 #  ifdef DEBUG

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -78,7 +78,8 @@ namespace internal
             result[i][d] = value[d][i][vector_lane];
       }
 
-      static void get_gradient(
+      static void
+      get_gradient(
         Tensor<1, dim, Tensor<1, n_components, VectorizedArray<Number>>> &value,
         const unsigned int   vector_lane,
         const gradient_type &result)
@@ -98,17 +99,18 @@ namespace internal
       }
 
       static void
-        get_value(Tensor<1, n_components, VectorizedArray<Number>> &value,
-                  const unsigned int                                vector_lane,
-                  const value_type &                                result)
+      get_value(Tensor<1, n_components, VectorizedArray<Number>> &value,
+                const unsigned int                                vector_lane,
+                const value_type &                                result)
       {
         for (unsigned int i = 0; i < n_components; ++i)
           value[i][vector_lane] = result[i];
       }
 
       template <typename Number2>
-      static Number2 &access(Tensor<1, n_components, Number2> &value,
-                             const unsigned int                component)
+      static Number2 &
+      access(Tensor<1, n_components, Number2> &value,
+             const unsigned int                component)
       {
         return value[component];
       }
@@ -153,9 +155,10 @@ namespace internal
           result[d] = value[d][vector_lane];
       }
 
-      static void get_gradient(Tensor<1, dim, VectorizedArray<Number>> &value,
-                               const unsigned int   vector_lane,
-                               const gradient_type &result)
+      static void
+      get_gradient(Tensor<1, dim, VectorizedArray<Number>> &value,
+                   const unsigned int                       vector_lane,
+                   const gradient_type &                    result)
       {
         for (unsigned int d = 0; d < dim; ++d)
           value[d][vector_lane] = result[d];
@@ -225,7 +228,8 @@ namespace internal
             result[i][d] = value[d][i][vector_lane];
       }
 
-      static void get_gradient(
+      static void
+      get_gradient(
         Tensor<1, dim, Tensor<1, dim, VectorizedArray<Number>>> &value,
         const unsigned int                                       vector_lane,
         const gradient_type &                                    result)
@@ -244,9 +248,10 @@ namespace internal
           result[i] = value[i][vector_lane];
       }
 
-      static void get_value(Tensor<1, dim, VectorizedArray<Number>> &value,
-                            const unsigned int vector_lane,
-                            const value_type & result)
+      static void
+      get_value(Tensor<1, dim, VectorizedArray<Number>> &value,
+                const unsigned int                       vector_lane,
+                const value_type &                       result)
       {
         for (unsigned int i = 0; i < dim; ++i)
           value[i][vector_lane] = result[i];
@@ -307,9 +312,10 @@ namespace internal
         result[0] = value[0][vector_lane];
       }
 
-      static void get_gradient(Tensor<1, 1, VectorizedArray<Number>> &value,
-                               const unsigned int   vector_lane,
-                               const gradient_type &result)
+      static void
+      get_gradient(Tensor<1, 1, VectorizedArray<Number>> &value,
+                   const unsigned int                     vector_lane,
+                   const gradient_type &                  result)
       {
         value[0][vector_lane] = result[0];
       }

--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -704,10 +704,12 @@ namespace internal
 
       if (local_line < 8)
         {
-          x =
-            (local_line % 4 == 0) ? 0 : (local_line % 4 == 1) ? fe_degree : dof;
-          y =
-            (local_line % 4 == 2) ? 0 : (local_line % 4 == 3) ? fe_degree : dof;
+          x = (local_line % 4 == 0) ? 0 :
+              (local_line % 4 == 1) ? fe_degree :
+                                      dof;
+          y = (local_line % 4 == 2) ? 0 :
+              (local_line % 4 == 3) ? fe_degree :
+                                      dof;
           z = (local_line / 4) * fe_degree;
         }
       else
@@ -910,19 +912,19 @@ namespace CUDAWrappers
       const unsigned int this_type =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_x :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_y :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_z;
       const unsigned int face1_type =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_y :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_z :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_x;
       const unsigned int face2_type =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_z :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_x :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::type_y;
 
@@ -931,30 +933,33 @@ namespace CUDAWrappers
       const unsigned int face1 =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_y :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_z :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_x;
       const unsigned int face2 =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_z :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_x :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::face_y;
       const unsigned int edge =
         (direction == 0) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::edge_yz :
-          (direction == 1) ?
+        (direction == 1) ?
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::edge_zx :
           dealii::internal::MatrixFreeFunctions::ConstraintTypes::edge_xy;
       const unsigned int constrained_face =
         constraint_mask & (face1 | face2 | edge);
 
-      const unsigned int interp_idx =
-        (direction == 0) ? x_idx : (direction == 1) ? y_idx : z_idx;
-      const unsigned int face1_idx =
-        (direction == 0) ? y_idx : (direction == 1) ? z_idx : x_idx;
-      const unsigned int face2_idx =
-        (direction == 0) ? z_idx : (direction == 1) ? x_idx : y_idx;
+      const unsigned int interp_idx = (direction == 0) ? x_idx :
+                                      (direction == 1) ? y_idx :
+                                                         z_idx;
+      const unsigned int face1_idx  = (direction == 0) ? y_idx :
+                                      (direction == 1) ? z_idx :
+                                                         x_idx;
+      const unsigned int face2_idx  = (direction == 0) ? z_idx :
+                                      (direction == 1) ? x_idx :
+                                                         y_idx;
 
       Number     t        = 0;
       const bool on_face1 = (constraint_mask & face1_type) ?
@@ -977,8 +982,7 @@ namespace CUDAWrappers
                 {
                   const unsigned int real_idx =
                     (direction == 0) ? index3<fe_degree + 1>(i, y_idx, z_idx) :
-                                       (direction == 1) ?
-                                       index3<fe_degree + 1>(x_idx, i, z_idx) :
+                    (direction == 1) ? index3<fe_degree + 1>(x_idx, i, z_idx) :
                                        index3<fe_degree + 1>(x_idx, y_idx, i);
 
                   const Number w =
@@ -994,8 +998,7 @@ namespace CUDAWrappers
                 {
                   const unsigned int real_idx =
                     (direction == 0) ? index3<fe_degree + 1>(i, y_idx, z_idx) :
-                                       (direction == 1) ?
-                                       index3<fe_degree + 1>(x_idx, i, z_idx) :
+                    (direction == 1) ? index3<fe_degree + 1>(x_idx, i, z_idx) :
                                        index3<fe_degree + 1>(x_idx, y_idx, i);
 
                   const Number w =

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -3368,9 +3368,9 @@ namespace internal
 
     template <typename Number, typename VectorizedArrayType>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::
-    operator()(const std::vector<Number> &v1,
-               const std::vector<Number> &v2) const
+    FPArrayComparator<Number, VectorizedArrayType>::operator()(
+      const std::vector<Number> &v1,
+      const std::vector<Number> &v2) const
     {
       const unsigned int s1 = v1.size(), s2 = v2.size();
       if (s1 < s2)
@@ -3390,9 +3390,9 @@ namespace internal
 
     template <typename Number, typename VectorizedArrayType>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::
-    operator()(const Tensor<1, VectorizedArrayType::size(), Number> &t1,
-               const Tensor<1, VectorizedArrayType::size(), Number> &t2) const
+    FPArrayComparator<Number, VectorizedArrayType>::operator()(
+      const Tensor<1, VectorizedArrayType::size(), Number> &t1,
+      const Tensor<1, VectorizedArrayType::size(), Number> &t2) const
     {
       for (unsigned int k = 0; k < VectorizedArrayType::size(); ++k)
         if (t1[k] < t2[k] - tolerance)
@@ -3446,9 +3446,9 @@ namespace internal
     template <typename Number, typename VectorizedArrayType>
     template <int dim>
     bool
-    FPArrayComparator<Number, VectorizedArrayType>::
-    operator()(const std::array<Tensor<2, dim, Number>, dim + 1> &t1,
-               const std::array<Tensor<2, dim, Number>, dim + 1> &t2) const
+    FPArrayComparator<Number, VectorizedArrayType>::operator()(
+      const std::array<Tensor<2, dim, Number>, dim + 1> &t1,
+      const std::array<Tensor<2, dim, Number>, dim + 1> &t2) const
     {
       for (unsigned int i = 0; i < t1.size(); ++i)
         for (unsigned int d = 0; d < dim; ++d)

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1726,7 +1726,7 @@ public:
    */
   template <typename DoFHandlerType>
   DEAL_II_DEPRECATED const DoFHandlerType &
-                           get_dof_handler(const unsigned int dof_handler_index = 0) const;
+  get_dof_handler(const unsigned int dof_handler_index = 0) const;
 
   /**
    * Return the cell iterator in deal.II speak to a given cell batch

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -313,7 +313,7 @@ namespace internal
               bool lex_faces = false>
     void
     apply_face(const Number *DEAL_II_RESTRICT in,
-               Number *DEAL_II_RESTRICT out) const;
+               Number *DEAL_II_RESTRICT       out) const;
 
     const Number2 *shape_values;
     const Number2 *shape_gradients;
@@ -335,9 +335,9 @@ namespace internal
                          n_columns,
                          Number,
                          Number2>::apply(const Number2 *DEAL_II_RESTRICT
-                                                        shape_data,
-                                         const Number * in,
-                                         Number *       out)
+                                                       shape_data,
+                                         const Number *in,
+                                         Number *      out)
   {
     static_assert(one_line == false || direction == dim - 1,
                   "Single-line evaluation only works for direction=dim-1.");
@@ -420,7 +420,7 @@ namespace internal
                          Number,
                          Number2>::apply_face(const Number *DEAL_II_RESTRICT in,
                                               Number *DEAL_II_RESTRICT
-                                                      out) const
+                                                out) const
   {
     Assert(dim > 0 && (lex_faces || dim < 4),
            ExcMessage("Only dim=1,2,3 supported"));
@@ -701,7 +701,7 @@ namespace internal
               bool lex_faces = false>
     void
     apply_face(const Number *DEAL_II_RESTRICT in,
-               Number *DEAL_II_RESTRICT out) const;
+               Number *DEAL_II_RESTRICT       out) const;
 
     const Number2 *    shape_values;
     const Number2 *    shape_gradients;
@@ -867,7 +867,7 @@ namespace internal
   inline void
   EvaluatorTensorProduct<evaluate_general, dim, 0, 0, Number, Number2>::
     apply_face(const Number *DEAL_II_RESTRICT in,
-               Number *DEAL_II_RESTRICT out) const
+               Number *DEAL_II_RESTRICT       out) const
   {
     static_assert(lex_faces == false, "Not implemented yet.");
 

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -761,7 +761,7 @@ namespace MatrixFreeTools
     const unsigned int first_selected_component)
   {
     std::unique_ptr<AffineConstraints<typename MatrixType::value_type>>
-                                                              constraints_for_matrix;
+      constraints_for_matrix;
     const AffineConstraints<typename MatrixType::value_type> &constraints =
       internal::create_new_affine_constraints_if_needed(matrix,
                                                         constraints_in,
@@ -879,15 +879,14 @@ namespace MatrixFreeTools
                    n_components,
                    Number,
                    VectorizedArrayType,
-                   MatrixType>(matrix_free,
-                               constraints,
-                               matrix,
-                               [&](auto &feeval) {
-                                 (owning_class->*cell_operation)(feeval);
-                               },
-                               dof_no,
-                               quad_no,
-                               first_selected_component);
+                   MatrixType>(
+      matrix_free,
+      constraints,
+      matrix,
+      [&](auto &feeval) { (owning_class->*cell_operation)(feeval); },
+      dof_no,
+      quad_no,
+      first_selected_component);
   }
 
 #endif // DOXYGEN

--- a/include/deal.II/meshworker/assemble_flags.h
+++ b/include/deal.II/meshworker/assemble_flags.h
@@ -173,7 +173,8 @@ namespace MeshWorker
    *
    * @ref AssembleFlags
    */
-  inline AssembleFlags operator&(AssembleFlags f1, AssembleFlags f2)
+  inline AssembleFlags
+  operator&(AssembleFlags f1, AssembleFlags f2)
   {
     return static_cast<AssembleFlags>(static_cast<unsigned int>(f1) &
                                       static_cast<unsigned int>(f2));

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -911,19 +911,20 @@ namespace MeshWorker
                                   copy_data);
       };
 
-    mesh_loop(begin,
-              end,
-              f_cell_worker,
-              [&main_class, copier](const CopyData &copy_data) {
-                (main_class.*copier)(copy_data);
-              },
-              sample_scratch_data,
-              sample_copy_data,
-              flags,
-              f_boundary_worker,
-              f_face_worker,
-              queue_length,
-              chunk_size);
+    mesh_loop(
+      begin,
+      end,
+      f_cell_worker,
+      [&main_class, copier](const CopyData &copy_data) {
+        (main_class.*copier)(copy_data);
+      },
+      sample_scratch_data,
+      sample_copy_data,
+      flags,
+      f_boundary_worker,
+      f_face_worker,
+      queue_length,
+      chunk_size);
   }
 
   /**

--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -413,13 +413,13 @@ template <class VectorType,
           class MatrixType,
           class PreconditionerType>
 void
-MGCoarseGridIterativeSolver<VectorType,
-                            SolverType,
-                            MatrixType,
-                            PreconditionerType>::
-operator()(const unsigned int /*level*/,
-           VectorType &      dst,
-           const VectorType &src) const
+                       MGCoarseGridIterativeSolver<
+                         VectorType,
+                         SolverType,
+                         MatrixType,
+                         PreconditionerType>::operator()(const unsigned int /*level*/,
+                                  VectorType &      dst,
+                                  const VectorType &src) const
 {
   Assert(solver != nullptr, ExcNotInitialized());
   Assert(matrix != nullptr, ExcNotInitialized());
@@ -455,10 +455,10 @@ MGCoarseGridHouseholder<number, VectorType>::initialize(
 
 template <typename number, class VectorType>
 void
-MGCoarseGridHouseholder<number, VectorType>::
-operator()(const unsigned int /*level*/,
-           VectorType &      dst,
-           const VectorType &src) const
+MGCoarseGridHouseholder<number, VectorType>::operator()(
+  const unsigned int /*level*/,
+  VectorType &      dst,
+  const VectorType &src) const
 {
   householder.least_squares(dst, src);
 }

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -247,7 +247,7 @@ MGConstrainedDoFs::initialize(
   const unsigned int max_level = (level_relevant_dofs.max_level() == 0) ?
                                    nlevels - 1 :
                                    level_relevant_dofs.max_level();
-  const bool user_level_dofs =
+  const bool         user_level_dofs =
     (level_relevant_dofs.max_level() == 0) ? false : true;
 
   // At this point level_constraint and refinement_edge_indices are empty.

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -73,7 +73,8 @@ namespace mg
     /**
      * Access matrix on a level.
      */
-    const LinearOperator<VectorType> &operator[](unsigned int level) const;
+    const LinearOperator<VectorType> &
+    operator[](unsigned int level) const;
 
     virtual void
     vmult(const unsigned int level,
@@ -235,8 +236,8 @@ namespace mg
 
 
   template <typename VectorType>
-  inline const LinearOperator<VectorType> &Matrix<VectorType>::
-                                           operator[](unsigned int level) const
+  inline const LinearOperator<VectorType> &
+  Matrix<VectorType>::operator[](unsigned int level) const
   {
     return matrices[level];
   }

--- a/include/deal.II/numerics/history.h
+++ b/include/deal.II/numerics/history.h
@@ -83,14 +83,16 @@ public:
    * counting from the last added element.
    * `index==0` therefore corresponds to the newset element.
    */
-  T &operator[](const std::size_t index);
+  T &
+  operator[](const std::size_t index);
 
   /**
    * Read access to an element with index @p index,
    * counting from the last added element.
    * `index==0` therefore corresponds to the newset element.
    */
-  const T &operator[](const std::size_t index) const;
+  const T &
+  operator[](const std::size_t index) const;
 
   /**
    * Return the current size of the history.
@@ -203,7 +205,8 @@ FiniteSizeHistory<T>::add(const T &element)
 
 
 template <typename T>
-T &FiniteSizeHistory<T>::operator[](const std::size_t ind)
+T &
+FiniteSizeHistory<T>::operator[](const std::size_t ind)
 {
   AssertIndexRange(ind, data.size());
   return *data[ind];
@@ -212,7 +215,8 @@ T &FiniteSizeHistory<T>::operator[](const std::size_t ind)
 
 
 template <typename T>
-const T &FiniteSizeHistory<T>::operator[](const std::size_t ind) const
+const T &
+FiniteSizeHistory<T>::operator[](const std::size_t ind) const
 {
   AssertIndexRange(ind, data.size());
   return *data[ind];

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -719,7 +719,7 @@ namespace MatrixCreator
     hp::QCollection<dim>                 q_collection(q);
     hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, number>
-                                                             assembler_data(fe_collection,
+      assembler_data(fe_collection,
                      update_values | update_JxW_values |
                        update_quadrature_points,
                      coefficient,
@@ -793,7 +793,7 @@ namespace MatrixCreator
            ExcDimensionMismatch(matrix.n(), dof.n_dofs()));
 
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, number>
-                                                             assembler_data(dof.get_fe_collection(),
+      assembler_data(dof.get_fe_collection(),
                      update_values | update_JxW_values |
                        (coefficient != nullptr ? update_quadrature_points :
                                                  UpdateFlags(0)),
@@ -864,7 +864,7 @@ namespace MatrixCreator
            ExcDimensionMismatch(matrix.n(), dof.n_dofs()));
 
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, number>
-                                                             assembler_data(dof.get_fe_collection(),
+      assembler_data(dof.get_fe_collection(),
                      update_values | update_JxW_values |
                        update_quadrature_points,
                      coefficient,
@@ -1875,7 +1875,7 @@ namespace MatrixCreator
     hp::QCollection<dim>                 q_collection(q);
     hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, double>
-                                                             assembler_data(fe_collection,
+      assembler_data(fe_collection,
                      update_gradients | update_JxW_values |
                        (coefficient != nullptr ? update_quadrature_points :
                                                  UpdateFlags(0)),
@@ -1948,7 +1948,7 @@ namespace MatrixCreator
     hp::QCollection<dim>                 q_collection(q);
     hp::MappingCollection<dim, spacedim> mapping_collection(mapping);
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, double>
-                                                             assembler_data(fe_collection,
+      assembler_data(fe_collection,
                      update_gradients | update_values | update_JxW_values |
                        update_quadrature_points,
                      coefficient,
@@ -2021,7 +2021,7 @@ namespace MatrixCreator
            ExcDimensionMismatch(matrix.n(), dof.n_dofs()));
 
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, double>
-                                                             assembler_data(dof.get_fe_collection(),
+      assembler_data(dof.get_fe_collection(),
                      update_gradients | update_JxW_values |
                        (coefficient != nullptr ? update_quadrature_points :
                                                  UpdateFlags(0)),
@@ -2092,7 +2092,7 @@ namespace MatrixCreator
            ExcDimensionMismatch(matrix.n(), dof.n_dofs()));
 
     MatrixCreator::internal::AssemblerData::Scratch<dim, spacedim, double>
-                                                             assembler_data(dof.get_fe_collection(),
+      assembler_data(dof.get_fe_collection(),
                      update_gradients | update_values | update_JxW_values |
                        update_quadrature_points,
                      coefficient,

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -498,8 +498,8 @@ template <typename Value,
           typename Box,
           typename Allocators>
 void
-ExtractLevelVisitor<Value, Options, Translator, Box, Allocators>::
-operator()(const ExtractLevelVisitor::InternalNode &node)
+ExtractLevelVisitor<Value, Options, Translator, Box, Allocators>::operator()(
+  const ExtractLevelVisitor::InternalNode &node)
 {
   using ElmentsType =
     typename boost::geometry::index::detail::rtree::elements_type<
@@ -542,8 +542,8 @@ template <typename Value,
           typename Box,
           typename Allocators>
 void
-ExtractLevelVisitor<Value, Options, Translator, Box, Allocators>::
-operator()(const ExtractLevelVisitor::Leaf &)
+ExtractLevelVisitor<Value, Options, Translator, Box, Allocators>::operator()(
+  const ExtractLevelVisitor::Leaf &)
 {}
 
 

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -52,7 +52,8 @@ namespace VectorTools
     template <int dim,
               int spacedim,
               typename number,
-              template <int, int> class M_or_MC>
+              template <int, int>
+              class M_or_MC>
     static inline void
     do_interpolate_boundary_values(
       const M_or_MC<dim, spacedim> &   mapping,
@@ -690,8 +691,10 @@ namespace VectorTools
 
     template <int dim,
               int spacedim,
-              template <int, int> class M_or_MC,
-              template <int> class Q_or_QC,
+              template <int, int>
+              class M_or_MC,
+              template <int>
+              class Q_or_QC,
               typename number>
     void
     do_project_boundary_values(
@@ -1528,9 +1531,8 @@ namespace VectorTools
               const unsigned int lines_per_face =
                 GeometryInfo<dim>::lines_per_face;
               std::vector<std::vector<unsigned int>>
-                                        associated_edge_dof_to_face_dof(lines_per_face,
-                                                                        std::vector<unsigned int>(degree +
-                                                                        1));
+                associated_edge_dof_to_face_dof(
+                  lines_per_face, std::vector<unsigned int>(degree + 1));
               std::vector<unsigned int> associated_edge_dofs(lines_per_face);
 
               for (unsigned int line = 0; line < lines_per_face; ++line)
@@ -2170,7 +2172,7 @@ namespace VectorTools
       const FiniteElement<2> &         fe      = cell->get_fe();
       const std::vector<Tensor<1, 2>> &normals = fe_values.get_normal_vectors();
       const unsigned int
-                                  face_coordinate_direction[GeometryInfo<2>::faces_per_cell] = {1,
+        face_coordinate_direction[GeometryInfo<2>::faces_per_cell] = {1,
                                                                       1,
                                                                       0,
                                                                       0};

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -492,10 +492,10 @@ namespace VectorTools
 
     // Create a small lambda capture wrapping function and call the
     // internal implementation
-    const auto function_map = [&function](
-      const typename DoFHandler<dim, spacedim>::active_cell_iterator &)
-      -> const Function<spacedim, typename VectorType::value_type> *
-    {
+    const auto function_map =
+      [&function](
+        const typename DoFHandler<dim, spacedim>::active_cell_iterator &)
+      -> const Function<spacedim, typename VectorType::value_type> * {
       return &function;
     };
 
@@ -824,10 +824,10 @@ namespace VectorTools
   {
     // Create a small lambda capture wrapping the function map and call the
     // internal implementation
-    const auto function_map = [&functions](
-      const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell)
-      -> const Function<spacedim, typename VectorType::value_type> *
-    {
+    const auto function_map =
+      [&functions](
+        const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell)
+      -> const Function<spacedim, typename VectorType::value_type> * {
       const auto function = functions.find(cell->material_id());
       if (function != functions.end())
         return function->second;

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -146,8 +146,8 @@ namespace VectorTools
           VectorType &                                               vec,
           const bool                 enforce_zero_boundary     = false,
           const Quadrature<dim - 1> &q_boundary                = (dim > 1 ?
-                                                     QGauss<dim - 1>(2) :
-                                                     Quadrature<dim - 1>(0)),
+                                                                    QGauss<dim - 1>(2) :
+                                                                    Quadrature<dim - 1>(0)),
           const bool                 project_to_boundary_first = false);
 
   /**
@@ -163,8 +163,8 @@ namespace VectorTools
           VectorType &                                               vec,
           const bool                 enforce_zero_boundary     = false,
           const Quadrature<dim - 1> &q_boundary                = (dim > 1 ?
-                                                     QGauss<dim - 1>(2) :
-                                                     Quadrature<dim - 1>(0)),
+                                                                    QGauss<dim - 1>(2) :
+                                                                    Quadrature<dim - 1>(0)),
           const bool                 project_to_boundary_first = false);
 
   /**

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -103,8 +103,10 @@ namespace VectorTools
      */
     template <int dim,
               int spacedim,
-              template <int, int> class M_or_MC,
-              template <int> class Q_or_QC,
+              template <int, int>
+              class M_or_MC,
+              template <int>
+              class Q_or_QC,
               typename number>
     void
     project_compute_b_v(
@@ -407,8 +409,10 @@ namespace VectorTools
     template <int dim,
               int spacedim,
               typename VectorType,
-              template <int, int> class M_or_MC,
-              template <int> class Q_or_QC>
+              template <int, int>
+              class M_or_MC,
+              template <int>
+              class Q_or_QC>
     void
     do_project(
       const M_or_MC<dim, spacedim> &                             mapping,

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -820,8 +820,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline bool
-  ParticleAccessor<dim, spacedim>::
-  operator!=(const ParticleAccessor<dim, spacedim> &other) const
+  ParticleAccessor<dim, spacedim>::operator!=(
+    const ParticleAccessor<dim, spacedim> &other) const
   {
     return !(*this == other);
   }
@@ -830,8 +830,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline bool
-  ParticleAccessor<dim, spacedim>::
-  operator==(const ParticleAccessor<dim, spacedim> &other) const
+  ParticleAccessor<dim, spacedim>::operator==(
+    const ParticleAccessor<dim, spacedim> &other) const
   {
     return (property_pool == other.property_pool) && (cell == other.cell) &&
            (particle_index_within_cell == other.particle_index_within_cell);

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -633,7 +633,7 @@ namespace Particles
      * @deprecated Use locally_owned_particle_ids() instead.
      */
     DEAL_II_DEPRECATED IndexSet
-                       locally_relevant_ids() const;
+    locally_relevant_ids() const;
 
     /**
      * Extract an IndexSet with global dimensions equal to
@@ -1261,7 +1261,7 @@ namespace Particles
     for (auto &p : *this)
       {
         auto       new_point(displace_particles ? p.get_location() :
-                                            Point<spacedim>());
+                                                  Point<spacedim>());
         const auto id = p.get_id();
         for (unsigned int i = 0; i < spacedim; ++i)
           new_point[i] += input_vector[id * spacedim + i];

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -65,12 +65,14 @@ namespace Particles
      * Dereferencing operator, returns a reference to an accessor. Usage is thus
      * like <tt>(*i).get_id ();</tt>
      */
-    const ParticleAccessor<dim, spacedim> &operator*() const;
+    const ParticleAccessor<dim, spacedim> &
+    operator*() const;
 
     /**
      * Dereferencing operator, non-@p const version.
      */
-    ParticleAccessor<dim, spacedim> &operator*();
+    ParticleAccessor<dim, spacedim> &
+    operator*();
 
     /**
      * Dereferencing operator, returns a pointer of the particle pointed to.
@@ -78,12 +80,14 @@ namespace Particles
      *
      * There is a @p const and a non-@p const version.
      */
-    const ParticleAccessor<dim, spacedim> *operator->() const;
+    const ParticleAccessor<dim, spacedim> *
+    operator->() const;
 
     /**
      * Dereferencing operator, non-@p const version.
      */
-    ParticleAccessor<dim, spacedim> *operator->();
+    ParticleAccessor<dim, spacedim> *
+    operator->();
 
     /**
      * Compare for equality.
@@ -169,8 +173,8 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline ParticleAccessor<dim, spacedim> &ParticleIterator<dim, spacedim>::
-                                          operator*()
+  inline ParticleAccessor<dim, spacedim> &
+  ParticleIterator<dim, spacedim>::operator*()
   {
     return accessor;
   }
@@ -178,8 +182,8 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline ParticleAccessor<dim, spacedim> *ParticleIterator<dim, spacedim>::
-                                          operator->()
+  inline ParticleAccessor<dim, spacedim> *
+  ParticleIterator<dim, spacedim>::operator->()
   {
     return &(this->operator*());
   }
@@ -188,7 +192,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline const ParticleAccessor<dim, spacedim> &
-    ParticleIterator<dim, spacedim>::operator*() const
+  ParticleIterator<dim, spacedim>::operator*() const
   {
     return accessor;
   }
@@ -197,7 +201,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline const ParticleAccessor<dim, spacedim> *
-    ParticleIterator<dim, spacedim>::operator->() const
+  ParticleIterator<dim, spacedim>::operator->() const
   {
     return &(this->operator*());
   }
@@ -206,8 +210,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline bool
-  ParticleIterator<dim, spacedim>::
-  operator!=(const ParticleIterator<dim, spacedim> &other) const
+  ParticleIterator<dim, spacedim>::operator!=(
+    const ParticleIterator<dim, spacedim> &other) const
   {
     return accessor != other.accessor;
   }
@@ -216,8 +220,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline bool
-  ParticleIterator<dim, spacedim>::
-  operator==(const ParticleIterator<dim, spacedim> &other) const
+  ParticleIterator<dim, spacedim>::operator==(
+    const ParticleIterator<dim, spacedim> &other) const
   {
     return accessor == other.accessor;
   }

--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -170,7 +170,8 @@ namespace SUNDIALS
       /**
        * Access the N_Vector that is viewed by this object.
        */
-      N_Vector operator->() const;
+      N_Vector
+      operator->() const;
 
     private:
       /**

--- a/include/deal.II/sundials/n_vector.templates.h
+++ b/include/deal.II/sundials/n_vector.templates.h
@@ -403,7 +403,8 @@ SUNDIALS::internal::NVectorView<VectorType>::operator N_Vector() const
 
 
 template <typename VectorType>
-N_Vector SUNDIALS::internal::NVectorView<VectorType>::operator->() const
+N_Vector
+SUNDIALS::internal::NVectorView<VectorType>::operator->() const
 {
   Assert(vector_ptr != nullptr, ExcNotInitialized());
   return vector_ptr.get();

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2094,7 +2094,8 @@ namespace DataOutBase
 
 
   template <int spacedim>
-  void Patch<0, spacedim>::swap(Patch<0, spacedim> &other_patch)
+  void
+  Patch<0, spacedim>::swap(Patch<0, spacedim> &other_patch)
   {
     std::swap(vertices, other_patch.vertices);
     std::swap(patch_index, other_patch.patch_index);
@@ -2904,11 +2905,12 @@ namespace DataOutBase
      * camera_horizontal, necessary for the correct alignment of the
      * later images), and the focus of the camera (float camera_focus).
      */
-    Point<2> svg_project_point(Point<3> point,
-                               Point<3> camera_position,
-                               Point<3> camera_direction,
-                               Point<3> camera_horizontal,
-                               float    camera_focus)
+    Point<2>
+    svg_project_point(Point<3> point,
+                      Point<3> camera_position,
+                      Point<3> camera_direction,
+                      Point<3> camera_horizontal,
+                      float    camera_focus)
     {
       Point<3> camera_vertical;
       camera_vertical[0] = camera_horizontal[1] * camera_direction[2] -
@@ -2961,7 +2963,8 @@ namespace DataOutBase
      * Function to compute the gradient parameters for a triangle with given
      * values for the vertices.
      */
-    Point<6> svg_get_gradient_parameters(Point<3> points[])
+    Point<6>
+    svg_get_gradient_parameters(Point<3> points[])
     {
       Point<3> v_min, v_max, v_inter;
 

--- a/source/base/function_lib_cutoff.cc
+++ b/source/base/function_lib_cutoff.cc
@@ -324,8 +324,8 @@ namespace Functions
         {
           const double d = this->center.distance(points[i]);
           values[i]      = ((d < this->radius) ?
-                         (this->radius - d) / this->radius * this->rescaling :
-                         0.);
+                              (this->radius - d) / this->radius * this->rescaling :
+                              0.);
         }
     else
       std::fill(values.begin(), values.end(), 0.);

--- a/source/base/function_spherical.cc
+++ b/source/base/function_spherical.cc
@@ -124,10 +124,11 @@ namespace Functions
      * calculates out[i][j] += v*(in1[i]*in2[j]+in1[j]*in2[i])
      */
     template <int dim>
-    void add_outer_product(SymmetricTensor<2, dim> &out,
-                           const double             val,
-                           const Tensor<1, dim> &   in1,
-                           const Tensor<1, dim> &   in2)
+    void
+    add_outer_product(SymmetricTensor<2, dim> &out,
+                      const double             val,
+                      const Tensor<1, dim> &   in1,
+                      const Tensor<1, dim> &   in2)
     {
       if (val != 0.)
         for (unsigned int i = 0; i < dim; i++)
@@ -139,9 +140,10 @@ namespace Functions
      * calculates out[i][j] += v*in[i]in[j]
      */
     template <int dim>
-    void add_outer_product(SymmetricTensor<2, dim> &out,
-                           const double             val,
-                           const Tensor<1, dim> &   in)
+    void
+    add_outer_product(SymmetricTensor<2, dim> &out,
+                      const double             val,
+                      const Tensor<1, dim> &   in)
     {
       if (val != 0.)
         for (unsigned int i = 0; i < dim; i++)

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -160,7 +160,8 @@ IndexSet::do_compress() const
 
 
 #ifndef DOXYGEN
-IndexSet IndexSet::operator&(const IndexSet &is) const
+IndexSet
+IndexSet::operator&(const IndexSet &is) const
 {
   Assert(size() == is.size(), ExcDimensionMismatch(size(), is.size()));
 

--- a/source/base/quadrature_lib.cc
+++ b/source/base/quadrature_lib.cc
@@ -870,7 +870,7 @@ QTelles<dim>::QTelles(const Quadrature<1> &base_quad,
     dim == 2 ?
       QAnisotropic<dim>(QTelles<1>(base_quad, Point<1>(singularity[0])),
                         QTelles<1>(base_quad, Point<1>(singularity[1]))) :
-      dim == 3 ?
+    dim == 3 ?
       QAnisotropic<dim>(QTelles<1>(base_quad, Point<1>(singularity[0])),
                         QTelles<1>(base_quad, Point<1>(singularity[1])),
                         QTelles<1>(base_quad, Point<1>(singularity[2]))) :

--- a/source/base/tensor.cc
+++ b/source/base/tensor.cc
@@ -23,8 +23,9 @@ DEAL_II_NAMESPACE_OPEN
 namespace
 {
   template <int dim, typename Number>
-  void calculate_svd_in_place(Tensor<2, dim, Number> &A_in_VT_out,
-                              Tensor<2, dim, Number> &U)
+  void
+  calculate_svd_in_place(Tensor<2, dim, Number> &A_in_VT_out,
+                         Tensor<2, dim, Number> &U)
   {
     // inputs: A
     // outputs: V^T, U

--- a/source/base/tensor_product_polynomials.cc
+++ b/source/base/tensor_product_polynomials.cc
@@ -549,8 +549,7 @@ AnisotropicPolynomials<dim>::compute_index(
 #endif
 
   if (dim == 0)
-    {
-    }
+    {}
   else if (dim == 1)
     internal::compute_tensor_index(i,
                                    polynomials[0].size(),

--- a/source/base/thread_management.cc
+++ b/source/base/thread_management.cc
@@ -32,7 +32,8 @@ namespace Threads
   namespace internal
   {
     [[noreturn]] void
-    handle_std_exception(const std::exception &exc) {
+    handle_std_exception(const std::exception &exc)
+    {
       // lock the following context
       // to ensure that we don't
       // print things over each other
@@ -70,7 +71,8 @@ namespace Threads
 
 
 
-      [[noreturn]] void handle_unknown_exception()
+    [[noreturn]] void
+    handle_unknown_exception()
     {
       // lock the following context
       // to ensure that we don't

--- a/source/differentiation/sd/symengine_number_types.cc
+++ b/source/differentiation/sd/symengine_number_types.cc
@@ -435,7 +435,8 @@ namespace Differentiation
     }
 
 
-    Expression operator!(const Expression &expression)
+    Expression
+    operator!(const Expression &expression)
     {
       Assert(SE::is_a_Boolean(expression.get_value()),
              ExcMessage("The expression must return a boolean type."));
@@ -447,7 +448,8 @@ namespace Differentiation
     }
 
 
-    Expression operator&(const Expression &lhs, const Expression &rhs)
+    Expression
+    operator&(const Expression &lhs, const Expression &rhs)
     {
       Assert(SE::is_a_Boolean(lhs.get_value()),
              ExcMessage("The lhs expression must return a boolean type."));
@@ -527,7 +529,8 @@ namespace Differentiation
     }
 
 
-    Expression operator*(Expression lhs, const Expression &rhs)
+    Expression
+    operator*(Expression lhs, const Expression &rhs)
     {
       lhs *= rhs;
       return lhs;

--- a/source/distributed/grid_refinement.inst.in
+++ b/source/distributed/grid_refinement.inst.in
@@ -93,9 +93,10 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
       \{
         namespace GridRefinement
         \{
-          template void refine_and_coarsen_fixed_number<deal_II_dimension - 1,
-                                                        S,
-                                                        deal_II_dimension>(
+          template void
+          refine_and_coarsen_fixed_number<deal_II_dimension - 1,
+                                          S,
+                                          deal_II_dimension>(
             parallel::distributed::Triangulation<deal_II_dimension - 1,
                                                  deal_II_dimension> &,
             const dealii::Vector<S> &,
@@ -103,9 +104,10 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
             const double,
             const types::global_cell_index);
 
-          template void refine_and_coarsen_fixed_fraction<deal_II_dimension - 1,
-                                                          S,
-                                                          deal_II_dimension>(
+          template void
+          refine_and_coarsen_fixed_fraction<deal_II_dimension - 1,
+                                            S,
+                                            deal_II_dimension>(
             parallel::distributed::Triangulation<deal_II_dimension - 1,
                                                  deal_II_dimension> &,
             const dealii::Vector<S> &,

--- a/source/distributed/p4est_wrappers.cc
+++ b/source/distributed/p4est_wrappers.cc
@@ -878,8 +878,9 @@ namespace internal
 
 
     template <>
-    bool quadrant_is_ancestor<1>(types<1>::quadrant const &q1,
-                                 types<1>::quadrant const &q2)
+    bool
+    quadrant_is_ancestor<1>(types<1>::quadrant const &q1,
+                            types<1>::quadrant const &q2)
     {
       // determine level of quadrants
       const int level_1 = (q1 << types<1>::max_n_child_indices_bits) >>
@@ -926,7 +927,8 @@ namespace internal
 
 
     template <>
-    void init_coarse_quadrant<1>(typename types<1>::quadrant &quad)
+    void
+    init_coarse_quadrant<1>(typename types<1>::quadrant &quad)
     {
       quad = 0;
     }

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1706,8 +1706,7 @@ namespace parallel
 #  ifndef DOXYGEN
 
     template <>
-    void
-    Triangulation<2, 2>::copy_new_triangulation_to_p4est(
+    void Triangulation<2, 2>::copy_new_triangulation_to_p4est(
       std::integral_constant<int, 2>)
     {
       const unsigned int dim = 2, spacedim = 2;
@@ -1773,8 +1772,7 @@ namespace parallel
     // TODO: This is a verbatim copy of the 2,2 case. However, we can't just
     // specialize the dim template argument, but let spacedim open
     template <>
-    void
-    Triangulation<2, 3>::copy_new_triangulation_to_p4est(
+    void Triangulation<2, 3>::copy_new_triangulation_to_p4est(
       std::integral_constant<int, 2>)
     {
       const unsigned int dim = 2, spacedim = 3;
@@ -1838,8 +1836,7 @@ namespace parallel
 
 
     template <>
-    void
-    Triangulation<3, 3>::copy_new_triangulation_to_p4est(
+    void Triangulation<3, 3>::copy_new_triangulation_to_p4est(
       std::integral_constant<int, 3>)
     {
       const int dim = 3, spacedim = 3;
@@ -2349,7 +2346,7 @@ namespace parallel
                   // comes out of this cell.
 
                   typename dealii::internal::p4est::types<dim>::quadrant
-                                                                      p4est_coarse_cell;
+                    p4est_coarse_cell;
                   typename dealii::internal::p4est::types<dim>::tree *tree =
                     init_tree(cell->index());
 
@@ -3144,7 +3141,7 @@ namespace parallel
               const unsigned int     second_dealii_idx_on_face =
                 lower_idx == 0 ? left_to_right[face_pair.orientation.to_ulong()]
                                               [first_dealii_idx_on_face] :
-                                 right_to_left[face_pair.orientation.to_ulong()]
+                                     right_to_left[face_pair.orientation.to_ulong()]
                                               [first_dealii_idx_on_face];
               const unsigned int second_dealii_idx_on_cell =
                 GeometryInfo<dim>::face_to_cell_vertices(

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -444,7 +444,8 @@ namespace internal
       }
 
       template <int spacedim>
-      static void reserve_space_mg(DoFHandler<1, spacedim> &dof_handler)
+      static void
+      reserve_space_mg(DoFHandler<1, spacedim> &dof_handler)
       {
         Assert(dof_handler.get_triangulation().n_levels() > 0,
                ExcMessage("Invalid triangulation"));
@@ -513,7 +514,8 @@ namespace internal
       }
 
       template <int spacedim>
-      static void reserve_space_mg(DoFHandler<2, spacedim> &dof_handler)
+      static void
+      reserve_space_mg(DoFHandler<2, spacedim> &dof_handler)
       {
         Assert(dof_handler.get_triangulation().n_levels() > 0,
                ExcMessage("Invalid triangulation"));
@@ -589,7 +591,8 @@ namespace internal
       }
 
       template <int spacedim>
-      static void reserve_space_mg(DoFHandler<3, spacedim> &dof_handler)
+      static void
+      reserve_space_mg(DoFHandler<3, spacedim> &dof_handler)
       {
         Assert(dof_handler.get_triangulation().n_levels() > 0,
                ExcMessage("Invalid triangulation"));
@@ -1451,7 +1454,8 @@ namespace internal
          * selected when calling @p distribute_dofs the last time.
          */
         template <int spacedim>
-        static void reserve_space(dealii::DoFHandler<1, spacedim> &dof_handler)
+        static void
+        reserve_space(dealii::DoFHandler<1, spacedim> &dof_handler)
         {
           Assert(dof_handler.fe_collection.size() > 0,
                  (typename dealii::DoFHandler<1, spacedim>::ExcNoFESelected()));
@@ -1475,7 +1479,8 @@ namespace internal
 
 
         template <int spacedim>
-        static void reserve_space(dealii::DoFHandler<2, spacedim> &dof_handler)
+        static void
+        reserve_space(dealii::DoFHandler<2, spacedim> &dof_handler)
         {
           Assert(dof_handler.fe_collection.size() > 0,
                  (typename dealii::DoFHandler<1, spacedim>::ExcNoFESelected()));
@@ -1501,7 +1506,8 @@ namespace internal
 
 
         template <int spacedim>
-        static void reserve_space(dealii::DoFHandler<3, spacedim> &dof_handler)
+        static void
+        reserve_space(dealii::DoFHandler<3, spacedim> &dof_handler)
         {
           Assert(dof_handler.fe_collection.size() > 0,
                  (typename dealii::DoFHandler<1, spacedim>::ExcNoFESelected()));

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1216,7 +1216,8 @@ namespace internal
          * by a dominating valid one.
          */
         template <int spacedim>
-        static void merge_invalid_line_dofs_on_ghost_interfaces(
+        static void
+        merge_invalid_line_dofs_on_ghost_interfaces(
           DoFHandler<1, spacedim> &dof_handler)
         {
           (void)dof_handler;
@@ -1505,7 +1506,8 @@ namespace internal
 
 
         template <int spacedim>
-        static void merge_invalid_quad_dofs_on_ghost_interfaces(
+        static void
+        merge_invalid_quad_dofs_on_ghost_interfaces(
           DoFHandler<3, spacedim> &dof_handler)
         {
           Assert(dof_handler.hp_capability_enabled == true,

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -601,7 +601,7 @@ namespace DoFRenumbering
               my_new_indices.size());
             {
               std::set<types::global_dof_index>::const_iterator
-                                      next_erased_index = erase_these_indices.begin();
+                next_erased_index = erase_these_indices.begin();
               types::global_dof_index next_new_index = 0;
               for (unsigned int i = 0; i < translate_indices.size(); ++i)
                 if ((next_erased_index != erase_these_indices.end()) &&

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -1021,8 +1021,8 @@ FiniteElement<dim, spacedim>::compare_for_domination(
 
 template <int dim, int spacedim>
 bool
-FiniteElement<dim, spacedim>::
-operator==(const FiniteElement<dim, spacedim> &f) const
+FiniteElement<dim, spacedim>::operator==(
+  const FiniteElement<dim, spacedim> &f) const
 {
   // Compare fields in roughly increasing order of how expensive the
   // comparison is
@@ -1036,8 +1036,8 @@ operator==(const FiniteElement<dim, spacedim> &f) const
 
 template <int dim, int spacedim>
 bool
-FiniteElement<dim, spacedim>::
-operator!=(const FiniteElement<dim, spacedim> &f) const
+FiniteElement<dim, spacedim>::operator!=(
+  const FiniteElement<dim, spacedim> &f) const
 {
   return !(*this == f);
 }

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -3238,7 +3238,7 @@ FE_Nedelec<dim>::convert_generalized_support_point_values_to_dof_values(
               system_matrix_inv.invert(system_matrix);
 
               const unsigned int
-                             line_coordinate[GeometryInfo<2>::lines_per_cell] = {1, 1, 0, 0};
+                line_coordinate[GeometryInfo<2>::lines_per_cell] = {1, 1, 0, 0};
               Vector<double> system_rhs(system_matrix.m());
               Vector<double> solution(system_rhs.size());
 

--- a/source/fe/fe_series_fourier.cc
+++ b/source/fe/fe_series_fourier.cc
@@ -27,14 +27,16 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace
 {
-  void set_k_vectors(Table<1, Tensor<1, 1>> &k_vectors, const unsigned int N)
+  void
+  set_k_vectors(Table<1, Tensor<1, 1>> &k_vectors, const unsigned int N)
   {
     k_vectors.reinit(TableIndices<1>(N));
     for (unsigned int i = 0; i < N; ++i)
       k_vectors(i)[0] = 2. * numbers::PI * i;
   }
 
-  void set_k_vectors(Table<2, Tensor<1, 2>> &k_vectors, const unsigned int N)
+  void
+  set_k_vectors(Table<2, Tensor<1, 2>> &k_vectors, const unsigned int N)
   {
     k_vectors.reinit(TableIndices<2>(N, N));
     for (unsigned int i = 0; i < N; ++i)
@@ -45,7 +47,8 @@ namespace
         }
   }
 
-  void set_k_vectors(Table<3, Tensor<1, 3>> &k_vectors, const unsigned int N)
+  void
+  set_k_vectors(Table<3, Tensor<1, 3>> &k_vectors, const unsigned int N)
   {
     k_vectors.reinit(TableIndices<3>(N, N, N));
     for (unsigned int i = 0; i < N; ++i)
@@ -224,8 +227,8 @@ namespace FESeries
 
   template <int dim, int spacedim>
   inline bool
-  Fourier<dim, spacedim>::
-  operator==(const Fourier<dim, spacedim> &fourier) const
+  Fourier<dim, spacedim>::operator==(
+    const Fourier<dim, spacedim> &fourier) const
   {
     return (
       (n_coefficients_per_direction == fourier.n_coefficients_per_direction) &&

--- a/source/fe/fe_series_legendre.cc
+++ b/source/fe/fe_series_legendre.cc
@@ -233,8 +233,8 @@ namespace FESeries
 
   template <int dim, int spacedim>
   inline bool
-  Legendre<dim, spacedim>::
-  operator==(const Legendre<dim, spacedim> &legendre) const
+  Legendre<dim, spacedim>::operator==(
+    const Legendre<dim, spacedim> &legendre) const
   {
     return (
       (n_coefficients_per_direction == legendre.n_coefficients_per_direction) &&

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1242,8 +1242,8 @@ FESystem<dim, spacedim>::compute_fill(
         const hp::QCollection<dim - 1> *face_quadrature     = nullptr;
         const Quadrature<dim - 1> *     sub_face_quadrature = nullptr;
         const unsigned int              n_q_points = quadrature.size() == 1 ?
-                                          quadrature[0].size() :
-                                          quadrature[face_no].size();
+                                                       quadrature[0].size() :
+                                                       quadrature[face_no].size();
 
         // static cast to the common base class of quadrature being either
         // Quadrature<dim> or Quadrature<dim-1>:

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2765,8 +2765,8 @@ FEValuesBase<dim, spacedim>::CellIterator<CI>::CellIterator(const CI &cell)
 
 template <int dim, int spacedim>
 template <typename CI>
-FEValuesBase<dim, spacedim>::CellIterator<CI>::
-operator typename Triangulation<dim, spacedim>::cell_iterator() const
+FEValuesBase<dim, spacedim>::CellIterator<
+  CI>::operator typename Triangulation<dim, spacedim>::cell_iterator() const
 {
   return cell;
 }

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -263,15 +263,16 @@ MappingQCache<dim, spacedim>::initialize(
 {
   AssertDimension(transformation_function.n_components, spacedim);
 
-  this->initialize(mapping,
-                   tria,
-                   [&](const auto &, const auto &point) {
-                     Point<spacedim> new_point;
-                     for (int c = 0; c < spacedim; ++c)
-                       new_point[c] = transformation_function.value(point, c);
-                     return new_point;
-                   },
-                   function_describes_relative_displacement);
+  this->initialize(
+    mapping,
+    tria,
+    [&](const auto &, const auto &point) {
+      Point<spacedim> new_point;
+      for (int c = 0; c < spacedim; ++c)
+        new_point[c] = transformation_function.value(point, c);
+      return new_point;
+    },
+    function_describes_relative_displacement);
 
   uses_level_info = true;
 }

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -235,7 +235,8 @@ namespace GridGenerator
         /**
          * Create a serial/parallel distributed triangulation.
          */
-        void create_triangulation(
+        void
+        create_triangulation(
           Triangulation<2> &                            tria_grid,
           std::vector<GridTools::PeriodicFacePair<
             typename Triangulation<2>::cell_iterator>> *periodic_faces) const
@@ -258,7 +259,8 @@ namespace GridGenerator
         /**
          * Specialization for parallel fully-distributed triangulations.
          */
-        void create_triangulation(
+        void
+        create_triangulation(
           parallel::fullydistributed::Triangulation<2> &parallel_grid,
           std::vector<GridTools::PeriodicFacePair<
             typename Triangulation<2>::cell_iterator>> *periodic_faces) const
@@ -815,7 +817,8 @@ namespace GridGenerator
          * Create 6 coarse grids based on points A-L (class fields) and merges
          * them to one triangulation.
          */
-        void make_coarse_grid(Triangulation<2> &tria) const
+        void
+        make_coarse_grid(Triangulation<2> &tria) const
         {
           // create vector of serial triangulations for each block and
           // temporary storage for merging them
@@ -900,7 +903,8 @@ namespace GridGenerator
          * - 4: upper far-field side
          * - 5: lower far-field side
          */
-        static void set_boundary_ids(Triangulation<2> &tria)
+        static void
+        set_boundary_ids(Triangulation<2> &tria)
         {
           for (auto cell : tria.active_cell_iterators())
             for (unsigned int f : GeometryInfo<2>::face_indices())
@@ -943,7 +947,8 @@ namespace GridGenerator
          * dense mesh next to airfoil geometry and receive an inclined boundary
          * between block 2&3 and 5&6, respectively
          */
-        void interpolate(Triangulation<2> &tria) const
+        void
+        interpolate(Triangulation<2> &tria) const
         {
           // array storing the information if a vertex was processed
           std::vector<bool> vertex_processed(tria.n_vertices(), false);
@@ -1148,7 +1153,8 @@ namespace GridGenerator
 
 
 
-    void internal_create_triangulation(
+    void
+    internal_create_triangulation(
       Triangulation<2, 2> &                            tria,
       std::vector<GridTools::PeriodicFacePair<
         typename Triangulation<2, 2>::cell_iterator>> *periodic_faces,
@@ -1170,7 +1176,8 @@ namespace GridGenerator
     }
 
     template <>
-    void create_triangulation(Triangulation<1, 1> &, const AdditionalData &)
+    void
+    create_triangulation(Triangulation<1, 1> &, const AdditionalData &)
     {
       Assert(false, ExcMessage("Airfoils only exist for 2D and 3D!"));
     }
@@ -1178,10 +1185,11 @@ namespace GridGenerator
 
 
     template <>
-    void create_triangulation(Triangulation<1, 1> &,
-                              std::vector<GridTools::PeriodicFacePair<
-                                typename Triangulation<1, 1>::cell_iterator>> &,
-                              const AdditionalData &)
+    void
+    create_triangulation(Triangulation<1, 1> &,
+                         std::vector<GridTools::PeriodicFacePair<
+                           typename Triangulation<1, 1>::cell_iterator>> &,
+                         const AdditionalData &)
     {
       Assert(false, ExcMessage("Airfoils only exist for 2D and 3D!"));
     }
@@ -1189,8 +1197,9 @@ namespace GridGenerator
 
 
     template <>
-    void create_triangulation(Triangulation<2, 2> & tria,
-                              const AdditionalData &additional_data)
+    void
+    create_triangulation(Triangulation<2, 2> & tria,
+                         const AdditionalData &additional_data)
     {
       internal_create_triangulation(tria, nullptr, additional_data);
     }
@@ -1198,7 +1207,8 @@ namespace GridGenerator
 
 
     template <>
-    void create_triangulation(
+    void
+    create_triangulation(
       Triangulation<2, 2> &                            tria,
       std::vector<GridTools::PeriodicFacePair<
         typename Triangulation<2, 2>::cell_iterator>> &periodic_faces,
@@ -1210,7 +1220,8 @@ namespace GridGenerator
 
 
     template <>
-    void create_triangulation(
+    void
+    create_triangulation(
       Triangulation<3, 3> &                            tria,
       std::vector<GridTools::PeriodicFacePair<
         typename Triangulation<3, 3>::cell_iterator>> &periodic_faces,
@@ -1249,10 +1260,11 @@ namespace GridGenerator
 
 
     template <int spacedim>
-    void colorize_subdivided_hyper_rectangle(Triangulation<1, spacedim> &tria,
-                                             const Point<spacedim> &,
-                                             const Point<spacedim> &,
-                                             const double)
+    void
+    colorize_subdivided_hyper_rectangle(Triangulation<1, spacedim> &tria,
+                                        const Point<spacedim> &,
+                                        const Point<spacedim> &,
+                                        const double)
     {
       for (typename Triangulation<1, spacedim>::cell_iterator cell =
              tria.begin();
@@ -1325,10 +1337,11 @@ namespace GridGenerator
      * Assign boundary number zero to the inner shell boundary and 1 to the
      * outer.
      */
-    void colorize_hyper_shell(Triangulation<2> &tria,
-                              const Point<2> &,
-                              const double,
-                              const double)
+    void
+    colorize_hyper_shell(Triangulation<2> &tria,
+                         const Point<2> &,
+                         const double,
+                         const double)
     {
       // In spite of receiving geometrical
       // data, we do this only based on
@@ -1350,10 +1363,11 @@ namespace GridGenerator
      * Assign boundary number zero to the inner shell boundary and 1 to the
      * outer.
      */
-    void colorize_hyper_shell(Triangulation<3> &tria,
-                              const Point<3> &,
-                              const double,
-                              const double)
+    void
+    colorize_hyper_shell(Triangulation<3> &tria,
+                         const Point<3> &,
+                         const double,
+                         const double)
     {
       // the following uses a good amount
       // of knowledge about the
@@ -1433,10 +1447,11 @@ namespace GridGenerator
      * shell boundary, two to the face with x=0, three to the face with y=0,
      * four to the face with z=0.
      */
-    void colorize_quarter_hyper_shell(Triangulation<3> &tria,
-                                      const Point<3> &  center,
-                                      const double      inner_radius,
-                                      const double      outer_radius)
+    void
+    colorize_quarter_hyper_shell(Triangulation<3> &tria,
+                                 const Point<3> &  center,
+                                 const double      inner_radius,
+                                 const double      outer_radius)
     {
       if (tria.n_cells() != 3)
         AssertThrow(false, ExcNotImplemented());
@@ -1792,11 +1807,12 @@ namespace GridGenerator
       }
   }
 
-  void moebius(Triangulation<3> & tria,
-               const unsigned int n_cells,
-               const unsigned int n_rotations,
-               const double       R,
-               const double       r)
+  void
+  moebius(Triangulation<3> & tria,
+          const unsigned int n_cells,
+          const unsigned int n_rotations,
+          const double       R,
+          const double       r)
   {
     const unsigned int dim = 3;
     Assert(n_cells > 4,
@@ -1867,11 +1883,12 @@ namespace GridGenerator
 
 
   template <>
-  void torus<2, 3>(Triangulation<2, 3> &tria,
-                   const double         R,
-                   const double         r,
-                   const unsigned int,
-                   const double)
+  void
+  torus<2, 3>(Triangulation<2, 3> &tria,
+              const double         R,
+              const double         r,
+              const unsigned int,
+              const double)
   {
     Assert(R > r,
            ExcMessage("Outer radius R must be greater than the inner "
@@ -2007,11 +2024,12 @@ namespace GridGenerator
 
 
   template <>
-  void torus<3, 3>(Triangulation<3, 3> &tria,
-                   const double         R,
-                   const double         r,
-                   const unsigned int   n_cells_toroidal,
-                   const double         phi)
+  void
+  torus<3, 3>(Triangulation<3, 3> &tria,
+              const double         R,
+              const double         r,
+              const unsigned int   n_cells_toroidal,
+              const double         phi)
   {
     Assert(R > r,
            ExcMessage("Outer radius R must be greater than the inner "
@@ -2168,26 +2186,29 @@ namespace GridGenerator
 
 
   template <>
-  void parallelogram(Triangulation<3> &,
-                     const Point<3> (&/*corners*/)[3],
-                     const bool /*colorize*/)
+  void
+  parallelogram(Triangulation<3> &,
+                const Point<3> (&/*corners*/)[3],
+                const bool /*colorize*/)
   {
     Assert(false, ExcNotImplemented());
   }
 
   template <>
-  void parallelogram(Triangulation<1> &,
-                     const Point<1> (&/*corners*/)[1],
-                     const bool /*colorize*/)
+  void
+  parallelogram(Triangulation<1> &,
+                const Point<1> (&/*corners*/)[1],
+                const bool /*colorize*/)
   {
     Assert(false, ExcNotImplemented());
   }
 
   // Implementation for 2D only
   template <>
-  void parallelogram(Triangulation<2> &tria,
-                     const Point<2> (&corners)[2],
-                     const bool colorize)
+  void
+  parallelogram(Triangulation<2> &tria,
+                const Point<2> (&corners)[2],
+                const bool colorize)
   {
     Point<2>                    origin;
     std::array<Tensor<1, 2>, 2> edges;
@@ -2894,11 +2915,11 @@ namespace GridGenerator
 
   template <>
   void
-    subdivided_hyper_rectangle(Triangulation<1> &                      tria,
-                               const std::vector<std::vector<double>> &spacing,
-                               const Point<1> &                        p,
-                               const Table<1, types::material_id> &material_id,
-                               const bool                          colorize)
+  subdivided_hyper_rectangle(Triangulation<1> &                      tria,
+                             const std::vector<std::vector<double>> &spacing,
+                             const Point<1> &                        p,
+                             const Table<1, types::material_id> &material_id,
+                             const bool                          colorize)
   {
     Assert(spacing.size() == 1, ExcInvalidRepetitionsDimension(1));
 
@@ -2952,11 +2973,11 @@ namespace GridGenerator
 
   template <>
   void
-    subdivided_hyper_rectangle(Triangulation<2> &                      tria,
-                               const std::vector<std::vector<double>> &spacing,
-                               const Point<2> &                        p,
-                               const Table<2, types::material_id> &material_id,
-                               const bool                          colorize)
+  subdivided_hyper_rectangle(Triangulation<2> &                      tria,
+                             const std::vector<std::vector<double>> &spacing,
+                             const Point<2> &                        p,
+                             const Table<2, types::material_id> &material_id,
+                             const bool                          colorize)
   {
     Assert(spacing.size() == 2, ExcInvalidRepetitionsDimension(2));
 
@@ -3046,11 +3067,11 @@ namespace GridGenerator
 
   template <>
   void
-    subdivided_hyper_rectangle(Triangulation<3> &                      tria,
-                               const std::vector<std::vector<double>> &spacing,
-                               const Point<3> &                        p,
-                               const Table<3, types::material_id> &material_id,
-                               const bool                          colorize)
+  subdivided_hyper_rectangle(Triangulation<3> &                      tria,
+                             const std::vector<std::vector<double>> &spacing,
+                             const Point<3> &                        p,
+                             const Table<3, types::material_id> &material_id,
+                             const bool                          colorize)
   {
     const unsigned int dim = 3;
 
@@ -3275,19 +3296,20 @@ namespace GridGenerator
 
 
   template <>
-  void plate_with_a_hole(Triangulation<1> & /*tria*/,
-                         const double /*inner_radius*/,
-                         const double /*outer_radius*/,
-                         const double /*pad_bottom*/,
-                         const double /*pad_top*/,
-                         const double /*pad_left*/,
-                         const double /*pad_right*/,
-                         const Point<1> & /*center*/,
-                         const types::manifold_id /*polar_manifold_id*/,
-                         const types::manifold_id /*tfi_manifold_id*/,
-                         const double /*L*/,
-                         const unsigned int /*n_slices*/,
-                         const bool /*colorize*/)
+  void
+  plate_with_a_hole(Triangulation<1> & /*tria*/,
+                    const double /*inner_radius*/,
+                    const double /*outer_radius*/,
+                    const double /*pad_bottom*/,
+                    const double /*pad_top*/,
+                    const double /*pad_left*/,
+                    const double /*pad_right*/,
+                    const Point<1> & /*center*/,
+                    const types::manifold_id /*polar_manifold_id*/,
+                    const types::manifold_id /*tfi_manifold_id*/,
+                    const double /*L*/,
+                    const unsigned int /*n_slices*/,
+                    const bool /*colorize*/)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -3295,11 +3317,12 @@ namespace GridGenerator
 
 
   template <>
-  void channel_with_cylinder(Triangulation<1> & /*tria*/,
-                             const double /*shell_region_width*/,
-                             const unsigned int /*n_shells*/,
-                             const double /*skewness*/,
-                             const bool /*colorize*/)
+  void
+  channel_with_cylinder(Triangulation<1> & /*tria*/,
+                        const double /*shell_region_width*/,
+                        const unsigned int /*n_shells*/,
+                        const double /*skewness*/,
+                        const bool /*colorize*/)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -3337,19 +3360,20 @@ namespace GridGenerator
 
 
   template <>
-  void plate_with_a_hole(Triangulation<2> &       tria,
-                         const double             inner_radius,
-                         const double             outer_radius,
-                         const double             pad_bottom,
-                         const double             pad_top,
-                         const double             pad_left,
-                         const double             pad_right,
-                         const Point<2> &         new_center,
-                         const types::manifold_id polar_manifold_id,
-                         const types::manifold_id tfi_manifold_id,
-                         const double             L,
-                         const unsigned int /*n_slices*/,
-                         const bool colorize)
+  void
+  plate_with_a_hole(Triangulation<2> &       tria,
+                    const double             inner_radius,
+                    const double             outer_radius,
+                    const double             pad_bottom,
+                    const double             pad_top,
+                    const double             pad_left,
+                    const double             pad_right,
+                    const Point<2> &         new_center,
+                    const types::manifold_id polar_manifold_id,
+                    const types::manifold_id tfi_manifold_id,
+                    const double             L,
+                    const unsigned int /*n_slices*/,
+                    const bool colorize)
   {
     const bool with_padding =
       pad_bottom > 0 || pad_top > 0 || pad_left > 0 || pad_right > 0;
@@ -3520,19 +3544,20 @@ namespace GridGenerator
 
 
   template <>
-  void plate_with_a_hole(Triangulation<3> &       tria,
-                         const double             inner_radius,
-                         const double             outer_radius,
-                         const double             pad_bottom,
-                         const double             pad_top,
-                         const double             pad_left,
-                         const double             pad_right,
-                         const Point<3> &         new_center,
-                         const types::manifold_id polar_manifold_id,
-                         const types::manifold_id tfi_manifold_id,
-                         const double             L,
-                         const unsigned int       n_slices,
-                         const bool               colorize)
+  void
+  plate_with_a_hole(Triangulation<3> &       tria,
+                    const double             inner_radius,
+                    const double             outer_radius,
+                    const double             pad_bottom,
+                    const double             pad_top,
+                    const double             pad_left,
+                    const double             pad_right,
+                    const Point<3> &         new_center,
+                    const types::manifold_id polar_manifold_id,
+                    const types::manifold_id tfi_manifold_id,
+                    const double             L,
+                    const unsigned int       n_slices,
+                    const bool               colorize)
   {
     Triangulation<2> tria_2;
     plate_with_a_hole(tria_2,
@@ -3569,11 +3594,12 @@ namespace GridGenerator
 
 
   template <>
-  void channel_with_cylinder(Triangulation<2> & tria,
-                             const double       shell_region_width,
-                             const unsigned int n_shells,
-                             const double       skewness,
-                             const bool         colorize)
+  void
+  channel_with_cylinder(Triangulation<2> & tria,
+                        const double       shell_region_width,
+                        const unsigned int n_shells,
+                        const double       skewness,
+                        const bool         colorize)
   {
     Assert(0.0 <= shell_region_width && shell_region_width < 0.05,
            ExcMessage("The width of the shell region must be less than 0.05 "
@@ -3798,11 +3824,12 @@ namespace GridGenerator
 
 
   template <>
-  void channel_with_cylinder(Triangulation<3> & tria,
-                             const double       shell_region_width,
-                             const unsigned int n_shells,
-                             const double       skewness,
-                             const bool         colorize)
+  void
+  channel_with_cylinder(Triangulation<3> & tria,
+                        const double       shell_region_width,
+                        const unsigned int n_shells,
+                        const double       skewness,
+                        const bool         colorize)
   {
     Triangulation<2> tria_2;
     channel_with_cylinder(
@@ -3912,27 +3939,7 @@ namespace GridGenerator
 
   template <>
   void
-    hyper_cube_slit(Triangulation<1> &, const double, const double, const bool)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-
-  template <>
-  void enclosed_hyper_cube(Triangulation<1> &,
-                           const double,
-                           const double,
-                           const double,
-                           const bool)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-
-  template <>
-  void hyper_L(Triangulation<1> &, const double, const double, const bool)
+  hyper_cube_slit(Triangulation<1> &, const double, const double, const bool)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -3941,25 +3948,11 @@ namespace GridGenerator
 
   template <>
   void
-    hyper_ball(Triangulation<1> &, const Point<1> &, const double, const bool)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-
-  template <>
-  void cylinder(Triangulation<1> &, const double, const double)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-  template <>
-  void subdivided_cylinder(Triangulation<1> &,
-                           const unsigned int,
-                           const double,
-                           const double)
+  enclosed_hyper_cube(Triangulation<1> &,
+                      const double,
+                      const double,
+                      const double,
+                      const bool)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -3968,7 +3961,7 @@ namespace GridGenerator
 
   template <>
   void
-    truncated_cone(Triangulation<1> &, const double, const double, const double)
+  hyper_L(Triangulation<1> &, const double, const double, const bool)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -3976,7 +3969,87 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_shell(Triangulation<1> &,
+  void
+  hyper_ball(Triangulation<1> &, const Point<1> &, const double, const bool)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+
+  template <>
+  void
+  cylinder(Triangulation<1> &, const double, const double)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+  template <>
+  void
+  subdivided_cylinder(Triangulation<1> &,
+                      const unsigned int,
+                      const double,
+                      const double)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+
+  template <>
+  void
+  truncated_cone(Triangulation<1> &, const double, const double, const double)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+
+  template <>
+  void
+  hyper_shell(Triangulation<1> &,
+              const Point<1> &,
+              const double,
+              const double,
+              const unsigned int,
+              const bool)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+  template <>
+  void
+  cylinder_shell(Triangulation<1> &,
+                 const double,
+                 const double,
+                 const double,
+                 const unsigned int,
+                 const unsigned int)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+  template <>
+  void
+  quarter_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+  template <>
+  void
+  half_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
+  {
+    Assert(false, ExcNotImplemented());
+  }
+
+
+  template <>
+  void
+  half_hyper_shell(Triangulation<1> &,
                    const Point<1> &,
                    const double,
                    const double,
@@ -3987,59 +4060,24 @@ namespace GridGenerator
   }
 
   template <>
-  void cylinder_shell(Triangulation<1> &,
-                      const double,
+  void
+  quarter_hyper_shell(Triangulation<1> &,
+                      const Point<1> &,
                       const double,
                       const double,
                       const unsigned int,
-                      const unsigned int)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-  template <>
-  void quarter_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-  template <>
-  void half_hyper_ball(Triangulation<1> &, const Point<1> &, const double)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-
-  template <>
-  void half_hyper_shell(Triangulation<1> &,
-                        const Point<1> &,
-                        const double,
-                        const double,
-                        const unsigned int,
-                        const bool)
+                      const bool)
   {
     Assert(false, ExcNotImplemented());
   }
 
   template <>
-  void quarter_hyper_shell(Triangulation<1> &,
-                           const Point<1> &,
-                           const double,
-                           const double,
-                           const unsigned int,
-                           const bool)
-  {
-    Assert(false, ExcNotImplemented());
-  }
-
-  template <>
-  void enclosed_hyper_cube(Triangulation<2> &tria,
-                           const double      left,
-                           const double      right,
-                           const double      thickness,
-                           const bool        colorize)
+  void
+  enclosed_hyper_cube(Triangulation<2> &tria,
+                      const double      left,
+                      const double      right,
+                      const double      thickness,
+                      const bool        colorize)
   {
     Assert(left < right,
            ExcMessage("Invalid left-to-right bounds of enclosed hypercube"));
@@ -4080,10 +4118,11 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void hyper_cube_slit(Triangulation<2> &tria,
-                       const double      left,
-                       const double      right,
-                       const bool        colorize)
+  void
+  hyper_cube_slit(Triangulation<2> &tria,
+                  const double      left,
+                  const double      right,
+                  const bool        colorize)
   {
     const double             rl2                 = (right + left) / 2;
     const Point<2>           vertices[10]        = {Point<2>(left, left),
@@ -4124,10 +4163,11 @@ namespace GridGenerator
 
 
   template <>
-  void truncated_cone(Triangulation<2> &triangulation,
-                      const double      radius_0,
-                      const double      radius_1,
-                      const double      half_length)
+  void
+  truncated_cone(Triangulation<2> &triangulation,
+                 const double      radius_0,
+                 const double      radius_1,
+                 const double      half_length)
   {
     Point<2> vertices_tmp[4];
 
@@ -4164,10 +4204,11 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void hyper_L(Triangulation<2> &tria,
-               const double      a,
-               const double      b,
-               const bool        colorize)
+  void
+  hyper_L(Triangulation<2> &tria,
+          const double      a,
+          const double      b,
+          const bool        colorize)
   {
     const Point<2> vertices[8]    = {Point<2>(a, a),
                                   Point<2>((a + b) / 2, a),
@@ -4287,10 +4328,11 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void hyper_ball(Triangulation<2> &tria,
-                  const Point<2> &  p,
-                  const double      radius,
-                  const bool        internal_manifolds)
+  void
+  hyper_ball(Triangulation<2> &tria,
+             const Point<2> &  p,
+             const double      radius,
+             const bool        internal_manifolds)
   {
     // equilibrate cell sizes at
     // transition from the inner part
@@ -4332,12 +4374,13 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_shell(Triangulation<2> & tria,
-                   const Point<2> &   center,
-                   const double       inner_radius,
-                   const double       outer_radius,
-                   const unsigned int n_cells,
-                   const bool         colorize)
+  void
+  hyper_shell(Triangulation<2> & tria,
+              const Point<2> &   center,
+              const double       inner_radius,
+              const double       outer_radius,
+              const unsigned int n_cells,
+              const bool         colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -4454,9 +4497,10 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void cylinder(Triangulation<2> &tria,
-                const double      radius,
-                const double      half_length)
+  void
+  cylinder(Triangulation<2> &tria,
+           const double      radius,
+           const double      half_length)
   {
     Point<2> p1(-half_length, -radius);
     Point<2> p2(half_length, radius);
@@ -4484,10 +4528,11 @@ namespace GridGenerator
   }
 
   template <>
-  void subdivided_cylinder(Triangulation<2> &,
-                           const unsigned int,
-                           const double,
-                           const double)
+  void
+  subdivided_cylinder(Triangulation<2> &,
+                      const unsigned int,
+                      const double,
+                      const double)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -4496,21 +4541,23 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void cylinder_shell(Triangulation<2> &,
-                      const double,
-                      const double,
-                      const double,
-                      const unsigned int,
-                      const unsigned int)
+  void
+  cylinder_shell(Triangulation<2> &,
+                 const double,
+                 const double,
+                 const double,
+                 const unsigned int,
+                 const unsigned int)
   {
     Assert(false, ExcNotImplemented());
   }
 
 
   template <>
-  void quarter_hyper_ball(Triangulation<2> &tria,
-                          const Point<2> &  p,
-                          const double      radius)
+  void
+  quarter_hyper_ball(Triangulation<2> &tria,
+                     const Point<2> &  p,
+                     const double      radius)
   {
     const unsigned int dim = 2;
 
@@ -4571,9 +4618,10 @@ namespace GridGenerator
 
 
   template <>
-  void half_hyper_ball(Triangulation<2> &tria,
-                       const Point<2> &  p,
-                       const double      radius)
+  void
+  half_hyper_ball(Triangulation<2> &tria,
+                  const Point<2> &  p,
+                  const double      radius)
   {
     // equilibrate cell sizes at
     // transition from the inner part
@@ -4637,12 +4685,13 @@ namespace GridGenerator
 
   // Implementation for 2D only
   template <>
-  void half_hyper_shell(Triangulation<2> & tria,
-                        const Point<2> &   center,
-                        const double       inner_radius,
-                        const double       outer_radius,
-                        const unsigned int n_cells,
-                        const bool         colorize)
+  void
+  half_hyper_shell(Triangulation<2> & tria,
+                   const Point<2> &   center,
+                   const double       inner_radius,
+                   const double       outer_radius,
+                   const unsigned int n_cells,
+                   const bool         colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -4720,12 +4769,13 @@ namespace GridGenerator
 
 
   template <>
-  void quarter_hyper_shell(Triangulation<2> & tria,
-                           const Point<2> &   center,
-                           const double       inner_radius,
-                           const double       outer_radius,
-                           const unsigned int n_cells,
-                           const bool         colorize)
+  void
+  quarter_hyper_shell(Triangulation<2> & tria,
+                      const Point<2> &   center,
+                      const double       inner_radius,
+                      const double       outer_radius,
+                      const unsigned int n_cells,
+                      const bool         colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -4804,10 +4854,11 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void hyper_cube_slit(Triangulation<3> &tria,
-                       const double      left,
-                       const double      right,
-                       const bool        colorize)
+  void
+  hyper_cube_slit(Triangulation<3> &tria,
+                  const double      left,
+                  const double      right,
+                  const bool        colorize)
   {
     const double rl2 = (right + left) / 2;
     const double len = (right - left) / 2.;
@@ -4852,11 +4903,12 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void enclosed_hyper_cube(Triangulation<3> &tria,
-                           const double      left,
-                           const double      right,
-                           const double      thickness,
-                           const bool        colorize)
+  void
+  enclosed_hyper_cube(Triangulation<3> &tria,
+                      const double      left,
+                      const double      right,
+                      const double      thickness,
+                      const bool        colorize)
   {
     Assert(left < right,
            ExcMessage("Invalid left-to-right bounds of enclosed hypercube"));
@@ -4905,10 +4957,11 @@ namespace GridGenerator
 
 
   template <>
-  void truncated_cone(Triangulation<3> &triangulation,
-                      const double      radius_0,
-                      const double      radius_1,
-                      const double      half_length)
+  void
+  truncated_cone(Triangulation<3> &triangulation,
+                 const double      radius_0,
+                 const double      radius_1,
+                 const double      half_length)
   {
     Assert(triangulation.n_cells() == 0,
            ExcMessage("The output triangulation object needs to be empty."));
@@ -4957,10 +5010,11 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void hyper_L(Triangulation<3> &tria,
-               const double      a,
-               const double      b,
-               const bool        colorize)
+  void
+  hyper_L(Triangulation<3> &tria,
+          const double      a,
+          const double      b,
+          const bool        colorize)
   {
     // we slice out the top back right
     // part of the cube
@@ -5027,10 +5081,11 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void hyper_ball(Triangulation<3> &tria,
-                  const Point<3> &  p,
-                  const double      radius,
-                  const bool        internal_manifold)
+  void
+  hyper_ball(Triangulation<3> &tria,
+             const Point<3> &  p,
+             const double      radius,
+             const bool        internal_manifold)
   {
     const double a =
       1. / (1 + std::sqrt(3.0)); // equilibrate cell sizes at transition
@@ -5093,9 +5148,10 @@ namespace GridGenerator
   }
 
 
-  void non_standard_orientation_mesh(Triangulation<2> &tria,
-                                     const bool        rotate_left_square,
-                                     const bool        rotate_right_square)
+  void
+  non_standard_orientation_mesh(Triangulation<2> &tria,
+                                const bool        rotate_left_square,
+                                const bool        rotate_right_square)
   {
     constexpr unsigned int dim = 2;
 
@@ -5173,11 +5229,12 @@ namespace GridGenerator
   }
 
 
-  void non_standard_orientation_mesh(Triangulation<3> &tria,
-                                     const bool        face_orientation,
-                                     const bool        face_flip,
-                                     const bool        face_rotation,
-                                     const bool        manipulate_left_cube)
+  void
+  non_standard_orientation_mesh(Triangulation<3> &tria,
+                                const bool        face_orientation,
+                                const bool        face_flip,
+                                const bool        face_rotation,
+                                const bool        manipulate_left_cube)
   {
     constexpr unsigned int dim = 3;
 
@@ -5443,9 +5500,10 @@ namespace GridGenerator
 
 
   template <int spacedim>
-  void hyper_sphere(Triangulation<spacedim - 1, spacedim> &tria,
-                    const Point<spacedim> &                p,
-                    const double                           radius)
+  void
+  hyper_sphere(Triangulation<spacedim - 1, spacedim> &tria,
+               const Point<spacedim> &                p,
+               const double                           radius)
   {
     Triangulation<spacedim> volume_mesh;
     GridGenerator::hyper_ball(volume_mesh, p, radius);
@@ -5460,10 +5518,11 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void subdivided_cylinder(Triangulation<3> & tria,
-                           const unsigned int x_subdivisions,
-                           const double       radius,
-                           const double       half_length)
+  void
+  subdivided_cylinder(Triangulation<3> & tria,
+                      const unsigned int x_subdivisions,
+                      const double       radius,
+                      const double       half_length)
   {
     // Copy the base from hyper_ball<3>
     // and transform it to yz
@@ -5586,17 +5645,19 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void cylinder(Triangulation<3> &tria,
-                const double      radius,
-                const double      half_length)
+  void
+  cylinder(Triangulation<3> &tria,
+           const double      radius,
+           const double      half_length)
   {
     subdivided_cylinder(tria, 2, radius, half_length);
   }
 
   template <>
-  void quarter_hyper_ball(Triangulation<3> &tria,
-                          const Point<3> &  center,
-                          const double      radius)
+  void
+  quarter_hyper_ball(Triangulation<3> &tria,
+                     const Point<3> &  center,
+                     const double      radius)
   {
     const unsigned int dim = 3;
 
@@ -5692,9 +5753,10 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void half_hyper_ball(Triangulation<3> &tria,
-                       const Point<3> &  center,
-                       const double      radius)
+  void
+  half_hyper_ball(Triangulation<3> &tria,
+                  const Point<3> &  center,
+                  const double      radius)
   {
     // These are for the two lower squares
     const double d = radius / std::sqrt(2.0);
@@ -5889,12 +5951,13 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_shell(Triangulation<3> & tria,
-                   const Point<3> &   p,
-                   const double       inner_radius,
-                   const double       outer_radius,
-                   const unsigned int n_cells,
-                   const bool         colorize)
+  void
+  hyper_shell(Triangulation<3> & tria,
+              const Point<3> &   p,
+              const double       inner_radius,
+              const double       outer_radius,
+              const unsigned int n_cells,
+              const bool         colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -6104,12 +6167,13 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void half_hyper_shell(Triangulation<3> &tria,
-                        const Point<3> &  center,
-                        const double      inner_radius,
-                        const double      outer_radius,
-                        const unsigned int /*n_cells*/,
-                        const bool colorize)
+  void
+  half_hyper_shell(Triangulation<3> &tria,
+                   const Point<3> &  center,
+                   const double      inner_radius,
+                   const double      outer_radius,
+                   const unsigned int /*n_cells*/,
+                   const bool colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -6204,12 +6268,13 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void quarter_hyper_shell(Triangulation<3> & tria,
-                           const Point<3> &   center,
-                           const double       inner_radius,
-                           const double       outer_radius,
-                           const unsigned int n,
-                           const bool         colorize)
+  void
+  quarter_hyper_shell(Triangulation<3> & tria,
+                      const Point<3> &   center,
+                      const double       inner_radius,
+                      const double       outer_radius,
+                      const unsigned int n,
+                      const bool         colorize)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -6272,12 +6337,13 @@ namespace GridGenerator
 
   // Implementation for 3D only
   template <>
-  void cylinder_shell(Triangulation<3> & tria,
-                      const double       length,
-                      const double       inner_radius,
-                      const double       outer_radius,
-                      const unsigned int n_radial_cells,
-                      const unsigned int n_axial_cells)
+  void
+  cylinder_shell(Triangulation<3> & tria,
+                 const double       length,
+                 const double       inner_radius,
+                 const double       outer_radius,
+                 const unsigned int n_radial_cells,
+                 const unsigned int n_axial_cells)
   {
     Assert((inner_radius > 0) && (inner_radius < outer_radius),
            ExcInvalidRadii());
@@ -7105,12 +7171,13 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<1> &,
-                                        const double,
-                                        const double,
-                                        const double,
-                                        const unsigned int,
-                                        const bool)
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<1> &,
+                                   const double,
+                                   const double,
+                                   const double,
+                                   const unsigned int,
+                                   const bool)
   {
     Assert(false, ExcNotImplemented());
   }
@@ -7118,12 +7185,13 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<2> &triangulation,
-                                        const double      inner_radius,
-                                        const double      outer_radius,
-                                        const double,       // width,
-                                        const unsigned int, // width_repetition,
-                                        const bool colorize)
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<2> &triangulation,
+                                   const double      inner_radius,
+                                   const double      outer_radius,
+                                   const double,       // width,
+                                   const unsigned int, // width_repetition,
+                                   const bool colorize)
   {
     const int dim = 2;
 
@@ -7333,12 +7401,13 @@ namespace GridGenerator
 
 
   template <>
-  void hyper_cube_with_cylindrical_hole(Triangulation<3> & triangulation,
-                                        const double       inner_radius,
-                                        const double       outer_radius,
-                                        const double       L,
-                                        const unsigned int Nz,
-                                        const bool         colorize)
+  void
+  hyper_cube_with_cylindrical_hole(Triangulation<3> & triangulation,
+                                   const double       inner_radius,
+                                   const double       outer_radius,
+                                   const double       L,
+                                   const unsigned int Nz,
+                                   const bool         colorize)
   {
     const int dim = 3;
 

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -240,7 +240,8 @@ for (deal_II_space_dimension : DIMENSIONS)
     \{
 
 #if deal_II_space_dimension >= 2
-      template void hyper_sphere<deal_II_space_dimension>(
+      template void
+      hyper_sphere<deal_II_space_dimension>(
         Triangulation<deal_II_space_dimension - 1, deal_II_space_dimension> &,
         const Point<deal_II_space_dimension> &,
         double);

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -964,8 +964,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
   // Write additional face information
 
   if (write_faces)
-    {
-    }
+    {}
   else
     {}
 

--- a/source/grid/grid_refinement.inst.in
+++ b/source/grid/grid_refinement.inst.in
@@ -56,38 +56,38 @@ for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS)
 
 #if deal_II_dimension < 3
     template void
-      GridRefinement::refine<deal_II_dimension, S, deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
-        const dealii::Vector<S> &,
-        const double,
-        const unsigned int);
+    GridRefinement::refine<deal_II_dimension, S, deal_II_dimension + 1>(
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+      const dealii::Vector<S> &,
+      const double,
+      const unsigned int);
 
     template void
-      GridRefinement::coarsen<deal_II_dimension, S, deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
-        const dealii::Vector<S> &,
-        const double);
+    GridRefinement::coarsen<deal_II_dimension, S, deal_II_dimension + 1>(
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+      const dealii::Vector<S> &,
+      const double);
 
     template void
-      GridRefinement::refine_and_coarsen_fixed_number<deal_II_dimension,
+    GridRefinement::refine_and_coarsen_fixed_number<deal_II_dimension,
+                                                    S,
+                                                    deal_II_dimension + 1>(
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+      const dealii::Vector<S> &,
+      const double,
+      const double,
+      const unsigned int);
+
+    template void
+    GridRefinement::refine_and_coarsen_fixed_fraction<deal_II_dimension,
                                                       S,
                                                       deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
-        const dealii::Vector<S> &,
-        const double,
-        const double,
-        const unsigned int);
-
-    template void
-      GridRefinement::refine_and_coarsen_fixed_fraction<deal_II_dimension,
-                                                        S,
-                                                        deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
-        const dealii::Vector<S> &,
-        const double,
-        const double,
-        const unsigned int,
-        const VectorTools::NormType);
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+      const dealii::Vector<S> &,
+      const double,
+      const double,
+      const unsigned int,
+      const VectorTools::NormType);
 
     template void GridRefinement::
       refine_and_coarsen_optimize<deal_II_dimension, S, deal_II_dimension + 1>(

--- a/source/grid/grid_reordering.cc
+++ b/source/grid/grid_reordering.cc
@@ -41,18 +41,21 @@ namespace
    * do the reordering of their
    * arguments in-place.
    */
-  void reorder_new_to_old_style(std::vector<CellData<1>> &)
+  void
+  reorder_new_to_old_style(std::vector<CellData<1>> &)
   {}
 
 
-  void reorder_new_to_old_style(std::vector<CellData<2>> &cells)
+  void
+  reorder_new_to_old_style(std::vector<CellData<2>> &cells)
   {
     for (auto &cell : cells)
       std::swap(cell.vertices[2], cell.vertices[3]);
   }
 
 
-  void reorder_new_to_old_style(std::vector<CellData<3>> &cells)
+  void
+  reorder_new_to_old_style(std::vector<CellData<3>> &cells)
   {
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
     for (auto &cell : cells)
@@ -68,18 +71,21 @@ namespace
   /**
    * And now also in the opposite direction.
    */
-  void reorder_old_to_new_style(std::vector<CellData<1>> &)
+  void
+  reorder_old_to_new_style(std::vector<CellData<1>> &)
   {}
 
 
-  void reorder_old_to_new_style(std::vector<CellData<2>> &cells)
+  void
+  reorder_old_to_new_style(std::vector<CellData<2>> &cells)
   {
     // just invert the permutation:
     reorder_new_to_old_style(cells);
   }
 
 
-  void reorder_old_to_new_style(std::vector<CellData<3>> &cells)
+  void
+  reorder_old_to_new_style(std::vector<CellData<3>> &cells)
   {
     // undo the ordering above
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1910,7 +1910,8 @@ namespace GridTools
 
     // overload of the function above for 1d -- there is nothing
     // to orient in that case
-    void reorient(std::vector<CellData<1>> &)
+    void
+    reorient(std::vector<CellData<1>> &)
     {}
   } // namespace
 

--- a/source/grid/grid_tools.inst.in
+++ b/source/grid/grid_tools.inst.in
@@ -484,16 +484,16 @@ for (deal_II_dimension : DIMENSIONS)
                       deal_II_dimension + 1>::active_cell_iterator);
 
     template void
-      GridTools::remove_hanging_nodes<deal_II_dimension, deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> & tria,
-        bool,
-        unsigned int);
+    GridTools::remove_hanging_nodes<deal_II_dimension, deal_II_dimension + 1>(
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> & tria,
+      bool,
+      unsigned int);
 
     template void
-      GridTools::remove_anisotropy<deal_II_dimension, deal_II_dimension + 1>(
-        Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
-        double,
-        unsigned int);
+    GridTools::remove_anisotropy<deal_II_dimension, deal_II_dimension + 1>(
+      Triangulation<deal_II_dimension, deal_II_dimension + 1> &,
+      double,
+      unsigned int);
 #endif
   }
 

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -881,7 +881,7 @@ namespace GridTools
     const double layer_thickness)
   {
     std::vector<typename MeshType::active_cell_iterator>
-                      subdomain_boundary_cells, active_cell_layer_within_distance;
+      subdomain_boundary_cells, active_cell_layer_within_distance;
     std::vector<bool> vertices_outside_subdomain(
       mesh.get_triangulation().n_vertices(), false);
 
@@ -2409,7 +2409,8 @@ namespace GridTools
 
 
   template <typename FaceIterator>
-  inline bool orthogonal_equality(
+  inline bool
+  orthogonal_equality(
     std::bitset<3> &                                              orientation,
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -249,7 +249,8 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
     namespace GridTools
     \{
 
-      template bool orthogonal_equality<X::active_face_iterator>(
+      template bool
+      orthogonal_equality<X::active_face_iterator>(
         std::bitset<3> &,
         const X::active_face_iterator &,
         const X::active_face_iterator &,
@@ -257,7 +258,8 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
-      template bool orthogonal_equality<X::face_iterator>(
+      template bool
+      orthogonal_equality<X::face_iterator>(
         std::bitset<3> &,
         const X::face_iterator &,
         const X::face_iterator &,

--- a/source/grid/intergrid_map.cc
+++ b/source/grid/intergrid_map.cc
@@ -153,8 +153,8 @@ InterGridMap<MeshType>::set_entries_to_cell(const cell_iterator &src_cell,
 
 
 template <class MeshType>
-typename InterGridMap<MeshType>::cell_iterator InterGridMap<MeshType>::
-                                               operator[](const cell_iterator &source_cell) const
+typename InterGridMap<MeshType>::cell_iterator
+InterGridMap<MeshType>::operator[](const cell_iterator &source_cell) const
 {
   Assert(source_cell.state() == IteratorState::valid,
          ExcInvalidKey(source_cell));

--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -626,7 +626,7 @@ SphericalManifold<dim, spacedim>::get_new_points(
     }
 
   boost::container::small_vector<std::pair<double, Tensor<1, spacedim>>, 100>
-                                                           new_candidates(new_points.size());
+    new_candidates(new_points.size());
   boost::container::small_vector<Tensor<1, spacedim>, 100> directions(
     surrounding_points.size(), Point<spacedim>());
   boost::container::small_vector<double, 100> distances(

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -477,8 +477,8 @@ namespace
   }
 
 
-  void reorder_compatibility(std::vector<CellData<2>> &cells,
-                             const SubCellData &)
+  void
+  reorder_compatibility(std::vector<CellData<2>> &cells, const SubCellData &)
   {
     for (auto &cell : cells)
       if (cell.vertices.size() == GeometryInfo<2>::vertices_per_cell)
@@ -486,8 +486,9 @@ namespace
   }
 
 
-  void reorder_compatibility(std::vector<CellData<3>> &cells,
-                             SubCellData &             subcelldata)
+  void
+  reorder_compatibility(std::vector<CellData<3>> &cells,
+                        SubCellData &             subcelldata)
   {
     unsigned int tmp[GeometryInfo<3>::vertices_per_cell];
     for (auto &cell : cells)
@@ -2107,7 +2108,8 @@ namespace internal
 
 
       template <int spacedim>
-      static void update_neighbors(Triangulation<1, spacedim> &)
+      static void
+      update_neighbors(Triangulation<1, spacedim> &)
       {}
 
 
@@ -2728,11 +2730,11 @@ namespace internal
        * argument and quads instead of lines.
        */
       template <int spacedim>
-      static void delete_children(
-        Triangulation<1, spacedim> &                        triangulation,
-        typename Triangulation<1, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int> &,
-        std::vector<unsigned int> &)
+      static void
+      delete_children(Triangulation<1, spacedim> &triangulation,
+                      typename Triangulation<1, spacedim>::cell_iterator &cell,
+                      std::vector<unsigned int> &,
+                      std::vector<unsigned int> &)
       {
         const unsigned int dim = 1;
 
@@ -2832,11 +2834,11 @@ namespace internal
 
 
       template <int spacedim>
-      static void delete_children(
-        Triangulation<2, spacedim> &                        triangulation,
-        typename Triangulation<2, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int> &                         line_cell_count,
-        std::vector<unsigned int> &)
+      static void
+      delete_children(Triangulation<2, spacedim> &triangulation,
+                      typename Triangulation<2, spacedim>::cell_iterator &cell,
+                      std::vector<unsigned int> &line_cell_count,
+                      std::vector<unsigned int> &)
       {
         const unsigned int        dim      = 2;
         const RefinementCase<dim> ref_case = cell->refinement_case();
@@ -2970,11 +2972,11 @@ namespace internal
 
 
       template <int spacedim>
-      static void delete_children(
-        Triangulation<3, spacedim> &                        triangulation,
-        typename Triangulation<3, spacedim>::cell_iterator &cell,
-        std::vector<unsigned int> &                         line_cell_count,
-        std::vector<unsigned int> &                         quad_cell_count)
+      static void
+      delete_children(Triangulation<3, spacedim> &triangulation,
+                      typename Triangulation<3, spacedim>::cell_iterator &cell,
+                      std::vector<unsigned int> &line_cell_count,
+                      std::vector<unsigned int> &quad_cell_count)
       {
         const unsigned int dim = 3;
 
@@ -3600,7 +3602,8 @@ namespace internal
        * "before") the reserved space.
        */
       template <int spacedim>
-      static void create_children(
+      static void
+      create_children(
         Triangulation<2, spacedim> &triangulation,
         unsigned int &              next_unused_vertex,
         typename Triangulation<2, spacedim>::raw_line_iterator
@@ -4540,8 +4543,8 @@ namespace internal
        */
       template <int spacedim>
       static typename Triangulation<1, spacedim>::DistortedCellList
-        execute_refinement(Triangulation<1, spacedim> &triangulation,
-                           const bool /*check_for_distorted_cells*/)
+      execute_refinement(Triangulation<1, spacedim> &triangulation,
+                         const bool /*check_for_distorted_cells*/)
       {
         const unsigned int dim = 1;
 
@@ -4771,8 +4774,8 @@ namespace internal
        */
       template <int spacedim>
       static typename Triangulation<2, spacedim>::DistortedCellList
-        execute_refinement(Triangulation<2, spacedim> &triangulation,
-                           const bool check_for_distorted_cells)
+      execute_refinement(Triangulation<2, spacedim> &triangulation,
+                         const bool                  check_for_distorted_cells)
       {
         const unsigned int dim = 2;
 
@@ -5089,8 +5092,8 @@ namespace internal
 
       template <int spacedim>
       static typename Triangulation<3, spacedim>::DistortedCellList
-        execute_refinement_isotropic(Triangulation<3, spacedim> &triangulation,
-                                     const bool check_for_distorted_cells)
+      execute_refinement_isotropic(Triangulation<3, spacedim> &triangulation,
+                                   const bool check_for_distorted_cells)
       {
         static const int          dim = 3;
         static const unsigned int X   = numbers::invalid_unsigned_int;
@@ -6326,8 +6329,8 @@ namespace internal
        */
       template <int spacedim>
       static typename Triangulation<3, spacedim>::DistortedCellList
-        execute_refinement(Triangulation<3, spacedim> &triangulation,
-                           const bool check_for_distorted_cells)
+      execute_refinement(Triangulation<3, spacedim> &triangulation,
+                         const bool                  check_for_distorted_cells)
       {
         const unsigned int dim = 3;
 
@@ -10681,7 +10684,8 @@ namespace internal
        * specialization).
        */
       template <int spacedim>
-      static void prevent_distorted_boundary_cells(Triangulation<1, spacedim> &)
+      static void
+      prevent_distorted_boundary_cells(Triangulation<1, spacedim> &)
       {}
 
 
@@ -10778,7 +10782,8 @@ namespace internal
 
 
       template <int spacedim>
-      static void prepare_refinement_dim_dependent(
+      static void
+      prepare_refinement_dim_dependent(
         Triangulation<3, spacedim> &triangulation)
       {
         const unsigned int dim = 3;
@@ -11031,7 +11036,8 @@ namespace internal
     struct ImplementationMixedMesh
     {
       template <int spacedim>
-      static void update_neighbors(Triangulation<1, spacedim> &)
+      static void
+      update_neighbors(Triangulation<1, spacedim> &)
       {}
 
       template <int dim, int spacedim>
@@ -11223,8 +11229,8 @@ Triangulation<dim, spacedim>::Triangulation(
 
 template <int dim, int spacedim>
 Triangulation<dim, spacedim> &
-Triangulation<dim, spacedim>::
-operator=(Triangulation<dim, spacedim> &&tria) noexcept
+Triangulation<dim, spacedim>::operator=(
+  Triangulation<dim, spacedim> &&tria) noexcept
 {
   Subscriptor::operator=(std::move(tria));
 

--- a/source/lac/block_sparsity_pattern.cc
+++ b/source/lac/block_sparsity_pattern.cc
@@ -107,8 +107,8 @@ BlockSparsityPatternBase<SparsityPatternBase>::reinit(
 
 template <class SparsityPatternBase>
 BlockSparsityPatternBase<SparsityPatternBase> &
-BlockSparsityPatternBase<SparsityPatternBase>::
-operator=(const BlockSparsityPatternBase<SparsityPatternBase> &bsp)
+BlockSparsityPatternBase<SparsityPatternBase>::operator=(
+  const BlockSparsityPatternBase<SparsityPatternBase> &bsp)
 {
   Assert(rows == bsp.rows, ExcDimensionMismatch(rows, bsp.rows));
   Assert(columns == bsp.columns, ExcDimensionMismatch(columns, bsp.columns));

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -268,7 +268,8 @@ namespace LinearAlgebra
 
 
     template <typename Number>
-    Number Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
+    Number
+    Vector<Number>::operator*(const VectorSpaceVector<Number> &V) const
     {
       // Check that casting will work
       Assert(dynamic_cast<const Vector<Number> *>(&V) != nullptr,

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -342,7 +342,8 @@ namespace PETScWrappers
 
 
 
-  PetscScalar VectorBase::operator*(const VectorBase &vec) const
+  PetscScalar
+  VectorBase::operator*(const VectorBase &vec) const
   {
     Assert(size() == vec.size(), ExcDimensionMismatch(size(), vec.size()));
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -282,7 +282,8 @@ namespace LinearAlgebra
 
 
 
-    double Vector::operator*(const VectorSpaceVector<double> &V) const
+    double
+    Vector::operator*(const VectorSpaceVector<double> &V) const
     {
       // Check that casting will work.
       Assert(dynamic_cast<const Vector *>(&V) != nullptr,

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1739,8 +1739,8 @@ namespace TrilinosWrappers
           (nonlocal_matrix.get() != nullptr &&
            matrix->RowMap().MyGID(
              static_cast<TrilinosWrappers::types::int_type>(row)) == false) ?
-            &nonlocal_matrix->Graph() :
-            &matrix->Graph();
+                                    &nonlocal_matrix->Graph() :
+                                    &matrix->Graph();
 
         indices.resize(graph->NumGlobalIndices(row));
         int n_indices = 0;
@@ -3060,8 +3060,9 @@ namespace TrilinosWrappers
 
 
 
-      TrilinosPayload operator*(const TrilinosPayload &first_op,
-                                const TrilinosPayload &second_op)
+      TrilinosPayload
+      operator*(const TrilinosPayload &first_op,
+                const TrilinosPayload &second_op)
       {
         using Domain        = typename TrilinosPayload::Domain;
         using Range         = typename TrilinosPayload::Range;

--- a/source/lac/vector.cc
+++ b/source/lac/vector.cc
@@ -28,17 +28,18 @@ template class Vector<std::complex<double>>;
 
 // instantiate for integers:
 template class Vector<int>;
-template Vector<double> &Vector<double>::
-                         operator=<int>(const dealii::Vector<int> &);
-template bool Vector<int>::operator==<int>(dealii::Vector<int> const &) const;
+template Vector<double> &
+Vector<double>::operator=<int>(const dealii::Vector<int> &);
+template bool
+Vector<int>::operator==<int>(dealii::Vector<int> const &) const;
 
 template void
 Vector<int>::reinit<double>(const Vector<double> &, const bool);
 
 // instantiate for long double manually because we use it in a few places:
 template class Vector<long double>;
-template long double Vector<long double>::
-                     operator*<long double>(const Vector<long double> &) const;
+template long double
+Vector<long double>::operator*<long double>(const Vector<long double> &) const;
 
 // do a few functions that currently don't fit the scheme because they have
 // two template arguments that need to be different (the case of same

--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -474,7 +474,7 @@ namespace NonMatching
 
     std::vector<
       std::vector<typename Triangulation<dim0, spacedim>::active_cell_iterator>>
-                                                       cell_container(n_active_c);
+      cell_container(n_active_c);
     std::vector<std::vector<std::vector<Point<dim0>>>> qpoints_container(
       n_active_c);
     std::vector<std::vector<std::vector<unsigned int>>> maps_container(

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -512,7 +512,7 @@ DataOutRotation<dim, spacedim>::build_patches(
       n_postprocessor_outputs[dataset] = 0;
 
   internal::DataOutRotationImplementation::ParallelData<dim, spacedim>
-                                                             thread_data(n_datasets,
+    thread_data(n_datasets,
                 n_subdivisions,
                 n_patches_per_circle,
                 n_postprocessor_outputs,

--- a/source/numerics/error_estimator_1d.cc
+++ b/source/numerics/error_estimator_1d.cc
@@ -396,9 +396,9 @@ KellyErrorEstimator<1, spacedim>::estimate(
   std::vector<std::vector<std::vector<Tensor<1, spacedim, number>>>>
     gradients_neighbor(gradients_here);
   std::vector<Vector<typename ProductType<number, double>::type>>
-  grad_dot_n_neighbor(n_solution_vectors,
-                      Vector<typename ProductType<number, double>::type>(
-                        n_components));
+    grad_dot_n_neighbor(n_solution_vectors,
+                        Vector<typename ProductType<number, double>::type>(
+                          n_components));
 
   // reserve some space for coefficient values at one point.  if there is no
   // coefficient, then we fill it by unity once and for all and don't set it

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -226,13 +226,13 @@ TimeDependent::start_sweep(const unsigned int s)
 void
 TimeDependent::end_sweep()
 {
-  parallel::apply_to_subranges(0U,
-                               timesteps.size(),
-                               [this](const unsigned int begin,
-                                      const unsigned int end) {
-                                 this->end_sweep(begin, end);
-                               },
-                               1);
+  parallel::apply_to_subranges(
+    0U,
+    timesteps.size(),
+    [this](const unsigned int begin, const unsigned int end) {
+      this->end_sweep(begin, end);
+    },
+    1);
 }
 
 

--- a/source/opencascade/utilities.cc
+++ b/source/opencascade/utilities.cc
@@ -90,14 +90,11 @@ namespace OpenCASCADE
     TopExp_Explorer exp;
     unsigned int    n_faces = 0, n_edges = 0, n_vertices = 0;
     for (exp.Init(shape, TopAbs_FACE); exp.More(); exp.Next(), ++n_faces)
-      {
-      }
+      {}
     for (exp.Init(shape, TopAbs_EDGE); exp.More(); exp.Next(), ++n_edges)
-      {
-      }
+      {}
     for (exp.Init(shape, TopAbs_VERTEX); exp.More(); exp.Next(), ++n_vertices)
-      {
-      }
+      {}
     return std::tuple<unsigned int, unsigned int, unsigned int>(n_faces,
                                                                 n_edges,
                                                                 n_vertices);

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -159,8 +159,8 @@ namespace Particles
 
   template <int dim, int spacedim>
   Particle<dim, spacedim> &
-  Particle<dim, spacedim>::
-  operator=(Particle<dim, spacedim> &&particle) noexcept
+  Particle<dim, spacedim>::operator=(
+    Particle<dim, spacedim> &&particle) noexcept
   {
     if (this != &particle)
       {

--- a/tests/aniso/mesh_3d_21.cc
+++ b/tests/aniso/mesh_3d_21.cc
@@ -56,7 +56,8 @@ FESubfaceValues<3> fe_face_values2(mapping,
                                    update_quadrature_points |
                                      update_JxW_values | update_normal_vectors);
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   DoFHandler<3> dof_handler(tria);
   dof_handler.distribute_dofs(fe);
@@ -99,7 +100,8 @@ void check_this(Triangulation<3> &tria)
 // perform the usual check, i.e. first refine a single cell (anisotropically),
 // then global refinement, then global coarsening. For each step, check, that
 // quadrature points both on faces and neighboring subfaces match.
-void check(Triangulation<3> &tria_org)
+void
+check(Triangulation<3> &tria_org)
 {
   for (unsigned int c = 0; c < tria_org.n_active_cells(); ++c)
     for (unsigned int i = 1; i < 8; ++i)
@@ -140,7 +142,8 @@ void check(Triangulation<3> &tria_org)
 // perform an additional check: simulate an isotropic refinement of a given cell
 // via several anisotropic refinements. Then, perform the usual checks. This
 // went wrong at some time, so check that it works now.
-void check2(Triangulation<3> &orig_tria)
+void
+check2(Triangulation<3> &orig_tria)
 {
   for (unsigned int i = 0; i < orig_tria.n_active_cells(); ++i)
     {

--- a/tests/arpack/step-36_parpack_mf.cc
+++ b/tests/arpack/step-36_parpack_mf.cc
@@ -147,10 +147,11 @@ test()
 
     const unsigned int num_arnoldi_vectors = 2 * eigenvalues.size() + 2;
     PArpackSolver<LinearAlgebra::distributed::Vector<double>>::AdditionalData
-    additional_data(num_arnoldi_vectors,
-                    PArpackSolver<LinearAlgebra::distributed::Vector<double>>::
-                      largest_magnitude,
-                    true);
+      additional_data(
+        num_arnoldi_vectors,
+        PArpackSolver<
+          LinearAlgebra::distributed::Vector<double>>::largest_magnitude,
+        true);
 
     SolverControl solver_control(dof_handler.n_dofs(),
                                  1e-9,

--- a/tests/arpack/step-36_parpack_mf_02.cc
+++ b/tests/arpack/step-36_parpack_mf_02.cc
@@ -145,11 +145,12 @@ test()
 
     const unsigned int num_arnoldi_vectors = 2 * eigenvalues.size() + 40;
     PArpackSolver<LinearAlgebra::distributed::Vector<double>>::AdditionalData
-    additional_data(num_arnoldi_vectors,
-                    PArpackSolver<LinearAlgebra::distributed::Vector<double>>::
-                      largest_magnitude,
-                    true,
-                    2);
+      additional_data(
+        num_arnoldi_vectors,
+        PArpackSolver<
+          LinearAlgebra::distributed::Vector<double>>::largest_magnitude,
+        true,
+        2);
 
     SolverControl solver_control(dof_handler.n_dofs(),
                                  1e-10,

--- a/tests/arpack/step-36_parpack_mf_03.cc
+++ b/tests/arpack/step-36_parpack_mf_03.cc
@@ -146,11 +146,12 @@ test()
 
     const unsigned int num_arnoldi_vectors = 2 * eigenvalues.size() + 10;
     PArpackSolver<LinearAlgebra::distributed::Vector<double>>::AdditionalData
-    additional_data(num_arnoldi_vectors,
-                    PArpackSolver<LinearAlgebra::distributed::Vector<double>>::
-                      largest_magnitude,
-                    true,
-                    1);
+      additional_data(
+        num_arnoldi_vectors,
+        PArpackSolver<
+          LinearAlgebra::distributed::Vector<double>>::largest_magnitude,
+        true,
+        1);
 
     SolverControl solver_control(dof_handler.n_dofs(),
                                  1e-9,

--- a/tests/base/cell_data_storage_03.cc
+++ b/tests/base/cell_data_storage_03.cc
@@ -42,10 +42,10 @@ struct Mat1 : MaterialBase
 constexpr unsigned int n_data_points_per_cell = 4;
 
 
-void setup_history(
-  Triangulation<2> &tria,
-  CellDataStorage<typename Triangulation<2>::active_cell_iterator, MaterialBase>
-    &storage)
+void
+setup_history(Triangulation<2> &             tria,
+              CellDataStorage<typename Triangulation<2>::active_cell_iterator,
+                              MaterialBase> &storage)
 {
   deallog << "initializing history" << std::endl;
   for (auto cell : tria.active_cell_iterators())
@@ -58,10 +58,10 @@ void setup_history(
     }
 }
 
-void read_history(
-  Triangulation<2> &tria,
-  CellDataStorage<typename Triangulation<2>::active_cell_iterator, MaterialBase>
-    &storage)
+void
+read_history(Triangulation<2> &             tria,
+             CellDataStorage<typename Triangulation<2>::active_cell_iterator,
+                             MaterialBase> &storage)
 {
   deallog << "reading history" << std::endl;
   for (auto cell : tria.active_cell_iterators())

--- a/tests/base/functions_04.cc
+++ b/tests/base/functions_04.cc
@@ -86,7 +86,7 @@ check_function(const Functions::FlowFunction<dim> &f,
         }
 
   std::vector<Vector<double>>      values(points.size(),
-                                          Vector<double>(f.n_components));
+                                     Vector<double>(f.n_components));
   std::vector<std::vector<double>> values2(f.n_components,
                                            std::vector<double>(points.size()));
   f.vector_value_list(points, values);

--- a/tests/base/functions_09.cc
+++ b/tests/base/functions_09.cc
@@ -37,7 +37,8 @@ struct FillTensor
 template <int dim>
 struct FillTensor<1, dim>
 {
-  static void fill_tensor(Tensor<1, dim> &tensor, int base)
+  static void
+  fill_tensor(Tensor<1, dim> &tensor, int base)
   {
     for (int i = 0; i < dim; ++i)
       tensor[i] = 10 * base + i;

--- a/tests/base/functions_singularity.cc
+++ b/tests/base/functions_singularity.cc
@@ -126,7 +126,7 @@ check_function_derivative(const Functions::FlowFunction<dim> &f,
         }
 
   std::vector<Vector<double>>      values(points.size(),
-                                          Vector<double>(f.n_components));
+                                     Vector<double>(f.n_components));
   std::vector<std::vector<double>> values2(f.n_components,
                                            std::vector<double>(points.size()));
   f.vector_value_list(points, values);

--- a/tests/base/parallel_transform_02.cc
+++ b/tests/base/parallel_transform_02.cc
@@ -39,12 +39,13 @@ main()
     }
 
   // set z=x+2y, which happens to be zero
-  parallel::transform(x.begin(),
-                      x.end(),
-                      y.begin(),
-                      z.begin(),
-                      [](double i, double j) { return i + 2 * j; },
-                      10);
+  parallel::transform(
+    x.begin(),
+    x.end(),
+    y.begin(),
+    z.begin(),
+    [](double i, double j) { return i + 2 * j; },
+    10);
 
   Assert(z.l2_norm() == 0, ExcInternalError());
 

--- a/tests/base/parallel_transform_03.cc
+++ b/tests/base/parallel_transform_03.cc
@@ -41,13 +41,14 @@ main()
 
   // set a=x+y-z, which happens to be
   // zero
-  parallel::transform(x.begin(),
-                      x.end(),
-                      y.begin(),
-                      z.begin(),
-                      a.begin(),
-                      [](double i, double j, double k) { return i + j - k; },
-                      10);
+  parallel::transform(
+    x.begin(),
+    x.end(),
+    y.begin(),
+    z.begin(),
+    a.begin(),
+    [](double i, double j, double k) { return i + j - k; },
+    10);
 
   AssertThrow(a.l2_norm() == 0, ExcInternalError());
 

--- a/tests/base/qprojector.cc
+++ b/tests/base/qprojector.cc
@@ -23,7 +23,8 @@
 #include "../tests.h"
 
 template <int dim>
-void check_line(Quadrature<1> &quadrature)
+void
+check_line(Quadrature<1> &quadrature)
 {
   Point<dim> p1;
   Point<dim> p2;
@@ -51,7 +52,8 @@ void check_line(Quadrature<1> &quadrature)
 }
 
 template <int dim>
-void check_face(Quadrature<1> &q1)
+void
+check_face(Quadrature<1> &q1)
 {
   deallog << "Checking dim " << dim << " 1d-points " << q1.size() << std::endl;
 
@@ -79,7 +81,8 @@ void check_face(Quadrature<1> &q1)
 }
 
 template <int dim>
-void check_faces(Quadrature<1> &q1)
+void
+check_faces(Quadrature<1> &q1)
 {
   const unsigned int nq = q1.size();
 
@@ -142,7 +145,8 @@ void check_faces(Quadrature<1> &q1)
 }
 
 
-void check(Quadrature<1> &q)
+void
+check(Quadrature<1> &q)
 {
   deallog << std::endl;
   deallog.push("line");

--- a/tests/base/quadrature_move_01.cc
+++ b/tests/base/quadrature_move_01.cc
@@ -21,7 +21,7 @@
 
 template <class Quad, typename... Args>
 std::string
-check_q_move(Args &&... args)
+check_q_move(Args &&...args)
 {
   Quad               quad1(args...);
   const unsigned int size1 = quad1.size();
@@ -46,7 +46,7 @@ check_q_move(Args &&... args)
 
 template <template <int dim> class Quad, typename... Args>
 void
-check_quadrature_move(Args &&... args)
+check_quadrature_move(Args &&...args)
 {
   deallog << check_q_move<Quad<1>>(std::forward<Args>(args)...) << 1 << " "
           << check_q_move<Quad<2>>(std::forward<Args>(args)...) << 2 << " "

--- a/tests/base/quadrature_move_02.cc
+++ b/tests/base/quadrature_move_02.cc
@@ -21,7 +21,7 @@
 
 template <template <int dim> class Quad, int dim, typename... Args>
 std::string
-check_q_assign_move(Args &&... args)
+check_q_assign_move(Args &&...args)
 {
   Quad<dim>                     quad1(args...);
   const unsigned int            size1    = quad1.size();
@@ -52,7 +52,7 @@ check_q_assign_move(Args &&... args)
 
 template <template <int dim> class Quad, typename... Args>
 void
-check_quadrature_assign_move(Args &&... args)
+check_quadrature_assign_move(Args &&...args)
 {
   deallog << check_q_assign_move<Quad, 1>(std::forward<Args>(args)...) << 1
           << " " << check_q_assign_move<Quad, 2>(std::forward<Args>(args)...)

--- a/tests/base/timer_08.cc
+++ b/tests/base/timer_08.cc
@@ -57,7 +57,8 @@ test(TimerOutput::OutputType output_type)
 
   std::string s = ss.str();
   std::replace_if(s.begin(), s.end(), ::isdigit, ' ');
-  std::replace_if(s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
+  std::replace_if(
+    s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
   deallog << s << std::endl << std::endl;
 }
 

--- a/tests/base/timer_08_b.cc
+++ b/tests/base/timer_08_b.cc
@@ -55,7 +55,8 @@ test(TimerOutput::OutputType output_type)
 
   std::string s = ss.str();
   std::replace_if(s.begin(), s.end(), ::isdigit, ' ');
-  std::replace_if(s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
+  std::replace_if(
+    s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
   deallog << s << std::endl << std::endl;
 }
 

--- a/tests/base/timer_09.cc
+++ b/tests/base/timer_09.cc
@@ -60,7 +60,8 @@ test()
 
   std::string s = ss.str();
   std::replace_if(s.begin(), s.end(), ::isdigit, ' ');
-  std::replace_if(s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
+  std::replace_if(
+    s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
 
   deallog << s << std::endl << std::endl;
 }

--- a/tests/base/timer_10.cc
+++ b/tests/base/timer_10.cc
@@ -61,7 +61,8 @@ test()
 
   std::string s = ss.str();
   std::replace_if(s.begin(), s.end(), ::isdigit, ' ');
-  std::replace_if(s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
+  std::replace_if(
+    s.begin(), s.end(), [](char x) { return x == '.'; }, ' ');
 
   deallog << s << std::endl << std::endl;
 }

--- a/tests/bits/cylinder_02.cc
+++ b/tests/bits/cylinder_02.cc
@@ -47,10 +47,12 @@ rotate_to_y(const Point<dim> &p)
     return Point<dim>(-p[1], p[0], p[2]);
 }
 
-void set_manifold(Triangulation<2> &triangulation)
+void
+set_manifold(Triangulation<2> &triangulation)
 {}
 
-void set_manifold(Triangulation<3> &triangulation)
+void
+set_manifold(Triangulation<3> &triangulation)
 {
   static const CylindricalManifold<3> boundary(1);
   triangulation.set_manifold(0, boundary);

--- a/tests/bits/cylinder_03.cc
+++ b/tests/bits/cylinder_03.cc
@@ -44,7 +44,8 @@ rotate_to_z(const Point<dim> &p)
   return Point<dim>(-p[2], p[1], p[0]);
 }
 
-void set_manifold(Triangulation<3> &triangulation)
+void
+set_manifold(Triangulation<3> &triangulation)
 {
   static const CylindricalManifold<3> boundary(2);
   triangulation.set_manifold(0, boundary);

--- a/tests/bits/find_cell_1.cc
+++ b/tests/bits/find_cell_1.cc
@@ -29,7 +29,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   Point<2> p(1. / 3., 1. / 2. - 1e-10); // avoid ambiguity for hypercube mesh
 

--- a/tests/bits/find_cell_10a.cc
+++ b/tests/bits/find_cell_10a.cc
@@ -48,7 +48,8 @@
 
 
 
-void create_coarse_grid(Triangulation<2> &coarse_grid)
+void
+create_coarse_grid(Triangulation<2> &coarse_grid)
 {
   static const Point<2> vertices_1[] = {
     Point<2>(9.6982181981258408e-02, 1.1255621492491609e+03), // 0

--- a/tests/bits/find_cell_13.cc
+++ b/tests/bits/find_cell_13.cc
@@ -33,7 +33,8 @@
 #include "../tests.h"
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   // generate some random points bounded by [0., 0.2)^2 in R^2 space
   // any point in this domain should be inside one of the cells

--- a/tests/bits/find_cell_2.cc
+++ b/tests/bits/find_cell_2.cc
@@ -28,7 +28,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   Point<3> p(1. / 3., 1. / 2., 1. / 5.);
 

--- a/tests/bits/find_cell_3.cc
+++ b/tests/bits/find_cell_3.cc
@@ -30,7 +30,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   Point<3> p(1. / 3., 1. / 2., -1. / 5.);
 

--- a/tests/bits/find_cell_4.cc
+++ b/tests/bits/find_cell_4.cc
@@ -30,7 +30,8 @@
 
 #include "../tests.h"
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   Point<3> p(0.75, 0, 0);
 

--- a/tests/bits/find_cell_5.cc
+++ b/tests/bits/find_cell_5.cc
@@ -32,7 +32,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   Point<3> p(0.75, 0.75, 0.75);
 

--- a/tests/bits/find_cell_6.cc
+++ b/tests/bits/find_cell_6.cc
@@ -30,7 +30,8 @@
 
 #include "../tests.h"
 
-bool inside(Triangulation<3> &tria, Point<3> &p)
+bool
+inside(Triangulation<3> &tria, Point<3> &p)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(0);
        cell != tria.end(0);

--- a/tests/bits/find_cell_7.cc
+++ b/tests/bits/find_cell_7.cc
@@ -39,7 +39,8 @@
 
 #include "../tests.h"
 
-bool inside(Triangulation<3> &tria, Point<3> &p)
+bool
+inside(Triangulation<3> &tria, Point<3> &p)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(0);
        cell != tria.end(0);

--- a/tests/bits/find_cell_8.cc
+++ b/tests/bits/find_cell_8.cc
@@ -30,7 +30,8 @@
 #include "../tests.h"
 
 
-void create_coarse_grid(Triangulation<2> &coarse_grid)
+void
+create_coarse_grid(Triangulation<2> &coarse_grid)
 {
   static const Point<2> vertices_1[] = {
     Point<2>(0., 0.),       // 0
@@ -62,7 +63,8 @@ void create_coarse_grid(Triangulation<2> &coarse_grid)
 }
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   Point<2> p(0.99, 1. / 2.);
 

--- a/tests/bits/find_cell_9.cc
+++ b/tests/bits/find_cell_9.cc
@@ -30,7 +30,8 @@
 #include "../tests.h"
 
 
-void create_coarse_grid(Triangulation<2> &coarse_grid)
+void
+create_coarse_grid(Triangulation<2> &coarse_grid)
 {
   static const Point<2> vertices_1[] = {
     Point<2>(0., 0.), // 0
@@ -65,7 +66,8 @@ void create_coarse_grid(Triangulation<2> &coarse_grid)
 }
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   Point<2> p(0.99, 1. / 2.);
 

--- a/tests/bits/find_cell_alt_1.cc
+++ b/tests/bits/find_cell_alt_1.cc
@@ -32,7 +32,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   MappingQ<2> map(3); // Let's take a higher order mapping
 

--- a/tests/bits/find_cell_alt_2.cc
+++ b/tests/bits/find_cell_alt_2.cc
@@ -30,7 +30,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   MappingQ<3> map(3);
 

--- a/tests/bits/find_cell_alt_3.cc
+++ b/tests/bits/find_cell_alt_3.cc
@@ -32,7 +32,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   MappingQ<3> map(3);
 

--- a/tests/bits/find_cell_alt_4.cc
+++ b/tests/bits/find_cell_alt_4.cc
@@ -30,7 +30,8 @@
 #include "../tests.h"
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   MappingQ<3> map(1);
 

--- a/tests/bits/find_cell_alt_5.cc
+++ b/tests/bits/find_cell_alt_5.cc
@@ -30,7 +30,8 @@
 #include "../tests.h"
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   MappingQ<3> map(1);
   Point<3>    p(0.75, 0.75, 0.75);

--- a/tests/bits/find_cell_alt_6.cc
+++ b/tests/bits/find_cell_alt_6.cc
@@ -41,7 +41,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   const std::vector<Point<2>> &v = tria.get_vertices();
   MappingQ<2>                  map(1);

--- a/tests/bits/find_cell_alt_7.cc
+++ b/tests/bits/find_cell_alt_7.cc
@@ -33,7 +33,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   MappingQ<2> map(5);
 

--- a/tests/bits/find_cells_adjacent_to_vertex_1.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_1.cc
@@ -39,7 +39,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_cells_adjacent_to_vertex_2.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_2.cc
@@ -28,7 +28,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_cells_adjacent_to_vertex_3.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_3.cc
@@ -30,7 +30,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_cells_adjacent_to_vertex_4.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_4.cc
@@ -30,7 +30,8 @@
 
 
 
-void check(Triangulation<2> &tria)
+void
+check(Triangulation<2> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_cells_adjacent_to_vertex_5.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_5.cc
@@ -29,7 +29,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_cells_adjacent_to_vertex_6.cc
+++ b/tests/bits/find_cells_adjacent_to_vertex_6.cc
@@ -34,7 +34,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   for (unsigned i = 0; i < tria.n_vertices(); i++)
     {

--- a/tests/bits/find_closest_vertex_1.cc
+++ b/tests/bits/find_closest_vertex_1.cc
@@ -30,7 +30,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   const std::vector<Point<3>> &v = tria.get_vertices();
   for (unsigned i = 0; i < v.size(); i++)

--- a/tests/bits/neighboring_cells_at_two_faces.cc
+++ b/tests/bits/neighboring_cells_at_two_faces.cc
@@ -44,7 +44,8 @@
 // not a, as it should. Simply looking at the identity of the neighboring cell
 // is not enough, we have to look at the (index of the) face instead.
 
-void create_grid(Triangulation<2> &tria)
+void
+create_grid(Triangulation<2> &tria)
 {
   const unsigned int n_points = 5;
 

--- a/tests/bits/q_points.cc
+++ b/tests/bits/q_points.cc
@@ -38,7 +38,8 @@
 
 
 
-void create_two_cubes(Triangulation<3> &coarse_grid)
+void
+create_two_cubes(Triangulation<3> &coarse_grid)
 {
   const Point<3>        points[6] = {Point<3>(0, 0, 0),
                               Point<3>(1, 0, 0),
@@ -75,7 +76,8 @@ void create_two_cubes(Triangulation<3> &coarse_grid)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   QGauss<2>       quadrature(3);
   FE_Q<3>         fe(1);

--- a/tests/bits/refine_and_coarsen_for_active_cell_index.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index.cc
@@ -41,7 +41,8 @@ check(const Triangulation<dim> &tria)
     Assert(cell->active_cell_index() == index, ExcInternalError());
 }
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   const int dim = 1;
 
@@ -51,7 +52,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -65,7 +67,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_02.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_02.cc
@@ -45,7 +45,8 @@ check(const Triangulation<dim> &tria)
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -53,7 +54,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -67,7 +69,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_03.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_03.cc
@@ -44,7 +44,8 @@ check(const Triangulation<dim> &tria)
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -52,7 +53,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -66,7 +68,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_04.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_04.cc
@@ -47,7 +47,8 @@ check(const Triangulation<dim> &tria)
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -55,7 +56,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -69,7 +71,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_active_cell_index_05.cc
+++ b/tests/bits/refine_and_coarsen_for_active_cell_index_05.cc
@@ -52,7 +52,8 @@ check(const Triangulation<dim> &tria)
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -60,7 +61,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -74,7 +76,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_parents.cc
+++ b/tests/bits/refine_and_coarsen_for_parents.cc
@@ -30,7 +30,8 @@
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   const int dim = 1;
 
@@ -40,7 +41,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -54,7 +56,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_parents_02.cc
+++ b/tests/bits/refine_and_coarsen_for_parents_02.cc
@@ -32,7 +32,8 @@
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -40,7 +41,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -54,7 +56,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/refine_and_coarsen_for_parents_03.cc
+++ b/tests/bits/refine_and_coarsen_for_parents_03.cc
@@ -31,7 +31,8 @@
 
 
 
-void do_refine(Triangulation<1> &tria)
+void
+do_refine(Triangulation<1> &tria)
 {
   tria.refine_global(2);
   tria.begin_active()->set_refine_flag();
@@ -39,7 +40,8 @@ void do_refine(Triangulation<1> &tria)
 }
 
 
-void do_refine(Triangulation<2> &tria)
+void
+do_refine(Triangulation<2> &tria)
 {
   const int dim = 2;
 
@@ -53,7 +55,8 @@ void do_refine(Triangulation<2> &tria)
 }
 
 
-void do_refine(Triangulation<3> &tria)
+void
+do_refine(Triangulation<3> &tria)
 {
   const int dim = 3;
 

--- a/tests/bits/rt_2.cc
+++ b/tests/bits/rt_2.cc
@@ -52,7 +52,8 @@
 #include "../tests.h"
 
 
-void evaluate_normal(DoFHandler<2> &dof_handler, Vector<double> &solution)
+void
+evaluate_normal(DoFHandler<2> &dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines
   // the points, where the continuity

--- a/tests/bits/step-14.cc
+++ b/tests/bits/step-14.cc
@@ -177,9 +177,9 @@ namespace Evaluation
 
   template <int dim>
   void
-  PointXDerivativeEvaluation<dim>::
-  operator()(const DoFHandler<dim> &dof_handler,
-             const Vector<double> & solution) const
+  PointXDerivativeEvaluation<dim>::operator()(
+    const DoFHandler<dim> &dof_handler,
+    const Vector<double> & solution) const
   {
     double point_derivative = 0;
 
@@ -1031,7 +1031,8 @@ namespace Data
 
 
   template <>
-  void Exercise_2_3<2>::create_coarse_grid(Triangulation<2> &coarse_grid)
+  void
+  Exercise_2_3<2>::create_coarse_grid(Triangulation<2> &coarse_grid)
   {
     const unsigned int dim = 2;
 
@@ -1686,8 +1687,7 @@ namespace LaplaceSolver
     for (unsigned int t = 0;
          (t < this_thread) && (cell != dual_solver.dof_handler.end());
          ++t, ++cell)
-      {
-      }
+      {}
 
 
     if (cell == dual_solver.dof_handler.end())
@@ -1739,8 +1739,7 @@ namespace LaplaceSolver
         for (unsigned int t = 0;
              ((t < n_threads) && (cell != dual_solver.dof_handler.end()));
              ++t, ++cell, ++cell_index)
-          {
-          }
+          {}
 
         if (cell == dual_solver.dof_handler.end())
           break;

--- a/tests/bits/step-2.cc
+++ b/tests/bits/step-2.cc
@@ -39,7 +39,8 @@
 std::ofstream logfile("output");
 
 
-void make_grid(Triangulation<2> &triangulation)
+void
+make_grid(Triangulation<2> &triangulation)
 {
   const Point<2> center(1, 0);
   const double   inner_radius = 0.5, outer_radius = 1.0;
@@ -75,7 +76,8 @@ void make_grid(Triangulation<2> &triangulation)
 }
 
 
-void distribute_dofs(DoFHandler<2> &dof_handler)
+void
+distribute_dofs(DoFHandler<2> &dof_handler)
 {
   static const FE_Q<2> finite_element(1);
   dof_handler.distribute_dofs(finite_element);
@@ -92,7 +94,8 @@ void distribute_dofs(DoFHandler<2> &dof_handler)
 
 
 
-void renumber_dofs(DoFHandler<2> &dof_handler)
+void
+renumber_dofs(DoFHandler<2> &dof_handler)
 {
   DoFRenumbering::Cuthill_McKee(dof_handler);
   SparsityPattern sparsity_pattern(dof_handler.n_dofs(), dof_handler.n_dofs());

--- a/tests/codim_one/bem_integration.cc
+++ b/tests/codim_one/bem_integration.cc
@@ -186,7 +186,8 @@ LaplaceKernelIntegration<dim>::term_D(const Tensor<1, 3> &r,
 }
 
 
-double integration(Point<3> point)
+double
+integration(Point<3> point)
 {
   Triangulation<2, 3> square;
   GridGenerator::hyper_cube<2, 3>(square, 0, 2);

--- a/tests/codim_one/extract_boundary_mesh_09.cc
+++ b/tests/codim_one/extract_boundary_mesh_09.cc
@@ -24,9 +24,10 @@
 
 
 
-void cylinder(Triangulation<3> &tria,
-              const double      radius      = 1,
-              const double      half_length = 1)
+void
+cylinder(Triangulation<3> &tria,
+         const double      radius      = 1,
+         const double      half_length = 1)
 {
   // Copy the base from hyper_ball<3>
   // and transform it to yz

--- a/tests/codim_one/tensor_matrix_conversion.cc
+++ b/tests/codim_one/tensor_matrix_conversion.cc
@@ -48,7 +48,8 @@ display_matrix(FullMatrix<number> M)
 }
 
 template <int b>
-void fill_tensor_2(Tensor<2, b> &T)
+void
+fill_tensor_2(Tensor<2, b> &T)
 {
   for (unsigned int i = 0; i < b; i++)
     for (unsigned int j = 0; j < b; j++)
@@ -57,7 +58,8 @@ void fill_tensor_2(Tensor<2, b> &T)
 
 
 template <int b>
-void display_tensor_2(Tensor<2, b> &T)
+void
+display_tensor_2(Tensor<2, b> &T)
 {
   deallog << b << "x" << b << " tensor" << std::endl;
   for (unsigned int i = 0; i < b; i++)

--- a/tests/cuda/coefficient_eval.cu
+++ b/tests/cuda/coefficient_eval.cu
@@ -54,12 +54,12 @@ public:
 
 template <int dim, int fe_degree>
 __device__ void
-DummyOperator<dim, fe_degree>::
-operator()(const unsigned int                                          cell,
-           const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
-           CUDAWrappers::SharedData<dim, double> *,
-           const double *,
-           double *dst) const
+DummyOperator<dim, fe_degree>::operator()(
+  const unsigned int                                          cell,
+  const typename CUDAWrappers::MatrixFree<dim, double>::Data *gpu_data,
+  CUDAWrappers::SharedData<dim, double> *,
+  const double *,
+  double *dst) const
 {
   const unsigned int pos = CUDAWrappers::local_q_point_id<dim, double>(
     cell, gpu_data, n_dofs_1d, n_q_points);

--- a/tests/cuda/create_mesh.h
+++ b/tests/cuda/create_mesh.h
@@ -27,7 +27,8 @@
 #include <iostream>
 
 
-void create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
+void
+create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
 {
   const unsigned int      dim = 2;
   std::vector<Point<dim>> points(12);
@@ -78,7 +79,8 @@ void create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
 
 
 
-void create_mesh(Triangulation<3> &tria, const double scale_grid = 1.)
+void
+create_mesh(Triangulation<3> &tria, const double scale_grid = 1.)
 {
   const unsigned int      dim = 3;
   std::vector<Point<dim>> points(24);

--- a/tests/cuda/cuda_tensor_01.cu
+++ b/tests/cuda/cuda_tensor_01.cu
@@ -39,7 +39,8 @@ test_cpu()
   deallog << "norm_square: " << t.norm_square() << std::endl;
 }
 
-__global__ void init_kernel(Tensor<2, 3> *t, const unsigned int N)
+__global__ void
+init_kernel(Tensor<2, 3> *t, const unsigned int N)
 {
   const unsigned int i = threadIdx.y;
   const unsigned int j = threadIdx.x;
@@ -47,7 +48,8 @@ __global__ void init_kernel(Tensor<2, 3> *t, const unsigned int N)
     (*t)[i][j] = j + i * N + 1.;
 }
 
-__global__ void norm_kernel(Tensor<2, 3> *t, double *norm, double *norm_square)
+__global__ void
+norm_kernel(Tensor<2, 3> *t, double *norm, double *norm_square)
 {
   if (threadIdx.x == 0)
     {

--- a/tests/cuda/cuda_tensor_02.cu
+++ b/tests/cuda/cuda_tensor_02.cu
@@ -89,14 +89,16 @@ division_kernel(Tensor<rank, dim, Number> *t,
 }
 
 template <int dim, typename Number>
-__global__ void init_kernel(Tensor<0, dim, Number> *t)
+__global__ void
+init_kernel(Tensor<0, dim, Number> *t)
 {
   if (threadIdx.x == 0)
     *t = 1.;
 }
 
 template <int dim, typename Number>
-__global__ void init_kernel(Tensor<1, dim, Number> *t)
+__global__ void
+init_kernel(Tensor<1, dim, Number> *t)
 {
   const unsigned int i = threadIdx.x;
   if (i < dim)
@@ -104,7 +106,8 @@ __global__ void init_kernel(Tensor<1, dim, Number> *t)
 }
 
 template <int dim, typename Number>
-__global__ void init_kernel(Tensor<2, dim, Number> *t)
+__global__ void
+init_kernel(Tensor<2, dim, Number> *t)
 {
   const unsigned int i = threadIdx.y;
   const unsigned int j = threadIdx.x;

--- a/tests/cuda/matrix_free_matrix_vector_10.cu
+++ b/tests/cuda/matrix_free_matrix_vector_10.cu
@@ -121,7 +121,7 @@ test()
                  fe_degree,
                  Number,
                  LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA>>
-                                                                mf(mf_data, coef_size);
+    mf(mf_data, coef_size);
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> in_dev;
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> out_dev;
   mf_data.initialize_dof_vector(in_dev);

--- a/tests/cuda/matrix_free_matrix_vector_19.cu
+++ b/tests/cuda/matrix_free_matrix_vector_19.cu
@@ -117,7 +117,7 @@ test()
                  fe_degree,
                  Number,
                  LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA>>
-                                                                mf(mf_data, coef_size);
+    mf(mf_data, coef_size);
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> in_dev(
     owned_set, MPI_COMM_WORLD);
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> out_dev(

--- a/tests/cuda/matrix_free_matrix_vector_25.cu
+++ b/tests/cuda/matrix_free_matrix_vector_25.cu
@@ -124,7 +124,7 @@ test()
                  fe_degree,
                  Number,
                  LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA>>
-                                                                mf(mf_data, coef_size);
+    mf(mf_data, coef_size);
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> in_dev;
   LinearAlgebra::distributed::Vector<Number, MemorySpace::CUDA> out_dev;
   mf_data.initialize_dof_vector(in_dev);

--- a/tests/cuda/matrix_vector_mf.h
+++ b/tests/cuda/matrix_vector_mf.h
@@ -35,7 +35,8 @@ public:
     : coef(coef)
   {}
 
-  __device__ void operator()(
+  __device__ void
+  operator()(
     CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number>
       *fe_eval) const;
 
@@ -46,9 +47,10 @@ private:
 
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
-__device__ void HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d>::
-                operator()(CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number>
-             *fe_eval) const
+__device__ void
+HelmholtzOperatorQuad<dim, fe_degree, Number, n_q_points_1d>::operator()(
+  CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, 1, Number> *fe_eval)
+  const
 {
   fe_eval->submit_value(coef * fe_eval->get_value());
   fe_eval->submit_gradient(fe_eval->get_gradient());
@@ -85,12 +87,12 @@ public:
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 __device__ void
-HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d>::
-operator()(const unsigned int                                          cell,
-           const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data,
-           CUDAWrappers::SharedData<dim, Number> *shared_data,
-           const Number *                         src,
-           Number *                               dst) const
+HelmholtzOperator<dim, fe_degree, Number, n_q_points_1d>::operator()(
+  const unsigned int                                          cell,
+  const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data,
+  CUDAWrappers::SharedData<dim, Number> *                     shared_data,
+  const Number *                                              src,
+  Number *                                                    dst) const
 {
   const unsigned int pos = CUDAWrappers::local_q_point_id<dim, Number>(
     cell, gpu_data, n_dofs_1d, n_q_points);
@@ -134,9 +136,9 @@ private:
 
 template <int dim, int fe_degree, typename Number, int n_q_points_1d>
 __device__ void
-VaryingCoefficientFunctor<dim, fe_degree, Number, n_q_points_1d>::
-operator()(const unsigned int                                          cell,
-           const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data)
+VaryingCoefficientFunctor<dim, fe_degree, Number, n_q_points_1d>::operator()(
+  const unsigned int                                          cell,
+  const typename CUDAWrappers::MatrixFree<dim, Number>::Data *gpu_data)
 {
   const unsigned int pos = CUDAWrappers::local_q_point_id<dim, Number>(
     cell, gpu_data, n_dofs_1d, n_q_points);

--- a/tests/cuda/solver_10.cu
+++ b/tests/cuda/solver_10.cu
@@ -102,7 +102,7 @@ test(Utilities::CUDA::Handle &cuda_handle)
   CUDAWrappers::SparseMatrix<double> A_diagonal_inverse_dev(cuda_handle,
                                                             A_diagonal_inverse);
   RelaxationOperator<CUDAWrappers::SparseMatrix<double>>
-                                              relaxation_operator_dev(A_dev, A_diagonal_inverse_dev);
+    relaxation_operator_dev(A_dev, A_diagonal_inverse_dev);
   LinearAlgebra::CUDAWrappers::Vector<double> sol_dev(size);
   LinearAlgebra::CUDAWrappers::Vector<double> rhs_dev(size);
   LinearAlgebra::ReadWriteVector<double>      rw_vector(size);

--- a/tests/dofs/dof_tools_21_b.cc
+++ b/tests/dofs/dof_tools_21_b.cc
@@ -56,7 +56,8 @@ std::ofstream logfile("output");
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation, int orientation)
+void
+generate_grid(Triangulation<2> &triangulation, int orientation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -111,7 +112,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
 }
 
 /* The 2D in 3D case */
-void generate_grid(Triangulation<2, 3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<2, 3> &triangulation, int orientation)
 {
   Point<3> vertices_1[] = {
     Point<3>(-1., -3., 0.),
@@ -166,7 +168,8 @@ void generate_grid(Triangulation<2, 3> &triangulation, int orientation)
 }
 
 /* The 3D case */
-void generate_grid(Triangulation<3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<3> &triangulation, int orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -58,7 +58,8 @@ std::ofstream logfile("output");
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation)
+void
+generate_grid(Triangulation<2> &triangulation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -108,7 +109,8 @@ void generate_grid(Triangulation<2> &triangulation)
 }
 
 /* The 2D in 3D case */
-void generate_grid(Triangulation<2, 3> &triangulation)
+void
+generate_grid(Triangulation<2, 3> &triangulation)
 {
   Point<3> vertices_1[] = {
     Point<3>(-1., -3., 0.),

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -92,7 +92,8 @@ std::ofstream logfile("output");
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation)
+void
+generate_grid(Triangulation<2> &triangulation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -142,7 +143,8 @@ void generate_grid(Triangulation<2> &triangulation)
 }
 
 /* The 2D in 3D case */
-void generate_grid(Triangulation<2, 3> &triangulation)
+void
+generate_grid(Triangulation<2, 3> &triangulation)
 {
   Point<3> vertices_1[] = {
     Point<3>(-1., -3., 0.),

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -56,7 +56,8 @@ std::ofstream logfile("output");
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation)
+void
+generate_grid(Triangulation<2> &triangulation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -107,7 +108,8 @@ void generate_grid(Triangulation<2> &triangulation)
 }
 
 /* The 2D in 3D case */
-void generate_grid(Triangulation<2, 3> &triangulation)
+void
+generate_grid(Triangulation<2, 3> &triangulation)
 {
   Point<3> vertices_1[] = {
     Point<3>(-1., -3., 0.),

--- a/tests/dofs/dof_tools_21_c.cc
+++ b/tests/dofs/dof_tools_21_c.cc
@@ -59,7 +59,8 @@ std::ofstream logfile("output");
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation, int orientation)
+void
+generate_grid(Triangulation<2> &triangulation, int orientation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -115,7 +116,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
 }
 
 /* The 2D in 3D case */
-void generate_grid(Triangulation<2, 3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<2, 3> &triangulation, int orientation)
 {
   Point<3> vertices_1[] = {
     Point<3>(-1., -3., 0.),
@@ -171,7 +173,8 @@ void generate_grid(Triangulation<2, 3> &triangulation, int orientation)
 }
 
 /* The 3D case */
-void generate_grid(Triangulation<3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<3> &triangulation, int orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/dofs/dof_tools_24.cc
+++ b/tests/dofs/dof_tools_24.cc
@@ -84,7 +84,8 @@ create_and_print_flux_sparsity_pattern(const DoFHandler<dim> &dof_handler)
  * Create the 3-cells-triangulation (described at the top) by first creating 2
  * cells one the same level and then refining the right one.
  */
-void create_3_elements_on_2_different_levels(Triangulation<1> &triangulation)
+void
+create_3_elements_on_2_different_levels(Triangulation<1> &triangulation)
 {
   const unsigned int n_elements = 3;
   GridGenerator::subdivided_hyper_cube(triangulation, n_elements - 1);

--- a/tests/dofs/dof_tools_25.cc
+++ b/tests/dofs/dof_tools_25.cc
@@ -116,7 +116,8 @@ test_with_both_dof_handlers(const Triangulation<dim> &triangulation)
 
 
 //  Create the 3-cell-triangulation described at the top.
-void create_3_cell_triangulation(Triangulation<1> &triangulation)
+void
+create_3_cell_triangulation(Triangulation<1> &triangulation)
 {
   const unsigned int n_elements = 3;
   const double       left       = -1;

--- a/tests/dofs/dof_tools_common.h
+++ b/tests/dofs/dof_tools_common.h
@@ -77,7 +77,8 @@ set_boundary_ids(Triangulation<dim> &tria)
 }
 
 
-void set_boundary_ids(Triangulation<1> &)
+void
+set_boundary_ids(Triangulation<1> &)
 {}
 
 

--- a/tests/dofs/dof_tools_periodic.h
+++ b/tests/dofs/dof_tools_periodic.h
@@ -60,7 +60,8 @@ output_bool_vector(std::vector<bool> &v)
 
 
 
-void set_boundary_ids(Triangulation<1> &)
+void
+set_boundary_ids(Triangulation<1> &)
 {}
 
 

--- a/tests/fail/abf_approximation_01.cc
+++ b/tests/fail/abf_approximation_01.cc
@@ -341,7 +341,8 @@ TestPoly<dim>::vector_value(const Point<dim> &p,
  * Check the value of the derivative field.
  */
 
-double TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
+double
+TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 {
   Vector<double> solution;
   solution.reinit(dof_handler->n_dofs());

--- a/tests/fail/hp-step-14.cc
+++ b/tests/fail/hp-step-14.cc
@@ -183,9 +183,9 @@ namespace Evaluation
 
   template <int dim>
   void
-  PointXDerivativeEvaluation<dim>::
-  operator()(const DoFHandler<dim> &dof_handler,
-             const Vector<double> & solution) const
+  PointXDerivativeEvaluation<dim>::operator()(
+    const DoFHandler<dim> &dof_handler,
+    const Vector<double> & solution) const
   {
     double point_derivative = 0;
 
@@ -1047,7 +1047,8 @@ namespace Data
 
 
   template <>
-  void Exercise_2_3<2>::create_coarse_grid(Triangulation<2> &coarse_grid)
+  void
+  Exercise_2_3<2>::create_coarse_grid(Triangulation<2> &coarse_grid)
   {
     const unsigned int dim = 2;
 

--- a/tests/fail/rt_distorted_01.cc
+++ b/tests/fail/rt_distorted_01.cc
@@ -267,9 +267,10 @@ TestDef3<dim>::vector_value(const Point<dim> &p,
  * Integrate the function value over the element.
  */
 
-double EvaluateArea(Mapping<2> &    mapping,
-                    DoFHandler<2> * dof_handler,
-                    Vector<double> &solution)
+double
+EvaluateArea(Mapping<2> &    mapping,
+             DoFHandler<2> * dof_handler,
+             Vector<double> &solution)
 {
   // Use a high order quadrature.
   QGauss<2>   quad(6);

--- a/tests/fail/rt_distorted_02.cc
+++ b/tests/fail/rt_distorted_02.cc
@@ -278,9 +278,10 @@ TestDef3<dim>::vector_value(const Point<dim> &p,
  * Check the value of the derivative field.
  */
 
-double EvaluateDiver(Mapping<2> &    mapping,
-                     DoFHandler<2> & dof_handler,
-                     Vector<double> &solution)
+double
+EvaluateDiver(Mapping<2> &    mapping,
+              DoFHandler<2> & dof_handler,
+              Vector<double> &solution)
 {
   // Use a high order quadrature.
   QGauss<2>   quad(6);

--- a/tests/fe/abf_01.cc
+++ b/tests/fe/abf_01.cc
@@ -61,7 +61,8 @@
  * Check the value of the derivative field.
  */
 
-void EvaluateDerivative(DoFHandler<2> *dof_handler, Vector<double> &solution)
+void
+EvaluateDerivative(DoFHandler<2> *dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines the points, where the
   // derivative will be evaluated.
@@ -545,7 +546,8 @@ project(const Mapping<dim> &             mapping,
 }
 
 
-int create_alternate_unitsquare(Triangulation<2> &tria)
+int
+create_alternate_unitsquare(Triangulation<2> &tria)
 {
   std::vector<Point<2>> points;
 

--- a/tests/fe/abf_02.cc
+++ b/tests/fe/abf_02.cc
@@ -60,7 +60,8 @@
  * Check the value of the derivative field.
  */
 
-void EvaluateDerivative(DoFHandler<3> &dof_handler, Vector<double> &solution)
+void
+EvaluateDerivative(DoFHandler<3> &dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines the points, where the
   // derivative will be evaluated.

--- a/tests/fe/bdm_2.cc
+++ b/tests/fe/bdm_2.cc
@@ -56,7 +56,8 @@ tilt_coordinates(const Point<2> p)
 }
 
 
-void transform_grid(Triangulation<2> &tria, const unsigned int transform)
+void
+transform_grid(Triangulation<2> &tria, const unsigned int transform)
 {
   switch (transform)
     {

--- a/tests/fe/br_approximation_01.cc
+++ b/tests/fe/br_approximation_01.cc
@@ -326,7 +326,8 @@ TestPoly<dim>::vector_value(const Point<dim> &p,
  * Check the value of the derivative field.
  */
 
-double TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
+double
+TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 {
   Vector<double> solution;
   solution.reinit(dof_handler->n_dofs());

--- a/tests/fe/deformed_projection.h
+++ b/tests/fe/deformed_projection.h
@@ -113,7 +113,8 @@ TestMap1<dim>::vector_value(const Point<dim> &p,
  * Check the value of the derivative field.
  */
 
-void EvaluateDerivative(DoFHandler<2> *dof_handler, Vector<double> &solution)
+void
+EvaluateDerivative(DoFHandler<2> *dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines the points, where the
   // derivative will be evaluated.
@@ -654,7 +655,8 @@ create_tria(unsigned int elm, Triangulation<2> &tria)
 }
 
 
-void plot_shapes(DoFHandler<2> &dof_handler)
+void
+plot_shapes(DoFHandler<2> &dof_handler)
 {
   Vector<double>         solution(dof_handler.n_dofs());
   std::set<unsigned int> face_dofs;

--- a/tests/fe/fe_data_test.cc
+++ b/tests/fe/fe_data_test.cc
@@ -89,7 +89,8 @@ test_2d_3d(std::vector<FiniteElement<dim> *> &fe_datas)
 
 
 
-void test_2d_3d(std::vector<FiniteElement<1> *> &fe_datas)
+void
+test_2d_3d(std::vector<FiniteElement<1> *> &fe_datas)
 {}
 
 

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -290,13 +290,15 @@ struct ParameterCollection
   void
   print();
 
-  void set_enrichment_point(Point<2> &p, const unsigned int i)
+  void
+  set_enrichment_point(Point<2> &p, const unsigned int i)
   {
     AssertDimension(dim, 2);
     p(0) = points_enrichments[2 * i];
     p(1) = points_enrichments[2 * i + 1];
   }
-  void set_enrichment_point(Point<3> &p, const unsigned int i)
+  void
+  set_enrichment_point(Point<3> &p, const unsigned int i)
   {
     AssertDimension(dim, 3);
     p(0) = points_enrichments[3 * i];

--- a/tests/fe/fe_face_orientation_nedelec.h
+++ b/tests/fe/fe_face_orientation_nedelec.h
@@ -33,7 +33,8 @@
 
 #include "../tests.h"
 
-void create_reference_triangulation(Triangulation<3> &tria)
+void
+create_reference_triangulation(Triangulation<3> &tria)
 {
   std::vector<unsigned int> repetitions(3, 1);
 
@@ -44,10 +45,11 @@ void create_reference_triangulation(Triangulation<3> &tria)
                                             Point<3>(1.0, 1.0, 1.0));
 }
 
-void create_triangulation(Triangulation<3> &tria,
-                          const bool        face_orientation,
-                          const bool        face_flip,
-                          const bool        face_rotation)
+void
+create_triangulation(Triangulation<3> &tria,
+                     const bool        face_orientation,
+                     const bool        face_flip,
+                     const bool        face_rotation)
 {
   std::vector<CellData<3>> cells(2);
 

--- a/tests/fe/fe_face_orientation_nedelec_0.cc
+++ b/tests/fe/fe_face_orientation_nedelec_0.cc
@@ -34,13 +34,15 @@
 
 #include "../tests.h"
 
-void create_reference_triangulation(Triangulation<3> &triangulation)
+void
+create_reference_triangulation(Triangulation<3> &triangulation)
 {
   GridGenerator::hyper_cube(triangulation, -1.0, 1.0);
   triangulation.refine_global(1);
 }
 
-void create_triangulation(Triangulation<3> &triangulation)
+void
+create_triangulation(Triangulation<3> &triangulation)
 {
   static const Point<3> vertices_parallelograms[] = {
     Point<3>(-1., -1., -1.), // 0

--- a/tests/fe/fe_nedelec_sz_face_orientation.cc
+++ b/tests/fe/fe_nedelec_sz_face_orientation.cc
@@ -34,7 +34,8 @@
 
 #include "../tests.h"
 
-void create_reference_triangulation(Triangulation<3> &tria)
+void
+create_reference_triangulation(Triangulation<3> &tria)
 {
   std::vector<unsigned int> repetitions(3, 1);
 
@@ -45,10 +46,11 @@ void create_reference_triangulation(Triangulation<3> &tria)
                                             Point<3>(1.0, 1.0, 1.0));
 }
 
-void create_triangulation(Triangulation<3> &tria,
-                          const bool        face_orientation,
-                          const bool        face_flip,
-                          const bool        face_rotation)
+void
+create_triangulation(Triangulation<3> &tria,
+                     const bool        face_orientation,
+                     const bool        face_flip,
+                     const bool        face_rotation)
 {
   std::vector<CellData<3>> cells(2);
 

--- a/tests/fe/fe_project_2d.cc
+++ b/tests/fe/fe_project_2d.cc
@@ -141,8 +141,9 @@ VectorFunction<dim>::vector_value(const Point<dim> &p,
     values(i) = value(p, i);
 }
 
-void create_tria(Triangulation<2> &triangulation,
-                 const Point<2> *  vertices_parallelograms)
+void
+create_tria(Triangulation<2> &triangulation,
+            const Point<2> *  vertices_parallelograms)
 {
   const std::vector<Point<2>> vertices(&vertices_parallelograms[0],
                                        &vertices_parallelograms[n_vertices]);

--- a/tests/fe/fe_project_3d.cc
+++ b/tests/fe/fe_project_3d.cc
@@ -190,8 +190,9 @@ VectorFunction<3>::gradient(const Point<3> &   p,
   return val;
 }
 
-void create_tria(Triangulation<3> &triangulation,
-                 const Point<3> *  vertices_parallelograms)
+void
+create_tria(Triangulation<3> &triangulation,
+            const Point<3> *  vertices_parallelograms)
 {
   const std::vector<Point<3>> vertices(&vertices_parallelograms[0],
                                        &vertices_parallelograms[n_vertices]);

--- a/tests/fe/fe_series_05.cc
+++ b/tests/fe/fe_series_05.cc
@@ -126,12 +126,14 @@ print(const Table<3, double> &coeff)
   deallog << std::endl;
 }
 
-void resize(Table<2, double> &coeff, const unsigned int N)
+void
+resize(Table<2, double> &coeff, const unsigned int N)
 {
   coeff.reinit(N, N);
 }
 
-void resize(Table<3, double> &coeff, const unsigned int N)
+void
+resize(Table<3, double> &coeff, const unsigned int N)
 {
   TableIndices<3> size;
   for (unsigned int d = 0; d < 3; d++)

--- a/tests/fe/fe_tools_test.cc
+++ b/tests/fe/fe_tools_test.cc
@@ -69,7 +69,8 @@ TestFunction::value(const Point<2> &p, const unsigned int component) const
 
 
 
-void make_grid(Triangulation<2> &triangulation)
+void
+make_grid(Triangulation<2> &triangulation)
 {
   GridGenerator::hyper_cube(triangulation);
 

--- a/tests/fe/nedelec.cc
+++ b/tests/fe/nedelec.cc
@@ -62,7 +62,8 @@ tilt_coordinates(const Point<2> p)
 }
 
 
-void transform_grid(Triangulation<2> &tria, const unsigned int transform)
+void
+transform_grid(Triangulation<2> &tria, const unsigned int transform)
 {
   switch (transform)
     {

--- a/tests/fe/rt_2.cc
+++ b/tests/fe/rt_2.cc
@@ -56,7 +56,8 @@ tilt_coordinates(const Point<2> p)
 }
 
 
-void transform_grid(Triangulation<2> &tria, const unsigned int transform)
+void
+transform_grid(Triangulation<2> &tria, const unsigned int transform)
 {
   switch (transform)
     {

--- a/tests/fe/rt_approximation_01.cc
+++ b/tests/fe/rt_approximation_01.cc
@@ -338,7 +338,8 @@ TestPoly<dim>::vector_value(const Point<dim> &p,
  * Check the value of the derivative field.
  */
 
-double TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
+double
+TestProjection(Mapping<2> &mapping, DoFHandler<2> *dof_handler)
 {
   Vector<double> solution;
   solution.reinit(dof_handler->n_dofs());

--- a/tests/fe/rt_bubbles_2.cc
+++ b/tests/fe/rt_bubbles_2.cc
@@ -56,7 +56,8 @@ tilt_coordinates(const Point<2> p)
 
 
 
-void transform_grid(Triangulation<2> &tria, const unsigned int transform)
+void
+transform_grid(Triangulation<2> &tria, const unsigned int transform)
 {
   switch (transform)
     {

--- a/tests/fe/rt_normal_02.cc
+++ b/tests/fe/rt_normal_02.cc
@@ -59,7 +59,8 @@ std::ofstream logfile("output");
  * Check if the normal component is continuous over element edges.
  */
 
-void EvaluateNormal2(DoFHandler<2> *dof_handler, Vector<double> &solution)
+void
+EvaluateNormal2(DoFHandler<2> *dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines the points, where the
   // continuity will be tested.
@@ -168,7 +169,8 @@ void EvaluateNormal2(DoFHandler<2> *dof_handler, Vector<double> &solution)
  * Check if the normal component is continuous over element edges.
  */
 
-void EvaluateNormal(DoFHandler<2> *dof_handler, Vector<double> &solution)
+void
+EvaluateNormal(DoFHandler<2> *dof_handler, Vector<double> &solution)
 {
   // This quadrature rule determines the points, where the
   // continuity will be tested.

--- a/tests/fe/shapes.h
+++ b/tests/fe/shapes.h
@@ -377,10 +377,11 @@ plot_face_shape_functions(Mapping<dim> &      mapping,
 
 
 template <>
-void plot_face_shape_functions(Mapping<1> &,
-                               FiniteElement<1> &,
-                               const char *,
-                               UpdateFlags)
+void
+plot_face_shape_functions(Mapping<1> &,
+                          FiniteElement<1> &,
+                          const char *,
+                          UpdateFlags)
 {}
 
 

--- a/tests/feinterface/fe_interface_values_01.cc
+++ b/tests/feinterface/fe_interface_values_01.cc
@@ -72,7 +72,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -83,7 +84,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_02.cc
+++ b/tests/feinterface/fe_interface_values_02.cc
@@ -36,7 +36,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -47,7 +48,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_03.cc
+++ b/tests/feinterface/fe_interface_values_03.cc
@@ -37,7 +37,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -48,7 +49,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_05.cc
+++ b/tests/feinterface/fe_interface_values_05.cc
@@ -72,7 +72,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -83,7 +84,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_06.cc
+++ b/tests/feinterface/fe_interface_values_06.cc
@@ -38,7 +38,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -49,7 +50,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_07.cc
+++ b/tests/feinterface/fe_interface_values_07.cc
@@ -38,7 +38,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -49,7 +50,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_08.cc
+++ b/tests/feinterface/fe_interface_values_08.cc
@@ -37,7 +37,8 @@ void
 make_2_cells(Triangulation<dim> &tria);
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -48,7 +49,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 }
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/fe_interface_values_09.cc
+++ b/tests/feinterface/fe_interface_values_09.cc
@@ -39,7 +39,8 @@ make_2_cells(Triangulation<dim> &tria);
 
 
 template <>
-void make_2_cells<2>(Triangulation<2> &tria)
+void
+make_2_cells<2>(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -52,7 +53,8 @@ void make_2_cells<2>(Triangulation<2> &tria)
 
 
 template <>
-void make_2_cells<3>(Triangulation<3> &tria)
+void
+make_2_cells<3>(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/feinterface/multigrid_01.cc
+++ b/tests/feinterface/multigrid_01.cc
@@ -66,7 +66,8 @@ inspect_fiv(FEInterfaceValues<dim> &fiv)
   deallog << std::endl;
 }
 
-void make_2_cells(Triangulation<2> &tria)
+void
+make_2_cells(Triangulation<2> &tria)
 {
   const unsigned int        dim         = 2;
   std::vector<unsigned int> repetitions = {2, 1};
@@ -76,7 +77,8 @@ void make_2_cells(Triangulation<2> &tria)
   GridGenerator::subdivided_hyper_rectangle(tria, repetitions, p1, p2);
 }
 
-void make_2_cells(Triangulation<3> &tria)
+void
+make_2_cells(Triangulation<3> &tria)
 {
   const unsigned int        dim         = 3;
   std::vector<unsigned int> repetitions = {2, 1, 1};

--- a/tests/grid/get_coarse_mesh_description_01.cc
+++ b/tests/grid/get_coarse_mesh_description_01.cc
@@ -24,7 +24,8 @@
 
 
 
-void setup_tria(Triangulation<1> &tria)
+void
+setup_tria(Triangulation<1> &tria)
 {
   GridGenerator::subdivided_hyper_rectangle(
     tria, std::vector<unsigned int>(5u, 1), Point<1>(), Point<1>(1.5), true);

--- a/tests/grid/grid_generator_10.cc
+++ b/tests/grid/grid_generator_10.cc
@@ -26,9 +26,10 @@
 
 
 
-void my_cylinder(Triangulation<3> &tria,
-                 const double      radius,
-                 const double      half_length)
+void
+my_cylinder(Triangulation<3> &tria,
+            const double      radius,
+            const double      half_length)
 {
   // Copy the base from hyper_ball<3>
   // and transform it to yz

--- a/tests/grid/grid_generator_marching_cube_algorithm_01.cc
+++ b/tests/grid/grid_generator_marching_cube_algorithm_01.cc
@@ -55,7 +55,8 @@ namespace dealii
   namespace GridGenerator
   {
     template <int dim, typename VectorType>
-    void create_triangulation_with_marching_cube_algorithm(
+    void
+    create_triangulation_with_marching_cube_algorithm(
       Triangulation<dim - 1, dim> &tria,
       const Mapping<dim> &         mapping,
       const DoFHandler<dim> &      background_dof_handler,

--- a/tests/grid/grid_out_gnuplot_01.cc
+++ b/tests/grid/grid_out_gnuplot_01.cc
@@ -29,18 +29,21 @@
 #include "../tests.h"
 
 // overloads to get multiple grids for multiple dim and spacedim combinations
-void make_grid(Triangulation<2, 2> &triangulation)
+void
+make_grid(Triangulation<2, 2> &triangulation)
 {
   GridGenerator::hyper_shell(triangulation, Point<2>(), 2.0, 6.0, 12);
 }
 
-void make_grid(Triangulation<2, 3> &triangulation)
+void
+make_grid(Triangulation<2, 3> &triangulation)
 {
   GridGenerator::hyper_sphere(triangulation, Point<3>(), 6.0);
   triangulation.refine_global(1); // need more cells
 }
 
-void make_grid(Triangulation<3, 3> &triangulation)
+void
+make_grid(Triangulation<3, 3> &triangulation)
 {
   GridGenerator::hyper_shell(triangulation, Point<3>(), 2.0, 6.0, 12);
   triangulation.refine_global(0);

--- a/tests/grid/grid_out_gnuplot_02.cc
+++ b/tests/grid/grid_out_gnuplot_02.cc
@@ -51,18 +51,21 @@ public:
 };
 
 // overloads to get multiple grids for multiple dim and spacedim combinations
-void make_grid(Triangulation<2, 2> &triangulation)
+void
+make_grid(Triangulation<2, 2> &triangulation)
 {
   GridGenerator::hyper_shell(triangulation, Point<2>(), 2.0, 6.0, 12);
 }
 
-void make_grid(Triangulation<2, 3> &triangulation)
+void
+make_grid(Triangulation<2, 3> &triangulation)
 {
   GridGenerator::hyper_sphere(triangulation, Point<3>(), 6.0);
   triangulation.refine_global(1); // need more cells
 }
 
-void make_grid(Triangulation<3, 3> &triangulation)
+void
+make_grid(Triangulation<3, 3> &triangulation)
 {
   GridGenerator::hyper_shell(triangulation, Point<3>(), 2.0, 6.0, 12);
   triangulation.refine_global(0);

--- a/tests/grid/grid_tools_05.cc
+++ b/tests/grid/grid_tools_05.cc
@@ -33,7 +33,8 @@
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation)
+void
+generate_grid(Triangulation<2> &triangulation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -86,7 +87,8 @@ void generate_grid(Triangulation<2> &triangulation)
 
 
 /* The 3D case */
-void generate_grid(Triangulation<3> &triangulation)
+void
+generate_grid(Triangulation<3> &triangulation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/grid/grid_tools_06.cc
+++ b/tests/grid/grid_tools_06.cc
@@ -35,7 +35,8 @@
  */
 
 /* The 2D case */
-void generate_grid(Triangulation<2> &triangulation, int orientation)
+void
+generate_grid(Triangulation<2> &triangulation, int orientation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -91,7 +92,8 @@ void generate_grid(Triangulation<2> &triangulation, int orientation)
 
 
 /* The 3D case */
-void generate_grid(Triangulation<3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<3> &triangulation, int orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/grid/grid_tools_active_cell_layer_within_distance_02.cc
+++ b/tests/grid/grid_tools_active_cell_layer_within_distance_02.cc
@@ -82,9 +82,9 @@ test()
     step_sizes.push_back(step_sizes_i);
 
   const Point<dim> bottom_left;
-  const Point<dim> upper_right =
-    dim == 1 ? Point<dim>(size) :
-               dim == 2 ? Point<dim>(size, size) : Point<dim>(size, size, size);
+  const Point<dim> upper_right = dim == 1 ? Point<dim>(size) :
+                                 dim == 2 ? Point<dim>(size, size) :
+                                            Point<dim>(size, size, size);
 
   Triangulation<dim> tria;
   GridGenerator::subdivided_hyper_rectangle(

--- a/tests/grid/grid_tools_transform_01.cc
+++ b/tests/grid/grid_tools_transform_01.cc
@@ -28,13 +28,15 @@ Point<dim>
 trans_func(Point<dim> &p);
 
 template <>
-Point<2> trans_func(Point<2> &p)
+Point<2>
+trans_func(Point<2> &p)
 {
   Point<2> r(p(0) + p(1) * p(1), p(1));
   return r;
 }
 template <>
-Point<3> trans_func(Point<3> &p)
+Point<3>
+trans_func(Point<3> &p)
 {
   Point<3> r(p(0) + p(1) * p(1), p(1), p(2));
   return r;

--- a/tests/grid/line_coarsening_3d.cc
+++ b/tests/grid/line_coarsening_3d.cc
@@ -28,8 +28,9 @@
 // to all cells, thus n_cells are neighboring at this line. in delete_children,
 // this is not accounted for (for n_cells>5) and the child lines are deleted,
 // although they are still needed.
-void create_star_structured_cylinder(Triangulation<3> & coarse_grid,
-                                     const unsigned int n_cells)
+void
+create_star_structured_cylinder(Triangulation<3> & coarse_grid,
+                                const unsigned int n_cells)
 {
   Assert(n_cells > 1, ExcNotImplemented());
 

--- a/tests/grid/measure_of_3d_face_01.cc
+++ b/tests/grid/measure_of_3d_face_01.cc
@@ -28,7 +28,8 @@
 
 // move backward two adjacent vertices of the top face up by one
 // unit. all faces remain flat this way
-Point<3> distort_planar(Point<3> p)
+Point<3>
+distort_planar(Point<3> p)
 {
   if (p(1) > 0.5 && p(2) > 0.5)
     {
@@ -40,7 +41,8 @@ Point<3> distort_planar(Point<3> p)
 
 // lift two opposite vertices of the top face up by one unit to create
 // a saddle surface
-Point<3> distort_twisted(Point<3> p)
+Point<3>
+distort_twisted(Point<3> p)
 {
   if (p(2) > 0.5 && ((p(0) > 0.5) ^ (p(1) > 0.5)))
     {

--- a/tests/grid/mesh_3d.h
+++ b/tests/grid/mesh_3d.h
@@ -26,7 +26,8 @@
 // match up for the standard orientation of the normals. we thus have
 // to store the face orientation in each cell
 
-void create_two_cubes(Triangulation<3> &coarse_grid)
+void
+create_two_cubes(Triangulation<3> &coarse_grid)
 {
   const Point<3>        points[6] = {Point<3>(0, 0, 0),
                               Point<3>(1, 0, 0),
@@ -68,8 +69,9 @@ void create_two_cubes(Triangulation<3> &coarse_grid)
 // the edges are not all ok and the common face is rotated. we thus have
 // to store the face rotation (and face flip) in each cell
 
-void create_two_cubes_rotation(Triangulation<3> & coarse_grid,
-                               const unsigned int n_rotations)
+void
+create_two_cubes_rotation(Triangulation<3> & coarse_grid,
+                          const unsigned int n_rotations)
 {
   Assert(n_rotations < 4, ExcNotImplemented());
 
@@ -112,7 +114,8 @@ void create_two_cubes_rotation(Triangulation<3> & coarse_grid,
 
 
 
-void create_L_shape(Triangulation<3> &coarse_grid)
+void
+create_L_shape(Triangulation<3> &coarse_grid)
 {
   std::vector<Point<3>>    vertices;
   std::vector<CellData<3>> cells;
@@ -163,7 +166,8 @@ void create_L_shape(Triangulation<3> &coarse_grid)
 }
 
 
-void coarsen_global(Triangulation<3> &grid)
+void
+coarsen_global(Triangulation<3> &grid)
 {
   for (Triangulation<3>::active_cell_iterator c = grid.begin_active();
        c != grid.end();

--- a/tests/grid/mesh_3d_10.cc
+++ b/tests/grid/mesh_3d_10.cc
@@ -40,7 +40,8 @@
 
 #include "mesh_3d.h"
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
@@ -59,7 +60,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_11.cc
+++ b/tests/grid/mesh_3d_11.cc
@@ -41,7 +41,8 @@
 
 #include "mesh_3d.h"
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
@@ -71,7 +72,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_12.cc
+++ b/tests/grid/mesh_3d_12.cc
@@ -45,7 +45,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   FE_Q<3>       fe(1);
   DoFHandler<3> dof_handler(tria);
@@ -69,7 +70,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   (++tria.begin_active())->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/grid/mesh_3d_13.cc
+++ b/tests/grid/mesh_3d_13.cc
@@ -38,7 +38,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   Triangulation<3>::active_cell_iterator cell = tria.begin_active();
   for (; cell != tria.end(); ++cell)
@@ -79,7 +80,8 @@ void check_this(Triangulation<3> &tria)
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   (++tria.begin_active())->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/grid/mesh_3d_14.cc
+++ b/tests/grid/mesh_3d_14.cc
@@ -41,7 +41,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   QTrapezoid<2>      quadrature;
   FE_Q<3>            fe(1);
@@ -99,7 +100,8 @@ void check_this(Triangulation<3> &tria)
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   (++tria.begin_active())->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/grid/mesh_3d_15.cc
+++ b/tests/grid/mesh_3d_15.cc
@@ -41,7 +41,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   FE_Q<3> fe(1);
 
@@ -92,7 +93,8 @@ void check_this(Triangulation<3> &tria)
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   (++tria.begin_active())->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/grid/mesh_3d_16.cc
+++ b/tests/grid/mesh_3d_16.cc
@@ -39,7 +39,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   FE_Q<3>       fe(1);
   DoFHandler<3> dof_handler(tria);

--- a/tests/grid/mesh_3d_17.cc
+++ b/tests/grid/mesh_3d_17.cc
@@ -34,7 +34,8 @@
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Coarse cell 0 vertices:" << std::endl;
   for (unsigned int i = 0; i < 8; ++i)

--- a/tests/grid/mesh_3d_20.cc
+++ b/tests/grid/mesh_3d_20.cc
@@ -40,7 +40,8 @@
 #include "../grid/mesh_3d.h"
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   QTrapezoid<2>   quadrature;
   FE_Q<3>         fe(1);
@@ -100,7 +101,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_21.cc
+++ b/tests/grid/mesh_3d_21.cc
@@ -38,7 +38,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   FE_Q<3>       fe(1);
   DoFHandler<3> dof_handler(tria);
@@ -100,7 +101,8 @@ void check_this(Triangulation<3> &tria)
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   (++tria.begin_active())->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/grid/mesh_3d_4.cc
+++ b/tests/grid/mesh_3d_4.cc
@@ -48,7 +48,8 @@ count_wrong_faces(const Triangulation<3> &tria)
 
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   const unsigned int initial_count = count_wrong_faces(tria);
   for (unsigned int r = 0; r < 3; ++r)

--- a/tests/grid/mesh_3d_5.cc
+++ b/tests/grid/mesh_3d_5.cc
@@ -30,7 +30,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   // look at all faces, not only
   // active ones
@@ -53,7 +54,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_6.cc
+++ b/tests/grid/mesh_3d_6.cc
@@ -38,7 +38,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   QMidpoint<2>    q;
   FE_Q<3>         fe(1);
@@ -88,7 +89,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_7.cc
+++ b/tests/grid/mesh_3d_7.cc
@@ -37,7 +37,8 @@
 
 
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   QTrapezoid<2>   quadrature;
   FE_Q<3>         fe(1);
@@ -98,7 +99,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_8.cc
+++ b/tests/grid/mesh_3d_8.cc
@@ -39,7 +39,8 @@
 
 #include "mesh_3d.h"
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
@@ -56,7 +57,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/grid/mesh_3d_9.cc
+++ b/tests/grid/mesh_3d_9.cc
@@ -40,7 +40,8 @@
 
 #include "mesh_3d.h"
 
-void check_this(Triangulation<3> &tria)
+void
+check_this(Triangulation<3> &tria)
 {
   for (Triangulation<3>::cell_iterator cell = tria.begin(); cell != tria.end();
        ++cell)
@@ -57,7 +58,8 @@ void check_this(Triangulation<3> &tria)
 }
 
 
-void check(Triangulation<3> &tria)
+void
+check(Triangulation<3> &tria)
 {
   deallog << "Initial check" << std::endl;
   check_this(tria);

--- a/tests/hp/fe_nothing_18.cc
+++ b/tests/hp/fe_nothing_18.cc
@@ -97,7 +97,7 @@ private:
   std::vector<types::global_dof_index> dofs_per_block;
 
   Triangulation<dim>
-                  triangulation; // a triangulation object of the "dim"-dimensional domain;
+    triangulation; // a triangulation object of the "dim"-dimensional domain;
   DoFHandler<dim> dof_handler; // is associated with triangulation;
 
   FESystem<dim>         elasticity_fe;

--- a/tests/hp/step-2.cc
+++ b/tests/hp/step-2.cc
@@ -36,7 +36,8 @@
 
 
 
-void make_grid(Triangulation<2> &triangulation)
+void
+make_grid(Triangulation<2> &triangulation)
 {
   const Point<2> center(1, 0);
   const double   inner_radius = 0.5, outer_radius = 1.0;
@@ -71,7 +72,8 @@ void make_grid(Triangulation<2> &triangulation)
 }
 
 
-void distribute_dofs(DoFHandler<2> &dof_handler)
+void
+distribute_dofs(DoFHandler<2> &dof_handler)
 {
   static const hp::FECollection<2> finite_element(FE_Q<2>(1));
   dof_handler.distribute_dofs(finite_element);
@@ -88,7 +90,8 @@ void distribute_dofs(DoFHandler<2> &dof_handler)
 
 
 
-void renumber_dofs(DoFHandler<2> &dof_handler)
+void
+renumber_dofs(DoFHandler<2> &dof_handler)
 {
   DoFRenumbering::Cuthill_McKee(dof_handler);
   SparsityPattern sparsity_pattern(dof_handler.n_dofs(), dof_handler.n_dofs());

--- a/tests/lac/constraints.cc
+++ b/tests/lac/constraints.cc
@@ -41,7 +41,8 @@
 std::ofstream logfile("output");
 
 
-void make_tria(Triangulation<3> &tria, int step)
+void
+make_tria(Triangulation<3> &tria, int step)
 {
   switch (step)
     {

--- a/tests/lac/gmres_reorthogonalize_04.cc
+++ b/tests/lac/gmres_reorthogonalize_04.cc
@@ -32,7 +32,8 @@ namespace dealii
 {
   template <typename Number>
   template <typename Number2>
-  Number Vector<Number>::operator*(const Vector<Number2> &v) const
+  Number
+  Vector<Number>::operator*(const Vector<Number2> &v) const
   {
     Number sum = 0;
     for (unsigned int i = 0; i < size(); ++i)

--- a/tests/lac/gmres_reorthogonalize_05.cc
+++ b/tests/lac/gmres_reorthogonalize_05.cc
@@ -32,7 +32,8 @@ namespace dealii
 {
   template <typename Number>
   template <typename Number2>
-  Number Vector<Number>::operator*(const Vector<Number2> &v) const
+  Number
+  Vector<Number>::operator*(const Vector<Number2> &v) const
   {
     Number sum = 0;
     for (unsigned int i = 0; i < size(); ++i)

--- a/tests/lac/utilities_02.cc
+++ b/tests/lac/utilities_02.cc
@@ -200,11 +200,12 @@ test()
 
     const unsigned int num_arnoldi_vectors = 2 * eigenvalues.size() + 10;
     PArpackSolver<LinearAlgebra::distributed::Vector<double>>::AdditionalData
-    additional_data(num_arnoldi_vectors,
-                    PArpackSolver<LinearAlgebra::distributed::Vector<double>>::
-                      largest_magnitude,
-                    true,
-                    1);
+      additional_data(
+        num_arnoldi_vectors,
+        PArpackSolver<
+          LinearAlgebra::distributed::Vector<double>>::largest_magnitude,
+        true,
+        1);
 
     SolverControl solver_control(dof_handler.n_dofs(),
                                  1e-10,

--- a/tests/manifold/elliptical_manifold_01.cc
+++ b/tests/manifold/elliptical_manifold_01.cc
@@ -84,11 +84,12 @@ namespace
   //
   // Eccentricity must be in range ]0,1[
   //
-  void build_simple_hyper_shell(Triangulation<2, 2> &grid,
-                                const Point<2> &     center,
-                                const double         inner_radius,
-                                const double         outer_radius,
-                                const double         eccentricity)
+  void
+  build_simple_hyper_shell(Triangulation<2, 2> &grid,
+                           const Point<2> &     center,
+                           const double         inner_radius,
+                           const double         outer_radius,
+                           const double         eccentricity)
   {
     unsigned int          cell[][4] = {{5, 6, 0, 1},
                               {6, 7, 1, 2},

--- a/tests/manifold/transfinite_manifold_07.cc
+++ b/tests/manifold/transfinite_manifold_07.cc
@@ -42,10 +42,11 @@ struct Geom_parameters
   std::vector<double>   radius;
 };
 
-void concentric_disks(Triangulation<2> &         tria,
-                      const double               s,
-                      const std::vector<double> &x,
-                      Geom_parameters &          gp)
+void
+concentric_disks(Triangulation<2> &         tria,
+                 const double               s,
+                 const std::vector<double> &x,
+                 Geom_parameters &          gp)
 {
   double r = x[0], d = 0.5 * x[0],
          q = 1.0 / sqrt(2.0); // q: corner points factor
@@ -262,9 +263,10 @@ void concentric_disks(Triangulation<2> &         tria,
   // --------------------------------------------------------------------------------
 }
 
-void concentric_disks(Triangulation<2> &  tria,
-                      std::vector<double> x,
-                      Geom_parameters &   gp)
+void
+concentric_disks(Triangulation<2> &  tria,
+                 std::vector<double> x,
+                 Geom_parameters &   gp)
 {
   concentric_disks(tria, 0.0, x, gp);
 }

--- a/tests/mappings/mapping.cc
+++ b/tests/mappings/mapping.cc
@@ -177,19 +177,21 @@ plot_subfaces(Mapping<dim> &                           mapping,
 
 
 template <>
-inline void plot_faces(Mapping<1> &,
-                       FiniteElement<1> &,
-                       DoFHandler<1>::cell_iterator &,
-                       const std::string &)
+inline void
+plot_faces(Mapping<1> &,
+           FiniteElement<1> &,
+           DoFHandler<1>::cell_iterator &,
+           const std::string &)
 {}
 
 
 
 template <>
-inline void plot_subfaces(Mapping<1> &,
-                          FiniteElement<1> &,
-                          DoFHandler<1>::cell_iterator &,
-                          const std::string &)
+inline void
+plot_subfaces(Mapping<1> &,
+              FiniteElement<1> &,
+              DoFHandler<1>::cell_iterator &,
+              const std::string &)
 {}
 
 
@@ -228,9 +230,10 @@ unsigned int                           mapping_size;
 
 
 template <>
-void create_triangulations(std::vector<Triangulation<1> *> &tria_ptr,
-                           std::vector<Manifold<1> *> &,
-                           std::vector<double> &exact_areas)
+void
+create_triangulations(std::vector<Triangulation<1> *> &tria_ptr,
+                      std::vector<Manifold<1> *> &,
+                      std::vector<double> &exact_areas)
 {
   show.resize(1, std::vector<unsigned int>(mapping_size, 0));
   Triangulation<1> *tria = new Triangulation<1>();
@@ -245,9 +248,10 @@ void create_triangulations(std::vector<Triangulation<1> *> &tria_ptr,
 
 
 template <>
-void create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
-                           std::vector<Manifold<2> *> &     boundary_ptr,
-                           std::vector<double> &            exact_areas)
+void
+create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
+                      std::vector<Manifold<2> *> &     boundary_ptr,
+                      std::vector<double> &            exact_areas)
 {
   Triangulation<2> *tria;
   show.clear();
@@ -358,9 +362,10 @@ void create_triangulations(std::vector<Triangulation<2> *> &tria_ptr,
 
 
 template <>
-void create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
-                           std::vector<Manifold<3> *> &     boundary_ptr,
-                           std::vector<double> &            exact_areas)
+void
+create_triangulations(std::vector<Triangulation<3> *> &tria_ptr,
+                      std::vector<Manifold<3> *> &     boundary_ptr,
+                      std::vector<double> &            exact_areas)
 {
   Triangulation<3> *tria;
   show.clear();

--- a/tests/mappings/mapping_q_cache_05.cc
+++ b/tests/mappings/mapping_q_cache_05.cc
@@ -88,28 +88,29 @@ main()
   initlog();
   do_test<2>(3, Solution<2>(true), true);
   do_test<2>(3, Solution<2>(false), false);
-  do_test<2>(3,
-             [](const typename Triangulation<2>::cell_iterator &,
-                const Point<2> &p) -> Point<2> {
-               Point<2> result;
+  do_test<2>(
+    3,
+    [](const typename Triangulation<2>::cell_iterator &,
+       const Point<2> &p) -> Point<2> {
+      Point<2> result;
 
-               for (unsigned int compontent = 0; compontent < 2; ++compontent)
-                 result[compontent] =
-                   std::sin(p[compontent] * 0.5 * numbers::PI) - p[compontent];
+      for (unsigned int compontent = 0; compontent < 2; ++compontent)
+        result[compontent] =
+          std::sin(p[compontent] * 0.5 * numbers::PI) - p[compontent];
 
-               return result;
-             },
-             true);
-  do_test<2>(3,
-             [](const typename Triangulation<2>::cell_iterator &,
-                const Point<2> &p) -> Point<2> {
-               Point<2> result;
+      return result;
+    },
+    true);
+  do_test<2>(
+    3,
+    [](const typename Triangulation<2>::cell_iterator &,
+       const Point<2> &p) -> Point<2> {
+      Point<2> result;
 
-               for (unsigned int compontent = 0; compontent < 2; ++compontent)
-                 result[compontent] =
-                   std::sin(p[compontent] * 0.5 * numbers::PI);
+      for (unsigned int compontent = 0; compontent < 2; ++compontent)
+        result[compontent] = std::sin(p[compontent] * 0.5 * numbers::PI);
 
-               return result;
-             },
-             false);
+      return result;
+    },
+    false);
 }

--- a/tests/mappings/mapping_q_mixed_manifolds_02.cc
+++ b/tests/mappings/mapping_q_mixed_manifolds_02.cc
@@ -56,7 +56,8 @@ const double Y_C = 0.2; // center
 const unsigned int MANIFOLD_ID = 1;
 
 
-void create_triangulation(Triangulation<2> &tria)
+void
+create_triangulation(Triangulation<2> &tria)
 {
   AssertThrow(std::abs((X_2 - X_1) - 2.0 * (X_C - X_1)) < 1.0e-12,
               ExcMessage("Geometry parameters X_1,X_2,X_C invalid!"));
@@ -165,7 +166,8 @@ void create_triangulation(Triangulation<2> &tria)
     }
 }
 
-void create_triangulation(Triangulation<3> &tria)
+void
+create_triangulation(Triangulation<3> &tria)
 {
   Triangulation<2> tria_2d;
   create_triangulation(tria_2d);

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -282,7 +282,7 @@ private:
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
 
             std::array<types::boundary_id, VectorizedArray<number>::size()>
-                                    boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
+              boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
             VectorizedArray<number> factor_boundary;
             for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               // interior face

--- a/tests/matrix_free/create_mesh.h
+++ b/tests/matrix_free/create_mesh.h
@@ -27,7 +27,8 @@
 #include <iostream>
 
 
-void create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
+void
+create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
 {
   const unsigned int      dim = 2;
   std::vector<Point<dim>> points(12);
@@ -78,7 +79,8 @@ void create_mesh(Triangulation<2> &tria, const double scale_grid = 1.)
 
 
 
-void create_mesh(Triangulation<3> &tria, const double scale_grid = 1.)
+void
+create_mesh(Triangulation<3> &tria, const double scale_grid = 1.)
 {
   const unsigned int      dim = 3;
   std::vector<Point<dim>> points(24);

--- a/tests/matrix_free/get_functions_variants.cc
+++ b/tests/matrix_free/get_functions_variants.cc
@@ -89,11 +89,11 @@ private:
 
 template <int dim, int fe_degree, typename Number>
 void
-MatrixFreeTest<dim, fe_degree, Number>::
-operator()(const MatrixFree<dim, Number> &data,
-           VectorType &,
-           const VectorType &                           src,
-           const std::pair<unsigned int, unsigned int> &cell_range) const
+MatrixFreeTest<dim, fe_degree, Number>::operator()(
+  const MatrixFree<dim, Number> &data,
+  VectorType &,
+  const VectorType &                           src,
+  const std::pair<unsigned int, unsigned int> &cell_range) const
 {
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(data);
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval2(data);

--- a/tests/matrix_free/get_functions_variants_gl.cc
+++ b/tests/matrix_free/get_functions_variants_gl.cc
@@ -85,11 +85,11 @@ private:
 
 template <int dim, int fe_degree, typename Number>
 void
-MatrixFreeTest<dim, fe_degree, Number>::
-operator()(const MatrixFree<dim, Number> &data,
-           VectorType &,
-           const VectorType &                           src,
-           const std::pair<unsigned int, unsigned int> &cell_range) const
+MatrixFreeTest<dim, fe_degree, Number>::operator()(
+  const MatrixFree<dim, Number> &data,
+  VectorType &,
+  const VectorType &                           src,
+  const std::pair<unsigned int, unsigned int> &cell_range) const
 {
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(data);
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval2(data);

--- a/tests/matrix_free/integrate_functions.cc
+++ b/tests/matrix_free/integrate_functions.cc
@@ -87,11 +87,11 @@ private:
 
 template <int dim, int fe_degree, typename Number>
 void
-MatrixFreeTest<dim, fe_degree, Number>::
-operator()(const MatrixFree<dim, Number> &data,
-           std::vector<Vector<Number> *> &dst,
-           const std::vector<Vector<Number> *> &,
-           const std::pair<unsigned int, unsigned int> &cell_range) const
+MatrixFreeTest<dim, fe_degree, Number>::operator()(
+  const MatrixFree<dim, Number> &data,
+  std::vector<Vector<Number> *> &dst,
+  const std::vector<Vector<Number> *> &,
+  const std::pair<unsigned int, unsigned int> &cell_range) const
 {
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval(data);
   const unsigned int                     n_q_points    = fe_eval.n_q_points;

--- a/tests/matrix_free/integrate_functions_multife.cc
+++ b/tests/matrix_free/integrate_functions_multife.cc
@@ -93,11 +93,11 @@ private:
 
 template <int dim, int fe_degree, typename Number>
 void
-MatrixFreeTest<dim, fe_degree, Number>::
-operator()(const MatrixFree<dim, Number> &data,
-           std::vector<Vector<Number>> &  dst,
-           const std::vector<Vector<Number>> &,
-           const std::pair<unsigned int, unsigned int> &cell_range) const
+MatrixFreeTest<dim, fe_degree, Number>::operator()(
+  const MatrixFree<dim, Number> &data,
+  std::vector<Vector<Number>> &  dst,
+  const std::vector<Vector<Number>> &,
+  const std::pair<unsigned int, unsigned int> &cell_range) const
 {
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval0(data, 0, 0);
   FEEvaluation<dim, fe_degree + 1, fe_degree + 2, 1, Number> fe_eval1(data,

--- a/tests/matrix_free/integrate_functions_multife2.cc
+++ b/tests/matrix_free/integrate_functions_multife2.cc
@@ -96,11 +96,11 @@ private:
 
 template <int dim, int fe_degree, typename Number>
 void
-MatrixFreeTest<dim, fe_degree, Number>::
-operator()(const MatrixFree<dim, Number> &data,
-           std::vector<Vector<Number>> &  dst,
-           const std::vector<Vector<Number>> &,
-           const std::pair<unsigned int, unsigned int> &cell_range) const
+MatrixFreeTest<dim, fe_degree, Number>::operator()(
+  const MatrixFree<dim, Number> &data,
+  std::vector<Vector<Number>> &  dst,
+  const std::vector<Vector<Number>> &,
+  const std::pair<unsigned int, unsigned int> &cell_range) const
 {
   FEEvaluation<dim, 0, 1, 1, Number>                     fe_eval0(data, 0, 0);
   FEEvaluation<dim, fe_degree, fe_degree + 1, 1, Number> fe_eval1(data, 1, 1);

--- a/tests/matrix_free/matrix_vector_faces_25.cc
+++ b/tests/matrix_free/matrix_vector_faces_25.cc
@@ -31,7 +31,8 @@
 
 
 
-void generate_grid(Triangulation<3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<3> &triangulation, int orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -332,7 +332,7 @@ private:
                         phif.inverse_jacobian(0))[dim - 1]) *
               (number)(std::max(1, fe_degree) * (fe_degree + 1.0)) * 2.;
             std::array<types::boundary_id, VectorizedArray<number>::size()>
-                                    boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
+              boundary_ids = data.get_faces_by_cells_boundary_id(cell, face);
             VectorizedArray<number> factor_boundary;
             for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               // interior face

--- a/tests/matrix_free/parallel_multigrid_adaptive_08.cc
+++ b/tests/matrix_free/parallel_multigrid_adaptive_08.cc
@@ -243,7 +243,7 @@ do_test(const DoFHandler<dim> &dof)
 
   MyLaplaceOperator<dim, fe_degree, double> fine_matrix;
   std::shared_ptr<MatrixFree<dim, double>>  fine_level_data(
-     new MatrixFree<dim, double>());
+    new MatrixFree<dim, double>());
 
   typename MatrixFree<dim, double>::AdditionalData fine_level_additional_data;
   fine_level_additional_data.tasks_parallel_scheme =

--- a/tests/matrix_free/pbc_orientation_01.cc
+++ b/tests/matrix_free/pbc_orientation_01.cc
@@ -54,7 +54,8 @@ public:
 
 
 
-void generate_grid(Triangulation<3> &triangulation, int orientation)
+void
+generate_grid(Triangulation<3> &triangulation, int orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-0., -0., -0.),
                            Point<3>(+1., -0., -0.),

--- a/tests/matrix_free/point_evaluation_09.cc
+++ b/tests/matrix_free/point_evaluation_09.cc
@@ -100,7 +100,7 @@ test(const unsigned int degree)
 
   std::vector<double>                      solution_values(fe.dofs_per_cell);
   std::vector<Vector<double>>              function_values(unit_points.size(),
-                                                           Vector<double>(dim + 1));
+                                              Vector<double>(dim + 1));
   std::vector<std::vector<Tensor<1, dim>>> function_gradients(
     unit_points.size(), std::vector<Tensor<1, dim>>(dim + 1));
 

--- a/tests/meshworker/mesh_loop_anistropic_01.cc
+++ b/tests/meshworker/mesh_loop_anistropic_01.cc
@@ -31,7 +31,8 @@
 
 
 // Create 2d grid
-void create_grid(Triangulation<2> &tria)
+void
+create_grid(Triangulation<2> &tria)
 {
   GridGenerator::hyper_cube(tria);
 
@@ -71,7 +72,8 @@ void create_grid(Triangulation<2> &tria)
 
 
 // Create 3d grid
-void create_grid(Triangulation<3> &tria)
+void
+create_grid(Triangulation<3> &tria)
 {
   GridGenerator::hyper_cube<3>(tria);
   tria.begin_active()->set_refine_flag(dealii::RefinementCase<3>::cut_x);

--- a/tests/mpi/cell_data_transfer_03.cc
+++ b/tests/mpi/cell_data_transfer_03.cc
@@ -89,13 +89,13 @@ test()
   // ----- transfer -----
   parallel::distributed::
     CellDataTransfer<dim, spacedim, std::vector<std::vector<int>>>
-    cell_data_transfer(
-      tria,
-      /*transfer_variable_size_data=*/true,
-      /*refinement_strategy=*/
-      &dealii::AdaptationStrategies::Refinement::
-        preserve<dim, spacedim, std::vector<int>>,
-      /*coarsening_strategy=*/&get_data_of_first_child<dim, spacedim>);
+      cell_data_transfer(
+        tria,
+        /*transfer_variable_size_data=*/true,
+        /*refinement_strategy=*/
+        &dealii::AdaptationStrategies::Refinement::
+          preserve<dim, spacedim, std::vector<int>>,
+        /*coarsening_strategy=*/&get_data_of_first_child<dim, spacedim>);
 
   cell_data_transfer.prepare_for_coarsening_and_refinement(cell_data);
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/error_prediction_01.cc
+++ b/tests/mpi/error_prediction_01.cc
@@ -120,10 +120,10 @@ test()
 
   // ----- execute adaptation -----
   parallel::distributed::CellDataTransfer<dim, dim, Vector<float>>
-  data_transfer(tria,
-                /*transfer_variable_size_data=*/false,
-                &AdaptationStrategies::Refinement::l2_norm<dim, dim, float>,
-                &AdaptationStrategies::Coarsening::l2_norm<dim, dim, float>);
+    data_transfer(tria,
+                  /*transfer_variable_size_data=*/false,
+                  &AdaptationStrategies::Refinement::l2_norm<dim, dim, float>,
+                  &AdaptationStrategies::Coarsening::l2_norm<dim, dim, float>);
 
   data_transfer.prepare_for_coarsening_and_refinement(predicted_errors);
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/error_prediction_02.cc
+++ b/tests/mpi/error_prediction_02.cc
@@ -146,10 +146,10 @@ test()
 
   // ----- execute adaptation -----
   parallel::distributed::CellDataTransfer<dim, dim, Vector<float>>
-  data_transfer(tria,
-                /*transfer_variable_size_data=*/false,
-                &AdaptationStrategies::Refinement::l2_norm<dim, dim, float>,
-                &AdaptationStrategies::Coarsening::l2_norm<dim, dim, float>);
+    data_transfer(tria,
+                  /*transfer_variable_size_data=*/false,
+                  &AdaptationStrategies::Refinement::l2_norm<dim, dim, float>,
+                  &AdaptationStrategies::Coarsening::l2_norm<dim, dim, float>);
 
   data_transfer.prepare_for_coarsening_and_refinement(predicted_errors);
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/mesh_worker_matrix_01.cc
+++ b/tests/mpi/mesh_worker_matrix_01.cc
@@ -274,7 +274,7 @@ test(const FiniteElement<dim> &fe)
             {
               std::ofstream                        f("ordering",
                               (myid > 0) ? std::ofstream::app :
-                                           std::ofstream::out);
+                                                                  std::ofstream::out);
               std::vector<types::global_dof_index> local_dof_indices(
                 fe.dofs_per_cell);
               for (typename DoFHandler<dim>::active_cell_iterator cell =

--- a/tests/mpi/parallel_partitioner_05.cc
+++ b/tests/mpi/parallel_partitioner_05.cc
@@ -65,8 +65,8 @@ test()
   local_relevant.add_indices(&ghost_indices[0], &ghost_indices[0] + 10);
   types::global_dof_index before_start = myid > 0 ? my_start - set / 4 : 0;
   types::global_dof_index after_end    = myid < numproc - 1 ?
-                                        my_start + local_size + set / 3 :
-                                        my_start + local_size;
+                                           my_start + local_size + set / 3 :
+                                           my_start + local_size;
   if (before_start < my_start)
     local_relevant.add_range(before_start, my_start);
   if (after_end > my_start + local_size)

--- a/tests/mpi/periodicity_04.cc
+++ b/tests/mpi/periodicity_04.cc
@@ -75,8 +75,9 @@ set_periodicity(parallel::distributed::Triangulation<dim> &triangulation,
 }
 
 /* The 2D case */
-void generate_grid(parallel::distributed::Triangulation<2> &triangulation,
-                   int                                      orientation)
+void
+generate_grid(parallel::distributed::Triangulation<2> &triangulation,
+              int                                      orientation)
 {
   Point<2> vertices_1[] = {
     Point<2>(-1., -3.),
@@ -115,8 +116,9 @@ void generate_grid(parallel::distributed::Triangulation<2> &triangulation,
 
 
 /* The 3D case */
-void generate_grid(parallel::distributed::Triangulation<3> &triangulation,
-                   int                                      orientation)
+void
+generate_grid(parallel::distributed::Triangulation<3> &triangulation,
+              int                                      orientation)
 {
   Point<3>              vertices_1[] = {Point<3>(-1., -1., -3.),
                            Point<3>(+1., -1., -3.),

--- a/tests/multigrid/step-16-50-mpi-linear-operator.cc
+++ b/tests/multigrid/step-16-50-mpi-linear-operator.cc
@@ -408,8 +408,7 @@ namespace Step50
                          local_dof_indices[j]) // ( boundary(i) && boundary(j)
                                                // && i==j )
                    ))
-                {
-                }
+                {}
               else
                 {
                   cell_matrix(i, j) = 0;

--- a/tests/multigrid/step-16-50-mpi-smoother.cc
+++ b/tests/multigrid/step-16-50-mpi-smoother.cc
@@ -407,8 +407,7 @@ namespace Step50
                          local_dof_indices[j]) // ( boundary(i) && boundary(j)
                                                // && i==j )
                    ))
-                {
-                }
+                {}
               else
                 {
                   cell_matrix(i, j) = 0;

--- a/tests/multigrid/step-16-50-mpi.cc
+++ b/tests/multigrid/step-16-50-mpi.cc
@@ -408,8 +408,7 @@ namespace Step50
                          local_dof_indices[j]) // ( boundary(i) && boundary(j)
                                                // && i==j )
                    ))
-                {
-                }
+                {}
               else
                 {
                   cell_matrix(i, j) = 0;

--- a/tests/multigrid/step-16-50-serial.cc
+++ b/tests/multigrid/step-16-50-serial.cc
@@ -346,8 +346,7 @@ LaplaceProblem<dim>::assemble_multigrid()
                   local_dof_indices[j]) // ( boundary(i) && boundary(j) &&
                                         // i==j )
                ))
-            {
-            }
+            {}
           else
             {
               cell_matrix(i, j) = 0;

--- a/tests/multigrid/step-50_02.cc
+++ b/tests/multigrid/step-50_02.cc
@@ -415,8 +415,7 @@ namespace Step50
                          local_dof_indices[j]) // ( boundary(i) && boundary(j)
                                                // && i==j )
                    ))
-                {
-                }
+                {}
               else
                 {
                   cell_matrix(i, j) = 0;

--- a/tests/multithreading/taskflow.h
+++ b/tests/multithreading/taskflow.h
@@ -126,19 +126,20 @@ namespace taskflow_v1
       const unsigned int chunk_size   = 8)
   {
     // forward to the other function
-    run(begin,
-        end,
-        [&main_object, worker](const Iterator &iterator,
-                               ScratchData &   scratch_data,
-                               CopyData &      copy_data) {
-          (main_object.*worker)(iterator, scratch_data, copy_data);
-        },
-        [&main_object, copier](const CopyData &copy_data) {
-          (main_object.*copier)(copy_data);
-        },
-        sample_scratch_data,
-        sample_copy_data,
-        queue_length,
-        chunk_size);
+    run(
+      begin,
+      end,
+      [&main_object, worker](const Iterator &iterator,
+                             ScratchData &   scratch_data,
+                             CopyData &      copy_data) {
+        (main_object.*worker)(iterator, scratch_data, copy_data);
+      },
+      [&main_object, copier](const CopyData &copy_data) {
+        (main_object.*copier)(copy_data);
+      },
+      sample_scratch_data,
+      sample_copy_data,
+      queue_length,
+      chunk_size);
   }
 } // namespace taskflow_v1

--- a/tests/multithreading/threads_02.cc
+++ b/tests/multithreading/threads_02.cc
@@ -370,19 +370,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_1(X<1> &)
+  X<0>
+  foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_1(X<1> &)
+  static X<0>
+  static_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_1(X<1> &)
+  X<0> &
+  ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -394,13 +397,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_1(X<1> &)
+  const X<0> &
+  const_ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_1(X<1> &)
+  const X<0> &
+  const_ref_foo_const_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -412,13 +417,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_1_const(X<1> &) const
+  const X<0> &
+  const_ref_foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_1_const(X<1> &) const
+  const X<0> &
+  const_ref_foo_const_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -430,13 +437,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_1(X<1> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_1(X<1> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -448,25 +457,29 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_1_const(X<1> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_1_const(X<1> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> &static_ref_foo_ref_1(X<1> &)
+  static X<0> &
+  static_ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_1(X<1> &)
+  static const X<0> &
+  static_const_ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -519,13 +532,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_1_const(X<1> &) const
+  X<0>
+  foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_1_const(X<1> &) const
+  X<0> &
+  ref_foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -557,13 +572,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_1_const(X<1> &) const
+  virtual X<0>
+  virtual_foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_1_const(X<1> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_1_const(X<1> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -595,13 +612,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_1(X<1> &)
+  virtual X<0>
+  virtual_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_1(X<1> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_1(X<1> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -651,19 +670,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_2(X<1> &, X<2> &)
+  X<0>
+  foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_2(X<1> &, X<2> &)
+  static X<0>
+  static_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_2(X<1> &, X<2> &)
+  X<0> &
+  ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -675,13 +697,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_2(X<1> &, X<2> &)
+  const X<0> &
+  const_ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_2(X<1> &, X<2> &)
+  const X<0> &
+  const_ref_foo_const_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -693,13 +717,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_2_const(X<1> &, X<2> &) const
+  const X<0> &
+  const_ref_foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_2_const(X<1> &, X<2> &) const
+  const X<0> &
+  const_ref_foo_const_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -711,13 +737,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_2(X<1> &, X<2> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_2(X<1> &, X<2> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -729,26 +757,29 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_2_const(X<1> &, X<2> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_2_const(X<1> &,
-                                                              X<2> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> &static_ref_foo_ref_2(X<1> &, X<2> &)
+  static X<0> &
+  static_ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_2(X<1> &, X<2> &)
+  static const X<0> &
+  static_const_ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -801,13 +832,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_2_const(X<1> &, X<2> &) const
+  X<0>
+  foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_2_const(X<1> &, X<2> &) const
+  X<0> &
+  ref_foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -839,13 +872,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_2_const(X<1> &, X<2> &) const
+  virtual X<0>
+  virtual_foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_2_const(X<1> &, X<2> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_2_const(X<1> &, X<2> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -877,13 +912,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_2(X<1> &, X<2> &)
+  virtual X<0>
+  virtual_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_2(X<1> &, X<2> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_2(X<1> &, X<2> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -933,19 +970,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_3(X<1> &, X<2> &, X<3> &)
+  X<0>
+  foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  static X<0>
+  static_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  X<0> &
+  ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -957,13 +997,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  const X<0> &
+  const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_3(X<1> &, X<2> &, X<3> &)
+  const X<0> &
+  const_ref_foo_const_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -975,13 +1017,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  const X<0> &
+  const_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  const X<0> &
+  const_ref_foo_const_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -993,13 +1037,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_3(X<1> &, X<2> &, X<3> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1012,26 +1058,28 @@ struct U
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  virtual_const_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_const_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  virtual_const_ref_foo_const_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> &static_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  static X<0> &
+  static_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  static const X<0> &
+  static_const_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1084,13 +1132,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  X<0>
+  foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  X<0> &
+  ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1122,13 +1172,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  virtual X<0>
+  virtual_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_3_const(X<1> &, X<2> &, X<3> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1162,13 +1214,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  virtual X<0>
+  virtual_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_3(X<1> &, X<2> &, X<3> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1218,19 +1272,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  X<0>
+  foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  static X<0>
+  static_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  X<0> &
+  ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1242,13 +1299,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  const X<0> &
+  const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  const X<0> &
+  const_ref_foo_const_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1260,14 +1319,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  const X<0> &
+  const_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   const X<0> &
-    const_ref_foo_const_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  const_ref_foo_const_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1280,14 +1340,14 @@ struct U
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  virtual_const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_const_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  virtual_const_ref_foo_const_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1301,28 +1361,28 @@ struct U
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  virtual_const_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_4_const(X<1> &,
-                                                              X<2> &,
-                                                              X<3> &,
-                                                              X<4> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> &static_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  static X<0> &
+  static_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  static const X<0> &
+  static_const_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1381,13 +1441,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  X<0>
+  foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  X<0> &
+  ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1425,14 +1487,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  virtual X<0>
+  virtual_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual X<0> &
-    virtual_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
+  virtual_ref_foo_ref_4_const(X<1> &, X<2> &, X<3> &, X<4> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1470,13 +1533,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  virtual X<0>
+  virtual_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_4(X<1> &, X<2> &, X<3> &, X<4> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1532,19 +1597,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  X<0>
+  foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  static X<0>
+  static_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  X<0> &
+  ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1556,13 +1624,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  const X<0> &
+  const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  const X<0> &
+  const_ref_foo_const_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1575,17 +1645,14 @@ struct U
     return x;
   }
   const X<0> &
-    const_ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
+  const_ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_5_const(X<1> &,
-                                              X<2> &,
-                                              X<3> &,
-                                              X<4> &,
-                                              X<5> &) const
+  const X<0> &
+  const_ref_foo_const_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1598,14 +1665,14 @@ struct U
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  virtual_const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_const_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  virtual_const_ref_foo_const_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1618,34 +1685,34 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_5_const(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+    const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_5_const(X<1> &,
-                                                              X<2> &,
-                                                              X<3> &,
-                                                              X<4> &,
-                                                              X<5> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_5_const(X<1> &,
+                                          X<2> &,
+                                          X<3> &,
+                                          X<4> &,
+                                          X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> &static_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  static X<0> &
+  static_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   static const X<0> &
-    static_const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  static_const_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1718,13 +1785,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
+  X<0>
+  foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
+  X<0> &
+  ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1765,14 +1834,14 @@ struct U
     return x;
   }
   virtual X<0>
-    virtual_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
+  virtual_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual X<0> &
-    virtual_ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
+  virtual_ref_foo_ref_5_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1812,13 +1881,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  virtual X<0>
+  virtual_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_5(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1876,19 +1947,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  X<0>
+  foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  static X<0>
+  static_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  X<0> &
+  ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1901,14 +1975,14 @@ struct U
     return x;
   }
   const X<0> &
-    const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   const X<0> &
-    const_ref_foo_const_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  const_ref_foo_const_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1920,23 +1994,21 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_6_const(X<1> &,
-                                        X<2> &,
-                                        X<3> &,
-                                        X<4> &,
-                                        X<5> &,
-                                        X<6> &) const
+  const X<0> &
+  const_ref_foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+    const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_6_const(X<1> &,
-                                              X<2> &,
-                                              X<3> &,
-                                              X<4> &,
-                                              X<5> &,
-                                              X<6> &) const
+  const X<0> &
+  const_ref_foo_const_ref_6_const(X<1> &,
+                                  X<2> &,
+                                  X<3> &,
+                                  X<4> &,
+                                  X<5> &,
+                                  X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1950,18 +2022,19 @@ struct U
     return x;
   }
   virtual const X<0> &
-    virtual_const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  virtual_const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_6(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_6(X<1> &,
+                                    X<2> &,
+                                    X<3> &,
+                                    X<4> &,
+                                    X<5> &,
+                                    X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -1974,37 +2047,39 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_6_const(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_6_const(X<1> &,
+                                    X<2> &,
+                                    X<3> &,
+                                    X<4> &,
+                                    X<5> &,
+                                    X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_6_const(X<1> &,
-                                                              X<2> &,
-                                                              X<3> &,
-                                                              X<4> &,
-                                                              X<5> &,
-                                                              X<6> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_6_const(X<1> &,
+                                          X<2> &,
+                                          X<3> &,
+                                          X<4> &,
+                                          X<5> &,
+                                          X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   static X<0> &
-    static_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  static_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   static const X<0> &
-    static_const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  static_const_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2082,14 +2157,15 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &) const
+  X<0>
+  foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   X<0> &
-    ref_foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &) const
+  ref_foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2132,23 +2208,16 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_6_const(X<1> &,
-                                       X<2> &,
-                                       X<3> &,
-                                       X<4> &,
-                                       X<5> &,
-                                       X<6> &) const
+  virtual X<0>
+  virtual_foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_6_const(X<1> &,
-                                            X<2> &,
-                                            X<3> &,
-                                            X<4> &,
-                                            X<5> &,
-                                            X<6> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_6_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+    const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2190,14 +2259,15 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  virtual X<0>
+  virtual_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   virtual X<0> &
-    virtual_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
+  virtual_ref_foo_ref_6(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2258,20 +2328,22 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  X<0>
+  foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   static X<0>
-    static_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  static_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  X<0> &
+  ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2284,19 +2356,20 @@ struct U
     return x;
   }
   const X<0> &
-    const_ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  const_ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_7(X<1> &,
-                                        X<2> &,
-                                        X<3> &,
-                                        X<4> &,
-                                        X<5> &,
-                                        X<6> &,
-                                        X<7> &)
+  const X<0> &
+  const_ref_foo_const_ref_7(X<1> &,
+                            X<2> &,
+                            X<3> &,
+                            X<4> &,
+                            X<5> &,
+                            X<6> &,
+                            X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2309,25 +2382,27 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_7_const(X<1> &,
-                                        X<2> &,
-                                        X<3> &,
-                                        X<4> &,
-                                        X<5> &,
-                                        X<6> &,
-                                        X<7> &) const
+  const X<0> &
+  const_ref_foo_ref_7_const(X<1> &,
+                            X<2> &,
+                            X<3> &,
+                            X<4> &,
+                            X<5> &,
+                            X<6> &,
+                            X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_7_const(X<1> &,
-                                              X<2> &,
-                                              X<3> &,
-                                              X<4> &,
-                                              X<5> &,
-                                              X<6> &,
-                                              X<7> &) const
+  const X<0> &
+  const_ref_foo_const_ref_7_const(X<1> &,
+                                  X<2> &,
+                                  X<3> &,
+                                  X<4> &,
+                                  X<5> &,
+                                  X<6> &,
+                                  X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2340,25 +2415,27 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_7(X<1> &,
-                                                  X<2> &,
-                                                  X<3> &,
-                                                  X<4> &,
-                                                  X<5> &,
-                                                  X<6> &,
-                                                  X<7> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_7(X<1> &,
+                              X<2> &,
+                              X<3> &,
+                              X<4> &,
+                              X<5> &,
+                              X<6> &,
+                              X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_7(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &,
-                                                        X<7> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_7(X<1> &,
+                                    X<2> &,
+                                    X<3> &,
+                                    X<4> &,
+                                    X<5> &,
+                                    X<6> &,
+                                    X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2376,44 +2453,47 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_7_const(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &,
-                                                        X<7> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_7_const(X<1> &,
+                                    X<2> &,
+                                    X<3> &,
+                                    X<4> &,
+                                    X<5> &,
+                                    X<6> &,
+                                    X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_7_const(X<1> &,
-                                                              X<2> &,
-                                                              X<3> &,
-                                                              X<4> &,
-                                                              X<5> &,
-                                                              X<6> &,
-                                                              X<7> &) const
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_7_const(X<1> &,
+                                          X<2> &,
+                                          X<3> &,
+                                          X<4> &,
+                                          X<5> &,
+                                          X<6> &,
+                                          X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
   static X<0> &
-    static_ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  static_ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_7(X<1> &,
-                                                X<2> &,
-                                                X<3> &,
-                                                X<4> &,
-                                                X<5> &,
-                                                X<6> &,
-                                                X<7> &)
+  static const X<0> &
+  static_const_ref_foo_ref_7(X<1> &,
+                             X<2> &,
+                             X<3> &,
+                             X<4> &,
+                             X<5> &,
+                             X<6> &,
+                             X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2496,20 +2576,16 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_7_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
-    const
+  X<0>
+  foo_ref_7_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_7_const(X<1> &,
-                            X<2> &,
-                            X<3> &,
-                            X<4> &,
-                            X<5> &,
-                            X<6> &,
-                            X<7> &) const
+  X<0> &
+  ref_foo_ref_7_const(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+    const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2555,25 +2631,27 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_7_const(X<1> &,
-                                       X<2> &,
-                                       X<3> &,
-                                       X<4> &,
-                                       X<5> &,
-                                       X<6> &,
-                                       X<7> &) const
+  virtual X<0>
+  virtual_foo_ref_7_const(X<1> &,
+                          X<2> &,
+                          X<3> &,
+                          X<4> &,
+                          X<5> &,
+                          X<6> &,
+                          X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_7_const(X<1> &,
-                                            X<2> &,
-                                            X<3> &,
-                                            X<4> &,
-                                            X<5> &,
-                                            X<6> &,
-                                            X<7> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_7_const(X<1> &,
+                              X<2> &,
+                              X<3> &,
+                              X<4> &,
+                              X<5> &,
+                              X<6> &,
+                              X<7> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2618,19 +2696,14 @@ struct U
     return x;
   }
   virtual X<0>
-    virtual_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
+  virtual_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_7(X<1> &,
-                                      X<2> &,
-                                      X<3> &,
-                                      X<4> &,
-                                      X<5> &,
-                                      X<6> &,
-                                      X<7> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_7(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2693,26 +2766,42 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_8(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &, X<8> &)
+  X<0>
+  foo_ref_8(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &, X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static X<0> static_foo_ref_8(X<1> &,
-                               X<2> &,
-                               X<3> &,
-                               X<4> &,
-                               X<5> &,
-                               X<6> &,
-                               X<7> &,
-                               X<8> &)
+  static X<0>
+  static_foo_ref_8(X<1> &,
+                   X<2> &,
+                   X<3> &,
+                   X<4> &,
+                   X<5> &,
+                   X<6> &,
+                   X<7> &,
+                   X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_8(X<1> &,
+  X<0> &
+  ref_foo_ref_8(X<1> &, X<2> &, X<3> &, X<4> &, X<5> &, X<6> &, X<7> &, X<8> &)
+  {
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
+    static X<0> x;
+    return x;
+  }
+  const X<0> &const_ref_foo_8(X<1>, X<2>, X<3>, X<4>, X<5>, X<6>, X<7>, X<8>)
+  {
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
+    static X<0> x;
+    return x;
+  }
+  const X<0> &
+  const_ref_foo_ref_8(X<1> &,
                       X<2> &,
                       X<3> &,
                       X<4> &,
@@ -2725,33 +2814,15 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_8(X<1>, X<2>, X<3>, X<4>, X<5>, X<6>, X<7>, X<8>)
-  {
-    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
-    static X<0> x;
-    return x;
-  }
-  const X<0> &const_ref_foo_ref_8(X<1> &,
-                                  X<2> &,
-                                  X<3> &,
-                                  X<4> &,
-                                  X<5> &,
-                                  X<6> &,
-                                  X<7> &,
-                                  X<8> &)
-  {
-    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
-    static X<0> x;
-    return x;
-  }
-  const X<0> &const_ref_foo_const_ref_8(X<1> &,
-                                        X<2> &,
-                                        X<3> &,
-                                        X<4> &,
-                                        X<5> &,
-                                        X<6> &,
-                                        X<7> &,
-                                        X<8> &)
+  const X<0> &
+  const_ref_foo_const_ref_8(X<1> &,
+                            X<2> &,
+                            X<3> &,
+                            X<4> &,
+                            X<5> &,
+                            X<6> &,
+                            X<7> &,
+                            X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2764,27 +2835,29 @@ struct U
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_ref_8_const(X<1> &,
-                                        X<2> &,
-                                        X<3> &,
-                                        X<4> &,
-                                        X<5> &,
-                                        X<6> &,
-                                        X<7> &,
-                                        X<8> &) const
+  const X<0> &
+  const_ref_foo_ref_8_const(X<1> &,
+                            X<2> &,
+                            X<3> &,
+                            X<4> &,
+                            X<5> &,
+                            X<6> &,
+                            X<7> &,
+                            X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  const X<0> &const_ref_foo_const_ref_8_const(X<1> &,
-                                              X<2> &,
-                                              X<3> &,
-                                              X<4> &,
-                                              X<5> &,
-                                              X<6> &,
-                                              X<7> &,
-                                              X<8> &) const
+  const X<0> &
+  const_ref_foo_const_ref_8_const(X<1> &,
+                                  X<2> &,
+                                  X<3> &,
+                                  X<4> &,
+                                  X<5> &,
+                                  X<6> &,
+                                  X<7> &,
+                                  X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2797,27 +2870,29 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_8(X<1> &,
-                                                  X<2> &,
-                                                  X<3> &,
-                                                  X<4> &,
-                                                  X<5> &,
-                                                  X<6> &,
-                                                  X<7> &,
-                                                  X<8> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_8(X<1> &,
+                              X<2> &,
+                              X<3> &,
+                              X<4> &,
+                              X<5> &,
+                              X<6> &,
+                              X<7> &,
+                              X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_8(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &,
-                                                        X<7> &,
-                                                        X<8> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_8(X<1> &,
+                                    X<2> &,
+                                    X<3> &,
+                                    X<4> &,
+                                    X<5> &,
+                                    X<6> &,
+                                    X<7> &,
+                                    X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2836,53 +2911,57 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual const X<0> &virtual_const_ref_foo_ref_8_const(X<1> &,
-                                                        X<2> &,
-                                                        X<3> &,
-                                                        X<4> &,
-                                                        X<5> &,
-                                                        X<6> &,
-                                                        X<7> &,
-                                                        X<8> &) const
-  {
-    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
-    static X<0> x;
-    return x;
-  }
-  virtual const X<0> &virtual_const_ref_foo_const_ref_8_const(X<1> &,
-                                                              X<2> &,
-                                                              X<3> &,
-                                                              X<4> &,
-                                                              X<5> &,
-                                                              X<6> &,
-                                                              X<7> &,
-                                                              X<8> &) const
-  {
-    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
-    static X<0> x;
-    return x;
-  }
-  static X<0> &static_ref_foo_ref_8(X<1> &,
+  virtual const X<0> &
+  virtual_const_ref_foo_ref_8_const(X<1> &,
                                     X<2> &,
                                     X<3> &,
                                     X<4> &,
                                     X<5> &,
                                     X<6> &,
                                     X<7> &,
-                                    X<8> &)
+                                    X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  static const X<0> &static_const_ref_foo_ref_8(X<1> &,
-                                                X<2> &,
-                                                X<3> &,
-                                                X<4> &,
-                                                X<5> &,
-                                                X<6> &,
-                                                X<7> &,
-                                                X<8> &)
+  virtual const X<0> &
+  virtual_const_ref_foo_const_ref_8_const(X<1> &,
+                                          X<2> &,
+                                          X<3> &,
+                                          X<4> &,
+                                          X<5> &,
+                                          X<6> &,
+                                          X<7> &,
+                                          X<8> &) const
+  {
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
+    static X<0> x;
+    return x;
+  }
+  static X<0> &
+  static_ref_foo_ref_8(X<1> &,
+                       X<2> &,
+                       X<3> &,
+                       X<4> &,
+                       X<5> &,
+                       X<6> &,
+                       X<7> &,
+                       X<8> &)
+  {
+    deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
+    static X<0> x;
+    return x;
+  }
+  static const X<0> &
+  static_const_ref_foo_ref_8(X<1> &,
+                             X<2> &,
+                             X<3> &,
+                             X<4> &,
+                             X<5> &,
+                             X<6> &,
+                             X<7> &,
+                             X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -2970,27 +3049,29 @@ struct U
     static X<0> x;
     return x;
   }
-  X<0> foo_ref_8_const(X<1> &,
-                       X<2> &,
-                       X<3> &,
-                       X<4> &,
-                       X<5> &,
-                       X<6> &,
-                       X<7> &,
-                       X<8> &) const
+  X<0>
+  foo_ref_8_const(X<1> &,
+                  X<2> &,
+                  X<3> &,
+                  X<4> &,
+                  X<5> &,
+                  X<6> &,
+                  X<7> &,
+                  X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  X<0> &ref_foo_ref_8_const(X<1> &,
-                            X<2> &,
-                            X<3> &,
-                            X<4> &,
-                            X<5> &,
-                            X<6> &,
-                            X<7> &,
-                            X<8> &) const
+  X<0> &
+  ref_foo_ref_8_const(X<1> &,
+                      X<2> &,
+                      X<3> &,
+                      X<4> &,
+                      X<5> &,
+                      X<6> &,
+                      X<7> &,
+                      X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -3039,27 +3120,29 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_8_const(X<1> &,
-                                       X<2> &,
-                                       X<3> &,
-                                       X<4> &,
-                                       X<5> &,
-                                       X<6> &,
-                                       X<7> &,
-                                       X<8> &) const
+  virtual X<0>
+  virtual_foo_ref_8_const(X<1> &,
+                          X<2> &,
+                          X<3> &,
+                          X<4> &,
+                          X<5> &,
+                          X<6> &,
+                          X<7> &,
+                          X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_8_const(X<1> &,
-                                            X<2> &,
-                                            X<3> &,
-                                            X<4> &,
-                                            X<5> &,
-                                            X<6> &,
-                                            X<7> &,
-                                            X<8> &) const
+  virtual X<0> &
+  virtual_ref_foo_ref_8_const(X<1> &,
+                              X<2> &,
+                              X<3> &,
+                              X<4> &,
+                              X<5> &,
+                              X<6> &,
+                              X<7> &,
+                              X<8> &) const
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
@@ -3106,27 +3189,29 @@ struct U
     static X<0> x;
     return x;
   }
-  virtual X<0> virtual_foo_ref_8(X<1> &,
-                                 X<2> &,
-                                 X<3> &,
-                                 X<4> &,
-                                 X<5> &,
-                                 X<6> &,
-                                 X<7> &,
-                                 X<8> &)
+  virtual X<0>
+  virtual_foo_ref_8(X<1> &,
+                    X<2> &,
+                    X<3> &,
+                    X<4> &,
+                    X<5> &,
+                    X<6> &,
+                    X<7> &,
+                    X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;
     return x;
   }
-  virtual X<0> &virtual_ref_foo_ref_8(X<1> &,
-                                      X<2> &,
-                                      X<3> &,
-                                      X<4> &,
-                                      X<5> &,
-                                      X<6> &,
-                                      X<7> &,
-                                      X<8> &)
+  virtual X<0> &
+  virtual_ref_foo_ref_8(X<1> &,
+                        X<2> &,
+                        X<3> &,
+                        X<4> &,
+                        X<5> &,
+                        X<6> &,
+                        X<7> &,
+                        X<8> &)
   {
     deallog << unify_pretty_function(__PRETTY_FUNCTION__) << std::endl;
     static X<0> x;

--- a/tests/numerics/no_flux_10.cc
+++ b/tests/numerics/no_flux_10.cc
@@ -51,10 +51,11 @@
 #include "../tests.h"
 
 
-void colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
-                                    const Point<3> &  center,
-                                    const double      inner_radius,
-                                    const double      outer_radius)
+void
+colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
+                               const Point<3> &  center,
+                               const double      inner_radius,
+                               const double      outer_radius)
 {
   //    if (tria.n_cells() != 4)
   //      AssertThrow (false, ExcNotImplemented());
@@ -137,10 +138,11 @@ void colorize_sixty_deg_hyper_shell(Triangulation<3> &tria,
       }
 }
 
-void sixty_deg_hyper_shell(Triangulation<3> &tria,
-                           const Point<3> &  center,
-                           const double      inner_radius,
-                           const double      outer_radius)
+void
+sixty_deg_hyper_shell(Triangulation<3> &tria,
+                      const Point<3> &  center,
+                      const double      inner_radius,
+                      const double      outer_radius)
 {
   const double r0 = inner_radius;
   const double r1 = outer_radius;

--- a/tests/numerics/project_to_surface_01.cc
+++ b/tests/numerics/project_to_surface_01.cc
@@ -63,7 +63,8 @@ do_rotate(Triangulation<dim> &tria)
 }
 
 
-void do_rotate(Triangulation<1> &)
+void
+do_rotate(Triangulation<1> &)
 {}
 
 

--- a/tests/numerics/project_to_surface_02.cc
+++ b/tests/numerics/project_to_surface_02.cc
@@ -63,7 +63,8 @@ do_rotate(Triangulation<dim> &tria)
 }
 
 
-void do_rotate(Triangulation<1> &)
+void
+do_rotate(Triangulation<1> &)
 {}
 
 

--- a/tests/numerics/smoothness_estimator_01.cc
+++ b/tests/numerics/smoothness_estimator_01.cc
@@ -149,12 +149,14 @@ compare(const Table<3, double> &coeff1, const Table<3, double> &coeff2)
 
 
 
-void resize(Table<2, double> &coeff, const unsigned int N)
+void
+resize(Table<2, double> &coeff, const unsigned int N)
 {
   coeff.reinit(N, N);
 }
 
-void resize(Table<3, double> &coeff, const unsigned int N)
+void
+resize(Table<3, double> &coeff, const unsigned int N)
 {
   TableIndices<3> size;
   for (unsigned int d = 0; d < 3; d++)

--- a/tests/numerics/smoothness_estimator_02.cc
+++ b/tests/numerics/smoothness_estimator_02.cc
@@ -98,8 +98,8 @@ PolyFunction<dim>::value(const Point<dim> &point, const unsigned int) const
 
 template <typename CoefficientType>
 void
-  prepare_symmetric_coefficients(Table<1, CoefficientType> &         coeff,
-                                 const std::vector<CoefficientType> &coeff_1d)
+prepare_symmetric_coefficients(Table<1, CoefficientType> &         coeff,
+                               const std::vector<CoefficientType> &coeff_1d)
 {
   Assert(coeff.size(0) == coeff_1d.size(), ExcInternalError());
 
@@ -109,8 +109,8 @@ void
 
 template <typename CoefficientType>
 void
-  prepare_symmetric_coefficients(Table<2, CoefficientType> &         coeff,
-                                 const std::vector<CoefficientType> &coeff_1d)
+prepare_symmetric_coefficients(Table<2, CoefficientType> &         coeff,
+                               const std::vector<CoefficientType> &coeff_1d)
 {
   for (unsigned int d = 0; d < 2; ++d)
     Assert(coeff.size(d) == coeff_1d.size(), ExcInternalError());
@@ -122,8 +122,8 @@ void
 
 template <typename CoefficientType>
 void
-  prepare_symmetric_coefficients(Table<3, CoefficientType> &         coeff,
-                                 const std::vector<CoefficientType> &coeff_1d)
+prepare_symmetric_coefficients(Table<3, CoefficientType> &         coeff,
+                               const std::vector<CoefficientType> &coeff_1d)
 {
   for (unsigned int d = 0; d < 3; ++d)
     Assert(coeff.size(d) == coeff_1d.size(), ExcInternalError());

--- a/tests/opencascade/step_create.cc
+++ b/tests/opencascade/step_create.cc
@@ -48,8 +48,7 @@ main()
       counter++;
       if ((counter == 4) || (counter == 5) || (counter == 6) ||
           (counter == 18) || (counter == 19))
-        {
-        }
+        {}
       else
         out << line << std::endl;
     }

--- a/tests/opencascade/step_write.cc
+++ b/tests/opencascade/step_write.cc
@@ -42,8 +42,7 @@ main()
       counter++;
       if ((counter == 4) || (counter == 5) || (counter == 6) ||
           (counter == 18) || (counter == 19))
-        {
-        }
+        {}
       else
         out << line << std::endl;
     }

--- a/tests/optimization/step-44.h
+++ b/tests/optimization/step-44.h
@@ -1387,12 +1387,12 @@ namespace Step44
                                    &ls_minimization_function_ptrb,
                                    &use_ptrb]() {
           const auto res_0 = (use_ptrb ? ls_minimization_function_ptrb(0.0) :
-                                         ls_minimization_function(0.0));
+                                               ls_minimization_function(0.0));
           Assert(res_0.second < 0.0,
                  ExcMessage("Gradient should be negative. Current value: " +
                             std::to_string(res_0.second)));
           const auto res_1 = (use_ptrb ? ls_minimization_function_ptrb(1.0) :
-                                         ls_minimization_function(1.0));
+                                               ls_minimization_function(1.0));
 
           // Wriggers discussion after 5.14
           if (res_0.second * res_1.second > 0.0)
@@ -1417,7 +1417,7 @@ namespace Step44
                                          a_max,
                                          max_evals,
                                          debug_linesearch) :
-                                       LineMinimization::line_search<double>(
+                                             LineMinimization::line_search<double>(
                                          ls_minimization_function,
                                          res_0.first,
                                          res_0.second,

--- a/tests/physics/notation-kelvin_01.cc
+++ b/tests/physics/notation-kelvin_01.cc
@@ -30,14 +30,16 @@
 using namespace dealii::Physics;
 
 template <int dim, typename Number>
-void initialize(Tensor<1, dim, Number> &x)
+void
+initialize(Tensor<1, dim, Number> &x)
 {
   for (unsigned int i = 0; i < x.n_independent_components; ++i)
     x[i] = i + 1;
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<2, dim, Number> &x)
+void
+initialize(Tensor<2, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -48,7 +50,8 @@ void initialize(Tensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<2, dim, Number> &x)
+void
+initialize(SymmetricTensor<2, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -59,7 +62,8 @@ void initialize(SymmetricTensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<3, dim, Number> &x)
+void
+initialize(Tensor<3, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -73,8 +77,8 @@ void initialize(Tensor<3, dim, Number> &x)
 // A specialised constructor mimicking the construction
 // of a rank-3 tensor with two symmetric components
 template <int dim, typename Number>
-void initialize(Tensor<3, dim, Number> &x,
-                const bool              left_components_are_symmetric)
+void
+initialize(Tensor<3, dim, Number> &x, const bool left_components_are_symmetric)
 {
   Tensor<1, dim, Number> v;
   initialize(v);
@@ -88,7 +92,8 @@ void initialize(Tensor<3, dim, Number> &x,
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<4, dim, Number> &x)
+void
+initialize(Tensor<4, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -101,7 +106,8 @@ void initialize(Tensor<4, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<4, dim, Number> &x)
+void
+initialize(SymmetricTensor<4, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)

--- a/tests/physics/notation-kelvin_02.cc
+++ b/tests/physics/notation-kelvin_02.cc
@@ -33,14 +33,16 @@
 using namespace dealii::Physics;
 
 template <int dim, typename Number>
-void initialize(Tensor<1, dim, Number> &x)
+void
+initialize(Tensor<1, dim, Number> &x)
 {
   for (unsigned int i = 0; i < x.n_independent_components; ++i)
     x[i] = i + 1;
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<2, dim, Number> &x)
+void
+initialize(Tensor<2, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -51,7 +53,8 @@ void initialize(Tensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<2, dim, Number> &x)
+void
+initialize(SymmetricTensor<2, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -62,7 +65,8 @@ void initialize(SymmetricTensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<3, dim, Number> &x)
+void
+initialize(Tensor<3, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -76,8 +80,8 @@ void initialize(Tensor<3, dim, Number> &x)
 // A specialised constructor mimicking the construction
 // of a rank-3 tensor with two symmetric components
 template <int dim, typename Number>
-void initialize(Tensor<3, dim, Number> &x,
-                const bool              left_components_are_symmetric)
+void
+initialize(Tensor<3, dim, Number> &x, const bool left_components_are_symmetric)
 {
   Tensor<1, dim, Number> v;
   initialize(v);
@@ -91,7 +95,8 @@ void initialize(Tensor<3, dim, Number> &x,
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<4, dim, Number> &x)
+void
+initialize(Tensor<4, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)
@@ -104,7 +109,8 @@ void initialize(Tensor<4, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<4, dim, Number> &x)
+void
+initialize(SymmetricTensor<4, dim, Number> &x)
 {
   unsigned int c = 1;
   for (unsigned int i = 0; i < dim; ++i)

--- a/tests/physics/notation-kelvin_03.cc
+++ b/tests/physics/notation-kelvin_03.cc
@@ -31,20 +31,23 @@
 using namespace dealii::Physics;
 
 template <int dim, typename Number>
-void initialize(Tensor<0, dim, Number> &x)
+void
+initialize(Tensor<0, dim, Number> &x)
 {
   x = 1.0;
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<1, dim, Number> &x)
+void
+initialize(Tensor<1, dim, Number> &x)
 {
   for (unsigned int i = 0; i < x.n_independent_components; ++i)
     x[i] = 1.0;
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<2, dim, Number> &x)
+void
+initialize(Tensor<2, dim, Number> &x)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = 0; j < dim; ++j)
@@ -54,7 +57,8 @@ void initialize(Tensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<2, dim, Number> &x)
+void
+initialize(SymmetricTensor<2, dim, Number> &x)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = i; j < dim; ++j)
@@ -64,7 +68,8 @@ void initialize(SymmetricTensor<2, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<3, dim, Number> &x)
+void
+initialize(Tensor<3, dim, Number> &x)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = 0; j < dim; ++j)
@@ -75,7 +80,8 @@ void initialize(Tensor<3, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(Tensor<4, dim, Number> &x)
+void
+initialize(Tensor<4, dim, Number> &x)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = 0; j < dim; ++j)
@@ -87,7 +93,8 @@ void initialize(Tensor<4, dim, Number> &x)
 }
 
 template <int dim, typename Number>
-void initialize(SymmetricTensor<4, dim, Number> &x)
+void
+initialize(SymmetricTensor<4, dim, Number> &x)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = i; j < dim; ++j)

--- a/tests/physics/step-18-rotation_matrix.cc
+++ b/tests/physics/step-18-rotation_matrix.cc
@@ -390,7 +390,7 @@ namespace Step18
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     BodyForce<dim>                       body_force;
     std::vector<Vector<double>>          body_force_values(n_q_points,
-                                                           Vector<double>(dim));
+                                                  Vector<double>(dim));
     typename DoFHandler<dim>::active_cell_iterator cell =
                                                      dof_handler.begin_active(),
                                                    endc = dof_handler.end();

--- a/tests/physics/step-18.cc
+++ b/tests/physics/step-18.cc
@@ -406,7 +406,7 @@ namespace Step18
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     BodyForce<dim>                       body_force;
     std::vector<Vector<double>>          body_force_values(n_q_points,
-                                                           Vector<double>(dim));
+                                                  Vector<double>(dim));
     typename DoFHandler<dim>::active_cell_iterator cell =
                                                      dof_handler.begin_active(),
                                                    endc = dof_handler.end();

--- a/tests/quick_tests/tbb.cc
+++ b/tests/quick_tests/tbb.cc
@@ -71,12 +71,13 @@ test2()
   for (unsigned int i = 0; i < v.size(); ++i)
     v[i] = i + 1;
   int result = 0;
-  WorkStream::run(v.begin(),
-                  v.end(),
-                  &assemble,
-                  [&result](const copy_data &data) { copy(result, data); },
-                  scratch_data(),
-                  copy_data());
+  WorkStream::run(
+    v.begin(),
+    v.end(),
+    &assemble,
+    [&result](const copy_data &data) { copy(result, data); },
+    scratch_data(),
+    copy_data());
   std::cout << "result: " << result << std::endl;
 
   if (result != maxi * (maxi + 1) / 2)

--- a/tests/serialization/dof_handler_01.cc
+++ b/tests/serialization/dof_handler_01.cc
@@ -146,7 +146,8 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 
 
 template <int spacedim>
-void do_boundary(Triangulation<1, spacedim> &)
+void
+do_boundary(Triangulation<1, spacedim> &)
 {}
 
 

--- a/tests/serialization/hp_dof_handler_01.cc
+++ b/tests/serialization/hp_dof_handler_01.cc
@@ -154,7 +154,8 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 
 
 template <int spacedim>
-void do_boundary(Triangulation<1, spacedim> &)
+void
+do_boundary(Triangulation<1, spacedim> &)
 {}
 
 

--- a/tests/serialization/triangulation_01.cc
+++ b/tests/serialization/triangulation_01.cc
@@ -136,7 +136,8 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 
 
 template <int spacedim>
-void do_boundary(Triangulation<1, spacedim> &)
+void
+do_boundary(Triangulation<1, spacedim> &)
 {}
 
 

--- a/tests/serialization/triangulation_02.cc
+++ b/tests/serialization/triangulation_02.cc
@@ -135,7 +135,8 @@ do_boundary(Triangulation<dim, spacedim> &t1)
 
 
 template <int spacedim>
-void do_boundary(Triangulation<1, spacedim> &)
+void
+do_boundary(Triangulation<1, spacedim> &)
 {}
 
 

--- a/tests/simplex/mapping_transformations_01.cc
+++ b/tests/simplex/mapping_transformations_01.cc
@@ -35,7 +35,8 @@
 
 using namespace dealii;
 
-void make_grid(Triangulation<2> &triangulation)
+void
+make_grid(Triangulation<2> &triangulation)
 {
   Triangulation<2> triangulation_temp;
 

--- a/tests/simplex/step-02.cc
+++ b/tests/simplex/step-02.cc
@@ -45,7 +45,8 @@
 
 using namespace dealii;
 
-void make_grid(Triangulation<2> &triangulation)
+void
+make_grid(Triangulation<2> &triangulation)
 {
   Triangulation<2> triangulation_temp;
 
@@ -60,7 +61,8 @@ void make_grid(Triangulation<2> &triangulation)
   triangulation.refine_global(); // WARNING: no local refinement is performed
 }
 
-void distribute_dofs(DoFHandler<2> &dof_handler)
+void
+distribute_dofs(DoFHandler<2> &dof_handler)
 {
   const FE_SimplexP<2> finite_element(1);
   dof_handler.distribute_dofs(finite_element);
@@ -76,7 +78,8 @@ void distribute_dofs(DoFHandler<2> &dof_handler)
   sparsity_pattern.print_svg(deallog.get_file_stream());
 }
 
-void renumber_dofs(DoFHandler<2> &dof_handler)
+void
+renumber_dofs(DoFHandler<2> &dof_handler)
 {
   DoFRenumbering::Cuthill_McKee(dof_handler);
 

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -899,7 +899,7 @@ namespace Step31
       const LinearSolvers::BlockSchurPreconditioner<
         TrilinosWrappers::PreconditionAMG,
         TrilinosWrappers::PreconditionIC>
-                    preconditioner(stokes_matrix, mp_inverse, *Amg_preconditioner);
+        preconditioner(stokes_matrix, mp_inverse, *Amg_preconditioner);
       SolverControl solver_control(stokes_matrix.m(),
                                    1e-6 * stokes_rhs.l2_norm());
       SolverGMRES<TrilinosWrappers::MPI::BlockVector> gmres(

--- a/tests/symengine/sd_common_tests/batch_optimizer_01.h
+++ b/tests/symengine/sd_common_tests/batch_optimizer_01.h
@@ -499,7 +499,8 @@ struct FunctionMin
 template <typename number_t,
           enum SD::OptimizerType     opt_method,
           enum SD::OptimizationFlags opt_flags,
-          template <typename> class FunctionStruct>
+          template <typename>
+          class FunctionStruct>
 void
 test_functions()
 {

--- a/tests/tensors/symmetric_tensor_34.cc
+++ b/tests/tensors/symmetric_tensor_34.cc
@@ -21,7 +21,8 @@
 
 
 template <int dim>
-void initialize(SymmetricTensor<2, dim> &st)
+void
+initialize(SymmetricTensor<2, dim> &st)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = i; j < dim; ++j)
@@ -30,7 +31,8 @@ void initialize(SymmetricTensor<2, dim> &st)
 
 
 template <int dim>
-void initialize(SymmetricTensor<4, dim> &st)
+void
+initialize(SymmetricTensor<4, dim> &st)
 {
   for (unsigned int i = 0; i < dim; ++i)
     for (unsigned int j = i; j < dim; ++j)

--- a/tests/tensors/symmetric_tensor_36.cc
+++ b/tests/tensors/symmetric_tensor_36.cc
@@ -30,7 +30,8 @@
 // from NumberType2
 template <int rank,
           int dim,
-          template <int, int, typename> class TensorType,
+          template <int, int, typename>
+          class TensorType,
           typename NumberType1,
           typename NumberType2>
 typename std::enable_if<!std::is_constructible<NumberType1, NumberType2>::value,
@@ -40,7 +41,8 @@ test_tensor_constructor(const std::string &, const std::string &)
 
 template <int rank,
           int dim,
-          template <int, int, typename> class TensorType,
+          template <int, int, typename>
+          class TensorType,
           typename NumberType1,
           typename NumberType2>
 typename std::enable_if<std::is_constructible<NumberType1, NumberType2>::value,
@@ -57,7 +59,8 @@ test_tensor_constructor(const std::string &type1, const std::string &type2)
 
 template <int rank,
           int dim,
-          template <int, int, typename> class TensorType,
+          template <int, int, typename>
+          class TensorType,
           typename NumberType1>
 void
 test_fixed_NT_2(const std::string &type1)

--- a/tests/tensors/symmetric_tensor_37.cc
+++ b/tests/tensors/symmetric_tensor_37.cc
@@ -29,8 +29,10 @@ template <int rank1,
           int rank3,
           int dim,
           typename number,
-          template <int, int, typename> class T1,
-          template <int, int, typename> class T3>
+          template <int, int, typename>
+          class T1,
+          template <int, int, typename>
+          class T3>
 void
 test_symm_tensor_contract_3(const T1<rank1, dim, number> &    l,
                             const Tensor<rank2, dim, number> &m,

--- a/tests/tensors/symmetric_tensor_39.cc
+++ b/tests/tensors/symmetric_tensor_39.cc
@@ -26,8 +26,8 @@
 // in clang-3.7.0 and clang-3.9.1 in release mode. Hence, use a separate
 // function.
 template <int dim, typename Number>
-void fill_tensor(
-  dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> &A)
+void
+fill_tensor(dealii::SymmetricTensor<2, dim, dealii::VectorizedArray<Number>> &A)
 {
   Number counter = 0.0;
   for (unsigned int i = 0; i < dim; ++i)

--- a/tests/tensors/symmetric_tensor_40.cc
+++ b/tests/tensors/symmetric_tensor_40.cc
@@ -46,7 +46,8 @@ is_unit_vector(const Tensor<1, dim> &v)
 }
 
 template <int dim>
-bool check_orientation(Tensor<1, dim> v1, Tensor<1, dim> v2)
+bool
+check_orientation(Tensor<1, dim> v1, Tensor<1, dim> v2)
 {
   v1 /= v1.norm();
   v2 /= v2.norm();

--- a/tests/tensors/symmetric_tensor_41.cc
+++ b/tests/tensors/symmetric_tensor_41.cc
@@ -46,9 +46,8 @@ is_unit_vector(const Tensor<1, dim> &v)
 }
 
 template <int dim>
-bool check_orientation(Tensor<1, dim> v1,
-                       Tensor<1, dim> v2,
-                       const double   tol = 1e-9)
+bool
+check_orientation(Tensor<1, dim> v1, Tensor<1, dim> v2, const double tol = 1e-9)
 {
   v1 /= v1.norm();
   v2 /= v2.norm();

--- a/tests/tensors/symmetric_tensor_44.cc
+++ b/tests/tensors/symmetric_tensor_44.cc
@@ -45,9 +45,11 @@ fill_tensor(Tensor<rank, dim, NumberType> &t)
 }
 
 template <int dim,
-          template <int, int, typename> class TensorType1,
+          template <int, int, typename>
+          class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 void
 print(const TensorType1<2, dim, NumberType1> &t2,
@@ -58,9 +60,11 @@ print(const TensorType1<2, dim, NumberType1> &t2,
 }
 
 template <int dim,
-          template <int, int, typename> class TensorType1,
+          template <int, int, typename>
+          class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 void
 print(const TensorType1<2, dim, NumberType1> &t2_1,
@@ -76,7 +80,8 @@ print(const TensorType1<2, dim, NumberType1> &t2_1,
 
 
 template <template <int, int, typename> class TensorType1,
-          template <int, int, typename> class TensorType2>
+          template <int, int, typename>
+          class TensorType2>
 struct AreSame : std::false_type
 {};
 
@@ -87,7 +92,8 @@ struct AreSame<TensorType1, TensorType1> : std::true_type
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 void
 test_one()
@@ -122,7 +128,8 @@ test_one()
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 typename std::enable_if<AreSame<TensorType1, TensorType2>::value>::type
 test_two()
@@ -175,7 +182,8 @@ test_two()
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 typename std::enable_if<!AreSame<TensorType1, TensorType2>::value>::type
 test_two()
@@ -183,7 +191,8 @@ test_two()
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 typename std::enable_if<(AreSame<TensorType1, SymmetricTensor>::value &&
                          AreSame<TensorType2, SymmetricTensor>::value)>::type
@@ -207,7 +216,8 @@ test_three()
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 typename std::enable_if<!(AreSame<TensorType1, SymmetricTensor>::value &&
                           AreSame<TensorType2, SymmetricTensor>::value)>::type
@@ -217,7 +227,8 @@ test_three()
 
 template <template <int, int, typename> class TensorType1,
           typename NumberType1,
-          template <int, int, typename> class TensorType2,
+          template <int, int, typename>
+          class TensorType2,
           typename NumberType2>
 void
 test_all()


### PR DESCRIPTION
Related to #11106, this shows the indentation with clang-format 11.
I am not opposed to updating but this will be a little annoying for everyone submitting a pull request at first. If we decide to do this, we also should also provide pre-compiled versions for various platforms which was a little of a struggle last time.

Some of the diffs are
```diff
diff --git a/include/deal.II/base/numbers.h b/include/deal.II/base/numbers.h
index 4e3432c7bc..452628021a 100644
--- a/include/deal.II/base/numbers.h
+++ b/include/deal.II/base/numbers.h
@@ -561,7 +561,7 @@ namespace numbers
 
   template <typename number>
   constexpr DEAL_II_CUDA_HOST_DEV const number &
-                                        NumberTraits<number>::conjugate(const number &x)
+  NumberTraits<number>::conjugate(const number &x)
   {
     return x;
   }
@@ -690,7 +690,7 @@ namespace internal
   struct NumberType
   {
     static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV const T &
-                                                                       value(const T &t)
+    value(const T &t)
     {
       return t;
     }
@@ -705,8 +705,8 @@ namespace internal
     // Type T is constructible from F.
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE DEAL_II_CUDA_HOST_DEV T
-                                                                 value(const F &f,
-                                                                       typename std::enable_if<
+    value(const F &f,
+          typename std::enable_if<
             !std::is_same<typename std::decay<T>::type,
                           typename std::decay<F>::type>::value &&
             std::is_constructible<T, F>::value>::type * = nullptr)
@@ -717,8 +717,8 @@ namespace internal
     // Type T is explicitly convertible (but not constructible) from F.
     template <typename F>
     static constexpr DEAL_II_ALWAYS_INLINE T
-                                           value(const F &f,
-                                                 typename std::enable_if<
+    value(const F &f,
+          typename std::enable_if<
             !std::is_same<typename std::decay<T>::type,
                           typename std::decay<F>::type>::value &&
             !std::is_constructible<T, F>::value &&
```
so there are at least some improvements.