### PR TITLE
MatrixFree: precompute subranges

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1472,32 +1472,7 @@ public:
     const unsigned int                           dof_handler_index = 0) const;
 
   /**
-   * In the hp-adaptive case, a subrange of internal faces as computed during
-   * loop() might contain internal faces with elements of different active
-   * FE indices. Use this function to compute what the subrange for a given pair
-   * of active FE indices is.
-   */
-  std::pair<unsigned int, unsigned int>
-  create_inner_face_subrange_hp_by_index(
-    const std::pair<unsigned int, unsigned int> &range,
-    const unsigned int                           fe_index_interior,
-    const unsigned int                           fe_index_exterior,
-    const unsigned int                           dof_handler_index = 0) const;
-
-  /**
-   * In the hp-adaptive case, a subrange of boundary faces as computed during
-   * loop() might contain boundary faces with elements of different active
-   * FE indices. Use this function to compute what the subrange for a given
-   * active FE indices is.
-   */
-  std::pair<unsigned int, unsigned int>
-  create_boundary_face_subrange_hp_by_index(
-    const std::pair<unsigned int, unsigned int> &range,
-    const unsigned int                           fe_index,
-    const unsigned int                           dof_handler_index = 0) const;
-
-  /**
-   * In the hp-adaptive case, return number of active_fe_indices.
+   * In the hp adaptive case, return number of active_fe_indices.
    */
   unsigned int
   n_active_fe_indices() const;
@@ -4642,49 +4617,51 @@ namespace internal
           }
     }
 
-    // Runs the assembler on interior faces. If no function is given, nothing
-    // is done
     virtual void
-    face(const std::pair<unsigned int, unsigned int> &face_range) override
+    cell(const unsigned int range_index) override
     {
-      if (face_function != nullptr && face_range.second > face_range.first)
-        for (unsigned int i = 0; i < matrix_free.n_active_fe_indices(); ++i)
-          for (unsigned int j = 0; j < matrix_free.n_active_fe_indices(); ++j)
-            {
-              const auto face_subrange =
-                matrix_free.create_inner_face_subrange_hp_by_index(face_range,
-                                                                   i,
-                                                                   j);
-
-              if (face_subrange.second <= face_subrange.first)
-                continue;
-              (container.*
-               face_function)(matrix_free, this->dst, this->src, face_subrange);
-            }
+      process_range(cell_function,
+                    matrix_free.get_task_info().cell_partition_data_hp_ptr,
+                    matrix_free.get_task_info().cell_partition_data_hp,
+                    range_index);
     }
 
-    // Runs the assembler on boundary faces. If no function is given, nothing
-    // is done
     virtual void
-    boundary(const std::pair<unsigned int, unsigned int> &face_range) override
+    face(const unsigned int range_index) override
     {
-      if (boundary_function != nullptr && face_range.second > face_range.first)
-        for (unsigned int i = 0; i < matrix_free.n_active_fe_indices(); ++i)
-          {
-            const auto face_subrange =
-              matrix_free.create_boundary_face_subrange_hp_by_index(face_range,
-                                                                    i);
-
-            if (face_subrange.second <= face_subrange.first)
-              continue;
-
-            (container.*boundary_function)(matrix_free,
-                                           this->dst,
-                                           this->src,
-                                           face_subrange);
-          }
+      process_range(face_function,
+                    matrix_free.get_task_info().face_partition_data_hp_ptr,
+                    matrix_free.get_task_info().face_partition_data_hp,
+                    range_index);
     }
 
+    virtual void
+    boundary(const unsigned int range_index) override
+    {
+      process_range(boundary_function,
+                    matrix_free.get_task_info().boundary_partition_data_hp_ptr,
+                    matrix_free.get_task_info().boundary_partition_data_hp,
+                    range_index);
+    }
+
+  private:
+    void
+    process_range(const function_type &            fu,
+                  const std::vector<unsigned int> &ptr,
+                  const std::vector<unsigned int> &data,
+                  const unsigned int               range_index)
+    {
+      if (fu == nullptr)
+        return;
+
+      for (unsigned int i = ptr[range_index]; i < ptr[range_index + 1]; ++i)
+        (container.*fu)(matrix_free,
+                        this->dst,
+                        this->src,
+                        std::make_pair(data[2 * i], data[2 * i + 1]));
+    }
+
+  public:
     // Starts the communication for the update ghost values operation. We
     // cannot call this update if ghost and destination are the same because
     // that would introduce spurious entries in the destination (there is also

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -78,15 +78,20 @@ namespace internal
     virtual void
     cell(const std::pair<unsigned int, unsigned int> &cell_range) = 0;
 
