### PR TITLE
Deprecate classes in Legacy namespace.

### DIFF
--- a/doc/news/changes/incompatibilities/20201120Fehling
+++ b/doc/news/changes/incompatibilities/20201120Fehling
@@ -1,0 +1,26 @@
+Deprecation announcement: The template arguments of the following
+classes will change in a future release:
+<ul>
+  <li>SolutionTransfer and parallel::distributed::SolutionTransfer
+  <li>Functions::FEFieldFunction
+  <li>DataOut
+  <li>DataOut_DoFData
+  <li>DataOutFaces
+  <li>DataOutRotation
+</ul>
+To make sure your code continues to compile when upgrading deal.II to 
+the upcoming release, you need to either update the template arguments
+according to the changes made in pull request
+[#11221](https://github.com/dealii/dealii/pull/11221),
+or fall back to legacy classes introduced in Legacy
+namespaces.
+<br>
+You can achieve the latter with a *search and replace* script like the
+following made for the *bash* shell:
+@code{.sh}
+classes=(SolutionTransfer FEFieldFunction DataOut DataOut_DoFData DataOutFaces DataOutRotation)
+for c in \${classes[@]}; do
+  find /path/to/your/code -type f -exec sed -i -E "/(\w\${c}|\${c}[^<]|Particles::\${c}|^\s*(\/\/|\*))/! s/\${c}/Legacy::\${c}/g" {} \;
+done
+@endcode
+(Marc Fehling, 2020/11/20)

--- a/doc/news/changes/incompatibilities/20201120Fehling
+++ b/doc/news/changes/incompatibilities/20201120Fehling
@@ -18,9 +18,9 @@ namespaces.
 You can achieve the latter with a *search and replace* script like the
 following made for the *bash* shell:
 @code{.sh}
-classes=(SolutionTransfer FEFieldFunction DataOut DataOut_DoFData DataOutFaces DataOutRotation)
+classes=(SolutionTransfer parallel::distributed::SolutionTransfer Functions::FEFieldFunction DataOut DataOut_DoFData DataOutFaces DataOutRotation)
 for c in \${classes[@]}; do
-  find /path/to/your/code -type f -exec sed -i -E "/(\w\${c}|\${c}[^<]|Particles::\${c}|^\s*(\/\/|\*))/! s/\${c}/Legacy::\${c}/g" {} \;
+  find /path/to/your/code -type f -exec sed -i -E "/(\w\${c}|\${c}[^<]|Particles::\${c}|distributed::\${c}|^\s*(\/\/|\*))/! s/\${c}/Legacy::\${c}/g" {} \;
 done
 @endcode
 (Marc Fehling, 2020/11/20)

--- a/doc/news/changes/incompatibilities/20201120Fehling
+++ b/doc/news/changes/incompatibilities/20201120Fehling
@@ -1,22 +1,24 @@
 Deprecation announcement: The template arguments of the following
 classes will change in a future release:
 <ul>
-  <li>SolutionTransfer and parallel::distributed::SolutionTransfer
+  <li>SolutionTransfer
+  <li>parallel::distributed::SolutionTransfer
   <li>Functions::FEFieldFunction
   <li>DataOut
   <li>DataOut_DoFData
   <li>DataOutFaces
   <li>DataOutRotation
 </ul>
-To make sure your code continues to compile when upgrading deal.II to 
-the upcoming release, you need to either update the template arguments
-according to the changes made in pull request
-[#11221](https://github.com/dealii/dealii/pull/11221),
-or fall back to legacy classes introduced in Legacy
-namespaces.
-<br>
-You can achieve the latter with a *search and replace* script like the
-following made for the *bash* shell:
+If for some reason, you need a code that is compatible with deal.II
+9.3 and the subsequent release, a Legacy namespace has been introduced
+with aliases of these classes with their original interface. You can
+make the following substitutions to your code for each of the affected
+classes:
+<ul>
+  <li>X &rarr; Legacy::X
+</ul>
+To perform this substitution automatically, you may use a *search and
+replace* script like the following made for the *bash* shell:
 @code{.sh}
 classes=(SolutionTransfer parallel::distributed::SolutionTransfer Functions::FEFieldFunction DataOut DataOut_DoFData DataOutFaces DataOutRotation)
 for c in \${classes[@]}; do

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -382,13 +382,8 @@ namespace parallel
       template <int dim,
                 typename VectorType,
                 typename DoFHandlerType = DoFHandler<dim>>
-      class DEAL_II_DEPRECATED SolutionTransfer
-        : public dealii::parallel::distributed::
-            SolutionTransfer<dim, VectorType, DoFHandlerType>
-      {
-        using dealii::parallel::distributed::
-          SolutionTransfer<dim, VectorType, DoFHandlerType>::SolutionTransfer;
-      };
+      using SolutionTransfer DEAL_II_DEPRECATED = dealii::parallel::
+        distributed::SolutionTransfer<dim, VectorType, DoFHandlerType>;
     } // namespace Legacy
   }   // namespace distributed
 } // namespace parallel

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -372,8 +372,14 @@ namespace parallel
       void
       register_data_attach();
     };
