### PR TITLE
Make FEEvaluationImpl work for ElementType::tensor_none

### DIFF
--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -91,7 +91,12 @@ namespace internal
        * of the unit interval 0.5 that additionally add a constant shape
        * function according to FE_Q_DG0.
        */
-      tensor_symmetric_plus_dg0 = 5
+      tensor_symmetric_plus_dg0 = 5,
+
+      /**
+       * Shape functions without an tensor product properties.
+       */
+      tensor_none = 6
     };
 
 


### PR DESCRIPTION
Depends on #11186. 

This implementation works for now only for a single component. Once we have decided that this is the right approach I will generalize the code.