### PR TITLE
Move two classes into an internal namespace.

### DIFF
--- a/doc/news/changes/incompatibilities/20201129Bangerth
+++ b/doc/news/changes/incompatibilities/20201129Bangerth
@@ -1,0 +1,8 @@
+Removed: The file `affine_constraints.h` had a class called
+`IsBlockMatrix` that, however, also allowed to check whether its
+template argument is in fact a block sparsity pattern. The class was
+likely never intended to be in the public interface, and has been
+moved to internal::AffineConstraints::IsBlockMatrix and now also
+internal::AffineConstraints::IsBlockSparsityPattern.
+<br>
+(Wolfgang Bangerth, 2020/11/29)

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2280,110 +2280,116 @@ class BlockSparsityPatternBase;
 template <typename number>
 class BlockSparseMatrixEZ;
 
-/**
- * A "traits" class that can be used to determine whether a given type is a
- * block matrix type or not. For example,
- * @code
- *   IsBlockMatrix<SparseMatrix<number> >::value
- * @endcode
- * has the value `false`, whereas
- * @code
- *   IsBlockMatrix<BlockSparseMatrix<number> >::value
- * @endcode
- * is true. This is sometimes useful in template contexts where we may want to
- * do things differently depending on whether a template type denotes a
- * regular or a block matrix type.
- *
- * @see
- * @ref GlossBlockLA "Block (linear algebra)"
- */
-template <typename MatrixType>
-struct IsBlockMatrix
+namespace internal
 {
-private:
-  /**
-   * Overload returning true if the class is derived from BlockMatrixBase,
-   * which is what block matrices do (with the exception of
-   * BlockSparseMatrixEZ).
-   */
-  template <typename T>
-  static std::true_type
-  check(const BlockMatrixBase<T> *);
+  namespace AffineConstraints
+  {
+    /**
+     * A "traits" class that can be used to determine whether a given type is a
+     * block matrix type or not. For example,
+     * @code
+     *   IsBlockMatrix<SparseMatrix<number> >::value
+     * @endcode
+     * has the value `false`, whereas
+     * @code
+     *   IsBlockMatrix<BlockSparseMatrix<number> >::value
+     * @endcode
+     * is true. This is sometimes useful in template contexts where we may want
+     * to do things differently depending on whether a template type denotes a
+     * regular or a block matrix type.
+     *
+     * @see
+     * @ref GlossBlockLA "Block (linear algebra)"
+     */
+    template <typename MatrixType>
+    struct IsBlockMatrix
+    {
+    private:
+      /**
+       * Overload returning true if the class is derived from BlockMatrixBase,
+       * which is what block matrices do (with the exception of
+       * BlockSparseMatrixEZ).
+       */
+      template <typename T>
+      static std::true_type
+      check(const BlockMatrixBase<T> *);
 
-  /**
-   * Overload for BlockSparseMatrixEZ, which is the only block matrix not
-   * derived from BlockMatrixBase at the time of writing this class.
-   */
-  template <typename T>
-  static std::true_type
-  check(const BlockSparseMatrixEZ<T> *);
+      /**
+       * Overload for BlockSparseMatrixEZ, which is the only block matrix not
+       * derived from BlockMatrixBase at the time of writing this class.
+       */
+      template <typename T>
+      static std::true_type
+      check(const BlockSparseMatrixEZ<T> *);
 
-  /**
-   * Catch all for all other potential types that are then apparently not block
-   * matrices.
-   */
-  static std::false_type
-  check(...);
+      /**
+       * Catch all for all other potential types that are then apparently not
+       * block matrices.
+       */
+      static std::false_type
+      check(...);
 
-public:
-  /**
-   * A statically computable value that indicates whether the template
-   * argument to this class is a block matrix (in fact whether the type is
-   * derived from BlockMatrixBase<T> or is one of the other block matrix
-   * types).
-   */
-  static const bool value =
-    std::is_same<decltype(check(std::declval<MatrixType *>())),
-                 std::true_type>::value;
-};
+    public:
+      /**
+       * A statically computable value that indicates whether the template
+       * argument to this class is a block matrix (in fact whether the type is
+       * derived from BlockMatrixBase<T> or is one of the other block matrix
+       * types).
+       */
+      static const bool value =
+        std::is_same<decltype(check(std::declval<MatrixType *>())),
+                     std::true_type>::value;
+    };
 
-// instantiation of the static member
-template <typename MatrixType>
-const bool IsBlockMatrix<MatrixType>::value;
+    // instantiation of the static member
+    template <typename MatrixType>
+    const bool IsBlockMatrix<MatrixType>::value;
 
 
-/**
- * A class that can be used to determine whether a given type is a block
- * sparsity pattern type or not. In this, it matches the IsBlockMatrix
- * class.
- *
- * @see
- * @ref GlossBlockLA "Block (linear algebra)"
- */
-template <typename MatrixType>
-struct IsBlockSparsityPattern
-{
-private:
-  /**
-   * Overload returning true if the class is derived from
-   * BlockSparsityPatternBase, which is what block sparsity patterns do.
-   */
-  template <typename T>
-  static std::true_type
-  check(const BlockSparsityPatternBase<T> *);
+    /**
+     * A class that can be used to determine whether a given type is a block
+     * sparsity pattern type or not. In this, it matches the IsBlockMatrix
+     * class.
+     *
+     * @see
+     * @ref GlossBlockLA "Block (linear algebra)"
+     */
+    template <typename MatrixType>
+    struct IsBlockSparsityPattern
+    {
+    private:
+      /**
+       * Overload returning true if the class is derived from
+       * BlockSparsityPatternBase, which is what block sparsity patterns do.
+       */
+      template <typename T>
+      static std::true_type
+      check(const BlockSparsityPatternBase<T> *);
 
-  /**
-   * Catch all for all other potential types that are then apparently not block
-   * sparsity patterns.
-   */
-  static std::false_type
-  check(...);
+      /**
+       * Catch all for all other potential types that are then apparently not
+       * block sparsity patterns.
+       */
+      static std::false_type
+      check(...);
 
-public:
-  /**
-   * A statically computable value that indicates whether the template
-   * argument to this class is a block sparsity pattern (in fact whether the
-   * type is derived from BlockSparsityPatternBase<T>).
-   */
-  static const bool value =
-    std::is_same<decltype(check(std::declval<MatrixType *>())),
-                 std::true_type>::value;
-};
+    public:
+      /**
+       * A statically computable value that indicates whether the template
+       * argument to this class is a block sparsity pattern (in fact whether the
+       * type is derived from BlockSparsityPatternBase<T>).
+       */
+      static const bool value =
+        std::is_same<decltype(check(std::declval<MatrixType *>())),
+                     std::true_type>::value;
+    };
 
-// instantiation of the static member
-template <typename MatrixType>
-const bool IsBlockSparsityPattern<MatrixType>::value;
+    // instantiation of the static member
+    template <typename MatrixType>
+    const bool IsBlockSparsityPattern<MatrixType>::value;
 
+  } // namespace AffineConstraints
+} // namespace internal
 
 
 template <typename number>
