### PR TITLE
Make tests/simplex/step-18 more robust

### DIFF
--- a/tests/simplex/step-18.cc
+++ b/tests/simplex/step-18.cc
@@ -669,10 +669,7 @@ namespace Step18
     assemble_system();
     deallog << " norm of rhs is " << system_rhs.l2_norm() << std::endl;
 
-    const unsigned int n_iterations = solve_linear_problem();
-
-    deallog << "    Solver converged in " << n_iterations << " iterations."
-            << std::endl;
+    solve_linear_problem();
 
     deallog << "    Updating quadrature point data..." << std::flush;
     update_quadrature_point_history();
@@ -684,6 +681,9 @@ namespace Step18
   unsigned int
   TopLevel<dim>::solve_linear_problem()
   {
+    // avoid output of iterative solver:
+    const unsigned int previous_depth = deallog.depth_file(0);
+
 #ifdef DEAL_II_WITH_PETSC
     PETScWrappers::MPI::Vector distributed_incremental_displacement(
       locally_owned_dofs, mpi_communicator);
@@ -712,6 +712,8 @@ namespace Step18
                  system_rhs,
                  PreconditionIdentity());
 #endif
+
+    deallog.depth_file(previous_depth);
 
     deallog << "norm: " << distributed_incremental_displacement.linfty_norm()
             << " " << distributed_incremental_displacement.l1_norm() << " "
