### PR TITLE
[WIP] Enable element activation distributed::SolutionTransfer

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -2060,6 +2060,27 @@ public:
    */
   unsigned int
   dominated_future_fe_on_children() const;
+
+  /**
+   * Return the fe_index of the finite element that was assigned to this
+   * cell before the triangulation gets refined and coarsened.
+   */
+  unsigned int
+  past_fe_index() const;
+
+  /**
+   * Set the fe_index of the finite element that was assigned to this
+   * cell next time the triangulation gets refined and coarsened. A previously
+   * assigned past finite element will be overwritten.
+   */
+  void
+  set_past_fe_index(const unsigned int i) const;
+
+  /**
+   * Return whether a past finite element has been set.
+   */
+  bool
+  past_fe_index_set() const;
   /**
    * @}
    */

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1505,6 +1505,13 @@ private:
     hp_cell_future_fe_indices;
 
   /**
+   * Past fe index of an active cell (identified by level and level index).
+   * This vector is only used in hp mode.
+   */
+  mutable std::vector<std::vector<active_fe_index_type>>
+    hp_cell_past_fe_indices;
+
+  /**
    * An array to store the indices for level degrees of freedom located at
    * vertices.
    */
@@ -1966,6 +1973,7 @@ DoFHandler<dim, spacedim>::save(Archive &ar, const unsigned int) const
 
       ar & this->hp_cell_active_fe_indices;
       ar & this->hp_cell_future_fe_indices;
+      ar & this->hp_cell_past_fe_indices;
 
       ar &hp_object_fe_ptr;
       ar &hp_object_fe_indices;
@@ -2022,6 +2030,7 @@ DoFHandler<dim, spacedim>::load(Archive &ar, const unsigned int)
 
       ar & this->hp_cell_active_fe_indices;
       ar & this->hp_cell_future_fe_indices;
+      ar & this->hp_cell_past_fe_indices;
 
       ar &hp_object_fe_ptr;
       ar &hp_object_fe_indices;

--- a/tests/hp/distributed_solution_transfer_02.cc
+++ b/tests/hp/distributed_solution_transfer_02.cc
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test parallel::distributed::SolutionTransfer for FE_Nothing
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+transfer(const MPI_Comm &comm, int test)
+{
+  AssertDimension(Utilities::MPI::n_mpi_processes(comm), 1);
+
+  parallel::distributed::Triangulation<dim> tria(comm);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(1);
+
+  hp::FECollection<dim> fe;
+  fe.push_back(FE_Q<dim>(1));
+  fe.push_back(FE_Nothing<dim>());
+
+  // create a DoFHandler on which we have both cells with FE_Q as well as
+  // FE_Nothing
+  DoFHandler<dim> dof_handler(tria, true);
+  int             i = 0;
+  if (test == 0)
+    {
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          if (i >= 2)
+            cell->set_active_fe_index(1);
+          ++i;
+        }
+    }
+  else
+    {
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          if (i < 2)
+            cell->set_active_fe_index(1);
+          ++i;
+        }
+    }
+
+
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+  LinearAlgebra::distributed::Vector<double> solution(
+    dof_handler.locally_owned_dofs(), locally_relevant_dofs, comm);
+  AffineConstraints<double> cm;
+  cm.close();
+
+  dof_handler.distribute_dofs(fe);
+  solution.reinit(dof_handler.n_dofs());
+
+  for (unsigned int i = 0; i < solution.size(); ++i)
+    solution(i) = i;
+
+  parallel::distributed::
+    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
+      soltrans(dof_handler);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    cell->set_future_fe_index(0);
+
+  LinearAlgebra::distributed::Vector<double> old_solution = solution;
+
+  tria.prepare_coarsening_and_refinement();
+  soltrans.prepare_for_coarsening_and_refinement(old_solution);
+  tria.execute_coarsening_and_refinement();
+  dof_handler.distribute_dofs(fe);
+  solution.reinit(dof_handler.n_dofs());
+
+  soltrans.interpolate(solution);
+
+  if (test == 0)
+    {
+      std::vector<double> ref = {0., 1., 2., 3., 4., 5., 0., 0., 0.};
+      for (unsigned int i = 0; i < ref.size(); ++i)
+        {
+          AssertThrow(std::abs(solution[i] - ref[i]) < 1e-12,
+                      ExcInternalError());
+        }
+    }
+  else
+    {
+      std::vector<double> ref = {0., 0., 0., 1., 0., 4., 2., 3., 5.};
+      for (unsigned int i = 0; i < ref.size(); ++i)
+        AssertThrow(std::abs(solution[i] - ref[i]) < 1e-12, ExcInternalError());
+    }
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  const MPI_Comm comm = MPI_COMM_WORLD;
+  initlog();
+
+  deallog.push("2D solution transfer");
+  transfer<2>(comm, 0);
+  transfer<2>(comm, 1);
+  deallog << "OK" << std::endl;
+  deallog.pop();
+}

--- a/tests/hp/distributed_solution_transfer_02.mpirun=1.output
+++ b/tests/hp/distributed_solution_transfer_02.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:2D solution transfer::OK

