### PR TITLE
Vector data exchange zero vector region vector

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3797,12 +3797,8 @@ namespace internal
     void
     zero_vector_region(const unsigned int range_index, VectorType &vec) const
     {
-      if (range_index == numbers::invalid_unsigned_int)
+      if (range_index == numbers::invalid_unsigned_int || range_index == 0)
         vec = typename VectorType::value_type();
-      else
-        {
-          Assert(false, ExcNotImplemented());
-        }
     }
 
 

--- a/tests/simplex/matrix_free_01.cc
+++ b/tests/simplex/matrix_free_01.cc
@@ -18,8 +18,6 @@
 // continuous elements and compare results between matrix-free and matrix-based
 // implementations.
 
-#include <deal.II/distributed/tria.h>
-
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_tools.h>
 
@@ -54,7 +52,7 @@ template <int dim>
 class PoissonOperator
 {
 public:
-  using VectorType = LinearAlgebra::distributed::Vector<double>;
+  using VectorType = Vector<double>;
 
   PoissonOperator(const MatrixFree<dim, double> &matrix_free,
                   const bool                     do_helmholtz)
@@ -179,7 +177,7 @@ test(const unsigned int degree, const bool do_helmholtz)
 
     PoissonOperator<dim> poisson_operator(matrix_free, do_helmholtz);
 
-    LinearAlgebra::distributed::Vector<double> x, b;
+    Vector<double> x, b;
     poisson_operator.initialize_dof_vector(x);
     poisson_operator.initialize_dof_vector(b);
 


### PR DESCRIPTION
While working on #11167, I had problem with using a serial vector. The error message was: 
```
5127: --------------------------------------------------------
5127: An error occurred in line <3804> of file </home/munch/sw-index/dealii/include/deal.II/matrix_free/matrix_free.h> in function
5127:     void dealii::internal::VectorDataExchange<dim, Number, VectorizedArrayType>::zero_vector_region(unsigned int, VectorType&) const [with VectorType = dealii::Vector<double>; typename std::enable_if<(! dealii::internal::has_exchange_on_subset<VectorType>::value), VectorType>::type* <anonymous> = 0; typename VectorType::value_type* <anonymous> = 0; int dim = 2; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 8>]
5127: The violated condition was: 
5127:     false
5127: Additional information: 
5127:     You are trying to use functionality in deal.II that is currently not implemented. In many cases, this indicates that there simply didn't appear much of a need for it, or that the author of the original code did not have the time to implement a particular case. If you hit this exception, it is therefore worth the time to look into the code to find out whether you may be able to implement the missing functionality. If you do, please consider providing a patch to the deal.II development sources (see the deal.II website on how to contribute).
5127: --------------------------------------------------------
```
It turned out the code path went via:

https://github.com/dealii/dealii/blob/05340618b4b908cfd70c20ee710ef182bcbc9c2f/source/matrix_free/task_info.cc#L606

Since the values only have to to set once (for `range_index=0`) and `range_index=-1` is already used in the threaded case:

https://github.com/dealii/dealii/blob/05340618b4b908cfd70c20ee710ef182bcbc9c2f/source/matrix_free/task_info.cc#L355

I think the function should accept all numbers but only zero out for -1 and 0. 

Note: Only the last commit is relevant.