### PR TITLE
Deprecate hp::DoFHandler.

### DIFF
--- a/include/deal.II/distributed/error_predictor.h
+++ b/include/deal.II/distributed/error_predictor.h
@@ -30,6 +30,9 @@ DEAL_II_NAMESPACE_OPEN
 
 // forward declarations
 #ifndef DOXYGEN
+template <int dim, int spacedim>
+class DoFHandler;
+
 template <typename Number>
 class Vector;
 
@@ -41,12 +44,6 @@ namespace parallel
     class Triangulation;
   }
 } // namespace parallel
-
-namespace hp
-{
-  template <int dim, int spacedim>
-  class DoFHandler;
-}
 #endif
 
 
@@ -129,12 +126,12 @@ namespace parallel
       /**
        * Constructor.
        *
-       * @param[in] dof The hp::DoFHandler on which all operations will
+       * @param[in] dof The DoFHandler on which all operations will
        *   happen. At the time when this constructor is called, the
        *   DoFHandler still points to the triangulation before the
        *   refinement in question happens.
        */
-      ErrorPredictor(const hp::DoFHandler<dim, spacedim> &dof);
+      ErrorPredictor(const DoFHandler<dim, spacedim> &dof);
 
       /**
        * Prepare the current object for coarsening and refinement.
@@ -191,7 +188,7 @@ namespace parallel
       /**
        * Pointer to the degree of freedom handler to work with.
        */
-      SmartPointer<const hp::DoFHandler<dim, spacedim>,
+      SmartPointer<const DoFHandler<dim, spacedim>,
                    ErrorPredictor<dim, spacedim>>
         dof_handler;
 

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -736,8 +736,6 @@ private:
   // functions.
   template <int, int>
   friend class DoFHandler;
-  template <int, int>
-  friend class hp::DoFHandler;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::
     Implementation;
@@ -1208,8 +1206,6 @@ protected:
   // functions.
   template <int, int>
   friend class DoFHandler;
-  template <int, int>
-  friend class hp::DoFHandler;
 
   friend struct dealii::internal::DoFHandlerImplementation::Policy::
     Implementation;

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -88,9 +88,7 @@ inline DoFAccessor<structdim, dim, spacedim, level_dof_access>::DoFAccessor(
   Assert(false,
          ExcMessage(
            "You are trying to assign iterators that are incompatible. "
-           "Reasons for incompatibility are that they point to different "
-           "types of DoFHandlers (e.g., dealii::DoFHandler and "
-           "dealii::hp::DoFHandler) or that they refer to objects of "
+           "The reason for incompatibility is that they refer to objects of "
            "different dimensionality (e.g., assigning a line iterator "
            "to a quad iterator)."));
 }
@@ -548,7 +546,7 @@ namespace internal
       {
         Assert(dof_handler.hp_capability_enabled == false,
                ExcMessage(
-                 "hp::DoFHandler does not implement multilevel DoFs."));
+                 "DoFHandler in hp-mode does not implement multilevel DoFs."));
 
         return dof_handler.mg_vertex_dofs[vertex_index].get_index(
           level, i, dof_handler.get_fe().n_dofs_per_vertex());
@@ -566,7 +564,7 @@ namespace internal
       {
         Assert(dof_handler.hp_capability_enabled == false,
                ExcMessage(
-                 "hp::DoFHandler does not implement multilevel DoFs."));
+                 "DoFHandler in hp-mode does not implement multilevel DoFs."));
 
         return dof_handler.mg_vertex_dofs[vertex_index].set_index(
           level, i, dof_handler.get_fe().n_dofs_per_vertex(), index);
@@ -1563,7 +1561,8 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::mg_vertex_dof_index(
   AssertIndexRange(i, this->dof_handler->get_fe(fe_index).n_dofs_per_vertex());
 
   Assert(dof_handler->hp_capability_enabled == false,
-         ExcMessage("hp::DoFHandler does not implement multilevel DoFs."));
+         ExcMessage(
+           "DoFHandler in hp-mode does not implement multilevel DoFs."));
 
   return this->dof_handler->mg_vertex_dofs[this->vertex_index(vertex)]
     .get_index(level, i, this->dof_handler->get_fe().n_dofs_per_vertex());
