### PR TITLE
Micro-optimization: Use move semantics in one place.

### DIFF
--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -692,7 +692,7 @@ namespace Particles
               }
 
             particles.emplace(local_cells_containing_particles[i_cell],
-                              particle);
+                              std::move(particle));
           }
       }
 


### PR DESCRIPTION
This is the last use of the variable in this location -- might as well move instead of
copy it.