### PR TITLE
Define DEAL_II_MPI_VERSION_GTE also for serial compilation

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -357,6 +357,8 @@
     DEAL_II_MPI_VERSION_MINOR) \
     >=  \
     (major)*100 + (minor))
+#else
+#  define DEAL_II_MPI_VERSION_GTE(major,minor) false
 #endif
 
 #cmakedefine DEAL_II_MPI_WITH_CUDA_SUPPORT


### PR DESCRIPTION
This PR allows me to simplify code in PR #11158. Having to write a nested if-statement like the following is really annoying:
```cpp
#ifdef DEAL_II_WITH_MPI
  #if DEAL_II_MPI_VERSION_GTE(3, 0)
    // bla bla
  #endif
#endif
```