@@ -1615,7 +1614,8 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::
   AssertIndexRange(i, this->dof_handler->get_fe(fe_index).n_dofs_per_vertex());
 
   Assert(dof_handler->hp_capability_enabled == false,
-         ExcMessage("hp::DoFHandler does not implement multilevel DoFs."));
+         ExcMessage(
+           "DoFHandler in hp-mode does not implement multilevel DoFs."));
 
   this->dof_handler->mg_vertex_dofs[this->vertex_index(vertex)].set_index(
     level, i, this->dof_handler->get_fe().n_dofs_per_vertex(), index);
@@ -2753,9 +2753,9 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_fe() const
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_active(),
          ExcMessage(
-           "In hp::DoFHandler objects, finite elements are only associated "
-           "with active cells. Consequently, you can not ask for the "
-           "active finite element on cells with children."));
+           "For DoFHandler objects in hp-mode, finite elements are only "
+           "associated with active cells. Consequently, you can not ask "
+           "for the active finite element on cells with children."));
 
   return this->dof_handler->get_fe(active_fe_index());
 }
@@ -2820,9 +2820,9 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_future_fe()
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_active(),
          ExcMessage(
-           "In hp::DoFHandler objects, finite elements are only associated "
-           "with active cells. Consequently, you can not ask for the "
-           "future finite element on cells with children."));
+           "For DoFHandler objects in hp-mode, finite elements are only "
+           "associated with active cells. Consequently, you can not ask "
+           "for the future finite element on cells with children."));
 
   return this->dof_handler->get_fe(future_fe_index());
 }

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -213,6 +213,101 @@ namespace parallel
  * using the same kind of finite element before re-loading data from the
  * serialization archive.
  *
+ *
+ * <h3>hp-adaptive finite element methods</h3>
+ *
+ * Instead of only using one particular FiniteElement on all cells, this class
+ * also allows for an enumeration of degrees of freedom on different finite
+ * elements on every cells. To this end, one assigns an
+ * <code>active_fe_index</code> to every cell that indicates which element
+ * within a collection of finite elements (represented by an object of type
+ * hp::FECollection) is the one that lives on this cell. The class then
+ * enumerates the degree of freedom associated with these finite elements on
+ * each cell of a triangulation and, if possible, identifies degrees of
+ * freedom at the interfaces of cells if they match. If neighboring cells
+ * have degrees of freedom along the common interface that do not immediate
+ * match (for example, if you have $Q_2$ and $Q_3$ elements meeting at a
+ * common face), then one needs to compute constraints to ensure that the
+ * resulting finite element space on the mesh remains conforming.
+ *
+ * The whole process of working with objects of this type is explained in
+ * step-27. Many of the algorithms this class implements are described in
+ * the
+ * @ref hp_paper "hp paper".
+ *
+ *
+ * <h3>Active FE indices and their behavior under mesh refinement</h3>
+ *
+ * The typical workflow for using this class is to create a mesh, assign an
+ * active FE index to every active cell, call DoFHandler::distribute_dofs(),
+ * and then assemble a linear system and solve a problem on this finite element
+ * space.
+ *
+ * Active FE indices will be automatically transferred during mesh adaptation
+ * from the old to the new mesh. Future FE indices are meant to determine the
+ * active FE index after mesh adaptation, and are used to prepare data on the
+ * old mesh for the new one. If no future FE index is specified, the finite
+ * element prevails.
+ *
+ * In particular, the following rules apply during adaptation:
+ * - Upon mesh refinement, child cells inherit the future FE index of
+ *   the parent.
+ * - When coarsening cells, the (now active) parent cell will be assigned
+ *   a future FE index that is determined from its (no longer active)
+ *   children, following the FiniteElementDomination logic: Out of the set of
+ *   elements previously assigned to the former children, we choose the one
+ *   dominated by all children for the parent cell. If none was found, we pick
+ *   the most dominant element in the whole collection that is dominated by
+ *   all former children. See hp::FECollection::find_dominated_fe_extended()
+ *   for further information on this topic.
+ *
+ * Strategies for automatic hp-adaptation which will set future FE indices based
+ * on criteria are available in the hp::Refinement namespace.
+ *
+ *
+ * <h3>Active FE indices and parallel meshes</h3>
+ *
+ * When this class is used with either a parallel::shared::Triangulation
+ * or a parallel::distributed::Triangulation, you can only set active
+ * FE indices on cells that are locally owned,
+ * using a call such as <code>cell-@>set_active_fe_index(...)</code>.
+ * On the other hand, setting the active FE index on ghost
+ * or artificial cells is not allowed.
+ *
+ * Ghost cells do acquire the information what element
+ * is active on them, however: whenever you call DoFHandler::distribute_dofs(),
+ * all processors that participate in the parallel mesh exchange information in
+ * such a way that the active FE index on ghost cells equals the active FE index
+ * that was set on that processor that owned that particular ghost cell.
+ * Consequently, one can <i>query</i> the @p active_fe_index on ghost
+ * cells, just not set it by hand.
+ *
+ * On artificial cells, no information is available about the
+ * @p active_fe_index used there. That's because we don't even know
+ * whether these cells exist at all, and even if they did, the
+ * current processor does not know anything specific about them.
+ * See
+ * @ref GlossArtificialCell "the glossary entry on artificial cells"
+ * for more information.
+ *
+ * During refinement and coarsening, information about the @p active_fe_index
+ * of each cell will be automatically transferred.
+ *
+ * However, using a parallel::distributed::Triangulation with a DoFHandler
+ * in hp-mode requires additional attention during serialization, since no
+ * information on active FE indices will be automatically transferred. This
+ * has to be done manually using the
+ * prepare_for_serialization_of_active_fe_indices() and
+ * deserialize_active_fe_indices() functions. The former has to be called
+ * before parallel::distributed::Triangulation::save() is invoked, and the
+ * latter needs to be run after parallel::distributed::Triangulation::load().
+ * If further data will be attached to the triangulation via the
+ * parallel::distributed::CellDataTransfer,
+ * parallel::distributed::SolutionTransfer, or Particles::ParticleHandler
+ * classes, all corresponding preparation and deserialization function calls
+ * need to happen in the same order. Consult the documentation of
+ * parallel::distributed::SolutionTransfer for more information.
+ *
  * @ingroup dofs
  */
 template <int dim, int spacedim = dim>

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4023,8 +4023,6 @@ private:
 
   friend struct dealii::internal::TriaAccessorImplementation::Implementation;
 
