### PR TITLE
Transfinite interpolation: inverse quadratic approximation in pull-back

### DIFF
--- a/doc/news/changes/minor/20201101MartinKronbichler
+++ b/doc/news/changes/minor/20201101MartinKronbichler
@@ -1,0 +1,6 @@
+Improved: An inverse quadratic approximation has been added for the pull-back
+operation in the TransfiniteInterpolationManifold::new_points() function. The
+better initial guesses for the Newton/Broyden iteration make the computation
+faster and more robust in some difficult scenarios.
+<br>
+(Martin Kronbichler, 2020/11/01)

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -997,11 +997,17 @@ namespace internal
       }
 
       /**
+       * Copy constructor.
+       */
+      InverseQuadraticApproximation(const InverseQuadraticApproximation &) =
+        default;
+
+      /**
        * Evaluate the quadratic approximation.
        */
       template <typename Number>
       Point<dim, Number>
-      compute(const Point<spacedim, Number> &p)
+      compute(const Point<spacedim, Number> &p) const
       {
         Point<dim, Number> result;
         for (unsigned int d = 0; d < dim; ++d)

--- a/include/deal.II/grid/manifold_lib.h
+++ b/include/deal.II/grid/manifold_lib.h
@@ -26,6 +26,17 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// forward declaration
+namespace internal
+{
+  namespace MappingQGenericImplementation
+  {
+    template <int, int>
+    class InverseQuadraticApproximation;
+  }
+} // namespace internal
+
+
 /**
  * Manifold description for a polar coordinate system.
  *
@@ -1132,6 +1143,14 @@ private:
    * use a FlatManifold description.
    */
   FlatManifold<dim> chart_manifold;
+
+  /**
+   * A vector of quadratic approximations to the inverse map from real points
+   * to chart points for each of the coarse mesh cells.
+   */
+  std::vector<internal::MappingQGenericImplementation::
+                InverseQuadraticApproximation<dim, spacedim>>
+    quadratic_approximation;
 
   /**
    * The connection to Triangulation::signals::clear that must be reset once


### PR DESCRIPTION
This PR adds the inverse quadratic approximation introduced in #11085 for transfinite interpolation. I construct the least squares fit on the points of a bi-/triquadratic forward operation, which makes the initial guess much better for curved cells, see also the test case added in #11085, https://github.com/dealii/dealii/blob/2d712df2abcc2da14253ed41288146364607311a/tests/mappings/mapping_q_inverse_quadratic_approximation.output#L50-L63 for a difference between an affine map and a quadratic one.

The question is whether we want to construct the least squares fit with say `4^dim` points rather than the minimum of `3^dim`. In general, the inverse map should become slightly better with more points. On the other hand, there are only 10 degrees of freedom for the quadratic function in 3d, and already 27 points with the tri-quadratic points for least squares, so I won't expect to get much more information.