+  } // namespace distributed
+} // namespace parallel
 
-    namespace Legacy
+namespace Legacy
+{
+  namespace parallel
+  {
+    namespace distributed
     {
       /**
        * @deprecated Use dealii::parallel::distributed::SolutionTransfer
@@ -384,9 +390,9 @@ namespace parallel
                 typename DoFHandlerType = DoFHandler<dim>>
       using SolutionTransfer DEAL_II_DEPRECATED = dealii::parallel::
         distributed::SolutionTransfer<dim, VectorType, DoFHandlerType>;
-    } // namespace Legacy
-  }   // namespace distributed
-} // namespace parallel
+    } // namespace distributed
+  }   // namespace parallel
+} // namespace Legacy
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -373,10 +373,25 @@ namespace parallel
       register_data_attach();
     };
 
-
-  } // namespace distributed
+    namespace Legacy
+    {
+      /**
+       * @deprecated Use dealii::parallel::distributed::SolutionTransfer
+       * without the DoFHandlerType template instead.
+       */
+      template <int dim,
+                typename VectorType,
+                typename DoFHandlerType = DoFHandler<dim>>
+      class DEAL_II_DEPRECATED SolutionTransfer
+        : public dealii::parallel::distributed::
+            SolutionTransfer<dim, VectorType, DoFHandlerType>
+      {
+        using dealii::parallel::distributed::
+          SolutionTransfer<dim, VectorType, DoFHandlerType>::SolutionTransfer;
+      };
+    } // namespace Legacy
+  }   // namespace distributed
 } // namespace parallel
-
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -388,8 +388,8 @@ namespace Legacy
       template <int dim,
                 typename VectorType,
                 typename DoFHandlerType = DoFHandler<dim>>
-      using SolutionTransfer DEAL_II_DEPRECATED = dealii::parallel::
-        distributed::SolutionTransfer<dim, VectorType, DoFHandlerType>;
+      using SolutionTransfer = dealii::parallel::distributed::
+        SolutionTransfer<dim, VectorType, DoFHandlerType>;
     } // namespace distributed
   }   // namespace parallel
 } // namespace Legacy

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -381,10 +381,6 @@ namespace Legacy
   {
     namespace distributed
     {
-      /**
-       * @deprecated Use dealii::parallel::distributed::SolutionTransfer
-       * without the DoFHandlerType template instead.
-       */
       template <int dim,
                 typename VectorType,
                 typename DoFHandlerType = DoFHandler<dim>>

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -381,11 +381,15 @@ namespace Legacy
   {
     namespace distributed
     {
+      /**
+       * @deprecated Use dealii::parallel::distributed::SolutionTransfer
+       * without the DoFHandlerType template instead.
+       */
       template <int dim,
                 typename VectorType,
                 typename DoFHandlerType = DoFHandler<dim>>
-      using SolutionTransfer = dealii::parallel::distributed::
-        SolutionTransfer<dim, VectorType, DoFHandlerType>;
+      using SolutionTransfer DEAL_II_DEPRECATED = dealii::parallel::
+        distributed::SolutionTransfer<dim, VectorType, DoFHandlerType>;
     } // namespace distributed
   }   // namespace parallel
 } // namespace Legacy

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -516,6 +516,18 @@ private:
                   const CurvedCellRegion              curved_cell_region);
 };
 