-  friend class hp::DoFHandler<dim, spacedim>;
-
   friend struct dealii::internal::TriangulationImplementation::Implementation;
   friend struct dealii::internal::TriangulationImplementation::
     ImplementationMixedMesh;

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -119,45 +119,13 @@ namespace hp
    * @ingroup dofs
    * @ingroup hp
    *
-   * @note Task is delegated to the base class dealii::DoFHandler.
+   * @deprecated The basic dealii::DoFHandler is capable of hp-adaptation now.
    */
   template <int dim, int spacedim = dim>
-  class DoFHandler : public dealii::DoFHandler<dim, spacedim>
+  class DEAL_II_DEPRECATED DoFHandler : public dealii::DoFHandler<dim, spacedim>
   {
-  public:
-    /**
-     * Default Constructor.
-     *
-     * @deprecated Use the overload taking a `bool` instead.
-     */
-    DEAL_II_DEPRECATED
-    DoFHandler();
-
-    /**
-     * Constructor. Take @p tria as the triangulation to work on.
-     *
-     * @deprecated Use the overload taking a
-     * `const Triangulation<dim, spacedim>&` and a `bool` instead.
-     */
-    DEAL_II_DEPRECATED
-    DoFHandler(const Triangulation<dim, spacedim> &tria);
-
-    /**
-     * Copy constructor. DoFHandler objects are large and expensive.
-     * They should not be copied, in particular not by accident, but
-     * rather deliberately constructed. As a consequence, this constructor
-     * is explicitly removed from the interface of this class.
-     */
-    DoFHandler(const DoFHandler &) = delete;
-
-    /**
-     * Copy operator. DoFHandler objects are large and expensive.
-     * They should not be copied, in particular not by accident, but
-     * rather deliberately constructed. As a consequence, this operator
-     * is explicitly removed from the interface of this class.
-     */
-    DoFHandler &
-    operator=(const DoFHandler &) = delete;
+    using dealii::DoFHandler<dim, spacedim>::DoFHandler;
+    using dealii::DoFHandler<dim, spacedim>::operator=;
   };
 
 } // namespace hp

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -631,14 +631,14 @@ public:
          const AdditionalData &additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but  using hp::DoFHandlers.
+   * Initializes the data structures. Same as above, but  using DoFHandlerType.
    *
    * @deprecated Use the overload taking a DoFHandler object instead.
    */
-  template <typename QuadratureType, typename number2>
+  template <typename QuadratureType, typename number2, typename DoFHandlerType>
   DEAL_II_DEPRECATED void
   reinit(const Mapping<dim> &                                   mapping,
-         const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+         const std::vector<const DoFHandlerType *> &            dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const std::vector<QuadratureType> &                    quad,
          const AdditionalData &additional_data = AdditionalData());
