### PR TITLE
Better document TriaAccessor::diagonal().

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1402,9 +1402,25 @@ public:
   /**
    * Diameter of the object.
    *
-   * The diameter of an object is computed to be the largest diagonal. This is
-   * not necessarily the true diameter for objects that may use higher order
-   * mappings, but completely sufficient for most computations.
+   * The diameter of an object is computed to be the largest diagonal of the
+   * current object. If this object is a quadrilateral, then there are two
+   * such diagonal, and if it is a hexahedron, then there are four diagonals
+   * that connect "opposite" points. For triangles and tetrahedra, the function
+   * simply returns the length of the longest edge.
+   *
+   * The situation is more difficult for wedges and pyramids: For wedges, we
+   * return the length of the longest diagonal of the three quadrilateral faces
+   * or the longest edge length of the two triangular faces. For pyramids,
+   * the same principle is applied.
+   *
+   * In all of these cases, this definition of "diameter" is
+   * not necessarily the true diameter in the sense of the largest distance
+   * between points inside the object. Indeed, one can often construct objects
+   * for which it is not, though these are generally quite deformed compared to
+   * the reference shape. Furthermore, for objects that may use higher order
+   * mappings, one may have bulging faces that also create trouble for
+   * computing an exact representation of the diameter of the object. That said,
+   * the definition used above is completely sufficient for most computations.
    */
   double
   diameter() const;


### PR DESCRIPTION
@peterrum This is a follow-up to #11271 and #11284. It describes a different algorithm than the one you implemented in #11271 because, after giving this some more thought, I think that your algorithm with the 6 diagonals is not good. Think of a wedge constructed in the following way:

* Start with a very small triangle inside a large triangle.
* Then lift the small triangle up into 3d by a small amount.
* Connect the two triangles so that you have a wedge.

For this thing, the diagonals of the three quadrilaterals that connect the edges of the outer triangle to the edges of the lifted inner triangle are only about half the length of what we want to think of the diameter of the object. I think we should also include the length of the triangle edges. Would you be willing to fix this in a follow-up?

One has to apply the same kind of thinking for a pyramid later on.

/rebuild