### PR TITLE
set number_cache.n_global_dofs to the right size in MultiGrid scenario

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -4561,7 +4561,7 @@ namespace internal
 
         NumberCache number_cache;
         number_cache.locally_owned_dofs = index_set;
-        number_cache.n_global_dofs      = dof_handler->n_dofs();
+        number_cache.n_global_dofs      = dof_handler->n_dofs(level);
         number_cache.n_locally_owned_dofs =
           number_cache.locally_owned_dofs.n_elements();
         return number_cache;


### PR DESCRIPTION
This should hopefully fix the problem, that after reordering of MG DoFs the number of level DoFs was set wrongly to the global number of DoFs, discussed [here](https://groups.google.com/forum/#!topic/dealii/VTrZS9xmk_I)