### PR TITLE
Consistency in using hp concatenation symbols.

### DIFF
--- a/doc/doxygen/headers/constraints.h
+++ b/doc/doxygen/headers/constraints.h
@@ -56,7 +56,7 @@
  *   are $x_{28}$ and $x_{40}$. Then, requiring that the finite element
  *   function be continuous is equivalent to requiring that $x_{12}=
  *   \frac 12 (x_{28}+x_{40})$. A similar situation occurs in the
- *   context of hp adaptive finite element methods.
+ *   context of hp-adaptive finite element methods.
  *   For example, when using Q1 and Q2 elements (i.e. using
  *   FE_Q(1) and FE_Q(2)) on the two marked cells of the mesh
  *       @image html hp-refinement-simple.png
@@ -99,7 +99,7 @@
  * This scheme of first building a linear system and then eliminating
  * constrained degrees of freedom is inefficient, and a bottleneck if there
  * are many constraints and matrices are full, i.e. especially for 3d and/or
- * higher order or hp finite elements. Furthermore, it is impossible to
+ * higher order or hp-finite elements. Furthermore, it is impossible to
  * implement for %parallel computations where a process may not have access
  * to elements of the matrix. We therefore offer a second way of
  * building linear systems, using the
@@ -204,8 +204,8 @@
  * Condensation is an expensive operation, in particular if there
  * are many constraints and/or if the matrix has many nonzero entries. Both
  * is typically the case for 3d, or high polynomial degree computations, as
- * well as for hp finite element methods, see for example the @ref hp_paper
- * "hp paper". This is the case discussed in the hp tutorial program, @ref
+ * well as for hp-finite element methods, see for example the @ref hp_paper
+ * "hp-paper". This is the case discussed in the hp-tutorial program, @ref
  * step_27 "step-27", as well as in step-22 and @ref step_31
  * "step-31".
  *

--- a/doc/doxygen/headers/glossary.h
+++ b/doc/doxygen/headers/glossary.h
@@ -1136,12 +1136,12 @@
  * </dd>
  *
  *
- * <dt class="glossary">@anchor hp_paper <b>%hp paper</b></dt>
- * <dd>The "hp paper" is a paper by W. Bangerth and O. Kayser-Herold, titled
+ * <dt class="glossary">@anchor hp_paper <b>%hp-paper</b></dt>
+ * <dd>The "hp-paper" is a paper by W. Bangerth and O. Kayser-Herold, titled
  * "Data Structures and Requirements for hp Finite Element Software", that
  * describes many of the algorithms and data structures used in the implementation
- * of the hp framework of deal.II. In particular, it summarizes many of the
- * tricky points that have to be considered for %hp finite elements using continuous
+ * of the hp-framework of deal.II. In particular, it summarizes many of the
+ * tricky points that have to be considered for %hp-finite elements using continuous
  * elements.
  *
  * The full reference for this paper is as follows:

--- a/doc/doxygen/headers/hp.h
+++ b/doc/doxygen/headers/hp.h
@@ -15,22 +15,22 @@
 
 
 /**
- * @defgroup hp hp finite element support
+ * @defgroup hp hp-finite element support
  *
- * Classes and functions that have to do with hp finite elements. The step-27
+ * Classes and functions that have to do with hp-finite elements. The step-27
  * tutorial program gives an overview of how to use the classes in this
  * namespace. A slightly more exotic application is given in step-46.
  *
- * The hp namespace implements the algorithms and data structures used for
- * the hp framework in deal.II. An overview over the details of how these
+ * The hp-namespace implements the algorithms and data structures used for
+ * the hp-framework in deal.II. An overview over the details of how these
  * algorithms work and what data structures are used is given in the
- * @ref hp_paper "hp paper".
+ * @ref hp_paper "hp-paper".
  */
 
 /**
- * @defgroup hpcollection hp Collections
+ * @defgroup hpcollection hp-Collections
  *
- * In the implementation of the hp finite element method, each cell might have
+ * In the implementation of the hp-finite element method, each cell might have
  * a different finite element associated with it. To handle this, the
  * hp::DoFHandler must have a whole set of finite element classes associated
  * with it. This concept is represented by the hp::FECollection class: Objects
@@ -82,14 +82,14 @@
  * element object. This same observation also holds for the other collection
  * classes.
  *
- * It is customary that within an hp finite element program, one keeps
+ * It is customary that within an hp-finite element program, one keeps
  * collections of finite elements and quadrature formulas with the same number
  * of elements, each element of the one collection matching the element in the
  * other. This is not necessary, but it often makes coding a lot simpler. If a
  * collection of mappings is used, the same holds for hp::MappingCollection
  * objects as well.
  *
- * Whenever p adaptivity is considered in an hp finite element program,
+ * Whenever p-adaptivity is considered in an hp-finite element program,
  * a hierarchy of finite elements needs to be established to determine
  * succeeding finite elements for refinement and preceding ones for coarsening.
  * Typically, this hierarchy considers how finite element spaces are nested:
@@ -109,7 +109,7 @@
 
 
 /**
- * A namespace for the implementation of hp finite element specific algorithms
+ * A namespace for the implementation of hp-finite element specific algorithms
  * and data structures.
  *
  * @ingroup hp

--- a/doc/doxygen/headers/main.h
+++ b/doc/doxygen/headers/main.h
@@ -201,7 +201,7 @@
  *
  *   The DoFHandler class and its associates are described in the @ref
  *   dofs module. In addition, there are specialized versions that can
- *   handle multilevel and hp discretizations. These are described in
+ *   handle multilevel and hp-discretizations. These are described in
  *   the @ref mg and @ref hp modules. Finite element methods frequently
  *   imply constraints on degrees of freedom, such as for hanging nodes
  *   or nodes at which boundary conditions apply; dealing with such

--- a/doc/doxygen/headers/matrixfree.h
+++ b/doc/doxygen/headers/matrixfree.h
@@ -292,7 +292,7 @@ digraph G
  * array. The access granularity in terms of a <i>cell index</i> is controlled
  * by the auxiliary field internal::MatrixFreeFunctions::DoFInfo::row_starts
  * that is similar to the rowstart index in a compressed matrix storage. The
- * scheme supports variable lengths because we support hp adaptivity and index
+ * scheme supports variable lengths because we support hp-adaptivity and index
  * indirections due to constraints that are contained in the main index
  * array. Due to vectorization over cells, the access granularity would
  * initially be in terms of <i>cell batches</i>. However, we must be able to
@@ -318,7 +318,7 @@ digraph G
  * </ol>
  * </li>
  *
- * <li>Information to extract the FE index in hp adaptive computations.</li>
+ * <li>Information to extract the FE index in hp-adaptive computations.</li>
  * <li>Information about the 'first access' into a particular vector entry
  * that is used to zero out the entries in a destination vectors within the
  * MatrixFree::loop shortly before accessing them the first time. This is used
@@ -408,7 +408,7 @@ digraph G
  * element. We use an auxiliary index array that points to the start of the
  * data for each cell, namely the `data_index_offsets` field for the
  * Jacobians, JxW values, and normal vectors, and `quadrature_point_offsets`
- * for the quadrature points. This offset enables hp adaptivity with variable
+ * for the quadrature points. This offset enables hp-adaptivity with variable
  * lengths of fields similar to what is done for DoFInfo, but it also enables
  * something we call <i>geometry compression</i>. In order to reduce the data
  * access, we detect simple geometries of cells where Jacobians are constant

--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -325,7 +325,7 @@
  *
  *   <tr valign="top">
  *       <td>step-27</td>
- *       <td> The hp finite element method.
+ *       <td> The hp-finite element method.
  *       <br/> Keywords: hp::DoFHandler, hp::FECollection, hp::QCollection,
  *       FESeries::Fourier, Triangulation::create_triangulation()
  *       </td></tr>
@@ -840,7 +840,7 @@
  *   </tr>
  *
  *   <tr valign="top">
- *     <td> hp finite elements
+ *     <td> hp-finite elements
  *     </td>
  *     <td>
  *       step-27,

--- a/examples/step-27/doc/intro.dox
+++ b/examples/step-27/doc/intro.dox
@@ -60,7 +60,7 @@ deal.II, and that we will only have to provide the logic of what the
 program should do, not exactly how all this is going to happen.
 
 In deal.II, the $hp$ functionality is largely packaged into
-the hp namespace. This namespace provides classes that handle
+the hp-namespace. This namespace provides classes that handle
 $hp$ discretizations, assembling matrices and vectors, and other
 tasks. We will get to know many of them further down below. In
 addition, most of the functions in the DoFTools, and VectorTools
@@ -71,7 +71,7 @@ module and the links found there.
 It may be worth giving a slightly larger perspective at the end of
 this first part of the introduction. $hp$ functionality has been
 implemented in a number of different finite element packages (see, for
-example, the list of references cited in the @ref hp_paper "hp paper").
+example, the list of references cited in the @ref hp_paper "hp-paper").
 However, by and large, most of these packages have implemented it only
 for the (i) the 2d case, and/or (ii) the discontinuous Galerkin
 method. The latter is a significant simplification because
@@ -85,7 +85,7 @@ the resulting complexity. In particular, it handles computing the
 constraints (similar to hanging node constraints) of elements of
 different degree meeting at a face or edge. The many algorithmic and
 data structure techniques necessary for this are described in the
-@ref hp_paper "hp paper" for those interested in such detail.
+@ref hp_paper "hp-paper" for those interested in such detail.
 
 We hope that providing such a general implementation will help explore
 the potential of $hp$ methods further.
@@ -177,7 +177,7 @@ the same time.
 
 
 
-<h3>Assembling matrices and vectors with hp objects</h3>
+<h3>Assembling matrices and vectors with hp-objects</h3>
 
 Following this, we have to set up matrices and vectors for the linear system
 of the correct size and assemble them. Setting them up works in exactly the
@@ -250,7 +250,7 @@ usual fashion to assemble local contributions.
 
 
 
-<h3>A simple indicator for hp refinement and estimating smoothness</h3>
+<h3>A simple indicator for hp-refinement and estimating smoothness</h3>
 
 One of the central pieces of the adaptive finite element method is that we
 inspect the computed solution (a posteriori) with an indicator that tells us
@@ -261,7 +261,7 @@ complicated strategies in some programs, most importantly in step-14.
 
 In any case, as long as the decision is only "refine this cell" or "do not
 refine this cell", the actual refinement step is not particularly
-challenging. However, here we have a code that is capable of hp refinement,
+challenging. However, here we have a code that is capable of hp-refinement,
 i.e. we suddenly have two choices whenever we detect that the error on a
 certain cell is too large for our liking: we can refine the cell by splitting
 it into several smaller ones, or we can increase the polynomial degree of the
@@ -611,7 +611,7 @@ estimated smoothness exponent will be the same in either case.
 
 
 
-<h3>Complications with linear systems for hp discretizations</h3>
+<h3>Complications with linear systems for hp-discretizations</h3>
 
 <h4>Creating the sparsity pattern</h4>
 
@@ -643,7 +643,7 @@ The early tutorial programs use first or second degree finite elements, so
 removing entries in the sparsity pattern corresponding to constrained degrees of
 freedom does not have a large impact on the overall number of zeros explicitly
 stored by the matrix. However, since as many as a third of the degrees of
-freedom may be constrained in an hp discretization (and, with higher degree
+freedom may be constrained in an hp-discretization (and, with higher degree
 elements, these constraints can couple one DoF to as many as ten or twenty other
 DoFs), it is worthwhile to take these constraints into consideration since the
 resulting matrix will be much sparser (and, therefore, matrix-vector products or

--- a/examples/step-27/doc/tooltip
+++ b/examples/step-27/doc/tooltip
@@ -1,1 +1,1 @@
-Using the hp finite element method for an elliptic problem.
+Using the hp-finite element method for an elliptic problem.

--- a/examples/step-27/step-27.cc
+++ b/examples/step-27/step-27.cc
@@ -257,7 +257,7 @@ namespace Step27
   // This function is again a verbatim copy of what we already did in
   // step-6. Despite function calls with exactly the same names and arguments,
   // the algorithms used internally are different in some aspect since the
-  // dof_handler variable here is an hp object.
+  // dof_handler variable here is an hp-object.
   template <int dim>
   void LaplaceProblem<dim>::setup_system()
   {

--- a/examples/step-30/doc/intro.dox
+++ b/examples/step-30/doc/intro.dox
@@ -428,7 +428,7 @@ steps:
   requested refinement, using the requested isotropic and anisotropic flags.
 </ol>
 This approach is similar to the one we have used in step-27
-for hp refinement and
+for hp-refinement and
 has the great advantage of flexibility: Any error indicator can be
 used in the anisotropic process, i.e. if you have quite involved a posteriori
 goal-oriented error indicators available you can use them as easily as a simple

--- a/examples/step-46/doc/intro.dox
+++ b/examples/step-46/doc/intro.dox
@@ -248,7 +248,7 @@ the two elements are just variations of each other in that they have the same
 number of vector components but have different polynomial degrees &mdash; this
 smells very much like what one would do in $hp$ finite element methods, and it
 is exactly what we are going to do here: we are going to (ab)use the classes
-and facilities of the hp namespace to assign different elements to different
+and facilities of the hp-namespace to assign different elements to different
 cells. In other words, we will use collect the two finite elements in an
 hp::FECollection, will integrate with an appropriate hp::QCollection using an
 hp::FEValues object, and our DoFHandler will be in <i>hp</i>-mode. You
@@ -256,7 +256,7 @@ may wish to take a look at step-27 for an overview of all of these concepts.
 
 Before going on describing the testcase, let us clarify a bit <i>why</i> this
 approach of extending the functions by zero to the entire domain and then
-mapping the problem on to the hp framework makes sense:
+mapping the problem on to the hp-framework makes sense:
 
 - It makes things uniform: On all cells, the number of vector components is
   the same (here, <code>2*dim+1</code>). This makes all sorts of
@@ -583,7 +583,7 @@ cell is on.
 Secondly, we use an object of type DoFHandler operating in <i>hp</i>-mode. This
 class needs to know which cells will use the Stokes and which the elasticity
 finite element. At the beginning of each refinement cycle we will therefore
-have to walk over all cells and set the (in hp parlance) active FE index to
+have to walk over all cells and set the (in hp-parlance) active FE index to
 whatever is appropriate in the current situation. While we can use symbolic
 names for the material id, the active FE index is in fact a number that will
 frequently be used to index into collections of objects (e.g. of type

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -153,9 +153,9 @@ namespace parallel
      * @endcode
      *
      *
-     * <h3>Note on usage with DoFHandler with hp capabilities</h3>
+     * <h3>Note on usage with DoFHandler with hp-capabilities</h3>
      *
-     * Since data on DoFHandler objects with hp capabilities is associated with
+     * Since data on DoFHandler objects with hp-capabilities is associated with
      * many different FiniteElement objects, each cell's data has to be
      * processed with its corresponding `future_fe_index`. Further, if
      * refinement is involved, data will be packed on the parent cell with its
@@ -166,11 +166,11 @@ namespace parallel
      * hp::FECollection::find_dominated_fe_extended() for more information).
      *
      * Transferring a solution across refinement works exactly like in the
-     * non-hp case. However, when considering serialization, we also have to
+     * non-hp-case. However, when considering serialization, we also have to
      * store the active_fe_indices in an additional step. A code snippet
      * demonstrating serialization with the
      * parallel::distributed::SolutionTransfer class with DoFHandler objects
-     * with hp capabilities is provided in the following. Here VectorType is
+     * with hp-capabilities is provided in the following. Here VectorType is
      * your favorite vector type, e.g. PETScWrappers::MPI::Vector,
      * TrilinosWrappers::MPI::Vector, or corresponding block vectors.
      *

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -167,7 +167,7 @@ namespace parallel
      *
      * Transferring a solution across refinement works exactly like in the
      * non-hp-case. However, when considering serialization, we also have to
-     * store the active_fe_indices in an additional step. A code snippet
+     * store the active FE indices in an additional step. A code snippet
      * demonstrating serialization with the
      * parallel::distributed::SolutionTransfer class with DoFHandler objects
      * with hp-capabilities is provided in the following. Here VectorType is
@@ -197,7 +197,7 @@ namespace parallel
      *
      * DoFHandler<dim,spacedim> hp_dof_handler(triangulation);
      * // We need to introduce our dof_handler to the fe_collection
-     * // before setting all active_fe_indices.
+     * // before setting all active FE indices.
      * hp_dof_handler.deserialize_active_fe_indices();
      * hp_dof_handler.distribute_dofs(fe_collection);
      *

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -487,7 +487,7 @@ namespace parallel
        * assembly and solving. In practice, determining this cost is of course
        * not trivial since we don't solve on isolated cells, but on the entire
        * mesh. In such cases, one could, for example, choose the weight equal
-       * to the number of unknowns per cell (in the context of hp finite
+       * to the number of unknowns per cell (in the context of hp-finite
        * element methods), or using a heuristic that estimates the cost on
        * each cell depending on whether, for example, one has to run some
        * expensive algorithm on some cells but not others (such as forming

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -539,8 +539,8 @@ public:
   n_active_fe_indices() const;
 
   /**
-   * Return the @p n-th active fe index on this object. For cells and all non-
-   * hp-objects, there is only a single active fe index, so the argument must
+   * Return the @p n-th active FE index on this object. For cells and all non-
+   * hp-objects, there is only a single active FE index, so the argument must
    * be equal to zero. For lower-dimensional hp-objects, there are
    * n_active_fe_indices() active finite elements, and this function can be
    * queried for their indices.
@@ -549,7 +549,7 @@ public:
   nth_active_fe_index(const unsigned int n) const;
 
   /**
-   * Returns all active fe indices on this object.
+   * Returns all active FE indices on this object.
    *
    * The size of the returned set equals the number of finite elements that
    * are active on this object.
@@ -1047,7 +1047,7 @@ public:
   n_active_fe_indices() const;
 
   /**
-   * Return the @p n-th active fe index on this object.
+   * Return the @p n-th active FE index on this object.
    *
    * Since vertices do not store the information necessary for this to be
    * calculated, this method just raises an exception and only exists to

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -399,7 +399,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler object has hp capabilities enabled,
+   * However, when the relevant DoFHandler object has hp-capabilities enabled,
    * different finite element objects may be used on different cells. On faces
    * between two cells, as well as vertices, there may therefore be two sets
    * of degrees of freedom, one for each of the finite elements used on the
@@ -449,7 +449,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when hp capabilities are enabled, different finite element
+   * However, when hp-capabilities are enabled, different finite element
    * objects may be used on different cells. On faces between two cells, as
    * well as vertices, there may therefore be two sets of degrees of freedom,
    * one for each of the finite elements used on the adjacent cells.  In order
@@ -483,7 +483,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when hp capabilities are enabled, different finite element
+   * However, when hp-capabilities are enabled, different finite element
    * objects may be used on different cells. On faces between two cells, as
    * well as vertices, there may therefore be two sets of degrees of freedom,
    * one for each of the finite elements used on the adjacent cells.  In order
@@ -528,8 +528,8 @@ public:
   /**
    * Return the number of finite elements that are active on a given object.
    *
-   * When hp capabilities are disabled the answer is, of course, always one.
-   * However, when hp capabilities are enabled, this isn't the case: If this
+   * When hp-capabilities are disabled the answer is, of course, always one.
+   * However, when hp-capabilities are enabled, this isn't the case: If this
    * is a cell, the answer is of course one. If it is a face, the answer may
    * be one or two, depending on whether the two adjacent cells use the same
    * finite element or not. If it is an edge in 3d, the possible return value
@@ -540,8 +540,8 @@ public:
 
   /**
    * Return the @p n-th active fe index on this object. For cells and all non-
-   * hp objects, there is only a single active fe index, so the argument must
-   * be equal to zero. For lower-dimensional hp objects, there are
+   * hp-objects, there is only a single active fe index, so the argument must
+   * be equal to zero. For lower-dimensional hp-objects, there are
    * n_active_fe_indices() active finite elements, and this function can be
    * queried for their indices.
    */
@@ -559,7 +559,7 @@ public:
 
   /**
    * Return true if the finite element with given index is active on the
-   * present object. When the current DoFHandler does not have hp
+   * present object. When the current DoFHandler does not have hp-
    * capabilities, this is of course the case only if @p fe_index equals
    * zero. For cells, it is the case if @p fe_index equals active_fe_index()
    * of this cell. For faces and other lower- dimensional objects, there may
@@ -670,7 +670,7 @@ protected:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -699,7 +699,7 @@ protected:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -947,7 +947,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -988,7 +988,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -1011,7 +1011,7 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -1155,7 +1155,7 @@ protected:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -1179,7 +1179,7 @@ protected:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when the relevant DoFHandler has hp capabilities, different
+   * However, when the relevant DoFHandler has hp-capabilities, different
    * finite element objects may be used on different cells. On faces between
    * two cells, as well as vertices, there may therefore be two sets of
    * degrees of freedom, one for each of the finite elements used on the
@@ -1632,11 +1632,11 @@ public:
    * we use the restriction matrices provided by the finite element class to
    * compute the interpolation from the children to the present cell.
    *
-   * If the cell is part of a DoFHandler with hp capabilities, cells only have
+   * If the cell is part of a DoFHandler with hp-capabilities, cells only have
    * an associated finite element space if they are active. However, this
    * function is supposed to also provide information on inactive cells with
    * children. Consequently, it carries a third argument that can be used in
-   * the hp context that denotes the finite element space we are supposed to
+   * the hp-context that denotes the finite element space we are supposed to
    * interpolate onto. If the cell is active, this function then obtains the
    * finite element function from the <code>values</code> vector on this cell
    * and interpolates it onto the space described by the
@@ -1685,10 +1685,10 @@ public:
    * the children of this cell. These requirements are not taken care of and
    * must be enforced by the user afterward.
    *
-   * If the cell is part of a DoFHandler with hp capabilities, cells only have
+   * If the cell is part of a DoFHandler with hp-capabilities, cells only have
    * an associated finite element space if they are active. However, this
    * function is supposed to also work on inactive cells with children.
-   * Consequently, it carries a third argument that can be used in the hp
+   * Consequently, it carries a third argument that can be used in the hp-
    * context that denotes the finite element space we are supposed to
    * interpret the input vector of this function in. If the cell is active,
    * this function then interpolates the input vector interpreted as an
@@ -1890,12 +1890,12 @@ public:
 
   /**
    * Return the finite element that is used on the cell pointed to by this
-   * iterator. For DoFHandler objects without hp capabilities, this is of
+   * iterator. For DoFHandler objects without hp-capabilities, this is of
    * course always the same element, independent of the cell we are presently
-   * on, but for hp DoFHandler objects this may change from cell to cell.
+   * on, but for hp-DoFHandler objects this may change from cell to cell.
    *
    * @note Since degrees of freedom only exist on active cells for DoFHandler
-   * objects with hp capabilities (i.e., there is currently no implementation
+   * objects with hp-capabilities (i.e., there is currently no implementation
    * of multilevel such objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,
@@ -1907,10 +1907,10 @@ public:
   /**
    * Return the index inside the hp::FECollection of the FiniteElement used
    * for this cell. This function is only useful if the DoFHandler object
-   * associated with the current cell has hp capabilities enabled.
+   * associated with the current cell has hp-capabilities enabled.
    *
    * @note Since degrees of freedom only exist on active cells for DoFHandler
-   * objects with hp capabilities (i.e., there is currently no implementation
+   * objects with hp-capabilities (i.e., there is currently no implementation
    * of multilevel such objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,
@@ -1935,11 +1935,11 @@ public:
   /**
    * Set the index of the FiniteElement used for this cell. This determines
    * which element in an hp::FECollection to use. This function is only useful
-   * if the DoF handler object associated with the current cell has hp
+   * if the DoF handler object associated with the current cell has hp-
    * capabilities enabled.
    *
    * @note Since degrees of freedom only exist on active cells for DoFHandler
-   * objects with hp capabilities (i.e., there is currently no implementation
+   * objects with hp-capabilities (i.e., there is currently no implementation
    * of multilevel such objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,
@@ -1997,12 +1997,12 @@ public:
    * active one will remain unchanged, in which case the active finite element
    * will be returned.
    *
-   * For DoFHandlers without hp capabilities enabled, this is of course always
-   * the same element, independent of the cell we are presently on, but for hp
+   * For DoFHandlers without hp-capabilities enabled, this is of course always
+   * the same element, independent of the cell we are presently on, but for hp-
    * DoFHandler objects this may change from cell to cell.
    *
    * @note Since degrees of freedom only exist on active cells for DoFHandler
-   * objects with hp capabilities (i.e., there is currently no implementation
+   * objects with hp-capabilities (i.e., there is currently no implementation
    * of multilevel such objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,
@@ -2019,7 +2019,7 @@ public:
    * which case the fe_index of the active finite element will be returned.
    *
    * @note Since degrees of freedom only exist on active cells for DoFHandler
-   * objects with hp capabilities (i.e., there is currently no implementation
+   * objects with hp-capabilities (i.e., there is currently no implementation
    * of multilevel such objects), it does not make sense to query the finite
    * element on non-active cells since they do not have finite element spaces
    * associated with them without having any degrees of freedom. Consequently,

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -605,7 +605,7 @@ namespace internal
 
 
       /**
-       * Return the fe index of the n-th finite element active on a given
+       * Return the FE index of the n-th finite element active on a given
        * vertex.
        */
       template <int dim, int spacedim, int d>
