### PR TITLE
Do not capture by reference in range-based for over IndexSet

### DIFF
--- a/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
@@ -135,7 +135,7 @@ namespace Utilities
           {
             recv_ranks.push_back(target_with_indexset.first);
 
-            for (const auto &cell_index : target_with_indexset.second)
+            for (const auto cell_index : target_with_indexset.second)
               recv_indices.push_back(cell_index);
 
             recv_ptr.push_back(recv_indices.size());
@@ -150,7 +150,7 @@ namespace Utilities
           {
             send_ranks.push_back(target_with_indexset.first);
 
-            for (const auto &cell_index : target_with_indexset.second)
+            for (const auto cell_index : target_with_indexset.second)
               send_indices.push_back(indexset_has.index_within_set(cell_index));
 
             send_ptr.push_back(send_indices.size() + recv_ptr.back());
@@ -171,14 +171,14 @@ namespace Utilities
       std::vector<types::global_dof_index> indices_has_clean;
       indices_has_clean.reserve(indices_has.size());
 
-      for (const auto &i : indices_has)
+      for (const auto i : indices_has)
         if (i != numbers::invalid_dof_index)
           indices_has_clean.push_back(i);
 
       std::vector<types::global_dof_index> indices_want_clean;
       indices_want_clean.reserve(indices_want.size());
 
-      for (const auto &i : indices_want)
+      for (const auto i : indices_want)
         if (i != numbers::invalid_dof_index)
           indices_want_clean.push_back(i);
 

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -599,7 +599,7 @@ namespace VectorTools
 
     // Compute the mean value of the sum which has been placed in
     // each entry of the output vector only at locally owned elements.
-    for (const auto &i : data_2.locally_owned_elements())
+    for (const auto i : data_2.locally_owned_elements())
       {
         const number touch_count_i =
           ::dealii::internal::ElementAccess<OutVector>::get(touch_count, i);

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -889,7 +889,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
 
       for (const auto &cell : tria.active_cell_iterators())
         {
-          for (const auto f : cell->face_indices())
+          for (const unsigned int f : cell->face_indices())
             {
               typename Triangulation<dim, spacedim>::face_iterator face =
                 cell->face(f);
@@ -919,7 +919,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
       for (const auto &cell : tria.active_cell_iterators())
         {
           // Little trick to get -1 for the interior
-          for (auto f : GeometryInfo<dim>::face_indices())
+          for (unsigned int f : GeometryInfo<dim>::face_indices())
             {
               out << ' '
                   << static_cast<std::make_signed<types::boundary_id>::type>(
@@ -4438,7 +4438,7 @@ namespace internal
           case 2:
             {
               for (const auto &cell : tria.active_cell_iterators())
-                for (const auto &line_no : cell->line_indices())
+                for (const unsigned int line_no : cell->line_indices())
                   {
                     typename dealii::Triangulation<dim, spacedim>::line_iterator
                       line = cell->line(line_no);
@@ -4608,7 +4608,7 @@ namespace internal
 
 
               for (const auto &cell : tria.active_cell_iterators())
-                for (const auto &line_no : cell->line_indices())
+                for (const unsigned int line_no : cell->line_indices())
                   {
                     typename dealii::Triangulation<dim, spacedim>::line_iterator
                       line = cell->line(line_no);
@@ -4797,7 +4797,7 @@ namespace internal
           // doing this multiply
           std::set<unsigned int> treated_vertices;
           for (const auto &cell : tria.active_cell_iterators())
-            for (const auto &vertex_no : cell->vertex_indices())
+            for (const unsigned int vertex_no : cell->vertex_indices())
               if (treated_vertices.find(cell->vertex_index(vertex_no)) ==
                   treated_vertices.end())
                 {

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -622,7 +622,7 @@ DynamicSparsityPattern::nonempty_rows() const
   std::vector<types::global_dof_index> rows;
   auto                                 line = lines.begin();
   AssertDimension(locally_stored_rows.n_elements(), lines.size());
-  for (const auto &row : locally_stored_rows)
+  for (const auto row : locally_stored_rows)
     {
       if (line->entries.size() > 0)
         rows.push_back(row);

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -603,7 +603,7 @@ namespace Particles
                   it.second.n_elements(),
                   std::vector<double>(n_properties_per_particle()));
                 unsigned int index = 0;
-                for (const auto &el : it.second)
+                for (const auto el : it.second)
                   properties_to_send[index++] = properties[el];
                 non_locally_owned_properties.insert(
                   {it.first, properties_to_send});
@@ -628,7 +628,7 @@ namespace Particles
                 std::vector<types::particle_index> ids_to_send(
                   it.second.n_elements());
                 unsigned int index = 0;
-                for (const auto &el : it.second)
+                for (const auto el : it.second)
                   ids_to_send[index++] = ids[el];
                 non_locally_owned_ids.insert({it.first, ids_to_send});
               }


### PR DESCRIPTION
As observed in #11074 and #11104, the OSX CI machines complain about us using a `const auto &i` to an `IndexSet`. We should capture that variable by value as it is simply an `unsigned int` or `unsigned long int`.