### PR TITLE
Update ghost particles without rebuilding them

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -709,7 +709,10 @@ namespace Particles
 
     /**
      * Update all particles that live in cells that are ghost cells to
-     * other processes.
+     * other processes. In this context, update means to update the
+     * location and the properties of the ghost particles assuming that
+     * the ghost particles have not changed cells. Consquently, this will
+     * not update the reference location of the particles.
      */
     void
     update_ghost_particles();

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -708,6 +708,13 @@ namespace Particles
     exchange_ghost_particles();
 
     /**
+     * Update all particles that live in cells that are ghost cells to
+     * other processes.
+     */
+    void
+    update_ghost_particles();
+
+    /**
      * Callback function that should be called before every refinement
      * and when writing checkpoints. This function is used to
      * register store_particles() with the triangulation. This function
@@ -808,6 +815,14 @@ namespace Particles
      * particles are equivalent to the ghost entries in distributed vectors.
      */
     std::multimap<internal::LevelInd, Particle<dim, spacedim>> ghost_particles;
+
+    /**
+     * Set of particles that currently live in the ghost cells of the local
+     * domain, organized by the subdomain_id. These
+     * particles are equivalent to the ghost entries in distributed vectors.
+     */
+    std::map<types::subdomain_id, std::vector<particle_iterator>>
+      ghost_particles_by_domain;
 
     /**
      * This variable stores how many particles are stored globally. It is

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1233,14 +1233,12 @@ namespace Particles
     const auto parallel_triangulation =
       dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
         &*triangulation);
-    if (parallel_triangulation != nullptr)
+    if (parallel_triangulation == nullptr ||
+        dealii::Utilities::MPI::n_mpi_processes(
+          parallel_triangulation->get_communicator()) == 1)
       {
-        if (dealii::Utilities::MPI::n_mpi_processes(
-              parallel_triangulation->get_communicator()) == 1)
-          return;
+        return;
       }
-    else
-      return;
 
 #ifdef DEAL_II_WITH_MPI
     // First clear the current ghost_particle information
@@ -1707,8 +1705,8 @@ namespace Particles
 
     switch (status)
       {
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_PERSIST: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_PERSIST:
+          {
             auto position_hint = particles.end();
             for (const auto &particle : loaded_particles_on_cell)
               {
@@ -1727,8 +1725,8 @@ namespace Particles
           }
           break;
 
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_COARSEN: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_COARSEN:
+          {
             typename std::multimap<internal::LevelInd,
                                    Particle<dim, spacedim>>::iterator
               position_hint = particles.end();
@@ -1753,8 +1751,8 @@ namespace Particles
           }
           break;
 
-          case parallel::distributed::Triangulation<dim,
-                                                    spacedim>::CELL_REFINE: {
+        case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
+          {
             std::vector<
               typename std::multimap<internal::LevelInd,
                                      Particle<dim, spacedim>>::iterator>

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -90,6 +90,7 @@ namespace Particles
     , property_pool(std::make_unique<PropertyPool>(0))
     , particles()
     , ghost_particles()
+    , ghost_particles_by_domain()
     , global_number_of_particles(0)
     , global_max_particles_per_cell(0)
     , next_free_particle_index(0)
@@ -111,6 +112,7 @@ namespace Particles
     , property_pool(std::make_unique<PropertyPool>(n_properties))
     , particles()
     , ghost_particles()
+    , ghost_particles_by_domain()
     , global_number_of_particles(0)
     , global_max_particles_per_cell(0)
     , next_free_particle_index(0)
@@ -164,10 +166,11 @@ namespace Particles
     global_number_of_particles = particle_handler.global_number_of_particles;
     global_max_particles_per_cell =
       particle_handler.global_max_particles_per_cell;
-    next_free_particle_index = particle_handler.next_free_particle_index;
-    particles                = particle_handler.particles;
-    ghost_particles          = particle_handler.ghost_particles;
-    handle                   = particle_handler.handle;
+    next_free_particle_index  = particle_handler.next_free_particle_index;
+    particles                 = particle_handler.particles;
+    ghost_particles           = particle_handler.ghost_particles;
+    ghost_particles_by_domain = particle_handler.ghost_particles_by_domain;
+    handle                    = particle_handler.handle;
 
     // copy dynamic properties
     auto from_particle = particle_handler.begin();
@@ -1176,8 +1179,8 @@ namespace Particles
     // First clear the current ghost_particle information
     ghost_particles.clear();
 
-    std::map<types::subdomain_id, std::vector<particle_iterator>>
-      ghost_particles_by_domain;
+    ghost_particles_by_domain.clear();
+
 
     const std::set<types::subdomain_id> ghost_owners =
       parallel_triangulation->ghost_owners();
@@ -1217,6 +1220,31 @@ namespace Particles
               }
           }
       }
+
+    send_recv_particles(ghost_particles_by_domain, ghost_particles);
+#endif
+  }
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::update_ghost_particles()
+  {
+    // Nothing to do in serial computations
+    const auto parallel_triangulation =
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+        &*triangulation);
+    if (parallel_triangulation != nullptr)
+      {
+        if (dealii::Utilities::MPI::n_mpi_processes(
+              parallel_triangulation->get_communicator()) == 1)
+          return;
+      }
+    else
+      return;
+
+#ifdef DEAL_II_WITH_MPI
+    // First clear the current ghost_particle information
+    ghost_particles.clear();
 
     send_recv_particles(ghost_particles_by_domain, ghost_particles);
 #endif
@@ -1679,8 +1707,8 @@ namespace Particles
 
     switch (status)
       {
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_PERSIST:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_PERSIST: {
             auto position_hint = particles.end();
             for (const auto &particle : loaded_particles_on_cell)
               {
@@ -1699,8 +1727,8 @@ namespace Particles
           }
           break;
 
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_COARSEN:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_COARSEN: {
             typename std::multimap<internal::LevelInd,
                                    Particle<dim, spacedim>>::iterator
               position_hint = particles.end();
@@ -1725,8 +1753,8 @@ namespace Particles
           }
           break;
 
-        case parallel::distributed::Triangulation<dim, spacedim>::CELL_REFINE:
-          {
+          case parallel::distributed::Triangulation<dim,
+                                                    spacedim>::CELL_REFINE: {
             std::vector<
               typename std::multimap<internal::LevelInd,
                                      Particle<dim, spacedim>>::iterator>

--- a/tests/particles/particle_handler_19.cc
+++ b/tests/particles/particle_handler_19.cc
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// like particle_handler_06, but after exchanging the ghost particles
+// modifies the location of the particles and updates them through
+// the update_ghosts mechanism. This test also adds a single property
+// to the particles. This property is also modified and then updated
+// through the update_ghosts mechanism.
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(2);
+    MappingQ<dim, spacedim> mapping(1);
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping, 1);
+
+    Point<spacedim> position;
+    Point<dim>      reference_position;
+
+    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+      for (unsigned int i = 0; i < dim; ++i)
+        position(i) = 0.475;
+    else
+      for (unsigned int i = 0; i < dim; ++i)
+        position(i) = 0.525;
+
+    Particles::Particle<dim, spacedim> particle(
+      position,
+      reference_position,
+      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+    typename Triangulation<dim, spacedim>::active_cell_iterator cell =
+      tr.begin_active();
+    particle_handler.insert_particle(particle, cell);
+
+    particle_handler.sort_particles_into_subdomains_and_cells();
+
+    // Set the properties of the particle to be a unique number
+    for (auto particle = particle_handler.begin();
+         particle != particle_handler.end();
+         ++particle)
+      {
+        particle->get_properties()[0] =
+          10 + Utilities::MPI::this_mpi_process(tr.get_communicator());
+      }
+
+
+    particle_handler.exchange_ghost_particles();
+
+    for (auto particle = particle_handler.begin();
+         particle != particle_handler.end();
+         ++particle)
+      deallog << "Particle id : " << particle->get_id()
+              << " location : " << particle->get_location()
+              << " property : " << particle->get_properties()[0]
+              << " is local on process : "
+              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << std::endl;
+
+    for (auto particle = particle_handler.begin_ghost();
+         particle != particle_handler.end_ghost();
+         ++particle)
+      deallog << "Particle id : " << particle->get_id()
+              << " location : " << particle->get_location()
+              << " property : " << particle->get_properties()[0]
+              << " is ghost on process : "
+              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << std::endl;
+
+    deallog << "Modifying particles positions and properties" << std::endl;
+
+    // Modify the location of a single particle on processor 0 and update the
+    // ghosts
+    for (auto particle = particle_handler.begin();
+         particle != particle_handler.end();
+         ++particle)
+      {
+        auto location = particle->get_location();
+        location[0] += 0.1;
+        particle->get_properties()[0] += 10;
+        particle->set_location(location);
+      }
+    particle_handler.update_ghost_particles();
+
+    for (auto particle = particle_handler.begin();
+         particle != particle_handler.end();
+         ++particle)
+      deallog << "Particle id : " << particle->get_id()
+              << " location : " << particle->get_location()
+              << " property : " << particle->get_properties()[0]
+              << " is local on process : "
+              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << std::endl;
+
+    for (auto particle = particle_handler.begin_ghost();
+         particle != particle_handler.end_ghost();
+         ++particle)
+      deallog << "Particle id : " << particle->get_id()
+              << " location : " << particle->get_location()
+              << " property : " << particle->get_properties()[0]
+              << " is ghost on process : "
+              << Utilities::MPI::this_mpi_process(tr.get_communicator())
+              << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("2d/3d");
+  test<2, 3>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/particle_handler_19.with_p4est=true.mpirun=2.output
+++ b/tests/particles/particle_handler_19.with_p4est=true.mpirun=2.output
@@ -1,0 +1,39 @@
+
+DEAL:0:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 is ghost on process : 0
+DEAL:0:2d/2d::Modifying particles positions and properties
+DEAL:0:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 is ghost on process : 0
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 is ghost on process : 0
+DEAL:0:2d/3d::Modifying particles positions and properties
+DEAL:0:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 is ghost on process : 0
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 is ghost on process : 0
+DEAL:0:3d/3d::Modifying particles positions and properties
+DEAL:0:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 is ghost on process : 0
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 is local on process : 1
+DEAL:1:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 is ghost on process : 1
+DEAL:1:2d/2d::Modifying particles positions and properties
+DEAL:1:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 is local on process : 1
+DEAL:1:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 is ghost on process : 1
+DEAL:1:2d/2d::OK
+DEAL:1:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 is local on process : 1
+DEAL:1:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 is ghost on process : 1
+DEAL:1:2d/3d::Modifying particles positions and properties
+DEAL:1:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 is local on process : 1
+DEAL:1:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 is ghost on process : 1
+DEAL:1:2d/3d::OK
+DEAL:1:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 is local on process : 1
+DEAL:1:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 is ghost on process : 1
+DEAL:1:3d/3d::Modifying particles positions and properties
+DEAL:1:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 is local on process : 1
+DEAL:1:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 is ghost on process : 1
+DEAL:1:3d/3d::OK
+


### PR DESCRIPTION
This is a work in progress ([WIP])
This PR aims at allowing for a function that updates the ghost particles without rebuilding them from scratch. Many numerical methods don't require that the particle interact with the mesh at every time step (e.g. MD based methods or DEM). This PR aims at addressing #11093 .

- [X] Create an update_ghost_particles function and move the necessary containers to particle_handler class member. In the update_ghost_particles remove the loop to generate the ghost_particles_by_domain
- [x] Add a unit test for ghost updates
- [ ] Modify send_rcv_particles (or write a new function alltogether) to enable updating existing particles without recreating them from scratch. This part i will do with the advices @peterrum (thanks again for helping me with this :).

The first modification already implemented allowed us a speed up of 100% in our DEM code on 2 cores (from 280s to 127s) and a 30% (103s to 72s) at 16 core. So this is already extremely significant. I think it's the last optimization we need in our case. This will also make the particle_handler a very very flexible class!