@@ -618,7 +618,7 @@ namespace internal
       {
         Assert(d == dim || obj_level == 0, ExcNotImplemented());
 
-        // for cells only one active fe index available
+        // for cells only one active FE index available
         Assert(((d == dim) &&
                 (local_index != DoFHandler<dim, spacedim>::default_fe_index)) ==
                  false,
@@ -648,7 +648,7 @@ namespace internal
 
 
       /**
-       * Returns all active fe indices on a given vertex.
+       * Returns all active FE indices on a given vertex.
        *
        * The size of the returned set equals the number of finite elements that
        * are active on this vertex.
@@ -1641,7 +1641,7 @@ DoFAccessor<structdim, dim, spacedim, level_dof_access>::get_fe(
   const unsigned int fe_index) const
 {
   Assert(fe_index_is_active(fe_index) == true,
-         ExcMessage("This function can only be called for active fe indices"));
+         ExcMessage("This function can only be called for active FE indices"));
 
   return this->dof_handler->get_fe(fe_index);
 }
@@ -2201,7 +2201,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return 0; // ::DoFHandler only supports a single active fe with index
+          return 0; // ::DoFHandler only supports a single active FE with index
                     // zero
 
         Assert(
@@ -2229,7 +2229,7 @@ namespace internal
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
           {
-            // ::DoFHandler only supports a single active fe with index zero
+            // ::DoFHandler only supports a single active FE with index zero
             AssertDimension(i, (DoFHandler<dim, spacedim>::default_fe_index));
             return;
           }
@@ -2260,7 +2260,7 @@ namespace internal
         if (accessor.dof_handler->hp_capability_enabled == false)
           return DoFHandler<dim, spacedim>::
             default_fe_index; // ::DoFHandler only supports
-                              // a single active fe with
+                              // a single active FE with
                               // index zero
 
         Assert(
@@ -2293,7 +2293,7 @@ namespace internal
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
           {
-            // ::DoFHandler only supports a single active fe with index zero
+            // ::DoFHandler only supports a single active FE with index zero
             AssertDimension(i, (DoFHandler<dim, spacedim>::default_fe_index));
             return;
           }
@@ -2322,7 +2322,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return false; // ::DoFHandler only supports a single active fe with
+          return false; // ::DoFHandler only supports a single active FE with
                         // index zero
 
         Assert(
@@ -2350,7 +2350,7 @@ namespace internal
         const DoFCellAccessor<dim, spacedim, level_dof_access> &accessor)
       {
         if (accessor.dof_handler->hp_capability_enabled == false)
-          return; // ::DoFHandler only supports a single active fe with index
+          return; // ::DoFHandler only supports a single active FE with index
                   // zero
 
         Assert(
@@ -2777,13 +2777,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_active(),
          ExcMessage(
-           "You can not ask for the active_fe_index on a cell that has "
+           "You can not ask for the active FE index on a cell that has "
            "children because no degrees of freedom are assigned "
            "to this cell and, consequently, no finite element "
            "is associated with it."));
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->is_locally_owned() || this->is_ghost()),
-         ExcMessage("You can only query active_fe_index information on cells "
+         ExcMessage("You can only query active FE index information on cells "
                     "that are either locally owned or (after distributing "
                     "degrees of freedom) are ghost cells."));
 
@@ -2800,13 +2800,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 {
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_active(),
-         ExcMessage("You can not set the active_fe_index on a cell that has "
+         ExcMessage("You can not set the active FE index on a cell that has "
                     "children because no degrees of freedom will be assigned "
                     "to this cell."));
 
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_locally_owned(),
-         ExcMessage("You can only set active_fe_index information on cells "
+         ExcMessage("You can only set active FE index information on cells "
                     "that are locally owned. On ghost cells, this information "
                     "will automatically be propagated from the owning process "
                     "of that cell, and there is no information at all on "
@@ -2844,13 +2844,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->has_children() == false),
          ExcMessage(
-           "You can not ask for the future_fe_index on a cell that has "
+           "You can not ask for the future FE index on a cell that has "
            "children because no degrees of freedom are assigned "
            "to this cell and, consequently, no finite element "
            "is associated with it."));
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->is_locally_owned()),
-         ExcMessage("You can only query future_fe_index information on cells "
+         ExcMessage("You can only query future FE index information on cells "
                     "that are locally owned."));
 
   return dealii::internal::DoFCellAccessorImplementation::Implementation::
@@ -2866,13 +2866,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
 {
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->has_children() == false),
-         ExcMessage("You can not set the future_fe_index on a cell that has "
+         ExcMessage("You can not set the future FE index on a cell that has "
                     "children because no degrees of freedom will be assigned "
                     "to this cell."));
 
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            this->is_locally_owned(),
-         ExcMessage("You can only set future_fe_index information on cells "
+         ExcMessage("You can only set future FE index information on cells "
                     "that are locally owned."));
 
   dealii::internal::DoFCellAccessorImplementation::Implementation::
@@ -2889,13 +2889,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->has_children() == false),
          ExcMessage(
-           "You can not ask for the future_fe_index on a cell that has "
+           "You can not ask for the future FE index on a cell that has "
            "children because no degrees of freedom are assigned "
            "to this cell and, consequently, no finite element "
            "is associated with it."));
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->is_locally_owned()),
-         ExcMessage("You can only query future_fe_index information on cells "
+         ExcMessage("You can only query future FE index information on cells "
                     "that are locally owned."));
 
   return dealii::internal::DoFCellAccessorImplementation::Implementation::
@@ -2912,13 +2912,13 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->has_children() == false),
          ExcMessage(
-           "You can not ask for the future_fe_index on a cell that has "
+           "You can not ask for the future FE index on a cell that has "
            "children because no degrees of freedom are assigned "
            "to this cell and, consequently, no finite element "
            "is associated with it."));
   Assert((this->dof_handler->hp_capability_enabled == false) ||
            (this->is_locally_owned()),
-         ExcMessage("You can only query future_fe_index information on cells "
+         ExcMessage("You can only query future FE index information on cells "
                     "that are locally owned."));
 
   dealii::internal::DoFCellAccessorImplementation::Implementation::

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -534,8 +534,8 @@ public:
   using offset_type = unsigned int;
 
   /**
-   * Invalid active_fe_index which will be used as a default value to determine
-   *  whether a future_fe_index has been set or not.
+   * Invalid active FE index which will be used as a default value to determine
+   *  whether a future FE index has been set or not.
    */
   static const active_fe_index_type invalid_active_fe_index =
     static_cast<active_fe_index_type>(-1);
@@ -1270,7 +1270,7 @@ public:
   /**
    * Whenever serialization with a parallel::distributed::Triangulation as the
    * underlying triangulation is considered, we also need to consider storing
-   * the active_fe_indices on all active cells as well.
+   * the active FE indices on all active cells as well.
    *
    * This function registers that these indices are to be stored whenever the
    * parallel::distributed::Triangulation::save() function is called on the
@@ -1289,10 +1289,10 @@ public:
   /**
    * Whenever serialization with a parallel::distributed::Triangulation as the
    * underlying triangulation is considered, we also need to consider storing
-   * the active_fe_indices on all active cells as well.
+   * the active FE indices on all active cells as well.
    *
    * This function deserializes and distributes the previously stored
-   * active_fe_indices on all active cells.
+   * active FE indices on all active cells.
    *
    * @note Currently only implemented for triangulations of type
    *   parallel::distributed::Triangulation. An assertion will be triggered if
@@ -1376,7 +1376,7 @@ public:
   DeclException2(ExcInvalidFEIndex,
                  int,
                  int,
-                 << "The mesh contains a cell with an active_fe_index of "
+                 << "The mesh contains a cell with an active FE index of "
                  << arg1 << ", but the finite element collection only has "
                  << arg2 << " elements");
 
@@ -1477,7 +1477,7 @@ private:
 
   /**
    * Whenever the underlying triangulation changes by either
-   * h/p refinement/coarsening and serialization, the active_fe_index of cells
+   * h/p-refinement/coarsening and serialization, the active FE index of cells
    * needs to be transferred. This structure stores all temporary information
    * required during that process.
    */
@@ -1502,14 +1502,14 @@ private:
     std::map<const cell_iterator, const unsigned int> coarsened_cells_fe_index;
 
     /**
-     * Container to temporarily store the active_fe_index of every locally
+     * Container to temporarily store the active FE index of every locally
      * owned cell for transfer across parallel::distributed::Triangulation
      * objects.
      */
     std::vector<unsigned int> active_fe_indices;
 
     /**
-     * Helper object to transfer all active_fe_indices on
+     * Helper object to transfer all active FE indices on
      * parallel::distributed::Triangulation objects during
      * refinement/coarsening and serialization.
      */
@@ -1600,7 +1600,7 @@ private:
     object_dof_ptr;
 
   /**
-   * Active fe indices of each geometric object. Identification
+   * Active FE indices of each geometric object. Identification
    * of the appropriate position of a cell in the vectors is done via
    * hp_object_fe_ptr (CRS scheme).
    */
@@ -1608,19 +1608,19 @@ private:
     hp_object_fe_indices;
 
   /**
-   * Pointer to the first fe index of a geometric object.
+   * Pointer to the first FE index of a geometric object.
    */
   mutable std::array<std::vector<offset_type>, dim + 1> hp_object_fe_ptr;
 
   /**
-   * Active fe index of an active cell (identified by level and level index).
+   * Active FE index of an active cell (identified by level and level index).
    * This vector is only used in hp-mode.
    */
   mutable std::vector<std::vector<active_fe_index_type>>
     hp_cell_active_fe_indices;
 
   /**
-   * Future fe index of an active cell (identified by level and level index).
+   * Future FE index of an active cell (identified by level and level index).
    * This vector is only used in hp-mode.
    */
   mutable std::vector<std::vector<active_fe_index_type>>
@@ -1721,7 +1721,7 @@ private:
    * Update tables for active and future fe_indices.
    *
    * Whenever the underlying triangulation changes (either by adaptation or
-   * deserialization), active and future fe index tables will be adjusted to the
+   * deserialization), active and future FE index tables will be adjusted to the
    * current structure of the triangulation. Missing values of active and future
    * indices will be initialized with their defaults (see
    * create_active_fe_table()).
@@ -1737,7 +1737,7 @@ private:
    * signal just before the associated Triangulation or
    * parallel::shared::Triangulation is modified.
    *
-   * The function that stores the active_fe_indices of all cells that will
+   * The function that stores the active FE indices of all cells that will
    * be refined or coarsened before the refinement happens, so that
    * they can be set again after refinement.
    */
@@ -1749,7 +1749,7 @@ private:
    * signal just after the associated Triangulation or
    * parallel::shared::Triangulation is modified.
    *
-   * The function that restores the active_fe_indices of all cells that
+   * The function that restores the active FE indices of all cells that
    * were refined or coarsened.
    */
   void
@@ -1760,7 +1760,7 @@ private:
    * signal just before the associated parallel::distributed::Triangulation is
    * modified.
    *
-   * The function that stores all active_fe_indices on locally owned cells for
+   * The function that stores all active FE indices on locally owned cells for
    * distribution over all participating processors.
    */
   void
@@ -1771,7 +1771,7 @@ private:
    * signal just after the associated parallel::distributed::Triangulation is
    * modified.
    *
-   * The function that restores all active_fe_indices on locally owned cells
+   * The function that restores all active FE indices on locally owned cells
    * that have been communicated.
    */
   void

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -233,7 +233,7 @@ namespace parallel
  * The whole process of working with objects of this type is explained in
  * step-27. Many of the algorithms this class implements are described in
  * the
- * @ref hp_paper "hp paper".
+ * @ref hp_paper "hp-paper".
  *
  *
  * <h3>Active FE indices and their behavior under mesh refinement</h3>
@@ -702,7 +702,7 @@ public:
   distribute_mg_dofs();
 
   /**
-   * Returns whether this DoFHandler has hp capabilities.
+   * Returns whether this DoFHandler has hp-capabilities.
    */
   bool
   has_hp_capabilities() const;
@@ -1382,19 +1382,19 @@ public:
 
   /**
    * Exception used when a certain feature doesn't make sense when
-   * DoFHandler does not hp capabilities.
+   * DoFHandler does not hp-capabilities.
    */
   DeclExceptionMsg(ExcNotAvailableWithoutHP,
                    "The current function doesn't make sense when used with a "
-                   "DoFHandler without hp capabilities.");
+                   "DoFHandler without hp-capabilities.");
 
   /**
    * Exception used when a certain feature is not implemented when the
-   * DoFHandler has hp capabilities.
+   * DoFHandler has hp-capabilities.
    */
   DeclExceptionMsg(ExcNotImplementedWithHP,
                    "The current function has not yet been implemented for a "
-                   "DoFHandler with hp capabilities.");
+                   "DoFHandler with hp-capabilities.");
 
 private:
   /**
@@ -1525,7 +1525,7 @@ private:
   BlockInfo block_info_object;
 
   /**
-   * Boolean indicating whether or not the current DoFHandler has hp
+   * Boolean indicating whether or not the current DoFHandler has hp-
    * capabilities.
    */
   bool hp_capability_enabled;
@@ -1593,7 +1593,7 @@ private:
    * relevant active finite elements.
    *
    * @note In normal mode it is possible to access this data strucutre directly.
-   *   In hp mode, an indirection via hp_object_fe_indices/hp_object_fe_ptr is
+   *   In hp-mode, an indirection via hp_object_fe_indices/hp_object_fe_ptr is
    * necessary.
    */
   mutable std::vector<std::array<std::vector<offset_type>, dim + 1>>
@@ -1614,14 +1614,14 @@ private:
 
   /**
    * Active fe index of an active cell (identified by level and level index).
-   * This vector is only used in hp mode.
+   * This vector is only used in hp-mode.
    */
   mutable std::vector<std::vector<active_fe_index_type>>
     hp_cell_active_fe_indices;
 
   /**
    * Future fe index of an active cell (identified by level and level index).
-   * This vector is only used in hp mode.
+   * This vector is only used in hp-mode.
    */
   mutable std::vector<std::vector<active_fe_index_type>>
     hp_cell_future_fe_indices;

--- a/include/deal.II/dofs/dof_objects.h
+++ b/include/deal.II/dofs/dof_objects.h
@@ -84,9 +84,9 @@ namespace internal
        *
        * The third argument, @p fe_index, must equal zero. It is otherwise
        * unused, but we retain the argument so that we can use the same
-       * interface for non-hp and hp finite element methods, in effect making
-       * it possible to share the DoFAccessor class hierarchy between hp and
-       * non-hp classes.
+       * interface for non-hp- and hp-finite element methods, in effect making
+       * it possible to share the DoFAccessor class hierarchy between hp- and
+       * non-hp-classes.
        */
       template <int dh_dim, int spacedim>
       void
@@ -104,9 +104,9 @@ namespace internal
        *
        * The third argument, @p fe_index, must equal zero. It is otherwise
        * unused, but we retain the argument so that we can use the same
-       * interface for non-hp and hp finite element methods, in effect making
-       * it possible to share the DoFAccessor class hierarchy between hp and
-       * non-hp classes.
+       * interface for non-hp- and hp-finite element methods, in effect making
+       * it possible to share the DoFAccessor class hierarchy between hp- and
+       * non-hp-classes.
        */
       template <int dh_dim, int spacedim>
       types::global_dof_index
@@ -187,7 +187,7 @@ namespace internal
       Assert((fe_index ==
               dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
              ExcMessage("Only zero fe_index values are allowed for "
-                        "non-hp DoFHandlers."));
+                        "non-hp-DoFHandlers."));
       return true;
     }
 
@@ -206,7 +206,7 @@ namespace internal
       Assert(
         (fe_index == dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
         ExcMessage(
-          "Only the default FE index is allowed for non-hp DoFHandler objects"));
+          "Only the default FE index is allowed for non-hp-DoFHandler objects"));
       Assert(
         local_index < dof_handler.get_fe().template n_dofs_per_object<dim>(),
         ExcIndexRange(local_index,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2337,7 +2337,7 @@ namespace DoFTools
                              const ComponentMask &mask = ComponentMask());
 
   /**
-   * Same as the previous function but for the hp case.
+   * Same as the previous function but for the hp-case.
    */
   template <int dim, int spacedim>
   void
@@ -2386,7 +2386,7 @@ namespace DoFTools
     const ComponentMask &                               mask = ComponentMask());
 
   /**
-   * Same as the previous function but for the hp case.
+   * Same as the previous function but for the hp-case.
    */
   template <int dim, int spacedim>
   void

--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -113,7 +113,7 @@ class FESystem;
  * particular feature is implemented. An example is whether an element
  * implements the information necessary to use it in the $hp$ finite element
  * context (see
- * @ref hp "hp finite element support").
+ * @ref hp "hp-finite element support").
  *
  *
  * <h3>Nomenclature</h3>
@@ -339,7 +339,7 @@ class FESystem;
  * neighboring (but differently refined) cells. The case that the finite
  * element spaces on different sides of a face are different, i.e., the $hp$
  * case (see
- * @ref hp "hp finite element support")
+ * @ref hp "hp-finite element support")
  * is handled by separate functions. See the
  * FiniteElement::get_face_interpolation_matrix() and
  * FiniteElement::get_subface_interpolation_matrix() functions.
@@ -820,7 +820,7 @@ public:
   /**
    * This operator returns a reference to the present object if the argument
    * given equals to zero. While this does not seem particularly useful, it is
-   * helpful in writing code that works with both ::DoFHandler and the hp
+   * helpful in writing code that works with both ::DoFHandler and the hp-
    * version hp::DoFHandler, since one can then write code like this:
    * @code
    * dofs_per_cell =
@@ -833,7 +833,7 @@ public:
    * doesn't offer a <code>dofs_per_cell</code> member variable: one first has
    * to select which finite element to work on, which is done using the
    * operator[]. Fortunately, <code>cell-@>active_fe_index()</code> also works
-   * for non-hp classes and simply returns zero in that case. The present
+   * for non-hp-classes and simply returns zero in that case. The present
    * operator[] accepts this zero argument, by returning the finite element
    * with index zero within its collection (that, of course, consists only of
    * the present finite element anyway).
@@ -1230,7 +1230,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".  That
+   * the new way, which has to be used to make elements "hp-compatible".  That
    * means, the element properly implements the get_face_interpolation_matrix
    * and get_subface_interpolation_matrix methods. Therefore the return value
    * also indicates whether a call to the get_face_interpolation_matrix()
@@ -1239,14 +1239,14 @@ public:
    *
    * Currently the main purpose of this function is to allow the
    * make_hanging_node_constraints method to decide whether the new
-   * procedures, which are supposed to work in the hp framework can be used,
-   * or if the old well verified but not hp capable functions should be used.
+   * procedures, which are supposed to work in the hp-framework can be used,
+   * or if the old well verified but not hp-capable functions should be used.
    * Once the transition to the new scheme for computing the interface
    * constraints is complete, this function will be superfluous and will
    * probably go away.
    *
    * Derived classes should implement this function accordingly. The default
-   * assumption is that a finite element does not provide hp capable face
+   * assumption is that a finite element does not provide hp-capable face
    * interpolation, and the default implementation therefore returns @p false.
    */
   virtual bool
