### PR TITLE
Use EvaluatorTensorProduct in Simplex code path

### DIFF
--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -625,6 +625,21 @@ namespace internal
              ExcDimensionMismatch(shape_hessians.size(), n_rows * n_columns));
     }
 
+    /**
+     * Constructor, taking the data from ShapeInfo
+     */
+    EvaluatorTensorProduct(const Number2 *    shape_values,
+                           const Number2 *    shape_gradients,
+                           const Number2 *    shape_hessians,
+                           const unsigned int n_rows,
+                           const unsigned int n_columns)
+      : shape_values(shape_values)
+      , shape_gradients(shape_gradients)
+      , shape_hessians(shape_hessians)
+      , n_rows(n_rows)
+      , n_columns(n_columns)
+    {}
+
     template <int direction, bool contract_over_rows, bool add>
     void
     values(const Number *in, Number *out) const


### PR DESCRIPTION
This PR simplifies the simplex matrix-free evaluation kernels by *misusing* `EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>` for performing a dense matrix-vector product or a transposed dense matrix-vector product. These kernels should work decently for small degrees and small number of quadrature points - as we need it for now. Once we go to higher degrees, we might  need to use different dense-matrix-vector product kernels: maybe BLAS :P 