### PR TITLE
Transfinite interpolation: Fix refresh of Jacobian

### DIFF
--- a/source/grid/manifold_lib.cc
+++ b/source/grid/manifold_lib.cc
@@ -2154,13 +2154,14 @@ TransfiniteInterpolationManifold<dim, spacedim>::pull_back(
       const Tensor<1, spacedim> old_residual = residual;
       while (alpha > 1e-4)
         {
-          Point<dim> guess = chart_point + alpha * update;
-          residual =
+          Point<dim>                guess = chart_point + alpha * update;
+          const Tensor<1, spacedim> residual_guess =
             point - compute_transfinite_interpolation(
                       *cell, guess, coarse_cell_is_flat[cell->index()]);
-          const double residual_norm_new = residual.norm_square();
+          const double residual_norm_new = residual_guess.norm_square();
           if (residual_norm_new < residual_norm_square)
             {
+              residual             = residual_guess;
               residual_norm_square = residual_norm_new;
               chart_point += alpha * update;
               break;
@@ -2198,7 +2199,7 @@ TransfiniteInterpolationManifold<dim, spacedim>::pull_back(
       // prevent division by zero. This number should be scale-invariant
       // because Jinv_deltaf carries no units and x is in reference
       // coordinates.
-      if (std::abs(delta_x * Jinv_deltaf) > 1e-12)
+      if (std::abs(delta_x * Jinv_deltaf) > 1e-12 && !must_recompute_jacobian)
         {
           const Tensor<1, dim> factor =
             (delta_x - Jinv_deltaf) / (delta_x * Jinv_deltaf);


### PR DESCRIPTION
In case the line search of the `pull_back()` function in the transfinite interpolation fails, the cause could be an inaccurate Jacobian approximation with Broyden's method. Thus, the code tries to compute a fresh Jacobian with finite differences. However, in that case the old code would use a spurious value of `residual` that resulted in the failure. We should compute a `residual_guess` at the temporary point `guess`, and only accept it as the new residual in case the line search succeeds.

@tamiko FYI.