@@ -1312,12 +1312,12 @@ public:
 
 
   /**
-   * @name Functions to support hp
+   * @name Functions to support hp-
    * @{
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -1362,7 +1362,7 @@ public:
    *
    * For a definition of domination, see FiniteElementDomination::Domination
    * and in particular the
-   * @ref hp_paper "hp paper".
+   * @ref hp_paper "hp-paper".
    */
   virtual FiniteElementDomination::Domination
   compare_for_domination(const FiniteElement<dim, spacedim> &fe_other,

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -46,9 +46,9 @@ namespace FiniteElementDomination
    * Q(k') if $k\le k'$.
    *
    * This enum is used in the FiniteElement::compare_for_domination() function
-   * that is used in the context of hp finite element methods when determining
+   * that is used in the context of hp-finite element methods when determining
    * what to do at faces where two different finite elements meet (see the
-   * @ref hp_paper "hp paper"
+   * @ref hp_paper "hp-paper"
    * for a more detailed description of the following). In that case, the
    * degrees of freedom of one side need to be constrained to those on the
    * other side. The determination which side is which is based on the outcome
@@ -56,7 +56,7 @@ namespace FiniteElementDomination
    * to the dominating one.
    *
    * Note that there are situations where neither side dominates. The
-   * @ref hp_paper "hp paper"
+   * @ref hp_paper "hp-paper"
    * lists two case, with the simpler one being that a $Q_2\times Q_1$ vector-
    * valued element (i.e. a <code>FESystem(FE_Q(2),1,FE_Q(1),1)</code>) meets
    * a $Q_1\times Q_2$ element: here, for each of the two vector-components,
@@ -80,7 +80,7 @@ namespace FiniteElementDomination
    * could also be used by discontinuous elements, for example.
    *
    * More details on domination can be found in the
-   * @ref hp_paper "hp paper".
+   * @ref hp_paper "hp-paper".
    */
   enum Domination
   {

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -138,13 +138,13 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    */
   virtual bool
   hp_constraints_are_implemented() const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_dgp.h
+++ b/include/deal.II/fe/fe_dgp.h
@@ -328,7 +328,7 @@ public:
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -373,7 +373,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_DGP class the result is always true (independent of the degree
    * of the element), as it has no hanging nodes (being a discontinuous

--- a/include/deal.II/fe/fe_dgp_monomial.h
+++ b/include/deal.II/fe/fe_dgp_monomial.h
@@ -303,7 +303,7 @@ public:
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -346,7 +346,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_DGPMonomial class the result is always true (independent of
    * the degree of the element), as it has no hanging nodes (being a

--- a/include/deal.II/fe/fe_dgp_nonparametric.h
+++ b/include/deal.II/fe/fe_dgp_nonparametric.h
@@ -420,7 +420,7 @@ public:
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -465,7 +465,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_DGPNonparametric class the result is always true (independent
    * of the degree of the element), as it has no hanging nodes (being a

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -229,7 +229,7 @@ public:
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -274,7 +274,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_DGQ class the result is always true (independent of the degree
    * of the element), as it has no hanging nodes (being a discontinuous

--- a/include/deal.II/fe/fe_enriched.h
+++ b/include/deal.II/fe/fe_enriched.h
@@ -118,7 +118,7 @@ DEAL_II_NAMESPACE_OPEN
  *
  * In most applications it is beneficial to introduce enrichments only in
  * some part of the domain (e.g. around a crack tip) and use standard FE (e.g.
- * FE_Q) elsewhere. This can be achieved by using the hp finite element
+ * FE_Q) elsewhere. This can be achieved by using the hp-finite element
  * framework in deal.II that allows for the use of different elements on
  * different cells. To make the resulting space $C^0$ continuous, it is then
  * necessary for the DoFHandler class and
@@ -194,7 +194,7 @@ public:
    * element within a DoFHandler with hp-capabilities.
    *
    * See the discussion in the class documentation on how to use this element
-   * in the context of hp finite element methods.
+   * in the context of hp-finite element methods.
    */
   FE_Enriched(const FiniteElement<dim, spacedim> &fe_base);
 
@@ -336,7 +336,7 @@ public:
    */
 
   /**
-   * Return whether this element implements hp constraints.
+   * Return whether this element implements hp-constraints.
    *
    * This function returns @p true if and only if all its base elements return @p true
    * for this function.
@@ -381,7 +381,7 @@ public:
     const unsigned int                  face_no = 0) const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -128,7 +128,7 @@ public:
    */
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -170,7 +170,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    */
   virtual bool
   hp_constraints_are_implemented() const override;
@@ -275,13 +275,13 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    */
   virtual bool
   hp_constraints_are_implemented() const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.
@@ -527,7 +527,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    */
   virtual bool
   hp_constraints_are_implemented() const override;

--- a/include/deal.II/fe/fe_nedelec.h
+++ b/include/deal.II/fe/fe_nedelec.h
@@ -177,11 +177,11 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the <tt>FE_Nedelec</tt> class the result is always true (independent
    * of the degree of the element), as it implements the complete set of
-   * functions necessary for hp capability.
+   * functions necessary for hp-capability.
    */
   virtual bool
   hp_constraints_are_implemented() const override;
@@ -194,7 +194,7 @@ public:
                          const unsigned int codim = 0) const override final;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -30,7 +30,7 @@ DEAL_II_NAMESPACE_OPEN
  * Definition of a finite element space with zero degrees of freedom and that,
  * consequently, can only represent a single function: the zero function.
  *
- * This class is useful (in the context of an hp method) to represent empty
+ * This class is useful (in the context of an hp-method) to represent empty
  * cells in the triangulation on which no degrees of freedom should be
  * allocated, or to describe a field that is extended by zero to a part of the
  * domain where we don't need it. Thus a triangulation may be divided into two

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -218,17 +218,17 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_Q class the result is always true (independent of the degree
    * of the element), as it implements the complete set of functions necessary
-   * for hp capability.
+   * for hp-capability.
    */
   virtual bool
   hp_constraints_are_implemented() const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_q_hierarchical.h
+++ b/include/deal.II/fe/fe_q_hierarchical.h
@@ -570,11 +570,11 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * For the FE_Q_Hierarchical class the result is always true (independent of
    * the degree of the element), as it implements the complete set of
-   * functions necessary for hp capability.
+   * functions necessary for hp-capability.
    */
   virtual bool
   hp_constraints_are_implemented() const override;
@@ -597,7 +597,7 @@ public:
       RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -932,7 +932,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    *
    * This function returns @p true if and only if all its base elements return
    * @p true for this function.
@@ -978,7 +978,7 @@ public:
     const unsigned int                  face_no = 0) const override;
 
   /**
-   * If, on a vertex, several finite elements are active, the hp code first
+   * If, on a vertex, several finite elements are active, the hp-code first
    * assigns the degrees of freedom of each of these FEs different global
    * indices. It then calls this function to find out which of them should get
    * identical values, and consequently can receive the same global DoF index.

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -219,7 +219,7 @@ namespace FETools
       // given FEs
       unsigned int n_shape_functions = 0;
       for (unsigned int i = 0; i < fes.size(); ++i)
-        if (multiplicities[i] > 0) // check needed as fe might be nullptr
+        if (multiplicities[i] > 0) // check needed as FE might be nullptr
           n_shape_functions += fes[i]->n_dofs_per_cell() * multiplicities[i];
 
       // generate the array that will hold the output
@@ -386,27 +386,27 @@ namespace FETools
       // given FEs
       unsigned int n_shape_functions = 0;
       for (unsigned int i = 0; i < fes.size(); ++i)
-        if (multiplicities[i] > 0) // needed because fe might be nullptr
+        if (multiplicities[i] > 0) // needed because FE might be nullptr
           n_shape_functions += fes[i]->n_dofs_per_cell() * multiplicities[i];
 
       unsigned int n_components = 0;
       if (do_tensor_product)
         {
           for (unsigned int i = 0; i < fes.size(); ++i)
-            if (multiplicities[i] > 0) // needed because fe might be nullptr
+            if (multiplicities[i] > 0) // needed because FE might be nullptr
               n_components += fes[i]->n_components() * multiplicities[i];
         }
       else
         {
           for (unsigned int i = 0; i < fes.size(); ++i)
-            if (multiplicities[i] > 0) // needed because fe might be nullptr
+            if (multiplicities[i] > 0) // needed because FE might be nullptr
               {
                 n_components = fes[i]->n_components();
                 break;
               }
           // Now check that all FEs have the same number of components:
           for (unsigned int i = 0; i < fes.size(); ++i)
-            if (multiplicities[i] > 0) // needed because fe might be nullptr
+            if (multiplicities[i] > 0) // needed because FE might be nullptr
               Assert(n_components == fes[i]->n_components(),
                      ExcDimensionMismatch(n_components,
                                           fes[i]->n_components()));

--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -297,7 +297,7 @@ namespace FETools
       cell = dof1.begin_active(),
       endc = dof1.end();
 
-    // map from possible fe objects in
+    // map from possible FE objects in
     // dof1 to the back_interpolation
     // matrices
     std::map<const FiniteElement<dim> *, std::unique_ptr<FullMatrix<double>>>

--- a/include/deal.II/fe/fe_trace.h
+++ b/include/deal.II/fe/fe_trace.h
@@ -94,7 +94,7 @@ public:
 
   /**
    * Return whether this element implements its hanging node constraints in
-   * the new way, which has to be used to make elements "hp compatible".
+   * the new way, which has to be used to make elements "hp-compatible".
    */
   virtual bool
   hp_constraints_are_implemented() const override;

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -3800,7 +3800,7 @@ public:
    *
    * Though it seems that it is not very useful, this function is there to
    * provide capability to the hp::FEValues class, in which case it provides
-   * the FEValues object for the present cell (remember that for hp finite
+   * the FEValues object for the present cell (remember that for hp-finite
    * elements, the actual FE object used may change from cell to cell, so we
    * also need different FEValues objects for different cells; once you
    * reinitialize the hp::FEValues object for a specific cell, it retrieves
@@ -4039,7 +4039,7 @@ public:
    *
    * Though it seems that it is not very useful, this function is there to
    * provide capability to the hp::FEValues class, in which case it provides
-   * the FEValues object for the present cell (remember that for hp finite
+   * the FEValues object for the present cell (remember that for hp-finite
    * elements, the actual FE object used may change from cell to cell, so we
    * also need different FEValues objects for different cells; once you
    * reinitialize the hp::FEValues object for a specific cell, it retrieves
@@ -4194,7 +4194,7 @@ public:
    *
    * Though it seems that it is not very useful, this function is there to
    * provide capability to the hp::FEValues class, in which case it provides
-   * the FEValues object for the present cell (remember that for hp finite
+   * the FEValues object for the present cell (remember that for hp-finite
    * elements, the actual FE object used may change from cell to cell, so we
    * also need different FEValues objects for different cells; once you
    * reinitialize the hp::FEValues object for a specific cell, it retrieves

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1252,7 +1252,7 @@ namespace GridTools
   /**
    * Another version where we use that mapping on a given
    * cell that corresponds to the active finite element index of that cell.
-   * This is obviously only useful for hp problems, since the active finite
+   * This is obviously only useful for hp-problems, since the active finite
    * element index for all other DoF handlers is always zero.
    */
   template <int dim, int spacedim>

--- a/include/deal.II/hp/dof_handler.h
+++ b/include/deal.II/hp/dof_handler.h
@@ -45,7 +45,7 @@ namespace hp
    * The whole process of working with objects of this type is explained in
    * step-27. Many of the algorithms this class implements are described in
    * the
-   * @ref hp_paper "hp paper".
+   * @ref hp_paper "hp-paper".
    *
    *
    * <h3>Active FE indices and their behavior under mesh refinement</h3>

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -52,7 +52,7 @@ namespace hp
   {
   public:
     /**
-     * Whenever p adaptivity is considered in an hp finite element program,
+     * Whenever p-adaptivity is considered in an hp-finite element program,
      * a hierarchy of finite elements needs to be established to determine
      * succeeding finite elements for refinement and preceding ones for
      * coarsening.
@@ -283,10 +283,10 @@ namespace hp
     /**
      * Return whether all elements in this collection implement the hanging
      * node constraints in the new way, which has to be used to make elements
-     * "hp compatible". If this is not the case, the function returns false,
+     * "hp-compatible". If this is not the case, the function returns false,
      * which implies, that at least one element in the FECollection does not
      * support the new face interface constraints. On the other hand, if this
-     * method does return true, this does not imply that the hp method will
+     * method does return true, this does not imply that the hp-method will
      * work!
      *
      * This behavior is related to the fact, that FiniteElement classes,

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -60,7 +60,7 @@ namespace hp
    * second the dimensionality of the object that we integrate on, i.e. for
    * usual @p hp::FEValues it is equal to the first one, while for face
    * integration it is one less. The third template parameter indicates the
-   * type of underlying non-hp FE*Values base type, i.e. it could either be
+   * type of underlying non-hp-FE*Values base type, i.e. it could either be
    * ::FEValues, ::FEFaceValues, or ::FESubfaceValues.
    *
    * @ingroup hp
@@ -231,11 +231,11 @@ namespace hp
 namespace hp
 {
   /**
-   * An hp equivalent of the ::FEValues class. See the step-27 tutorial
+   * An hp-equivalent of the ::FEValues class. See the step-27 tutorial
    * program for examples of use.
    *
    * The idea of this class is as follows: when one assembled matrices in the
-   * hp finite element method, there may be different finite elements on
+   * hp-finite element method, there may be different finite elements on
    * different cells, and consequently one may also want to use different
    * quadrature formulas for different cells. On the other hand, the
    * ::FEValues efficiently handles pre-evaluating whatever information is
@@ -255,7 +255,7 @@ namespace hp
    * ::FEValues object that then fits the finite element and quadrature
    * formula for the current cell can then be accessed using the
    * get_present_fe_values() function, and one would work with it just like
-   * with any ::FEValues object for non-hp DoF handler objects.
+   * with any ::FEValues object for non-hp-DoFHandler objects.
    *
    * The reinit() functions have additional arguments with default values. If
    * not specified, the function takes the index into the hp::FECollection,
@@ -336,7 +336,7 @@ namespace hp
      * quadrature formula for each finite element in the hp::FECollection. As
      * a special case, if the quadrature collection contains only a single
      * element (a frequent case if one wants to use the same quadrature object
-     * for all finite elements in an hp discretization, even if that may not
+     * for all finite elements in an hp-discretization, even if that may not
      * be the most efficient), then this single quadrature is used unless a
      * different value for this argument is specified. On the other hand, if a
      * value is given for this argument, it overrides the choice of
@@ -349,7 +349,7 @@ namespace hp
      * <code>cell-@>active_fe_index()</code>, i.e. the same index as that of
      * the finite element. As above, if the mapping collection contains only a
      * single element (a frequent case if one wants to use a $Q_1$ mapping for
-     * all finite elements in an hp discretization), then this single mapping
+     * all finite elements in an hp-discretization), then this single mapping
      * is used unless a different value for this argument is specified.
      */
     template <bool lda>
@@ -455,7 +455,7 @@ namespace hp
      * quadrature formula for each finite element in the hp::FECollection. As
      * a special case, if the quadrature collection contains only a single
      * element (a frequent case if one wants to use the same quadrature object
-     * for all finite elements in an hp discretization, even if that may not
+     * for all finite elements in an hp-discretization, even if that may not
      * be the most efficient), then this single quadrature is used unless a
      * different value for this argument is specified. On the other hand, if a
      * value is given for this argument, it overrides the choice of
@@ -468,7 +468,7 @@ namespace hp
      * <code>cell-@>active_fe_index()</code>, i.e. the same index as that of
      * the finite element. As above, if the mapping collection contains only a
      * single element (a frequent case if one wants to use a $Q_1$ mapping for
-     * all finite elements in an hp discretization), then this single mapping
+     * all finite elements in an hp-discretization), then this single mapping
      * is used unless a different value for this argument is specified.
      */
     template <bool lda>
@@ -576,7 +576,7 @@ namespace hp
      * quadrature formula for each finite element in the hp::FECollection. As
      * a special case, if the quadrature collection contains only a single
      * element (a frequent case if one wants to use the same quadrature object
-     * for all finite elements in an hp discretization, even if that may not
+     * for all finite elements in an hp-discretization, even if that may not
      * be the most efficient), then this single quadrature is used unless a
      * different value for this argument is specified. On the other hand, if a
      * value is given for this argument, it overrides the choice of
@@ -589,7 +589,7 @@ namespace hp
      * <code>cell-@>active_fe_index()</code>, i.e. the same index as that of
      * the finite element. As above, if the mapping collection contains only a
      * single element (a frequent case if one wants to use a $Q_1$ mapping for
-     * all finite elements in an hp discretization), then this single mapping
+     * all finite elements in an hp-discretization), then this single mapping
      * is used unless a different value for this argument is specified.
      */
     template <bool lda>

--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -248,7 +248,7 @@ namespace hp
    * hp::FECollection and hp::QCollection. Later on, when one sits on a
    * concrete cell, one would call the reinit() function for this particular
    * cell, just as one does for a regular ::FEValues object. The difference is
-   * that this time, the reinit() function looks up the active_fe_index of
+   * that this time, the reinit() function looks up the active FE index of
    * that cell, if necessary creates a ::FEValues object that matches the
    * finite element and quadrature formulas with that particular index in
    * their collections, and then re-initializes it for the current cell. The
@@ -260,7 +260,7 @@ namespace hp
    * The reinit() functions have additional arguments with default values. If
    * not specified, the function takes the index into the hp::FECollection,
    * hp::QCollection, and hp::MappingCollection objects from the
-   * active_fe_index of the cell, as explained above. However, one can also
+   * active FE index of the cell, as explained above. However, one can also
    * select different indices for a current cell. For example, by specifying a
    * different index into the hp::QCollection class, one does not need to sort
    * the quadrature objects in the quadrature collection so that they match

--- a/include/deal.II/hp/mapping_collection.h
+++ b/include/deal.II/hp/mapping_collection.h
@@ -100,7 +100,7 @@ namespace hp
 
     /**
      * Return the mapping object which was specified by the user for the
-     * active_fe_index which is provided as a parameter to this method.
+     * active FE index which is provided as a parameter to this method.
      *
      * @pre @p index must be between zero and the number of elements of the
      * collection.

--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -620,7 +620,7 @@ namespace hp
      *
      * @note The function Triangulation::prepare_coarsening_and_refinement()
      *   will clean up all h-coarsening flags if they are not shared among
-     *   all siblings. In the hp case, we need to bring forward this decision:
+     *   all siblings. In the hp-case, we need to bring forward this decision:
      *   If the cell will not be coarsened, but qualifies for p-adaptivity,
      *   we have to set all flags accordingly. So this function anticipates
      *   the decision that Triangulation::prepare_coarsening_and_refinement()

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -443,7 +443,7 @@ class AffineConstraints;
  *
  * The algorithms used in the implementation of this class are described in
  * some detail in the
- * @ref hp_paper "hp paper".
+ * @ref hp_paper "hp-paper".
  * There is also a significant amount of documentation on how to use this
  * class in the
  * @ref constraints
@@ -1442,7 +1442,7 @@ public:
    * sparsity pattern entries.
    *
    * As explained in the
-   * @ref hp_paper "hp paper"
+   * @ref hp_paper "hp-paper"
    * and in step-27, first allocating a sparsity pattern and later coming back
    * and allocating additional entries for those matrix entries that will be
    * written to due to the elimination of constrained degrees of freedom

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -129,9 +129,9 @@ namespace internal
       clear();
 
       /**
-       * Return the FE index for a given finite element degree. If not in hp
+       * Return the FE index for a given finite element degree. If not in hp-
        * mode, this function always returns index 0. If an index is not found
-       * in hp mode, it returns numbers::invalid_unsigned_int.
+       * in hp-mode, it returns numbers::invalid_unsigned_int.
        */
       unsigned int
       fe_index_from_degree(const unsigned int first_selected_component,
@@ -634,7 +634,7 @@ namespace internal
        * account. This information is encoded in the row_starts variables
        * directly.
        *
-       * The outer vector goes through the various fe indices in the hp case,
+       * The outer vector goes through the various fe indices in the hp-case,
        * similarly to the @p dofs_per_cell variable.
        */
       std::vector<std::vector<unsigned int>> component_dof_indices_offset;
@@ -655,20 +655,20 @@ namespace internal
       bool store_plain_indices;
 
       /**
-       * Stores the index of the active finite element in the hp case.
+       * Stores the index of the active finite element in the hp-case.
        */
       std::vector<unsigned int> cell_active_fe_index;
 
       /**
-       * Stores the maximum degree of different finite elements for the hp
+       * Stores the maximum degree of different finite elements for the hp-
        * case.
        */
       unsigned int max_fe_index;
 
       /**
-       * To each of the slots in an hp adaptive case, the inner vector stores
+       * To each of the slots in an hp-adaptive case, the inner vector stores
        * the corresponding element degree. This is used by the constructor of
-       * FEEvaluationBase to identify the correct data slot in the hp case.
+       * FEEvaluationBase to identify the correct data slot in the hp-case.
        */
       std::vector<std::vector<unsigned int>> fe_index_conversion;
 

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -634,7 +634,7 @@ namespace internal
        * account. This information is encoded in the row_starts variables
        * directly.
        *
-       * The outer vector goes through the various fe indices in the hp-case,
+       * The outer vector goes through the various FE indices in the hp-case,
        * similarly to the @p dofs_per_cell variable.
        */
       std::vector<std::vector<unsigned int>> component_dof_indices_offset;

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -520,7 +520,7 @@ namespace internal
     {
       (void)constraint_pool_row_index;
 
-      // first reorder the active fe index.
+      // first reorder the active FE index.
       const bool have_hp = dofs_per_cell.size() > 1;
       if (cell_active_fe_index.size() > 0)
         {

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -1072,7 +1072,7 @@ namespace internal
       operator()(const FaceToCellTopology<length> &face1,
                  const FaceToCellTopology<length> &face2) const
       {
-        // check if active fe indices match
+        // check if active FE indices match
         if (active_fe_indices.size() > 0)
           {
             // ... for interior faces

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -257,7 +257,7 @@ public:
   get_current_cell_index() const;
 
   /**
-   * Return the active fe index for this class for efficient indexing in the hp
+   * Return the active fe index for this class for efficient indexing in the hp-
    * case.
    */
   unsigned int
@@ -265,7 +265,7 @@ public:
 
   /**
    * Return the active quadrature index for this class for efficient indexing in
-   * the hp case.
+   * the hp-case.
    */
   unsigned int
   get_active_quadrature_index() const;
@@ -360,13 +360,13 @@ protected:
     VectorizedArrayType> *mapping_data;
 
   /**
-   * The active fe index for this class for efficient indexing in the hp case.
+   * The active fe index for this class for efficient indexing in the hp-case.
    */
   const unsigned int active_fe_index;
 
   /**
    * The active quadrature index for this class for efficient indexing in the
-   * hp case.
+   * hp-case.
    */
   const unsigned int active_quad_index;
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -257,7 +257,7 @@ public:
   get_current_cell_index() const;
 
   /**
-   * Return the active fe index for this class for efficient indexing in the hp-
+   * Return the active FE index for this class for efficient indexing in the hp-
    * case.
    */
   unsigned int
@@ -360,7 +360,7 @@ protected:
     VectorizedArrayType> *mapping_data;
 
   /**
-   * The active fe index for this class for efficient indexing in the hp-case.
+   * The active FE index for this class for efficient indexing in the hp-case.
    */
   const unsigned int active_fe_index;
 

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -104,7 +104,7 @@ namespace internal
      * The third component is a descriptor of data from the unit cells, called
      * QuadratureDescriptor, which contains the quadrature weights and
      * permutations of how to go through quadrature points in case of face
-     * data. The latter comes in a vector for the support of hp adaptivity,
+     * data. The latter comes in a vector for the support of hp-adaptivity,
      * with several data fields for the individual quadrature formulas.
      *
      * @ingroup matrixfree
@@ -188,7 +188,7 @@ namespace internal
       /**
        * A class describing the layout of the sections in the @p data_storage
        * field and also includes some data that depends on the number of
-       * quadrature points in the hp context such as the inner quadrature
+       * quadrature points in the hp-context such as the inner quadrature
        * formula and re-indexing for faces that are not in the standard
        * orientation.
        */
@@ -289,7 +289,7 @@ namespace internal
 
       /**
        * Returns the quadrature index for a given number of quadrature
-       * points. If not in hp mode or if the index is not found, this
+       * points. If not in hp-mode or if the index is not found, this
        * function always returns index 0. Hence, this function does not
        * check whether the given degree is actually present.
        */
@@ -456,7 +456,7 @@ namespace internal
 
       /**
        * Internal function to compute the geometry for the case the mapping is
-       * a MappingQ and a single quadrature formula per slot (non-hp case) is
+       * a MappingQ and a single quadrature formula per slot (non-hp-case) is
        * used. This method computes all data from the underlying cell
        * quadrature points using the fast operator evaluation techniques from
        * the matrix-free framework itself, i.e., it uses a polynomial

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -961,7 +961,7 @@ namespace internal
               dealii::FEValues<dim> &fe_val = *fe_values[my_q][fe_index];
               cell_data.resize(n_q_points);
 
-              // if the fe index has changed from the previous cell, set the
+              // if the FE index has changed from the previous cell, set the
               // old cell type to invalid (otherwise, we might detect
               // similarity due to some cells further ahead)
               if (my_q > 0)
@@ -1846,9 +1846,9 @@ namespace internal
                               1);
 #endif
 
-              // We assume that we have the faces sorted by the active fe
-              // indices so that the active fe index of the interior side of the
-              // face batch is the same as the fe index of the interior side of
+              // We assume that we have the faces sorted by the active FE
+              // indices so that the active FE index of the interior side of the
+              // face batch is the same as the FE index of the interior side of
               // its first entry.
               const unsigned int fe_index =
                 active_fe_index.size() > 0 ?
@@ -2026,9 +2026,9 @@ namespace internal
                           GeometryInfo<dim>::max_children_per_cell)
                         {
                           // We assume that we have the faces sorted by the
-                          // active fe indices so that the active fe index of
+                          // active FE indices so that the active FE index of
                           // the exterior side of the face batch is the same as
-                          // the fe index of the exterior side of its first
+                          // the FE index of the exterior side of its first
                           // entry.
                           const unsigned int fe_index =
                             active_fe_index.size() > 0 ?

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -460,7 +460,7 @@ namespace internal
             }
         }
 
-      // In case we have no hp adaptivity (active_fe_index is empty), we have
+      // In case we have no hp-adaptivity (active_fe_index is empty), we have
       // cells, and the mapping is MappingQGeneric or a derived class, we can
       // use the fast method.
       if (active_fe_index.empty() && !cells.empty() && mapping->size() == 1 &&
@@ -904,7 +904,7 @@ namespace internal
         GeometryType cell_t_prev = general;
 
         // fe_values object that is used to compute the mapping data. for
-        // the hp case there might be more than one finite element. since we
+        // the hp-case there might be more than one finite element. since we
         // manually select the active FE index and not via a
         // DoFHandler<dim>::active_cell_iterator, we need to manually
         // select the correct finite element, so just hold a vector of
@@ -1840,7 +1840,7 @@ namespace internal
                ++my_q)
             {
 #ifndef DEAL_II_WITH_SIMPLEX_SUPPORT
-              // currently only non-hp case...
+              // currently only non-hp-case...
               AssertDimension(mapping_in.size(), 1);
               AssertDimension(mapping_info.face_data[my_q].descriptor.size(),
                               1);

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1484,8 +1484,8 @@ public:
   /**
    * In the hp-adaptive case, a subrange of internal faces as computed during
    * loop() might contain internal faces with elements of different active
-   * fe indices. Use this function to compute what the subrange for a given pair
-   * of active fe indices is.
+   * FE indices. Use this function to compute what the subrange for a given pair
+   * of active FE indices is.
    */
   std::pair<unsigned int, unsigned int>
   create_inner_face_subrange_hp_by_index(
@@ -1497,8 +1497,8 @@ public:
   /**
    * In the hp-adaptive case, a subrange of boundary faces as computed during
    * loop() might contain boundary faces with elements of different active
-   * fe indices. Use this function to compute what the subrange for a given
-   * active fe indices is.
+   * FE indices. Use this function to compute what the subrange for a given
+   * active FE indices is.
    */
   std::pair<unsigned int, unsigned int>
   create_boundary_face_subrange_hp_by_index(

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -163,7 +163,7 @@ public:
    * The two parameters `cell_vectorization_categories` and
    * `cell_vectorization_categories_strict` control the formation of batches
    * for vectorization over several cells. It is used implicitly when working
-   * with hp adaptivity but can also be useful in other contexts, such as in
+   * with hp-adaptivity but can also be useful in other contexts, such as in
    * local time stepping where one would like to control which elements
    * together form a batch of cells. The array `cell_vectorization_categories`
    * is accessed by the number given by cell->active_cell_index() when working
@@ -511,7 +511,7 @@ public:
     /**
      * This data structure allows to assign a fraction of cells to different
      * categories when building the information for vectorization. It is used
-     * implicitly when working with hp adaptivity but can also be useful in
+     * implicitly when working with hp-adaptivity but can also be useful in
      * other contexts, such as in local time stepping where one would like to
      * control which elements together form a batch of cells.
      *
@@ -1458,7 +1458,7 @@ public:
       DataAccessOnFaces::unspecified) const;
 
   /**
-   * In the hp adaptive case, a subrange of cells as computed during the cell
+   * In the hp-adaptive case, a subrange of cells as computed during the cell
    * loop might contain elements of different degrees. Use this function to
    * compute what the subrange for an individual finite element degree is. The
    * finite element degree is associated to the vector component given in the
@@ -1470,9 +1470,9 @@ public:
                           const unsigned int dof_handler_index = 0) const;
 
   /**
-   * In the hp adaptive case, a subrange of cells as computed during the cell
+   * In the hp-adaptive case, a subrange of cells as computed during the cell
    * loop might contain elements of different degrees. Use this function to
-   * compute what the subrange for a given index the hp finite element, as
+   * compute what the subrange for a given index the hp-finite element, as
    * opposed to the finite element degree in the other function.
    */
   std::pair<unsigned int, unsigned int>
@@ -1482,7 +1482,7 @@ public:
     const unsigned int                           dof_handler_index = 0) const;
 
   /**
-   * In the hp adaptive case, a subrange of internal faces as computed during
+   * In the hp-adaptive case, a subrange of internal faces as computed during
    * loop() might contain internal faces with elements of different active
    * fe indices. Use this function to compute what the subrange for a given pair
    * of active fe indices is.
@@ -1495,7 +1495,7 @@ public:
     const unsigned int                           dof_handler_index = 0) const;
 
   /**
-   * In the hp adaptive case, a subrange of boundary faces as computed during
+   * In the hp-adaptive case, a subrange of boundary faces as computed during
    * loop() might contain boundary faces with elements of different active
    * fe indices. Use this function to compute what the subrange for a given
    * active fe indices is.
@@ -1507,20 +1507,20 @@ public:
     const unsigned int                           dof_handler_index = 0) const;
 
   /**
-   * In the hp adaptive case, return number of active_fe_indices.
+   * In the hp-adaptive case, return number of active_fe_indices.
    */
   unsigned int
   n_active_fe_indices() const;
 
   /**
-   * In the hp adaptive case, return the active_fe_index of a cell range.
+   * In the hp-adaptive case, return the active_fe_index of a cell range.
    */
   unsigned int
   get_cell_active_fe_index(
     const std::pair<unsigned int, unsigned int> range) const;
 
   /**
-   * In the hp adaptive case, return the active_fe_index of a face range.
+   * In the hp-adaptive case, return the active_fe_index of a face range.
    */
   unsigned int
   get_face_active_fe_index(const std::pair<unsigned int, unsigned int> range,
@@ -1862,14 +1862,14 @@ public:
   n_active_entries_per_face_batch(const unsigned int face_batch_index) const;
 
   /**
-   * Return the number of degrees of freedom per cell for a given hp index.
+   * Return the number of degrees of freedom per cell for a given hp-index.
    */
   unsigned int
   get_dofs_per_cell(const unsigned int dof_handler_index  = 0,
                     const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Return the number of quadrature points per cell for a given hp index.
+   * Return the number of quadrature points per cell for a given hp-index.
    */
   unsigned int
   get_n_q_points(const unsigned int quad_index         = 0,
@@ -1877,7 +1877,7 @@ public:
 
   /**
    * Return the number of degrees of freedom on each face of the cell for
-   * given hp index.
+   * given hp-index.
    */
   unsigned int
   get_dofs_per_face(const unsigned int dof_handler_index  = 0,
@@ -1885,21 +1885,21 @@ public:
 
   /**
    * Return the number of quadrature points on each face of the cell for
-   * given hp index.
+   * given hp-index.
    */
   unsigned int
   get_n_q_points_face(const unsigned int quad_index         = 0,
                       const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Return the quadrature rule for given hp index.
+   * Return the quadrature rule for given hp-index.
    */
   const Quadrature<dim> &
   get_quadrature(const unsigned int quad_index         = 0,
                  const unsigned int hp_active_fe_index = 0) const;
 
   /**
-   * Return the quadrature rule for given hp index.
+   * Return the quadrature rule for given hp-index.
    */
   const Quadrature<dim - 1> &
   get_face_quadrature(const unsigned int quad_index         = 0,
@@ -1908,7 +1908,7 @@ public:
   /**
    * Return the category the current batch of cells was assigned to. Categories
    * run between the given values in the field
-   * AdditionalData::cell_vectorization_category for non-hp DoFHandler types
+   * AdditionalData::cell_vectorization_category for non-hp-DoFHandler types
    * and return the active FE index in the hp-adaptive case.
    */
   unsigned int
@@ -2012,7 +2012,7 @@ public:
   constraint_pool_end(const unsigned int pool_index) const;
 
   /**
-   * Return the unit cell information for given hp index.
+   * Return the unit cell information for given hp-index.
    */
   const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &
   get_shape_info(const unsigned int dof_handler_index_component = 0,

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -106,7 +106,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::create_cell_subrange_hp_by_index(
         Assert(
           fe_indices[i] >= fe_indices[i - 1],
           ExcMessage(
-            "Cell range must be over sorted range of fe indices in hp-case!"));
+            "Cell range must be over sorted range of FE indices in hp-case!"));
       AssertIndexRange(range.first, fe_indices.size() + 1);
       AssertIndexRange(range.second, fe_indices.size() + 1);
 #endif

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -106,7 +106,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::create_cell_subrange_hp_by_index(
         Assert(
           fe_indices[i] >= fe_indices[i - 1],
           ExcMessage(
-            "Cell range must be over sorted range of fe indices in hp case!"));
+            "Cell range must be over sorted range of fe indices in hp-case!"));
       AssertIndexRange(range.first, fe_indices.size() + 1);
       AssertIndexRange(range.second, fe_indices.size() + 1);
 #endif
@@ -579,7 +579,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
     {
       if (dof_handler.size() > 1)
         {
-          // check if all DoHandlers are in the same hp mode; and if hp
+          // check if all DoHandlers are in the same hp-mode; and if hp-
           // capabilities are enabled: check if active_fe_indices of all
           // DoFHandler are the same.
           for (unsigned int i = 1; i < dof_handler.size(); ++i)

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -151,7 +151,7 @@ namespace internal
        * interleaving cell and face integrals.
        *
        * @param categories_are_hp Defines whether
-       * `cell_vectorization_categories` is originating from a hp adaptive
+       * `cell_vectorization_categories` is originating from a hp-adaptive
        * computation with variable polynomial degree or a user-defined
        * variant.
        *
@@ -246,7 +246,7 @@ namespace internal
        * some SIMD lanes in VectorizedArray would not be filled for a given
        * cell batch index.
        *
-       * @param hp_bool Defines whether we are in hp mode or not
+       * @param hp_bool Defines whether we are in hp-mode or not
        */
       void
       make_thread_graph_partition_color(
@@ -285,7 +285,7 @@ namespace internal
        * some SIMD lanes in VectorizedArray would not be filled for a given
        * cell batch index.
        *
-       * @param hp_bool Defines whether we are in hp mode or not
+       * @param hp_bool Defines whether we are in hp-mode or not
        */
       void
       make_thread_graph_partition_partition(
@@ -316,7 +316,7 @@ namespace internal
        * some SIMD lanes in VectorizedArray would not be filled for a given
        * cell batch index.
        *
-       * @param hp_bool Defines whether we are in hp mode or not
+       * @param hp_bool Defines whether we are in hp-mode or not
        */
       void
       make_thread_graph(const std::vector<unsigned int> &cell_active_fe_index,

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -38,7 +38,7 @@ namespace internal
 
 
 /**
- * Class for transfer between two multigrid levels for p or global coarsening.
+ * Class for transfer between two multigrid levels for p- or global coarsening.
  */
 template <int dim, typename VectorType>
 class MGTwoLevelTransfer
@@ -60,7 +60,7 @@ public:
 
 
 /**
- * Class for transfer between two multigrid levels for p or global coarsening.
+ * Class for transfer between two multigrid levels for p- or global coarsening.
  * Specialization for LinearAlgebra::distributed::Vector.
  */
 template <int dim, typename Number>

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -948,7 +948,7 @@ namespace internal
         dof_handler_coarse.get_fe(0).dofs_per_cell *
         GeometryInfo<dim>::max_children_per_cell;
 
-      // degree of fe on coarse and fine cell
+      // degree of FE on coarse and fine cell
       transfer.schemes[0].degree_coarse   = transfer.schemes[0].degree_fine =
         transfer.schemes[1].degree_coarse = dof_handler_coarse.get_fe(0).degree;
       transfer.schemes[1].degree_fine =

--- a/include/deal.II/numerics/error_estimator.h
+++ b/include/deal.II/numerics/error_estimator.h
@@ -429,7 +429,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -452,7 +452,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -474,7 +474,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -497,7 +497,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -715,7 +715,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -738,7 +738,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -760,7 +760,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void
@@ -783,7 +783,7 @@ public:
 
   /**
    * Equivalent to the set of functions above, except that this one takes a
-   * quadrature collection for hp finite element dof handlers.
+   * quadrature collection for hp-finite element dof handlers.
    */
   template <typename InputVector>
   static void

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -84,7 +84,7 @@ namespace internal
    * needs not allocate memory itself, or synchronize with other threads.
    *
    * The sizes of the arrays are initialized with the maximal number of
-   * entries necessary for the hp case. Within the loop over individual
+   * entries necessary for the hp-case. Within the loop over individual
    * cells, we then resize the arrays as necessary. Since for std::vector
    * resizing to a smaller size doesn't imply memory allocation, this is
    * fast.
@@ -195,7 +195,7 @@ namespace internal
 
     /**
      * Resize the arrays so that they fit the number of quadrature points
-     * associated with the given finite element index into the hp
+     * associated with the given finite element index into the hp-
      * collections.
      */
     void
@@ -700,7 +700,7 @@ namespace internal
                ExcInternalError());
 
         // get restriction of finite element function of @p{neighbor} to the
-        // common face. in the hp case, use the quadrature formula that
+        // common face. in the hp-case, use the quadrature formula that
         // matches the one we would use for the present cell
         fe_face_values_neighbor.reinit(neighbor,
                                        neighbor_neighbor,

--- a/include/deal.II/numerics/matrix_tools.h
+++ b/include/deal.II/numerics/matrix_tools.h
@@ -318,7 +318,7 @@ namespace MatrixCreator
     const AffineConstraints<number> &constraints = AffineConstraints<number>());
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -331,7 +331,7 @@ namespace MatrixCreator
     const AffineConstraints<number> &constraints = AffineConstraints<number>());
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -343,7 +343,7 @@ namespace MatrixCreator
     const AffineConstraints<number> &constraints = AffineConstraints<number>());
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -358,7 +358,7 @@ namespace MatrixCreator
     const AffineConstraints<number> &constraints = AffineConstraints<number>());
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -430,7 +430,7 @@ namespace MatrixCreator
     std::vector<unsigned int>               component_mapping = {});
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -447,7 +447,7 @@ namespace MatrixCreator
     std::vector<unsigned int>               component_mapping = {});
 
   /**
-   * Same function as above, but for hp objects.
+   * Same function as above, but for hp-objects.
    */
   template <int dim, int spacedim, typename number>
   void
@@ -550,8 +550,7 @@ namespace MatrixCreator
     const AffineConstraints<double> &constraints = AffineConstraints<double>());
 
   /**
-   * Like the functions above, but for hp dof handlers, mappings, and
-   * quadrature collections.
+   * Like the functions above, but for hp-objects.
    */
   template <int dim, int spacedim>
   void
@@ -564,8 +563,7 @@ namespace MatrixCreator
     const AffineConstraints<double> &constraints = AffineConstraints<double>());
 
   /**
-   * Like the functions above, but for hp dof handlers, mappings, and
-   * quadrature collections.
+   * Like the functions above, but for hp-objects.
    */
   template <int dim, int spacedim>
   void
@@ -577,8 +575,7 @@ namespace MatrixCreator
     const AffineConstraints<double> &constraints = AffineConstraints<double>());
 
   /**
-   * Like the functions above, but for hp dof handlers, mappings, and
-   * quadrature collections.
+   * Like the functions above, but for hp-objects.
    */
   template <int dim, int spacedim>
   void
@@ -593,8 +590,7 @@ namespace MatrixCreator
     const AffineConstraints<double> &constraints = AffineConstraints<double>());
 
   /**
-   * Like the functions above, but for hp dof handlers, mappings, and
-   * quadrature collections.
+   * Like the functions above, but for hp-objects.
    */
   template <int dim, int spacedim>
   void

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -291,7 +291,7 @@ DEAL_II_NAMESPACE_OPEN
  * necessary to call AffineConstraints::distribute().
  *
  *
- * <h3>Implementation in the context of hp finite elements</h3>
+ * <h3>Implementation in the context of hp-finite elements</h3>
  *
  * In the case of DoFHandlers with hp-capabilities, nothing defines which of the
  * finite elements that are part of the hp::FECollection associated with the
@@ -323,7 +323,7 @@ DEAL_II_NAMESPACE_OPEN
  *   active_fe_index for a different space post-refinement and before calling
  *   DoFHandler::distribute_dofs()).
  *
- * @note In the context of hp refinement, if cells are coarsened or the
+ * @note In the context of hp-refinement, if cells are coarsened or the
  * polynomial degree is lowered on some cells, then the old finite element
  * space is not a subspace of the new space and you may run into the same
  * situation as discussed above with hanging nodes. You may want to consider

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -297,7 +297,7 @@ DEAL_II_NAMESPACE_OPEN
  * finite elements that are part of the hp::FECollection associated with the
  * DoFHandler, should be considered on cells that are not active (i.e., that
  * have children). This is because degrees of freedom are only allocated for
- * active cells and, in fact, it is not allowed to set an active_fe_index on
+ * active cells and, in fact, it is not allowed to set an active FE index on
  * non- active cells using DoFAccessor::set_active_fe_index().
  *
  * It is, thus, not entirely natural what should happen if, for example, a few
@@ -320,7 +320,7 @@ DEAL_II_NAMESPACE_OPEN
  *   cell. After refinement, this Q3 function on the mother cell is then
  *   interpolated into the space the user has selected for this cell (which may
  *   be different from Q3, in this example, if the user has set the
- *   active_fe_index for a different space post-refinement and before calling
+ *   active FE index for a different space post-refinement and before calling
  *   DoFHandler::distribute_dofs()).
  *
  * @note In the context of hp-refinement, if cells are coarsened or the

--- a/include/deal.II/numerics/vector_tools_boundary.h
+++ b/include/deal.II/numerics/vector_tools_boundary.h
@@ -625,7 +625,7 @@ namespace VectorTools
    * a problem when using the previous function in conjunction with non-
    * rectangular geometries (i.e. elements with non-rectangular faces). The
    * L2-projection method used has been taken from the paper "Electromagnetic
-   * scattering simulation using an H (curl) conforming hp finite element
+   * scattering simulation using an H (curl) conforming hp-finite element
    * method in three dimensions" by PD Ledger, K Morgan and O Hassan ( Int. J.
    * Num. Meth. Fluids, Volume 53, Issue 8, pages 1267-1296).
    *

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -2928,13 +2928,13 @@ namespace VectorTools
       // compute_face_projection_curl_conforming_l2
       //
       // For details see (for example) section 4.2:
-      // Electromagnetic scattering simulation using an H (curl) conforming hp
+      // Electromagnetic scattering simulation using an H (curl) conforming hp-
       // finite element method in three dimensions, PD Ledger, K Morgan, O
       // Hassan, Int. J.  Num. Meth. Fluids, Volume 53, Issue 8, pages
       // 1267-1296, 20 March 2007:
       // http://onlinelibrary.wiley.com/doi/10.1002/fld.1223/abstract
 
-      // Create hp FEcollection, dof_handler can be either hp or standard type.
+      // Create hp-FEcollection, dof_handler can be either hp- or standard type.
       // From here on we can treat it like a hp-namespace object.
       const hp::FECollection<dim> &fe_collection(
         dof_handler.get_fe_collection());
@@ -3216,7 +3216,7 @@ namespace VectorTools
     AffineConstraints<number> &  constraints,
     const Mapping<dim> &         mapping)
   {
-    // non-hp version - calls the internal
+    // non-hp-version - calls the internal
     // compute_project_boundary_values_curl_conforming_l2() function
     // above after recasting the mapping.
 
@@ -3240,7 +3240,7 @@ namespace VectorTools
     AffineConstraints<number> &            constraints,
     const hp::MappingCollection<dim, dim> &mapping_collection)
   {
-    // hp version - calls the internal
+    // hp-version - calls the internal
     // compute_project_boundary_values_curl_conforming_l2() function above.
     internals::compute_project_boundary_values_curl_conforming_l2(
       dof_handler,

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -367,7 +367,7 @@ namespace VectorTools
                             }
                         }
                       else
-                        // fe has only one component, so save some computations
+                        // FE has only one component, so save some computations
                         {
                           // get only the one component that this function has
                           dof_values_scalar.resize(fe.n_dofs_per_face(face_no));

--- a/include/deal.II/numerics/vector_tools_interpolate.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.h
@@ -73,7 +73,7 @@ namespace VectorTools
     const ComponentMask &component_mask = ComponentMask());
 
   /**
-   * Same as above but in an hp context.
+   * Same as above but in an hp-context.
    */
   template <int dim, int spacedim, typename VectorType>
   void

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -188,7 +188,7 @@ namespace VectorTools
               for (unsigned int m = 0; m < multiplicity; ++m)
                 {
                   // recursively call apply_transform to make sure to
-                  // correctly handle nested fe systems.
+                  // correctly handle nested FE systems.
                   current_offset = apply_transform(base_fe,
                                                    current_offset,
                                                    fe_values_jacobians,
@@ -276,7 +276,7 @@ namespace VectorTools
       std::vector<types::global_dof_index> dofs_on_cell(fe.max_dofs_per_cell());
 
       // Temporary storage for cell-wise interpolation operation. We store a
-      // variant for every fe we encounter to speed up resizing operations.
+      // variant for every FE we encounter to speed up resizing operations.
       // The first vector is used for local function evaluation. The vector
       // dof_values is used to store intermediate cell-wise interpolation
       // results (see the detailed explanation in the for loop further down

--- a/include/deal.II/numerics/vector_tools_point_value.h
+++ b/include/deal.II/numerics/vector_tools_point_value.h
@@ -152,9 +152,9 @@ namespace VectorTools
    * Call the create_point_source_vector() function, see above, with
    * an implied default $Q_1$ mapping object.
    *
-   * Note that if your DoFHandler uses any active fe index other than zero, then
+   * Note that if your DoFHandler uses any active FE index other than zero, then
    * you need to call the function above that provides a mapping object for each
-   * active fe index.
+   * active FE index.
    */
   template <int dim, int spacedim>
   void
@@ -204,9 +204,9 @@ namespace VectorTools
    * Call the create_point_source_vector() function for vector-valued finite
    * elements, see above, with an implied default $Q_1$ mapping object.
    *
-   * Note that if your DoFHandler uses any active fe index other than zero, then
+   * Note that if your DoFHandler uses any active FE index other than zero, then
    * you need to call the function above that provides a mapping object for each
-   * active fe index.
+   * active FE index.
    */
   template <int dim, int spacedim>
   void

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -165,7 +165,7 @@ namespace VectorTools
   /**
    * Call the create_boundary_right_hand_side() function, see above, with a
    * single Q1 mapping as collection. This function therefore will only work
-   * if the only active fe index in use is zero.
+   * if the only active FE index in use is zero.
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"

--- a/include/deal.II/numerics/vector_tools_rhs.h
+++ b/include/deal.II/numerics/vector_tools_rhs.h
@@ -82,7 +82,7 @@ namespace VectorTools
       AffineConstraints<typename VectorType::value_type>());
 
   /**
-   * Like the previous set of functions, but for hp objects.
+   * Like the previous set of functions, but for hp-objects.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -96,7 +96,7 @@ namespace VectorTools
       AffineConstraints<typename VectorType::value_type>());
 
   /**
-   * Like the previous set of functions, but for hp objects.
+   * Like the previous set of functions, but for hp-objects.
    */
   template <int dim, int spacedim, typename VectorType>
   void
@@ -146,7 +146,7 @@ namespace VectorTools
       std::set<types::boundary_id>());
 
   /**
-   * Same as the set of functions above, but for hp objects.
+   * Same as the set of functions above, but for hp-objects.
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"

--- a/source/distributed/error_predictor.cc
+++ b/source/distributed/error_predictor.cc
@@ -214,7 +214,7 @@ namespace parallel
                   (**estimated_error_it)[cell->active_cell_index()] *
                   (gamma_h * std::pow(.5, future_fe_degree));
 
-                // If the future fe index differs from the active one, also take
+                // If the future FE index differs from the active one, also take
                 // into account p-adaptation.
                 if (cell->future_fe_index_set())
                   *predicted_error_it *=

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -308,7 +308,7 @@ namespace parallel
                 dim,
                 DoFHandlerType::space_dimension>::CELL_COARSEN:
                 {
-                  // In case of coarsening, we need to find a suitable fe index
+                  // In case of coarsening, we need to find a suitable FE index
                   // for the parent cell. We choose the 'least dominant fe'
                   // on all children from the associated FECollection.
 #  ifdef DEBUG
@@ -383,10 +383,10 @@ namespace parallel
                 DoFHandlerType::space_dimension>::CELL_REFINE:
                 {
                   // After refinement, this particular cell is no longer active,
-                  // and its children have inherited its fe index. However, to
-                  // unpack the data on the old cell, we need to recover its fe
+                  // and its children have inherited its FE index. However, to
+                  // unpack the data on the old cell, we need to recover its FE
                   // index from one of the children. Just to be sure, we also
-                  // check if all children have the same fe index.
+                  // check if all children have the same FE index.
                   fe_index = cell->child(0)->active_fe_index();
                   for (unsigned int child_index = 1;
                        child_index < cell->n_children();

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -111,7 +111,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
                "finite element index because they do not have naturally "
                "associated finite element spaces associated: degrees "
                "of freedom are only distributed on active cells for which "
-               "the active_fe_index has been set."));
+               "the active FE index has been set."));
 
       const FiniteElement<dim, spacedim> &fe =
         this->get_dof_handler().get_fe(fe_index);

--- a/source/dofs/dof_accessor_get.cc
+++ b/source/dofs/dof_accessor_get.cc
@@ -97,7 +97,7 @@ DoFCellAccessor<dim, spacedim, lda>::get_interpolated_dof_values(
     // children recursively.
     {
       // we are on a non-active cell. these do not have any finite
-      // element associated with them in the hp context (in the non-hp
+      // element associated with them in the hp-context (in the non-hp-
       // context, we can simply assume that the FE space to which we
       // want to interpolate is the same as for all elements in the
       // mesh). consequently, we cannot interpolate from children's FE

--- a/source/dofs/dof_accessor_set.cc
+++ b/source/dofs/dof_accessor_set.cc
@@ -101,7 +101,7 @@ DoFCellAccessor<dim, spacedim, lda>::set_dof_values_by_interpolation(
                "finite element index because they do not have naturally "
                "associated finite element spaces associated: degrees "
                "of freedom are only distributed on active cells for which "
-               "the active_fe_index has been set."));
+               "the active FE index has been set."));
 
       const FiniteElement<dim, spacedim> &fe =
         this->get_dof_handler().get_fe(fe_index);

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2445,7 +2445,7 @@ DoFHandler<dim, spacedim>::set_fe(const hp::FECollection<dim, spacedim> &ff)
       AssertThrow(
         hp_capability_enabled || !contains_multiple_fes,
         ExcMessage(
-          "You cannot re-enable hp capabilities after you registered a single "
+          "You cannot re-enable hp-capabilities after you registered a single "
           "finite element. Please create a new DoFHandler object instead."));
     }
 
@@ -2524,7 +2524,7 @@ DoFHandler<dim, spacedim>::distribute_dofs(
       AssertThrow(
         hp_capability_enabled || !contains_multiple_fes,
         ExcMessage(
-          "You cannot re-enable hp capabilities after you registered a single "
+          "You cannot re-enable hp-capabilities after you registered a single "
           "finite element. Please call reinit() or create a new DoFHandler "
           "object instead."));
     }

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1010,7 +1010,7 @@ namespace internal
       struct Implementation
       {
         /**
-         * No future_fe_indices should have been assigned when partitioning a
+         * No future FE indices should have been assigned when partitioning a
          * triangulation, since they are only available locally and will not be
          * communicated.
          */
@@ -1068,7 +1068,7 @@ namespace internal
                                      [cell->vertex_index(v)] = true;
 
                 // in debug mode, make sure that each vertex is associated
-                // with at least one fe (note that except for unused
+                // with at least one FE (note that except for unused
                 // vertices, all vertices are actually active). this is of
                 // course only true for vertices that are part of either
                 // ghost or locally owned cells
@@ -1237,7 +1237,7 @@ namespace internal
           // description in hp::DoFLevel) with the indices we will
           // need. Note that our task is more complicated than for the
           // cell case above since two adjacent cells may have different
-          // active_fe_indices, in which case we need to allocate
+          // active FE indices, in which case we need to allocate
           // *two* sets of face dofs for the same face. But they don't
           // *have* to be different, and so we need to prepare for this
           // as well.
@@ -1698,7 +1698,7 @@ namespace internal
 
         /**
          * Given a DoFHandler object in hp-mode, make sure that the
-         * active_fe_indices that a user has set for locally owned cells are
+         * active FE indices that a user has set for locally owned cells are
          * communicated to all other relevant cells as well.
          *
          * For parallel::shared::Triangulation objects,
@@ -1722,9 +1722,9 @@ namespace internal
             {
               // we have a shared triangulation. in this case, every processor
               // knows about all cells, but every processor only has knowledge
-              // about the active_fe_index on the cells it owns.
+              // about the active FE index on the cells it owns.
               //
-              // we can create a complete set of active_fe_indices by letting
+              // we can create a complete set of active FE indices by letting
               // every processor create a vector of indices for all cells,
               // filling only those on the cells it owns and setting the indices
               // on the other cells to zero. then we add all of these vectors
@@ -1741,7 +1741,7 @@ namespace internal
                                   tr->get_communicator(),
                                   active_fe_indices);
 
-              // now go back and fill the active_fe_index on all other
+              // now go back and fill the active FE index on all other
               // cells. we would like to call cell->set_active_fe_index(),
               // but that function does not allow setting these indices on
               // non-locally_owned cells. so we have to work around the
@@ -1809,7 +1809,7 @@ namespace internal
          * future refinement and coarsening. Further, prepare those indices to
          * be distributed on on the updated triangulation later.
          *
-         * On cells to be refined, the active_fe_index will be inherited to
+         * On cells to be refined, the active FE index will be inherited to
          * their children and thus will be stored as such.
          *
          * On cells to be coarsened, we choose the finite element on the parent
@@ -1821,7 +1821,7 @@ namespace internal
          * information.
          *
          * On cells intended for p-refinement or p-coarsening, those
-         * active_fe_indices will be determined by the corresponding flags that
+         * active FE indices will be determined by the corresponding flags that
          * have been set on the relevant cells.
          */
         template <int dim, int spacedim>
@@ -1836,7 +1836,7 @@ namespace internal
               {
                 if (cell->refine_flag_set())
                   {
-                    // Store the active_fe_index of each cell that will be
+                    // Store the active FE index of each cell that will be
                     // refined to and distribute it later on its children.
                     // Pick their future index if flagged for p-refinement.
                     fe_transfer->refined_cells_fe_index.insert(
@@ -1845,18 +1845,18 @@ namespace internal
                 else if (cell->coarsen_flag_set())
                   {
                     // From all cells that will be coarsened, determine their
-                    // parent and calculate its proper active_fe_index, so that
+                    // parent and calculate its proper active FE index, so that
                     // it can be set after refinement. But first, check if that
                     // particular cell has a parent at all.
                     Assert(cell->level() > 0, ExcInternalError());
                     const auto &parent = cell->parent();
 
-                    // Check if the active_fe_index for the current cell has
+                    // Check if the active FE index for the current cell has
                     // been determined already.
                     if (fe_transfer->coarsened_cells_fe_index.find(parent) ==
                         fe_transfer->coarsened_cells_fe_index.end())
                       {
-                        // Find a suitable active_fe_index for the parent cell
+                        // Find a suitable active FE index for the parent cell
                         // based on the 'least dominant finite element' of its
                         // children. Consider the childrens' hypothetical future
                         // index when they have been flagged for p-refinement.
@@ -1879,7 +1879,7 @@ namespace internal
                   {
                     // No h-refinement is scheduled for this cell.
                     // However, it may have p-refinement indicators, so we
-                    // choose a new active_fe_index based on its flags.
+                    // choose a new active FE index based on its flags.
                     if (cell->future_fe_index_set() == true)
                       fe_transfer->persisting_cells_fe_index.insert(
                         {cell, cell->future_fe_index()});
@@ -1900,7 +1900,7 @@ namespace internal
         {
           const auto &fe_transfer = dof_handler.active_fe_index_transfer;
 
-          // Set active_fe_indices on persisting cells.
+          // Set active FE indices on persisting cells.
           for (const auto &persist : fe_transfer->persisting_cells_fe_index)
             {
               const auto &cell = persist.first;
@@ -1912,7 +1912,7 @@ namespace internal
                 }
             }
 
-          // Distribute active_fe_indices from all refined cells on their
+          // Distribute active FE indices from all refined cells on their
           // respective children.
           for (const auto &refine : fe_transfer->refined_cells_fe_index)
             {
@@ -1926,7 +1926,7 @@ namespace internal
                 }
             }
 
-          // Set active_fe_indices on coarsened cells that have been determined
+          // Set active FE indices on coarsened cells that have been determined
           // before the actual coarsening happened.
           for (const auto &coarsen : fe_transfer->coarsened_cells_fe_index)
             {
@@ -1940,7 +1940,7 @@ namespace internal
 
         /**
          * Coarsening strategy for the CellDataTransfer object responsible for
-         * transferring the active_fe_index of each cell on
+         * transferring the active FE index of each cell on
          * parallel::distributed::Triangulation objects that have been refined.
          *
          * A finite element index needs to be determined for the (not yet
@@ -2440,7 +2440,7 @@ DoFHandler<dim, spacedim>::set_fe(const hp::FECollection<dim, spacedim> &ff)
           this->hp_cell_future_fe_indices.shrink_to_fit();
         }
 
-      // re-enabling hp-mode is not permitted since the active and future fe
+      // re-enabling hp-mode is not permitted since the active and future FE
       // tables are no longer available
       AssertThrow(
         hp_capability_enabled || !contains_multiple_fes,
@@ -2451,13 +2451,13 @@ DoFHandler<dim, spacedim>::set_fe(const hp::FECollection<dim, spacedim> &ff)
 
   if (hp_capability_enabled)
     {
-      // make sure every processor knows the active_fe_indices
+      // make sure every processor knows the active FE indices
       // on both its own cells and all ghost cells
       dealii::internal::hp::DoFHandlerImplementation::Implementation::
         communicate_active_fe_indices(*this);
 
-      // make sure that the fe collection is large enough to
-      // cover all fe indices presently in use on the mesh
+      // make sure that the FE collection is large enough to
+      // cover all FE indices presently in use on the mesh
       for (const auto &cell : this->active_cell_iterators())
         if (!cell->is_artificial())
           Assert(cell->active_fe_index() < this->fe_collection.size(),
@@ -2519,7 +2519,7 @@ DoFHandler<dim, spacedim>::distribute_dofs(
           this->hp_cell_future_fe_indices.shrink_to_fit();
         }
 
-      // re-enabling hp-mode is not permitted since the active and future fe
+      // re-enabling hp-mode is not permitted since the active and future FE
       // tables are no longer available
       AssertThrow(
         hp_capability_enabled || !contains_multiple_fes,
@@ -2534,14 +2534,14 @@ DoFHandler<dim, spacedim>::distribute_dofs(
   //
   if (hp_capability_enabled)
     {
-      // make sure every processor knows the active_fe_indices
+      // make sure every processor knows the active FE indices
       // on both its own cells and all ghost cells
       internal::hp::DoFHandlerImplementation::Implementation::
         communicate_active_fe_indices(*this);
 
 #ifdef DEBUG
-      // make sure that the fe collection is large enough to
-      // cover all fe indices presently in use on the mesh
+      // make sure that the FE collection is large enough to
+      // cover all FE indices presently in use on the mesh
       for (const auto &cell : this->active_cell_iterators())
         {
           if (!cell->is_artificial())
@@ -3043,7 +3043,7 @@ DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
     [this]() { this->create_active_fe_table(); }));
 
   // attach corresponding callback functions dealing with the transfer of
-  // active_fe_indices depending on the type of triangulation
+  // active FE indices depending on the type of triangulation
   if (dynamic_cast<
         const dealii::parallel::DistributedTriangulationBase<dim, spacedim> *>(
         &this->get_triangulation()))
@@ -3123,7 +3123,7 @@ DoFHandler<dim, spacedim>::create_active_fe_table()
   this->hp_cell_future_fe_indices.resize(this->tria->n_levels());
 
   // then make sure that on each level we have the appropriate size
-  // of active_fe_indices; preset them to zero, i.e. the default FE
+  // of active FE indices; preset them to zero, i.e. the default FE
   for (unsigned int level = 0; level < this->hp_cell_future_fe_indices.size();
        ++level)
     {
@@ -3137,7 +3137,7 @@ DoFHandler<dim, spacedim>::create_active_fe_table()
         }
       else
         {
-          // Either the active_fe_indices have size zero because
+          // Either the active FE indices have size zero because
           // they were just created, or the correct size. Other
           // sizes indicate that something went wrong.
           Assert(this->hp_cell_active_fe_indices[level].size() ==
@@ -3148,7 +3148,7 @@ DoFHandler<dim, spacedim>::create_active_fe_table()
         }
 
       // it may be that the previous table was compressed; in that
-      // case, restore the correct active_fe_index. the fact that
+      // case, restore the correct active FE index. the fact that
       // this no longer matches the indices in the table is of no
       // importance because the current function is called at a
       // point where we have to recreate the dof_indices tables in
@@ -3183,13 +3183,13 @@ DoFHandler<dim, spacedim>::update_active_fe_table()
 
   for (unsigned int i = 0; i < this->hp_cell_future_fe_indices.size(); ++i)
     {
-      // Resize active_fe_indices vectors. Use zero indicator to extend.
+      // Resize active FE indices vectors. Use zero indicator to extend.
       this->hp_cell_active_fe_indices[i].resize(this->tria->n_raw_cells(i), 0);
 
-      // Resize future_fe_indices vectors. Make sure that all
-      // future_fe_indices have been cleared after refinement happened.
+      // Resize future FE indices vectors. Make sure that all
+      // future FE indices have been cleared after refinement happened.
       //
-      // We have used future_fe_indices to update all active_fe_indices
+      // We have used future FE indices to update all active FE indices
       // before refinement happened, thus we are safe to clear them now.
       this->hp_cell_future_fe_indices[i].assign(this->tria->n_raw_cells(i),
                                                 invalid_active_fe_index);
@@ -3233,12 +3233,12 @@ DoFHandler<dim, spacedim>::pre_distributed_transfer_action()
   active_fe_index_transfer = std::make_unique<ActiveFEIndexTransfer>();
 
   // If we work on a p::d::Triangulation, we have to transfer all
-  // active_fe_indices since ownership of cells may change. We will
+  // active FE indices since ownership of cells may change. We will
   // use our p::d::CellDataTransfer member to achieve this. Further,
   // we prepare the values in such a way that they will correspond to
-  // the active_fe_indices on the new mesh.
+  // the active FE indices on the new mesh.
 
-  // Gather all current future_fe_indices.
+  // Gather all current future FE indices.
   active_fe_index_transfer->active_fe_indices.resize(
     get_triangulation().n_active_cells(), numbers::invalid_unsigned_int);
 
@@ -3289,7 +3289,7 @@ DoFHandler<dim, spacedim>::post_transfer_action()
   dealii::internal::hp::DoFHandlerImplementation::Implementation::
     distribute_fe_indices_on_refined_cells(*this);
 
-  // We have to distribute the information about active_fe_indices
+  // We have to distribute the information about active FE indices
   // of all cells (including the artificial ones) on all processors,
   // if a parallel::shared::Triangulation has been used.
   dealii::internal::hp::DoFHandlerImplementation::Implementation::
@@ -3312,17 +3312,17 @@ DoFHandler<dim, spacedim>::post_distributed_transfer_action()
 
   Assert(this->active_fe_index_transfer != nullptr, ExcInternalError());
 
-  // Unpack active_fe_indices.
+  // Unpack active FE indices.
   this->active_fe_index_transfer->active_fe_indices.resize(
     this->get_triangulation().n_active_cells(), numbers::invalid_unsigned_int);
   this->active_fe_index_transfer->cell_data_transfer->unpack(
     this->active_fe_index_transfer->active_fe_indices);
 
-  // Update all locally owned active_fe_indices.
+  // Update all locally owned active FE indices.
   this->set_active_fe_indices(
     this->active_fe_index_transfer->active_fe_indices);
 
-  // Update active_fe_indices on ghost cells.
+  // Update active FE indices on ghost cells.
   dealii::internal::hp::DoFHandlerImplementation::Implementation::
     communicate_active_fe_indices(*this);
 
@@ -3378,9 +3378,9 @@ DoFHandler<dim, spacedim>::prepare_for_serialization_of_active_fe_indices()
     });
 
   // If we work on a p::d::Triangulation, we have to transfer all
-  // active fe indices since ownership of cells may change.
+  // active FE indices since ownership of cells may change.
 
-  // Gather all current active_fe_indices
+  // Gather all current active FE indices
   get_active_fe_indices(active_fe_index_transfer->active_fe_indices);
 
   // Attach to transfer object
@@ -3435,16 +3435,16 @@ DoFHandler<dim, spacedim>::deserialize_active_fe_indices()
                                                   fe_collection);
     });
 
-  // Unpack active_fe_indices.
+  // Unpack active FE indices.
   active_fe_index_transfer->active_fe_indices.resize(
     get_triangulation().n_active_cells(), numbers::invalid_unsigned_int);
   active_fe_index_transfer->cell_data_transfer->deserialize(
     active_fe_index_transfer->active_fe_indices);
 
-  // Update all locally owned active_fe_indices.
+  // Update all locally owned active FE indices.
   set_active_fe_indices(active_fe_index_transfer->active_fe_indices);
 
-  // Update active_fe_indices on ghost cells.
+  // Update active FE indices on ghost cells.
   dealii::internal::hp::DoFHandlerImplementation::Implementation::
     communicate_active_fe_indices(*this);
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -223,7 +223,7 @@ namespace internal
 
           // Note: we may wish to have something here similar to what
           // we do for lines and quads, namely that we only identify
-          // dofs for any fe towards the most dominating one. however,
+          // dofs for any FE towards the most dominating one. however,
           // it is not clear whether this is actually necessary for
           // vertices at all, I can't think of a finite element that
           // would make that necessary...
@@ -297,7 +297,7 @@ namespace internal
                           // are not yet constrained to anything else,
                           // except for to each other. use the rule that
                           // we will always constrain the dof with the
-                          // higher fe index to the one with the lower,
+                          // higher FE index to the one with the lower,
                           // to avoid circular reasoning.
                           for (const auto &identity : identities)
                             {
@@ -1070,7 +1070,7 @@ namespace internal
 
           // Note: we may wish to have something here similar to what
           // we do for lines and quads, namely that we only identify
-          // dofs for any fe towards the most dominating one. however,
+          // dofs for any FE towards the most dominating one. however,
           // it is not clear whether this is actually necessary for
           // vertices at all, I can't think of a finite element that
           // would make that necessary...
@@ -1157,7 +1157,7 @@ namespace internal
                           // are not yet constrained to anything else,
                           // except for to each other. use the rule that
                           // we will always constrain the dof with the
-                          // higher fe index to the one with the lower,
+                          // higher FE index to the one with the lower,
                           // to avoid circular reasoning.
                           for (const auto &identity : identities)
                             {
@@ -1186,7 +1186,7 @@ namespace internal
                               // we need to work on.
                               //
                               // all degrees of freedom belonging to
-                              // dominating fe indices or to a processor
+                              // dominating FE indices or to a processor
                               // with a higher rank have been set at this
                               // point (either in Phase 2, or after the
                               // first ghost exchange in Phase 5). thus,
@@ -1459,7 +1459,7 @@ namespace internal
                                     // we need to work on.
                                     //
                                     // all degrees of freedom belonging to
-                                    // dominating fe indices or to a processor
+                                    // dominating FE indices or to a processor
                                     // with a higher rank have been set at this
                                     // point (either in Phase 2, or after the
                                     // first ghost exchange in Phase 5). thus,
@@ -1614,7 +1614,7 @@ namespace internal
                                 // we need to work on.
                                 //
                                 // all degrees of freedom belonging to
-                                // dominating fe indices or to a processor with
+                                // dominating FE indices or to a processor with
                                 // a higher rank have been set at this point
                                 // (either in Phase 2, or after the first ghost
                                 // exchange in Phase 5). thus, we only have to
@@ -1935,7 +1935,7 @@ namespace internal
                       // the previous indices were all valid. this really should
                       // be the case: we allocated space for these vertex dofs,
                       // i.e., at least one adjacent cell has a valid
-                      // active_fe_index, so there are DoFs that really live
+                      // active FE index, so there are DoFs that really live
                       // on this vertex. if check_validity is set, then we
                       // must make sure that they have been set to something
                       // useful
@@ -3919,7 +3919,7 @@ namespace internal
 
           // If the DoFHandler has hp-capabilities enabled, then we may have
           // received valid indices of degrees of freedom that are dominated
-          // by a fe object adjacent to a ghost interface.  thus, we overwrite
+          // by a FE object adjacent to a ghost interface.  thus, we overwrite
           // the remaining invalid indices with the valid ones in this step.
           Implementation::merge_invalid_dof_indices_on_ghost_interfaces(
             *dof_handler);
@@ -4432,7 +4432,7 @@ namespace internal
 
               // if the DoFHandler has hp-capabilities then we may have
               // received valid indices of degrees of freedom that are
-              // dominated by a fe object adjacent to a ghost interface.
+              // dominated by a FE object adjacent to a ghost interface.
               // thus, we overwrite the remaining invalid indices with the
               // valid ones in this step.
               Implementation::merge_invalid_dof_indices_on_ghost_interfaces(

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -402,7 +402,7 @@ namespace internal
             dof_handler.get_triangulation())
             .clear_user_flags_line();
 
-          // An implementation of the algorithm described in the hp paper,
+          // An implementation of the algorithm described in the hp-paper,
           // including the modification mentioned later in the "complications in
           // 3-d" subsections
           //
@@ -446,7 +446,7 @@ namespace internal
                                            fe_index_2 =
                                              line->nth_active_fe_index(g);
 
-                        // as described in the hp paper, we only unify on lines
+                        // as described in the hp-paper, we only unify on lines
                         // when there are at most two different FE objects
                         // assigned on it.
                         // however, more than two 'active_fe_indices' can be
@@ -777,7 +777,7 @@ namespace internal
             dof_handler.get_triangulation())
             .clear_user_flags_quad();
 
-          // An implementation of the algorithm described in the hp
+          // An implementation of the algorithm described in the hp-
           // paper, including the modification mentioned later in the
           // "complications in 3-d" subsections
           //
@@ -1020,7 +1020,7 @@ namespace internal
         /**
          * Once degrees of freedom have been distributed on all cells, see if
          * we can identify DoFs on neighboring cells. This function does
-         * nothing unless the DoFHandler has hp capabilities.
+         * nothing unless the DoFHandler has hp-capabilities.
          *
          * Return the final number of degrees of freedom, which is the old one
          * minus however many were identified.
@@ -1252,7 +1252,7 @@ namespace internal
               for (const auto l : cell->line_indices())
                 cell->line(l)->set_user_flag();
 
-          // An implementation of the algorithm described in the hp paper,
+          // An implementation of the algorithm described in the hp-paper,
           // including the modification mentioned later in the "complications in
           // 3-d" subsections
           //
@@ -1533,7 +1533,7 @@ namespace internal
               for (const auto q : cell->face_indices())
                 cell->quad(q)->set_user_flag();
 
-          // An implementation of the algorithm described in the hp
+          // An implementation of the algorithm described in the hp-
           // paper, including the modification mentioned later in the
           // "complications in 3-d" subsections
           //
@@ -1649,7 +1649,7 @@ namespace internal
          * know the indices of all dominating DoFs, and we have to assign those
          * invalid entries to their corresponding global value.
          *
-         * This function does nothing unless the DoFHandler has hp
+         * This function does nothing unless the DoFHandler has hp-
          * capabilities.
          */
         template <int dim, int spacedim>
@@ -1958,7 +1958,7 @@ namespace internal
                           // non-locally owned DoF for which we don't know the
                           // new number yet and so set it to an invalid index.
                           // This will later be fixed up after the first ghost
-                          // exchange phase when we unify hp DoFs on neighboring
+                          // exchange phase when we unify hp-DoFs on neighboring
                           // cells.
                           if (indices_we_care_about.size() == 0)
                             dealii::internal::DoFAccessorImplementation::
@@ -2052,7 +2052,7 @@ namespace internal
                         // DoF for which we don't know the new number yet and so
                         // set it to an invalid index. This will later be fixed
                         // up after the first ghost exchange phase when we unify
-                        // hp DoFs on neighboring cells.
+                        // hp-DoFs on neighboring cells.
                         if (indices_we_care_about.size() == 0)
                           cell->set_dof_index(d,
                                               new_numbers[old_dof_index],
@@ -2163,7 +2163,7 @@ namespace internal
                                   // for which we don't know the new number yet
                                   // and so set it to an invalid index. This
                                   // will later be fixed up after the first
-                                  // ghost exchange phase when we unify hp DoFs
+                                  // ghost exchange phase when we unify hp-DoFs
                                   // on neighboring cells.
                                   if (indices_we_care_about.size() == 0)
                                     line->set_dof_index(
@@ -2272,7 +2272,7 @@ namespace internal
                                   // for which we don't know the new number yet
                                   // and so set it to an invalid index. This
                                   // will later be fixed up after the first
-                                  // ghost exchange phase when we unify hp DoFs
+                                  // ghost exchange phase when we unify hp-DoFs
                                   // on neighboring cells.
                                   if (indices_we_care_about.size() == 0)
                                     line->set_dof_index(
@@ -2350,7 +2350,7 @@ namespace internal
                                   // for which we don't know the new number yet
                                   // and so set it to an invalid index. This
                                   // will later be fixed up after the first
-                                  // ghost exchange phase when we unify hp DoFs
+                                  // ghost exchange phase when we unify hp-DoFs
                                   // on neighboring cells.
                                   if (indices_we_care_about.size() == 0)
                                     quad->set_dof_index(
@@ -2845,7 +2845,7 @@ namespace internal
         // return a sequential, complete index set. take into account that the
         // number of DoF indices may in fact be smaller than there were before
         // if some previously separately numbered dofs have been identified.
-        // this is, for example, what we do when the DoFHandler has hp
+        // this is, for example, what we do when the DoFHandler has hp-
         // capabilities enabled: it first enumerates all DoFs on cells
         // independently, and then unifies some located at vertices or faces;
         // this leaves us with fewer DoFs than there were before, so use the
@@ -3819,7 +3819,7 @@ namespace internal
         // --------- Phase 2: eliminate dof duplicates on all cells:
         //                    - un-numerate dofs on interfaces to ghost cells
         //                      that we don't own
-        //                    - in case of hp support, unify dofs
+        //                    - in case of hp-support, unify dofs
         std::vector<dealii::types::global_dof_index> renumbering(
           n_initial_local_dofs, enumeration_dof_index);
 
@@ -3830,7 +3830,7 @@ namespace internal
           invalidate_dof_indices_on_weaker_ghost_cells_for_renumbering(
             renumbering, subdomain_id, *dof_handler);
 
-        // then, we identify DoF duplicates if the DoFHandler has hp
+        // then, we identify DoF duplicates if the DoFHandler has hp-
         // capabilities
         std::vector<std::map<types::global_dof_index, types::global_dof_index>>
           all_constrained_indices(dim);
@@ -3917,7 +3917,7 @@ namespace internal
           // done twice
           communicate_dof_indices_on_marked_cells(*dof_handler);
 
-          // If the DoFHandler has hp capabilities enabled, then we may have
+          // If the DoFHandler has hp-capabilities enabled, then we may have
           // received valid indices of degrees of freedom that are dominated
           // by a fe object adjacent to a ghost interface.  thus, we overwrite
           // the remaining invalid indices with the valid ones in this step.
@@ -4410,7 +4410,7 @@ namespace internal
             //
             // This is the same as phase 5+6 in the distribute_dofs() algorithm,
             // taking into account that we have to unify a few DoFs in between
-            // then communication phases if we do hp numbering
+            // then communication phases if we do hp-numbering
             {
               std::vector<bool> user_flags;
               triangulation->save_user_flags(user_flags);
@@ -4430,7 +4430,7 @@ namespace internal
               // done twice
               communicate_dof_indices_on_marked_cells(*dof_handler);
 
-              // if the DoFHandler has hp capabilities then we may have
+              // if the DoFHandler has hp-capabilities then we may have
               // received valid indices of degrees of freedom that are
               // dominated by a fe object adjacent to a ghost interface.
               // thus, we overwrite the remaining invalid indices with the

--- a/source/dofs/dof_objects.cc
+++ b/source/dofs/dof_objects.cc
@@ -50,7 +50,7 @@ namespace internal
       Assert(
         (fe_index == dealii::DoFHandler<dh_dim, spacedim>::default_fe_index),
         ExcMessage(
-          "Only the default FE index is allowed for non-hp DoFHandler objects"));
+          "Only the default FE index is allowed for non-hp-DoFHandler objects"));
       Assert(
         local_index < dof_handler.get_fe().template n_dofs_per_object<dim>(),
         ExcIndexRange(local_index,

--- a/source/dofs/dof_renumbering.inst.in
+++ b/source/dofs/dof_renumbering.inst.in
@@ -21,7 +21,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     \{
       namespace boost
       \{
-        // TODO[WB]: also implement the following boost for hp DoFHandlers etc.
+        // TODO[WB]: also implement the following boost for hp-DoFHandlers etc.
       \}
 
 
@@ -78,7 +78,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     \{
       namespace boost
       \{
-        // TODO[WB]: also implement the following boost for hp DoFHandlers etc.
+        // TODO[WB]: also implement the following boost for hp-DoFHandlers etc.
         template void
         Cuthill_McKee(DoFHandler<deal_II_dimension> &, bool, bool);
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -701,7 +701,7 @@ namespace DoFTools
                     // non-primitive, but use usual convention (see docs)
                     {
                       // first get at the cell-global number of a face dof,
-                      // to ask the fe certain questions
+                      // to ask the FE certain questions
                       const unsigned int cell_index =
                         (dim == 1 ?
                            i :
@@ -2201,7 +2201,7 @@ namespace DoFTools
         for (unsigned int fe_index = 0; fe_index < fe_collection.size();
              ++fe_index)
           {
-            // check whether every fe in the collection has support points
+            // check whether every FE in the collection has support points
             Assert(fe_collection[fe_index].has_support_points(),
                    typename FiniteElement<dim>::ExcFEHasNoSupportPoints());
             q_coll_dummy.push_back(Quadrature<dim>(

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -646,7 +646,7 @@ namespace DoFTools
           for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->has_children())
               {
-                // in any case, faces can have at most two active fe indices,
+                // in any case, faces can have at most two active FE indices,
                 // but here the face can have only one (namely the same as that
                 // from the cell we're sitting on), and each of the children can
                 // have only one as well. check this
@@ -664,7 +664,7 @@ namespace DoFTools
                            ExcInternalError());
 
                 // right now, all that is implemented is the case that both
-                // sides use the same fe
+                // sides use the same FE
                 for (unsigned int c = 0; c < cell->face(face)->n_children();
                      ++c)
                   if (!cell->neighbor_child_on_subface(face, c)
@@ -747,7 +747,7 @@ namespace DoFTools
             else
               {
                 // this face has no children, but it could still be that it is
-                // shared by two cells that use a different fe index. check a
+                // shared by two cells that use a different FE index. check a
                 // couple of things, but ignore the case that the neighbor is an
                 // artificial cell
                 if (!cell->at_boundary(face) &&
@@ -808,7 +808,7 @@ namespace DoFTools
                          RefinementCase<dim - 1>::isotropic_refinement,
                        ExcNotImplemented());
 
-                // in any case, faces can have at most two active fe indices,
+                // in any case, faces can have at most two active FE indices,
                 // but here the face can have only one (namely the same as that
                 // from the cell we're sitting on), and each of the children can
                 // have only one as well. check this
@@ -825,7 +825,7 @@ namespace DoFTools
 
                 // right now, all that is implemented is the case that both
                 // sides use the same fe, and not only that but also that all
-                // lines bounding this face and the children have the same fe
+                // lines bounding this face and the children have the same FE
                 for (unsigned int c = 0; c < cell->face(face)->n_children();
                      ++c)
                   if (!cell->neighbor_child_on_subface(face, c)
@@ -991,7 +991,7 @@ namespace DoFTools
             else
               {
                 // this face has no children, but it could still be that it is
-                // shared by two cells that use a different fe index. check a
+                // shared by two cells that use a different FE index. check a
                 // couple of things, but ignore the case that the neighbor is an
                 // artificial cell
                 if (!cell->at_boundary(face) &&
@@ -1086,7 +1086,7 @@ namespace DoFTools
                 // so now we've found a face of an active cell that has
                 // children. that means that there are hanging nodes here.
 
-                // in any case, faces can have at most two sets of active fe
+                // in any case, faces can have at most two sets of active FE
                 // indices, but here the face can have only one (namely the same
                 // as that from the cell we're sitting on), and each of the
                 // children can have only one as well. check this
@@ -1466,7 +1466,7 @@ namespace DoFTools
             else
               {
                 // this face has no children, but it could still be that it is
-                // shared by two cells that use a different fe index
+                // shared by two cells that use a different FE index
                 Assert(cell->face(face)->fe_index_is_active(
                          cell->active_fe_index()) == true,
                        ExcInternalError());
@@ -1474,12 +1474,12 @@ namespace DoFTools
                 // see if there is a neighbor that is an artificial cell. in
                 // that case, we're not interested in this interface. we test
                 // this case first since artificial cells may not have an
-                // active_fe_index set, etc
+                // active FE index set, etc
                 if (!cell->at_boundary(face) &&
                     cell->neighbor(face)->is_artificial())
                   continue;
 
-                // Only if there is a neighbor with a different active_fe_index
+                // Only if there is a neighbor with a different active FE index
                 // and the same h-level, some action has to be taken.
                 if ((dof_handler.has_hp_capabilities()) &&
                     !cell->face(face)->at_boundary() &&

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -149,7 +149,7 @@ namespace DoFTools
       /**
        * When restricting, on a face, the degrees of freedom of fe1 to the space
        * described by fe2 (for example for the complex case described
-       * in the @ref hp_paper "hp paper"), we have to select fe2.dofs_per_face
+       * in the @ref hp_paper "hp-paper"), we have to select fe2.dofs_per_face
        * out of the fe1.dofs_per_face face DoFs as the
        * primary dofs, and the rest become dependent dofs. This function selects
        * which ones will be primary, and which ones will be dependents.
@@ -395,7 +395,7 @@ namespace DoFTools
       /**
        * Given the face interpolation matrix between two elements, split it into
        * its primary and dependent parts and invert the primary part as
-       * explained in the @ref hp_paper "hp paper".
+       * explained in the @ref hp_paper "hp-paper".
        */
       void
       ensure_existence_of_split_face_matrix(
@@ -457,7 +457,7 @@ namespace DoFTools
 
       /**
        * A function that returns how many different finite elements a dof
-       * handler uses. This is one for non-hp DoFHandlers and
+       * handler uses. This is one for non-hp-DoFHandlers and
        * dof_handler.get_fe().size() for the hp-versions.
        */
       template <int dim, int spacedim>
@@ -476,7 +476,7 @@ namespace DoFTools
        * Copy constraints into an AffineConstraints object.
        *
        * This function removes zero constraints and those, which constrain a DoF
-       * which was already eliminated in one of the previous steps of the hp
+       * which was already eliminated in one of the previous steps of the hp-
        * hanging node procedure.
        *
        * It also suppresses very small entries in the AffineConstraints object
@@ -1016,7 +1016,7 @@ namespace DoFTools
       AffineConstraints<number> &      constraints)
     {
       // note: this function is going to be hard to understand if you haven't
-      // read the hp paper. however, we try to follow the notation laid out
+      // read the hp-paper. however, we try to follow the notation laid out
       // there, so go read the paper before you try to understand what is going
       // on here
 
@@ -1046,7 +1046,7 @@ namespace DoFTools
       // primary and dependent parts, and for which the primary part is
       // inverted. these two matrices are derived from the face interpolation
       // matrix
-      // as described in the @ref hp_paper "hp paper"
+      // as described in the @ref hp_paper "hp-paper"
       Table<2,
             std::unique_ptr<std::pair<FullMatrix<double>, FullMatrix<double>>>>
         split_face_interpolation_matrices(n_finite_elements(dof_handler),
@@ -1104,7 +1104,7 @@ namespace DoFTools
                            ExcInternalError());
 
                 // first find out whether we can constrain each of the subfaces
-                // to the mother face. in the lingo of the hp paper, this would
+                // to the mother face. in the lingo of the hp-paper, this would
                 // be the simple case. note that we can short-circuit this
                 // decision if the dof_handler doesn't support hp at all
                 //
@@ -1142,7 +1142,7 @@ namespace DoFTools
                     case FiniteElementDomination::either_element_can_dominate:
                       {
                         // Case 1 (the simple case and the only case that can
-                        // happen for non-hp DoFHandlers): The coarse element
+                        // happen for non-hp-DoFHandlers): The coarse element
                         // dominates the elements on the subfaces (or they are
                         // all the same)
                         //
@@ -1255,10 +1255,10 @@ namespace DoFTools
                       {
                         // Case 2 (the "complex" case): at least one (the
                         // neither_... case) of the finer elements or all of
-                        // them (the other_... case) is dominating. See the hp
+                        // them (the other_... case) is dominating. See the hp-
                         // paper for a way how to deal with this situation
                         //
-                        // since this is something that can only happen for hp
+                        // since this is something that can only happen for hp-
                         // dof handlers, add a check here...
                         Assert(dof_handler.has_hp_capabilities() == true,
                                ExcInternalError());
@@ -1389,7 +1389,7 @@ namespace DoFTools
 
 
                         // next we have to deal with the subfaces. do as
-                        // discussed in the hp paper
+                        // discussed in the hp-paper
                         for (unsigned int sf = 0;
                              sf < cell->face(face)->n_children();
                              ++sf)
@@ -1581,7 +1581,7 @@ namespace DoFTools
                             // our best bet is to find the common space among
                             // other FEs in FECollection and then constrain both
                             // FEs to that one. More precisely, we follow the
-                            // strategy outlined on page 17 of the hp paper:
+                            // strategy outlined on page 17 of the hp-paper:
                             // First we find the dominant FE space S. Then we
                             // divide our dofs in primary and dependent such
                             // that I^{face,primary}_{S^{face}->S} is
@@ -3156,7 +3156,7 @@ namespace DoFTools
     Assert(coarse_grid.get_fe_collection().size() == 1 &&
              fine_grid.get_fe_collection().size() == 1,
            ExcMessage("This function is not yet implemented for DoFHandlers "
-                      "using hp capabilities."));
+                      "using hp-capabilities."));
     // store the weights with which a dof on the parameter grid contributes to a
     // dof on the fine grid. see the long doc below for more info
     //
@@ -3340,7 +3340,7 @@ namespace DoFTools
     Assert(coarse_grid.get_fe_collection().size() == 1 &&
              fine_grid.get_fe_collection().size() == 1,
            ExcMessage("This function is not yet implemented for DoFHandlers "
-                      "using hp capabilities."));
+                      "using hp-capabilities."));
     // store the weights with which a dof on the parameter grid contributes to a
     // dof on the fine grid. see the long doc below for more info
     //

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -765,7 +765,7 @@ namespace DoFTools
     namespace
     {
       // implementation of the same function in namespace DoFTools for
-      // non-hp DoFHandlers
+      // non-hp-DoFHandlers
       template <int dim,
                 int spacedim,
                 typename SparsityPatternType,
@@ -1103,7 +1103,7 @@ namespace DoFTools
           {
             // while the implementation above is quite optimized and caches a
             // lot of data (see e.g. the int/flux_dof_mask tables), this is no
-            // longer practical for the hp version since we would have to have
+            // longer practical for the hp-version since we would have to have
             // it for all combinations of elements in the hp::FECollection.
             // consequently, the implementation here is simpler and probably
             // less efficient but at least readable...
@@ -1189,7 +1189,7 @@ namespace DoFTools
                           if (!face_has_flux_coupling(cell, face))
                             continue;
 
-                          // Like the non-hp case: If the cells are on the same
+                          // Like the non-hp-case: If the cells are on the same
                           // level (and both are active, locally-owned cells)
                           // then only add to the sparsity pattern if the
                           // current cell is 'greater' in the total ordering.
@@ -1198,7 +1198,7 @@ namespace DoFTools
                               neighbor->is_active() &&
                               neighbor->is_locally_owned())
                             continue;
-                          // Again, like the non-hp case: If we are more refined
+                          // Again, like the non-hp-case: If we are more refined
                           // then the neighbor, then we will automatically find
                           // the active neighbor cell when we call 'neighbor
                           // (face)' above. The opposite is not true; if the

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -260,7 +260,7 @@ std::vector<std::pair<unsigned int, unsigned int>>
 FE_Bernstein<dim, spacedim>::hp_line_dof_identities(
   const FiniteElement<dim, spacedim> &) const
 {
-  // Since this fe is not interpolatory but on the vertices, we can
+  // Since this FE is not interpolatory but on the vertices, we can
   // not identify dofs on lines and on quads even if there are dofs
   // on lines and on quads.
   //
@@ -276,7 +276,7 @@ FE_Bernstein<dim, spacedim>::hp_quad_dof_identities(
   const FiniteElement<dim, spacedim> &,
   const unsigned int) const
 {
-  // Since this fe is not interpolatory but on the vertices, we can
+  // Since this FE is not interpolatory but on the vertices, we can
   // not identify dofs on lines and on quads even if there are dofs
   // on lines and on quads.
   //

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -131,7 +131,7 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
       // Make sure that the element for which the DoFs should be constrained
       // is the one with the higher polynomial degree.  Actually the procedure
       // will work also if this assertion is not satisfied. But the matrices
-      // produced in that case might lead to problems in the hp procedures,
+      // produced in that case might lead to problems in the hp-procedures,
       // which use this method.
       Assert(
         this->n_dofs_per_face(face_no) <= source_fe->n_dofs_per_face(face_no),

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -428,7 +428,7 @@ FE_Enriched<dim, spacedim>::initialize(
   Assert(fes.size() == multiplicities.size(),
          ExcDimensionMismatch(fes.size(), multiplicities.size()));
 
-  // Note that we need to skip every fe with multiplicity 0 in the following
+  // Note that we need to skip every FE with multiplicity 0 in the following
   // block of code
   this->base_to_block_indices.reinit(0, 0);
 
@@ -475,7 +475,7 @@ FE_Enriched<dim, spacedim>::initialize(
   // However, functions like interpolate_boundary_values() need all FEs inside
   // FECollection to be able to provide support points irrespectively whether
   // this FE sits on the boundary or not. Thus for moment just copy support
-  // points from fe system:
+  // points from FE system:
   {
     this->unit_support_points      = fe_system->unit_support_points;
     this->unit_face_support_points = fe_system->unit_face_support_points;
@@ -1296,8 +1296,8 @@ namespace ColorEnriched
        * on adjacent cells, an enriched FE [0 0 1] should exist and is
        * found as the least dominating finite element for the two cells by
        * DoFTools::make_hanging_node_constraints, using the above mentioned
-       * hp::FECollection functions. Denoting the fe set in adjacent cells as
-       * {1,3} and {2,3}, this implies that an fe set {3} needs to be added!
+       * hp::FECollection functions. Denoting the FE set in adjacent cells as
+       * {1,3} and {2,3}, this implies that an FE set {3} needs to be added!
        * Based on the predicate configuration, this may not be automatically
        * done without the following special treatment.
        */
@@ -1319,10 +1319,10 @@ namespace ColorEnriched
                   const auto nbr_fe_index =
                     cell->neighbor(face)->active_fe_index();
 
-                  // find corresponding fe set
+                  // find corresponding FE set
                   const auto nbr_fe_set = fe_sets.at(nbr_fe_index);
 
-                  // find intersection of the fe sets: fe_set and nbr_fe_set
+                  // find intersection of the FE sets: fe_set and nbr_fe_set
                   std::set<unsigned int> intersection_set;
                   std::set_intersection(
                     fe_set.begin(),

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -181,7 +181,7 @@ FE_FaceQ<dim, spacedim>::get_subface_interpolation_matrix(
       // Make sure that the element for which the DoFs should be constrained
       // is the one with the higher polynomial degree.  Actually the procedure
       // will work also if this assertion is not satisfied. But the matrices
-      // produced in that case might lead to problems in the hp procedures,
+      // produced in that case might lead to problems in the hp-procedures,
       // which use this method.
       Assert(
         this->n_dofs_per_face(face_no) <= source_fe->n_dofs_per_face(face_no),
@@ -910,7 +910,7 @@ FE_FaceP<dim, spacedim>::get_subface_interpolation_matrix(
       // Make sure that the element for which the DoFs should be constrained
       // is the one with the higher polynomial degree.  Actually the procedure
       // will work also if this assertion is not satisfied. But the matrices
-      // produced in that case might lead to problems in the hp procedures,
+      // produced in that case might lead to problems in the hp-procedures,
       // which use this method.
       Assert(
         this->n_dofs_per_face(face_no) <= source_fe->n_dofs_per_face(face_no),

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -2500,7 +2500,7 @@ FE_Nedelec<dim>::get_face_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));
@@ -2607,7 +2607,7 @@ FE_Nedelec<dim>::get_subface_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -220,7 +220,7 @@ FE_Nothing<dim, spacedim>::compare_for_domination(
     // if it does and the other is FE_Nothing, either can dominate
     return FiniteElementDomination::either_element_can_dominate;
   else
-    // otherwise we dominate whatever fe is provided
+    // otherwise we dominate whatever FE is provided
     return FiniteElementDomination::this_element_dominates;
 }
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -644,7 +644,7 @@ FE_Q_Base<PolynomialType, dim, spacedim>::get_subface_interpolation_matrix(
       // Make sure that the element for which the DoFs should be constrained
       // is the one with the higher polynomial degree.  Actually the procedure
       // will work also if this assertion is not satisfied. But the matrices
-      // produced in that case might lead to problems in the hp procedures,
+      // produced in that case might lead to problems in the hp-procedures,
       // which use this method.
       Assert(
         this->n_dofs_per_face(face_no) <= source_fe->n_dofs_per_face(face_no),

--- a/source/fe/fe_q_hierarchical.cc
+++ b/source/fe/fe_q_hierarchical.cc
@@ -965,7 +965,7 @@ FE_Q_Hierarchical<dim>::get_face_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));
@@ -1053,7 +1053,7 @@ FE_Q_Hierarchical<dim>::get_subface_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          (typename FiniteElement<dim>::ExcInterpolationNotImplemented()));

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -378,7 +378,7 @@ FE_RaviartThomasNodal<dim>::
 // TODO: There are tests that check that the following few functions don't
 // produce assertion failures, but none that actually check whether they do the
 // right thing. one example for such a test would be to project a function onto
-// an hp space and make sure that the convergence order is correct with regard
+// an hp-space and make sure that the convergence order is correct with regard
 // to the lowest used polynomial degree
 
 template <int dim>
@@ -625,7 +625,7 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          typename FiniteElement<dim>::ExcInterpolationNotImplemented());
@@ -733,7 +733,7 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
   // satisfied. But the matrices
   // produced in that case might
   // lead to problems in the
-  // hp procedures, which use this
+  // hp-procedures, which use this
   // method.
   Assert(this->n_dofs_per_face(face_no) <= source_fe.n_dofs_per_face(face_no),
          typename FiniteElement<dim>::ExcInterpolationNotImplemented());

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1625,7 +1625,7 @@ FESystem<dim, spacedim>::initialize(
   Assert(count_nonzeros(multiplicities) > 0,
          ExcMessage("You only passed FiniteElements with multiplicity 0."));
 
-  // Note that we need to skip every fe with multiplicity 0 in the following
+  // Note that we need to skip every FE with multiplicity 0 in the following
   // block of code
 
   this->base_to_block_indices.reinit(0, 0);

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -37,7 +37,7 @@ namespace hp
   namespace Refinement
   {
     /**
-     * Setting p adaptivity flags
+     * Setting p-adaptivity flags
      */
     template <int dim, int spacedim>
     void
@@ -631,7 +631,7 @@ namespace hp
 
 
     /**
-     * Decide between h and p adaptivity
+     * Decide between h- and p-adaptivity
      */
     template <int dim, int spacedim>
     void
@@ -695,9 +695,9 @@ namespace hp
             cell->clear_refine_flag();
 
             // A cell will only be coarsened into its parent if all of its
-            // siblings are flagged for h coarsening as well. We must take this
-            // into account for our decision whether we would like to impose h
-            // or p adaptivity.
+            // siblings are flagged for h-coarsening as well. We must take this
+            // into account for our decision whether we would like to impose h-
+            // or p-adaptivity.
             if (cell->coarsen_flag_set())
               {
                 const auto &       parent     = cell->parent();
@@ -737,8 +737,8 @@ namespace hp
                 if (h_flagged_children == n_children &&
                     p_flagged_children != n_children)
                   {
-                    // Perform pure h coarsening and
-                    // drop all p adaptation flags.
+                    // Perform pure h-coarsening and
+                    // drop all p-adaptation flags.
                     for (const auto &child : parent->child_iterators())
                       {
                         // h_flagged_children == n_children implies
@@ -750,8 +750,8 @@ namespace hp
                   }
                 else
                   {
-                    // Perform p adaptation on all children and
-                    // drop all h coarsening flags.
+                    // Perform p-adaptation on all children and
+                    // drop all h-coarsening flags.
                     for (const auto &child : parent->child_iterators())
                       {
                         if (child->is_active() && child->is_locally_owned())

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -798,7 +798,7 @@ namespace internal
       // a. Only cells belonging to the same category (or next higher if the
       // cell_vectorization_categories_strict is false) can be grouped into
       // the same SIMD batch
-      // b. hp adaptive computations must form contiguous ranges for the same
+      // b. hp-adaptive computations must form contiguous ranges for the same
       // degree (category) in cell_partition_data
       // c. We want to group the cells with the same parent in the same SIMD
       // lane if possible
@@ -954,7 +954,7 @@ namespace internal
 
       // Step 5: Sort the batches of cells by their last cell index to get
       // good locality, assuming that the initial cell order is of good
-      // locality. In case we have hp calculations with categories, we need to
+      // locality. In case we have hp-calculations with categories, we need to
       // sort also by the category.
       std::vector<std::array<unsigned int, 3>> batch_order;
       std::vector<std::array<unsigned int, 3>> batch_order_comm;

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -287,7 +287,7 @@ DataOutStack<dim, spacedim, void>::build_patches(
   // create collection objects from
   // single quadratures,
   // and finite elements. if we have
-  // an hp DoFHandler,
+  // an hp-DoFHandler,
   // dof_handler.get_fe() returns a
   // collection of which we do a
   // shallow copy instead

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -787,7 +787,7 @@ namespace DerivativeApproximation
       // derivatives
       typename DerivativeDescription::Derivative projected_derivative;
 
-      // reinit fe values object...
+      // reinit FE values object...
       x_fe_midpoint_value.reinit(cell);
       const FEValues<dim> &fe_midpoint_value =
         x_fe_midpoint_value.get_present_fe_values();
@@ -825,7 +825,7 @@ namespace DerivativeApproximation
         {
           const auto neighbor = *neighbor_ptr;
 
-          // reinit fe values object...
+          // reinit FE values object...
           x_fe_midpoint_value.reinit(neighbor);
           const FEValues<dim> &neighbor_fe_midpoint_value =
             x_fe_midpoint_value.get_present_fe_values();

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -752,7 +752,7 @@ namespace DerivativeApproximation
       // create collection objects from
       // single quadratures, mappings,
       // and finite elements. if we have
-      // an hp DoFHandler,
+      // an hp-DoFHandler,
       // dof_handler.get_fe() returns a
       // collection of which we do a
       // shallow copy instead

--- a/source/numerics/matrix_creator.inst.in
+++ b/source/numerics/matrix_creator.inst.in
@@ -21,7 +21,7 @@ for (scalar : REAL_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
-    // non-hp version of create_mass_matrix
+    // non-hp-version of create_mass_matrix
     template void MatrixCreator::
       create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
@@ -38,7 +38,7 @@ for (scalar : REAL_SCALARS; deal_II_dimension : DIMENSIONS;
         const Function<deal_II_space_dimension, scalar> *const coefficient,
         const AffineConstraints<scalar> &                      constraints);
 
-    // hp versions of functions
+    // hp-versions of functions
     template void MatrixCreator::
       create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
@@ -66,7 +66,7 @@ for (scalar : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
      deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
-    // non-hp version of create_mass_matrix
+    // non-hp-version of create_mass_matrix
     template void MatrixCreator::
       create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
         const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,
@@ -87,7 +87,7 @@ for (scalar : REAL_AND_COMPLEX_SCALARS; deal_II_dimension : DIMENSIONS;
         const Function<deal_II_space_dimension, scalar> *const coefficient,
         const AffineConstraints<scalar> &                      constraints);
 
-    // hp version
+    // hp-version
     template void MatrixCreator::
       create_mass_matrix<deal_II_dimension, deal_II_space_dimension, scalar>(
         const hp::MappingCollection<deal_II_dimension, deal_II_space_dimension>
@@ -183,7 +183,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension == deal_II_space_dimension
 
-    // non-hp versions of create_laplace_matrix
+    // non-hp-versions of create_laplace_matrix
     template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &    dof,
       const Quadrature<deal_II_dimension> &    q,
@@ -215,7 +215,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
       const Function<deal_II_dimension> *const coefficient,
       const AffineConstraints<double> &        constraints);
 
-    // hp versions of create_laplace_matrix
+    // hp-versions of create_laplace_matrix
     template void MatrixCreator::create_laplace_matrix<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &     dof,
       const hp::QCollection<deal_II_dimension> &q,
@@ -253,7 +253,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension < deal_II_space_dimension
-    // non-hp version of create_laplace_matrix
+    // non-hp-version of create_laplace_matrix
     template void MatrixCreator::create_laplace_matrix<deal_II_dimension,
                                                        deal_II_space_dimension>(
       const Mapping<deal_II_dimension, deal_II_space_dimension> &   mapping,

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -278,7 +278,7 @@ PointValueHistory<dim>::add_point(const Point<dim> &location)
   // the requested point for all finite
   // element components lie in the same cell.
   // this could possibly be violated if
-  // components use different fe orders,
+  // components use different FE orders,
   // requested points are on the edge or
   // vertex of a cell and we are unlucky with
   // floating point rounding. Worst case

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -505,7 +505,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::interpolate(
                 {
                   // make sure that the size of the stored indices is the same
                   // as dofs_per_cell. this is kind of a test if we use the same
-                  // fe in the hp-case. to really do that test we would have to
+                  // FE in the hp-case. to really do that test we would have to
                   // store the fe_index of all cells
                   const Vector<typename VectorType::value_type> *data = nullptr;
                   const unsigned int active_fe_index = cell->active_fe_index();

--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -351,9 +351,9 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
       else if (cell->has_children() && cell->child(0)->coarsen_flag_set())
         {
           // we will need to interpolate from the children of this cell
-          // to the current one. in the hp context, this also means
+          // to the current one. in the hp-context, this also means
           // we need to figure out which finite element space to interpolate
-          // to since that is not implied by the global FE as in the non-hp
+          // to since that is not implied by the global FE as in the non-hp-
           // case. we choose the 'least dominant fe' on all children from
           // the associated FECollection.
           std::set<unsigned int> fe_indices_children;
@@ -505,7 +505,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::interpolate(
                 {
                   // make sure that the size of the stored indices is the same
                   // as dofs_per_cell. this is kind of a test if we use the same
-                  // fe in the hp case. to really do that test we would have to
+                  // fe in the hp-case. to really do that test we would have to
                   // store the fe_index of all cells
                   const Vector<typename VectorType::value_type> *data = nullptr;
                   const unsigned int active_fe_index = cell->active_fe_index();

--- a/tests/aniso/hp_constraints_dgp_08.cc
+++ b/tests/aniso/hp_constraints_dgp_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGP elements correctly
+// check that computation of hp-constraints works for DGP elements correctly
 
 char logname[] = "output";
 

--- a/tests/aniso/hp_constraints_dgp_monomial_08.cc
+++ b/tests/aniso/hp_constraints_dgp_monomial_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGP_Monomial elements
+// check that computation of hp-constraints works for DGP_Monomial elements
 // correctly
 
 char logname[] = "output";

--- a/tests/aniso/hp_constraints_dgp_nonparametric_08.cc
+++ b/tests/aniso/hp_constraints_dgp_nonparametric_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGPNonparametric elements
+// check that computation of hp-constraints works for DGPNonparametric elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 char logname[] = "output";

--- a/tests/aniso/hp_constraints_dgq_08.cc
+++ b/tests/aniso/hp_constraints_dgq_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGQ elements correctly
+// check that computation of hp-constraints works for DGQ elements correctly
 
 char logname[] = "output";
 

--- a/tests/bits/count_dofs_per_component_hp_01.cc
+++ b/tests/bits/count_dofs_per_component_hp_01.cc
@@ -28,7 +28,7 @@
 // check
 //   DoFTools::
 //   count_dofs_per_component (...);
-// for the hp case
+// for the hp-case
 
 
 using namespace std;

--- a/tests/bits/count_dofs_per_component_hp_02.cc
+++ b/tests/bits/count_dofs_per_component_hp_02.cc
@@ -32,7 +32,7 @@
 // check
 //   DoFTools::
 //   count_dofs_per_component (...);
-// for the hp case
+// for the hp-case
 //
 // in contrast to the _01 test also check that this works if the element
 // collection has more than one element

--- a/tests/bits/face_orientation_crash.cc
+++ b/tests/bits/face_orientation_crash.cc
@@ -73,7 +73,7 @@ check()
 
       // then build hanging node
       // constraints. this should trip the
-      // new code using the hp constraints,
+      // new code using the hp-constraints,
       // added in late July 2006
       AffineConstraints<double> constraints;
       DoFTools::make_hanging_node_constraints(dof, constraints);

--- a/tests/bits/fe_tools_09.cc
+++ b/tests/bits/fe_tools_09.cc
@@ -29,8 +29,8 @@ template <int dim>
 void
 check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
 {
-  // check that the name of the fe
-  // and the name of the fe that we
+  // check that the name of the FE
+  // and the name of the FE that we
   // re-create from this name are
   // identitical. this is also a
   // pretty good indication that the

--- a/tests/bits/fe_tools_10.cc
+++ b/tests/bits/fe_tools_10.cc
@@ -51,8 +51,8 @@ template <int dim>
 void
 check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
 {
-  // check that the name of the fe
-  // and the name of the fe that we
+  // check that the name of the FE
+  // and the name of the FE that we
   // re-create from this name are
   // identitical. this is also a
   // pretty good indication that the

--- a/tests/bits/fe_tools_11.cc
+++ b/tests/bits/fe_tools_11.cc
@@ -50,8 +50,8 @@ template <int dim>
 void
 check_this(const FiniteElement<dim> &fe1, const FiniteElement<dim> &fe2)
 {
-  // check that the name of the fe
-  // and the name of the fe that we
+  // check that the name of the FE
+  // and the name of the FE that we
   // re-create from this name are
   // identitical. this is also a
   // pretty good indication that the

--- a/tests/bits/fe_tools_cpfqpm_01.cc
+++ b/tests/bits/fe_tools_cpfqpm_01.cc
@@ -45,7 +45,7 @@ check_this(const FiniteElement<dim> &fe, const FiniteElement<dim> & /*fe2*/)
   if (fe.n_components() != 1)
     return;
 
-  // ignore this check if this fe has already
+  // ignore this check if this FE has already
   // been treated
   static std::set<std::string> already_checked;
   if (already_checked.find(fe.get_name()) != already_checked.end())

--- a/tests/bits/fe_tools_cpfqpm_02.cc
+++ b/tests/bits/fe_tools_cpfqpm_02.cc
@@ -44,7 +44,7 @@ check_this(const FiniteElement<dim> &fe, const FiniteElement<dim> & /*fe2*/)
   if (fe.n_components() != 1)
     return;
 
-  // ignore this check if this fe has already
+  // ignore this check if this FE has already
   // been treated
   static std::set<std::string> already_checked;
   if (already_checked.find(fe.get_name()) != already_checked.end())

--- a/tests/bits/fe_tools_cpfqpm_03.cc
+++ b/tests/bits/fe_tools_cpfqpm_03.cc
@@ -45,7 +45,7 @@ check_this(const FiniteElement<dim> &fe, const FiniteElement<dim> & /*fe2*/)
   if (fe.n_components() != 1)
     return;
 
-  // ignore this check if this fe has already
+  // ignore this check if this FE has already
   // been treated
   static std::set<std::string> already_checked;
   if (already_checked.find(fe.get_name()) != already_checked.end())

--- a/tests/bits/fe_tools_cpfqpm_04.cc
+++ b/tests/bits/fe_tools_cpfqpm_04.cc
@@ -44,7 +44,7 @@ check_this(const FiniteElement<dim> &fe, const FiniteElement<dim> & /*fe2*/)
   if (fe.n_components() != 1)
     return;
 
-  // ignore this check if this fe has already
+  // ignore this check if this FE has already
   // been treated
   static std::set<std::string> already_checked;
   if (already_checked.find(fe.get_name()) != already_checked.end())

--- a/tests/bits/fe_tools_cpfqpm_05.cc
+++ b/tests/bits/fe_tools_cpfqpm_05.cc
@@ -90,7 +90,7 @@ check_this(const FiniteElement<dim, spacedim> &fe,
   if (fe.n_components() != 1)
     return;
 
-  // ignore this check if this fe has already
+  // ignore this check if this FE has already
   // been treated
   static std::set<std::string> already_checked;
   if (already_checked.find(fe.get_name()) != already_checked.end())

--- a/tests/bits/map_dofs_to_support_points_hp_01.cc
+++ b/tests/bits/map_dofs_to_support_points_hp_01.cc
@@ -31,7 +31,7 @@
 // check
 //   DoFTools::
 //   map_dofs_to_support_points(...);
-// for the hp case
+// for the hp-case
 
 
 using namespace std;

--- a/tests/bits/map_dofs_to_support_points_hp_02.cc
+++ b/tests/bits/map_dofs_to_support_points_hp_02.cc
@@ -32,7 +32,7 @@
 // check
 //   DoFTools::
 //   map_dofs_to_support_points(...);
-// for the hp case with different finite elements
+// for the hp-case with different finite elements
 // on different cells.
 
 

--- a/tests/bits/point_gradient_hp_01.cc
+++ b/tests/bits/point_gradient_hp_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// check VectorTools::point_gradient for a hp dofhandler.
+// check VectorTools::point_gradient for a hp-dofhandler.
 
 
 

--- a/tests/bits/point_value_hp_01.cc
+++ b/tests/bits/point_value_hp_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// check VectorTools::point_value for a hp dofhandler.
+// check VectorTools::point_value for a hp-dofhandler.
 
 
 

--- a/tests/dofs/dof_tools_10.cc
+++ b/tests/dofs/dof_tools_10.cc
@@ -31,7 +31,7 @@ template <int dim>
 void
 check_this(const DoFHandler<dim> &dof_handler)
 {
-  // don't check if fe has no support
+  // don't check if FE has no support
   // points
   if (dof_handler.get_fe().get_unit_support_points().size() == 0)
     return;

--- a/tests/fail/hp_constraints_q_08.cc
+++ b/tests/fail/hp_constraints_q_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for Q elements correctly
+// check that computation of hp-constraints works for Q elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_q_system_08.cc
+++ b/tests/fail/hp_constraints_q_system_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for FESystem(FE_Q) elements
+// check that computation of hp-constraints works for FESystem(FE_Q) elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 char logname[] = "output";

--- a/tests/fail/hp_constraints_q_system_x_08.cc
+++ b/tests/fail/hp_constraints_q_system_x_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for FESystem(FE_Q) elements
+// check that computation of hp-constraints works for FESystem(FE_Q) elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 // these tests check that we can deal with FESystem(FE_Q(p),FE_DGQ(q)) for

--- a/tests/fail/hp_constraints_rt_01.cc
+++ b/tests/fail/hp_constraints_rt_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_rt_02.cc
+++ b/tests/fail/hp_constraints_rt_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_rt_03.cc
+++ b/tests/fail/hp_constraints_rt_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_rt_04.cc
+++ b/tests/fail/hp_constraints_rt_04.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_rt_05.cc
+++ b/tests/fail/hp_constraints_rt_05.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/hp_constraints_rt_06.cc
+++ b/tests/fail/hp_constraints_rt_06.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/fail/vectors_boundary_rhs_hp_02.cc
+++ b/tests/fail/vectors_boundary_rhs_hp_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs_02, but for hp objects. here, each hp
+// like deal.II/vectors_boundary_rhs_02, but for hp-objects. here, each hp-
 // object has only a single component, so we expect exactly the same output as
 // for the old test. vectors_boundary_rhs_hp_02_hp tests for different finite
 // elements

--- a/tests/fail/vectors_rhs_hp_02.cc
+++ b/tests/fail/vectors_rhs_hp_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs_hp_02, but for hp objects. here, each hp object has
+// like deal.II/vectors_rhs_hp_02, but for hp-objects. here, each hp-object has
 // only a single component, so we expect exactly the same output as for the old
 // test. vectors_rhs_hp_02_hp tests for different finite elements
 

--- a/tests/fe/fe_enriched_07.cc
+++ b/tests/fe/fe_enriched_07.cc
@@ -96,7 +96,7 @@ test6(const bool         do_href,
   fe_collection.push_back(FE_Enriched<dim>(FE_Q<dim>(p_feq)));
   fe_collection.push_back(
     FE_Enriched<dim>(FE_Q<dim>(p_feen), FE_Q<dim>(1), &function));
-  // push back to be able to resolve hp constrains:
+  // push back to be able to resolve hp-constrains:
   fe_collection.push_back(FE_Enriched<dim>(FE_Q<dim>(p_feen)));
 
   GridGenerator::hyper_cube(triangulation);

--- a/tests/fe/fe_enriched_08.cc
+++ b/tests/fe/fe_enriched_08.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// check constraints on hp dofhandler with 2 neighboring cells where one
+// check constraints on hp-dofhandler with 2 neighboring cells where one
 // cell is enriched and nother is not.
 
 #include <deal.II/base/function.h>
@@ -110,7 +110,7 @@ test2cells(const unsigned int p_feq = 2, const unsigned int p_feen = 1)
   fe_collection.push_back(FE_Enriched<dim>(FE_Q<dim>(p_feq)));
   fe_collection.push_back(
     FE_Enriched<dim>(FE_Q<dim>(p_feen), FE_Q<dim>(1), &function));
-  // push back to be able to resolve hp constrains:
+  // push back to be able to resolve hp-constrains:
   fe_collection.push_back(FE_Enriched<dim>(FE_Q<dim>(p_feen)));
 
   dof_handler.begin_active()->set_active_fe_index(1); // POU

--- a/tests/fe/fe_enriched_08a.cc
+++ b/tests/fe/fe_enriched_08a.cc
@@ -77,7 +77,7 @@ test2cellsFESystem(const unsigned int p_feq = 2, const unsigned int p_feen = 1)
     FESystem<dim>(FE_Q<dim>(p_feq), 1, FE_Nothing<dim>(), 1));
   fe_collection.push_back(FESystem<dim>(FE_Q<dim>(p_feen), 1, FE_Q<dim>(1), 1));
 
-  // push back to be able to resolve hp constrains:
+  // push back to be able to resolve hp-constrains:
   fe_collection.push_back(
     FESystem<dim>(FE_Q<dim>(p_feen), 1, FE_Nothing<dim>(), 1));
 

--- a/tests/fe/fe_enriched_color_03.cc
+++ b/tests/fe/fe_enriched_color_03.cc
@@ -16,7 +16,7 @@
 /*
  * Test function - ColorEnriched::internal::set_cellwise_color_set_and_fe_index
  * for a set of predicates.
- * Check for each cell, if appropriate fe index and color-index map is set.
+ * Check for each cell, if appropriate FE index and color-index map is set.
  * Color-index map associates different colors of different enrichment
  * functions with corresponding enrichment function index.
  */
@@ -123,13 +123,13 @@ main(int argc, char **argv)
     fe_sets);
 
   /*
-   * Run through active cells to check fe index, colors of
+   * Run through active cells to check FE index, colors of
    * enrichment functions associated with it.
    *
-   * A unique color set corresponds to an fe index.
+   * A unique color set corresponds to an FE index.
    *
-   * Eg: If an fe index 1 corresponds to color set {2,3},
-   * means that a cell with fe index 1 has enrichment functions
+   * Eg: If an FE index 1 corresponds to color set {2,3},
+   * means that a cell with FE index 1 has enrichment functions
    * which are colored 2 and 3. Here different enrichment function
    * have same color 2 but for a given cell only one of them would
    * be relevant. So all additional information we need is which
@@ -162,7 +162,7 @@ main(int argc, char **argv)
                   << color_predicate_pair.second << "):";
         }
 
-      // For a cell, print fe active index and corresponding fe set.
+      // For a cell, print FE active index and corresponding FE set.
       //{1,2} indicates 2 enrichment functions of color 1 and 2 are relevant.
       deallog << ":fe_active_index:" << cell->active_fe_index() << ":fe_set:";
       for (auto fe_set_element : fe_sets[cell->active_fe_index()])

--- a/tests/fe/fe_enriched_color_05.cc
+++ b/tests/fe/fe_enriched_color_05.cc
@@ -233,7 +233,7 @@ main(int argc, char **argv)
     fe_nothing,
     fe_collection);
 
-  // print all the different fe sets needed by different cells
+  // print all the different FE sets needed by different cells
   deallog << "fe sets:" << std::endl;
   for (auto fe_set : fe_sets)
     {

--- a/tests/fe/fe_enriched_color_06.cc
+++ b/tests/fe/fe_enriched_color_06.cc
@@ -118,7 +118,7 @@ main(int argc, char **argv)
       vec_enrichments.push_back(std::make_shared<ConstantFunction<dim>>(func));
     }
 
-  // Construct helper class to construct fe collection
+  // Construct helper class to construct FE collection
   FE_Q<dim>                         fe_base(2);
   FE_Q<dim>                         fe_enriched(1);
   static ColorEnriched::Helper<dim> fe_space(fe_base,

--- a/tests/fe/fe_enriched_color_07.cc
+++ b/tests/fe/fe_enriched_color_07.cc
@@ -1350,7 +1350,7 @@ LaplaceProblem<dim>::build_fe_space()
         {
           pcout << "...start print fe indices" << std::endl;
 
-          // print fe index
+          // print FE index
           const std::string base_filename =
             "fe_indices" + dealii::Utilities::int_to_string(dim) + "_p" +
             dealii::Utilities::int_to_string(0);
@@ -1739,7 +1739,7 @@ LaplaceProblem<dim>::run()
   pcout << "...run problem" << std::endl;
   double norm_soln_old(0), norm_rel_change_old(1);
 
-  // Run making grids and building fe space only once.
+  // Run making grids and building FE space only once.
   initialize();
   build_fe_space();
 

--- a/tests/fe/fe_enriched_color_08.cc
+++ b/tests/fe/fe_enriched_color_08.cc
@@ -247,7 +247,7 @@ main(int argc, char **argv)
         std::make_shared<Functions::ConstantFunction<dim>>(func));
     }
 
-  // Construct helper class to construct fe collection
+  // Construct helper class to construct FE collection
   FE_Q<dim> fe_base(2);
   FE_Q<dim> fe_enriched(1);
 

--- a/tests/fe/fe_enriched_step-36.cc
+++ b/tests/fe/fe_enriched_step-36.cc
@@ -246,7 +246,7 @@ namespace Step36
     fe_collection.push_back(
       FE_Enriched<dim>(FE_Q<dim>(2), FE_Q<dim>(1), &enrichment));
 
-    // assign fe index in the constructor so that FE/FE+POU is determined
+    // assign FE index in the constructor so that FE/FE+POU is determined
     // on the coarsest mesh to avoid issues like
     // +---------+----+----+
     // |         | fe |    |

--- a/tests/fe/fe_enriched_step-36b.cc
+++ b/tests/fe/fe_enriched_step-36b.cc
@@ -256,7 +256,7 @@ namespace Step36
     // enriched elements (active_fe_index==1):
     fe_collection.push_back(FESystem<dim>(FE_Q<dim>(2), 1, FE_Q<dim>(1), 1));
 
-    // assign fe index in the constructor so that FE/FE+POU is determined
+    // assign FE index in the constructor so that FE/FE+POU is determined
     // on the coarsest mesh to avoid issues like
     // +---------+----+----+
     // |         | fe |    |

--- a/tests/fe/fe_nedelec_sz_non_rect_face.cc
+++ b/tests/fe/fe_nedelec_sz_non_rect_face.cc
@@ -251,7 +251,7 @@ namespace Maxwell
         // Store computed values at quad points:
         fe_values[E_re].get_function_values(solution, sol);
 
-        // Calc values of curlE from fe solution:
+        // Calc values of curlE from FE solution:
         cell->get_dof_indices(local_dof_indices);
         // Loop over quad points to calculate solution:
         for (const auto q_point : fe_values.quadrature_point_indices())

--- a/tests/fe/injection_common.h
+++ b/tests/fe/injection_common.h
@@ -80,7 +80,7 @@ do_check(const FiniteElement<dim> &coarse_fe, const FiniteElement<dim> &fine_fe)
         }
 
         // check 2: first to finer cells,
-        // then to finer fe
+        // then to finer FE
         {
           FullMatrix<double> tmp1(coarse_fe.dofs_per_cell,
                                   coarse_fe.dofs_per_cell);

--- a/tests/fe/multiple_redistribute_dofs_01.cc
+++ b/tests/fe/multiple_redistribute_dofs_01.cc
@@ -50,7 +50,7 @@ test()
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);
 
-  // This stores a pointer to the fe in dh.
+  // This stores a pointer to the FE in dh.
   FEValues<dim, spacedim> fe_v(dh.get_fe(), QGauss<dim>(1), update_values);
 
   tria.refine_global(1);

--- a/tests/fe/multiple_redistribute_dofs_02.cc
+++ b/tests/fe/multiple_redistribute_dofs_02.cc
@@ -51,7 +51,7 @@ test()
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe_collection);
 
-  // This stores a pointer to the fe in dh.
+  // This stores a pointer to the FE in dh.
   hp::FEValues<dim, spacedim> fe_v(dh.get_fe_collection(),
                                    hp::QCollection<dim>(QGauss<dim>(1)),
                                    update_values);

--- a/tests/fe/nedelec_crash_hp.cc
+++ b/tests/fe/nedelec_crash_hp.cc
@@ -83,7 +83,7 @@ test()
         deallog << "Testing " << fe[i].get_name() << " vs. " << fe[j].get_name()
                 << std::endl;
 
-        // set fe on coarse cell to 'i', on
+        // set FE on coarse cell to 'i', on
         // all fine cells to 'j'
         typename DoFHandler<dim>::active_cell_iterator cell =
           dof_handler.begin_active();

--- a/tests/fe/nedelec_non_rect_face.cc
+++ b/tests/fe/nedelec_non_rect_face.cc
@@ -252,7 +252,7 @@ namespace Maxwell
         // Store computed values at quad points:
         fe_values[E_re].get_function_values(solution, sol);
 
-        // Calc values of curlE from fe solution:
+        // Calc values of curlE from FE solution:
         cell->get_dof_indices(local_dof_indices);
         // Loop over quad points to calculate solution:
         for (const auto q_point : fe_values.quadrature_point_indices())

--- a/tests/grid/grid_tools_extract_used_vertices_03.cc
+++ b/tests/grid/grid_tools_extract_used_vertices_03.cc
@@ -40,7 +40,7 @@ test(const Point<spacedim> &p)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(1);
 
-  // Vector fe
+  // Vector FE
   FESystem<dim, spacedim>   fe{FE_Q<dim, spacedim>(1), spacedim};
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);

--- a/tests/grid/grid_tools_find_closest_vertex_01.cc
+++ b/tests/grid/grid_tools_find_closest_vertex_01.cc
@@ -40,7 +40,7 @@ test(const Point<spacedim> &p)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(1);
 
-  // Vector fe
+  // Vector FE
   FESystem<dim, spacedim>   fe{FE_Q<dim, spacedim>(1), spacedim};
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);

--- a/tests/grid/grid_tools_find_closest_vertex_02.cc
+++ b/tests/grid/grid_tools_find_closest_vertex_02.cc
@@ -40,7 +40,7 @@ test(const Point<spacedim> &p, double displacement)
   GridGenerator::hyper_cube(tria);
   tria.refine_global();
 
-  // Vector fe
+  // Vector FE
   FESystem<dim, spacedim>   fe{FE_Q<dim, spacedim>(1), spacedim};
   DoFHandler<dim, spacedim> dh(tria);
   dh.distribute_dofs(fe);

--- a/tests/grid/grid_tools_halo_layer_04.cc
+++ b/tests/grid/grid_tools_halo_layer_04.cc
@@ -114,7 +114,7 @@ test()
     write_vtk(dof_handler, filename.c_str());
   }
 
-  // Compute a halo layer around active fe index 2 and set it to active fe index
+  // Compute a halo layer around active FE index 2 and set it to active FE index
   // 3
   std::function<bool(const cell_iterator &)> predicate =
     IteratorFilters::ActiveFEIndexEqualTo(2, true);

--- a/tests/grid/grid_tools_halo_layer_05.cc
+++ b/tests/grid/grid_tools_halo_layer_05.cc
@@ -119,7 +119,7 @@ test()
     write_vtk(dof_handler, filename.c_str());
   }
 
-  // Compute a halo layer around active fe indices 2,3 and set it to active fe
+  // Compute a halo layer around active FE indices 2,3 and set it to active FE
   // index 4
   std::set<unsigned int> index_set;
   index_set.insert(2);

--- a/tests/grid/mesh_3d_18.cc
+++ b/tests/grid/mesh_3d_18.cc
@@ -16,7 +16,7 @@
 
 
 // adapted from hp/crash_06, which itself is from
-// make_hanging_node_constraints for hp elements. used to crash. triggers the
+// make_hanging_node_constraints for hp-elements. used to crash. triggers the
 // crash that at the time of writing the test afflicts all
 // hp/hp_constraints_*_03 tests
 

--- a/tests/grid/vertex_as_face_07.cc
+++ b/tests/grid/vertex_as_face_07.cc
@@ -16,7 +16,7 @@
 
 // verify that we can do things like cell->face() in 1d as well. here:
 // test cell->face(0)->get_dof_indices()
-// compared to _06, we now test for an hp DoFHandler
+// compared to _06, we now test for an hp-DoFHandler
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/boundary_matrices.cc
+++ b/tests/hp/boundary_matrices.cc
@@ -16,7 +16,7 @@
 
 
 // Like hp/matrices, but only the boundary mass matrices for vector-valued
-// (non-primitive) hp objects are being tested.
+// (non-primitive) hp-objects are being tested.
 
 
 #include <deal.II/base/function_lib.h>

--- a/tests/hp/boundary_matrices_hp.cc
+++ b/tests/hp/boundary_matrices_hp.cc
@@ -16,7 +16,7 @@
 
 
 // Same as hp/boundary_matrices, but with different FE objects. Tests
-// the boundary mass matrces for vector-valued (non-primiteve) hp
+// the boundary mass matrces for vector-valued (non-primiteve) hp-
 // FE objects.
 
 

--- a/tests/hp/compare_hp_vs_nonhp_01.cc
+++ b/tests/hp/compare_hp_vs_nonhp_01.cc
@@ -16,7 +16,7 @@
 
 
 // a test adapted from little programs by Markus Buerg that makes sure
-// we compute the same solution for hp and non-hp cases
+// we compute the same solution for hp- and non-hp-cases
 
 
 #include <deal.II/base/function.h>

--- a/tests/hp/crash_08.cc
+++ b/tests/hp/crash_08.cc
@@ -15,7 +15,7 @@
 
 
 
-// the crash_08 testcase discussed in the hp paper. this produces a cyclic
+// the crash_08 testcase discussed in the hp-paper. this produces a cyclic
 // constraint between degrees of freedom 3->14->17->6->3 with the algorithm
 // that is presently in make_hanging_node_constraints
 

--- a/tests/hp/crash_09.cc
+++ b/tests/hp/crash_09.cc
@@ -116,7 +116,7 @@ main()
   // out the numbers of the dofs that
   // belong to the shared edge
   // (that's the one that has three
-  // different fe indices associated
+  // different FE indices associated
   // with it). note that there is
   // only one such line so we can
   // quit the loop once we find it

--- a/tests/hp/crash_09.cc
+++ b/tests/hp/crash_09.cc
@@ -16,7 +16,7 @@
 
 
 // a test where a degree of freedom was constrained multiple times,
-// but with different weights. see the hp paper for more on this
+// but with different weights. see the hp-paper for more on this
 
 char logname[] = "output";
 

--- a/tests/hp/crash_11.cc
+++ b/tests/hp/crash_11.cc
@@ -16,7 +16,7 @@
 
 
 // a test where a degree of freedom was constrained multiple times,
-// but with different weights. see the hp paper for more on this
+// but with different weights. see the hp-paper for more on this
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/quadrature_lib.h>

--- a/tests/hp/crash_11.cc
+++ b/tests/hp/crash_11.cc
@@ -98,7 +98,7 @@ main()
   // out the numbers of the dofs that
   // belong to the shared edge
   // (that's the one that has four
-  // different fe indices associated
+  // different FE indices associated
   // with it). note that there is
   // only one such line so we can
   // quit the loop once we find it

--- a/tests/hp/crash_12.cc
+++ b/tests/hp/crash_12.cc
@@ -20,7 +20,7 @@
 //
 // this code in particular tests some compensating code in
 // dof_tools.cc, where we have to make sure that we select a suitable
-// set of primary dofs. this is mostly trivial in 2d and for most fe
+// set of primary dofs. this is mostly trivial in 2d and for most FE
 // combinations in 3d as well. the exceptions are that it doesn't work
 // as easily in 3d for the combinations Q4/Q3, Q5/Q3, and
 // Q5/Q4. Higher order finite elements in 3d will probably only
@@ -91,7 +91,7 @@ test()
         deallog << "Testing " << fe[i].get_name() << " vs. " << fe[j].get_name()
                 << std::endl;
 
-        // set fe on coarse cell to 'i', on
+        // set FE on coarse cell to 'i', on
         // all fine cells to 'j'
         typename DoFHandler<dim>::active_cell_iterator cell =
           dof_handler.begin_active();

--- a/tests/hp/crash_12.cc
+++ b/tests/hp/crash_12.cc
@@ -15,7 +15,7 @@
 
 
 
-// check the complex case described in the hp paper by playing through all
+// check the complex case described in the hp-paper by playing through all
 // sorts of arrangements of finite elements on one coarse and one refined cell
 //
 // this code in particular tests some compensating code in

--- a/tests/hp/crash_15.cc
+++ b/tests/hp/crash_15.cc
@@ -102,9 +102,9 @@ test()
             }
 
 
-          // if there are multiple active fe
+          // if there are multiple active FE
           // indices, make sure that all their
-          // fe indices were unified
+          // FE indices were unified
           for (unsigned int i = 0; i < cell->line(line)->n_active_fe_indices();
                ++i)
             for (unsigned int j = i + 1;

--- a/tests/hp/crash_15.cc
+++ b/tests/hp/crash_15.cc
@@ -22,7 +22,7 @@
 // apparently, what is happening is that we don't unify more than 2 finite
 // elements on an edge in 3d, according to a comment at the top of
 // hp::DoFHandler::compute_line_dof_identities at the time of this writing
-// (and referring to a comment in the hp paper). there is now code that deals
+// (and referring to a comment in the hp-paper). there is now code that deals
 // with the more narrow special case we have here
 
 #include <deal.II/dofs/dof_accessor.h>

--- a/tests/hp/crash_20.cc
+++ b/tests/hp/crash_20.cc
@@ -16,8 +16,8 @@
 
 
 // if the mesh is generated after the hp::DoFHandler is attached to the
-// triangulation object, then we can't set active fe indices -- which is
-// somewhat tragic since we have to assign active fe indices before we can
+// triangulation object, then we can't set active FE indices -- which is
+// somewhat tragic since we have to assign active FE indices before we can
 // call distribute_dofs
 //
 // originally, this problem was avoided because the hp::DoFHandler listens to

--- a/tests/hp/crash_21.cc
+++ b/tests/hp/crash_21.cc
@@ -17,7 +17,7 @@
 
 // a problem uncovered by Baerbel Janssen in that
 // DoFTools::make_flux_sparsity_pattern aborted in 1d with adaptively refined
-// meshes and hp DoFHandlers. this actually uncovered all sorts of other
+// meshes and hp-DoFHandlers. this actually uncovered all sorts of other
 // problems that led to a long sequence of assertions triggered every time one
 // of them was fixed. this test cumulatively makes sure everything is ok
 

--- a/tests/hp/create_rhs_01.cc
+++ b/tests/hp/create_rhs_01.cc
@@ -63,7 +63,7 @@ test()
   DoFHandler<2> hp_dof_handler(triangulation);
   DoFHandler<2> hp_dof_handler2(triangulation);
 
-  // set different fe for testing
+  // set different FE for testing
   DoFHandler<2>::active_cell_iterator cell = hp_dof_handler.begin_active(),
                                       endc = hp_dof_handler.end();
 

--- a/tests/hp/dof_handler_number_cache.cc
+++ b/tests/hp/dof_handler_number_cache.cc
@@ -16,7 +16,7 @@
 
 
 // Check the consistency of the number cache of DoFHandler for a sequential
-// object. Like deal.II/dof_handler_number_cache but for an hp object
+// object. Like deal.II/dof_handler_number_cache but for an hp-object
 
 
 #include <deal.II/base/tensor.h>

--- a/tests/hp/error_prediction_01.cc
+++ b/tests/hp/error_prediction_01.cc
@@ -16,7 +16,7 @@
 
 
 // validate combination of error prediction and cell data transfer algorithms
-// for hp adaptive methods
+// for hp-adaptive methods
 
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/fe_collection_05.cc
+++ b/tests/hp/fe_collection_05.cc
@@ -15,7 +15,7 @@
 
 
 /* clang-format off */
-// find the least dominating fe from a set of fes on faces (codim=1).
+// find the least dominating FE from a set of FEs on faces (codim=1).
 // for this task we concatenate the two functions
 // FECollection::find_common_subspace() and FECollection::find_dominated_fe().
 // we test the results for the following collections:

--- a/tests/hp/fe_collection_06.cc
+++ b/tests/hp/fe_collection_06.cc
@@ -15,7 +15,7 @@
 
 
 /* clang-format off */
-// find the most dominating fe from a set of fes on faces (codim=1).
+// find the most dominating FE from a set of FEs on faces (codim=1).
 // for this task we concatenate the two functions
 // FECollection::find_encapsulating_space() and FECollection::find_dominating_fe().
 // we test the results for the following collections:

--- a/tests/hp/fe_hierarchy.cc
+++ b/tests/hp/fe_hierarchy.cc
@@ -35,7 +35,7 @@ test()
 
   while (fe_collection.size() < 3)
     {
-      // add dummy fe to collection
+      // add dummy FE to collection
       fe_collection.push_back(FE_Q<dim>(1));
       deallog << "size:" << fe_collection.size() << std::endl;
 

--- a/tests/hp/fe_nothing_11.cc
+++ b/tests/hp/fe_nothing_11.cc
@@ -16,7 +16,7 @@
 
 
 // test that FE_Nothing can be called with interpolate_boundary_values
-// with vector elements in the hp context with each element active
+// with vector elements in the hp-context with each element active
 // only in a subdomain
 
 

--- a/tests/hp/fe_nothing_20.cc
+++ b/tests/hp/fe_nothing_20.cc
@@ -15,7 +15,7 @@
 
 
 
-// interpolate() can not deal with FE_Nothing in an hp setting
+// interpolate() can not deal with FE_Nothing in an hp-setting
 
 
 #include <deal.II/base/function.h>

--- a/tests/hp/flux_sparsity.cc
+++ b/tests/hp/flux_sparsity.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 // A test that checks make_flux_sparsity_pattern
-// with vector-valued hp objects and coupling masks
+// with vector-valued hp-objects and coupling masks
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/flux_sparsity_02.cc
+++ b/tests/hp/flux_sparsity_02.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 // A second test that checks make_flux_sparsity_pattern
-// with scalar valued hp objects.
+// with scalar valued hp-objects.
 
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/future_fe_indices.cc
+++ b/tests/hp/future_fe_indices.cc
@@ -15,7 +15,7 @@
 
 
 
-// check if future fe indices will be set correctly
+// check if future FE indices will be set correctly
 
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/get_interpolated_dof_values_01.cc
+++ b/tests/hp/get_interpolated_dof_values_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->get_interpolated_dof_values can not work properly in the hp
+// cell->get_interpolated_dof_values can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 

--- a/tests/hp/get_interpolated_dof_values_01.debug.output
+++ b/tests/hp/get_interpolated_dof_values_01.debug.output
@@ -2,12 +2,12 @@
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception 2!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")

--- a/tests/hp/get_interpolated_dof_values_02.cc
+++ b/tests/hp/get_interpolated_dof_values_02.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->get_interpolated_dof_values can not work properly in the hp
+// cell->get_interpolated_dof_values can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 //

--- a/tests/hp/get_interpolated_dof_values_03.cc
+++ b/tests/hp/get_interpolated_dof_values_03.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->get_interpolated_dof_values can not work properly in the hp
+// cell->get_interpolated_dof_values can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 //

--- a/tests/hp/hp_coarsening.cc
+++ b/tests/hp/hp_coarsening.cc
@@ -15,8 +15,8 @@
 
 
 
-// validate hp decision algorithms on grid coarsening
-// that depend on the composition of h and p adaptivity flags
+// validate hp-decision algorithms on grid coarsening
+// that depend on the composition of h- and p-adaptivity flags
 
 
 #include <deal.II/dofs/dof_handler.h>
@@ -53,7 +53,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(1);
 
-  // Set h and p flags on all cells.
+  // Set h- and p-flags on all cells.
   for (const auto &cell : dh.active_cell_iterators())
     {
       cell->set_coarsen_flag();

--- a/tests/hp/hp_constraints_b.cc
+++ b/tests/hp/hp_constraints_b.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for Bernstein elements
+// check that computation of hp-constraints works for Bernstein elements
 // correctly
 
 char logname[] = "output";

--- a/tests/hp/hp_constraints_common.h
+++ b/tests/hp/hp_constraints_common.h
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// common framework to check hp constraints
+// common framework to check hp-constraints
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/function_lib.h>

--- a/tests/hp/hp_constraints_common.h
+++ b/tests/hp/hp_constraints_common.h
@@ -369,7 +369,7 @@ test_interpolation_base(const hp::FECollection<dim> &    fe,
         deallog << "Testing " << fe[fe1].get_name() << " vs. "
                 << fe[fe2].get_name() << std::endl;
 
-        // set fe on coarse cell to 'i', on
+        // set FE on coarse cell to 'i', on
         // all fine cells to 'j'
         typename DoFHandler<dim>::active_cell_iterator cell =
           dof_handler.begin_active();

--- a/tests/hp/hp_constraints_common_no_support.h
+++ b/tests/hp/hp_constraints_common_no_support.h
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// common framework to check hp constraints for fe without support points
+// common framework to check hp-constraints for fe without support points
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/function_lib.h>

--- a/tests/hp/hp_constraints_common_no_support.h
+++ b/tests/hp/hp_constraints_common_no_support.h
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// common framework to check hp-constraints for fe without support points
+// common framework to check hp-constraints for FE without support points
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/function_lib.h>
@@ -365,7 +365,7 @@ test_interpolation_base(const hp::FECollection<dim> &    fe,
         deallog << "Testing " << fe[fe1].get_name() << " vs. "
                 << fe[fe2].get_name() << std::endl;
 
-        // set fe on coarse cell to 'i', on
+        // set FE on coarse cell to 'i', on
         // all fine cells to 'j'
         typename DoFHandler<dim>::active_cell_iterator cell =
           dof_handler.begin_active();

--- a/tests/hp/hp_constraints_dgp.cc
+++ b/tests/hp/hp_constraints_dgp.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGP elements correctly
+// check that computation of hp-constraints works for DGP elements correctly
 
 char logname[] = "output";
 

--- a/tests/hp/hp_constraints_dgp_monomial.cc
+++ b/tests/hp/hp_constraints_dgp_monomial.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGP_Monomial elements
+// check that computation of hp-constraints works for DGP_Monomial elements
 // correctly
 
 char logname[] = "output";

--- a/tests/hp/hp_constraints_dgp_nonparametric.cc
+++ b/tests/hp/hp_constraints_dgp_nonparametric.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGPNonparametric elements
+// check that computation of hp-constraints works for DGPNonparametric elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 char logname[] = "output";

--- a/tests/hp/hp_constraints_dgq.cc
+++ b/tests/hp/hp_constraints_dgq.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGQ elements correctly
+// check that computation of hp-constraints works for DGQ elements correctly
 
 char logname[] = "output";
 

--- a/tests/hp/hp_constraints_neither_dominate_01.cc
+++ b/tests/hp/hp_constraints_neither_dominate_01.cc
@@ -95,7 +95,7 @@ test2cells(const unsigned int p1 = 2, const unsigned int p2 = 1)
   fe_collection.push_back(
     FESystem<dim>(FE_Q<dim>(p1), 1, FE_Nothing<dim>(1, true), 1));
   fe_collection.push_back(FESystem<dim>(FE_Q<dim>(p2), 1, FE_Q<dim>(1), 1));
-  // push back to be able to resolve hp constrains no matter what:
+  // push back to be able to resolve hp-constrains no matter what:
   fe_collection.push_back(
     FESystem<dim>(FE_Q<dim>(p2), 1, FE_Nothing<dim>(1, true), 1));
 

--- a/tests/hp/hp_constraints_q.cc
+++ b/tests/hp/hp_constraints_q.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for Q elements correctly
+// check that computation of hp-constraints works for Q elements correctly
 
 char logname[] = "output";
 

--- a/tests/hp/hp_constraints_q_hierarchical.cc
+++ b/tests/hp/hp_constraints_q_hierarchical.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for DGP_Monomial elements
+// check that computation of hp-constraints works for DGP_Monomial elements
 // correctly
 
 char logname[] = "output";

--- a/tests/hp/hp_constraints_q_system.cc
+++ b/tests/hp/hp_constraints_q_system.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for FESystem(FE_Q) elements
+// check that computation of hp-constraints works for FESystem(FE_Q) elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 char logname[] = "output";

--- a/tests/hp/hp_constraints_q_system_x.cc
+++ b/tests/hp/hp_constraints_q_system_x.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for FESystem(FE_Q) elements
+// check that computation of hp-constraints works for FESystem(FE_Q) elements
 // correctly on a uniformly refined mesh for functions of degree q
 
 // these tests check that we can deal with FESystem(FE_Q(p),FE_DGQ(q)) for

--- a/tests/hp/hp_constraints_rt_nodal.cc
+++ b/tests/hp/hp_constraints_rt_nodal.cc
@@ -15,7 +15,7 @@
 
 
 
-// check that computation of hp constraints works for RT elements correctly
+// check that computation of hp-constraints works for RT elements correctly
 
 char logname[] = "output";
 

--- a/tests/hp/hp_hanging_nodes_01.cc
+++ b/tests/hp/hp_hanging_nodes_01.cc
@@ -48,7 +48,7 @@
 #include "../tests.h"
 
 
-// This a test for the hp capable version of the make_hanging_node_constraints
+// This a test for the hp-capable version of the make_hanging_node_constraints
 // method. It uses a triangulation with one refined element beside an
 // unrefined element to create the constraints for this configuration.
 

--- a/tests/hp/hp_q_hierarchical_constraints.cc
+++ b/tests/hp/hp_q_hierarchical_constraints.cc
@@ -72,7 +72,7 @@ test(const bool apply_constrains, const unsigned int hp)
   AffineConstraints<double> constraints; // for boundary conditions
 
 
-  // populate fe system:
+  // populate FE system:
   fe.push_back(FE_Q_Hierarchical<dim>(2));
   fe.push_back(FE_Q_Hierarchical<dim>(4));
 
@@ -82,7 +82,7 @@ test(const bool apply_constrains, const unsigned int hp)
   cell->set_active_fe_index(1);
 
   // need to distribute dofs before refinement,
-  // otherwise active fe index will not transfer to child cells
+  // otherwise active FE index will not transfer to child cells
   dof_handler.distribute_dofs(fe);
 
   // refine first cell (simple case)

--- a/tests/hp/interpolate_nothing_02.cc
+++ b/tests/hp/interpolate_nothing_02.cc
@@ -166,7 +166,7 @@ diffusionMechanics<dim>::cell_is_in_omega2_domain(
   return (cell->material_id() == omega2_domain_id);
 }
 
-// Set active fe indices in each sub-domain
+// Set active FE indices in each sub-domain
 template <int dim>
 void
 diffusionMechanics<dim>::set_active_fe_indices()

--- a/tests/hp/laplace.h
+++ b/tests/hp/laplace.h
@@ -427,7 +427,7 @@ Laplace<dim>::refine_grid(const unsigned int cycle)
   // 3.2. Mark cells for h-refinement
   mark_h_cells();
 
-  // 3.3. Substitute h for p refinement
+  // 3.3. Substitute h- for p-refinement
   substitute_h_for_p();
 
   // prepare refinement and store number of flagged cells
@@ -457,7 +457,7 @@ Laplace<dim>::refine_grid(const unsigned int cycle)
   // 3.5. h-refinement and p-refinement
   triangulation.execute_coarsening_and_refinement();
 
-  // FIXME: some hp strategies might need:
+  // FIXME: some hp-strategies might need:
   // post_execute_coarsening_and_refinement();
 
   // 3.6. Setup

--- a/tests/hp/matrices.cc
+++ b/tests/hp/matrices.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/matrices, but for hp objects. here, each hp object has only a
+// like deal.II/matrices, but for hp-objects. here, each hp-object has only a
 // single component, so we expect exactly the same output as for the old test.
 // matrices_hp tests for different finite elements
 

--- a/tests/hp/matrices_hp.cc
+++ b/tests/hp/matrices_hp.cc
@@ -15,7 +15,7 @@
 
 
 
-// like hp/matrices, but with different fe objects
+// like hp/matrices, but with different FE objects
 
 
 #include <deal.II/base/function_lib.h>

--- a/tests/hp/n_boundary_dofs.cc
+++ b/tests/hp/n_boundary_dofs.cc
@@ -16,7 +16,7 @@
 
 
 // Check the consistency of the number cache of DoFHandler for a sequential
-// object. Like deal.II/n_boundary_dofs but for an hp object
+// object. Like deal.II/n_boundary_dofs but for an hp-object
 
 
 #include <deal.II/base/tensor.h>

--- a/tests/hp/p_adaptivity_absolute_threshold.cc
+++ b/tests/hp/p_adaptivity_absolute_threshold.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_absolute_threshold.cc
+++ b/tests/hp/p_adaptivity_absolute_threshold.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_fixed_number.cc
+++ b/tests/hp/p_adaptivity_fixed_number.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_fixed_number.cc
+++ b/tests/hp/p_adaptivity_fixed_number.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_flags.cc
+++ b/tests/hp/p_adaptivity_flags.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_flags.cc
+++ b/tests/hp/p_adaptivity_flags.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_full.cc
+++ b/tests/hp/p_adaptivity_full.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_reference.cc
+++ b/tests/hp/p_adaptivity_reference.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_reference.cc
+++ b/tests/hp/p_adaptivity_reference.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_regularity.cc
+++ b/tests/hp/p_adaptivity_regularity.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_regularity.cc
+++ b/tests/hp/p_adaptivity_regularity.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/p_adaptivity_relative_threshold.cc
+++ b/tests/hp/p_adaptivity_relative_threshold.cc
@@ -99,8 +99,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   const unsigned int n_active = tria.n_active_cells();

--- a/tests/hp/p_adaptivity_relative_threshold.cc
+++ b/tests/hp/p_adaptivity_relative_threshold.cc
@@ -57,7 +57,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   typename DoFHandler<dim>::cell_iterator cell = dh.begin(1), endc = dh.end(1);
   for (unsigned int counter = 0; cell != endc; ++counter, ++cell)

--- a/tests/hp/refinement_01.cc
+++ b/tests/hp/refinement_01.cc
@@ -57,7 +57,7 @@ test()
 
   for (cell = dh.begin_active(); cell != dh.end(); ++cell)
     {
-      // set active fe index
+      // set active FE index
       if (i >= fe_collection.size())
         i = 0;
       cell->set_active_fe_index(i++);

--- a/tests/hp/set_dof_values_by_interpolation_01.cc
+++ b/tests/hp/set_dof_values_by_interpolation_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->set_dof_values_by_interpolation can not work properly in the hp
+// cell->set_dof_values_by_interpolation can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 

--- a/tests/hp/set_dof_values_by_interpolation_01.debug.output
+++ b/tests/hp/set_dof_values_by_interpolation_01.debug.output
@@ -2,12 +2,12 @@
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")
 DEAL::Yes, exception 1!
 DEAL::ExcMessage( "For DoFHandler objects in hp-mode, finite elements are only " "associated with active cells. Consequently, you can not ask " "for the active finite element on cells with children.")
 DEAL::Yes, exception!
-DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active_fe_index has been set.")
+DEAL::ExcMessage( "You cannot call this function on non-active cells " "of DoFHandler objects unless you provide an explicit " "finite element index because they do not have naturally " "associated finite element spaces associated: degrees " "of freedom are only distributed on active cells for which " "the active FE index has been set.")

--- a/tests/hp/set_dof_values_by_interpolation_02.cc
+++ b/tests/hp/set_dof_values_by_interpolation_02.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->set_dof_values_by_interpolation can not work properly in the hp
+// cell->set_dof_values_by_interpolation can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 //

--- a/tests/hp/set_dof_values_by_interpolation_03.cc
+++ b/tests/hp/set_dof_values_by_interpolation_03.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// cell->set_dof_values_by_interpolation can not work properly in the hp
+// cell->set_dof_values_by_interpolation can not work properly in the hp-
 // context when called on non-active cells because these do not have a
 // finite element associated with them
 //

--- a/tests/hp/solution_transfer.cc
+++ b/tests/hp/solution_transfer.cc
@@ -208,7 +208,7 @@ transfer(std::ostream &out)
               std::fabs(func.value(fe_val.quadrature_point(q), 0) - vals[q]);
           }
       }
-    deallog << "Error in interpolating hp FE_Q: " << error << std::endl;
+    deallog << "Error in interpolating hp-FE_Q: " << error << std::endl;
   }
   {
     double                                         error = 0;
@@ -231,7 +231,7 @@ transfer(std::ostream &out)
               std::fabs(func.value(fe_val.quadrature_point(q), 0) - vals[q]);
           }
       }
-    deallog << "Error in interpolating hp FE_DGQ: " << error << std::endl;
+    deallog << "Error in interpolating hp-FE_DGQ: " << error << std::endl;
   }
 }
 

--- a/tests/hp/solution_transfer.output
+++ b/tests/hp/solution_transfer.output
@@ -1,10 +1,10 @@
 
 DEAL::   1D solution transfer
-DEAL::Error in interpolating hp FE_Q: 0
-DEAL::Error in interpolating hp FE_DGQ: 0
+DEAL::Error in interpolating hp-FE_Q: 0
+DEAL::Error in interpolating hp-FE_DGQ: 0
 DEAL::   2D solution transfer
-DEAL::Error in interpolating hp FE_Q: 0
-DEAL::Error in interpolating hp FE_DGQ: 0
+DEAL::Error in interpolating hp-FE_Q: 0
+DEAL::Error in interpolating hp-FE_DGQ: 0
 DEAL::   3D solution transfer
-DEAL::Error in interpolating hp FE_Q: 0
-DEAL::Error in interpolating hp FE_DGQ: 0
+DEAL::Error in interpolating hp-FE_Q: 0
+DEAL::Error in interpolating hp-FE_DGQ: 0

--- a/tests/hp/solution_transfer_02.cc
+++ b/tests/hp/solution_transfer_02.cc
@@ -16,7 +16,7 @@
 
 
 // SolutionTransfer wanted to compute interpolation matrices between
-// all pairs of elements used on a mesh in the hp case. unfortunately,
+// all pairs of elements used on a mesh in the hp-case. unfortunately,
 // not all pairs are actually supported, e.g. between FE_Nothing and
 // FE_Q, but that shouldn't matter as long as these combinations are
 // never exercised on actual cells

--- a/tests/hp/solution_transfer_09.cc
+++ b/tests/hp/solution_transfer_09.cc
@@ -15,7 +15,7 @@
 
 
 
-// Like _07 but with all same fe indices. This triggered yet another place
+// Like _07 but with all same FE indices. This triggered yet another place
 // where we had the same kind of error.
 
 #include <deal.II/dofs/dof_handler.h>

--- a/tests/hp/solution_transfer_12.cc
+++ b/tests/hp/solution_transfer_12.cc
@@ -222,7 +222,7 @@ transfer(std::ostream &out)
               std::fabs(func.value(fe_val.quadrature_point(q), 0) - vals[q]);
           }
       }
-    deallog << "Error in interpolating hp FE_Q_Hierarchical: " << error
+    deallog << "Error in interpolating hp-FE_Q_Hierarchical: " << error
             << std::endl;
   }
 }

--- a/tests/hp/solution_transfer_12.output
+++ b/tests/hp/solution_transfer_12.output
@@ -1,7 +1,7 @@
 
 DEAL::   1D solution transfer
-DEAL::Error in interpolating hp FE_Q_Hierarchical: 0
+DEAL::Error in interpolating hp-FE_Q_Hierarchical: 0
 DEAL::   2D solution transfer
-DEAL::Error in interpolating hp FE_Q_Hierarchical: 0
+DEAL::Error in interpolating hp-FE_Q_Hierarchical: 0
 DEAL::   3D solution transfer
-DEAL::Error in interpolating hp FE_Q_Hierarchical: 0
+DEAL::Error in interpolating hp-FE_Q_Hierarchical: 0

--- a/tests/hp/vectors_boundary_rhs_01.cc
+++ b/tests/hp/vectors_boundary_rhs_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs, but for hp objects. here, each hp object
+// like deal.II/vectors_boundary_rhs, but for hp-objects. here, each hp-object
 // has only a single component, so we expect exactly the same output as for the
 // old test. vectors_boundary_rhs_hp tests for different finite elements
 

--- a/tests/hp/vectors_boundary_rhs_02.cc
+++ b/tests/hp/vectors_boundary_rhs_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs_02_02, but for hp objects. here, each hp
+// like deal.II/vectors_boundary_rhs_02_02, but for hp-objects. here, each hp-
 // object has only a single component, so we expect exactly the same output as
 // for the old test. vectors_boundary_rhs_02_hp tests for different finite
 // elements

--- a/tests/hp/vectors_boundary_rhs_03.cc
+++ b/tests/hp/vectors_boundary_rhs_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs_03, but for hp objects. here, each hp
+// like deal.II/vectors_boundary_rhs_03, but for hp-objects. here, each hp-
 // object has only a single component, so we expect exactly the same output as
 // for the old test. vectors_boundary_rhs_03_hp tests for different finite
 // elements

--- a/tests/hp/vectors_boundary_rhs_hp_01.cc
+++ b/tests/hp/vectors_boundary_rhs_hp_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs, but for hp objects. here, each hp object
+// like deal.II/vectors_boundary_rhs, but for hp-objects. here, each hp-object
 // has only a single component, so we expect exactly the same output as for the
 // old test. vectors_boundary_rhs_hp_hp tests for different finite elements
 

--- a/tests/hp/vectors_boundary_rhs_hp_03.cc
+++ b/tests/hp/vectors_boundary_rhs_hp_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_boundary_rhs_03, but for hp objects. here, each hp
+// like deal.II/vectors_boundary_rhs_03, but for hp-objects. here, each hp-
 // object has only a single component, so we expect exactly the same output as
 // for the old test. vectors_boundary_rhs_hp_03_hp tests for different finite
 // elements

--- a/tests/hp/vectors_point_source_01.cc
+++ b/tests/hp/vectors_point_source_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_point_source, but for hp objects. here, each hp object
+// like deal.II/vectors_point_source, but for hp-objects. here, each hp-object
 // has only a single component, so we expect exactly the same output as for the
 // old test. vectors_point_source_hp tests for different finite elements
 

--- a/tests/hp/vectors_point_source_hp_01.cc
+++ b/tests/hp/vectors_point_source_hp_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_point_source_hp, but for hp objects. here, each hp
+// like deal.II/vectors_point_source_hp, but for hp-objects. here, each hp-
 // object has only a single component, so we expect exactly the same output as
 // for the old test. vectors_point_source_hp_hp tests for different finite
 // elements

--- a/tests/hp/vectors_rhs_01.cc
+++ b/tests/hp/vectors_rhs_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs, but for hp objects. here, each hp object has only a
+// like deal.II/vectors_rhs, but for hp-objects. here, each hp-object has only a
 // single component, so we expect exactly the same output as for the old test.
 // vectors_rhs_hp tests for different finite elements
 

--- a/tests/hp/vectors_rhs_02.cc
+++ b/tests/hp/vectors_rhs_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs_02_02, but for hp objects. here, each hp object has
+// like deal.II/vectors_rhs_02_02, but for hp-objects. here, each hp-object has
 // only a single component, so we expect exactly the same output as for the old
 // test. vectors_rhs_02_hp tests for different finite elements
 

--- a/tests/hp/vectors_rhs_03.cc
+++ b/tests/hp/vectors_rhs_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs_03, but for hp objects. here, each hp object has
+// like deal.II/vectors_rhs_03, but for hp-objects. here, each hp-object has
 // only a single component, so we expect exactly the same output as for the old
 // test. vectors_rhs_03_hp tests for different finite elements
 

--- a/tests/hp/vectors_rhs_hp_01.cc
+++ b/tests/hp/vectors_rhs_hp_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs_hp, but for hp objects. here, each hp object has
+// like deal.II/vectors_rhs_hp, but for hp-objects. here, each hp-object has
 // only a single component, so we expect exactly the same output as for the old
 // test. vectors_rhs_hp_hp tests for different finite elements
 

--- a/tests/hp/vectors_rhs_hp_03.cc
+++ b/tests/hp/vectors_rhs_hp_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// like deal.II/vectors_rhs_hp_03, but for hp objects. here, each hp object has
+// like deal.II/vectors_rhs_hp_03, but for hp-objects. here, each hp-object has
 // only a single component, so we expect exactly the same output as for the old
 // test. vectors_rhs_hp_03_hp tests for different finite elements
 

--- a/tests/lac/constraints.cc
+++ b/tests/lac/constraints.cc
@@ -285,7 +285,7 @@ main()
 
           constraints.print(logfile);
 
-          // release fe
+          // release FE
           dof.clear();
 
           deallog << std::endl;

--- a/tests/lac/inhomogeneous_constraints.cc
+++ b/tests/lac/inhomogeneous_constraints.cc
@@ -17,7 +17,7 @@
 
 // this function tests the correctness of the implementation of
 // inhomogeneous constraints. The program is a modification of the step-27
-// tutorial program with hp elements and the constraints arising in that
+// tutorial program with hp-elements and the constraints arising in that
 // situation. the idea of the test is to set up a matrix with standard tools
 // (i.e., constraints and the boundary value list), and compare that with
 // the new function.

--- a/tests/matrix_free/matrix_vector_hp.cc
+++ b/tests/matrix_free/matrix_vector_hp.cc
@@ -17,7 +17,7 @@
 
 // this function tests the correctness of the implementation of matrix free
 // matrix-vector products by comparing with the result of deal.II sparse
-// matrix for hp DoFHandler on a hyperball mesh with hanging nodes and finite
+// matrix for hp-DoFHandler on a hyperball mesh with hanging nodes and finite
 // elements orders distributed randomly.
 
 #include <deal.II/base/function.h>

--- a/tests/matrix_free/matrix_vector_hp_no_template.cc
+++ b/tests/matrix_free/matrix_vector_hp_no_template.cc
@@ -17,7 +17,7 @@
 
 // this function tests the correctness of the implementation of matrix free
 // matrix-vector products by comparing with the result of deal.II sparse
-// matrix for hp DoFHandler on a hyperball mesh with hanging nodes and finite
+// matrix for hp-DoFHandler on a hyperball mesh with hanging nodes and finite
 // elements orders distributed randomly.
 
 #include <deal.II/base/function.h>

--- a/tests/matrix_free/thread_correctness_hp.cc
+++ b/tests/matrix_free/thread_correctness_hp.cc
@@ -16,7 +16,7 @@
 
 
 // this function tests the correctness of the implementation of parallel
-// matrix free matrix-vector products for hp elements by comparing to the
+// matrix free matrix-vector products for hp-elements by comparing to the
 // serial version
 
 #include <deal.II/base/function.h>

--- a/tests/mpi/error_predictor_02.cc
+++ b/tests/mpi/error_predictor_02.cc
@@ -66,7 +66,7 @@ test()
   DoFHandler<dim> dh(tria);
   for (const auto &cell : dh.active_cell_iterators())
     {
-      // set active fe index
+      // set active FE index
       if (cell->is_locally_owned())
         cell->set_active_fe_index(1);
     }

--- a/tests/mpi/hp_active_fe_indices_transfer_01.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_01.cc
@@ -15,7 +15,7 @@
 
 
 
-// active fe indices transfer on refinement
+// active FE indices transfer on refinement
 
 
 #include <deal.II/distributed/tria.h>
@@ -55,7 +55,7 @@ test()
   for (auto &cell : dh.active_cell_iterators())
     if (cell->is_locally_owned())
       {
-        // set active fe index
+        // set active FE index
         if (!(cell->is_artificial()))
           {
             if (i >= fe_collection.size())

--- a/tests/mpi/hp_active_fe_indices_transfer_02.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_02.cc
@@ -15,7 +15,7 @@
 
 
 
-// active fe indices transfer on serialization
+// active FE indices transfer on serialization
 
 
 #include <deal.II/distributed/tria.h>
@@ -54,7 +54,7 @@ test()
     for (auto &cell : dh.active_cell_iterators())
       if (cell->is_locally_owned())
         {
-          // set active fe index
+          // set active FE index
           if (!(cell->is_artificial()))
             {
               if (i >= fe_collection.size())

--- a/tests/mpi/hp_active_fe_indices_transfer_03.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_03.cc
@@ -15,7 +15,7 @@
 
 
 
-// active fe indices transfer on repartitioning
+// active FE indices transfer on repartitioning
 
 
 #include <deal.II/distributed/cell_weights.h>
@@ -54,7 +54,7 @@ test()
   for (auto &cell : dh.active_cell_iterators())
     if (cell->is_locally_owned())
       {
-        // set active fe index
+        // set active FE index
         if (!(cell->is_artificial()))
           cell->set_active_fe_index(myid);
 

--- a/tests/mpi/hp_active_fe_indices_transfer_04.cc
+++ b/tests/mpi/hp_active_fe_indices_transfer_04.cc
@@ -15,7 +15,7 @@
 
 
 
-// active fe indices serialization with a different number of cpus
+// active FE indices serialization with a different number of cpus
 
 
 #include <deal.II/distributed/tria.h>
@@ -63,7 +63,7 @@ test()
       for (auto &cell : dh.active_cell_iterators())
         if (cell->is_locally_owned())
           {
-            // set active fe index
+            // set active FE index
             if (i >= fe_collection.size())
               i = 0;
             cell->set_active_fe_index(i++);

--- a/tests/mpi/hp_constraints_consistent_01.cc
+++ b/tests/mpi/hp_constraints_consistent_01.cc
@@ -84,7 +84,7 @@ test(const unsigned int degree_center,
   for (const auto &cell : dh.active_cell_iterators())
     if (cell->is_locally_owned() && cell->id().to_string() == "1_0:")
       {
-        // set different fe on center cell
+        // set different FE on center cell
         cell->set_active_fe_index(1);
 
 #ifdef DEBUG

--- a/tests/mpi/hp_constraints_consistent_02.cc
+++ b/tests/mpi/hp_constraints_consistent_02.cc
@@ -84,7 +84,7 @@ test(const unsigned int degree_center,
   for (const auto &cell : dh.active_cell_iterators())
     if (cell->is_locally_owned() && cell->id().to_string() == "1_0:")
       {
-        // set different fe on center cell
+        // set different FE on center cell
         cell->set_active_fe_index(1);
 
 #ifdef DEBUG

--- a/tests/mpi/hp_constraints_consistent_03.cc
+++ b/tests/mpi/hp_constraints_consistent_03.cc
@@ -86,7 +86,7 @@ test(const unsigned int degree_center,
       {
         if (cell->id().to_string() == "1_0:")
           {
-            // set different fe on center cell
+            // set different FE on center cell
             cell->set_active_fe_index(1);
 
 #ifdef DEBUG

--- a/tests/mpi/hp_refinement_01.cc
+++ b/tests/mpi/hp_refinement_01.cc
@@ -73,7 +73,7 @@ test()
 
       if (cell->is_locally_owned())
         {
-          // set active fe index
+          // set active FE index
           if (i >= fe_collection.size())
             i = 0;
           cell->set_active_fe_index(i++);

--- a/tests/mpi/hp_refinement_02.cc
+++ b/tests/mpi/hp_refinement_02.cc
@@ -73,7 +73,7 @@ test()
 
       if (cell->is_locally_owned())
         {
-          // set active fe index
+          // set active FE index
           if (i >= fe_collection.size())
             i = 0;
           cell->set_active_fe_index(i++);

--- a/tests/mpi/hp_step-4.cc
+++ b/tests/mpi/hp_step-4.cc
@@ -197,7 +197,7 @@ namespace Step4
     DoFTools::make_zero_boundary_constraints(dof_handler, constraints);
 
 #ifdef DEBUG
-    // We did not think about hp constraints on ghost cells yet.
+    // We did not think about hp-constraints on ghost cells yet.
     // Thus, we are content with verifying their consistency for now.
     IndexSet locally_active_dofs;
     DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);

--- a/tests/mpi/hp_unify_dof_indices_01.cc
+++ b/tests/mpi/hp_unify_dof_indices_01.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp
+// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp-
 // case with an FECollection that contains multiple copies of the same
-// FE_Q(2) element. the hp code will unify DoF indices on boundaries
+// FE_Q(2) element. the hp-code will unify DoF indices on boundaries
 // between all subdomains.
 
 

--- a/tests/mpi/hp_unify_dof_indices_02.cc
+++ b/tests/mpi/hp_unify_dof_indices_02.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains multiple copies of the same
-// FE_Q(2) element. the hp code will unify DoF indices on boundaries
+// FE_Q(2) element. the hp-code will unify DoF indices on boundaries
 // between all subdomains.
 //
 // in this testcase, three FE objects are distributed on four cells,

--- a/tests/mpi/hp_unify_dof_indices_03.cc
+++ b/tests/mpi/hp_unify_dof_indices_03.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains a FE_Q(4) and a FE_Q(2) element.
-// the hp code will unify DoF indices on boundaries between all subdomains.
+// the hp-code will unify DoF indices on boundaries between all subdomains.
 //
 // in this testcase, each cell has a face neighbor with a different
 // active_fe_index, which is either locally owned or a ghost cell.

--- a/tests/mpi/hp_unify_dof_indices_04.cc
+++ b/tests/mpi/hp_unify_dof_indices_04.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains a FE_Q(4) and a FE_Q(2) element.
-// the hp code will unify DoF indices on boundaries between all subdomains.
+// the hp-code will unify DoF indices on boundaries between all subdomains.
 //
 // in this testcase, each cell has a face neighbor which is
 //  - locally owned with the same active_fe_index

--- a/tests/mpi/hp_unify_dof_indices_05.cc
+++ b/tests/mpi/hp_unify_dof_indices_05.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains a FE_Q(4) and a FE_Q(2) element.
-// the hp code will unify DoF indices on boundaries between all subdomains.
+// the hp-code will unify DoF indices on boundaries between all subdomains.
 //
 // in this testcase, each cell has a face neighbor which is
 //  - locally owned with a different active_fe_index

--- a/tests/mpi/hp_unify_dof_indices_06.cc
+++ b/tests/mpi/hp_unify_dof_indices_06.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains multiple copies of the same
-// FE_Q(2) element. the hp code will unify DoF indices on boundaries
+// FE_Q(2) element. the hp-code will unify DoF indices on boundaries
 // between all subdomains.
 //
 // in this testcase, the dominating FE object is located on a cell

--- a/tests/mpi/hp_unify_dof_indices_07.cc
+++ b/tests/mpi/hp_unify_dof_indices_07.cc
@@ -15,11 +15,11 @@
 
 
 
-// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp
+// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp-
 // case with an FECollection that contains multiple copies of the same
-// FE_Q(2) element. in the sequential case, the hp code will unify DoF
+// FE_Q(2) element. in the sequential case, the hp-code will unify DoF
 // indices on boundaries between locally owned subdomains; in early
-// versions of the parallel hp support, we don't do that, but the
+// versions of the parallel hp-support, we don't do that, but the
 // final version now does
 //
 // this test gives a different perspective on this issue. in the _01

--- a/tests/mpi/hp_unify_dof_indices_08.cc
+++ b/tests/mpi/hp_unify_dof_indices_08.cc
@@ -15,12 +15,12 @@
 
 
 
-// Read in a large grid from a file and distribute hp DoFs on it using
+// Read in a large grid from a file and distribute hp-DoFs on it using
 // FE_Q elements of different orders on different cells. The
 // active_fe_index on each cell is determined in a mostly random way,
 // but so that it is the same regardless of the number of processors.
 //
-// We used to treat hp DoF unification on vertices and faces
+// We used to treat hp-DoF unification on vertices and faces
 // differently depending on whether we are in the interior of a
 // subdomain or at a processor boundary. But later versions of the
 // code did away with this distinction, and now the total number of

--- a/tests/mpi/hp_unify_dof_indices_09.cc
+++ b/tests/mpi/hp_unify_dof_indices_09.cc
@@ -16,7 +16,7 @@
 
 // This test provides a hp::DoFHandler with two FE_Q(2) elements
 // assigned on a p::d::Triangulation consisting of 64x64 cells, on which
-// active fe indices are mostly randomly distributed. This DoF
+// active FE indices are mostly randomly distributed. This DoF
 // distribution test repeats for an increasing amount of processors.
 //
 // At some point, this test failed to provide a consistent number of

--- a/tests/mpi/hp_unify_dof_indices_10.cc
+++ b/tests/mpi/hp_unify_dof_indices_10.cc
@@ -15,9 +15,9 @@
 
 
 
-// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp
+// have a 2x2 coarse mesh (or 2x2x1) and verify DoF indices in the hp-
 // case with an FECollection that contains multiple copies of the same
-// FESystem object, consisting of two FE_Q(2) elements. the hp code will
+// FESystem object, consisting of two FE_Q(2) elements. the hp-code will
 // unify DoF indices on boundaries between all subdomains.
 //
 // in this testcase, three FESystem objects are distributed on four

--- a/tests/mpi/hp_unify_dof_indices_11.cc
+++ b/tests/mpi/hp_unify_dof_indices_11.cc
@@ -15,11 +15,11 @@
 
 
 
-// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp
+// have a 2x1 coarse mesh (or 2x1x1) and verify DoF indices in the hp-
 // case with a FECollection that contains two finite elements that do
 // not dominate each other. Here, a (FE_Q(1) x FE_Q(2)) and a
 // (FE_Q(2) x FE_Q(1)) element on two separate subdomains face each
-// other. the hp code will unify DoF indices on boundaries between all
+// other. the hp-code will unify DoF indices on boundaries between all
 // subdomains.
 
 

--- a/tests/mpi/p_adaptivity_fixed_number.cc
+++ b/tests/mpi/p_adaptivity_fixed_number.cc
@@ -104,8 +104,8 @@ test()
 
 
   // We flag the first half of all cells to be refined and the last half of all
-  // cells to be coarsened for p adapativity. Ultimately, the first quarter of
-  // all cells will be flagged for p refinement, and the last quarter for p
+  // cells to be coarsened for p-adapativity. Ultimately, the first quarter of
+  // all cells will be flagged for p-refinement, and the last quarter for p-
   // coarsening.
 
   Vector<double> indicators(tria.n_active_cells());

--- a/tests/mpi/p_adaptivity_fixed_number.cc
+++ b/tests/mpi/p_adaptivity_fixed_number.cc
@@ -66,7 +66,7 @@ setup(Triangulation<dim> &tria, const DoFHandler<dim> &dh)
   GridGenerator::subdivided_hyper_cube(tria, 4);
   Assert(tria.n_cells(0) == tria.n_global_active_cells(), ExcInternalError());
 
-  // Set all active fe indices to 1.
+  // Set all active FE indices to 1.
   // Flag first half of cells for refinement, and the other half for coarsening.
   for (const auto &cell : dh.active_cell_iterators())
     if (!cell->is_artificial() && cell->is_locally_owned())

--- a/tests/mpi/solution_transfer_04.cc
+++ b/tests/mpi/solution_transfer_04.cc
@@ -61,7 +61,7 @@ test()
     {
       if (cell->is_locally_owned())
         {
-          // set active fe index
+          // set active FE index
           if (!(cell->is_artificial()))
             {
               if (i >= fe_collection.size())

--- a/tests/mpi/solution_transfer_05.cc
+++ b/tests/mpi/solution_transfer_05.cc
@@ -60,7 +60,7 @@ test()
 
   DoFHandler<dim> dgq_dof_handler(tria);
 
-  // randomly assign fes
+  // randomly assign FEs
   for (const auto &cell : dgq_dof_handler.active_cell_iterators())
     if (cell->is_locally_owned())
       cell->set_active_fe_index(Testing::rand() % max_degree);

--- a/tests/mpi/trilinos_step-27.cc
+++ b/tests/mpi/trilinos_step-27.cc
@@ -226,7 +226,7 @@ namespace Step27
                                              Functions::ZeroFunction<dim>(),
                                              constraints);
 #ifdef DEBUG
-    // We did not think about hp constraints on ghost cells yet.
+    // We did not think about hp-constraints on ghost cells yet.
     // Thus, we are content with verifying their consistency for now.
     IndexSet locally_active_dofs;
     DoFTools::extract_locally_active_dofs(dof_handler, locally_active_dofs);

--- a/tests/numerics/project_parallel_qpmf_common.h
+++ b/tests/numerics/project_parallel_qpmf_common.h
@@ -266,7 +266,7 @@ test_with_hanging_nodes(const FiniteElement<dim> &fe, const unsigned int p)
 }
 
 
-// same as above but for multiple fes
+// same as above but for multiple FEs
 template <int fe_degree, int n_q_points_1d, int dim>
 void
 test_with_hanging_nodes(const std::vector<const FiniteElement<dim> *> &fes,

--- a/tests/vector_tools/boundaries_complex_hp.cc
+++ b/tests/vector_tools/boundaries_complex_hp.cc
@@ -16,7 +16,7 @@
 
 
 // check interpolation of boundary values for complex-valued
-// objects and the hp case
+// objects and the hp-case
 
 
 #include <deal.II/base/function_lib.h>


### PR DESCRIPTION
~~Blocked by #11214.~~

Part of #10333.

---

In the deal.II hp paper and the the original hp papers by Babuska and Suri, any term regarding hp adaptation was written in the following style with a space in between:
```
hp adaptation, h refinement, ...
```

In more recent papers, you find a hyphen for concatenation. (I also used this stye in my dissertation.)
```
hp-adaptation, h-refinement, ...
```

Right now in the library, we use both versions inconsistently. This PR is an attempt to adapt to the **original** nomenclature.

Additionally, I removed the underscores from the `active_fe_index` terms in the documentation.

---

This is an entirely cosmetic change to the documentation, and there might be other opinions on which version to choose.

Especially for @bangerth: What are your thoughts on that?