### PR TITLE
Fix MappingQEulerian::clone()

### DIFF
--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -88,7 +88,7 @@ std::unique_ptr<Mapping<dim, spacedim>>
 MappingQEulerian<dim, VectorType, spacedim>::clone() const
 {
   return std::make_unique<MappingQEulerian<dim, VectorType, spacedim>>(
-    this->get_degree(), *euler_dof_handler, *euler_vector);
+    this->get_degree(), *euler_dof_handler, *euler_vector, this->level);
 }
 
 


### PR DESCRIPTION
Fixes the failing tests:

> mappings/mapping_q_eulerian_08.mpirun=1.debug 
mappings/mapping_q_eulerian_08.mpirun=1.release 
mappings/mapping_q_eulerian_08.mpirun=3.debug 
mappings/mapping_q_eulerian_08.mpirun=3.release

Revealed by #11209: during `MatrixFree::reinit()` a `Mapping` is inserted into a `MappingCollection`, which calls the `clone()` method.