### PR TITLE
Deprecate MatrixFree::reinit() functions with default Mapping argument

### DIFF
--- a/doc/news/changes/incompatibilities/20201111Munch
+++ b/doc/news/changes/incompatibilities/20201111Munch
@@ -1,0 +1,4 @@
+Deprecated: All `MatrixFree::reinit()` functions without `Mapping` as argument 
+have been deprecated. Use the functions that explicit provide the Mapping instead.
+<br>
+(Peter Munch, 2020/11/11)

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -513,7 +513,8 @@ void LaplaceProblem<dim, degree>::setup_system()
             (update_gradients | update_JxW_values | update_quadrature_points);
           std::shared_ptr<MatrixFree<dim, double>> mf_storage =
             std::make_shared<MatrixFree<dim, double>>();
-          mf_storage->reinit(dof_handler,
+          mf_storage->reinit(mapping,
+                             dof_handler,
                              constraints,
                              QGauss<1>(degree + 1),
                              additional_data);
@@ -615,7 +616,8 @@ void LaplaceProblem<dim, degree>::setup_multigrid()
               additional_data.mg_level = level;
               std::shared_ptr<MatrixFree<dim, float>> mf_storage_level(
                 new MatrixFree<dim, float>());
-              mf_storage_level->reinit(dof_handler,
+              mf_storage_level->reinit(mapping,
+                                       dof_handler,
                                        level_constraints,
                                        QGauss<1>(degree + 1),
                                        additional_data);

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -931,6 +931,8 @@ namespace Step59
     FE_DGQHermite<dim> fe;
     DoFHandler<dim>    dof_handler;
 
+    MappingQ1<dim> mapping;
+
     using SystemMatrixType = LaplaceOperator<dim, fe_degree, double>;
     SystemMatrixType system_matrix;
 
@@ -1022,10 +1024,8 @@ namespace Step59
          update_quadrature_points);
       const auto system_mf_storage =
         std::make_shared<MatrixFree<dim, double>>();
-      system_mf_storage->reinit(dof_handler,
-                                dummy,
-                                QGauss<1>(fe.degree + 1),
-                                additional_data);
+      system_mf_storage->reinit(
+        mapping, dof_handler, dummy, QGauss<1>(fe.degree + 1), additional_data);
       system_matrix.initialize(system_mf_storage);
     }
 
@@ -1054,7 +1054,8 @@ namespace Step59
         additional_data.mg_level = level;
         const auto mg_mf_storage_level =
           std::make_shared<MatrixFree<dim, float>>();
-        mg_mf_storage_level->reinit(dof_handler,
+        mg_mf_storage_level->reinit(mapping,
+                                    dof_handler,
                                     dummy,
                                     QGauss<1>(fe.degree + 1),
                                     additional_data);
@@ -1290,7 +1291,8 @@ namespace Step59
   void LaplaceProblem<dim, fe_degree>::analyze_results() const
   {
     Vector<float> error_per_cell(triangulation.n_active_cells());
-    VectorTools::integrate_difference(dof_handler,
+    VectorTools::integrate_difference(mapping,
+                                      dof_handler,
                                       solution,
                                       Solution<dim>(),
                                       error_per_cell,

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -591,9 +591,11 @@ public:
   /**
    * Initializes the data structures. Same as above, but using a $Q_1$
    * mapping.
+   *
+   * @deprecated Use the overload taking a Mapping object instead.
    */
   template <typename QuadratureType, typename number2>
-  void
+  DEAL_II_DEPRECATED void
   reinit(const DoFHandler<dim> &           dof_handler,
          const AffineConstraints<number2> &constraint,
          const QuadratureType &            quad,
@@ -644,9 +646,11 @@ public:
   /**
    * Initializes the data structures. Same as above, but  using a $Q_1$
    * mapping.
+   *
+   * @deprecated Use the overload taking a Mapping object instead.
    */
   template <typename QuadratureType, typename number2>
-  void
+  DEAL_II_DEPRECATED void
   reinit(const std::vector<const DoFHandler<dim> *> &           dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const std::vector<QuadratureType> &                    quad,
@@ -658,7 +662,7 @@ public:
    * @deprecated Use the overload taking a DoFHandler object instead.
    */
   template <typename QuadratureType, typename number2>
-  void
+  DEAL_II_DEPRECATED void
   reinit(const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const std::vector<QuadratureType> &                    quad,
@@ -695,9 +699,11 @@ public:
   /**
    * Initializes the data structures. Same as above, but  using a $Q_1$
    * mapping.
+   *
+   * @deprecated Use the overload taking a Mapping object instead.
    */
   template <typename QuadratureType, typename number2>
-  void
+  DEAL_II_DEPRECATED void
   reinit(const std::vector<const DoFHandler<dim> *> &           dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const QuadratureType &                                 quad,


### PR DESCRIPTION
We have not made up our mind related the default Mapping arguments, but this does not mean that we cannot deprecate such functions in `MatrixFree`.