### PR TITLE
Provide a serial implementation of ConsensusAlgorithms::Interface

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -191,6 +191,11 @@ namespace Utilities
         const MPI_Comm &comm;
 
         /**
+         * Cache if job supports MPI.
+         */
+        const bool job_supports_mpi;
+
+        /**
          * Rank of this process.
          */
         const unsigned int my_rank;
@@ -438,6 +443,29 @@ namespace Utilities
          */
         void
         clean_up_and_end_communication();
+      };
+
+      /**
+       * A serial fall back for the above classes to allow programming
+       * independently of whether MPI is used or not.
+       */
+      template <typename T1, typename T2>
+      class Serial : public Interface<T1, T2>
+      {
+      public:
+        /**
+         * Constructor.
+         *
+         * @param process Process to be run during consensus algorithm.
+         * @param comm MPI Communicator (ignored)
+         */
+        Serial(Process<T1, T2> &process, const MPI_Comm &comm);
+
+        /**
+         * @copydoc Interface::run()
+         */
+        virtual void
+        run() override;
       };
 
       /**

--- a/source/base/mpi_consensus_algorithms.cc
+++ b/source/base/mpi_consensus_algorithms.cc
@@ -29,6 +29,8 @@ namespace Utilities
 
       template class PEX<unsigned int, unsigned int>;
 
+      template class Serial<unsigned int, unsigned int>;
+
       template class Selector<unsigned int, unsigned int>;
 
 
@@ -44,6 +46,10 @@ namespace Utilities
         std::pair<types::global_dof_index, types::global_dof_index>,
         unsigned int>;
 
+      template class Serial<
+        std::pair<types::global_dof_index, types::global_dof_index>,
+        unsigned int>;
+
       template class PEX<
         std::pair<types::global_dof_index, types::global_dof_index>,
         unsigned int>;
@@ -52,6 +58,8 @@ namespace Utilities
       template class Process<types::global_dof_index, unsigned int>;
 
       template class NBX<types::global_dof_index, unsigned int>;
+
+      template class Serial<types::global_dof_index, unsigned int>;
 
       template class PEX<types::global_dof_index, unsigned int>;
 


### PR DESCRIPTION
Fixes the failing tests:

>base/mpi_noncontiguous_partitioner_02.mpirun=1.debug
base/mpi_noncontiguous_partitioner_02.mpirun=1.release
multigrid-global-coarsening/mg_transfer_a_01.mpirun=1.debug
multigrid-global-coarsening/mg_transfer_a_01.mpirun=1.release
multigrid-global-coarsening/mg_transfer_a_02.mpirun=1.debug
multigrid-global-coarsening/mg_transfer_a_02.mpirun=1.release

The check `if (this->n_procs > 1)` introduced in #11105 was not correct because there places in the library where we expect that the consensus algorithm is run even for a single process. This PR introduces a serial fall back.