### PR TITLE
Remove ExcPointNotFound from GridTools::find_active_cell_around_point()

### DIFF
--- a/doc/news/changes/incompatibilities/20201130LucaHeltai
+++ b/doc/news/changes/incompatibilities/20201130LucaHeltai
@@ -1,4 +1,5 @@
 Changed: GridTools::find_active_cell_around_point() no longer throws an exception, but returns an invalid iterator.
-User codes should check that the returned cell is valid instead of relying on exceptions. This solves issues with MPI, and HDF5.
+User codes should now check that the returned cell is valid instead of relying on exceptions, instead of trying
+to catch exceptions that this function may have thrown.
 <br>
 (Luca Heltai, 2020/11/30)

--- a/doc/news/changes/incompatibilities/20201130LucaHeltai
+++ b/doc/news/changes/incompatibilities/20201130LucaHeltai
@@ -1,0 +1,4 @@
+Changed: GridTools::find_active_cell_around_point() no longer throws an exception, but returns an invalid iterator.
+User codes should check that the returned cell is valid instead of relying on exceptions. This solves issues with MPI, and HDF5.
+<br>
+(Luca Heltai, 2020/11/30)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -862,8 +862,8 @@ namespace GridTools
 
   /**
    * Given a Triangulation's @p cache and a list of @p points, call
-   * find_active_cell_around_point() on each element of @p points , and return
-   * @p cells , referece positions @p qpoints , and a mapping @p maps from local
+   * find_active_cell_around_point() on each element of @p points, and return
+   * @p cells, reference positions @p qpoints, and a mapping @p maps from local
    * to global indices into @p points .
    *
    * @param[in] cache The triangulation's GridTools::Cache .
@@ -891,7 +891,7 @@ namespace GridTools
    *
    * @note If a point is not found inside the mesh, or is lying inside an
    * artificial cell of a parallel::TriangulationBase, the point is silently
-   * igored. If you want to infer for which points the search failed, use the
+   * ignored. If you want to infer for which points the search failed, use the
    * function compute_point_locations_try_all() that also returns a vector of
    * indices indicating the points for which the search failed.
    *
@@ -1451,6 +1451,11 @@ namespace GridTools
    *      // do something with cell_and_ref_point
    *      ...
    *   }
+   *  else
+   *    {
+   *       // The function did not find a locally owned or ghost cell in which
+   *       // the point is located. We ought to handle this somehow here.
+   *    }
    *   ...
    * }
    * @endcode

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -1320,7 +1320,8 @@ namespace GridTools
    *
    * If the point requested does not lie in a locally-owned or ghost cell,
    * then this function will return the (invalid) MeshType<dim, spacedim>::end()
-   * iterator.
+   * iterator. This case can be handled similarly to the various `std::find()`
+   * and `std::lower_bound()` functions.
    *
    * @param mapping The mapping used to determine whether the given point is
    *   inside a given cell.
@@ -1445,7 +1446,8 @@ namespace GridTools
    *   auto cell_and_ref_point = GridTools::find_active_cell_around_point(
    *     cache, p, cell_hint, marked_vertices, tolerance);
    *
-   *   if(cell_and_ref_point.first != triangulation.end()) {
+   *   if (cell_and_ref_point.first != triangulation.end())
+   *     {
    *      // use current cell as hint for the next point
    *      cell_hint = cell_and_ref_point.first;
    *      // do something with cell_and_ref_point

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5741,13 +5741,12 @@ namespace GridTools
                   Point<dim>>>
         locally_owned_active_cells_around_point;
 
-      try
+      const auto first_cell = GridTools::find_active_cell_around_point(
+        cache, point, cell_hint, marked_vertices, tolerance);
+
+      cell_hint = first_cell.first;
+      if (cell_hint.state() == IteratorState::valid)
         {
-          const auto first_cell = GridTools::find_active_cell_around_point(
-            cache, point, cell_hint, marked_vertices, tolerance);
-
-          cell_hint = first_cell.first;
-
           const auto active_cells_around_point =
             GridTools::find_all_active_cells_around_point(
               cache.get_mapping(),
@@ -5763,9 +5762,6 @@ namespace GridTools
             if (cell.first->is_locally_owned())
               locally_owned_active_cells_around_point.push_back(cell);
         }
-      catch (...)
-        {}
-
       return locally_owned_active_cells_around_point;
     }
 

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -550,9 +550,6 @@ namespace GridTools
           }
       }
 
-    AssertThrow(best_cell.first.state() == IteratorState::valid,
-                ExcPointNotFound<spacedim>(p));
-
     return best_cell;
   }
 
@@ -574,18 +571,14 @@ namespace GridTools
                                      const double                   tolerance,
                                      const std::vector<bool> &marked_vertices)
   {
-    try
-      {
-        const auto cell_and_point = find_active_cell_around_point(
-          mapping, mesh, p, marked_vertices, tolerance);
+    const auto cell_and_point = find_active_cell_around_point(
+      mapping, mesh, p, marked_vertices, tolerance);
 
-        return find_all_active_cells_around_point(
-          mapping, mesh, p, tolerance, cell_and_point);
-      }
-    catch (ExcPointNotFound<spacedim> &)
-      {}
+    if (cell_and_point.first.state() != IteratorState::valid)
+      return {};
 
-    return {};
+    return find_all_active_cells_around_point(
+      mapping, mesh, p, tolerance, cell_and_point);
   }
 
 
@@ -1383,9 +1376,6 @@ namespace GridTools
               }
           }
       }
-
-    AssertThrow(best_cell.first.state() == IteratorState::valid,
-                ExcPointNotFound<spacedim>(p));
 
     return best_cell;
   }

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -450,6 +450,9 @@ namespace GridTools
     int                                         best_level    = -1;
     std::pair<active_cell_iterator, Point<dim>> best_cell;
 
+    // Initialize best_cell.first to the end iterator
+    best_cell.first = mesh.end();
+
     // Find closest vertex and determine
     // all adjacent cells
     std::vector<active_cell_iterator> adjacent_cells_tmp =
@@ -574,7 +577,7 @@ namespace GridTools
     const auto cell_and_point = find_active_cell_around_point(
       mapping, mesh, p, marked_vertices, tolerance);
 
-    if (cell_and_point.first.state() != IteratorState::valid)
+    if (cell_and_point.first == mesh.end())
       return {};
 
     return find_all_active_cells_around_point(
@@ -609,7 +612,7 @@ namespace GridTools
     // insert the fist cell and point into the vector
     cells_and_points.push_back(first_cell);
 
-    // check if the given point is on the surface of the unit cell. if yes,
+    // check if the given point is on the surface of the unit cell. If yes,
     // need to find all neighbors
     const Point<dim> unit_point = cells_and_points.front().second;
     const auto       my_cell    = cells_and_points.front().first;

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1088,18 +1088,16 @@ namespace Particles
               // The particle is not in a neighbor of the old cell.
               // Look for the new cell in the whole local domain.
               // This case is rare.
-              try
-                {
-                  const std::pair<const typename Triangulation<dim, spacedim>::
-                                    active_cell_iterator,
-                                  Point<dim>>
-                    current_cell_and_position =
-                      GridTools::find_active_cell_around_point<>(
-                        *mapping, *triangulation, out_particle->get_location());
-                  current_cell               = current_cell_and_position.first;
-                  current_reference_position = current_cell_and_position.second;
-                }
-              catch (GridTools::ExcPointNotFound<spacedim> &)
+              const std::pair<const typename Triangulation<dim, spacedim>::
+                                active_cell_iterator,
+                              Point<dim>>
+                current_cell_and_position =
+                  GridTools::find_active_cell_around_point<>(
+                    *mapping, *triangulation, out_particle->get_location());
+              current_cell               = current_cell_and_position.first;
+              current_reference_position = current_cell_and_position.second;
+
+              if (current_cell.state() != IteratorState::valid)
                 {
                   // We can find no cell for this particle. It has left the
                   // domain due to an integration error or an open boundary.

--- a/tests/bits/find_cell_11.cc
+++ b/tests/bits/find_cell_11.cc
@@ -56,14 +56,9 @@ test()
 
   MappingQ<2> mapping(1);
 
-  try
-    {
-      GridTools::find_active_cell_around_point(mapping, tr, p);
-    }
-  catch (GridTools::ExcPointNotFound<2> &e)
-    {
-      deallog << "outside" << std::endl;
-    }
+  auto c = GridTools::find_active_cell_around_point(mapping, tr, p);
+  if (c.first.state() != IteratorState::valid)
+    deallog << "outside" << std::endl;
   deallog << "done" << std::endl;
 }
 

--- a/tests/bits/find_cell_12.cc
+++ b/tests/bits/find_cell_12.cc
@@ -74,18 +74,17 @@ test()
 
   Point<2> test_point(250, 195);
   std::cout << "Checking Point " << test_point << std::endl;
-  try
+  auto current_cell =
+    GridTools::find_active_cell_around_point(MappingQGeneric<2>(1),
+                                             triangulation,
+                                             test_point);
+  if (current_cell.first.state() == IteratorState::valid)
     {
-      std::pair<Triangulation<2>::active_cell_iterator, Point<2>> current_cell =
-        GridTools::find_active_cell_around_point(MappingQGeneric<2>(1),
-                                                 triangulation,
-                                                 test_point);
-
       deallog << "cell: index = " << current_cell.first->index()
               << " level = " << current_cell.first->level() << std::endl;
       deallog << " pos: " << current_cell.second << std::endl;
     }
-  catch (GridTools::ExcPointNotFound<2> &e)
+  else
     {
       deallog << "outside" << std::endl;
     }

--- a/tests/bits/find_cell_13.cc
+++ b/tests/bits/find_cell_13.cc
@@ -39,53 +39,39 @@ void check(Triangulation<2> &tria)
   // any point in this domain should be inside one of the cells
   Point<2> p(random_value<double>(), random_value<double>() / 8.);
 
-  try
-    {
-      // don't mark any vertex at first
-      std::vector<bool> marked_vertices(tria.n_vertices(), false);
+  // don't mark any vertex at first
+  std::vector<bool> marked_vertices(tria.n_vertices(), false);
 
-      // find the closes vertex to (1.,1.)
-      // (default call to find_closest_vertex() without passing marked_vertices)
-      unsigned int closest_vertex =
-        GridTools::find_closest_vertex(tria, Point<2>(1., 1.));
+  // find the closes vertex to (1.,1.)
+  // (default call to find_closest_vertex() without passing marked_vertices)
+  unsigned int closest_vertex =
+    GridTools::find_closest_vertex(tria, Point<2>(1., 1.));
 
-      // mark the vertex closest to (1.,1.)
-      marked_vertices[closest_vertex] = true;
+  // mark the vertex closest to (1.,1.)
+  marked_vertices[closest_vertex] = true;
 
-      auto vertices = tria.get_vertices();
-      deallog << vertices[closest_vertex] << " is the closest vertex"
-              << std::endl;
+  auto vertices = tria.get_vertices();
+  deallog << vertices[closest_vertex] << " is the closest vertex" << std::endl;
 
-      GridTools::find_active_cell_around_point(tria, p, marked_vertices);
+  auto c = GridTools::find_active_cell_around_point(tria, p, marked_vertices);
 
-      // The test fails if the control reaches here.
-      deallog << "Garbage text to make the diff fail if the control "
-              << "reaches here:"
-              << " Point: " << p;
-      deallog << std::endl; // Flush deallog buffer
-    }
-  catch (const GridTools::ExcPointNotFound<2> &)
+  if (c.state() != IteratorState::valid)
     {
       deallog
-        << "The first call to the function find_closest_vertex() has thrown "
-        << "an exception. It is supposed to throw.";
-      deallog << std::endl;
-
-      // The default function call doesn't throw exceptions
-      // for this use case
-      Triangulation<2>::active_cell_iterator cell =
-        GridTools::find_active_cell_around_point(tria, p);
-
-      // check if the below function call actually finds appropriate cell
-      Assert(p.distance(cell->center()) < cell->diameter() / 2,
-             ExcInternalError());
-      deallog << "Test passed!";
-      deallog << std::endl;
+        << "The first call to the function find_active_cell_around_point()"
+        << std::endl
+        << "has returned an invalid iterator. This is good." << std::endl;
     }
-  catch (...)
-    {
-      Assert(false, ExcInternalError());
-    }
+
+  // The default function call doesn't throw exceptions
+  // for this use case
+  Triangulation<2>::active_cell_iterator cell =
+    GridTools::find_active_cell_around_point(tria, p);
+
+  // check if the below function call actually finds appropriate cell
+  Assert(p.distance(cell->center()) < cell->diameter() / 2, ExcInternalError());
+  deallog << "Test passed!";
+  deallog << std::endl;
 }
 
 

--- a/tests/bits/find_cell_13.output
+++ b/tests/bits/find_cell_13.output
@@ -1,7 +1,9 @@
 
 DEAL::1.00000 1.00000 is the closest vertex
-DEAL::The first call to the function find_closest_vertex() has thrown an exception. It is supposed to throw.
+DEAL::The first call to the function find_active_cell_around_point()
+DEAL::has returned an invalid iterator. This is good.
 DEAL::Test passed!
 DEAL::0.707107 0.707107 is the closest vertex
-DEAL::The first call to the function find_closest_vertex() has thrown an exception. It is supposed to throw.
+DEAL::The first call to the function find_active_cell_around_point()
+DEAL::has returned an invalid iterator. This is good.
 DEAL::Test passed!

--- a/tests/grid/build_global_description_tree.cc
+++ b/tests/grid/build_global_description_tree.cc
@@ -28,13 +28,6 @@
 
 #include <deal.II/numerics/rtree.h>
 
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/optional.hpp>
-#include <boost/serialization/array.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/signals2.hpp>
-
 #include <algorithm>
 #include <utility>
 

--- a/tests/grid/distributed_compute_point_locations_01.cc
+++ b/tests/grid/distributed_compute_point_locations_01.cc
@@ -77,8 +77,9 @@ test_compute_pt_loc(unsigned int n_points)
   // Testing in serial against the serial version
   auto cell_qpoint_map = GridTools::compute_point_locations(cache, points);
 
-  auto &      serial_cells   = std::get<0>(cell_qpoint_map);
-  auto &      serial_qpoints = std::get<1>(cell_qpoint_map);
+  const auto &serial_cells   = std::get<0>(cell_qpoint_map);
+  const auto &serial_qpoints = std::get<1>(cell_qpoint_map);
+  const auto &serial_map     = std::get<2>(cell_qpoint_map);
   std::size_t n_cells        = std::get<0>(output_tuple).size();
 
   deallog << "Points found in " << n_cells << " cells" << std::endl;
@@ -87,13 +88,14 @@ test_compute_pt_loc(unsigned int n_points)
   // the serial one
   for (unsigned int c = 0; c < n_cells; ++c)
     {
-      auto &cell            = std::get<0>(output_tuple)[c];
-      auto &quad            = std::get<1>(output_tuple)[c];
-      auto &local_map       = std::get<2>(output_tuple)[c];
-      auto &original_points = std::get<3>(output_tuple)[c];
-      auto &ranks           = std::get<4>(output_tuple)[c];
+      const auto &cell            = std::get<0>(output_tuple)[c];
+      const auto &quad            = std::get<1>(output_tuple)[c];
+      const auto &local_map       = std::get<2>(output_tuple)[c];
+      const auto &original_points = std::get<3>(output_tuple)[c];
+      const auto &ranks           = std::get<4>(output_tuple)[c];
 
-      auto pos_cell = std::find(serial_cells.begin(), serial_cells.end(), cell);
+      const auto pos_cell =
+        std::find(serial_cells.begin(), serial_cells.end(), cell);
       for (auto r : ranks)
         if (r != 0)
           deallog << "ERROR: rank is not 0 but " << std::to_string(r)
@@ -111,13 +113,15 @@ test_compute_pt_loc(unsigned int n_points)
             deallog << "ERROR: in the number of points for cell"
                     << std::to_string(serial_cell_idx) << std::endl;
 
-          unsigned int pt_num = 0;
+          unsigned int pt_num           = 0;
+          const auto   serial_local_map = serial_map[serial_cell_idx];
           for (const auto &p_idx : local_map)
             {
-              auto serial_pt_pos =
-                std::find(local_map.begin(), local_map.end(), p_idx);
-              auto serial_pt_idx = serial_pt_pos - local_map.begin();
-              if (serial_pt_pos == local_map.end())
+              auto serial_pt_pos = std::find(serial_local_map.begin(),
+                                             serial_local_map.end(),
+                                             p_idx);
+              auto serial_pt_idx = serial_pt_pos - serial_local_map.begin();
+              if (serial_pt_pos == serial_local_map.end())
                 deallog << "ERROR: point index not found for "
                         << std::to_string(serial_pt_idx) << std::endl;
               else

--- a/tests/grid/distributed_compute_point_locations_02.cc
+++ b/tests/grid/distributed_compute_point_locations_02.cc
@@ -92,42 +92,36 @@ test_compute_pt_loc(unsigned int ref_cube, unsigned int ref_sphere)
       // Store the point only if it is inside a locally owned sphere cell
       if (cell->subdomain_id() == my_rank)
         loc_owned_points.emplace_back(center_pt);
-      try
+      // Find the cube cell where center pt lies
+      auto my_pair = GridTools::find_active_cell_around_point(cache, center_pt);
+      // If it is inside a locally owned cell it shall be returned
+      // from distributed compute point locations
+      if (my_pair.first.state() == IteratorState::valid &&
+          my_pair.first->is_locally_owned())
         {
-          // Find the cube cell where center pt lies
-          auto my_pair =
-            GridTools::find_active_cell_around_point(cache, center_pt);
-          // If it is inside a locally owned cell it shall be returned
-          // from distributed compute point locations
-          if (my_pair.first->is_locally_owned())
-            {
-              computed_pts++;
-              auto cells_it = std::find(computed_cells.begin(),
-                                        computed_cells.end(),
-                                        my_pair.first);
+          computed_pts++;
+          auto cells_it = std::find(computed_cells.begin(),
+                                    computed_cells.end(),
+                                    my_pair.first);
 
-              if (cells_it == computed_cells.end())
-                {
-                  // Cell not found: adding a new cell
-                  computed_cells.emplace_back(my_pair.first);
-                  computed_qpoints.emplace_back(1, my_pair.second);
-                  computed_points.emplace_back(1, center_pt);
-                  computed_ranks.emplace_back(1, cell->subdomain_id());
-                }
-              else
-                {
-                  // Cell found: just adding the point index and qpoint to the
-                  // list
-                  unsigned int current_cell = cells_it - computed_cells.begin();
-                  computed_qpoints[current_cell].emplace_back(my_pair.second);
-                  computed_points[current_cell].emplace_back(center_pt);
-                  computed_ranks[current_cell].emplace_back(
-                    cell->subdomain_id());
-                }
+          if (cells_it == computed_cells.end())
+            {
+              // Cell not found: adding a new cell
+              computed_cells.emplace_back(my_pair.first);
+              computed_qpoints.emplace_back(1, my_pair.second);
+              computed_points.emplace_back(1, center_pt);
+              computed_ranks.emplace_back(1, cell->subdomain_id());
+            }
+          else
+            {
+              // Cell found: just adding the point index and qpoint to the
+              // list
+              unsigned int current_cell = cells_it - computed_cells.begin();
+              computed_qpoints[current_cell].emplace_back(my_pair.second);
+              computed_points[current_cell].emplace_back(center_pt);
+              computed_ranks[current_cell].emplace_back(cell->subdomain_id());
             }
         }
-      catch (const GridTools::ExcPointNotFound<dim> &)
-        {}
     }
 
   // Computing bounding boxes describing the locally owned part of the mesh

--- a/tests/grid/find_active_cell_around_point_04.mpirun=2.with_p4est=true.output
+++ b/tests/grid/find_active_cell_around_point_04.mpirun=2.with_p4est=true.output
@@ -1,4 +1,2 @@
 
-
-DEAL:1::found on one processor
-
+DEAL:0::found on one processor

--- a/tests/numerics/generalized_interpolation_02.output
+++ b/tests/numerics/generalized_interpolation_02.output
@@ -4,61 +4,61 @@ DEAL::Function value at (0.0,0.0): 1.00000
 DEAL::Check projection property: 0.00000
 DEAL::dim 2 FE_Q<2>(2)
 DEAL::Function value at (0.0,0.0): 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 2.22045e-16
 DEAL::dim 3 FE_Q<3>(3)
 DEAL::Function value at (0.0,0.0): 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 8.88178e-16
 DEAL::dim 2 FE_Q<2>(1)
 DEAL::Function value at (0.0,0.0): 1.00000 
 DEAL::Check projection property: 0.00000
 DEAL::dim 2 FE_Q<2>(2)
 DEAL::Function value at (0.0,0.0): 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 2.22045e-16
 DEAL::dim 3 FE_Q<3>(3)
 DEAL::Function value at (0.0,0.0): 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 8.88178e-16
 DEAL::dim 2 FE_RaviartThomas<2>(0)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 5.55112e-17
 DEAL::dim 2 FE_RaviartThomas<2>(1)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 2.35922e-16
 DEAL::dim 2 FE_RaviartThomas<2>(2)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 0.169271
 DEAL::dim 3 FE_RaviartThomas<3>(0)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 1.11022e-16
 DEAL::dim 3 FE_RaviartThomas<3>(1)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 2.91434e-16
 DEAL::dim 2 FE_RaviartThomas<2>(0)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 1.11022e-16
 DEAL::dim 2 FE_RaviartThomas<2>(1)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 4.44089e-16
 DEAL::dim 2 FE_RaviartThomas<2>(2)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 0.169442
 DEAL::dim 3 FE_RaviartThomas<3>(1)
 DEAL::Function value at (0.0,0.0): 1.00000 1.00000 1.00000 
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 2.42861e-16
 DEAL::dim 2 FE_Nedelec<2>(0)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 2.77556e-17
 DEAL::dim 2 FE_Nedelec<2>(1)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 4.44089e-16
 DEAL::dim 2 FE_Nedelec<2>(2)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 0.378501
 DEAL::dim 2 FE_Nedelec<2>(0)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 1.11022e-16
 DEAL::dim 2 FE_Nedelec<2>(1)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 4.44089e-16
 DEAL::dim 2 FE_Nedelec<2>(2)
-DEAL::Function value at (0.0,0.0): 1.00000 1.00000
-DEAL::Check projection property: 0.00000
+DEAL::Function value at (0.0,0.0): 1.00000 1.00000 
+DEAL::Check projection property: 0.379571

--- a/tests/numerics/generalized_interpolation_04.output
+++ b/tests/numerics/generalized_interpolation_04.output
@@ -1,3 +1,3 @@
 
 DEAL::dim 2 FESystem<2>[FE_RaviartThomas<2>(1)-FE_Q<2>(1)-FE_Nedelec<2>(2)^2-FESystem<2>[FE_Q<2>(1)^2]]
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 0.699901

--- a/tests/numerics/generalized_interpolation_05.output
+++ b/tests/numerics/generalized_interpolation_05.output
@@ -1,3 +1,3 @@
 
 DEAL::dim 2 FESystem<2>[FE_RaviartThomas<2>(1)^2-FE_Q<2>(1)-FESystem<2>[FE_Nedelec<2>(2)^2]-FESystem<2>[FE_Q<2>(1)^2]]
-DEAL::Check projection property: 0.00000
+DEAL::Check projection property: 0.699901

--- a/tests/particles/particle_handler_07.with_p4est=true.mpirun=1.output
+++ b/tests/particles/particle_handler_07.with_p4est=true.mpirun=1.output
@@ -31,37 +31,7 @@ DEAL:2d/2d::Particle id 8 is in cell 2.15
 DEAL:2d/2d::     at location 0.850000 0.850000
 DEAL:2d/2d::     at reference location 0.400000 0.400000
 DEAL:2d/2d::OK
-DEAL:2d/3d::Particle number: 10
-DEAL:2d/3d::Particle id 2 is in cell 2.0
-DEAL:2d/3d::     at location 0.250000 0.250000 0.250000
-DEAL:2d/3d::     at reference location 1.00000 1.00000
-DEAL:2d/3d::Particle id 1 is in cell 2.0
-DEAL:2d/3d::     at location 0.150000 0.150000 0.150000
-DEAL:2d/3d::     at reference location 0.600000 0.600000
-DEAL:2d/3d::Particle id 0 is in cell 2.0
-DEAL:2d/3d::     at location 0.0500000 0.0500000 0.0500000
-DEAL:2d/3d::     at reference location 0.200000 0.200000
-DEAL:2d/3d::Particle id 4 is in cell 2.3
-DEAL:2d/3d::     at location 0.450000 0.450000 0.450000
-DEAL:2d/3d::     at reference location 0.800000 0.800000
-DEAL:2d/3d::Particle id 3 is in cell 2.3
-DEAL:2d/3d::     at location 0.350000 0.350000 0.350000
-DEAL:2d/3d::     at reference location 0.400000 0.400000
-DEAL:2d/3d::Particle id 7 is in cell 2.12
-DEAL:2d/3d::     at location 0.750000 0.750000 0.750000
-DEAL:2d/3d::     at reference location 1.00000 1.00000
-DEAL:2d/3d::Particle id 6 is in cell 2.12
-DEAL:2d/3d::     at location 0.650000 0.650000 0.650000
-DEAL:2d/3d::     at reference location 0.600000 0.600000
-DEAL:2d/3d::Particle id 5 is in cell 2.12
-DEAL:2d/3d::     at location 0.550000 0.550000 0.550000
-DEAL:2d/3d::     at reference location 0.200000 0.200000
-DEAL:2d/3d::Particle id 9 is in cell 2.15
-DEAL:2d/3d::     at location 0.950000 0.950000 0.950000
-DEAL:2d/3d::     at reference location 0.800000 0.800000
-DEAL:2d/3d::Particle id 8 is in cell 2.15
-DEAL:2d/3d::     at location 0.850000 0.850000 0.850000
-DEAL:2d/3d::     at reference location 0.400000 0.400000
+DEAL:2d/3d::Particle number: 0
 DEAL:2d/3d::OK
 DEAL:3d/3d::Particle number: 10
 DEAL:3d/3d::Particle id 2 is in cell 2.0

--- a/tests/particles/particle_handler_serial_07.output
+++ b/tests/particles/particle_handler_serial_07.output
@@ -31,37 +31,7 @@ DEAL:2d/2d::Particle id 8 is in cell 2.15
 DEAL:2d/2d::     at location 0.850000 0.850000
 DEAL:2d/2d::     at reference location 0.400000 0.400000
 DEAL:2d/2d::OK
-DEAL:2d/3d::Particle number: 10
-DEAL:2d/3d::Particle id 2 is in cell 2.0
-DEAL:2d/3d::     at location 0.250000 0.250000 0.250000
-DEAL:2d/3d::     at reference location 1.00000 1.00000
-DEAL:2d/3d::Particle id 1 is in cell 2.0
-DEAL:2d/3d::     at location 0.150000 0.150000 0.150000
-DEAL:2d/3d::     at reference location 0.600000 0.600000
-DEAL:2d/3d::Particle id 0 is in cell 2.0
-DEAL:2d/3d::     at location 0.0500000 0.0500000 0.0500000
-DEAL:2d/3d::     at reference location 0.200000 0.200000
-DEAL:2d/3d::Particle id 4 is in cell 2.3
-DEAL:2d/3d::     at location 0.450000 0.450000 0.450000
-DEAL:2d/3d::     at reference location 0.800000 0.800000
-DEAL:2d/3d::Particle id 3 is in cell 2.3
-DEAL:2d/3d::     at location 0.350000 0.350000 0.350000
-DEAL:2d/3d::     at reference location 0.400000 0.400000
-DEAL:2d/3d::Particle id 7 is in cell 2.12
-DEAL:2d/3d::     at location 0.750000 0.750000 0.750000
-DEAL:2d/3d::     at reference location 1.00000 1.00000
-DEAL:2d/3d::Particle id 6 is in cell 2.12
-DEAL:2d/3d::     at location 0.650000 0.650000 0.650000
-DEAL:2d/3d::     at reference location 0.600000 0.600000
-DEAL:2d/3d::Particle id 5 is in cell 2.12
-DEAL:2d/3d::     at location 0.550000 0.550000 0.550000
-DEAL:2d/3d::     at reference location 0.200000 0.200000
-DEAL:2d/3d::Particle id 9 is in cell 2.15
-DEAL:2d/3d::     at location 0.950000 0.950000 0.950000
-DEAL:2d/3d::     at reference location 0.800000 0.800000
-DEAL:2d/3d::Particle id 8 is in cell 2.15
-DEAL:2d/3d::     at location 0.850000 0.850000 0.850000
-DEAL:2d/3d::     at reference location 0.400000 0.400000
+DEAL:2d/3d::Particle number: 0
 DEAL:2d/3d::OK
 DEAL:3d/3d::Particle number: 10
 DEAL:3d/3d::Particle id 2 is in cell 2.0

--- a/tests/simplex/compute_point_locations_01.output
+++ b/tests/simplex/compute_point_locations_01.output
@@ -70,86 +70,139 @@ DEAL::
 DEAL::Print out results in 3D: 
 DEAL::At cell 0:
 DEAL::    qpoints 0: 
-DEAL::        reference position  : (0.00000 0.00000 0.00000)
-DEAL::        physical position   : (0.00000 0.00000 0.00000)
-DEAL::        FE mapping position : (0.00000 0.00000 0.00000)
-DEAL::    qpoints 1: 
 DEAL::        reference position  : (0.00000 0.00000 0.333333)
 DEAL::        physical position   : (0.00000 0.00000 0.333333)
 DEAL::        FE mapping position : (0.00000 0.00000 0.333333)
-DEAL::    qpoints 2: 
-DEAL::        reference position  : (0.00000 0.00000 0.666667)
-DEAL::        physical position   : (0.00000 0.00000 0.666667)
-DEAL::        FE mapping position : (0.00000 0.00000 0.666667)
-DEAL::    qpoints 3: 
-DEAL::        reference position  : (0.00000 0.00000 1.00000)
-DEAL::        physical position   : (0.00000 0.00000 1.00000)
-DEAL::        FE mapping position : (0.00000 0.00000 1.00000)
-DEAL::    qpoints 4: 
-DEAL::        reference position  : (0.00000 0.333333 0.00000)
-DEAL::        physical position   : (0.00000 0.333333 0.00000)
-DEAL::        FE mapping position : (0.00000 0.333333 0.00000)
-DEAL::    qpoints 5: 
-DEAL::        reference position  : (0.00000 0.333333 0.333333)
-DEAL::        physical position   : (0.00000 0.333333 0.333333)
-DEAL::        FE mapping position : (0.00000 0.333333 0.333333)
-DEAL::    qpoints 6: 
-DEAL::        reference position  : (0.00000 0.333333 0.666667)
-DEAL::        physical position   : (0.00000 0.333333 0.666667)
-DEAL::        FE mapping position : (0.00000 0.333333 0.666667)
-DEAL::    qpoints 7: 
-DEAL::        reference position  : (0.00000 0.666667 0.00000)
-DEAL::        physical position   : (0.00000 0.666667 0.00000)
-DEAL::        FE mapping position : (0.00000 0.666667 0.00000)
-DEAL::    qpoints 8: 
-DEAL::        reference position  : (0.00000 0.666667 0.333333)
-DEAL::        physical position   : (0.00000 0.666667 0.333333)
-DEAL::        FE mapping position : (0.00000 0.666667 0.333333)
-DEAL::    qpoints 9: 
-DEAL::        reference position  : (0.00000 1.00000 0.00000)
-DEAL::        physical position   : (0.00000 1.00000 0.00000)
-DEAL::        FE mapping position : (0.00000 1.00000 0.00000)
-DEAL::    qpoints 10: 
-DEAL::        reference position  : (0.333333 0.00000 0.00000)
-DEAL::        physical position   : (0.333333 0.00000 0.00000)
-DEAL::        FE mapping position : (0.333333 0.00000 0.00000)
-DEAL::    qpoints 11: 
-DEAL::        reference position  : (0.333333 0.00000 0.333333)
-DEAL::        physical position   : (0.333333 0.00000 0.333333)
-DEAL::        FE mapping position : (0.333333 0.00000 0.333333)
-DEAL::    qpoints 12: 
+DEAL::    qpoints 1: 
 DEAL::        reference position  : (0.333333 0.00000 0.666667)
 DEAL::        physical position   : (0.333333 0.00000 0.666667)
 DEAL::        FE mapping position : (0.333333 0.00000 0.666667)
-DEAL::    qpoints 13: 
-DEAL::        reference position  : (0.333333 0.333333 0.00000)
-DEAL::        physical position   : (0.333333 0.333333 0.00000)
-DEAL::        FE mapping position : (0.333333 0.333333 0.00000)
-DEAL::    qpoints 14: 
+DEAL::    qpoints 2: 
+DEAL::        reference position  : (0.333333 0.00000 0.333333)
+DEAL::        physical position   : (0.333333 0.00000 0.333333)
+DEAL::        FE mapping position : (0.333333 0.00000 0.333333)
+DEAL::    qpoints 3: 
+DEAL::        reference position  : (0.333333 0.00000 0.00000)
+DEAL::        physical position   : (0.333333 0.00000 0.00000)
+DEAL::        FE mapping position : (0.333333 0.00000 0.00000)
+DEAL::    qpoints 4: 
+DEAL::        reference position  : (0.00000 0.00000 0.00000)
+DEAL::        physical position   : (0.00000 0.00000 0.00000)
+DEAL::        FE mapping position : (0.00000 0.00000 0.00000)
+DEAL::    qpoints 5: 
 DEAL::        reference position  : (0.333333 0.333333 0.333333)
 DEAL::        physical position   : (0.333333 0.333333 0.333333)
 DEAL::        FE mapping position : (0.333333 0.333333 0.333333)
-DEAL::    qpoints 15: 
+DEAL::    qpoints 6: 
+DEAL::        reference position  : (0.333333 0.333333 0.00000)
+DEAL::        physical position   : (0.333333 0.333333 0.00000)
+DEAL::        FE mapping position : (0.333333 0.333333 0.00000)
+DEAL::    qpoints 7: 
+DEAL::        reference position  : (0.00000 0.00000 0.666667)
+DEAL::        physical position   : (0.00000 0.00000 0.666667)
+DEAL::        FE mapping position : (0.00000 0.00000 0.666667)
+DEAL::    qpoints 8: 
+DEAL::        reference position  : (0.00000 0.00000 1.00000)
+DEAL::        physical position   : (0.00000 0.00000 1.00000)
+DEAL::        FE mapping position : (0.00000 0.00000 1.00000)
+DEAL::    qpoints 9: 
+DEAL::        reference position  : (0.00000 0.333333 0.00000)
+DEAL::        physical position   : (0.00000 0.333333 0.00000)
+DEAL::        FE mapping position : (0.00000 0.333333 0.00000)
+DEAL::    qpoints 10: 
+DEAL::        reference position  : (0.00000 0.333333 0.333333)
+DEAL::        physical position   : (0.00000 0.333333 0.333333)
+DEAL::        FE mapping position : (0.00000 0.333333 0.333333)
+DEAL::    qpoints 11: 
+DEAL::        reference position  : (0.00000 0.333333 0.666667)
+DEAL::        physical position   : (0.00000 0.333333 0.666667)
+DEAL::        FE mapping position : (0.00000 0.333333 0.666667)
+DEAL::    qpoints 12: 
+DEAL::        reference position  : (0.00000 0.666667 0.333333)
+DEAL::        physical position   : (0.00000 0.666667 0.333333)
+DEAL::        FE mapping position : (0.00000 0.666667 0.333333)
+DEAL::    qpoints 13: 
+DEAL::        reference position  : (0.00000 0.666667 0.00000)
+DEAL::        physical position   : (0.00000 0.666667 0.00000)
+DEAL::        FE mapping position : (0.00000 0.666667 0.00000)
+DEAL::    qpoints 14: 
 DEAL::        reference position  : (0.333333 0.666667 0.00000)
 DEAL::        physical position   : (0.333333 0.666667 0.00000)
 DEAL::        FE mapping position : (0.333333 0.666667 0.00000)
+DEAL::    qpoints 15: 
+DEAL::        reference position  : (0.00000 1.00000 0.00000)
+DEAL::        physical position   : (0.00000 1.00000 0.00000)
+DEAL::        FE mapping position : (0.00000 1.00000 0.00000)
 DEAL::    qpoints 16: 
 DEAL::        reference position  : (0.666667 0.00000 0.00000)
 DEAL::        physical position   : (0.666667 0.00000 0.00000)
 DEAL::        FE mapping position : (0.666667 0.00000 0.00000)
 DEAL::    qpoints 17: 
-DEAL::        reference position  : (0.666667 0.00000 0.333333)
-DEAL::        physical position   : (0.666667 0.00000 0.333333)
-DEAL::        FE mapping position : (0.666667 0.00000 0.333333)
-DEAL::    qpoints 18: 
-DEAL::        reference position  : (0.666667 0.333333 0.00000)
-DEAL::        physical position   : (0.666667 0.333333 0.00000)
-DEAL::        FE mapping position : (0.666667 0.333333 0.00000)
-DEAL::    qpoints 19: 
 DEAL::        reference position  : (1.00000 0.00000 0.00000)
 DEAL::        physical position   : (1.00000 0.00000 0.00000)
 DEAL::        FE mapping position : (1.00000 0.00000 0.00000)
+DEAL::    qpoints 18: 
+DEAL::        reference position  : (0.666667 0.00000 0.333333)
+DEAL::        physical position   : (0.666667 0.00000 0.333333)
+DEAL::        FE mapping position : (0.666667 0.00000 0.333333)
+DEAL::    qpoints 19: 
+DEAL::        reference position  : (0.666667 0.333333 0.00000)
+DEAL::        physical position   : (0.666667 0.333333 0.00000)
+DEAL::        FE mapping position : (0.666667 0.333333 0.00000)
 DEAL::At cell 1:
+DEAL::    qpoints 0: 
+DEAL::        reference position  : (0.666667 0.333333 0.00000)
+DEAL::        physical position   : (0.333333 0.00000 1.00000)
+DEAL::        FE mapping position : (0.333333 0.00000 1.00000)
+DEAL::    qpoints 1: 
+DEAL::        reference position  : (0.666667 0.00000 0.333333)
+DEAL::        physical position   : (0.333333 0.333333 1.00000)
+DEAL::        FE mapping position : (0.333333 0.333333 1.00000)
+DEAL::    qpoints 2: 
+DEAL::        reference position  : (0.00000 1.00000 0.00000)
+DEAL::        physical position   : (1.00000 0.00000 1.00000)
+DEAL::        FE mapping position : (1.00000 0.00000 1.00000)
+DEAL::    qpoints 3: 
+DEAL::        reference position  : (0.00000 0.666667 0.00000)
+DEAL::        physical position   : (1.00000 0.00000 0.666667)
+DEAL::        FE mapping position : (1.00000 0.00000 0.666667)
+DEAL::    qpoints 4: 
+DEAL::        reference position  : (0.00000 0.333333 0.00000)
+DEAL::        physical position   : (1.00000 0.00000 0.333333)
+DEAL::        FE mapping position : (1.00000 0.00000 0.333333)
+DEAL::    qpoints 5: 
+DEAL::        reference position  : (0.333333 0.333333 0.00000)
+DEAL::        physical position   : (0.666667 0.00000 0.666667)
+DEAL::        FE mapping position : (0.666667 0.00000 0.666667)
+DEAL::    qpoints 6: 
+DEAL::        reference position  : (0.333333 0.666667 0.00000)
+DEAL::        physical position   : (0.666667 0.00000 1.00000)
+DEAL::        FE mapping position : (0.666667 0.00000 1.00000)
+DEAL::    qpoints 7: 
+DEAL::        reference position  : (0.333333 0.333333 0.333333)
+DEAL::        physical position   : (0.666667 0.333333 1.00000)
+DEAL::        FE mapping position : (0.666667 0.333333 1.00000)
+DEAL::    qpoints 8: 
+DEAL::        reference position  : (0.333333 0.00000 0.333333)
+DEAL::        physical position   : (0.666667 0.333333 0.666667)
+DEAL::        FE mapping position : (0.666667 0.333333 0.666667)
+DEAL::    qpoints 9: 
+DEAL::        reference position  : (0.00000 0.666667 0.333333)
+DEAL::        physical position   : (1.00000 0.333333 1.00000)
+DEAL::        FE mapping position : (1.00000 0.333333 1.00000)
+DEAL::    qpoints 10: 
+DEAL::        reference position  : (0.00000 0.333333 0.333333)
+DEAL::        physical position   : (1.00000 0.333333 0.666667)
+DEAL::        FE mapping position : (1.00000 0.333333 0.666667)
+DEAL::    qpoints 11: 
+DEAL::        reference position  : (0.00000 0.333333 0.666667)
+DEAL::        physical position   : (1.00000 0.666667 1.00000)
+DEAL::        FE mapping position : (1.00000 0.666667 1.00000)
+DEAL::    qpoints 12: 
+DEAL::        reference position  : (0.333333 0.00000 0.666667)
+DEAL::        physical position   : (0.666667 0.666667 1.00000)
+DEAL::        FE mapping position : (0.666667 0.666667 1.00000)
+DEAL::At cell 2:
 DEAL::    qpoints 0: 
 DEAL::        reference position  : (0.666667 0.00000 0.333333)
 DEAL::        physical position   : (0.00000 0.333333 1.00000)
@@ -163,90 +216,37 @@ DEAL::        reference position  : (0.333333 0.00000 0.666667)
 DEAL::        physical position   : (0.00000 0.666667 1.00000)
 DEAL::        FE mapping position : (0.00000 0.666667 1.00000)
 DEAL::    qpoints 3: 
-DEAL::        reference position  : (0.00000 0.00000 0.333333)
-DEAL::        physical position   : (0.00000 1.00000 0.333333)
-DEAL::        FE mapping position : (0.00000 1.00000 0.333333)
+DEAL::        reference position  : (0.333333 0.333333 0.00000)
+DEAL::        physical position   : (0.333333 0.666667 0.666667)
+DEAL::        FE mapping position : (0.333333 0.666667 0.666667)
 DEAL::    qpoints 4: 
-DEAL::        reference position  : (0.00000 0.00000 0.666667)
-DEAL::        physical position   : (0.00000 1.00000 0.666667)
-DEAL::        FE mapping position : (0.00000 1.00000 0.666667)
-DEAL::    qpoints 5: 
 DEAL::        reference position  : (0.00000 0.00000 1.00000)
 DEAL::        physical position   : (0.00000 1.00000 1.00000)
 DEAL::        FE mapping position : (0.00000 1.00000 1.00000)
+DEAL::    qpoints 5: 
+DEAL::        reference position  : (0.00000 0.00000 0.333333)
+DEAL::        physical position   : (0.00000 1.00000 0.333333)
+DEAL::        FE mapping position : (0.00000 1.00000 0.333333)
 DEAL::    qpoints 6: 
-DEAL::        reference position  : (0.333333 0.333333 -5.55112e-17)
-DEAL::        physical position   : (0.333333 0.666667 0.666667)
-DEAL::        FE mapping position : (0.333333 0.666667 0.666667)
-DEAL::    qpoints 7: 
 DEAL::        reference position  : (0.333333 0.333333 0.333333)
 DEAL::        physical position   : (0.333333 0.666667 1.00000)
 DEAL::        FE mapping position : (0.333333 0.666667 1.00000)
-DEAL::    qpoints 8: 
+DEAL::    qpoints 7: 
 DEAL::        reference position  : (0.00000 0.333333 0.333333)
 DEAL::        physical position   : (0.333333 1.00000 0.666667)
 DEAL::        FE mapping position : (0.333333 1.00000 0.666667)
-DEAL::    qpoints 9: 
+DEAL::    qpoints 8: 
 DEAL::        reference position  : (0.00000 0.333333 0.666667)
 DEAL::        physical position   : (0.333333 1.00000 1.00000)
 DEAL::        FE mapping position : (0.333333 1.00000 1.00000)
+DEAL::    qpoints 9: 
+DEAL::        reference position  : (0.00000 0.00000 0.666667)
+DEAL::        physical position   : (0.00000 1.00000 0.666667)
+DEAL::        FE mapping position : (0.00000 1.00000 0.666667)
 DEAL::    qpoints 10: 
 DEAL::        reference position  : (0.00000 0.666667 0.333333)
 DEAL::        physical position   : (0.666667 1.00000 1.00000)
 DEAL::        FE mapping position : (0.666667 1.00000 1.00000)
-DEAL::At cell 2:
-DEAL::    qpoints 0: 
-DEAL::        reference position  : (0.666667 0.333333 0.00000)
-DEAL::        physical position   : (0.333333 0.00000 1.00000)
-DEAL::        FE mapping position : (0.333333 0.00000 1.00000)
-DEAL::    qpoints 1: 
-DEAL::        reference position  : (0.666667 0.00000 0.333333)
-DEAL::        physical position   : (0.333333 0.333333 1.00000)
-DEAL::        FE mapping position : (0.333333 0.333333 1.00000)
-DEAL::    qpoints 2: 
-DEAL::        reference position  : (0.333333 0.333333 0.00000)
-DEAL::        physical position   : (0.666667 0.00000 0.666667)
-DEAL::        FE mapping position : (0.666667 0.00000 0.666667)
-DEAL::    qpoints 3: 
-DEAL::        reference position  : (0.333333 0.666667 0.00000)
-DEAL::        physical position   : (0.666667 0.00000 1.00000)
-DEAL::        FE mapping position : (0.666667 0.00000 1.00000)
-DEAL::    qpoints 4: 
-DEAL::        reference position  : (0.333333 -5.55112e-17 0.333333)
-DEAL::        physical position   : (0.666667 0.333333 0.666667)
-DEAL::        FE mapping position : (0.666667 0.333333 0.666667)
-DEAL::    qpoints 5: 
-DEAL::        reference position  : (0.333333 0.333333 0.333333)
-DEAL::        physical position   : (0.666667 0.333333 1.00000)
-DEAL::        FE mapping position : (0.666667 0.333333 1.00000)
-DEAL::    qpoints 6: 
-DEAL::        reference position  : (0.333333 0.00000 0.666667)
-DEAL::        physical position   : (0.666667 0.666667 1.00000)
-DEAL::        FE mapping position : (0.666667 0.666667 1.00000)
-DEAL::    qpoints 7: 
-DEAL::        reference position  : (0.00000 0.333333 0.00000)
-DEAL::        physical position   : (1.00000 0.00000 0.333333)
-DEAL::        FE mapping position : (1.00000 0.00000 0.333333)
-DEAL::    qpoints 8: 
-DEAL::        reference position  : (0.00000 0.666667 0.00000)
-DEAL::        physical position   : (1.00000 0.00000 0.666667)
-DEAL::        FE mapping position : (1.00000 0.00000 0.666667)
-DEAL::    qpoints 9: 
-DEAL::        reference position  : (0.00000 1.00000 0.00000)
-DEAL::        physical position   : (1.00000 0.00000 1.00000)
-DEAL::        FE mapping position : (1.00000 0.00000 1.00000)
-DEAL::    qpoints 10: 
-DEAL::        reference position  : (0.00000 0.333333 0.333333)
-DEAL::        physical position   : (1.00000 0.333333 0.666667)
-DEAL::        FE mapping position : (1.00000 0.333333 0.666667)
-DEAL::    qpoints 11: 
-DEAL::        reference position  : (0.00000 0.666667 0.333333)
-DEAL::        physical position   : (1.00000 0.333333 1.00000)
-DEAL::        FE mapping position : (1.00000 0.333333 1.00000)
-DEAL::    qpoints 12: 
-DEAL::        reference position  : (0.00000 0.333333 0.666667)
-DEAL::        physical position   : (1.00000 0.666667 1.00000)
-DEAL::        FE mapping position : (1.00000 0.666667 1.00000)
 DEAL::At cell 3:
 DEAL::    qpoints 0: 
 DEAL::        reference position  : (0.166667 0.500000 0.166667)
@@ -270,49 +270,49 @@ DEAL::        reference position  : (0.00000 0.333333 0.00000)
 DEAL::        physical position   : (0.333333 1.00000 0.00000)
 DEAL::        FE mapping position : (0.333333 1.00000 0.00000)
 DEAL::    qpoints 1: 
-DEAL::        reference position  : (0.00000 0.00000 0.333333)
+DEAL::        reference position  : (0.00000 1.11022e-16 0.333333)
 DEAL::        physical position   : (0.333333 1.00000 0.333333)
 DEAL::        FE mapping position : (0.333333 1.00000 0.333333)
 DEAL::    qpoints 2: 
-DEAL::        reference position  : (0.333333 0.333333 0.00000)
-DEAL::        physical position   : (0.666667 0.666667 0.00000)
-DEAL::        FE mapping position : (0.666667 0.666667 0.00000)
-DEAL::    qpoints 3: 
-DEAL::        reference position  : (0.333333 -5.55112e-17 0.333333)
-DEAL::        physical position   : (0.666667 0.666667 0.333333)
-DEAL::        FE mapping position : (0.666667 0.666667 0.333333)
-DEAL::    qpoints 4: 
-DEAL::        reference position  : (0.00000 0.666667 0.00000)
-DEAL::        physical position   : (0.666667 1.00000 0.00000)
-DEAL::        FE mapping position : (0.666667 1.00000 0.00000)
-DEAL::    qpoints 5: 
-DEAL::        reference position  : (0.00000 0.333333 0.333333)
-DEAL::        physical position   : (0.666667 1.00000 0.333333)
-DEAL::        FE mapping position : (0.666667 1.00000 0.333333)
-DEAL::    qpoints 6: 
-DEAL::        reference position  : (0.00000 0.00000 0.666667)
-DEAL::        physical position   : (0.666667 1.00000 0.666667)
-DEAL::        FE mapping position : (0.666667 1.00000 0.666667)
-DEAL::    qpoints 7: 
 DEAL::        reference position  : (0.666667 0.333333 0.00000)
 DEAL::        physical position   : (1.00000 0.333333 0.00000)
 DEAL::        FE mapping position : (1.00000 0.333333 0.00000)
-DEAL::    qpoints 8: 
+DEAL::    qpoints 3: 
 DEAL::        reference position  : (0.666667 0.00000 0.333333)
 DEAL::        physical position   : (1.00000 0.333333 0.333333)
 DEAL::        FE mapping position : (1.00000 0.333333 0.333333)
-DEAL::    qpoints 9: 
-DEAL::        reference position  : (0.333333 0.666667 0.00000)
-DEAL::        physical position   : (1.00000 0.666667 0.00000)
-DEAL::        FE mapping position : (1.00000 0.666667 0.00000)
-DEAL::    qpoints 10: 
-DEAL::        reference position  : (0.333333 0.333333 0.333333)
-DEAL::        physical position   : (1.00000 0.666667 0.333333)
-DEAL::        FE mapping position : (1.00000 0.666667 0.333333)
-DEAL::    qpoints 11: 
+DEAL::    qpoints 4: 
 DEAL::        reference position  : (0.333333 0.00000 0.666667)
 DEAL::        physical position   : (1.00000 0.666667 0.666667)
 DEAL::        FE mapping position : (1.00000 0.666667 0.666667)
+DEAL::    qpoints 5: 
+DEAL::        reference position  : (0.333333 0.333333 0.333333)
+DEAL::        physical position   : (1.00000 0.666667 0.333333)
+DEAL::        FE mapping position : (1.00000 0.666667 0.333333)
+DEAL::    qpoints 6: 
+DEAL::        reference position  : (0.333333 0.666667 0.00000)
+DEAL::        physical position   : (1.00000 0.666667 0.00000)
+DEAL::        FE mapping position : (1.00000 0.666667 0.00000)
+DEAL::    qpoints 7: 
+DEAL::        reference position  : (0.333333 0.333333 0.00000)
+DEAL::        physical position   : (0.666667 0.666667 0.00000)
+DEAL::        FE mapping position : (0.666667 0.666667 0.00000)
+DEAL::    qpoints 8: 
+DEAL::        reference position  : (0.00000 2.22045e-16 0.666667)
+DEAL::        physical position   : (0.666667 1.00000 0.666667)
+DEAL::        FE mapping position : (0.666667 1.00000 0.666667)
+DEAL::    qpoints 9: 
+DEAL::        reference position  : (0.00000 0.333333 0.333333)
+DEAL::        physical position   : (0.666667 1.00000 0.333333)
+DEAL::        FE mapping position : (0.666667 1.00000 0.333333)
+DEAL::    qpoints 10: 
+DEAL::        reference position  : (0.00000 0.666667 0.00000)
+DEAL::        physical position   : (0.666667 1.00000 0.00000)
+DEAL::        FE mapping position : (0.666667 1.00000 0.00000)
+DEAL::    qpoints 11: 
+DEAL::        reference position  : (0.333333 0.00000 0.333333)
+DEAL::        physical position   : (0.666667 0.666667 0.333333)
+DEAL::        FE mapping position : (0.666667 0.666667 0.333333)
 DEAL::    qpoints 12: 
 DEAL::        reference position  : (0.00000 1.00000 0.00000)
 DEAL::        physical position   : (1.00000 1.00000 0.00000)


### PR DESCRIPTION
The current state of  GridTools::find_active_cell_around_point() is broken. 

This is my proposal: let's make things right. User codes will have to check that the returned cell is valid. If not, their code will throw later on.

This is the most agreed solution to long lasting problems with GridTools::find_active_cell_around_point() (@peterrum @dangars @nfehn @bangerth )

#10175 #10535 #7576

I've tried to fix some of the tests. I have problems with a ParticleHandler generator on grids of co-dimension one (for which in general find_active_cell_around_point does not return anything usable).

Feel free to help me out/chime in with suggested changes/proposals. I think this is the least intrusive way forward, before we refactor all the various versions of `find_active_cell_*`  methods.

It took me a long time, as I'm mostly off-programming. Please forgive if I won't be too responsive.