### PR TITLE
Deprecated FiniteElement::operator[].

### DIFF
--- a/doc/news/changes/incompatibilities/20201111Fehling
+++ b/doc/news/changes/incompatibilities/20201111Fehling
@@ -1,0 +1,5 @@
+Deprecated: The operator FiniteElement::operator[] has been deprecated.
+Use DoFHandler::get_fe() with a specified index instead of code like
+dof_handler->get_fe()[index].
+<br>
+(Marc Fehling, 2020/11/11)

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -837,9 +837,12 @@ public:
    * operator[] accepts this zero argument, by returning the finite element
    * with index zero within its collection (that, of course, consists only of
    * the present finite element anyway).
+   *
+   * @deprecated With DoFHandler::get_fe(int) and the deprecation of the
+   * hp::DoFHandler class, there is no more use of this operator.
    */
-  const FiniteElement<dim, spacedim> &
-  operator[](const unsigned int fe_index) const;
+  DEAL_II_DEPRECATED const FiniteElement<dim, spacedim> &
+                           operator[](const unsigned int fe_index) const;
 
   /**
    * @name Shape function access


### PR DESCRIPTION
With `DoFHandler::get_fe(int index)` and the deprecation of the `hp::DoFHandler` class, there is simply no more use of this operator as the reason for its introduction is now obsolete.