### PR TITLE
Mark some variables as constexpr.

### DIFF
--- a/include/deal.II/base/std_cxx17/cmath.h
+++ b/include/deal.II/base/std_cxx17/cmath.h
@@ -28,11 +28,11 @@ DEAL_II_NAMESPACE_OPEN
 namespace std_cxx17
 {
 #ifndef DEAL_II_HAVE_CXX17_BESSEL_FUNCTIONS
-  double (&cyl_bessel_j)(double,
-                         double) = boost::math::cyl_bessel_j<double, double>;
-  float (&cyl_bessel_jf)(float,
-                         float)  = boost::math::cyl_bessel_j<float, float>;
-  long double (&cyl_bessel_jl)(long double, long double) =
+  constexpr double (&cyl_bessel_j)(double, double) =
+    boost::math::cyl_bessel_j<double, double>;
+  constexpr float (&cyl_bessel_jf)(float, float) =
+    boost::math::cyl_bessel_j<float, float>;
+  constexpr long double (&cyl_bessel_jl)(long double, long double) =
     boost::math::cyl_bessel_j<long double, long double>;
 #else
   using std::cyl_bessel_j;


### PR DESCRIPTION
These are global variables, and as such should not actually have been declared in
a header file without marking them as 'extern' and providing a definition in a .cc file.
If the compiler had not inlined the definitions of these variables, we would have
gotten duplicate symbol linker errors. C++11 provides us with a way around this:
mark these variables as 'constexpr', thereby avoiding the bug we currently have.

Seen while considering #11283 . @marcfehling -- FYI.

/rebuild