+namespace Legacy
+{
+  /**
+   * @deprecated Use dealii::DataOut without the DoFHandlerType template
+   * instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  class DEAL_II_DEPRECATED DataOut : public dealii::DataOut<dim, DoFHandlerType>
+  {
+    using dealii::DataOut<dim, DoFHandlerType>::DataOut;
+  };
+} // namespace Legacy
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -518,10 +518,6 @@ private:
 
 namespace Legacy
 {
-  /**
-   * @deprecated Use dealii::DataOut without the DoFHandlerType template
-   * instead.
-   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
   using DataOut = dealii::DataOut<dim, DoFHandlerType>;
 } // namespace Legacy

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -523,10 +523,7 @@ namespace Legacy
    * instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  class DEAL_II_DEPRECATED DataOut : public dealii::DataOut<dim, DoFHandlerType>
-  {
-    using dealii::DataOut<dim, DoFHandlerType>::DataOut;
-  };
+  using DataOut DEAL_II_DEPRECATED = dealii::DataOut<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -523,7 +523,7 @@ namespace Legacy
    * instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOut DEAL_II_DEPRECATED = dealii::DataOut<dim, DoFHandlerType>;
+  using DataOut = dealii::DataOut<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out.h
+++ b/include/deal.II/numerics/data_out.h
@@ -518,8 +518,12 @@ private:
 
 namespace Legacy
 {
+  /**
+   * @deprecated Use dealii::DataOut without the DoFHandlerType template
+   * instead.
+   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOut = dealii::DataOut<dim, DoFHandlerType>;
+  using DataOut DEAL_II_DEPRECATED = dealii::DataOut<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1243,6 +1243,23 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
         patches[i].neighbors[n] += old_n_patches;
 }
 
+namespace Legacy
+{
+  /**
+   * @deprecated Use dealii::DataOut_DoFData without the DoFHandlerType
+   * template instead.
+   */
+  template <typename DoFHandlerType,
+            int patch_dim,
+            int patch_space_dim = patch_dim>
+  class DEAL_II_DEPRECATED DataOut_DoFData
+    : public dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>
+  {
+    using dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
+      DataOut_DoFData;
+  };
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1252,7 +1252,7 @@ namespace Legacy
   template <typename DoFHandlerType,
             int patch_dim,
             int patch_space_dim = patch_dim>
-  using DataOut_DoFData DEAL_II_DEPRECATED =
+  using DataOut_DoFData =
     dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>;
 } // namespace Legacy
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1245,10 +1245,6 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
 
 namespace Legacy
 {
-  /**
-   * @deprecated Use dealii::DataOut_DoFData without the DoFHandlerType
-   * template instead.
-   */
   template <typename DoFHandlerType,
             int patch_dim,
             int patch_space_dim = patch_dim>

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1245,10 +1245,14 @@ DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::merge_patches(
 
 namespace Legacy
 {
+  /**
+   * @deprecated Use dealii::DataOut_DoFData without the DoFHandlerType
+   * template instead.
+   */
   template <typename DoFHandlerType,
             int patch_dim,
             int patch_space_dim = patch_dim>
-  using DataOut_DoFData =
+  using DataOut_DoFData DEAL_II_DEPRECATED =
     dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>;
 } // namespace Legacy
 

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1252,12 +1252,8 @@ namespace Legacy
   template <typename DoFHandlerType,
             int patch_dim,
             int patch_space_dim = patch_dim>
-  class DEAL_II_DEPRECATED DataOut_DoFData
-    : public dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>
-  {
-    using dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>::
-      DataOut_DoFData;
-  };
+  using DataOut_DoFData DEAL_II_DEPRECATED =
+    dealii::DataOut_DoFData<DoFHandlerType, patch_dim, patch_space_dim>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -250,6 +250,20 @@ private:
     DataOutBase::Patch<dimension - 1, space_dimension> &patch);
 };
 
