### PR TITLE
Remove hp::DoFHandler instantiation from SolutionTransfer.

### DIFF
--- a/source/numerics/solution_transfer.inst.in
+++ b/source/numerics/solution_transfer.inst.in
@@ -22,9 +22,5 @@ for (VEC : VECTOR_TYPES; deal_II_dimension : DIMENSIONS;
       deal_II_dimension,
       VEC,
       DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
-    template class SolutionTransfer<
-      deal_II_dimension,
-      VEC,
-      hp::DoFHandler<deal_II_dimension, deal_II_space_dimension>>;
 #endif
   }


### PR DESCRIPTION
I've noticed that the `hp::DoFHandler` instantiation from the basic `SolutionTransfer` class has been removed in #10328.

So this should also apply for the `p::d::SolutionTransfer` class, right?