--- a/tests/hp/distributed_solution_transfer_03.cc
+++ b/tests/hp/distributed_solution_transfer_03.cc
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test parallel::distributed::SolutionTransfer for FE_Nothing with MPI
+
+#include <deal.II/base/function.h>
+
+#include <deal.II/distributed/solution_transfer.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_nothing.h>
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_refinement.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <iostream>
+#include <vector>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+transfer(const MPI_Comm &comm, int test)
+{
+  parallel::distributed::Triangulation<dim> tria(comm);
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  hp::FECollection<dim> fe;
+  fe.push_back(FE_Q<dim>(1));
+  fe.push_back(FE_Nothing<dim>());
+
+  // create a DoFHandler on which we have both cells with FE_Q as well as
+  // FE_Nothing
+  DoFHandler<dim> dof_handler(tria, true);
+  int             i = 0;
+  if (test == 0)
+    {
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          if (cell->is_locally_owned())
+            if (cell->center()[1] < 0.5)
+              cell->set_active_fe_index(1);
+        }
+    }
+  else
+    {
+      for (const auto &cell : dof_handler.active_cell_iterators())
+        {
+          if (cell->is_locally_owned())
+            {
+              if (i < 2)
+                cell->set_active_fe_index(1);
+              ++i;
+            }
+        }
+    }
+  AffineConstraints<double> cm;
+  cm.close();
+
+  dof_handler.distribute_dofs(fe);
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+  dof_handler.locally_owned_dofs().print(std::cout);
+  locally_relevant_dofs.print(std::cout);
+
+  LinearAlgebra::distributed::Vector<double> solution(
+    dof_handler.locally_owned_dofs(), locally_relevant_dofs, comm);
+
+  for (unsigned int i = 0; i < solution.local_size(); ++i)
+    solution.local_element(i) = i;
+  solution.compress(VectorOperation::insert);
+  solution.update_ghost_values();
+
+  solution.print(std::cout);
+
+  parallel::distributed::
+    SolutionTransfer<dim, LinearAlgebra::distributed::Vector<double>>
+      soltrans(dof_handler);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    if (cell->is_locally_owned())
+      cell->set_future_fe_index(0);
+
+  tria.prepare_coarsening_and_refinement();
+  soltrans.prepare_for_coarsening_and_refinement(solution);
+  tria.execute_coarsening_and_refinement();
+  dof_handler.distribute_dofs(fe);
+
+  IndexSet new_locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler,
+                                          new_locally_relevant_dofs);
+  LinearAlgebra::distributed::Vector<double> interpolated_solution(
+    dof_handler.locally_owned_dofs(), new_locally_relevant_dofs, comm);
+
+  soltrans.interpolate(interpolated_solution);
+
+  MPI_Barrier(MPI_COMM_WORLD);
+  std::cout << "-------------------------" << std::endl;
+  solution.print(std::cout);
+
+  // if (test == 0)
+  //   {
+  //     std::vector<double> ref = {0., 1., 2., 3., 4., 5., 0., 0., 0.};
+  //     for (unsigned int i = 0; i < ref.size(); ++i)
+  //       {
+  //         AssertThrow(std::abs(solution[i] - ref[i]) < 1e-12,
+  //                     ExcInternalError());
+  //       }
+  //   }
+  // else
+  //   {
+  //     std::vector<double> ref = {0., 0., 0., 1., 0., 4., 2., 3., 5.};
+  //     for (unsigned int i = 0; i < ref.size(); ++i)
+  //       AssertThrow(std::abs(solution[i] - ref[i]) < 1e-12,
+  //       ExcInternalError());
+  //   }
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  const MPI_Comm comm = MPI_COMM_WORLD;
+  initlog();
+
+  deallog.push("2D solution transfer");
+  transfer<2>(comm, 0);
+  //  transfer<2>(comm, 1);
+  deallog << "OK" << std::endl;
+  deallog.pop();
+}

--- a/tests/hp/distributed_solution_transfer_03.mpirun=2.output
+++ b/tests/hp/distributed_solution_transfer_03.mpirun=2.output
@@ -1,0 +1,2 @@
+
+DEAL:2D solution transfer::OK


### PR DESCRIPTION
I am trying to extent `distributed::SolutionTransfer` but I am stuck and I would appreciate any pointer (@marcfehling ?). Here is what I want to achieve, I want to be able to activate cell over time, i.e., I want to be able to do `p-refinement` where a cell changes from `FE_Nothing` to `FE_Q`. After activating new cells, we end up with new dofs whose values cannot be determined from the interpolation from the previous mesh. Ideally, I would set the values in the vector before `interpolate` and `interpolate` would not touch these values since it doesn't know how to treat them anyway. Currently if `FE_Nothing` is attached to a cell, the cell is skipped in the `pack_data` and `unpack_data` functions. This doesn't allow for a `FE_Nothing` cell to change to an active cell (non-`FE_Nothing` cell). To fix that I have created a new variable `past_fe_index` similar to `future_fe_index`. This record the `fe_index` before refinement and this allows me to skip cells that were `FE_Nothing` but that have been activated. This works in serial and does what I want. However, a problem appears when using MPI. Let's assume that you have two processors and on one processor all the cells are `FE_Nothing`. This processor won't do anything while the other correctly interpolates the values. Everything is fine until we call `compress(VectorOperation::insert)`. Now the locally owned value and the ghost value don't match and the code crashes. Note that in the case described here, the dofs can migrate from one processor to the other and so the ghost value has the correct value and the locally owned value is wrong. I could try to introduce a new version of `compress` that does the right thing but I was hoping that someone had a better solution.
