### PR TITLE
Particle property pool improvements

### DIFF
--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -51,12 +51,11 @@ namespace Particles
     , reference_location(particle.get_reference_location())
     , id(particle.get_id())
     , property_pool(particle.property_pool)
-    , properties((particle.has_properties()) ?
-                   property_pool->allocate_properties_array() :
-                   PropertyPool::invalid_handle)
+    , properties(PropertyPool::invalid_handle)
   {
     if (particle.has_properties())
       {
+        properties = property_pool->allocate_properties_array();
         const ArrayView<double> my_properties =
           property_pool->get_properties(properties);
         const ArrayView<const double> their_properties =

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -87,6 +87,7 @@ namespace Particles
   template <int dim, int spacedim>
   ParticleHandler<dim, spacedim>::ParticleHandler()
     : triangulation()
+    , mapping()
     , property_pool(std::make_unique<PropertyPool>(0))
     , particles()
     , ghost_particles()
@@ -159,6 +160,8 @@ namespace Particles
     initialize(*particle_handler.triangulation,
                *particle_handler.mapping,
                n_properties);
+    property_pool->reserve(particle_handler.particles.size() +
+                           particle_handler.ghost_particles.size());
 
     // copy static members
     global_number_of_particles = particle_handler.global_number_of_particles;
@@ -177,7 +180,6 @@ namespace Particles
     for (auto &particle : *this)
       {
         particle.set_property_pool(*property_pool);
-        particle.set_properties(from_particle->get_properties());
         ++from_particle;
       }
 
@@ -186,7 +188,6 @@ namespace Particles
          ++ghost, ++from_ghost)
       {
         ghost->set_property_pool(*property_pool);
-        ghost->set_properties(from_ghost->get_properties());
       }
   }
 
@@ -209,6 +210,11 @@ namespace Particles
   ParticleHandler<dim, spacedim>::clear_particles()
   {
     particles.clear();
+    ghost_particles.clear();
+
+    // the particle properties have already been deleted by their destructor,
+    // but the memory is still allocated. Return the memory as well.
+    property_pool->clear();
   }
 
 

--- a/tests/particles/particle_handler_18.cc
+++ b/tests/particles/particle_handler_18.cc
@@ -63,6 +63,12 @@ test()
     Particles::ParticleHandler<dim, spacedim> particle_handler_copy;
     particle_handler_copy.copy_from(particle_handler);
 
+    // Make sure the old particle handler and the property pool
+    // are cleared. This catches problems if the new particles try to access
+    // old memory addresses (this was a bug, fixed in
+    // https://github.com/dealii/dealii/pull/11314)
+    particle_handler.clear();
+
     for (const auto &particle : particle_handler_copy)
       deallog << "After copying particle id " << particle.get_id()
               << " has first property " << particle.get_properties()[0]

--- a/tests/serialization/particle_01.cc
+++ b/tests/serialization/particle_01.cc
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2010 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check and illustrate the serialization process for individual particles
+// outside a ParticleHandler class
+
+#include <deal.II/particles/particle.h>
+#include <deal.II/particles/property_pool.h>
+
+#include "serialization.h"
+
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  // save data to archive
+  std::ostringstream oss;
+  {
+    Point<spacedim> location;
+    Point<dim>      reference_location;
+
+    location[spacedim - 1]      = 0.3;
+    reference_location[dim - 1] = 0.5;
+    const unsigned int      id  = 6;
+    Particles::PropertyPool property_pool(2);
+
+    Particles::Particle<dim, spacedim> particle(location,
+                                                reference_location,
+                                                id);
+    particle.set_property_pool(property_pool);
+    particle.get_properties()[0] = 0.1;
+    particle.get_properties()[1] = 0.7;
+
+    deallog << "Before serialization particle id " << particle.get_id()
+            << " has location " << particle.get_location()
+            << ", has reference location " << particle.get_reference_location()
+            << ", and has properties " << particle.get_properties()[0] << " "
+            << particle.get_properties()[1] << std::endl;
+
+    boost::archive::text_oarchive oa(oss, boost::archive::no_header);
+    oa << particle;
+
+    // archive and stream closed when
+    // destructors are called
+  }
+  deallog << "Serialized string: " << oss.str() << std::endl;
+
+  // verify correctness of the serialization.
+  {
+    std::istringstream            iss(oss.str());
+    boost::archive::text_iarchive ia(iss, boost::archive::no_header);
+
+    Particles::PropertyPool property_pool(2);
+
+    Particles::Particle<dim, spacedim> particle;
+    particle.set_property_pool(property_pool);
+
+    ia >> particle;
+
+    deallog << "After serialization particle id " << particle.get_id()
+            << " has location " << particle.get_location()
+            << ", has reference location " << particle.get_reference_location()
+            << ", and has properties " << particle.get_properties()[0] << " "
+            << particle.get_properties()[1] << std::endl;
+  }
+
+  deallog << "OK" << std::endl << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("2d/3d");
+  test<2, 3>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/serialization/particle_01.with_p4est=true.mpirun=1.output
+++ b/tests/serialization/particle_01.with_p4est=true.mpirun=1.output
@@ -1,0 +1,19 @@
+
+DEAL:0:2d/2d::Before serialization particle id 6 has location 0.00000 0.300000, has reference location 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:2d/2d::Serialized string: 0 0 0 0 0 0 2 0 0 0.00000000000000000e+00 2.99999999999999989e-01 2 0.00000000000000000e+00 5.00000000000000000e-01 6 2 1.00000000000000006e-01 6.99999999999999956e-01
+
+DEAL:0:2d/2d::After serialization particle id 6 has location 0.00000 0.300000, has reference location 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:2d/2d::OK
+DEAL:0:2d/2d::
+DEAL:0:2d/3d::Before serialization particle id 6 has location 0.00000 0.00000 0.300000, has reference location 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:2d/3d::Serialized string: 0 0 0 0 0 0 3 0 0 0.00000000000000000e+00 0.00000000000000000e+00 2.99999999999999989e-01 0 0 0 0 2 0 0 0.00000000000000000e+00 5.00000000000000000e-01 6 2 1.00000000000000006e-01 6.99999999999999956e-01
+
+DEAL:0:2d/3d::After serialization particle id 6 has location 0.00000 0.00000 0.300000, has reference location 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:2d/3d::OK
+DEAL:0:2d/3d::
+DEAL:0:3d/3d::Before serialization particle id 6 has location 0.00000 0.00000 0.300000, has reference location 0.00000 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:3d/3d::Serialized string: 0 0 0 0 0 0 3 0 0 0.00000000000000000e+00 0.00000000000000000e+00 2.99999999999999989e-01 3 0.00000000000000000e+00 0.00000000000000000e+00 5.00000000000000000e-01 6 2 1.00000000000000006e-01 6.99999999999999956e-01
+
+DEAL:0:3d/3d::After serialization particle id 6 has location 0.00000 0.00000 0.300000, has reference location 0.00000 0.00000 0.500000, and has properties 0.100000 0.700000
+DEAL:0:3d/3d::OK
+DEAL:0:3d/3d::


