### PR TITLE
Correct poor naming of a class.

### DIFF
--- a/tests/lac/is_block_matrix.cc
+++ b/tests/lac/is_block_matrix.cc
@@ -46,11 +46,12 @@ test()
           << IsBlockMatrix<BlockSparseMatrixEZ<double>>::value << ' '
           << IsBlockMatrix<BlockSparseMatrixEZ<float>>::value << std::endl;
 
-  deallog << IsBlockMatrix<SparsityPattern>::value << ' '
-          << IsBlockMatrix<DynamicSparsityPattern>::value << std::endl;
+  deallog << IsBlockSparsityPattern<SparsityPattern>::value << ' '
+          << IsBlockSparsityPattern<DynamicSparsityPattern>::value << std::endl;
 
-  deallog << IsBlockMatrix<BlockSparsityPattern>::value << ' '
-          << IsBlockMatrix<BlockDynamicSparsityPattern>::value << std::endl;
+  deallog << IsBlockSparsityPattern<BlockSparsityPattern>::value << ' '
+          << IsBlockSparsityPattern<BlockDynamicSparsityPattern>::value
+          << std::endl;
 }
 
 


### PR DESCRIPTION
Specifically, the IsBlockMatrix class was also used to ask whether a class is
a block sparsity pattern. That's poor programming style, but easy to fix by
duplicating the class.

/rebuild