+namespace Legacy
+{
+  /**
+   * @deprecated Use dealii::DataOutFaces without the DoFHandlerType template
+   * instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  class DEAL_II_DEPRECATED DataOutFaces
+    : public dealii::DataOutFaces<dim, DoFHandlerType>
+  {
+    using dealii::DataOutFaces<dim, DoFHandlerType>::DataOutFaces;
+  };
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -257,8 +257,7 @@ namespace Legacy
    * instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOutFaces DEAL_II_DEPRECATED =
-    dealii::DataOutFaces<dim, DoFHandlerType>;
+  using DataOutFaces = dealii::DataOutFaces<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -252,8 +252,13 @@ private:
 
 namespace Legacy
 {
+  /**
+   * @deprecated Use dealii::DataOutFaces without the DoFHandlerType template
+   * instead.
+   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOutFaces = dealii::DataOutFaces<dim, DoFHandlerType>;
+  using DataOutFaces DEAL_II_DEPRECATED =
+    dealii::DataOutFaces<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -252,10 +252,6 @@ private:
 
 namespace Legacy
 {
-  /**
-   * @deprecated Use dealii::DataOutFaces without the DoFHandlerType template
-   * instead.
-   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
   using DataOutFaces = dealii::DataOutFaces<dim, DoFHandlerType>;
 } // namespace Legacy

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -257,11 +257,8 @@ namespace Legacy
    * instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  class DEAL_II_DEPRECATED DataOutFaces
-    : public dealii::DataOutFaces<dim, DoFHandlerType>
-  {
-    using dealii::DataOutFaces<dim, DoFHandlerType>::DataOutFaces;
-  };
+  using DataOutFaces DEAL_II_DEPRECATED =
+    dealii::DataOutFaces<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -217,10 +217,6 @@ private:
 
 namespace Legacy
 {
-  /**
-   * @deprecated Use dealii::DataOutRotation without the DoFHandlerType
-   * template instead.
-   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
   using DataOutRotation = dealii::DataOutRotation<dim, DoFHandlerType>;
 } // namespace Legacy

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -222,8 +222,7 @@ namespace Legacy
    * template instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOutRotation DEAL_II_DEPRECATED =
-    dealii::DataOutRotation<dim, DoFHandlerType>;
+  using DataOutRotation = dealii::DataOutRotation<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -215,6 +215,20 @@ private:
       &my_patches);
 };
 
+namespace Legacy
+{
+  /**
+   * @deprecated Use dealii::DataOutRotation without the DoFHandlerType
+   * template instead.
+   */
+  template <int dim, typename DoFHandlerType = DoFHandler<dim>>
+  class DEAL_II_DEPRECATED DataOutRotation
+    : dealii::DataOutRotation<dim, DoFHandlerType>
+  {
+    using dealii::DataOutRotation<dim, DoFHandlerType>::DataOutRotation;
+  };
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -217,8 +217,13 @@ private:
 
 namespace Legacy
 {
+  /**
+   * @deprecated Use dealii::DataOutRotation without the DoFHandlerType
+   * template instead.
+   */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  using DataOutRotation = dealii::DataOutRotation<dim, DoFHandlerType>;
+  using DataOutRotation DEAL_II_DEPRECATED =
+    dealii::DataOutRotation<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -222,11 +222,8 @@ namespace Legacy
    * template instead.
    */
   template <int dim, typename DoFHandlerType = DoFHandler<dim>>
-  class DEAL_II_DEPRECATED DataOutRotation
-    : dealii::DataOutRotation<dim, DoFHandlerType>
-  {
-    using dealii::DataOutRotation<dim, DoFHandlerType>::DataOutRotation;
-  };
+  using DataOutRotation DEAL_II_DEPRECATED =
+    dealii::DataOutRotation<dim, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -500,7 +500,7 @@ namespace Legacy
     template <int dim,
               typename DoFHandlerType = DoFHandler<dim>,
               typename VectorType     = Vector<double>>
-    using FEFieldFunction DEAL_II_DEPRECATED =
+    using FEFieldFunction =
       dealii::Functions::FEFieldFunction<dim, DoFHandlerType, VectorType>;
   } // namespace Functions
 } // namespace Legacy

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -493,10 +493,6 @@ namespace Legacy
 {
   namespace Functions
   {
-    /**
-     * @deprecated Use dealii::Functions::FEFieldFunction without the
-     * DoFHandlerType template instead.
-     */
     template <int dim,
               typename DoFHandlerType = DoFHandler<dim>,
               typename VectorType     = Vector<double>>

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -493,10 +493,14 @@ namespace Legacy
 {
   namespace Functions
   {
+    /**
+     * @deprecated Use dealii::Functions::FEFieldFunction without the
+     * DoFHandlerType template instead.
+     */
     template <int dim,
               typename DoFHandlerType = DoFHandler<dim>,
               typename VectorType     = Vector<double>>
-    using FEFieldFunction =
+    using FEFieldFunction DEAL_II_DEPRECATED =
       dealii::Functions::FEFieldFunction<dim, DoFHandlerType, VectorType>;
   } // namespace Functions
 } // namespace Legacy

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -487,8 +487,11 @@ namespace Functions
       const typename DoFHandlerType::active_cell_iterator &cell,
       const Point<dim> &                                   point) const;
   };
+} // namespace Functions
 
-  namespace Legacy
+namespace Legacy
+{
+  namespace Functions
   {
     /**
      * @deprecated Use dealii::Functions::FEFieldFunction without the
@@ -499,8 +502,8 @@ namespace Functions
               typename VectorType     = Vector<double>>
     using FEFieldFunction DEAL_II_DEPRECATED =
       dealii::Functions::FEFieldFunction<dim, DoFHandlerType, VectorType>;
-  } // namespace Legacy
-} // namespace Functions
+  } // namespace Functions
+} // namespace Legacy
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -487,7 +487,26 @@ namespace Functions
       const typename DoFHandlerType::active_cell_iterator &cell,
       const Point<dim> &                                   point) const;
   };
+
+  namespace Legacy
+  {
+    /**
+     * @deprecated Use dealii::Functions::FEFieldFunction without the
+     * DoFHandlerType template instead.
+     */
+    template <int dim,
+              typename DoFHandlerType = DoFHandler<dim>,
+              typename VectorType     = Vector<double>>
+    class DEAL_II_DEPRECATED FEFieldFunction
+      : public dealii::Functions::
+          FEFieldFunction<dim, DoFHandlerType, VectorType>
+    {
+      using dealii::Functions::
+        FEFieldFunction<dim, DoFHandlerType, VectorType>::FEFieldFunction;
+    };
+  } // namespace Legacy
 } // namespace Functions
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/fe_field_function.h
+++ b/include/deal.II/numerics/fe_field_function.h
@@ -497,13 +497,8 @@ namespace Functions
     template <int dim,
               typename DoFHandlerType = DoFHandler<dim>,
               typename VectorType     = Vector<double>>
