### PR TITLE
Avoid MPI calls in the HDF5 destructors when there is an exception

### DIFF
--- a/doc/news/changes/minor/20201223GarciaSanchez
+++ b/doc/news/changes/minor/20201223GarciaSanchez
@@ -1,0 +1,5 @@
+Improved: If there is an uncaught exception the destructor of the HDF5
+interface does not call H5Dclose, H5Gclose or H5Fclose. In addition,
+to avoid MPI synchronization and a possible deadlock, the destructor
+calls MPI_Abort().
+(Daniel Garcia-Sanchez, 2020/12/23)

--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -326,38 +326,6 @@ DEAL_II_NAMESPACE_OPEN
  * thread-safe HDF5 version serializes the API but does not provide any level of
  * concurrency. To achieve high parallel performance with HDF5, we advice to use
  * HDF5 with MPI.
- *
- * # Exceptions and parallel HDF5
- * In certain corner cases, exceptions combined with parallel HDF5 can freeze
- * deal.II. If one MPI process throws an exception and not the other ones, then
- * deal.II freezes. The reason is that the following happens:
- * 1. On the processor that calls the exception we try to close the parallel
- *   MPI file (H5F_try_close) which ultimately results in a barrier
- *   (MPI_barrier). This is triggered by the destructor of an HDF5Object.
- * 2. On the processor that does not call the exception we call
- *   H5VL_dataset_write() and end up in MPI_Allreduce().
- *
- * This could happen if an error is found in all the processes except one. For
- * example, the following code could potentially freeze deal.II:
- * @code
- * HDF5::File data_file(filename,
- *                            HDF5::File::FileAccessMode::create,
- *                            mpi_communicator);
- * {
- *  auto  dataset_a =
- *        data_file.create_dataset<double>(dataset_name_a, dataset_dimensions_a);
- *  dataset_a.write_selection(data_a, coordinates_a);
- * }
- *
- * AssertThrow(Utilities::MPI::this_mpi_process(mpi_communicator) == 0,
- *                   ExcInternalError());
- *
- * {
- *  auto  dataset_b =
- *        data_file.create_dataset<double>(dataset_name_b, dataset_dimensions_b);
- *  dataset_b.write_selection(data_b, coordinates_b);
- * }
- * @endcode
  */
 // clang-format on
 namespace HDF5

--- a/source/base/hdf5.cc
+++ b/source/base/hdf5.cc
@@ -105,18 +105,80 @@ namespace HDF5
     , global_no_collective_cause(H5D_MPIO_SET_INDEPENDENT)
   {
     hdf5_reference = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
+#  ifdef DEAL_II_WITH_MPI
+#    if __cpp_lib_uncaught_exceptions >= 201411
+      // std::uncaught_exception() is deprecated in c++17
+      if (std::uncaught_exceptions() == 0)
+#    else
+      if (std::uncaught_exception() == false)
+#    endif
+        {
+          // Release the HDF5 resource
+          const herr_t ret = H5Dclose(*pointer);
+          AssertNothrow(ret >= 0, ExcInternalError());
+          (void)ret;
+          delete pointer;
+        }
+      else
+        {
+          std::cerr
+            << "---------------------------------------------------------\n"
+            << "HDF5 DataSet objects call H5Dclose to end access to the\n"
+            << "dataset and release resources used by it. This call\n"
+            << "requires MPI synchronization. Since an exception is\n"
+            << "currently uncaught, this synchronization will be skipped\n"
+            << "to avoid a possible deadlock. As a result the HDF5 file\n"
+            << "might be corrupted.\n"
+            << "---------------------------------------------------------"
+            << std::endl;
+
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+#  else
       // Release the HDF5 resource
       const herr_t ret = H5Dclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
       (void)ret;
       delete pointer;
+#  endif
     });
