### PR TITLE
MatrixFree: accept shmem communicator neq MPI_COMM_SELF

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -353,9 +353,6 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
           task_info.n_procs =
             Utilities::MPI::n_mpi_processes(task_info.communicator);
 
-          Assert(additional_data.communicator_sm == MPI_COMM_SELF,
-                 ExcNotImplemented());
-
           task_info.communicator_sm = additional_data.communicator_sm;
         }
       else


### PR DESCRIPTION
I think it is time to remove this restriction.