-    class DEAL_II_DEPRECATED FEFieldFunction
-      : public dealii::Functions::
-          FEFieldFunction<dim, DoFHandlerType, VectorType>
-    {
-      using dealii::Functions::
-        FEFieldFunction<dim, DoFHandlerType, VectorType>::FEFieldFunction;
-    };
+    using FEFieldFunction DEAL_II_DEPRECATED =
+      dealii::Functions::FEFieldFunction<dim, DoFHandlerType, VectorType>;
   } // namespace Legacy
 } // namespace Functions
 

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -574,6 +574,23 @@ private:
     dof_values_on_cell;
 };
 
+namespace Legacy
+{
+  /**
+   * @deprecated Use dealii::SolutionTransfer without the DoFHandlerType
+   * template instead.
+   */
+  template <int dim,
+            typename VectorType     = Vector<double>,
+            typename DoFHandlerType = DoFHandler<dim>>
+  class DEAL_II_DEPRECATED SolutionTransfer
+    : public dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>
+  {
+    using dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>::
+      SolutionTransfer;
+  };
+} // namespace Legacy
+
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -583,7 +583,7 @@ namespace Legacy
   template <int dim,
             typename VectorType     = Vector<double>,
             typename DoFHandlerType = DoFHandler<dim>>
-  using SolutionTransfer DEAL_II_DEPRECATED =
+  using SolutionTransfer =
     dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>;
 } // namespace Legacy
 

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -576,10 +576,6 @@ private:
 
 namespace Legacy
 {
-  /**
-   * @deprecated Use dealii::SolutionTransfer without the DoFHandlerType
-   * template instead.
-   */
   template <int dim,
             typename VectorType     = Vector<double>,
             typename DoFHandlerType = DoFHandler<dim>>

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -576,10 +576,14 @@ private:
 
 namespace Legacy
 {
+  /**
+   * @deprecated Use dealii::SolutionTransfer without the DoFHandlerType
+   * template instead.
+   */
   template <int dim,
             typename VectorType     = Vector<double>,
             typename DoFHandlerType = DoFHandler<dim>>
-  using SolutionTransfer =
+  using SolutionTransfer DEAL_II_DEPRECATED =
     dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>;
 } // namespace Legacy
 

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -583,12 +583,8 @@ namespace Legacy
   template <int dim,
             typename VectorType     = Vector<double>,
             typename DoFHandlerType = DoFHandler<dim>>
-  class DEAL_II_DEPRECATED SolutionTransfer
-    : public dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>
-  {
-    using dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>::
-      SolutionTransfer;
-  };
+  using SolutionTransfer DEAL_II_DEPRECATED =
+    dealii::SolutionTransfer<dim, VectorType, DoFHandlerType>;
 } // namespace Legacy
 
 

--- a/source/numerics/fe_field_function.cc
+++ b/source/numerics/fe_field_function.cc
@@ -33,9 +33,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-namespace Functions
-{
+
 #include "fe_field_function.inst"
-}
+
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/numerics/fe_field_function.inst.in
+++ b/source/numerics/fe_field_function.inst.in
@@ -18,7 +18,10 @@
 for (DoFHandler : DOFHANDLER_TEMPLATES; VECTOR : VECTOR_TYPES;
      deal_II_dimension : DIMENSIONS)
   {
-    template class FEFieldFunction<deal_II_dimension,
-                                   DoFHandler<deal_II_dimension>,
-                                   VECTOR>;
+    namespace Functions
+    \{
+      template class FEFieldFunction<deal_II_dimension,
+                                     DoFHandler<deal_II_dimension>,
+                                     VECTOR>;
+    \}
   }


### PR DESCRIPTION
Part of #10333, #11222. Blocked by #11220.

For the subsequent release, we would like to deprecate the classes in the `Legacy` namespace. This PR stays WIP until after the 9.3 release.