### PR TITLE
Updated documentation to avoid hp::DoFHandler.

### DIFF
--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -137,9 +137,9 @@ DEAL_II_NAMESPACE_OPEN
  * For example, a vector holding densities at each quadrature point which is
  * used with LocalIntegrators::L2::weighted_mass_matrix() to assemble the local
  * matrix could be resized to the corresponding number of quadrature points of
- * the current cell in hp::DoFHandler. Similarly, local stiffness matrix in
- * CopyData can be resized in accordance with the number of local DoFs on the
- * current cell.
+ * the current cell in DoFHandlers with hp-capabilities. Similarly, local
+ * stiffness matrix in CopyData can be resized in accordance with the number of
+ * local DoFs on the current cell.
  *
  * @note For integration over cells and faces, it is often useful to use
  * methods more specific to the task than the current function (which doesn't

--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -31,14 +31,14 @@ namespace parallel
    * Anytime a parallel::TriangulationBase is repartitioned, either upon request
    * or by refinement/coarsening, cells will be distributed amongst all
    * subdomains to achieve an equally balanced workload. If the workload per
-   * cell varies, which is in general the case for hp::DoFHandler objects, we
-   * can take that into account by introducing individual weights for
-   * different cells.
+   * cell varies, which is in general the case for DoFHandler objects with
+   * hp-capabilities, we can take that into account by introducing individual
+   * weights for different cells.
    *
    * This class allows computing these weights for load balancing by
    * consulting the FiniteElement that is associated with each cell of
-   * a hp::DoFHandler. One can choose from predefined weighting
-   * algorithms provided by this class or provide a custom one.
+   * a DoFHandler. One can choose from predefined weighting algorithms provided
+   * by this class or provide a custom one.
    *
    * This class offers two different ways of connecting the chosen weighting
    * function to the corresponding signal of the linked
@@ -76,7 +76,7 @@ namespace parallel
    * @note Be aware that this class connects the weight function to the
    * Triangulation during this class's constructor. If the Triangulation
    * associated with the DoFHandler changes during the lifetime of the
-   * latter via hp::DoFHandler::initialize(), an assertion will be triggered in
+   * latter via DoFHandler::reinit(), an assertion will be triggered in
    * the weight_callback() function. Use CellWeights::reinit() to deregister the
    * weighting function on the old Triangulation and connect it to the new one.
    *
@@ -103,7 +103,7 @@ namespace parallel
     /**
      * Constructor.
      *
-     * @param[in] dof_handler The hp::DoFHandler which will be used to
+     * @param[in] dof_handler The DoFHandler which will be used to
      *    determine each cell's finite element.
      * @param[in] weighting_function The function that determines each
      *    cell's weight during load balancing.
@@ -189,7 +189,7 @@ namespace parallel
     /**
      * Constructor.
      *
-     * @param[in] dof_handler The hp::DoFHandler which will be used to
+     * @param[in] dof_handler The DoFHandler which will be used to
      *    determine each cell's finite element.
      */
     DEAL_II_DEPRECATED
@@ -229,7 +229,7 @@ namespace parallel
      *    the weight of each cell as an unsigned integer. It is required
      *    to have two arguments, namely the FiniteElement that will be
      *    active on the particular cell, and the cell itself of type
-     *    hp::DoFHandler::cell_iterator. We require both to make sure to
+     *    DoFHandler::cell_iterator. We require both to make sure to
      *    get the right active FiniteElement on each cell in case that we
      *    coarsen the Triangulation.
      */

--- a/include/deal.II/distributed/error_predictor.h
+++ b/include/deal.II/distributed/error_predictor.h
@@ -53,7 +53,7 @@ namespace parallel
   {
     /**
      * Predict how current error indicators will change after refinement and
-     * coarsening were to happen on the provided hp::DoFHandler in context of a
+     * coarsening were to happen on the provided DoFHandler in context of a
      * parallel::distributed::Triangulation.
      *
      * This algorithm follows the same logic as the error prediction algorithm

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -91,9 +91,9 @@ namespace parallel
      * including ways that are dictated by the application and not by the
      * desire to minimize the length of the interface between subdomains owned
      * by processors (as is done by the METIS and Zoltan packages, both of
-     * which are options for partitioning). Both the DoFHandler and
-     * hp::DoFHandler classes know how to enumerate degrees of freedom in ways
-     * appropriate for the partitioned mesh.
+     * which are options for partitioning). The DoFHandler class knows how to
+     * enumerate degrees of freedom in ways appropriate for the partitioned
+     * mesh.
      *
      * @ingroup distributed
      */

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -153,40 +153,31 @@ namespace parallel
      * @endcode
      *
      *
-     * <h3>Note on usage with hp::DoFHandler</h3>
+     * <h3>Note on usage with DoFHandler with hp capabilities</h3>
      *
-     * If an object of the hp::DoFHandler class is registered with an
-     * instantiation of this parallel::distributed::SolutionTransfer
-     * class, it is necessary to explicitly specify this in the template
-     * argument list of this class, i.e.:
-     * @code
-     * parallel::distributed::SolutionsTransfer<dim, VectorType,
-     *   hp::DoFHandler<dim, spacedim>> sol_trans(hp_dof_handler);
-     * @endcode
-     *
-     * Since data on hp::DoFHandler objects is associated with many different
-     * FiniteElement objects, each cell's data has to be processed with its
-     * correpsonding `active_fe_index`. Further, if refinement is involved,
-     * data will be packed on the parent cell with its `active_fe_index` and
-     * unpacked later with the same index on its children. If cells get
-     * coarsened into one, data will be packed on the children with the least
-     * dominant finite element of their common subspace, and unpacked on the
-     * parent with this particular finite element (consult
+     * Since data on DoFHandler objects with hp capabilities is associated with
+     * many different FiniteElement objects, each cell's data has to be
+     * processed with its corresponding `future_fe_index`. Further, if
+     * refinement is involved, data will be packed on the parent cell with its
+     * `future_fe_index` and unpacked later with the same index on its children.
+     * If cells get coarsened into one, data will be packed on the children with
+     * the least dominant finite element of their common subspace, and unpacked
+     * on the parent with this particular finite element (consult
      * hp::FECollection::find_dominated_fe_extended() for more information).
      *
      * Transferring a solution across refinement works exactly like in the
      * non-hp case. However, when considering serialization, we also have to
      * store the active_fe_indices in an additional step. A code snippet
      * demonstrating serialization with the
-     * parallel::distributed::SolutionTransfer class with hp::DoFHandler objects
-     * is provided in the following. Here VectorType is your favorite vector
-     * type, e.g. PETScWrappers::MPI::Vector, TrilinosWrappers::MPI::Vector, or
-     * corresponding block vectors.
+     * parallel::distributed::SolutionTransfer class with DoFHandler objects
+     * with hp capabilities is provided in the following. Here VectorType is
+     * your favorite vector type, e.g. PETScWrappers::MPI::Vector,
+     * TrilinosWrappers::MPI::Vector, or corresponding block vectors.
      *
      * If vector has the locally relevant DoFs, serialization works as follows:
      * @code
      * parallel::distributed::
-     *   SolutionTransfer<dim, VectorType, hp::DoFHandler<dim,spacedim>>
+     *   SolutionTransfer<dim, VectorType, DoFHandler<dim,spacedim>>
      *     sol_trans(hp_dof_handler);
      *
      * hp_dof_handler.prepare_for_serialization_of_active_fe_indices();
@@ -204,16 +195,15 @@ namespace parallel
      * hp::FECollection<dim,spacedim> fe_collection;
      * //[prepare identical fe_collection...]
      *
-     * hp::DoFHandler<dim,spacedim> hp_dof_handler(triangulation);
+     * DoFHandler<dim,spacedim> hp_dof_handler(triangulation);
      * // We need to introduce our dof_handler to the fe_collection
      * // before setting all active_fe_indices.
-     * hp_dof_handler.set_fe(fe_collection);
      * hp_dof_handler.deserialize_active_fe_indices();
      * hp_dof_handler.distribute_dofs(fe_collection);
      *
      * parallel::distributed::
-     *   SolutionTransfer<dim,VectorType,hp::DoFHandler<dim,spacedim>>
-     *     sol_trans(dof_handler);
+     *   SolutionTransfer<dim,VectorType,DoFHandler<dim,spacedim>>
+     *     sol_trans(hp_dof_handler);
      * sol_trans.deserialize(distributed_vector);
      * @endcode
      *
@@ -243,10 +233,10 @@ namespace parallel
       /**
        * Constructor.
        *
-       * @param[in] dof The DoFHandler or hp::DoFHandler on which all
-       *   operations will happen. At the time when this constructor
-       *   is called, the DoFHandler still points to the triangulation
-       *   before the refinement in question happens.
+       * @param[in] dof The DoFHandler on which all operations will happen.
+       *   At the time when this constructor is called, the DoFHandler still
+       *   points to the Triangulation before the refinement in question
+       *   happens.
        */
       SolutionTransfer(const DoFHandlerType &dof);
 

--- a/include/deal.II/dofs/block_info.h
+++ b/include/deal.II/dofs/block_info.h
@@ -85,8 +85,8 @@ class DoFHandler;
  * levels of <tt>mg_vector</tt> will have the block structure needed on that
  * level.
  *
- * @todo Extend the functions local() and renumber() to the concept to
- * hp::DoFHandler.
+ * @todo Extend the functions local() and renumber() to allow for
+ * hp-capablilites.
  *
  * @ingroup dofs
  */

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -33,9 +33,8 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * Implementation of a number of renumbering algorithms for the degrees of
  * freedom on a triangulation. The functions in this namespace compute
- * new indices for each degree of freedom of a DoFHandler or
- * hp::DoFHandler object, and then call DoFHandler::renumber_dofs() or
- * hp::DoFHandler::renumber_dofs().
+ * new indices for each degree of freedom of a DoFHandler object, and then call
+ * DoFHandler::renumber_dofs().
  *
  *
  * <h3>Cuthill-McKee like algorithms</h3>
@@ -524,7 +523,7 @@ namespace DoFRenumbering
    * comparison of various algorithms in the documentation of the
    * DoFRenumbering namespace.
    *
-   * @param dof_handler The DoFHandler or hp::DoFHandler object to work on.
+   * @param dof_handler The DoFHandler object to work on.
    * @param reversed_numbering Whether to use the original Cuthill-McKee
    *   algorithm, or to reverse the ordering.
    * @param use_constraints Whether or not to use hanging node constraints in

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -250,24 +250,7 @@ namespace DoFTools
 
   /**
    * Map a coupling table from the user friendly organization by components to
-   * the organization by blocks. Specializations of this function for
-   * DoFHandler and hp::DoFHandler are required due to the different results
-   * of their finite element access.
-   *
-   * The return vector will be initialized to the correct length inside this
-   * function.
-   */
-  template <int dim, int spacedim>
-  void
-  convert_couplings_to_blocks(const DoFHandler<dim, spacedim> &dof_handler,
-                              const Table<2, Coupling> &table_by_component,
-                              std::vector<Table<2, Coupling>> &tables_by_block);
-
-  /**
-   * Map a coupling table from the user friendly organization by components to
-   * the organization by blocks. Specializations of this function for
-   * DoFHandler and hp::DoFHandler are required due to the different results
-   * of their finite element access.
+   * the organization by blocks.
    *
    * The return vector will be initialized to the correct length inside this
    * function.
@@ -362,8 +345,8 @@ namespace DoFTools
    * methods for building the sparsity patterns that depend on the exact
    * formulation of the problem. You will have to do this yourself then.
    *
-   * @param[in] dof_handler The DoFHandler or hp::DoFHandler object that
-   * describes which degrees of freedom live on which cells.
+   * @param[in] dof_handler The DoFHandler object that describes which degrees
+   * of freedom live on which cells.
    *
    * @param[out] sparsity_pattern The sparsity pattern to be filled with
    * entries.
@@ -562,8 +545,8 @@ namespace DoFTools
    * strict super-set of nonzero entries compared to the work done by
    * make_sparsity_pattern().
    *
-   * @param[in] dof_handler The DoFHandler or hp::DoFHandler object that
-   * describes which degrees of freedom live on which cells.
+   * @param[in] dof_handler The DoFHandler object that describes which degrees
+   * of freedom live on which cells.
    *
    * @param[out] sparsity_pattern The sparsity pattern to be filled with
    * entries.
@@ -770,14 +753,11 @@ namespace DoFTools
    * This function does not close the object since you may want to
    * enter other constraints later on yourself.
    *
-   * In the hp-case, i.e. when the argument is of type hp::DoFHandler, we
-   * consider constraints due to different finite elements used on two sides
-   * of a face between cells as hanging nodes as well. In other words, for hp
-   * finite elements, this function computes all constraints due to differing
-   * mesh sizes (h) or polynomial degrees (p) between adjacent cells.
-   *
-   * The template argument (and by consequence the type of the first argument
-   * to this function) can be either ::DoFHandler or hp::DoFHandler.
+   * Using a DoFHandler with hp-capabilities, we consider constraints due to
+   * different finite elements used on two sides of a face between cells as
+   * hanging nodes as well. In other words, in hp-mode, this function computes
+   * all constraints due to differing mesh sizes (h) or polynomial degrees (p)
+   * between adjacent cells.
    *
    * @ingroup constraints
    */
@@ -2221,14 +2201,13 @@ namespace DoFTools
                          std::vector<unsigned int>());
 
   /**
-   * For each active cell of a DoFHandler or hp::DoFHandler, extract the
-   * active finite element index and fill the vector given as second argument.
-   * This vector is assumed to have as many entries as there are active cells.
+   * For each active cell of a DoFHandler, extract the active finite element
+   * index and fill the vector given as second argument. This vector is assumed
+   * to have as many entries as there are active cells.
    *
-   * For non-hp DoFHandler objects given as first argument, the returned
-   * vector will consist of only zeros, indicating that all cells use the same
-   * finite element. For a hp::DoFHandler, the values may be different,
-   * though.
+   * For DoFHandler objects without hp-capabilities given as first argument, the
+   * returned vector will consist of only zeros, indicating that all cells use
+   * the same finite element. In hp-mode, the values may be different, though.
    */
   template <int dim, int spacedim>
   void
@@ -2667,8 +2646,8 @@ namespace DoFTools
    */
   DeclException0(ExcGridsDontMatch);
   /**
-   * The ::DoFHandler or hp::DoFHandler was not initialized with a finite
-   * element. Please call DoFHandler::distribute_dofs() etc. first.
+   * The DoFHandler was not initialized with a finite element. Please call
+   * DoFHandler::distribute_dofs() first.
    *
    * @ingroup Exceptions
    */

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -230,7 +230,7 @@ public:
    * As for the enriched finite element space, FE_Nothing is used.
    * Continuity constraints will be automatically generated when
    * this non-enriched element is used in conjunction with enriched finite
-   * element within the hp::DoFHandler.
+   * element within a DoFHandler with hp-capabilities.
    *
    * See the discussion in the class documentation on how to use this element
    * in the context of hp finite element methods.
@@ -716,7 +716,7 @@ private:
 /**
  * This namespace consists of a class needed to create a collection
  * of FE_Enriched finite elements (hp::FECollection)
- * to be used with hp::DoFHandler in a domain with multiple, possibly
+ * to be used with DoFHandler in hp-mode on a domain with multiple, possibly
  * overlapping, sub-domains with individual enrichment functions.
  *
  * To create hp::FECollection, a graph coloring algorithm is used to assign
@@ -741,7 +741,7 @@ namespace ColorEnriched
   {
     /**
      * Returns true if there is a connection between subdomains in the mesh
-     * associated with @p hp::DoFHandler i.e., if the subdomains share at least
+     * associated with @p dof_handler i.e., if the subdomains share at least
      * a vertex. The two subdomains are defined by predicates provided by
      * @p predicate_1 and @p predicate_2. A predicate is a function (or
      * object of a type with an operator()) which takes in a cell iterator and
@@ -778,7 +778,7 @@ namespace ColorEnriched
      *  predicate<dim>(Point<dim>(2,2), 1));
      * @endcode
      *
-     * @param[in] hp::DoFHandler object
+     * @param[in] dof_handler DoFHandler object
      * @param[in] predicate_1 A function (or object of a type with an
      * operator()) defining the subdomain 1. The function takes in a cell and
      * returns a boolean.
@@ -799,7 +799,7 @@ namespace ColorEnriched
      * subdomain
      * is defined using a predicate function of @p predicates.
      *
-     * @param[in] dof_handler a hp::DoFHandler object
+     * @param[in] dof_handler a DoFHandler object
      * @param[in] predicates predicates defining the subdomains
      * @param[out] predicate_colors Colors (unsigned int) associated with each
      * subdomain.
@@ -813,7 +813,7 @@ namespace ColorEnriched
 
     /**
      * Used to construct data members @p cellwise_color_predicate_map and
-     * @p fe_sets of Helper class. Inputs are hp::DoFHandler object,
+     * @p fe_sets of Helper class. Inputs are DoFHandler object,
      * vector of predicates and colors associated with them. Before calling
      * this function, colors can be assigned to predicates (i.e subdomains)
      * using the function color_predicates.
@@ -841,7 +841,7 @@ namespace ColorEnriched
      * the map will insert pairs (1, 4) and (2, 5) at key 100 (i.e unique id
      * of cell is mapped with a map which associates color with predicate id).
      *
-     * @param[in] dof_handler hp::DoFHandler object
+     * @param[in] dof_handler DoFHandler object
      * @param[in] predicates vector of predicates defining the subdomains.
      * <code>@p predicates[i]</code> returns true for a cell if it
      * belongs to subdomain with index i.
@@ -931,7 +931,7 @@ namespace ColorEnriched
 
   /**
    * ColorEnriched::Helper class creates a collection of FE_Enriched finite
-   * elements (hp::FECollection) to be used with hp::DoFHandler in a domain
+   * elements (hp::FECollection) to be used with DoFHandler in a domain
    * with multiple, possibly overlapping, sub-domains with individual
    * enrichment functions. Note that the overlapping regions may have
    * multiple enrichment functions associated with them. This is implemented
@@ -1003,9 +1003,9 @@ namespace ColorEnriched
    * enrichment functions), a vector of predicate
    * functions (used to define sub-domains) as well as the corresponding
    * enrichment functions. The FECollection object, a collection of FE_Enriched
-   * objects to be used with an hp::DoFHandler object, can be retrieved
+   * objects to be used with a DoFHandler object, can be retrieved
    * using the member function build_fe_collection which also modifies the
-   * active FE indices of the hp::DoFHandler object (provided as an argument
+   * active FE indices of the DoFHandler object (provided as an argument
    * to the build_fe_collection function).
    *
    * <h3>Simple example</h3>
@@ -1084,8 +1084,8 @@ namespace ColorEnriched
    * std::vector< predicate_function<dim> > predicates;
    * std::vector< std::shared_ptr<Function<dim>> > enrichments;
    *
-   * Triangulation<dim>  triangulation;
-   * hp::DoFHandler<dim> dof_handler(triangulation);
+   * Triangulation<dim> triangulation;
+   * DoFHandler<dim>    dof_handler(triangulation);
    *
    * static ColorEnriched::Helper<dim> FE_helper(fe_base,
    *                                             fe_enriched,
@@ -1114,11 +1114,11 @@ namespace ColorEnriched
            const std::vector<std::shared_ptr<Function<spacedim>>> &enrichments);
 
     /**
-     * Prepares an hp::DoFHandler object. The active FE indices of
+     * Prepares a DoFHandler object. The active FE indices of
      * mesh cells are initialized to work with
      * ColorEnriched::Helper<dim,spacedim>::fe_collection.
      *
-     * @param dof_handler an hp::DoFHandler object
+     * @param dof_handler a DoFHandler object
      * @return hp::FECollection, a collection of
      * finite elements needed by @p dof_handler.
      */
@@ -1127,8 +1127,8 @@ namespace ColorEnriched
 
   private:
     /**
-     * Contains a collection of FiniteElement objects needed by an
-     * hp::DoFHandler object.
+     * Contains a collection of FiniteElement objects needed by a DoFHandler
+     * object.
      */
     hp::FECollection<dim, spacedim> fe_collection;
 
@@ -1210,7 +1210,7 @@ namespace ColorEnriched
 
     /**
      * A vector of different possible color sets for a given set of
-     * predicates and hp::DoFHandler object
+     * predicates and DoFHandler object
      */
     std::vector<std::set<unsigned int>> fe_sets;
   };

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -29,17 +29,17 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * Definition of a finite element space with zero degrees of freedom and that,
  * consequently, can only represent a single function: the zero function.
- * This class is
- * useful (in the context of an hp method) to represent empty cells in the
- * triangulation on which no degrees of freedom should be allocated, or to
- * describe a field that is extended by zero to a part of the domain where we
- * don't need it.  Thus a triangulation may be divided into two regions: an
- * active region where normal elements are used, and an inactive region where
- * FE_Nothing elements are used.  The hp::DoFHandler will therefore assign no
- * degrees of freedom to the FE_Nothing cells, and this subregion is therefore
- * implicitly deleted from the computation. step-10 and step-46 show use cases
- * for this element. An interesting application for this element is also
- * presented in the paper @cite Cangiani2012.
+ *
+ * This class is useful (in the context of an hp method) to represent empty
+ * cells in the triangulation on which no degrees of freedom should be
+ * allocated, or to describe a field that is extended by zero to a part of the
+ * domain where we don't need it. Thus a triangulation may be divided into two
+ * regions: an active region where normal elements are used, and an inactive
+ * region where FE_Nothing elements are used. The DoFHandler will therefore
+ * assign no degrees of freedom to the FE_Nothing cells, and this subregion is
+ * therefore implicitly deleted from the computation. step-10 and step-46 show
+ * use cases for this element. An interesting application for this element is
+ * also presented in the paper @cite Cangiani2012.
  *
  * Note that some care must be taken that the resulting mesh topology
  * continues to make sense when FE_Nothing elements are introduced. This is

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -653,11 +653,11 @@ namespace FETools
 
   /**
    * Compute the interpolation of a the @p dof1-function @p u1 to a @p
-   * dof2-function @p u2. @p dof1 and @p dof2 need to be DoFHandlers (or
-   * hp::DoFHandlers) based on the same triangulation.  @p constraints is a
-   * hanging node constraints object corresponding to @p dof2. This object is
-   * particular important when interpolating onto continuous elements on grids
-   * with hanging nodes (locally refined grids).
+   * dof2-function @p u2. @p dof1 and @p dof2 need to be DoFHandlers based on
+   * the same triangulation. @p constraints is a hanging node constraints object
+   * corresponding to @p dof2. This object is particular important when
+   * interpolating onto continuous elements on grids with hanging nodes (locally
+   * refined grids).
    *
    * If the elements @p fe1 and @p fe2 are either both continuous or both
    * discontinuous then this interpolation is the usual point interpolation.
@@ -684,8 +684,6 @@ namespace FETools
    * Note, that this function does not work on continuous elements at hanging
    * nodes. For that case use the @p back_interpolate function, below, that
    * takes an additional @p AffineConstraints object.
-   *
-   * @p dof1 might be a DoFHandler or a hp::DoFHandler onject.
    *
    * Furthermore note, that for the specific case when the finite element
    * space corresponding to @p fe1 is a subset of the finite element space

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -2154,11 +2154,11 @@ namespace GridGenerator
    * @ref ConceptMeshType "MeshType concept".
    * The map that is returned will be between cell iterators pointing into the
    * container describing the surface mesh and face iterators of the volume
-   * mesh container. If MeshType is DoFHandler or hp::DoFHandler, then the
-   * function will re-build the triangulation underlying the second argument
-   * and return a map between appropriate iterators into the MeshType
-   * arguments. However, the function will not actually distribute degrees of
-   * freedom on this newly created surface mesh.
+   * mesh container. If MeshType is DoFHandler, then the function will re-build
+   * the triangulation underlying the second argument and return a map between
+   * appropriate iterators into the MeshType arguments. However, the function
+   * will not actually distribute degrees of freedom on this newly created
+   * surface mesh.
    *
    * @tparam dim The dimension of the cells of the volume mesh. For example,
    * if dim==2, then the cells are quadrilaterals that either live in the

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1505,8 +1505,8 @@ namespace GridTools
    * GridTools::compute_active_cell_halo_layer(
    *   tria, IteratorFilters::MaterialIdEqualTo(1, true));
    * @endcode
-   * or around all cells with one of a set of active FE indices for an
-   * hp::DoFHandler
+   * or around all cells with one of a set of active FE indices for a DoFHandler
+   * with hp-capabilities
    * @code
    * GridTools::compute_active_cell_halo_layer(
    *   hp_dof_handler, IteratorFilters::ActiveFEIndexEqualTo({1,2}, true));
@@ -1517,8 +1517,7 @@ namespace GridTools
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
-   * @param[in] mesh A mesh (i.e. objects of type Triangulation, DoFHandler,
-   * or hp::DoFHandler).
+   * @param[in] mesh A mesh (i.e. objects of type Triangulation or DoFHandler).
    * @param[in] predicate A function  (or object of a type with an operator())
    * defining the subdomain around which the halo layer is to be extracted. It
    * is a function that takes in an active cell and returns a boolean.
@@ -1558,8 +1557,7 @@ namespace GridTools
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
-   * @param[in] mesh A mesh (i.e. objects of type Triangulation, DoFHandler,
-   * or hp::DoFHandler).
+   * @param[in] mesh A mesh (i.e. objects of type Triangulation or DoFHandler).
    * @return A list of ghost cells
    */
   template <class MeshType>
@@ -1598,8 +1596,7 @@ namespace GridTools
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
-   * @param mesh A mesh (i.e. objects of type Triangulation, DoFHandler,
-   * or hp::DoFHandler).
+   * @param mesh A mesh (i.e. objects of type Triangulation or DoFHandler).
    * @param predicate A function  (or object of a type with an operator())
    * defining the subdomain around which the halo layer is to be extracted. It
    * is a function that takes in an active cell and returns a boolean.
@@ -1636,8 +1633,7 @@ namespace GridTools
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
-   * @param mesh A mesh (i.e. objects of type Triangulation, DoFHandler,
-   * or hp::DoFHandler).
+   * @param mesh A mesh (i.e. objects of type Triangulation or DoFHandler).
    * @param layer_thickness specifies the geometric distance within
    * which the function searches for active cells from the locally owned cells.
    * @return A subset of ghost cells within a given geometric distance of @p
@@ -2180,12 +2176,12 @@ namespace GridTools
   /*@{*/
 
   /**
-   * Given two meshes (i.e. objects of type Triangulation, DoFHandler, or
-   * hp::DoFHandler) that are based on the same coarse mesh, this function
-   * figures out a set of cells that are matched between the two meshes and
-   * where at most one of the meshes is more refined on this cell. In other
-   * words, it finds the smallest cells that are common to both meshes, and
-   * that together completely cover the domain.
+   * Given two meshes (i.e. objects of type Triangulation or DoFHandler) that
+   * are based on the same coarse mesh, this function figures out a set of cells
+   * that are matched between the two meshes and where at most one of the meshes
+   * is more refined on this cell. In other words, it finds the smallest cells
+   * that are common to both meshes, and that together completely cover the
+   * domain.
    *
    * This function is useful, for example, in time-dependent or nonlinear
    * application, where one has to integrate a solution defined on one mesh
@@ -2232,10 +2228,10 @@ namespace GridTools
                         const Triangulation<dim, spacedim> &mesh_2);
 
   /**
-   * The same function as above, but working on arguments of type DoFHandler,
-   * or hp::DoFHandler. This function is provided to allow calling
-   * have_same_coarse_mesh for all types of containers representing
-   * triangulations or the classes built on triangulations.
+   * The same function as above, but working on arguments of type DoFHandler.
+   * This function is provided to allow calling have_same_coarse_mesh for all
+   * types of containers representing triangulations or the classes built on
+   * triangulations.
    *
    * @tparam MeshType A type that satisfies the requirements of the
    * @ref ConceptMeshType "MeshType concept".
@@ -2889,12 +2885,12 @@ namespace GridTools
    * in a concrete context. It is taken from the code that makes
    * sure that the @p active_fe_index (a single unsigned integer) is
    * transported from locally owned cells where one can set it in
-   * hp::DoFHandler objects, to the corresponding ghost cells on
-   * other processors to ensure that one can query the right value
-   * also on those processors:
+   * DoFHandler objects with hp-capabilities, to the corresponding ghost cells
+   * on other processors to ensure that one can query the right value also on
+   * those processors:
    * @code
    * using active_cell_iterator =
-   *   typename dealii::hp::DoFHandler<dim,spacedim>::active_cell_iterator;
+   *   typename dealii::DoFHandler<dim,spacedim>::active_cell_iterator;
    * auto pack = [] (const active_cell_iterator &cell) -> unsigned int
    *             {
    *               return cell->active_fe_index();
@@ -2907,9 +2903,9 @@ namespace GridTools
    *               };
    *
    * GridTools::exchange_cell_data_to_ghosts<
-   *   unsigned int, dealii::hp::DoFHandler<dim,spacedim>> (dof_handler,
-   *                                                        pack,
-   *                                                        unpack);
+   *   unsigned int, dealii::DoFHandler<dim,spacedim>> (dof_handler,
+   *                                                    pack,
+   *                                                    unpack);
    * @endcode
    *
    * You will notice that the @p pack lambda function returns an `unsigned int`,

--- a/include/deal.II/grid/intergrid_map.h
+++ b/include/deal.II/grid/intergrid_map.h
@@ -106,7 +106,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * Note that the template parameters to this class have to be given as
  * <tt>InterGridMap<DoFHandler<2> ></tt>, which here is DoFHandler (and could
- * equally well be Triangulation, PersistentTriangulation, or hp::DoFHandler).
+ * equally well be Triangulation or PersistentTriangulation).
  *
  * @ingroup grid
  */

--- a/include/deal.II/grid/tria_iterator.h
+++ b/include/deal.II/grid/tria_iterator.h
@@ -167,11 +167,10 @@ class TriaActiveIterator;
  * add functionality.
  *
  * The accessors provided by the library consist of two groups, determined by
- * whether they access the data of Triangulation objects or
- * DoFHandler/hp::DoFHandler objects. They are derived from TriaAccessor and
- * DoFAccessor, respectively. Each group also has specialized accessors for
- * cells (as opposed to faces and lines) that offer more functionality such as
- * accessing neighbors.
+ * whether they access the data of Triangulation objects or DoFHandler objects.
+ * They are derived from TriaAccessor and DoFAccessor, respectively. Each group
+ * also has specialized accessors for cells (as opposed to faces and lines) that
+ * offer more functionality such as accessing neighbors.
  *
  * @attention It seems impossible to preserve constness of a triangulation
  * through iterator usage. Thus, if you declare pointers to a <tt>const</tt>

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -30,8 +30,7 @@ namespace hp
 {
   /**
    * This class acts as a collection of finite element objects used in the
-   * hp::DoFHandler. It is thus to a hp::DoFHandler what a FiniteElement is to
-   * a ::DoFHandler.
+   * DoFHandler.
    *
    * It implements the concepts stated in the
    * @ref hpcollection

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -875,7 +875,7 @@ namespace internal
         // fe_values object that is used to compute the mapping data. for
         // the hp case there might be more than one finite element. since we
         // manually select the active FE index and not via a
-        // hp::DoFHandler<dim>::active_cell_iterator, we need to manually
+        // DoFHandler<dim>::active_cell_iterator, we need to manually
         // select the correct finite element, so just hold a vector of
         // FEValues
         std::vector<std::vector<std::shared_ptr<dealii::FEValues<dim>>>>

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -145,7 +145,7 @@ public:
    * the indices are to be used. If the level is set to
    * numbers::invalid_unsigned_int, the active cells are traversed, and
    * otherwise the cells in the given level. This option has no effect in case
-   * a DoFHandler or hp::DoFHandler is given.
+   * a DoFHandler is given.
    *
    * The parameter @p initialize_plain_indices indicates whether the DoFInfo
    * class should also allow for access to vectors without resolving

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -179,7 +179,7 @@ public:
    * deformation of each vertex.
    *
    * @todo The @p mapping argument should be replaced by a
-   * hp::MappingCollection in case of a hp::DoFHandler.
+   * hp::MappingCollection in case of a DoFHandler with hp-capabilities.
    */
   virtual void
   build_patches(const Mapping<dimension> &mapping,

--- a/include/deal.II/numerics/smoothness_estimator.h
+++ b/include/deal.II/numerics/smoothness_estimator.h
@@ -128,7 +128,7 @@ namespace SmoothnessEstimator
      * This object needs to be initialized to have at least $p+1$ coefficients
      * in each direction for every finite element in the collection, where $p$
      * is its polynomial degree.
-     * @param [in] dof_handler An hp::DoFHandler.
+     * @param [in] dof_handler A DoFHandler.
      * @param [in] solution A solution vector.
      * @param [out] smoothness_indicators A vector for smoothness indicators.
      * @param [in] regression_strategy Determines which norm will be used on the
@@ -180,7 +180,7 @@ namespace SmoothnessEstimator
      * @param [in] fe_legendre FESeries::Legendre object to calculate coefficients.
      * This object needs to be initialized to have at least $p+1$ coefficients
      * in each direction, where $p$ is the maximum polynomial degree to be used.
-     * @param [in] dof_handler An hp::DoFHandler
+     * @param [in] dof_handler A DoFHandler
      * @param [in] solution A solution vector
      * @param [out] smoothness_indicators A vector for smoothness indicators
      * @param [in] coefficients_predicate A predicate to select Legendre

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -293,27 +293,27 @@ DEAL_II_NAMESPACE_OPEN
  *
  * <h3>Implementation in the context of hp finite elements</h3>
  *
- * In the case of hp::DoFHandlers, nothing defines which of the finite
- * elements that are part of the hp::FECollection associated with the DoF
- * handler, should be considered on cells that are not active (i.e., that have
- * children). This is because degrees of freedom are only allocated for active
- * cells and, in fact, it is not allowed to set an active_fe_index on non-
- * active cells using DoFAccessor::set_active_fe_index().
+ * In the case of DoFHandlers with hp-capabilities, nothing defines which of the
+ * finite elements that are part of the hp::FECollection associated with the
+ * DoFHandler, should be considered on cells that are not active (i.e., that
+ * have children). This is because degrees of freedom are only allocated for
+ * active cells and, in fact, it is not allowed to set an active_fe_index on
+ * non- active cells using DoFAccessor::set_active_fe_index().
  *
  * It is, thus, not entirely natural what should happen if, for example, a few
  * cells are coarsened away. This class then implements the following
  * algorithm:
  * - If a cell is refined, then the values of the solution vector(s) are
- *   saved before refinement on the to-be-refined cell and in the space
- *   associated with this cell. These values are then interpolated to the finite
- *   element spaces of the children post-refinement. This may lose information
- *   if, for example, the old cell used a Q2 space and the children use Q1
- *   spaces, or the information may be prolonged if the mother cell used a Q1
- *   space and the children are Q2s.
+ *   interpolated before refinement on the to-be-refined cell from the space of
+ *   the active finite element to the one of the future finite element. These
+ *   values are then distributed on the finite element spaces of the children
+ *   post-refinement. This may lose information if, for example, the old cell
+ *   used a Q2 space and the children use Q1 spaces, or the information may be
+ *   prolonged if the mother cell used a Q1 space and the children are Q2s.
  * - If cells are to be coarsened, then the values from the child cells are
- *   interpolated to the mother cell using the largest of the child cell spaces,
- *   which will be identified as the least dominant element following the
- *   FiniteElementDomination logic (consult
+ *   interpolated to the mother cell using the largest of the child cell future
+ *   finite element spaces, which will be identified as the least dominant
+ *   element following the FiniteElementDomination logic (consult
  *   hp::FECollection::find_dominated_fe_extended() for more information). For
  *   example, if the children of a cell use Q1, Q2 and Q3 spaces, then the
  *   values from the children are interpolated into a Q3 space on the mother
@@ -321,7 +321,7 @@ DEAL_II_NAMESPACE_OPEN
  *   interpolated into the space the user has selected for this cell (which may
  *   be different from Q3, in this example, if the user has set the
  *   active_fe_index for a different space post-refinement and before calling
- *   hp::DoFHandler::distribute_dofs()).
+ *   DoFHandler::distribute_dofs()).
  *
  * @note In the context of hp refinement, if cells are coarsened or the
  * polynomial degree is lowered on some cells, then the old finite element

--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -107,8 +107,8 @@ namespace VectorTools
     const ComponentMask &component_mask = ComponentMask());
 
   /**
-   * Like the previous function, but take a mapping collection to go with the
-   * hp::DoFHandler object.
+   * Like the previous function, but take a mapping collection to go with
+   * DoFHandler objects with hp-capabilities.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -395,7 +395,7 @@ namespace VectorTools
     std::vector<unsigned int>                  component_mapping = {});
 
   /**
-   * Same as above, but for objects of type hp::DoFHandler
+   * Same as above, but with hp-capabilities.
    */
   template <int dim, int spacedim, typename number>
   void

--- a/include/deal.II/numerics/vector_tools_integrate_difference.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.h
@@ -247,7 +247,7 @@ namespace VectorTools
   /**
    * Same as above for hp.
    *
-   * @deprecated Use integrate_difference(const hp::MappingCollection<dim, spacedim> &, const hp::DoFHandler<dim, spacedim> &, const InVector &, const Function<spacedim, typename InVector::value_type> &, OutVector &, const hp::QCollection<dim> &, const NormType &, const Function<spacedim, double> *, const double) instead.
+   * @deprecated Use integrate_difference(const hp::MappingCollection<dim, spacedim> &, const DoFHandler<dim, spacedim> &, const InVector &, const Function<spacedim, typename InVector::value_type> &, OutVector &, const hp::QCollection<dim> &, const NormType &, const Function<spacedim, double> *, const double) instead.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_DEPRECATED typename std::enable_if<
@@ -266,7 +266,7 @@ namespace VectorTools
    * Call the integrate_difference() function, see above, with
    * <tt>mapping=MappingQGeneric@<dim@>(1)</tt>.
    *
-   * @deprecated Use integrate_difference(const hp::DoFHandler<dim, spacedim> &, const InVector &, const Function<spacedim, typename InVector::value_type> &, OutVector &, const hp::QCollection<dim> &, const NormType &, const Function<spacedim, double> *, const double) instead.
+   * @deprecated Use integrate_difference(const DoFHandler<dim, spacedim> &, const InVector &, const Function<spacedim, typename InVector::value_type> &, OutVector &, const hp::QCollection<dim> &, const NormType &, const Function<spacedim, double> *, const double) instead.
    */
   template <int dim, class InVector, class OutVector, int spacedim>
   DEAL_II_DEPRECATED typename std::enable_if<

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -138,17 +138,7 @@ namespace VectorTools
                              Vector<double> &                 rhs_vector);
 
   /**
-   * Call the create_point_source_vector() function, see above, with
-   * an implied default $Q_1$ mapping object.
-   */
-  template <int dim, int spacedim>
-  void
-  create_point_source_vector(const DoFHandler<dim, spacedim> &dof_handler,
-                             const Point<spacedim, double> &  p,
-                             Vector<double> &                 rhs_vector);
-
-  /**
-   * Like the previous set of functions, but for hp objects.
+   * Like the previous function, but for hp-objects.
    */
   template <int dim, int spacedim>
   void
@@ -159,10 +149,12 @@ namespace VectorTools
     Vector<double> &                            rhs_vector);
 
   /**
-   * Like the previous set of functions, but for hp objects. The function uses
-   * an implied default $Q_1$ mapping object. Note that if your hp::DoFHandler
-   * uses any active fe index other than zero, then you need to call the
-   * function above that provides a mapping object for each active fe index.
+   * Call the create_point_source_vector() function, see above, with
+   * an implied default $Q_1$ mapping object.
+   *
+   * Note that if your DoFHandler uses any active fe index other than zero, then
+   * you need to call the function above that provides a mapping object for each
+   * active fe index.
    */
   template <int dim, int spacedim>
   void