@@ -657,13 +657,13 @@ public:
          const AdditionalData &additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but  using hp::DoFHandlers.
+   * Initializes the data structures. Same as above, but  using DoFHandlerType.
    *
    * @deprecated Use the overload taking a DoFHandler object instead.
    */
-  template <typename QuadratureType, typename number2>
+  template <typename QuadratureType, typename number2, typename DoFHandlerType>
   DEAL_II_DEPRECATED void
-  reinit(const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  reinit(const std::vector<const DoFHandlerType *> &            dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const std::vector<QuadratureType> &                    quad,
          const AdditionalData &additional_data = AdditionalData());
@@ -684,14 +684,14 @@ public:
          const AdditionalData &additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but  using hp::DoFHandlers.
+   * Initializes the data structures. Same as above, but  using DoFHandlerType.
    *
    * @deprecated Use the overload taking a DoFHandler object instead.
    */
-  template <typename QuadratureType, typename number2>
+  template <typename QuadratureType, typename number2, typename DoFHandlerType>
   DEAL_II_DEPRECATED void
   reinit(const Mapping<dim> &                                   mapping,
-         const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+         const std::vector<const DoFHandlerType *> &            dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const QuadratureType &                                 quad,
          const AdditionalData &additional_data = AdditionalData());
@@ -710,13 +710,13 @@ public:
          const AdditionalData &additional_data = AdditionalData());
 
   /**
-   * Initializes the data structures. Same as above, but  using hp::DoFHandlers.
+   * Initializes the data structures. Same as above, but  using DoFHandlerType.
    *
    * @deprecated Use the overload taking a DoFHandler object instead.
    */
-  template <typename QuadratureType, typename number2>
+  template <typename QuadratureType, typename number2, typename DoFHandlerType>
   DEAL_II_DEPRECATED void
-  reinit(const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  reinit(const std::vector<const DoFHandlerType *> &            dof_handler,
          const std::vector<const AffineConstraints<number2> *> &constraint,
          const QuadratureType &                                 quad,
          const AdditionalData &additional_data = AdditionalData());
@@ -1749,6 +1749,8 @@ public:
                     const unsigned int fe_component = 0) const;
 
   /**
+   * @copydoc MatrixFree::get_cell_iterator()
+   *
    * @deprecated Use get_cell_iterator() instead.
    */
   DEAL_II_DEPRECATED typename DoFHandler<dim>::active_cell_iterator
@@ -2922,19 +2924,22 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
-template <typename QuadratureType, typename number2>
+template <typename QuadratureType, typename number2, typename DoFHandlerType>
 void
 MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   const Mapping<dim> &                                   mapping,
-  const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  const std::vector<const DoFHandlerType *> &            dof_handler,
   const std::vector<const AffineConstraints<number2> *> &constraint,
   const std::vector<QuadratureType> &                    quad,
   const AdditionalData &                                 additional_data)
 {
+  static_assert(dim == DoFHandlerType::dimension,
+                "Dimension dim not equal to DoFHandlerType::dimension.");
+
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
-  for (const auto dof_handler : dof_handler_hp)
-    dof_handlers.push_back(dof_handler);
+  for (const auto dh : dof_handler)
+    dof_handlers.push_back(dh);
 
   this->reinit(mapping, dof_handlers, constraint, quad, additional_data);
 }
