### PR TITLE
Created Legacy namespaces with copies of ...

### DIFF
--- a/doc/news/changes/incompatibilities/20201120Fehling
+++ b/doc/news/changes/incompatibilities/20201120Fehling
@@ -1,0 +1,28 @@
+Deprecation announcement: The template arguments of the following
+classes will change in a future release:
+<ul>
+  <li>SolutionTransfer
+  <li>parallel::distributed::SolutionTransfer
+  <li>Functions::FEFieldFunction
+  <li>DataOut
+  <li>DataOut_DoFData
+  <li>DataOutFaces
+  <li>DataOutRotation
+</ul>
+If for some reason, you need a code that is compatible with deal.II
+9.3 and the subsequent release, a Legacy namespace has been introduced
+with aliases of these classes with their original interface. You can
+make the following substitutions to your code for each of the affected
+classes:
+<ul>
+  <li>X &rarr; Legacy::X
+</ul>
+To perform this substitution automatically, you may use a *search and
+replace* script like the following made for the *bash* shell:
+@code{.sh}
+classes=(SolutionTransfer parallel::distributed::SolutionTransfer Functions::FEFieldFunction DataOut DataOut_DoFData DataOutFaces DataOutRotation)
+for c in \${classes[@]}; do
+  find /path/to/your/code -type f -exec sed -i -E "/(\w\${c}|\${c}[^<]|Particles::\${c}|distributed::\${c}|^\s*(\/\/|\*))/! s/\${c}/Legacy::\${c}/g" {} \;
+done
+@endcode
+(Marc Fehling, 2020/11/20)

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -372,11 +372,29 @@ namespace parallel
       void
       register_data_attach();
     };
-
-
   } // namespace distributed
 } // namespace parallel
 
+namespace Legacy
+{
+  namespace parallel
+  {
+    namespace distributed
+    {
+      /**
+       * The template arguments of the original
+       * dealii::parallel::distributed::SolutionTransfer class will change in a
+       * future release. If for some reason, you need a code that is compatible
+       * with deal.II 9.3 and the subsequent release, use this alias instead.
+       */
+      template <int dim,
+                typename VectorType,
+                typename DoFHandlerType = DoFHandler<dim>>
+      using SolutionTransfer = dealii::parallel::distributed::
+        SolutionTransfer<dim, VectorType, DoFHandlerType>;
+    } // namespace distributed
+  }   // namespace parallel
+} // namespace Legacy
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -516,6 +516,17 @@ private:
                   const CurvedCellRegion              curved_cell_region);
 };
 
+namespace Legacy
+{
+  /**
+   * The template arguments of the original dealii::DataOut class will
+   * change in a future release. If for some reason, you need a code that is
+   * compatible with deal.II 9.3 and the subsequent release, use this alias
+   * instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  using DataOut = dealii::DataOut<dim, DoFHandlerType>;
+} // namespace Legacy
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1243,6 +1243,21 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
         patches[i].neighbors[n] += old_n_patches;
 }
 
+namespace Legacy
+{
+  /**
+   * The template arguments of the original dealii::DataOut_DoFData class will
+   * change in a future release. If for some reason, you need a code that is
+   * compatible with deal.II 9.3 and the subsequent release, use this alias
+   * instead.
+   */
+  template <typename DoFHandlerType,
+            int patch_dim,
+            int patch_space_dim = patch_dim>
+  using DataOut_DoFData =
+    dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>;
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -250,6 +250,18 @@ private:
     DataOutBase::Patch<dimension - 1, space_dimension> &patch);
 };
 
+namespace Legacy
+{
+  /**
+   * The template arguments of the original dealii::DataOutFaces class will
+   * change in a future release. If for some reason, you need a code that is
+   * compatible with deal.II 9.3 and the subsequent release, use this alias
+   * instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  using DataOutFaces = dealii::DataOutFaces<dim, DoFHandlerType>;
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -215,6 +215,18 @@ private:
       &my_patches);
 };
 
+namespace Legacy
+{
+  /**
+   * The template arguments of the original dealii::DataOutRotation class will
+   * change in a future release. If for some reason, you need a code that is
+   * compatible with deal.II 9.3 and the subsequent release, use this alias
+   * instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  using DataOutRotation = dealii::DataOutRotation<dim, DoFHandlerType>;
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -489,6 +489,25 @@ namespace Functions
   };
 } // namespace Functions
 
+namespace Legacy
+{
+  namespace Functions
+  {
+    /**
+     * The template arguments of the original dealii::Functions::FEFieldFunction
+     * class will change in a future release. If for some reason, you need a
+     * code that is compatible with deal.II 9.3 and the subsequent release, use
+     * this alias instead.
+     */
+    template <int dim,
+              typename DoFHandlerType = DoFHandler<dim>,
+              typename VectorType     = Vector<double>>
+    using FEFieldFunction =
+      dealii::Functions::FEFieldFunction<dim, DoFHandlerType, VectorType>;
+  } // namespace Functions
+} // namespace Legacy
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -574,6 +574,21 @@ private:
     dof_values_on_cell;
 };
 
+namespace Legacy
+{
+  /**
+   * The template arguments of the original dealii::SolutionTransfer class will
+   * change in a future release. If for some reason, you need a code that is
+   * compatible with deal.II 9.3 and the subsequent release, use this alias
+   * instead.
+   */
+  template <int dim,
+            typename VectorType     = Vector<double>,
+            typename DoFHandlerType = DoFHandler<dim>>
+  using SolutionTransfer =
+    dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>;
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/numerics/fe_field_function.cc
+++ b/source/numerics/fe_field_function.cc
@@ -33,9 +33,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace Functions
-{
+
 #include "fe_field_function.inst"
-}
+
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/fe_field_function.inst.in
+++ b/source/numerics/fe_field_function.inst.in
@@ -18,7 +18,10 @@
 for (DoFHandler : DOFHANDLER_TEMPLATES; VECTOR : VECTOR_TYPES;
      deal_II_dimension : DIMENSIONS)
   {
-    template class FEFieldFunction<deal_II_dimension,
-                                   DoFHandler<deal_II_dimension>,
-                                   VECTOR>;
+    namespace Functions
+    \{
+      template class FEFieldFunction<deal_II_dimension,
+                                     DoFHandler<deal_II_dimension>,
+                                     VECTOR>;
+    \}
   }


### PR DESCRIPTION
... SolutionTransfer, FEFieldFunction, DataOut, DataOut_DoFData, DataOutFaces, DataOutRotation.

Part of #10333.

Removing the `DoFHandlerType` template argument in these classes is not trivial, as we still need the `spacedim` argument. Since "overloading" template arguments is not possible, we could think about giving these classes new names, but since they are so fundamentally rooted with the `deal.II` library a lot of users wouldn't be happy about (and we would need to change a lot of tutorial programs for this).

So I propose to go a different route: Create a new namespace `DoFHandlerTypeLegacy` (name open for discussion) which features the old interface to which user can fall back, and provide the affected classes with the new `spacedim` argument.

We may split this over two releases: In the next release, we would introduce the legacy namespace and warn users about the upcoming change in the changelog. For the succeeding release, we would actually change the template arguments. What do you think?