-    dataspace      = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
+    dataspace = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
+#  ifdef DEAL_II_WITH_MPI
+#    if __cpp_lib_uncaught_exceptions >= 201411
+      // std::uncaught_exception() is deprecated in c++17
+      if (std::uncaught_exceptions() == 0)
+#    else
+      if (std::uncaught_exception() == false)
+#    endif
+        {
+          // Release the HDF5 resource
+          const herr_t ret = H5Sclose(*pointer);
+          AssertNothrow(ret >= 0, ExcInternalError());
+          (void)ret;
+          delete pointer;
+        }
+      else
+        {
+          std::cerr
+            << "---------------------------------------------------------\n"
+            << "HDF5 DataSet objects call H5Sclose to end access to the\n"
+            << "dataspace and release resources used by it. This call\n"
+            << "requires MPI synchronization. Since an exception is\n"
+            << "currently uncaught, this synchronization will be skipped\n"
+            << "to avoid a possible deadlock. As a result the HDF5 file\n"
+            << "might be corrupted.\n"
+            << "---------------------------------------------------------"
+            << std::endl;
+
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+#  else
       // Release the HDF5 resource
       const herr_t ret = H5Sclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
       (void)ret;
       delete pointer;
+#  endif
     });
 
     *dataspace = H5Screate_simple(rank, dimensions.data(), nullptr);
@@ -279,11 +341,42 @@ namespace HDF5
     : HDF5Object(name, mpi)
   {
     hdf5_reference = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
+#  ifdef DEAL_II_WITH_MPI
+#    if __cpp_lib_uncaught_exceptions >= 201411
+      // std::uncaught_exception() is deprecated in c++17
+      if (std::uncaught_exceptions() == 0)
+#    else
+      if (std::uncaught_exception() == false)
+#    endif
+        {
+          // Release the HDF5 resource
+          const herr_t ret = H5Gclose(*pointer);
+          AssertNothrow(ret >= 0, ExcInternalError());
+          (void)ret;
+          delete pointer;
+        }
+      else
+        {
+          std::cerr
+            << "---------------------------------------------------------\n"
+            << "HDF5 Group objects call H5Gclose to end access to the\n"
+            << "group and release resources used by it. This call\n"
+            << "requires MPI synchronization. Since an exception is\n"
+            << "currently uncaught, this synchronization will be skipped\n"
+            << "to avoid a possible deadlock. As a result the HDF5 file\n"
+            << "might be corrupted.\n"
+            << "---------------------------------------------------------"
+            << std::endl;
+
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+#  else
       // Release the HDF5 resource
       const herr_t ret = H5Gclose(*pointer);
       AssertNothrow(ret >= 0, ExcInternalError());
       (void)ret;
       delete pointer;
+#  endif
     });
     switch (mode)
       {
@@ -367,11 +460,42 @@ namespace HDF5
     : Group(name, mpi)
   {
     hdf5_reference = std::shared_ptr<hid_t>(new hid_t, [](hid_t *pointer) {
+#  ifdef DEAL_II_WITH_MPI
+#    if __cpp_lib_uncaught_exceptions >= 201411
+      // std::uncaught_exception() is deprecated in c++17
+      if (std::uncaught_exceptions() == 0)
+#    else
+      if (std::uncaught_exception() == false)
+#    endif
+        {
+          // Release the HDF5 resource
+          const herr_t err = H5Fclose(*pointer);
+          AssertNothrow(err >= 0, ExcInternalError());
+          (void)err;
+          delete pointer;
+        }
+      else
+        {
+          std::cerr
+            << "---------------------------------------------------------\n"
+            << "HDF5 File objects call H5Fclose to end access to the\n"
+            << "file and release resources used by it. This call\n"
+            << "requires MPI synchronization. Since an exception is\n"
+            << "currently uncaught, this synchronization will be skipped\n"
+            << "to avoid a possible deadlock. As a result the HDF5 file\n"
+            << "might be corrupted.\n"
+            << "---------------------------------------------------------"
+            << std::endl;
+
+          MPI_Abort(MPI_COMM_WORLD, 1);
+        }
+#  else
       // Release the HDF5 resource
       const herr_t err = H5Fclose(*pointer);
       AssertNothrow(err >= 0, ExcInternalError());
       (void)err;
       delete pointer;
+#  endif
     });
 
     hid_t  plist;


### PR DESCRIPTION
This is work in progress.

@tjhei  As we discussed in #10737 I placed the code with `std::uncaught_exception` in the deleters of `hdf5_reference` and `dataset`. But I think that is not enough. The test from this PR still hangs.

The structure of the test is
```
Open HDF5::File, HDF5::Group and HDF5::Dataset

AssertThrow(Utilities::MPI::this_mpi_process(mpi_communicator) == 0,
                     ExcInternalError());

Do some operations with HDF5::Dataset
```

I think that I have to place `std::uncaught_exception` in other places. I have to do some debugging. I'll come back to you when I have more results.