### PR TITLE
Fix Wedge::n_faces().

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -812,7 +812,7 @@ namespace ReferenceCell
         unsigned int
         n_faces() const override
         {
-          return 6;
+          return 5;
         }
 
         std::array<unsigned int, 2>


### PR DESCRIPTION
Wedges have five faces. I noticed this when writing tests for #10899.

/rebuild