@@ -2404,7 +2410,9 @@ AffineConstraints<number>::distribute_local_to_global(
     global_matrix,
     dummy,
     false,
-    std::integral_constant<bool, IsBlockMatrix<MatrixType>::value>());
+    std::integral_constant<
+      bool,
+      internal::AffineConstraints::IsBlockMatrix<MatrixType>::value>());
 }
 
 
@@ -2429,7 +2437,9 @@ AffineConstraints<number>::distribute_local_to_global(
     global_matrix,
     global_vector,
     use_inhomogeneities_for_rhs,
-    std::integral_constant<bool, IsBlockMatrix<MatrixType>::value>());
+    std::integral_constant<
+      bool,
+      internal::AffineConstraints::IsBlockMatrix<MatrixType>::value>());
 }
 
 
@@ -2450,9 +2460,9 @@ AffineConstraints<number>::add_entries_local_to_global(
     sparsity_pattern,
     keep_constrained_entries,
     dof_mask,
-    std::integral_constant<
-      bool,
-      IsBlockSparsityPattern<SparsityPatternType>::value>());
+    std::integral_constant<bool,
+                           internal::AffineConstraints::IsBlockSparsityPattern<
+                             SparsityPatternType>::value>());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/tests/lac/is_block_matrix.cc
+++ b/tests/lac/is_block_matrix.cc
@@ -36,21 +36,41 @@ test()
   deallog << std::setprecision(2);
   deallog.attach(logfile);
 
-  deallog << IsBlockMatrix<SparseMatrix<double>>::value << ' '
-          << IsBlockMatrix<SparseMatrix<float>>::value << ' '
-          << IsBlockMatrix<SparseMatrixEZ<double>>::value << ' '
-          << IsBlockMatrix<SparseMatrixEZ<float>>::value << std::endl;
+  deallog
+    << internal::AffineConstraints::IsBlockMatrix<SparseMatrix<double>>::value
+    << ' '
+    << internal::AffineConstraints::IsBlockMatrix<SparseMatrix<float>>::value
+    << ' '
+    << internal::AffineConstraints::IsBlockMatrix<SparseMatrixEZ<double>>::value
+    << ' '
+    << internal::AffineConstraints::IsBlockMatrix<SparseMatrixEZ<float>>::value
+    << std::endl;
 
-  deallog << IsBlockMatrix<BlockSparseMatrix<double>>::value << ' '
-          << IsBlockMatrix<BlockSparseMatrix<float>>::value << ' '
-          << IsBlockMatrix<BlockSparseMatrixEZ<double>>::value << ' '
-          << IsBlockMatrix<BlockSparseMatrixEZ<float>>::value << std::endl;
+  deallog << internal::AffineConstraints::IsBlockMatrix<
+               BlockSparseMatrix<double>>::value
+          << ' '
+          << internal::AffineConstraints::IsBlockMatrix<
+               BlockSparseMatrix<float>>::value
+          << ' '
+          << internal::AffineConstraints::IsBlockMatrix<
+               BlockSparseMatrixEZ<double>>::value
+          << ' '
+          << internal::AffineConstraints::IsBlockMatrix<
+               BlockSparseMatrixEZ<float>>::value
+          << std::endl;
 
-  deallog << IsBlockSparsityPattern<SparsityPattern>::value << ' '
-          << IsBlockSparsityPattern<DynamicSparsityPattern>::value << std::endl;
+  deallog << internal::AffineConstraints::IsBlockSparsityPattern<
+               SparsityPattern>::value
+          << ' '
+          << internal::AffineConstraints::IsBlockSparsityPattern<
+               DynamicSparsityPattern>::value
+          << std::endl;
 
-  deallog << IsBlockSparsityPattern<BlockSparsityPattern>::value << ' '
-          << IsBlockSparsityPattern<BlockDynamicSparsityPattern>::value
+  deallog << internal::AffineConstraints::IsBlockSparsityPattern<
+               BlockSparsityPattern>::value
+          << ' '
+          << internal::AffineConstraints::IsBlockSparsityPattern<
+               BlockDynamicSparsityPattern>::value
           << std::endl;
 }
 


### PR DESCRIPTION
This is a follow-up to #11244. Move these classes into the internal namespace -- I don't think they were ever meant to be in the public namespace to begin with, given how well they were hidden in the bottom part of a file...

/rebuild