### PR TITLE
CI: select 64bit windows platform

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,6 +21,7 @@ jobs:
     - name: info
       run: |
         cmake --version
+        cmake -h
         wmic logicaldisk get size, freespace, caption
     - name: configure
       shell: bash
@@ -28,7 +29,7 @@ jobs:
         mkdir build
         mkdir c:/project
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_WITH_ZLIB=off -DDEAL_II_CXX_FLAGS="-WX" -T host=x64 ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=c:/project -DDEAL_II_WITH_ZLIB=off -DDEAL_II_CXX_FLAGS="-WX" -T host=x64 -A x64 ..
     - name: archive logs
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
alternative to #11354
fixes the broken windows-2016 build that hangs during testing.