### PR TITLE
MatrixFree: deprecate n_macro_cells

### DIFF
--- a/examples/step-37/doc/results.dox
+++ b/examples/step-37/doc/results.dox
@@ -569,7 +569,7 @@ void LaplaceProblem<dim>::assemble_rhs()
   const Table<2, VectorizedArray<double>> &coefficient = system_matrix.get_coefficient();
   FEEvaluation<dim, degree_finite_element> phi(*system_matrix.get_matrix_free());
   for (unsigned int cell = 0;
-       cell < system_matrix.get_matrix_free()->n_macro_cells();
+       cell < system_matrix.get_matrix_free()->n_cell_batches();
        ++cell)
     {
       phi.reinit(cell);
@@ -656,7 +656,7 @@ void LaplaceProblem<dim>::assemble_rhs()
   FEEvaluation<dim, degree_finite_element> phi(
     *inhomogeneous_operator.get_matrix_free());
   for (unsigned int cell = 0;
-       cell < inhomogeneous_operator.get_matrix_free()->n_macro_cells();
+       cell < inhomogeneous_operator.get_matrix_free()->n_cell_batches();
        ++cell)
     {
       phi.reinit(cell);

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -281,7 +281,7 @@ namespace Step37
   void LaplaceOperator<dim, fe_degree, number>::evaluate_coefficient(
     const Coefficient<dim> &coefficient_function)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
+    const unsigned int n_cells = this->data->n_cell_batches();
     FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(*this->data);
 
     coefficient.reinit(n_cells, phi.n_q_points);
@@ -314,7 +314,7 @@ namespace Step37
   // actually seeing a group of quadrature points of several cells as one
   // block. This is done to enable a higher degree of vectorization.  The
   // number of such "cells" or "cell batches" is stored in MatrixFree and can
-  // be queried through MatrixFree::n_macro_cells(). Compared to the deal.II
+  // be queried through MatrixFree::n_cell_batches(). Compared to the deal.II
   // cell iterators, in this class all cells are laid out in a plain array
   // with no direct knowledge of level or neighborship relations, which makes
   // it possible to index the cells by unsigned integers.
@@ -398,7 +398,7 @@ namespace Step37
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(coefficient.size(0), data.n_macro_cells());
+        AssertDimension(coefficient.size(0), data.n_cell_batches());
         AssertDimension(coefficient.size(1), phi.n_q_points);
 
         phi.reinit(cell);
@@ -423,7 +423,7 @@ namespace Step37
   // @code
   // src.update_ghost_values();
   // local_apply(*this->data, dst, src, std::make_pair(0U,
-  //                                                   data.n_macro_cells()));
+  //                                                   data.n_cell_batches()));
   // dst.compress(VectorOperation::add);
   // @endcode
   //
@@ -437,7 +437,7 @@ namespace Step37
   // one hand, it will split the update_ghost_values() and compress() calls in
   // a way to allow for overlapping communication and computation. The
   // local_apply function is then called with three cell ranges representing
-  // partitions of the cell range from 0 to MatrixFree::n_macro_cells(). On
+  // partitions of the cell range from 0 to MatrixFree::n_cell_batches(). On
   // the other hand, cell_loop also supports thread parallelism in which case
   // the cell ranges are split into smaller chunks and scheduled in an
   // advanced way that avoids access to the same vector entry by several
@@ -620,7 +620,7 @@ namespace Step37
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(coefficient.size(0), data.n_macro_cells());
+        AssertDimension(coefficient.size(0), data.n_cell_batches());
         AssertDimension(coefficient.size(1), phi.n_q_points);
 
         phi.reinit(cell);
@@ -907,7 +907,7 @@ namespace Step37
     FEEvaluation<dim, degree_finite_element> phi(
       *system_matrix.get_matrix_free());
     for (unsigned int cell = 0;
-         cell < system_matrix.get_matrix_free()->n_macro_cells();
+         cell < system_matrix.get_matrix_free()->n_cell_batches();
          ++cell)
       {
         phi.reinit(cell);

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -251,7 +251,7 @@ Coefficient<dim>::make_coefficient_table(
 
   FEEvaluation<dim, -1, 0, 1, number> fe_eval(mf_storage);
 
-  const unsigned int n_cells    = mf_storage.n_macro_cells();
+  const unsigned int n_cells    = mf_storage.n_cell_batches();
   const unsigned int n_q_points = fe_eval.n_q_points;
 
   coefficient_table->reinit(n_cells, 1);
@@ -948,7 +948,7 @@ void LaplaceProblem<dim, degree>::assemble_rhs()
     *mf_system_matrix.get_matrix_free());
 
   for (unsigned int cell = 0;
-       cell < mf_system_matrix.get_matrix_free()->n_macro_cells();
+       cell < mf_system_matrix.get_matrix_free()->n_cell_batches();
        ++cell)
     {
       phi.reinit(cell);

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1574,7 +1574,7 @@ namespace Euler_DG
     MatrixFreeOperators::CellwiseInverseMassMatrix<dim, degree, dim + 2, Number>
       inverse(phi);
     solution.zero_out_ghosts();
-    for (unsigned int cell = 0; cell < data.n_macro_cells(); ++cell)
+    for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         phi.reinit(cell);
         for (unsigned int q = 0; q < phi.n_q_points; ++q)

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -1978,12 +1978,12 @@ namespace internal
 
       types::global_dof_index counter      = 0;
       const unsigned int      n_components = start_components.back();
-      const unsigned int      n_macro_cells =
+      const unsigned int      n_cell_batches =
         n_vectorization_lanes_filled[dof_access_cell].size();
-      Assert(n_macro_cells <=
+      Assert(n_cell_batches <=
                (row_starts.size() - 1) / vectorization_length / n_components,
              ExcInternalError());
-      for (unsigned int cell_no = 0; cell_no < n_macro_cells; ++cell_no)
+      for (unsigned int cell_no = 0; cell_no < n_cell_batches; ++cell_no)
         {
           // do not renumber in case we have constraints
           if (row_starts[cell_no * n_components * vectorization_length]

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -165,8 +165,8 @@ public:
 
   /**
    * Provides a unified interface to access data in a vector of
-   * VectorizedArray fields of length MatrixFree::n_macro_cells() +
-   * MatrixFree::n_macro_ghost_cells() for both cells (plain read) and faces
+   * VectorizedArray fields of length MatrixFree::n_cell_batches() +
+   * MatrixFree::n_ghost_cell_batches() for both cells (plain read) and faces
    * (indirect addressing).
    */
   VectorizedArrayType
@@ -174,8 +174,8 @@ public:
 
   /**
    * Provides a unified interface to set data in a vector of
-   * VectorizedArray fields of length MatrixFree::n_macro_cells() +
-   * MatrixFree::n_macro_ghost_cells() for both cells (plain read) and faces
+   * VectorizedArray fields of length MatrixFree::n_cell_batches() +
+   * MatrixFree::n_ghost_cell_batches() for both cells (plain read) and faces
    * (indirect addressing).
    */
   void

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1470,16 +1470,16 @@ namespace internal
       const unsigned int n_cells = cells.size();
       const unsigned int n_lanes = VectorizedArrayType::size();
       Assert(n_cells % n_lanes == 0, ExcInternalError());
-      const unsigned int n_macro_cells = n_cells / n_lanes;
-      cell_type.resize(n_macro_cells);
+      const unsigned int n_cell_batches = n_cells / n_lanes;
+      cell_type.resize(n_cell_batches);
 
-      if (n_macro_cells == 0)
+      if (n_cell_batches == 0)
         return;
 
       // Create as many chunks of cells as we have threads and spawn the work
       unsigned int work_per_chunk =
         std::max(8U,
-                 (n_macro_cells + MultithreadInfo::n_threads() - 1) /
+                 (n_cell_batches + MultithreadInfo::n_threads() - 1) /
                    MultithreadInfo::n_threads());
 
       std::vector<std::pair<
@@ -1494,7 +1494,7 @@ namespace internal
       {
         Threads::TaskGroup<>                  tasks;
         std::pair<unsigned int, unsigned int> cell_range(0U, work_per_chunk);
-        while (cell_range.first < n_macro_cells)
+        while (cell_range.first < n_cell_batches)
           {
             data_cells_local.push_back(std::make_pair(
               std::vector<

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1612,13 +1612,7 @@ public:
   n_physical_cells() const;
 
   /**
-   * Return the number of cell batches that this structure works on.  The
-   * batches are formed by application of vectorization over several cells in
-   * general. The cell range in @p cell_loop runs from zero to n_cell_batches()
-   * (exclusive), so this is the appropriate size if you want to store arrays
-   * of data for all cells to be worked on. This number is approximately
-   * `n_physical_cells()/VectorizedArray::%size()` (depending on how
-   * many cell chunks that do not get filled up completely).
+   * @deprecated Use n_cell_batches() instead.
    */
   unsigned int
   n_macro_cells() const;
@@ -1630,7 +1624,7 @@ public:
    * n_cell_batches() (exclusive), so this is the appropriate size if you want
    * to store arrays of data for all cells to be worked on. This number is
    * approximately `n_physical_cells()/VectorizedArray::%size()`
-   * (depending on how many cell chunks that do not get filled up completely).
+   * (depending on how many cell batches that do not get filled up completely).
    */
   unsigned int
   n_cell_batches() const;
@@ -2344,9 +2338,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::get_faces_by_cells_boundary_id(
   const unsigned int macro_cell,
   const unsigned int face_number) const
 {
-  AssertIndexRange(macro_cell, n_macro_cells());
+  AssertIndexRange(macro_cell, n_cell_batches());
   AssertIndexRange(face_number, GeometryInfo<dim>::faces_per_cell);
-  Assert(face_info.cell_and_face_boundary_id.size(0) >= n_macro_cells(),
+  Assert(face_info.cell_and_face_boundary_id.size(0) >= n_cell_batches(),
          ExcNotInitialized());
   std::array<types::boundary_id, VectorizedArrayType::size()> result;
   result.fill(numbers::invalid_boundary_id);

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -853,7 +853,7 @@ namespace MatrixFreeOperators
      * coefficient = std::make_shared<Table<2, VectorizedArray<double> > >();
      * {
      *   FEEvaluation<dim,fe_degree,n_q_points_1d,1,double> fe_eval(mf_data);
-     *   const unsigned int n_cells = mf_data.n_macro_cells();
+     *   const unsigned int n_cells = mf_data.n_cell_batches();
      *   const unsigned int n_q_points = fe_eval.n_q_points;
      *   coefficient->reinit(n_cells, n_q_points);
      *   for (unsigned int cell=0; cell<n_cells; ++cell)
@@ -1274,7 +1274,7 @@ namespace MatrixFreeOperators
 
     for (unsigned int j = 0; j < selected_rows.size(); ++j)
       {
-        if (data_->n_macro_cells() > 0)
+        if (data_->n_cell_batches() > 0)
           {
             AssertDimension(level, data_->get_cell_iterator(0, 0, j)->level());
           }

--- a/include/deal.II/multigrid/multigrid.h
+++ b/include/deal.II/multigrid/multigrid.h
@@ -77,6 +77,10 @@ namespace mg
      * This signal is triggered before (@p before is true) and after (@p before
      * is
      * false) the call to the coarse solver on @p level.
+     *
+     * The coarse solve will be done with ``defect[leve]`` and returned in
+     * ``solution[level]``, which can be inspected by the user using this
+     * signal.
      */
     boost::signals2::signal<void(const bool before, const unsigned int level)>
       coarse_solve;
@@ -85,6 +89,9 @@ namespace mg
      * This signal is triggered before (@p before is true) and after (@p before
      * is false) the call to MGTransfer::restrict_and_add() which restricts a
      * vector from @p level to the next coarser one (@p level - 1).
+     *
+     * The vector ``defect[level-1]`` will be updated between these two
+     * triggers and can be inspected by the user using this signal.
      */
     boost::signals2::signal<void(const bool before, const unsigned int level)>
       restriction;
@@ -101,6 +108,9 @@ namespace mg
      * This signal is triggered before (@p before is true) and after (@p before
      * is false) the call to a pre-smoothing step via MGPreSmoother::apply() on
      * @p level.
+     *
+     * The smoother result will be stored in ``solution[level]`` and can be
+     * inspected by the user using this signal.
      */
     boost::signals2::signal<void(const bool before, const unsigned int level)>
       pre_smoother_step;

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -216,7 +216,8 @@ namespace VectorTools
         // account for inhomogeneous constraints
         inhomogeneities.update_ghost_values();
         FEEvaluation<dim, -1, 0, components, Number> phi(*matrix_free);
-        for (unsigned int cell = 0; cell < matrix_free->n_macro_cells(); ++cell)
+        for (unsigned int cell = 0; cell < matrix_free->n_cell_batches();
+             ++cell)
           {
             phi.reinit(cell);
             phi.read_dof_values_plain(inhomogeneities);

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -1076,17 +1076,17 @@ namespace internal
       std::vector<unsigned int> &      renumbering,
       std::vector<unsigned char> &     incompletely_filled_vectorization)
     {
-      const unsigned int n_macro_cells =
+      const unsigned int n_cell_batches =
         (n_active_cells + vectorization_length - 1) / vectorization_length;
       const unsigned int n_ghost_slots =
         (n_ghost_cells + vectorization_length - 1) / vectorization_length;
-      incompletely_filled_vectorization.resize(n_macro_cells + n_ghost_slots);
-      if (n_macro_cells * vectorization_length > n_active_cells)
-        incompletely_filled_vectorization[n_macro_cells - 1] =
+      incompletely_filled_vectorization.resize(n_cell_batches + n_ghost_slots);
+      if (n_cell_batches * vectorization_length > n_active_cells)
+        incompletely_filled_vectorization[n_cell_batches - 1] =
           vectorization_length -
-          (n_macro_cells * vectorization_length - n_active_cells);
+          (n_cell_batches * vectorization_length - n_active_cells);
       if (n_ghost_slots * vectorization_length > n_ghost_cells)
-        incompletely_filled_vectorization[n_macro_cells + n_ghost_slots - 1] =
+        incompletely_filled_vectorization[n_cell_batches + n_ghost_slots - 1] =
           vectorization_length -
           (n_ghost_slots * vectorization_length - n_ghost_cells);
 
@@ -1116,13 +1116,13 @@ namespace internal
             (boundary_cells.size() + vectorization_length - 1) /
             vectorization_length;
           cell_partition_data.push_back(
-            (n_macro_cells - n_macro_boundary_cells) / 2);
+            (n_cell_batches - n_macro_boundary_cells) / 2);
           cell_partition_data.push_back(cell_partition_data[1] +
                                         n_macro_boundary_cells);
         }
       else
         AssertDimension(boundary_cells.size(), 0);
-      cell_partition_data.push_back(n_macro_cells);
+      cell_partition_data.push_back(n_cell_batches);
       cell_partition_data.push_back(cell_partition_data.back() + n_ghost_slots);
       partition_row_index.resize(n_procs > 1 ? 4 : 2);
       partition_row_index[0] = 0;
@@ -1171,8 +1171,8 @@ namespace internal
       std::vector<unsigned char> &irregular_cells,
       const bool)
     {
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
-      if (n_macro_cells == 0)
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
+      if (n_cell_batches == 0)
         return;
 
       Assert(vectorization_length > 0, ExcInternalError());
@@ -1238,8 +1238,8 @@ namespace internal
 
       // set the start list for each block and compute the renumbering of
       // cells
-      std::vector<unsigned int>  block_start(n_macro_cells + 1);
-      std::vector<unsigned char> irregular(n_macro_cells);
+      std::vector<unsigned int>  block_start(n_cell_batches + 1);
+      std::vector<unsigned char> irregular(n_cell_batches);
 
       unsigned int mcell_start = 0;
       block_start[0]           = 0;
@@ -1247,7 +1247,7 @@ namespace internal
         {
           block_start[block + 1] = block_start[block];
           for (unsigned int mcell = mcell_start;
-               mcell < std::min(mcell_start + block_size, n_macro_cells);
+               mcell < std::min(mcell_start + block_size, n_cell_batches);
                ++mcell)
             {
               unsigned int n_comp = (irregular_cells[mcell] > 0) ?
@@ -1261,7 +1261,7 @@ namespace internal
       counter                    = 0;
       unsigned int counter_macro = 0;
       unsigned int block_size_last =
-        n_macro_cells - block_size * (n_blocks - 1);
+        n_cell_batches - block_size * (n_blocks - 1);
       if (block_size_last == 0)
         block_size_last = block_size;
 
@@ -1290,7 +1290,7 @@ namespace internal
 
       irregular_cells.swap(irregular);
       AssertDimension(counter, n_active_cells);
-      AssertDimension(counter_macro, n_macro_cells);
+      AssertDimension(counter_macro, n_cell_batches);
 
       // check that the renumbering is one-to-one
 #ifdef DEBUG
@@ -1306,7 +1306,7 @@ namespace internal
       update_task_info(
         partition); // Actually sets too much for partition color case
 
-      AssertDimension(cell_partition_data.back(), n_macro_cells);
+      AssertDimension(cell_partition_data.back(), n_cell_batches);
     }
 
 
@@ -1319,8 +1319,8 @@ namespace internal
       std::vector<unsigned char> &     irregular_cells,
       const bool                       hp_bool)
     {
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
-      if (n_macro_cells == 0)
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
+      if (n_cell_batches == 0)
         return;
 
       Assert(vectorization_length > 0, ExcInternalError());
@@ -1435,8 +1435,8 @@ namespace internal
         {
           // set the start list for each block and compute the renumbering of
           // cells
-          std::vector<unsigned int>  block_start(n_macro_cells + 1);
-          std::vector<unsigned char> irregular(n_macro_cells);
+          std::vector<unsigned int>  block_start(n_cell_batches + 1);
+          std::vector<unsigned char> irregular(n_cell_batches);
 
           unsigned int counter     = 0;
           unsigned int mcell_start = 0;
@@ -1445,7 +1445,7 @@ namespace internal
             {
               block_start[block + 1] = block_start[block];
               for (unsigned int mcell = mcell_start;
-                   mcell < std::min(mcell_start + block_size, n_macro_cells);
+                   mcell < std::min(mcell_start + block_size, n_cell_batches);
                    ++mcell)
                 {
                   unsigned int n_comp = (irregular_cells[mcell] > 0) ?
@@ -1459,7 +1459,7 @@ namespace internal
           counter                    = 0;
           unsigned int counter_macro = 0;
           unsigned int block_size_last =
-            n_macro_cells - block_size * (n_blocks - 1);
+            n_cell_batches - block_size * (n_blocks - 1);
           if (block_size_last == 0)
             block_size_last = block_size;
 
@@ -1488,7 +1488,7 @@ namespace internal
 
           irregular_cells.swap(irregular);
           AssertDimension(counter, n_active_cells);
-          AssertDimension(counter_macro, n_macro_cells);
+          AssertDimension(counter_macro, n_cell_batches);
           // check that the renumbering is one-to-one
 #ifdef DEBUG
           {
@@ -1514,8 +1514,8 @@ namespace internal
       std::vector<unsigned char> &     irregular_cells,
       const bool                       hp_bool)
     {
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
-      if (n_macro_cells == 0)
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
+      if (n_cell_batches == 0)
         return;
 
       const unsigned int cluster_size = block_size * vectorization_length;
@@ -1523,7 +1523,7 @@ namespace internal
       // Create cell-block  partitioning.
 
       // For each block of cells, this variable saves to which partitions the
-      // block belongs. Initialize all to n_macro_cells to mark them as not
+      // block belongs. Initialize all to n_cell_batches to mark them as not
       // yet assigned a partition.
       std::vector<unsigned int> cell_partition(n_active_cells,
                                                numbers::invalid_unsigned_int);
@@ -1631,9 +1631,9 @@ namespace internal
       std::vector<unsigned int> &      partition_partition_list,
       std::vector<unsigned char> &     irregular_cells)
     {
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
       const unsigned int n_ghost_slots =
-        *(cell_partition_data.end() - 1) - n_macro_cells;
+        *(cell_partition_data.end() - 1) - n_cell_batches;
 
       // List of cells in previous partition
       std::vector<unsigned int> neighbor_list;
@@ -1658,7 +1658,7 @@ namespace internal
         // Create partitioning within partitions.
 
         // For each block of cells, this variable saves to which partitions
-        // the block belongs. Initialize all to n_macro_cells to mark them as
+        // the block belongs. Initialize all to n_cell_batches to mark them as
         // not yet assigned a partition.
         std::vector<unsigned int> cell_partition_l2(
           n_active_cells, numbers::invalid_unsigned_int);
@@ -1948,8 +1948,8 @@ namespace internal
       const std::vector<unsigned int> &partition_size,
       std::vector<unsigned int> &      partition_color_list)
     {
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
-      std::vector<unsigned int> cell_color(n_blocks, n_macro_cells);
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
+      std::vector<unsigned int> cell_color(n_blocks, n_cell_batches);
       std::vector<bool>         color_finder;
 
       partition_row_index.resize(partition + 1);
@@ -2025,7 +2025,7 @@ namespace internal
 
     {
       // For each block of cells, this variable saves to which partitions the
-      // block belongs. Initialize all to n_macro_cells to mark them as not
+      // block belongs. Initialize all to n_cell_batches to mark them as not
       // yet assigned a partition.
       // std::vector<unsigned int> cell_partition (n_active_cells,
       //                                          numbers::invalid_unsigned_int);
@@ -2050,11 +2050,11 @@ namespace internal
             (cell_partition_data[2] - cell_partition_data[1]) :
           0;
 
-      const unsigned int n_macro_cells = *(cell_partition_data.end() - 2);
-      if (n_macro_cells == 0)
+      const unsigned int n_cell_batches = *(cell_partition_data.end() - 2);
+      if (n_cell_batches == 0)
         return;
       if (scheme == color)
-        start_nonboundary = n_macro_cells;
+        start_nonboundary = n_cell_batches;
       if (scheme == partition_color ||
           scheme == color) // blocking_connectivity == true
         start_nonboundary = ((start_nonboundary + block_size - 1) / block_size);

--- a/tests/lac/utilities_02.cc
+++ b/tests/lac/utilities_02.cc
@@ -141,7 +141,7 @@ test()
     mf_data->initialize_dof_vector(inv_mass_matrix);
     FEEvaluation<dim, fe_degree> fe_eval(*mf_data);
     const unsigned int           n_q_points = fe_eval.n_q_points;
-    for (unsigned int cell = 0; cell < mf_data->n_macro_cells(); ++cell)
+    for (unsigned int cell = 0; cell < mf_data->n_cell_batches(); ++cell)
       {
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)

--- a/tests/mappings/mapping_q_eulerian_08.cc
+++ b/tests/mappings/mapping_q_eulerian_08.cc
@@ -237,8 +237,8 @@ test(const unsigned int n_ref = 0)
         matrix_free_euler);
       FEEvaluation<dim, fe_degree, n_q_points, 1, NumberType> fe_eval(
         matrix_free);
-      const unsigned int n_cells = matrix_free_euler.n_macro_cells();
-      Assert(matrix_free_euler.n_macro_cells() == matrix_free.n_macro_cells(),
+      const unsigned int n_cells = matrix_free_euler.n_cell_batches();
+      Assert(matrix_free_euler.n_cell_batches() == matrix_free.n_cell_batches(),
              ExcInternalError());
       const unsigned int nqp = fe_eval.n_q_points;
       for (unsigned int cell = 0; cell < n_cells; ++cell)
@@ -315,8 +315,8 @@ test(const unsigned int n_ref = 0)
           mg_level_euler);
         FEEvaluation<dim, fe_degree, n_q_points, 1, NumberType> fe_eval(
           mg_level);
-        const unsigned int n_cells = mg_level_euler.n_macro_cells();
-        Assert(mg_level_euler.n_macro_cells() == mg_level.n_macro_cells(),
+        const unsigned int n_cells = mg_level_euler.n_cell_batches();
+        Assert(mg_level_euler.n_cell_batches() == mg_level.n_cell_batches(),
                ExcInternalError());
         const unsigned int nqp = fe_eval.n_q_points;
         for (unsigned int cell = 0; cell < n_cells; ++cell)

--- a/tests/matrix_free/cell_categorization.cc
+++ b/tests/matrix_free/cell_categorization.cc
@@ -88,8 +88,9 @@ test()
   data.cell_vectorization_categories_strict = false;
   mf_data.reinit(dof, constraints, QGauss<1>(2), data);
 
-  deallog << "Number of cell batches: " << mf_data.n_macro_cells() << std::endl;
-  for (unsigned int i = 0; i < mf_data.n_macro_cells(); ++i)
+  deallog << "Number of cell batches: " << mf_data.n_cell_batches()
+          << std::endl;
+  for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
     for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;
@@ -97,8 +98,9 @@ test()
 
   data.cell_vectorization_categories_strict = true;
   mf_data.reinit(dof, constraints, QGauss<1>(2), data);
-  deallog << "Number of cell batches: " << mf_data.n_macro_cells() << std::endl;
-  for (unsigned int i = 0; i < mf_data.n_macro_cells(); ++i)
+  deallog << "Number of cell batches: " << mf_data.n_cell_batches()
+          << std::endl;
+  for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
     for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;
@@ -112,8 +114,9 @@ test()
 
   data.cell_vectorization_categories_strict = false;
   mf_data.reinit(dof, constraints, QGauss<1>(2), data);
-  deallog << "Number of cell batches: " << mf_data.n_macro_cells() << std::endl;
-  for (unsigned int i = 0; i < mf_data.n_macro_cells(); ++i)
+  deallog << "Number of cell batches: " << mf_data.n_cell_batches()
+          << std::endl;
+  for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
     for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
       deallog << mf_data.get_cell_iterator(i, c)->id() << " with "
               << mf_data.get_cell_category(i) << std::endl;

--- a/tests/matrix_free/cell_categorization_02.cc
+++ b/tests/matrix_free/cell_categorization_02.cc
@@ -159,7 +159,7 @@ test()
                                 mg_additional_data[level]);
     }
 
-  for (unsigned int i = 0; i < mf_data.n_macro_cells(); ++i)
+  for (unsigned int i = 0; i < mf_data.n_cell_batches(); ++i)
     {
       const unsigned int m_id = mf_data.get_cell_iterator(i, 0)->material_id();
       for (unsigned int c = 0; c < mf_data.n_components_filled(i); ++c)
@@ -173,7 +173,7 @@ test()
   for (unsigned int level = 0; level <= max_level; ++level)
     {
       const auto &level_data = mg_mf_data[level];
-      for (unsigned int i = 0; i < level_data->n_macro_cells(); ++i)
+      for (unsigned int i = 0; i < level_data->n_cell_batches(); ++i)
         {
           const unsigned int m_id =
             level_data->get_cell_iterator(i, 0)->material_id();

--- a/tests/matrix_free/cell_level_and_index.cc
+++ b/tests/matrix_free/cell_level_and_index.cc
@@ -42,7 +42,7 @@ template <int dim, typename number>
 void
 compare_indices(const MatrixFree<dim, number> *mf_data)
 {
-  const unsigned int n_batches = mf_data->n_macro_cells();
+  const unsigned int n_batches = mf_data->n_cell_batches();
   for (unsigned int batch_no = 0; batch_no < n_batches; ++batch_no)
     {
       const unsigned int n_lanes_filled =

--- a/tests/matrix_free/compress_mapping.cc
+++ b/tests/matrix_free/compress_mapping.cc
@@ -82,15 +82,15 @@ test()
   data.tasks_parallel_scheme = MatrixFree<dim>::AdditionalData::none;
   mf.reinit(dof, constraints, quad, data);
 
-  const unsigned int        n_macro_cells = mf.n_macro_cells();
+  const unsigned int        n_cell_batches = mf.n_cell_batches();
   std::vector<unsigned int> n_cell_types(4, 0);
-  for (unsigned int i = 0; i < n_macro_cells; ++i)
+  for (unsigned int i = 0; i < n_cell_batches; ++i)
     n_cell_types[mf.get_mapping_info().get_cell_type(i)]++;
 
   // should do at least some compression
   Assert(n_cell_types[0] + n_cell_types[1] > 0, ExcInternalError());
   Assert(mf.get_mapping_info().cell_data[0].jacobians[0].size() <
-           (n_cell_types[3] * quad.size() + n_macro_cells - n_cell_types[3]),
+           (n_cell_types[3] * quad.size() + n_cell_batches - n_cell_types[3]),
          ExcInternalError());
   deallog << "OK" << std::endl;
 }
@@ -119,15 +119,15 @@ test_cube()
   data.tasks_parallel_scheme = MatrixFree<dim>::AdditionalData::none;
   mf.reinit(dof, constraints, quad, data);
 
-  const unsigned int        n_macro_cells = mf.n_macro_cells();
+  const unsigned int        n_cell_batches = mf.n_cell_batches();
   std::vector<unsigned int> n_cell_types(4, 0);
-  for (unsigned int i = 0; i < n_macro_cells; ++i)
+  for (unsigned int i = 0; i < n_cell_batches; ++i)
     n_cell_types[mf.get_mapping_info().get_cell_type(i)]++;
 
   // should have one Cartesian cell and no other cell type
-  AssertDimension(n_cell_types[0], n_macro_cells);
+  AssertDimension(n_cell_types[0], n_cell_batches);
   AssertDimension(mf.get_mapping_info().cell_data[0].jacobians[0].size(), 2);
-  Assert(n_macro_cells > 1, ExcInternalError());
+  Assert(n_cell_batches > 1, ExcInternalError());
   deallog << "OK" << std::endl;
 }
 
@@ -162,16 +162,16 @@ test_parallelogram()
   data.tasks_parallel_scheme = MatrixFree<dim>::AdditionalData::none;
   mf.reinit(dof, constraints, quad, data);
 
-  const unsigned int        n_macro_cells = mf.n_macro_cells();
+  const unsigned int        n_cell_batches = mf.n_cell_batches();
   std::vector<unsigned int> n_cell_types(4, 0);
-  for (unsigned int i = 0; i < n_macro_cells; ++i)
+  for (unsigned int i = 0; i < n_cell_batches; ++i)
     n_cell_types[mf.get_mapping_info().get_cell_type(i)]++;
 
   // should have one affine cell and no other
   // cell type
-  AssertDimension(n_cell_types[1], n_macro_cells);
+  AssertDimension(n_cell_types[1], n_cell_batches);
   AssertDimension(mf.get_mapping_info().cell_data[0].jacobians[0].size(), 2);
-  Assert(n_macro_cells > 1, ExcInternalError());
+  Assert(n_cell_batches > 1, ExcInternalError());
   deallog << "OK" << std::endl;
 }
 
@@ -236,16 +236,16 @@ test_deformed_cube()
     update_gradients | update_normal_vectors;
 
   mf.reinit(dof, constraints, quad, data);
-  const unsigned int n_macro_cells = mf.n_macro_cells();
-  Assert(n_macro_cells > 1, ExcInternalError());
+  const unsigned int n_cell_batches = mf.n_cell_batches();
+  Assert(n_cell_batches > 1, ExcInternalError());
 
   {
     std::vector<unsigned int> n_cell_types(4, 0);
-    for (unsigned int i = 0; i < n_macro_cells; ++i)
+    for (unsigned int i = 0; i < n_cell_batches; ++i)
       n_cell_types[mf.get_mapping_info().get_cell_type(i)]++;
 
     // should have all Cartesian type and no other cell type
-    AssertDimension(n_cell_types[0], n_macro_cells);
+    AssertDimension(n_cell_types[0], n_cell_batches);
 
     // should have as many different Jacobians as we have cell batches in x
     // direction; as the mesh is a cube, we can easily calculate it
@@ -260,11 +260,11 @@ test_deformed_cube()
     mf.reinit(mapping, dof, constraints, quad, data);
 
     std::vector<unsigned int> n_cell_types(4, 0);
-    for (unsigned int i = 0; i < n_macro_cells; ++i)
+    for (unsigned int i = 0; i < n_cell_batches; ++i)
       n_cell_types[mf.get_mapping_info().get_cell_type(i)]++;
 
     // should have all general type and no other cell type
-    AssertDimension(n_cell_types[3], n_macro_cells);
+    AssertDimension(n_cell_types[3], n_cell_batches);
 
     // should have as many different Jacobians as we have cell batches in x
     // direction times the number of quadrature points; as the mesh is a cube,

--- a/tests/matrix_free/dof_info_01.cc
+++ b/tests/matrix_free/dof_info_01.cc
@@ -97,7 +97,7 @@ test(const bool adaptive_ref = true)
     mf_data->reinit(dof, constraints, quad, data);
   }
 
-  const unsigned int     n_cells         = mf_data->n_macro_cells();
+  const unsigned int     n_cells         = mf_data->n_cell_batches();
   const auto &           dof_info        = mf_data->get_dof_info();
   constexpr unsigned int n_vectorization = VectorizedArray<number>::size();
 

--- a/tests/matrix_free/dof_info_02.cc
+++ b/tests/matrix_free/dof_info_02.cc
@@ -99,7 +99,7 @@ test(const bool adaptive_ref = true)
     mf_data->reinit(dof, constraints, quad, data);
   }
 
-  const unsigned int     n_cells         = mf_data->n_macro_cells();
+  const unsigned int     n_cells         = mf_data->n_cell_batches();
   const auto &           dof_info        = mf_data->get_dof_info();
   constexpr unsigned int n_vectorization = VectorizedArray<number>::size();
 

--- a/tests/matrix_free/jxw_values.cc
+++ b/tests/matrix_free/jxw_values.cc
@@ -79,7 +79,7 @@ test()
   QGauss<dim>          quad(2);
   FEValues<dim>        fe_values(fe, quad, update_JxW_values);
   FEEvaluation<dim, 1> fe_eval(mf_data);
-  for (unsigned int cell = 0; cell < mf_data.n_macro_cells(); ++cell)
+  for (unsigned int cell = 0; cell < mf_data.n_cell_batches(); ++cell)
     {
       fe_eval.reinit(cell);
       for (unsigned int v = 0; v < mf_data.n_components_filled(cell); ++v)

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -163,7 +163,7 @@ test()
   {
     FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> fe_eval(*mf_data);
 
-    const unsigned int n_cells    = mf_data->n_macro_cells();
+    const unsigned int n_cells    = mf_data->n_cell_batches();
     const unsigned int n_q_points = fe_eval.n_q_points;
 
     coefficient->reinit(n_cells, n_q_points);

--- a/tests/matrix_free/quadrature_points.cc
+++ b/tests/matrix_free/quadrature_points.cc
@@ -83,7 +83,7 @@ test()
   }
 
   double                       error_points = 0, abs_points = 0;
-  const unsigned int           n_cells = mf_data.n_macro_cells();
+  const unsigned int           n_cells = mf_data.n_cell_batches();
   FEEvaluation<dim, fe_degree> fe_eval(mf_data);
   FEValues<dim>                fe_values(mapping,
                           fe,

--- a/tests/matrix_free/step-37-inhomogeneous-1.cc
+++ b/tests/matrix_free/step-37-inhomogeneous-1.cc
@@ -211,7 +211,7 @@ namespace Step37
   LaplaceOperator<dim, fe_degree, number>::evaluate_coefficient(
     const Coefficient<dim> &coefficient_function)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
+    const unsigned int n_cells = this->data->n_cell_batches();
     FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(*this->data);
 
     coefficient.reinit(n_cells, phi.n_q_points);
@@ -238,7 +238,7 @@ namespace Step37
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(coefficient.size(0), data.n_macro_cells());
+        AssertDimension(coefficient.size(0), data.n_cell_batches());
         AssertDimension(coefficient.size(1), phi.n_q_points);
 
         phi.reinit(cell);
@@ -307,7 +307,7 @@ namespace Step37
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(coefficient.size(0), data.n_macro_cells());
+        AssertDimension(coefficient.size(0), data.n_cell_batches());
         AssertDimension(coefficient.size(1), phi.n_q_points);
 
         phi.reinit(cell);
@@ -490,7 +490,7 @@ namespace Step37
     FEEvaluation<dim, degree_finite_element> phi(
       *system_matrix.get_matrix_free());
     for (unsigned int cell = 0;
-         cell < system_matrix.get_matrix_free()->n_macro_cells();
+         cell < system_matrix.get_matrix_free()->n_cell_batches();
          ++cell)
       {
         phi.reinit(cell);

--- a/tests/matrix_free/step-37.cc
+++ b/tests/matrix_free/step-37.cc
@@ -233,7 +233,7 @@ namespace Step37
   LaplaceOperator<dim, fe_degree, number>::evaluate_coefficient(
     const Coefficient<dim> &coefficient_function)
   {
-    const unsigned int n_cells = data.n_macro_cells();
+    const unsigned int n_cells = data.n_cell_batches();
     FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(data);
     coefficient.resize(n_cells * phi.n_q_points);
     for (unsigned int cell = 0; cell < n_cells; ++cell)
@@ -256,7 +256,7 @@ namespace Step37
     const std::pair<unsigned int, unsigned int> &cell_range) const
   {
     FEEvaluation<dim, fe_degree, fe_degree + 1, 1, number> phi(data);
-    AssertDimension(coefficient.size(), data.n_macro_cells() * phi.n_q_points);
+    AssertDimension(coefficient.size(), data.n_cell_batches() * phi.n_q_points);
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {

--- a/tests/matrix_free/step-48.cc
+++ b/tests/matrix_free/step-48.cc
@@ -97,7 +97,7 @@ namespace Step48
     FEEvaluation<dim, -1> fe_eval(data);
     const unsigned int    n_q_points = fe_eval.n_q_points;
 
-    for (unsigned int cell = 0; cell < data.n_macro_cells(); ++cell)
+    for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)

--- a/tests/matrix_free/step-48b.cc
+++ b/tests/matrix_free/step-48b.cc
@@ -91,7 +91,7 @@ namespace Step48
     FEEvaluation<dim, -1> fe_eval(data);
     const unsigned int    n_q_points = fe_eval.n_q_points;
 
-    for (unsigned int cell = 0; cell < data.n_macro_cells(); ++cell)
+    for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)

--- a/tests/matrix_free/step-48c.cc
+++ b/tests/matrix_free/step-48c.cc
@@ -97,7 +97,7 @@ namespace Step48
     FEEvaluation<dim, -1> fe_eval(data);
     const unsigned int    n_q_points = fe_eval.n_q_points;
 
-    for (unsigned int cell = 0; cell < data.n_macro_cells(); ++cell)
+    for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         fe_eval.reinit(cell);
         for (unsigned int q = 0; q < n_q_points; ++q)

--- a/tests/matrix_free/stokes_computation.cc
+++ b/tests/matrix_free/stokes_computation.cc
@@ -474,7 +474,7 @@ namespace StokesClass
   StokesOperator<dim, degree_v, number>::evaluate_2_x_viscosity(
     const Viscosity<dim> &viscosity_function)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
+    const unsigned int n_cells = this->data->n_cell_batches();
     FEEvaluation<dim, degree_v, degree_v + 1, dim, number> velocity(*this->data,
                                                                     0);
     viscosity_x_2.reinit(n_cells, velocity.n_q_points);
@@ -609,7 +609,7 @@ namespace StokesClass
   MassMatrixOperator<dim, degree_p, number>::evaluate_1_over_viscosity(
     const Viscosity<dim> &viscosity_function)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
+    const unsigned int n_cells = this->data->n_cell_batches();
     FEEvaluation<dim, degree_p, degree_p + 2, 1, number> pressure(*this->data,
                                                                   0);
     one_over_viscosity.reinit(n_cells, pressure.n_q_points);
@@ -643,7 +643,7 @@ namespace StokesClass
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(one_over_viscosity.size(0), data.n_macro_cells());
+        AssertDimension(one_over_viscosity.size(0), data.n_cell_batches());
         AssertDimension(one_over_viscosity.size(1), pressure.n_q_points);
 
         pressure.reinit(cell);
@@ -787,7 +787,7 @@ namespace StokesClass
   ABlockOperator<dim, degree_v, number>::evaluate_2_x_viscosity(
     const Viscosity<dim> &viscosity_function)
   {
-    const unsigned int n_cells = this->data->n_macro_cells();
+    const unsigned int n_cells = this->data->n_cell_batches();
     FEEvaluation<dim, degree_v, degree_v + 1, dim, number> velocity(*this->data,
                                                                     0);
     viscosity_x_2.reinit(n_cells, velocity.n_q_points);
@@ -823,7 +823,7 @@ namespace StokesClass
 
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
-        AssertDimension(viscosity_x_2.size(0), data.n_macro_cells());
+        AssertDimension(viscosity_x_2.size(0), data.n_cell_batches());
         AssertDimension(viscosity_x_2.size(1), velocity.n_q_points);
 
         velocity.reinit(cell);
@@ -1210,7 +1210,7 @@ namespace StokesClass
       pressure(*stokes_matrix.get_matrix_free(), 1);
 
     for (unsigned int cell = 0;
-         cell < stokes_matrix.get_matrix_free()->n_macro_cells();
+         cell < stokes_matrix.get_matrix_free()->n_cell_batches();
          ++cell)
       {
         velocity.reinit(cell);

--- a/tests/mpi/step-37.cc
+++ b/tests/mpi/step-37.cc
@@ -351,7 +351,7 @@ namespace Step37
     FEEvaluation<dim, degree_finite_element> phi(
       *system_matrix.get_matrix_free());
     for (unsigned int cell = 0;
-         cell < system_matrix.get_matrix_free()->n_macro_cells();
+         cell < system_matrix.get_matrix_free()->n_cell_batches();
          ++cell)
       {
         phi.reinit(cell);

--- a/tests/numerics/project_parallel_qpmf_common.h
+++ b/tests/numerics/project_parallel_qpmf_common.h
@@ -159,7 +159,7 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
       {
         FEEvaluation<dim, fe_degree, n_q_points_1d, 1, double> fe_eval(
           *data, fe_index);
-        const unsigned int n_cells    = data->n_macro_cells();
+        const unsigned int n_cells    = data->n_cell_batches();
         const unsigned int n_q_points = fe_eval.n_q_points;
 
         qp_data.reinit(n_cells, n_q_points);


### PR DESCRIPTION
For the longest time we had n_macro_cells() and n_cell_batches() return
the same thing.
While n_cell_batches() has fewer uses (27 vs 136), I find the term
"macro cell" confusing and incorrect.