### PR TITLE
fix type in Physics rotation_matrix_2d and 3d

### DIFF
--- a/include/deal.II/physics/transformations.h
+++ b/include/deal.II/physics/transformations.h
@@ -944,7 +944,7 @@ template <typename Number>
 Tensor<2, 2, Number>
 Physics::Transformations::Rotations::rotation_matrix_2d(const Number &angle)
 {
-  const double rotation[2][2] = {{std::cos(angle), -std::sin(angle)},
+  const Number rotation[2][2] = {{std::cos(angle), -std::sin(angle)},
                                  {std::sin(angle), std::cos(angle)}};
   return Tensor<2, 2>(rotation);
 }
@@ -962,7 +962,7 @@ Physics::Transformations::Rotations::rotation_matrix_3d(
   const Number c              = std::cos(angle);
   const Number s              = std::sin(angle);
   const Number t              = 1. - c;
-  const double rotation[3][3] = {{t * axis[0] * axis[0] + c,
+  const Number rotation[3][3] = {{t * axis[0] * axis[0] + c,
                                   t * axis[0] * axis[1] - s * axis[2],
                                   t * axis[0] * axis[2] + s * axis[1]},
                                  {t * axis[0] * axis[1] + s * axis[2],


### PR DESCRIPTION
The values were computed as doubles, which means this function can not
be used with Number=float (no constructor for Tensor exists). Fix this.