@@ -1011,6 +1013,8 @@ int
 main(int argc, char **argv)
 {
   initlog();
+
+  deallog.depth_file(1);
 
   try
     {

--- a/tests/simplex/step-18.mpirun=1.with_petsc=false.with_simplex_support=on.output
+++ b/tests/simplex/step-18.mpirun=1.with_petsc=false.with_simplex_support=on.output
@@ -4,91 +4,61 @@ DEAL::  Cycle 0:
 DEAL::    Number of active cells:       1875 (by partition: 1875)
 DEAL::    Number of degrees of freedom: 1728 (by partition: 1728)
 DEAL::    Assembling system... norm of rhs is 2.45750e+10
-DEAL:cg::Starting value 1.95453e+10
-DEAL:cg::Convergence step 126 value 2.13799e-06
 DEAL::norm: 0.0800000 25.2034 1.12390
-DEAL::    Solver converged in 126 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 2 at time 2.00000
 DEAL::    Assembling system... norm of rhs is 2.49844e+10
-DEAL:cg::Starting value 2.03490e+10
-DEAL:cg::Convergence step 127 value 1.74037e-06
 DEAL::norm: 0.0800000 25.3187 1.12498
-DEAL::    Solver converged in 127 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 3 at time 3.00000
 DEAL::    Assembling system... norm of rhs is 2.54414e+10
-DEAL:cg::Starting value 2.12110e+10
-DEAL:cg::Convergence step 127 value 2.31040e-06
 DEAL::norm: 0.0800000 25.4405 1.12611
-DEAL::    Solver converged in 127 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 4 at time 4.00000
 DEAL::    Assembling system... norm of rhs is 2.59506e+10
-DEAL:cg::Starting value 2.21374e+10
-DEAL:cg::Convergence step 127 value 2.50495e-06
 DEAL::norm: 0.0800000 25.5693 1.12729
-DEAL::    Solver converged in 127 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 5 at time 5.00000
 DEAL::    Assembling system... norm of rhs is 2.65175e+10
-DEAL:cg::Starting value 2.31346e+10
-DEAL:cg::Convergence step 128 value 2.04181e-06
 DEAL::norm: 0.0800000 25.7059 1.12851
-DEAL::    Solver converged in 128 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 6 at time 6.00000
 DEAL::    Assembling system... norm of rhs is 2.71482e+10
-DEAL:cg::Starting value 2.42104e+10
-DEAL:cg::Convergence step 129 value 2.29400e-06
 DEAL::norm: 0.0800000 25.8512 1.12979
-DEAL::    Solver converged in 129 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 7 at time 7.00000
 DEAL::    Assembling system... norm of rhs is 2.78496e+10
-DEAL:cg::Starting value 2.53733e+10
-DEAL:cg::Convergence step 131 value 2.19345e-06
 DEAL::norm: 0.0800000 26.0062 1.13114
-DEAL::    Solver converged in 131 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 8 at time 8.00000
 DEAL::    Assembling system... norm of rhs is 2.86298e+10
-DEAL:cg::Starting value 2.66332e+10
-DEAL:cg::Convergence step 132 value 2.63526e-06
 DEAL::norm: 0.0800000 26.1724 1.13256
-DEAL::    Solver converged in 132 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 9 at time 9.00000
 DEAL::    Assembling system... norm of rhs is 2.94979e+10
-DEAL:cg::Starting value 2.80016e+10
-DEAL:cg::Convergence step 135 value 2.78060e-06
 DEAL::norm: 0.0800000 26.3512 1.13406
-DEAL::    Solver converged in 135 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 10 at time 10.0000
 DEAL::    Assembling system... norm of rhs is 3.04646e+10
-DEAL:cg::Starting value 2.94916e+10
-DEAL:cg::Convergence step 137 value 2.61758e-06
 DEAL::norm: 0.0800000 26.5447 1.13566
-DEAL::    Solver converged in 137 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::

--- a/tests/simplex/step-18.mpirun=1.with_petsc=true.with_simplex_support=on.output
+++ b/tests/simplex/step-18.mpirun=1.with_petsc=true.with_simplex_support=on.output
@@ -4,91 +4,61 @@ DEAL::  Cycle 0:
 DEAL::    Number of active cells:       1875 (by partition: 1875)
 DEAL::    Number of degrees of freedom: 1728 (by partition: 1728)
 DEAL::    Assembling system... norm of rhs is 6.42608e+09
-DEAL::Starting value 0.406456
-DEAL::Convergence step 49 value 2.89749e-07
 DEAL::norm: 0.0800000 25.2034 1.12390
-DEAL::    Solver converged in 49 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 2 at time 2.00000
 DEAL::    Assembling system... norm of rhs is 6.38314e+09
-DEAL::Starting value 0.413459
-DEAL::Convergence step 48 value 2.33590e-07
 DEAL::norm: 0.0800000 25.3187 1.12498
-DEAL::    Solver converged in 48 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 3 at time 3.00000
 DEAL::    Assembling system... norm of rhs is 6.34811e+09
-DEAL::Starting value 0.420747
-DEAL::Convergence step 47 value 2.56013e-07
 DEAL::norm: 0.0800000 25.4405 1.12611
-DEAL::    Solver converged in 47 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 4 at time 4.00000
 DEAL::    Assembling system... norm of rhs is 6.32248e+09
-DEAL::Starting value 0.428346
-DEAL::Convergence step 45 value 6.05128e-07
 DEAL::norm: 0.0800000 25.5693 1.12729
-DEAL::    Solver converged in 45 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 5 at time 5.00000
 DEAL::    Assembling system... norm of rhs is 6.30808e+09
-DEAL::Starting value 0.436284
-DEAL::Convergence step 45 value 1.99224e-07
 DEAL::norm: 0.0800000 25.7059 1.12851
-DEAL::    Solver converged in 45 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 6 at time 6.00000
 DEAL::    Assembling system... norm of rhs is 6.30720e+09
-DEAL::Starting value 0.444594
-DEAL::Convergence step 43 value 5.57039e-07
 DEAL::norm: 0.0800000 25.8512 1.12979
-DEAL::    Solver converged in 43 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 7 at time 7.00000
 DEAL::    Assembling system... norm of rhs is 6.32271e+09
-DEAL::Starting value 0.453310
-DEAL::Convergence step 42 value 3.35520e-07
 DEAL::norm: 0.0800000 26.0062 1.13114
-DEAL::    Solver converged in 42 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 8 at time 8.00000
 DEAL::    Assembling system... norm of rhs is 6.35827e+09
-DEAL::Starting value 0.462469
-DEAL::Convergence step 41 value 2.38274e-07
 DEAL::norm: 0.0800000 26.1724 1.13256
-DEAL::    Solver converged in 41 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 9 at time 9.00000
 DEAL::    Assembling system... norm of rhs is 6.41862e+09
-DEAL::Starting value 0.472114
-DEAL::Convergence step 40 value 2.20795e-07
 DEAL::norm: 0.0800000 26.3512 1.13406
-DEAL::    Solver converged in 40 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::
 DEAL::Timestep 10 at time 10.0000
 DEAL::    Assembling system... norm of rhs is 6.50998e+09
-DEAL::Starting value 0.482291
-DEAL::Convergence step 38 value 4.09099e-07
 DEAL::norm: 0.0800000 26.5447 1.13566
-DEAL::    Solver converged in 38 iterations.
 DEAL::    Updating quadrature point data...
 DEAL::    Moving mesh...
 DEAL::


### PR DESCRIPTION
Fixes:

> simplex/step-18.mpirun=1.debug
simplex/step-18.mpirun=1.release

Instead of printing the number of iterations, print the L2 norm of the solution.
