### PR TITLE
Add new constructors to FE(Face)Evaluation

### DIFF
--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -183,8 +183,7 @@ public:
 
     matrix_free.template cell_loop<VectorType, int>(
       [&](const auto &data, auto &dst, const auto &, const auto range) {
-        const auto       i = data.get_cell_active_fe_index(range);
-        FECellIntegrator phi(matrix_free, 0, 0, 0, i, i);
+        FECellIntegrator phi(matrix_free, range);
 
         for (unsigned int cell = range.first; cell < range.second; ++cell)
           {
@@ -206,8 +205,7 @@ public:
   {
     matrix_free.template cell_loop<VectorType, VectorType>(
       [&](const auto &data, auto &dst, const auto &src, const auto range) {
-        const auto       i = data.get_cell_active_fe_index(range);
-        FECellIntegrator phi(matrix_free, 0, 0, 0, i, i);
+        FECellIntegrator phi(matrix_free, range);
 
         for (unsigned int cell = range.first; cell < range.second; ++cell)
           {


### PR DESCRIPTION
As discussed in https://github.com/dealii/dealii/pull/11260#issuecomment-734672241.

@kronbichler What do think about the proposed constructor? I am not sure about how to deal with the active quadrature index (but we could use here the same logic as in the setup routines of `MappingInfo`). This PR is orthogonal to #11260: what is common is `MatrixFree::get_cell_active_fe_index()` and `MatrixFree::get_face_active_fe_index()`. I could move these into separate PR?