@@ -197,18 +189,7 @@ namespace VectorTools
                              Vector<double> &                 rhs_vector);
 
   /**
-   * Call the create_point_source_vector() function for vector-valued finite
-   * elements, see above, with an implied default $Q_1$ mapping object.
-   */
-  template <int dim, int spacedim>
-  void
-  create_point_source_vector(const DoFHandler<dim, spacedim> &dof_handler,
-                             const Point<spacedim, double> &  p,
-                             const Point<dim, double> &       direction,
-                             Vector<double> &                 rhs_vector);
-
-  /**
-   * Like the previous set of functions, but for hp objects.
+   * Like the previous function, but for hp-objects.
    */
   template <int dim, int spacedim>
   void
@@ -220,10 +201,12 @@ namespace VectorTools
     Vector<double> &                            rhs_vector);
 
   /**
-   * Like the previous set of functions, but for hp objects. The function uses
-   * an implied default $Q_1$ mapping object. Note that if your hp::DoFHandler
-   * uses any active fe index other than zero, then you need to call the
-   * function above that provides a mapping object for each active fe index.
+   * Call the create_point_source_vector() function for vector-valued finite
+   * elements, see above, with an implied default $Q_1$ mapping object.
+   *
+   * Note that if your DoFHandler uses any active fe index other than zero, then
+   * you need to call the function above that provides a mapping object for each
+   * active fe index.
    */
   template <int dim, int spacedim>
   void
