### PR TITLE
Finish mechanism for the update of ghost particles

### DIFF
--- a/doc/news/changes/major/20201110Blais
+++ b/doc/news/changes/major/20201110Blais
@@ -1,0 +1,3 @@
+New: Added capacity to update ghost particles without rebuilding them from scratch in the particle_handler
+<br>
+(Bruno Blais, Peter Munch, 2020/11/10)

--- a/include/deal.II/base/mpi_tags.h
+++ b/include/deal.II/base/mpi_tags.h
@@ -109,6 +109,8 @@ namespace Utilities
           /// ParticleHandler<dim, spacedim>::send_recv_particles
           particle_handler_send_recv_particles_setup,
           /// ParticleHandler<dim, spacedim>::send_recv_particles
+          particle_handler_send_recv_particles_cache_setup,
+          /// ParticleHandler<dim, spacedim>::send_recv_particles
           particle_handler_send_recv_particles_send,
 
           /// ScaLAPACKMatrix<NumberType>::copy_to

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -416,6 +416,12 @@ namespace Particles
     void
     load(Archive &ar, const unsigned int version);
 
+    /**
+     * Free the memory of the property pool
+     */
+    void
+    free_properties();
+
 #ifdef DOXYGEN
     /**
      * Write and read the data of this object from a stream for the purpose

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -180,6 +180,14 @@ namespace Particles
       property_pool->deallocate_properties_array(properties);
   }
 
+  template <int dim, int spacedim>
+  void
+  Particle<dim, spacedim>::free_properties()
+  {
+    if (property_pool != nullptr && properties != PropertyPool::invalid_handle)
+      property_pool->deallocate_properties_array(properties);
+  }
+
 
 
   template <int dim, int spacedim>

--- a/tests/particles/particle_handler_19.with_p4est=true.mpirun=2.output
+++ b/tests/particles/particle_handler_19.with_p4est=true.mpirun=2.output
@@ -1,39 +1,39 @@
 
-DEAL:0:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 is local on process : 0
-DEAL:0:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 is ghost on process : 0
+DEAL:0:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 and 100.000 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 and 101.000 is ghost on process : 0
 DEAL:0:2d/2d::Modifying particles positions and properties
-DEAL:0:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 is local on process : 0
-DEAL:0:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 is ghost on process : 0
+DEAL:0:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 and 200.000 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 and 201.000 is ghost on process : 0
 DEAL:0:2d/2d::OK
-DEAL:0:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 is local on process : 0
-DEAL:0:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 is ghost on process : 0
+DEAL:0:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 and 100.000 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 and 101.000 is ghost on process : 0
 DEAL:0:2d/3d::Modifying particles positions and properties
-DEAL:0:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 is local on process : 0
-DEAL:0:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 is ghost on process : 0
+DEAL:0:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 and 200.000 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 and 201.000 is ghost on process : 0
 DEAL:0:2d/3d::OK
-DEAL:0:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 is local on process : 0
-DEAL:0:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 is ghost on process : 0
+DEAL:0:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 and 100.000 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 and 101.000 is ghost on process : 0
 DEAL:0:3d/3d::Modifying particles positions and properties
-DEAL:0:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 is local on process : 0
-DEAL:0:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 is ghost on process : 0
+DEAL:0:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 and 200.000 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 and 201.000 is ghost on process : 0
 DEAL:0:3d/3d::OK
 
-DEAL:1:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 is local on process : 1
-DEAL:1:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 1 location : 0.525000 0.525000 property : 11.0000 and 101.000 is local on process : 1
+DEAL:1:2d/2d::Particle id : 0 location : 0.475000 0.475000 property : 10.0000 and 100.000 is ghost on process : 1
 DEAL:1:2d/2d::Modifying particles positions and properties
-DEAL:1:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 is local on process : 1
-DEAL:1:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 1 location : 0.625000 0.525000 property : 21.0000 and 201.000 is local on process : 1
+DEAL:1:2d/2d::Particle id : 0 location : 0.575000 0.475000 property : 20.0000 and 200.000 is ghost on process : 1
 DEAL:1:2d/2d::OK
-DEAL:1:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 is local on process : 1
-DEAL:1:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 1 location : 0.525000 0.525000 0.00000 property : 11.0000 and 101.000 is local on process : 1
+DEAL:1:2d/3d::Particle id : 0 location : 0.475000 0.475000 0.00000 property : 10.0000 and 100.000 is ghost on process : 1
 DEAL:1:2d/3d::Modifying particles positions and properties
-DEAL:1:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 is local on process : 1
-DEAL:1:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 1 location : 0.625000 0.525000 0.00000 property : 21.0000 and 201.000 is local on process : 1
+DEAL:1:2d/3d::Particle id : 0 location : 0.575000 0.475000 0.00000 property : 20.0000 and 200.000 is ghost on process : 1
 DEAL:1:2d/3d::OK
-DEAL:1:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 is local on process : 1
-DEAL:1:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 1 location : 0.525000 0.525000 0.525000 property : 11.0000 and 101.000 is local on process : 1
+DEAL:1:3d/3d::Particle id : 0 location : 0.475000 0.475000 0.475000 property : 10.0000 and 100.000 is ghost on process : 1
 DEAL:1:3d/3d::Modifying particles positions and properties
-DEAL:1:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 is local on process : 1
-DEAL:1:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 1 location : 0.625000 0.525000 0.525000 property : 21.0000 and 201.000 is local on process : 1
+DEAL:1:3d/3d::Particle id : 0 location : 0.575000 0.475000 0.475000 property : 20.0000 and 200.000 is ghost on process : 1
 DEAL:1:3d/3d::OK
 

--- a/tests/particles/particle_handler_20.with_p4est=true.mpirun=2.output
+++ b/tests/particles/particle_handler_20.with_p4est=true.mpirun=2.output
@@ -1,0 +1,51 @@
+
+DEAL:0:2d/2d::Particle id : 0 location : 0.410000 0.410000 property : 1000.00 and 2000.00 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.420000 0.420000 property : 1010.00 and 2010.00 is local on process : 0
+DEAL:0:2d/2d::Particle id : 2 location : 0.430000 0.430000 property : 1020.00 and 2020.00 is local on process : 0
+DEAL:0:2d/2d::Modifying particles positions and properties
+DEAL:0:2d/2d::Particle id : 0 location : 0.510000 0.410000 property : 11000.0 and 12000.0 is local on process : 0
+DEAL:0:2d/2d::Particle id : 1 location : 0.520000 0.420000 property : 11010.0 and 12010.0 is local on process : 0
+DEAL:0:2d/2d::Particle id : 2 location : 0.530000 0.430000 property : 11020.0 and 12020.0 is local on process : 0
+DEAL:0:2d/2d::OK
+DEAL:0:2d/3d::Particle id : 0 location : 0.410000 0.410000 0.00000 property : 1000.00 and 2000.00 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.420000 0.420000 0.00000 property : 1010.00 and 2010.00 is local on process : 0
+DEAL:0:2d/3d::Particle id : 2 location : 0.430000 0.430000 0.00000 property : 1020.00 and 2020.00 is local on process : 0
+DEAL:0:2d/3d::Modifying particles positions and properties
+DEAL:0:2d/3d::Particle id : 0 location : 0.510000 0.410000 0.00000 property : 11000.0 and 12000.0 is local on process : 0
+DEAL:0:2d/3d::Particle id : 1 location : 0.520000 0.420000 0.00000 property : 11010.0 and 12010.0 is local on process : 0
+DEAL:0:2d/3d::Particle id : 2 location : 0.530000 0.430000 0.00000 property : 11020.0 and 12020.0 is local on process : 0
+DEAL:0:2d/3d::OK
+DEAL:0:3d/3d::Particle id : 0 location : 0.410000 0.410000 0.410000 property : 1000.00 and 2000.00 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.420000 0.420000 0.420000 property : 1010.00 and 2010.00 is local on process : 0
+DEAL:0:3d/3d::Particle id : 2 location : 0.430000 0.430000 0.430000 property : 1020.00 and 2020.00 is local on process : 0
+DEAL:0:3d/3d::Modifying particles positions and properties
+DEAL:0:3d/3d::Particle id : 0 location : 0.510000 0.410000 0.410000 property : 11000.0 and 12000.0 is local on process : 0
+DEAL:0:3d/3d::Particle id : 1 location : 0.520000 0.420000 0.420000 property : 11010.0 and 12010.0 is local on process : 0
+DEAL:0:3d/3d::Particle id : 2 location : 0.530000 0.430000 0.430000 property : 11020.0 and 12020.0 is local on process : 0
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Particle id : 0 location : 0.410000 0.410000 property : 1000.00 and 2000.00 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 1 location : 0.420000 0.420000 property : 1010.00 and 2010.00 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 2 location : 0.430000 0.430000 property : 1020.00 and 2020.00 is ghost on process : 1
+DEAL:1:2d/2d::Modifying particles positions and properties
+DEAL:1:2d/2d::Particle id : 0 location : 0.510000 0.410000 property : 11000.0 and 12000.0 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 1 location : 0.520000 0.420000 property : 11010.0 and 12010.0 is ghost on process : 1
+DEAL:1:2d/2d::Particle id : 2 location : 0.530000 0.430000 property : 11020.0 and 12020.0 is ghost on process : 1
+DEAL:1:2d/2d::OK
+DEAL:1:2d/3d::Particle id : 0 location : 0.410000 0.410000 0.00000 property : 1000.00 and 2000.00 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 1 location : 0.420000 0.420000 0.00000 property : 1010.00 and 2010.00 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 2 location : 0.430000 0.430000 0.00000 property : 1020.00 and 2020.00 is ghost on process : 1
+DEAL:1:2d/3d::Modifying particles positions and properties
+DEAL:1:2d/3d::Particle id : 0 location : 0.510000 0.410000 0.00000 property : 11000.0 and 12000.0 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 1 location : 0.520000 0.420000 0.00000 property : 11010.0 and 12010.0 is ghost on process : 1
+DEAL:1:2d/3d::Particle id : 2 location : 0.530000 0.430000 0.00000 property : 11020.0 and 12020.0 is ghost on process : 1
+DEAL:1:2d/3d::OK
+DEAL:1:3d/3d::Particle id : 0 location : 0.410000 0.410000 0.410000 property : 1000.00 and 2000.00 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 1 location : 0.420000 0.420000 0.420000 property : 1010.00 and 2010.00 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 2 location : 0.430000 0.430000 0.430000 property : 1020.00 and 2020.00 is ghost on process : 1
+DEAL:1:3d/3d::Modifying particles positions and properties
+DEAL:1:3d/3d::Particle id : 0 location : 0.510000 0.410000 0.410000 property : 11000.0 and 12000.0 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 1 location : 0.520000 0.420000 0.420000 property : 11010.0 and 12010.0 is ghost on process : 1
+DEAL:1:3d/3d::Particle id : 2 location : 0.530000 0.430000 0.430000 property : 11020.0 and 12020.0 is ghost on process : 1
+DEAL:1:3d/3d::OK
+


### PR DESCRIPTION
In this PR, we add a new feature that allow ghost particles to be recreated without recreating the map from scratch.
This is achieved by caching the necessary communication information in a new send_recv_cache_particles function (which at the moment has a lot of code duplication from send_recv_particles, but this was the least invasive way to do this).
Then we have a new function which only takes care of the update of particles themselves without altering the map.
The code could be made even more efficient by replacing the "destruction/deallocation/reconstruction" of the particles by a new Particle function that would "rewrite/update" the particle data. This would be done in  a follow-up PR.

The code is still a WIP, but it works. We have seen crazy performance improvement (from 2x to 6x as fast on 16 cores) on our applications. For us this PR is a game changer. Simulations that took days now take a few hours.

Right now the code is still in an ugly state (and I hate the fact that I had to copy over send_recv_particles). I will try to clean it ASAP, but I welcome any comments on how to make this better.
Again, this really makes me doubt that the multimap was the right structure for particle, but changing the particle container is out of the scope of the present PR. 



This closes #11093 