### PR TITLE
Avoid printing gcc information in OSX CI

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -44,13 +44,12 @@ jobs:
         brew install openmpi
         cmake --version
         # uncomment these for a gcc based build
-        #export OMPI_CXX=g++-9
-        #export OMPI_CC=gcc-9
-        #export OMPI_FC=gfortran-9
+        #export OMPI_CXX=g++
+        #export OMPI_CC=gcc
+        #export OMPI_FC=gfortran
         ./contrib/utilities/download_clang_format
     - name: info
       run: |
-        g++-10 -v
         mpicxx -v
         cmake --version
     - name: configure


### PR DESCRIPTION
I don't see a reason to explicitly print `gcc` version information here if it's not used as compiler.