@@ -231,7 +214,6 @@ namespace VectorTools
                              const Point<spacedim, double> &  p,
                              const Point<dim, double> &       direction,
                              Vector<double> &                 rhs_vector);
-
   // @}
 
   /**

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -170,8 +170,7 @@ namespace VectorTools
           const bool                 project_to_boundary_first = false);
 
   /**
-   * Same as above, but for arguments of type hp::DoFHandler, hp::QCollection,
-   * and hp::MappingCollection.
+   * Same as above, but with hp-capabilities.
    */
   template <int dim, typename VectorType, int spacedim>
   void

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -72,7 +72,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
         {
           // well, here we need to first get the values from the current
           // cell and then interpolate it to the element requested. this
-          // can clearly only happen for hp::DoFHandler objects
+          // can clearly only happen for DoFHandler objects in hp-mode
           const unsigned int dofs_per_cell = this->get_fe().n_dofs_per_cell();
           if (dofs_per_cell == 0)
             {

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1716,9 +1716,9 @@ namespace internal
 
 
         /**
-         * Given a hp::DoFHandler object, make sure that the active_fe_indices
-         * that a user has set for locally owned cells are communicated to all
-         * other relevant cells as well.
+         * Given a DoFHandler object in hp-mode, make sure that the
+         * active_fe_indices that a user has set for locally owned cells are
+         * communicated to all other relevant cells as well.
          *
          * For parallel::shared::Triangulation objects,
          * this information is distributed on both ghost and artificial cells.


### PR DESCRIPTION
While browsing through the documentation, I've found duplicates of functions in header files that I removed.

So although this PR effectively just changes the documentation, please run the testsuite to be sure nothing breaks.