### PR TITLE
Simplify some code with stuff from later C++ standards.

### DIFF
--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -32,6 +32,7 @@
 #include <cmath>
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -65,28 +66,19 @@ template <typename VectorType>
 struct IsBlockVector
 {
 private:
-  struct yes_type
-  {
-    char c[1];
-  };
-  struct no_type
-  {
-    char c[2];
-  };
-
   /**
    * Overload returning true if the class is derived from BlockVectorBase,
    * which is what block vectors do.
    */
   template <typename T>
-  static yes_type
+  static std::true_type
   check_for_block_vector(const BlockVectorBase<T> *);
 
   /**
    * Catch all for all other potential vector types that are not block
    * matrices.
    */
-  static no_type
+  static std::false_type
   check_for_block_vector(...);
 
 public:
@@ -96,8 +88,8 @@ public:
    * derived from BlockVectorBase<T>).
    */
   static const bool value =
-    (sizeof(check_for_block_vector(static_cast<VectorType *>(nullptr))) ==
-     sizeof(yes_type));
+    std::is_same<decltype(check_for_block_vector(std::declval<VectorType *>())),
+                 std::true_type>::value;
 };
 
 


### PR DESCRIPTION
No need to re-invent wheels. It would be nice if we could have used std::is_base_of,
but that doesn't work because we don't know for sure which ones of the
possible BlockVectorBase<T> classes is the right base class, given that we don't
know T.

/rebuild