+    /// Runs the cell work specified by MatrixFree::loop or
+    /// MatrixFree::cell_loop
+    virtual void
+    cell(const unsigned int range_index) = 0;
+
     /// Runs the body of the work on interior faces specified by
     /// MatrixFree::loop
     virtual void
-    face(const std::pair<unsigned int, unsigned int> &face_range) = 0;
+    face(const unsigned int range_index) = 0;
 
     /// Runs the body of the work on boundary faces specified by
     /// MatrixFree::loop
     virtual void
-    boundary(const std::pair<unsigned int, unsigned int> &face_range) = 0;
+    boundary(const unsigned int range_index) = 0;
   };
 
 
@@ -469,6 +474,19 @@ namespace internal
       std::vector<unsigned int> cell_partition_data;
 
       /**
+       * Like cell_partition_data but with precomputed subranges for each
+       * active fe index. The start and end point of a partition is given
+       * by cell_partition_data_hp_ptr.
+       */
+      std::vector<unsigned int> cell_partition_data_hp;
+
+      /**
+       * Pointers within cell_partition_data_hp, indicating the start and end
+       * of a partition.
+       */
+      std::vector<unsigned int> cell_partition_data_hp_ptr;
+
+      /**
        * This is a linear storage of all partitions of inner faces, building a
        * range of indices of the form face_partition_data[idx] to
        * face_partition_data[idx+1] within the integer list of all interior
@@ -478,6 +496,19 @@ namespace internal
       std::vector<unsigned int> face_partition_data;
 
       /**
+       * Like face_partition_data but with precomputed subranges for each
+       * active fe index pair. The start and end point of a partition is given
+       * by face_partition_data_hp_ptr.
+       */
+      std::vector<unsigned int> face_partition_data_hp;
+
+      /**
+       * Pointers within face_partition_data_hp, indicating the start and end
+       * of a partition.
+       */
+      std::vector<unsigned int> face_partition_data_hp_ptr;
+
+      /**
        * This is a linear storage of all partitions of boundary faces,
        * building a range of indices of the form boundary_partition_data[idx]
        * to boundary_partition_data[idx+1] within the integer list of all
@@ -485,6 +516,19 @@ namespace internal
        * partition_row_index.
        */
       std::vector<unsigned int> boundary_partition_data;
+
+      /**
+       * Like boundary_partition_data but with precomputed subranges for each
+       * active fe index. The start and end point of a partition is given
+       * by boundary_partition_data_hp_ptr.
+       */
+      std::vector<unsigned int> boundary_partition_data_hp;
+
+      /**
+       * Pointers within boundary_partition_data_hp, indicating the start and
+       * end of a partition.
+       */
+      std::vector<unsigned int> boundary_partition_data_hp_ptr;
 
       /**
        * This is a linear storage of all partitions of interior faces on

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -77,19 +77,12 @@ namespace internal
           MFWorkerInterface *used_worker =
             worker != nullptr ? worker : *worker_pointer;
           Assert(used_worker != nullptr, ExcInternalError());
-          used_worker->cell(
-            std::make_pair(task_info.cell_partition_data[partition],
-                           task_info.cell_partition_data[partition + 1]));
+          used_worker->cell(partition);
 
           if (task_info.face_partition_data.empty() == false)
             {
-              used_worker->face(
-                std::make_pair(task_info.face_partition_data[partition],
-                               task_info.face_partition_data[partition + 1]));
-
-              used_worker->boundary(std::make_pair(
-                task_info.boundary_partition_data[partition],
-                task_info.boundary_partition_data[partition + 1]));
+              used_worker->face(partition);
+              used_worker->boundary(partition);
             }
         }
 
@@ -607,20 +600,16 @@ namespace internal
                   AssertIndexRange(i + 1, cell_partition_data.size());
                   if (cell_partition_data[i + 1] > cell_partition_data[i])
                     {
-                      funct.cell(std::make_pair(cell_partition_data[i],
-                                                cell_partition_data[i + 1]));
+                      funct.cell(i);
                     }
 
                   if (face_partition_data.empty() == false)
                     {
                       if (face_partition_data[i + 1] > face_partition_data[i])
-                        funct.face(std::make_pair(face_partition_data[i],
-                                                  face_partition_data[i + 1]));
+                        funct.face(i);
                       if (boundary_partition_data[i + 1] >
                           boundary_partition_data[i])
-                        funct.boundary(
-                          std::make_pair(boundary_partition_data[i],
-                                         boundary_partition_data[i + 1]));
+                        funct.boundary(i);
                     }
                   funct.cell_loop_post_range(i);
                 }


### PR DESCRIPTION
Follow-up PR to #11260. As discussed in https://github.com/dealii/dealii/pull/11260#discussion_r531150297 and https://github.com/dealii/dealii/pull/11260#discussion_r533412552, subranges should be precomputed in `MatrixFree`.