### PR TITLE
Deprecate DoFHandler initialization interface.

### DIFF
--- a/doc/news/changes/incompatibilities/20201030Fehling
+++ b/doc/news/changes/incompatibilities/20201030Fehling
@@ -1,0 +1,8 @@
+Deprecated: The initialization interface for the DoFHandler class has
+changed. DoFHandler::initialize() and DoFHandler::set_fe() have been
+deprecated. Instead, use the constructor DoFHandler::DoFHandler(tria) or
+DoFHandler::DoFHandler() followed by DoFHandler::reinit(tria) to attach
+a Triangulation tria, and DoFHandler::distribute_dofs() to enumerate
+degrees of freedom.
+<br>
+(Marc Fehling, 2020/10/30)

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -672,6 +672,7 @@ namespace Step69
                                 const Discretization<dim> &discretization,
                                 const std::string &        subsection)
     : ParameterAcceptor(subsection)
+    , dof_handler(discretization.triangulation)
     , mpi_communicator(mpi_communicator)
     , computing_timer(computing_timer)
     , discretization(&discretization)
@@ -691,8 +692,7 @@ namespace Step69
       TimerOutput::Scope scope(computing_timer,
                                "offline_data - distribute dofs");
 
-      dof_handler.initialize(discretization->triangulation,
-                             discretization->finite_element);
+      dof_handler.distribute_dofs(discretization->finite_element);
 
       locally_owned   = dof_handler.locally_owned_dofs();
       n_locally_owned = locally_owned.n_elements();

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -542,8 +542,7 @@ public:
 
   /**
    * Standard constructor, not initializing any data. After constructing an
-   * object with this constructor, use initialize() to make a valid
-   * DoFHandler.
+   * object with this constructor, use reinit() to get a valid DoFHandler.
    */
   DoFHandler();
 
@@ -577,14 +576,20 @@ public:
   /**
    * Assign a Triangulation and a FiniteElement to the DoFHandler and compute
    * the distribution of degrees of freedom over the mesh.
+   *
+   * @deprecated Use reinit() and distribute_dofs() instead.
    */
+  DEAL_II_DEPRECATED
   void
   initialize(const Triangulation<dim, spacedim> &tria,
              const FiniteElement<dim, spacedim> &fe);
 
   /**
    * Same as above but taking an hp::FECollection object.
+   *
+   * @deprecated Use reinit() and distribute_dofs() instead.
    */
+  DEAL_II_DEPRECATED
   void
   initialize(const Triangulation<dim, spacedim> &   tria,
              const hp::FECollection<dim, spacedim> &fe);
@@ -609,13 +614,19 @@ public:
    * either not been distributed yet, or are distributed using a previously set
    * element. In both cases, accessing degrees of freedom will lead to invalid
    * results. To restore consistency, call distribute_dofs().
+   *
+   * @deprecated Use distribute_dofs() instead.
    */
+  DEAL_II_DEPRECATED
   void
   set_fe(const FiniteElement<dim, spacedim> &fe);
 
   /**
    * Same as above but taking an hp::FECollection object.
+   *
+   * @deprecated Use distribute_dofs() instead.
    */
+  DEAL_II_DEPRECATED
   void
   set_fe(const hp::FECollection<dim, spacedim> &fe);
 
@@ -633,6 +644,16 @@ public:
    */
   void
   get_active_fe_indices(std::vector<unsigned int> &active_fe_indices) const;
+
+  /**
+   * Assign a Triangulation to the DoFHandler.
+   *
+   * Remove all associations with the previous Triangulation object and
+   * establish connections with the new one. All information about previous
+   * degrees of freedom will be removed. Activates hp-mode.
+   */
+  void
+  reinit(const Triangulation<dim, spacedim> &tria);
 
   /**
    * Go through the triangulation and "distribute" the degrees of


### PR DESCRIPTION
Split from #11133 and only addresses the deprecation of the DoFHandler initialization.

Part of #11102 and #10333.

This PR simplifies the initialization interface for the DoFHandler class by keeping the most common way of initialization (`DoFHandler(tria)` and `distribute_dofs(fe)`) and deprecating the remaining. 