### PR TITLE
Use upper-case letters for vectors in the documentation.

### DIFF
--- a/include/deal.II/numerics/vector_tools.h
+++ b/include/deal.II/numerics/vector_tools.h
@@ -146,7 +146,7 @@ DEAL_II_NAMESPACE_OPEN
  * a right hand side do, but without assembling a matrix.
  *
  * <li> Creation of right hand side vectors for point sources: The
- * create_point_source_vector() function computes the vector $f_i =
+ * create_point_source_vector() function computes the vector $F_i =
  * \int_\Omega \delta(x-x_0) \phi_i(x) dx$.
  *
  * <li> Creation of boundary right hand side vectors: The


### PR DESCRIPTION
Specifically, here use 'F' instead of 'f' as that is also the letters used in the
detailed documentation of the function we're referring to.