### PR TITLE
Avoid using 'import' as function name in internal interfaces.

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -99,7 +99,7 @@ namespace LinearAlgebra
         {}
 
         static void
-        import(
+        import_elements(
           const ::dealii::LinearAlgebra::ReadWriteVector<Number> & /*V*/,
           ::dealii::VectorOperation::values /*operation*/,
           const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner> &
@@ -247,7 +247,7 @@ namespace LinearAlgebra
         }
 
         static void
-        import(
+        import_elements(
           const ::dealii::LinearAlgebra::ReadWriteVector<Number> &V,
           ::dealii::VectorOperation::values                       operation,
           const std::shared_ptr<const ::dealii::Utilities::MPI::Partitioner>
@@ -354,13 +354,15 @@ namespace LinearAlgebra
         }
 
         static void
-        import(const ReadWriteVector<Number> &V,
-               VectorOperation::values        operation,
-               std::shared_ptr<const Utilities::MPI::Partitioner>
-                               communication_pattern,
-               const IndexSet &locally_owned_elem,
-               ::dealii::MemorySpace::
-                 MemorySpaceData<Number, ::dealii::MemorySpace::CUDA> &data)
+        import_elements(
+          const ReadWriteVector<Number> &V,
+          VectorOperation::values        operation,
+          std::shared_ptr<const Utilities::MPI::Partitioner>
+                          communication_pattern,
+          const IndexSet &locally_owned_elem,
+          ::dealii::MemorySpace::MemorySpaceData<Number,
+                                                 ::dealii::MemorySpace::CUDA>
+            &data)
         {
           Assert(
             (operation == ::dealii::VectorOperation::add) ||
@@ -884,7 +886,7 @@ namespace LinearAlgebra
       Assert(partitioner->ghost_indices() == src.partitioner->ghost_indices(),
              ExcMessage("Ghost indices should be identical."));
       ::dealii::internal::VectorOperations::
-        functions<Number, Number, MemorySpaceType>::import(
+        functions<Number, Number, MemorySpaceType>::import_elements(
           thread_loop_partitioner, allocated_size, operation, src.data, data);
     }
 

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -1639,7 +1639,7 @@ namespace internal
 
       template <typename MemorySpace2>
       static void
-      import(
+      import_elements(
         const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner> &
         /*thread_loop_partitioner*/,
         const size_type /*size*/,
@@ -1996,18 +1996,19 @@ namespace internal
 
       template <typename MemorySpace2>
       static void
-      import(const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
-               &                     thread_loop_partitioner,
-             const size_type         size,
-             VectorOperation::values operation,
-             const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
-               &v_data,
-             ::dealii::MemorySpace::MemorySpaceData<Number,
-                                                    ::dealii::MemorySpace::Host>
-               &data,
-             typename std::enable_if<
-               std::is_same<MemorySpace2, dealii::MemorySpace::Host>::value,
-               int>::type = 0)
+      import_elements(
+        const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+          &                     thread_loop_partitioner,
+        const size_type         size,
+        VectorOperation::values operation,
+        const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
+          &v_data,
+        ::dealii::MemorySpace::MemorySpaceData<Number,
+                                               ::dealii::MemorySpace::Host>
+          &data,
+        typename std::enable_if<
+          std::is_same<MemorySpace2, dealii::MemorySpace::Host>::value,
+          int>::type = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2026,18 +2027,19 @@ namespace internal
 #ifdef DEAL_II_COMPILER_CUDA_AWARE
       template <typename MemorySpace2>
       static void
-      import(const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
-               & /*thread_loop_partitioner*/,
-             const size_type         size,
-             VectorOperation::values operation,
-             const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
-               &v_data,
-             ::dealii::MemorySpace::MemorySpaceData<Number,
-                                                    ::dealii::MemorySpace::Host>
-               &data,
-             typename std::enable_if<
-               std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
-               int>::type = 0)
+      import_elements(
+        const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+          & /*thread_loop_partitioner*/,
+        const size_type         size,
+        VectorOperation::values operation,
+        const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
+          &v_data,
+        ::dealii::MemorySpace::MemorySpaceData<Number,
+                                               ::dealii::MemorySpace::Host>
+          &data,
+        typename std::enable_if<
+          std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
+          int>::type = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2512,18 +2514,19 @@ namespace internal
 
       template <typename MemorySpace2>
       static void
-      import(const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
-               &                     thread_loop_partitioner,
-             const size_type         size,
-             VectorOperation::values operation,
-             const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
-               &v_data,
-             ::dealii::MemorySpace::MemorySpaceData<Number,
-                                                    ::dealii::MemorySpace::CUDA>
-               &data,
-             typename std::enable_if<
-               std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
-               int>::type = 0)
+      import_elements(
+        const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+          &                     thread_loop_partitioner,
+        const size_type         size,
+        VectorOperation::values operation,
+        const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
+          &v_data,
+        ::dealii::MemorySpace::MemorySpaceData<Number,
+                                               ::dealii::MemorySpace::CUDA>
+          &data,
+        typename std::enable_if<
+          std::is_same<MemorySpace2, ::dealii::MemorySpace::CUDA>::value,
+          int>::type = 0)
       {
         if (operation == VectorOperation::insert)
           {
@@ -2541,18 +2544,19 @@ namespace internal
 
       template <typename MemorySpace2>
       static void
-      import(const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
-               & /*thread_loop_partitioner*/,
-             const size_type         size,
-             VectorOperation::values operation,
-             const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
-               &v_data,
-             ::dealii::MemorySpace::MemorySpaceData<Number,
-                                                    ::dealii::MemorySpace::CUDA>
-               &data,
-             typename std::enable_if<
-               std::is_same<MemorySpace2, ::dealii::MemorySpace::Host>::value,
-               int>::type = 0)
+      import_elements(
+        const std::shared_ptr<::dealii::parallel::internal::TBBPartitioner>
+          & /*thread_loop_partitioner*/,
+        const size_type         size,
+        VectorOperation::values operation,
+        const ::dealii::MemorySpace::MemorySpaceData<Number, MemorySpace2>
+          &v_data,
+        ::dealii::MemorySpace::MemorySpaceData<Number,
+                                               ::dealii::MemorySpace::CUDA>
+          &data,
+        typename std::enable_if<
+          std::is_same<MemorySpace2, ::dealii::MemorySpace::Host>::value,
+          int>::type = 0)
       {
         if (operation == VectorOperation::insert)
           {


### PR DESCRIPTION
See #11234 . These are functions in an `internal` namespace, so there should be no problem with renaming them.

/rebuild