### PR TITLE
Fix some typos in particle documentation

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -712,7 +712,7 @@ namespace Particles
      * Update all particles that live in cells that are ghost cells to
      * other processes. In this context, update means to update the
      * location and the properties of the ghost particles assuming that
-     * the ghost particles have not changed cells. Consquently, this will
+     * the ghost particles have not changed cells. Consequently, this will
      * not update the reference location of the particles.
      */
     void
@@ -923,7 +923,7 @@ namespace Particles
      *
      * @param [in] enable_cache Optional bool that enables updating
      * the ghost particles without rebuilding them from scratch by
-     * building a cache of type GhostParticlePartitioner which
+     * building a cache of type GhostParticlePartitioner, which
      * stores the necessary information to update the ghost particles.
      * Once this cache is built, the ghost particles can be updated
      * by a call to send_recv_particles_properties_and_location().
@@ -950,15 +950,15 @@ namespace Particles
      * GhostParticlePartitioner as a caching structure to update the particles.
      * It inherently assumes that particles cannot have changed cell.
      * All updated particles will be appended to the
-     * @p received_particles vector.
+     * @p received_particles container.
      *
      * @param [in] particles_to_send All particles for which information
      * should be sent and their new subdomain_ids are in this map.
      *
      * @param [in,out] received_particles A map with all received
-     * particles. Note that it is not required nor checked that the list
-     * is empty, received particles are simply attached to the end of
-     * the vector.
+     * particles. Note that it is not required nor checked that the container
+     * is empty, received particles are simply inserted into
+     * the map.
      *
      */
     void

--- a/include/deal.II/particles/partitioner.h
+++ b/include/deal.II/particles/partitioner.h
@@ -34,8 +34,8 @@ namespace Particles
      * This structure should only be used when one wishes to carry out work
      * using the particles without calling
      * sort_particles_into_subdomain_and_cells at every iteration. This is
-     * useful when particle-particle interaction occur at a different time
-     * scale than particle-FEM interaction.
+     * useful when particle-particle interaction occurs at a different time
+     * scale than particle-mesh interaction.
      */
     template <int dim, int spacedim>
     struct GhostParticlePartitioner
@@ -78,7 +78,7 @@ namespace Particles
        * Vector of size (neighbors.size()+1) used to store the start and the
        * end point of the data that must be received from neighbor[i] on
        * the current subdomain. For neighbor i, recv_pointers[i] indicate the
-       * beggining and reicv_pointers[i+1] indicates the end of the data that
+       * beginning and recv_pointers[i+1] indicates the end of the data that
        * must be received.
        *
        * This structure is similar to


### PR DESCRIPTION
@blaisb, @kronbichler, @peterrum: I am sorry I had no time to look at #11152, #11104, #11125, but I had a look now and it looks really cool, there may even be some things we can use in ASPECT too (e.g. check which ghost particles have actually moved and only recreate the ones that have changed cells and update the rest). I found some small typos in the documentation that are fixed in this PR. I should have more time after mid December, happy to help out with discussions or implementations.