### PR DESCRIPTION
This is the very first step towards #11206 and also limits the performance impact of #11059. It combines a few changes that only make sense together. It does:
1. Allocate particle properties in a common vector, instead of one array per particle. This speeds up allocation and removes the need for deallocation for every particle.
2. Instead of tracking every open handle, it only tracks handles that have been allocated and returned (i.e. they are available for reuse). It is assumed that all handles that have not been returned are still in use. To check whether all handles have been returned we can now check the number of available handles against the size of the properties vector.
3. Instead of a std::set of handles it tracks a std::vector. This offers a huge performance boost (larger than the actual allocation/deallocation itself), with the minor drawback that now it is expensive to check if a particular handle has been returned (we would need to search through the vector of available handles).

I started out only wanting to implement 1., but in my benchmark I noticed that the tracking of handles is very expensive. I used a benchmark program for the timing below that first allocates 1e7 particle properties, then iterates over them, then removes some (two times 25% of the total number to mess up the order in the available handles), then reallocate properties up to the full size of 1e7, then iterate again (to measure iteration over unsorted properties), then deallocate everything. Everything is happening in release mode. This PR is more than 10X faster than master, and it is even faster than master without tracking the handles (i.e. before #11059). It also speeds up iterating over the particle properties (as long as each particle only has a few properties and they are roughly sorted) because memory access is not longer as fragmented.

I still need to do some testing, and there are some limitations, but I do not know when I can get back to this, so I wanted to ask for opinions at this point.

Limitations:
1. ~~No way to reduce the memory allocation as of yet. The PropertyPool will require as much memory as it needed for the maximum number of particles during its lifetime, so it is not growing indefinitely, but it may get large.~~ Edit: Memory will be reduced and reallocated whenever ParticleHandler::clear_particles is called.
2. ~~I need to test serialization more.~~ Tests seem to work.
3. No way of sorting properties in order ~~after they got allocatet as of yet~~ except for copying the whole particle handler or during mesh refinement.

Master:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      41.5s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Property allocation             |         1 |      19.6s |        47% |
| Property deallocation 1, 25%    |         1 |      3.95s |       9.5% |
| Property deallocation 2, 18.75% |         1 |      3.09s |       7.5% |
| Property deallocation, all      |         1 |      7.51s |        18% |
| Property iteration, sorted      |         1 |     0.269s |      0.65% |
| Property iteration, unsorted    |         1 |     0.391s |      0.94% |
| Property reallocation, 43.75%   |         1 |       5.9s |        14% |
+---------------------------------+-----------+------------+------------+
```
Master without tracking the handles:
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |       5.7s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Property allocation             |         1 |       1.8s |        32% |
| Property deallocation 1, 25%    |         1 |     0.889s |        16% |
| Property deallocation 2, 18.75% |         1 |     0.882s |        15% |
| Property deallocation, all      |         1 |     0.714s |        13% |
| Property iteration, sorted      |         1 |     0.142s |       2.5% |
| Property iteration, unsorted    |         1 |     0.259s |       4.5% |
| Property reallocation, 43.75%   |         1 |     0.879s |        15% |
+---------------------------------+-----------+------------+------------+
```
This PR (tracking available handles, vector storage for handles, vector storage for properties):
```
+---------------------------------------------+------------+------------+
| Total wallclock time elapsed since start    |      2.99s |            |
|                                             |            |            |
| Section                         | no. calls |  wall time | % of total |
+---------------------------------+-----------+------------+------------+
| Property allocation             |         1 |     0.606s |        20% |
| Property deallocation 1, 25%    |         1 |      0.79s |        26% |
| Property deallocation 2, 18.75% |         1 |     0.795s |        27% |
| Property deallocation, all      |         1 |     0.217s |       7.3% |
| Property iteration, sorted      |         1 |    0.0901s |         3% |
| Property iteration, unsorted    |         1 |     0.115s |       3.9% |
| Property reallocation, 43.75%   |         1 |     0.219s |       7.3% |
+---------------------------------+-----------+------------+------------+
```