### PR TITLE
Add assert to extract_vtk_patch_info

### DIFF
--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -598,11 +598,17 @@ namespace
   {
     std::array<unsigned int, 3> vtk_cell_id{};
 
-    if (write_higher_order_cells &&
-        patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+    if (write_higher_order_cells)
       {
-        vtk_cell_id[0] = vtk_lagrange_cell_type[dim];
-        vtk_cell_id[1] = 1;
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+          {
+            vtk_cell_id[0] = vtk_lagrange_cell_type[dim];
+            vtk_cell_id[1] = 1;
+          }
+        else
+          {
+            Assert(false, ExcNotImplemented());
+          }
       }
     else if (patch.reference_cell_type == ReferenceCell::Type::Tri &&
              patch.data.n_cols() == 3)


### PR DESCRIPTION
 to prevent `write_higher_order_cells` with non-hypercube cells.