### PR TITLE
Switch SymmetricTensor -> Tensor for better performance

### DIFF
--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -912,7 +912,7 @@ namespace internal
             return;
           }
 
-        SymmetricTensor<2, n_functions> matrix;
+        Tensor<2, n_functions>          matrix;
         std::array<double, n_functions> shape_values;
         for (unsigned int q = 0; q < unit_support_points.size(); ++q)
           {
@@ -935,7 +935,7 @@ namespace internal
             // reference point positions which sets up an inverse
             // interpolation.
             for (unsigned int i = 0; i < n_functions; ++i)
-              for (unsigned int j = 0; j <= i; ++j)
+              for (unsigned int j = 0; j < n_functions; ++j)
                 matrix[i][j] += shape_values[i] * shape_values[j];
             for (unsigned int i = 0; i < n_functions; ++i)
               coefficients[i] += shape_values[i] * unit_support_points[q];


### PR DESCRIPTION
Follow-up to #11085: Some of my profiles revealed that using `SymmetricTensor` in loops which are not unrolled is a bad idea, because the access functionality is slow (like 10x the number of instructions compared to the new version with `Tensor`). Given that I don't know how to improve that I simply set up the full matrix on the stack despite its symmetry; computing it all allows the innermost loop to be vectorized by the compiler, which gains more speed than skipping the upper diagonal.