@@ -2967,17 +2972,20 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
-template <typename QuadratureType, typename number2>
+template <typename QuadratureType, typename number2, typename DoFHandlerType>
 void
 MatrixFree<dim, Number, VectorizedArrayType>::reinit(
-  const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  const std::vector<const DoFHandlerType *> &            dof_handler,
   const std::vector<const AffineConstraints<number2> *> &constraint,
   const std::vector<QuadratureType> &                    quad,
   const AdditionalData &                                 additional_data)
 {
+  static_assert(dim == DoFHandlerType::dimension,
+                "Dimension dim not equal to DoFHandlerType::dimension.");
+
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
-  for (const auto dof_handler : dof_handler_hp)
+  for (const auto dh : dof_handler)
     dof_handlers.push_back(dof_handler);
 
   this->reinit(dof_handlers, constraint, quad, additional_data);
@@ -3039,18 +3047,21 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
-template <typename QuadratureType, typename number2>
+template <typename QuadratureType, typename number2, typename DoFHandlerType>
 void
 MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   const Mapping<dim> &                                   mapping,
-  const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  const std::vector<const DoFHandlerType *> &            dof_handler,
   const std::vector<const AffineConstraints<number2> *> &constraint,
   const QuadratureType &                                 quad,
   const AdditionalData &                                 additional_data)
 {
+  static_assert(dim == DoFHandlerType::dimension,
+                "Dimension dim not equal to DoFHandlerType::dimension.");
+
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
-  for (const auto dof_handler : dof_handler_hp)
+  for (const auto dh : dof_handler)
     dof_handlers.push_back(dof_handler);
 
   this->reinit(mapping, dof_handlers, constraint, quad, additional_data);
@@ -3059,17 +3070,20 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
-template <typename QuadratureType, typename number2>
+template <typename QuadratureType, typename number2, typename DoFHandlerType>
 void
 MatrixFree<dim, Number, VectorizedArrayType>::reinit(
-  const std::vector<const hp::DoFHandler<dim> *> &       dof_handler_hp,
+  const std::vector<const DoFHandlerType *> &            dof_handler,
   const std::vector<const AffineConstraints<number2> *> &constraint,
   const QuadratureType &                                 quad,
   const AdditionalData &                                 additional_data)
 {
+  static_assert(dim == DoFHandlerType::dimension,
+                "Dimension dim not equal to DoFHandlerType::dimension.");
+
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
-  for (const auto dof_handler : dof_handler_hp)
+  for (const auto dh : dof_handler)
     dof_handlers.push_back(dof_handler);
 
   this->reinit(dof_handlers, constraint, quad, additional_data);

--- a/source/distributed/error_predictor.cc
+++ b/source/distributed/error_predictor.cc
@@ -22,12 +22,11 @@
 #  include <deal.II/distributed/tria.h>
 
 #  include <deal.II/dofs/dof_accessor.h>
+#  include <deal.II/dofs/dof_handler.h>
 #  include <deal.II/dofs/dof_tools.h>
 
 #  include <deal.II/grid/tria_accessor.h>
 #  include <deal.II/grid/tria_iterator.h>
-
-#  include <deal.II/hp/dof_handler.h>
 
 #  include <deal.II/lac/block_vector.h>
 #  include <deal.II/lac/la_parallel_block_vector.h>
@@ -51,18 +50,18 @@ namespace parallel
   {
     template <int dim, int spacedim>
     ErrorPredictor<dim, spacedim>::ErrorPredictor(
-      const hp::DoFHandler<dim, spacedim> &dof)
+      const DoFHandler<dim, spacedim> &dof)
       : dof_handler(&dof, typeid(*this).name())
       , handle(numbers::invalid_unsigned_int)
       , gamma_p(0.)
       , gamma_h(0.)
       , gamma_n(0.)
     {
-      Assert(
-        (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim>
-                        *>(&dof_handler->get_triangulation()) != nullptr),
-        ExcMessage(
-          "parallel::distributed::ErrorPredictor requires a parallel::distributed::Triangulation object."));
+      Assert((dynamic_cast<
+                const parallel::distributed::Triangulation<dim, spacedim> *>(
+                &dof_handler->get_triangulation()) != nullptr),
+             ExcMessage("parallel::distributed::ErrorPredictor requires a "
+                        "parallel::distributed::Triangulation object."));
     }
 
 
@@ -167,8 +166,8 @@ namespace parallel
       const typename Triangulation<dim, spacedim>::cell_iterator &cell_,
       const typename Triangulation<dim, spacedim>::CellStatus     status)
     {
-      typename hp::DoFHandler<dim, spacedim>::cell_iterator cell(*cell_,
-                                                                 dof_handler);
+      typename DoFHandler<dim, spacedim>::cell_iterator cell(*cell_,
+                                                             dof_handler);
 
       // create buffer for each individual input vector
       std::vector<float> predicted_errors(error_indicators.size());

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -107,7 +107,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
                (fe_index != DoFHandler<dim, spacedim>::invalid_fe_index),
              ExcMessage(
                "You cannot call this function on non-active cells "
-               "of hp::DoFHandler objects unless you provide an explicit "
+               "of DoFHandler objects unless you provide an explicit "
                "finite element index because they do not have naturally "
                "associated finite element spaces associated: degrees "
                "of freedom are only distributed on active cells for which "

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -97,7 +97,7 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_values_by_interpolation(
                (fe_index != DoFHandler<dim, spacedim>::invalid_fe_index),
              ExcMessage(
                "You cannot call this function on non-active cells "
-               "of hp::DoFHandler objects unless you provide an explicit "
+               "of DoFHandler objects unless you provide an explicit "
                "finite element index because they do not have naturally "
                "associated finite element spaces associated: degrees "
                "of freedom are only distributed on active cells for which "

--- a/source/hp/dof_handler.cc
+++ b/source/hp/dof_handler.cc
@@ -17,22 +17,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace hp
-{
-  template <int dim, int spacedim>
-  DoFHandler<dim, spacedim>::DoFHandler()
-    : dealii::DoFHandler<dim, spacedim>()
-  {}
-
-
-
-  template <int dim, int spacedim>
-  DoFHandler<dim, spacedim>::DoFHandler(
-    const Triangulation<dim, spacedim> &tria)
-    : dealii::DoFHandler<dim, spacedim>(tria)
-  {}
-
-} // namespace hp
 
 /*-------------- Explicit Instantiations -------------------------------*/
 #include "dof_handler.inst"

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -543,8 +543,7 @@ namespace hp
       unsigned int parent_future_fe_index = numbers::invalid_unsigned_int;
       // store all determined future finite element indices on parent cells for
       // coarsening
-      std::map<typename hp::DoFHandler<dim, spacedim>::cell_iterator,
-               unsigned int>
+      std::map<typename DoFHandler<dim, spacedim>::cell_iterator, unsigned int>
         future_fe_indices_on_coarsened_cells;
 
       // deep copy error indicators
@@ -670,16 +669,17 @@ namespace hp
       if (dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
             &dof_handler.get_triangulation()))
         {
-          auto pack = [](
-                        const typename dealii::hp::DoFHandler<dim, spacedim>::
-                          active_cell_iterator &cell) -> std::pair<bool, bool> {
+          auto pack =
+            [](const typename dealii::DoFHandler<dim,
+                                                 spacedim>::active_cell_iterator
+                 &cell) -> std::pair<bool, bool> {
             return {cell->coarsen_flag_set(), cell->future_fe_index_set()};
           };
 
-          auto unpack = [&ghost_buffer](
-                          const typename dealii::hp::DoFHandler<dim, spacedim>::
-                            active_cell_iterator &    cell,
-                          const std::pair<bool, bool> pair) -> void {
+          auto unpack =
+            [&ghost_buffer](const typename dealii::DoFHandler<dim, spacedim>::
+                              active_cell_iterator &    cell,
+                            const std::pair<bool, bool> pair) -> void {
             ghost_buffer.emplace(cell->id(), pair);
           };
 

--- a/tests/hp/get_interpolated_dof_values_01.debug.output
+++ b/tests/hp/get_interpolated_dof_values_01.debug.output
@@ -1,13 +1,13 @@
 
 DEAL::Yes, exception 1!
-DEAL::ExcMessage ("In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage ("You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
 DEAL::Yes, exception 1!
-DEAL::ExcMessage ("In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage ("You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
 DEAL::Yes, exception 1!
-DEAL::ExcMessage ("In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage ("You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")

--- a/tests/hp/set_dof_values_by_interpolation_01.debug.output
+++ b/tests/hp/set_dof_values_by_interpolation_01.debug.output
@@ -1,13 +1,13 @@
 
 DEAL::Yes, exception 1!
-DEAL::ExcMessage( "In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
 DEAL::Yes, exception 1!
-DEAL::ExcMessage( "In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
 DEAL::Yes, exception 1!
-DEAL::ExcMessage( "In hp::DoFHandler objects, finite elements are only associated " "with active cells. Consequently, you can not ask for the " "active finite element on cells with children.")
+DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of hp::DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")


### PR DESCRIPTION
~~Blocked by #11160.~~ (EDIT: With the use of constructor aliases, there is no need to wait on a decision for the DoFHandler interface)

As there is no need for the hp-specialization anymore since #10328, we can deprecate `hp::DoFHandler`. @peterrum already left a changelog in that particular PR.

In this PR, we actually set the corresponding deprecated flag for `hp::DoFHandler`, and adjust the general documentation for the basic `DoFHandler` class. Further, all references to that particular class are removed in the deal.II library (in those entities which are not deprecated).

I'll address removing the `hp::DoFHandler` from the documentation in a separate PR.

Part of #10333.