### PR TITLE
Deprecate MatrixFree::get_dof_handler.

### DIFF
--- a/doc/news/changes/incompatibilities/20201113Fehling
+++ b/doc/news/changes/incompatibilities/20201113Fehling
@@ -1,0 +1,5 @@
+Deprecated: The variant of the function MatrixFree::get_dof_handler
+expecting a DoFHandlerType template has been deprecated. Use the 
+template-less variant returning a DoFHandler instead.
+<br>
+(Marc Fehling, 2020/11/13)

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1691,15 +1691,24 @@ public:
 
   /**
    * Return the DoFHandler with the index as given to the respective
+   * `std::vector` argument in the reinit() function.
+   */
+  const DoFHandler<dim> &
+  get_dof_handler(const unsigned int dof_handler_index = 0) const;
+
+  /**
+   * Return the DoFHandler with the index as given to the respective
    * `std::vector` argument in the reinit() function. Note that if you want to
    * call this function with a template parameter different than the default
    * one, you will need to use the `template` before the function call, i.e.,
    * you will have something like `matrix_free.template
    * get_dof_handler<hp::DoFHandler<dim>>()`.
+   *
+   * @deprecated Use the non-templated equivalent of this function.
    */
-  template <typename DoFHandlerType = DoFHandler<dim>>
-  const DoFHandlerType &
-  get_dof_handler(const unsigned int dof_handler_index = 0) const;
+  template <typename DoFHandlerType>
+  DEAL_II_DEPRECATED const DoFHandlerType &
+                           get_dof_handler(const unsigned int dof_handler_index = 0) const;
 
   /**
    * Return the cell iterator in deal.II speak to a given cell in the

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -135,6 +135,18 @@ MatrixFree<dim, Number, VectorizedArrayType>::renumber_dofs(
 
 
 template <int dim, typename Number, typename VectorizedArrayType>
+const DoFHandler<dim> &
+MatrixFree<dim, Number, VectorizedArrayType>::get_dof_handler(
+  const unsigned int dof_handler_index) const
+{
+  AssertIndexRange(dof_handler_index, n_components());
+
+  return *(dof_handlers[dof_handler_index]);
+}
+
+
+
+template <int dim, typename Number, typename VectorizedArrayType>
 template <typename DoFHandlerType>
 const DoFHandlerType &
 MatrixFree<dim, Number, VectorizedArrayType>::get_dof_handler(

--- a/source/matrix_free/matrix_free.inst.in
+++ b/source/matrix_free/matrix_free.inst.in
@@ -42,12 +42,6 @@ for (deal_II_dimension : DIMENSIONS;
         const std::vector<IndexSet> &,
         const std::vector<hp::QCollection<deal_II_dimension>> &,
         const AdditionalData &);
-
-    template const DoFHandler<deal_II_dimension> &
-    MatrixFree<deal_II_dimension,
-               deal_II_scalar_vectorized::value_type,
-               deal_II_scalar_vectorized>::
-      get_dof_handler<DoFHandler<deal_II_dimension>>(const unsigned int) const;
   }
 
 


### PR DESCRIPTION
Introduces `get_dof_handler` with a non-template parameter and deprecates the templated equivalent.

I am not confident on how I implemented this so I need to count on your opinion: Removing the explicit instantiation will throw an error if someone writes `matrix_free.template get_dof_handler<DoFHandler<dim>>();` because of ambiguity. However, this will probably never happen as the default template is way more convenient to use.

Reverts #9216. Part of #10333.