### PR TITLE
Cleaned up literature references in FE Enriched.

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -953,30 +953,6 @@ year = {2008},
   Url                      = {https://arxiv.org/abs/1904.03317}
 }
 
-@article{ainsworth1998hp,
-  author    = {Ainsworth, Mark and Senior, Bill},
-  title     = {An adaptive refinement strategy for hp-finite element computations},
-  journal   = {{Applied Numerical Mathematics}},
-  volume    = {26},
-  number    = {1--2},
-  pages     = {165--178},
-  publisher = {Elsevier},
-  year      = {1998},
-  doi       = {10.1016/S0168-9274(97)00083-4}
-}
-
-@article{melenk2001hp,
-  author    = {Melenk, Jens Markus and Wohlmuth, Barbara I.},
-  title     = {{On residual-based a posteriori error estimation in hp-FEM}},
-  journal   = {{Advances in Computational Mathematics}},
-  volume    = {15},
-  number    = {1},
-  pages     = {311--331},
-  publisher = {Springer US},
-  year      = {2001},
-  doi       = {10.1023/A:1014268310921}
-}
-
 
 
 @Book{CodeComplete,
@@ -997,3 +973,24 @@ year = {2008},
   publisher={SIAM}
 }
 
+@article{melenk1996,
+  title   = {The partition of unity finite element method: Basic theory and applications},
+  author  = {Melenk, J.M. and Babu\v{s}ka, I.},
+  journal = {Computer Methods in Applied Mechanics and Engineering},
+  year    = {1996},
+  number  = {1--4},
+  pages   = {289 -- 314},
+  volume  = {139},
+  doi     = {10.1016/S0045-7825(96)01087-0}
+}
+
+@article{babuska1997,
+  title   = {The partition of unity method},
+  author  = {Babu\v{s}ka, I. and Melenk, J. M.},
+  journal = {International Journal for Numerical Methods in Engineering},
+  year    = {1997},
+  number  = {4},
+  pages   = {727--758},
+  volume  = {40},
+  doi     = {10.1002/(SICI)1097-0207(19970228)40:4<727::AID-NME86>3.0.CO;2-N}
+}

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -144,47 +144,8 @@ DEAL_II_NAMESPACE_OPEN
  *
  * <h3>References</h3>
  *
- * When using this class, please cite
- * @code{.bib}
- * @article{Davydov2017,
- *   author  = {Denis Davydov and Tymofiy Gerasimov and Jean-Paul Pelteret and
- *              Paul Steinmann},
- *   title   = {Convergence study of the h-adaptive PUM and the hp-adaptive FEM
- *              applied to eigenvalue problems in quantum mechanics},
- *   journal = {Advanced Modeling and Simulation in Engineering Sciences},
- *   year    = {2017},
- *   volume  = {4},
- *   number  = {1},
- *   pages   = {7},
- *   month   = {Dec},
- *   issn    = {2213-7467},
- *   day     = {12},
- *   doi     = {10.1186/s40323-017-0093-0},
- *   url     = {https://doi.org/10.1186/s40323-017-0093-0},
- * }
- * @endcode
- * The PUM was introduced in
- * @code{.bib}
- * @article{Melenk1996,
- *   title   = {The partition of unity finite element method: Basic theory and
- *              applications},
- *   author  = {Melenk, J.M. and Babu\v{s}ka, I.},
- *   journal = {Computer Methods in Applied Mechanics and Engineering},
- *   year    = {1996},
- *   number  = {1--4},
- *   pages   = {289 -- 314},
- *   volume  = {139},
- * }
- * @article{Babuska1997,
- *   title   = {The partition of unity method},
- *   author  = {Babu\v{s}ka, I. and Melenk, J. M.},
- *   journal = {International Journal for Numerical Methods in Engineering},
- *   year    = {1997},
- *   number  = {4},
- *   pages   = {727--758},
- *   volume  = {40},
- * }
- * @endcode
+ * When using this class, please cite @cite davydov2017hp .
+ * The PUM was introduced in @cite melenk1996 and @cite babuska1997 .
  *
  * <h3>Implementation</h3>
  *


### PR DESCRIPTION
- Removed duplicates in `doc/doxygen/references.bib`.
- Moved literature references from ` include/deal.II/fe/fe_enriched.h` to `doc/doxygen/references.bib`.