### PR TITLE
Make clear that 'throw' is not a function.

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2470,7 +2470,7 @@ namespace FETools
             // Now, just the [...]
             // part should be left.
             if (name.size() == 0 || name[0] != '[')
-              throw(std::string("Invalid first character in ") + name);
+              throw std::string("Invalid first character in ") + name;
             do
               {
                 // Erase the
@@ -2524,7 +2524,7 @@ namespace FETools
             // we actually had a ']'
             // there
             if (name.size() == 0 || name[0] != ']')
-              throw(std::string("Invalid first character in ") + name);
+              throw std::string("Invalid first character in ") + name;
             name.erase(0, 1);
             // just one more sanity check
             Assert((base_fes.size() == base_multiplicities.size()) &&
@@ -2572,7 +2572,7 @@ namespace FETools
             // or (Quadrature<1>(degree+1))
             // part should be left.
             if (name.size() == 0 || name[0] != '(')
-              throw(std::string("Invalid first character in ") + name);
+              throw std::string("Invalid first character in ") + name;
             name.erase(0, 1);
             if (name[0] != 'Q')
               {


### PR DESCRIPTION
I was looking at the fact that C++17 has removed the `throw()` specification one used to be able to attach to function declarations (the old-style equivalent of saying `noexcept`) and wondering whether we actually use that anywhere. We don't, but I found a couple of places where we throw exceptions and use a syntax that might suggest that `throw` is actually a function -- which it isn't, it's a keyword that is followed by an expression.

Make this a bit easier to read.

/rebuild