### PR TITLE
Make Particles::Property pool a template <dim,spacedim>.

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -190,8 +190,8 @@ namespace Particles
      * contains serialized data of the same length and type that is allocated
      * by @p property_pool.
      */
-    Particle(const void *&       begin_data,
-             PropertyPool *const property_pool = nullptr);
+    Particle(const void *&                      begin_data,
+             PropertyPool<dim, spacedim> *const property_pool = nullptr);
 
     /**
      * Move constructor for Particle, creates a particle from an existing
@@ -360,7 +360,7 @@ namespace Particles
      * allocated in the new property pool.
      */
     void
-    set_property_pool(PropertyPool &property_pool);
+    set_property_pool(PropertyPool<dim, spacedim> &property_pool);
 
     /**
      * Return whether this particle has a valid property pool and a valid
@@ -478,12 +478,12 @@ namespace Particles
      * A pointer to the property pool. Necessary to translate from the
      * handle to the actual memory locations.
      */
-    PropertyPool *property_pool;
+    PropertyPool<dim, spacedim> *property_pool;
 
     /**
      * A handle to all particle properties
      */
-    PropertyPool::Handle properties;
+    typename PropertyPool<dim, spacedim>::Handle properties;
   };
 
   /* ---------------------- inline and template functions ------------------ */
@@ -523,7 +523,7 @@ namespace Particles
   {
     unsigned int n_properties = 0;
     if ((property_pool != nullptr) &&
-        (properties != PropertyPool::invalid_handle))
+        (properties != PropertyPool<dim, spacedim>::invalid_handle))
       n_properties = get_properties().size();
 
     ar &location &reference_location &id &n_properties;
@@ -591,13 +591,16 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline void
-  Particle<dim, spacedim>::set_property_pool(PropertyPool &new_property_pool)
+  Particle<dim, spacedim>::set_property_pool(
+    PropertyPool<dim, spacedim> &new_property_pool)
   {
     // First, we do want to save any properties that may
     // have previously been set, and copy them over to the memory allocated
     // on the new pool
-    PropertyPool::Handle new_handle = PropertyPool::invalid_handle;
-    if (property_pool != nullptr && properties != PropertyPool::invalid_handle)
+    typename PropertyPool<dim, spacedim>::Handle new_handle =
+      PropertyPool<dim, spacedim>::invalid_handle;
+    if (property_pool != nullptr &&
+        properties != PropertyPool<dim, spacedim>::invalid_handle)
       {
         new_handle = new_property_pool.allocate_properties_array();
 
@@ -611,7 +614,8 @@ namespace Particles
 
     // If the particle currently has a reference to properties, then
     // release those.
-    if (property_pool != nullptr && properties != PropertyPool::invalid_handle)
+    if (property_pool != nullptr &&
+        properties != PropertyPool<dim, spacedim>::invalid_handle)
       property_pool->deallocate_properties_array(properties);
 
 
@@ -639,7 +643,7 @@ namespace Particles
   Particle<dim, spacedim>::has_properties() const
   {
     return (property_pool != nullptr) &&
-           (properties != PropertyPool::invalid_handle);
+           (properties != PropertyPool<dim, spacedim>::invalid_handle);
   }
 
 } // namespace Particles

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -127,7 +127,7 @@ namespace Particles
      * function is after particle transfer to a new process.
      */
     void
-    set_property_pool(PropertyPool &property_pool);
+    set_property_pool(PropertyPool<dim, spacedim> &property_pool);
 
     /**
      * Return whether this particle has a valid property pool and a valid
@@ -384,7 +384,7 @@ namespace Particles
   template <int dim, int spacedim>
   inline void
   ParticleAccessor<dim, spacedim>::set_property_pool(
-    PropertyPool &new_property_pool)
+    PropertyPool<dim, spacedim> &new_property_pool)
   {
     Assert(particle != map->end(), ExcInternalError());
 

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -680,7 +680,7 @@ namespace Particles
      * Return a reference to the property pool that owns all particle
      * properties, and organizes them physically.
      */
-    PropertyPool &
+    PropertyPool<dim, spacedim> &
     get_property_pool() const;
 
     /**
@@ -805,7 +805,7 @@ namespace Particles
      * precedes the declaration of the `particles` and `ghost_particles`
      * members.
      */
-    std::unique_ptr<PropertyPool> property_pool;
+    std::unique_ptr<PropertyPool<dim, spacedim>> property_pool;
 
     /**
      * Set of particles currently living in the local domain, organized by

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -44,6 +44,7 @@ namespace Particles
    * memory with varying sizes per particle (this memory would not be managed by
    * this class).
    */
+  template <int dim, int spacedim = dim>
   class PropertyPool
   {
   public:
@@ -142,10 +143,13 @@ namespace Particles
     std::vector<Handle> currently_available_handles;
   };
 
+
+
   /* ---------------------- inline and template functions ------------------ */
 
+  template <int dim, int spacedim>
   inline ArrayView<double>
-  PropertyPool::get_properties(const Handle handle)
+  PropertyPool<dim, spacedim>::get_properties(const Handle handle)
   {
     const std::vector<double>::size_type data_index =
       (handle != invalid_handle) ? handle * n_properties : 0;

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -27,7 +27,7 @@ namespace Particles
     , reference_location(numbers::signaling_nan<Point<dim>>())
     , id(0)
     , property_pool(nullptr)
-    , properties(PropertyPool::invalid_handle)
+    , properties(PropertyPool<dim, spacedim>::invalid_handle)
   {}
 
 
@@ -40,7 +40,7 @@ namespace Particles
     , reference_location(reference_location)
     , id(id)
     , property_pool(nullptr)
-    , properties(PropertyPool::invalid_handle)
+    , properties(PropertyPool<dim, spacedim>::invalid_handle)
   {}
 
 
@@ -51,7 +51,7 @@ namespace Particles
     , reference_location(particle.get_reference_location())
     , id(particle.get_id())
     , property_pool(particle.property_pool)
-    , properties(PropertyPool::invalid_handle)
+    , properties(PropertyPool<dim, spacedim>::invalid_handle)
   {
     if (particle.has_properties())
       {
@@ -70,8 +70,9 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  Particle<dim, spacedim>::Particle(const void *&       data,
-                                    PropertyPool *const new_property_pool)
+  Particle<dim, spacedim>::Particle(
+    const void *&                      data,
+    PropertyPool<dim, spacedim> *const new_property_pool)
   {
     const types::particle_index *id_data =
       static_cast<const types::particle_index *>(data);
@@ -88,7 +89,7 @@ namespace Particles
     if (property_pool != nullptr)
       properties = property_pool->allocate_properties_array();
     else
-      properties = PropertyPool::invalid_handle;
+      properties = PropertyPool<dim, spacedim>::invalid_handle;
 
     // See if there are properties to load
     if (has_properties())
@@ -113,7 +114,7 @@ namespace Particles
     , property_pool(std::move(particle.property_pool))
     , properties(std::move(particle.properties))
   {
-    particle.properties = PropertyPool::invalid_handle;
+    particle.properties = PropertyPool<dim, spacedim>::invalid_handle;
   }
 
 
@@ -142,7 +143,7 @@ namespace Particles
                       my_properties.begin());
           }
         else
-          properties = PropertyPool::invalid_handle;
+          properties = PropertyPool<dim, spacedim>::invalid_handle;
       }
     return *this;
   }
@@ -165,7 +166,7 @@ namespace Particles
         // We stole the rhs's properties, so we need to invalidate
         // the handle the rhs holds lest it releases the memory that
         // we still reference here.
-        particle.properties = PropertyPool::invalid_handle;
+        particle.properties = PropertyPool<dim, spacedim>::invalid_handle;
       }
     return *this;
   }
@@ -175,7 +176,8 @@ namespace Particles
   template <int dim, int spacedim>
   Particle<dim, spacedim>::~Particle()
   {
-    if (property_pool != nullptr && properties != PropertyPool::invalid_handle)
+    if (property_pool != nullptr &&
+        properties != PropertyPool<dim, spacedim>::invalid_handle)
       property_pool->deallocate_properties_array(properties);
   }
 
@@ -183,7 +185,8 @@ namespace Particles
   void
   Particle<dim, spacedim>::free_properties()
   {
-    if (property_pool != nullptr && properties != PropertyPool::invalid_handle)
+    if (property_pool != nullptr &&
+        properties != PropertyPool<dim, spacedim>::invalid_handle)
       property_pool->deallocate_properties_array(properties);
   }
 
@@ -274,7 +277,7 @@ namespace Particles
     Assert(property_pool != nullptr, ExcInternalError());
 
     // If we haven't allocated memory yet, do so now
-    if (properties == PropertyPool::invalid_handle)
+    if (properties == PropertyPool<dim, spacedim>::invalid_handle)
       properties = property_pool->allocate_properties_array();
 
     const ArrayView<double> property_values =
@@ -304,7 +307,7 @@ namespace Particles
     Assert(property_pool != nullptr, ExcInternalError());
 
     // If this particle has no properties yet, allocate and initialize them.
-    if (properties == PropertyPool::invalid_handle)
+    if (properties == PropertyPool<dim, spacedim>::invalid_handle)
       {
         properties = property_pool->allocate_properties_array();
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -52,8 +52,8 @@ namespace Particles
     std::vector<Particle<dim, spacedim>>
     unpack_particles(
       const boost::iterator_range<std::vector<char>::const_iterator>
-        &           data_range,
-      PropertyPool &property_pool)
+        &                          data_range,
+      PropertyPool<dim, spacedim> &property_pool)
     {
       std::vector<Particle<dim, spacedim>> particles;
 
@@ -88,7 +88,7 @@ namespace Particles
   ParticleHandler<dim, spacedim>::ParticleHandler()
     : triangulation()
     , mapping()
-    , property_pool(std::make_unique<PropertyPool>(0))
+    , property_pool(std::make_unique<PropertyPool<dim, spacedim>>(0))
     , particles()
     , ghost_particles()
     , global_number_of_particles(0)
@@ -109,7 +109,7 @@ namespace Particles
     const unsigned int                  n_properties)
     : triangulation(&triangulation, typeid(*this).name())
     , mapping(&mapping, typeid(*this).name())
-    , property_pool(std::make_unique<PropertyPool>(n_properties))
+    , property_pool(std::make_unique<PropertyPool<dim, spacedim>>(n_properties))
     , particles()
     , ghost_particles()
     , global_number_of_particles(0)
@@ -137,7 +137,7 @@ namespace Particles
     mapping       = &new_mapping;
 
     // Create the memory pool that will store all particle properties
-    property_pool = std::make_unique<PropertyPool>(n_properties);
+    property_pool = std::make_unique<PropertyPool<dim, spacedim>>(n_properties);
 
     // Create the grid cache to cache the information about the triangulation
     // that is used to locate the particles into subdomains and cells
@@ -879,7 +879,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  PropertyPool &
+  PropertyPool<dim, spacedim> &
   ParticleHandler<dim, spacedim>::get_property_pool() const
   {
     return *property_pool;

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -20,24 +20,31 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace Particles
 {
-  const PropertyPool::Handle PropertyPool::invalid_handle =
-    static_cast<Handle>(-1);
+  template <int dim, int spacedim>
+  const typename PropertyPool<dim, spacedim>::Handle
+    PropertyPool<dim, spacedim>::invalid_handle = static_cast<Handle>(-1);
 
 
-  PropertyPool::PropertyPool(const unsigned int n_properties_per_slot)
+
+  template <int dim, int spacedim>
+  PropertyPool<dim, spacedim>::PropertyPool(
+    const unsigned int n_properties_per_slot)
     : n_properties(n_properties_per_slot)
   {}
 
 
-  PropertyPool::~PropertyPool()
+
+  template <int dim, int spacedim>
+  PropertyPool<dim, spacedim>::~PropertyPool()
   {
     clear();
   }
 
 
 
+  template <int dim, int spacedim>
   void
-  PropertyPool::clear()
+  PropertyPool<dim, spacedim>::clear()
   {
     if (n_properties > 0)
       {
@@ -63,8 +70,9 @@ namespace Particles
 
 
 
-  PropertyPool::Handle
-  PropertyPool::allocate_properties_array()
+  template <int dim, int spacedim>
+  typename PropertyPool<dim, spacedim>::Handle
+  PropertyPool<dim, spacedim>::allocate_properties_array()
   {
     Handle handle = invalid_handle;
     if (n_properties > 0)
@@ -86,8 +94,9 @@ namespace Particles
 
 
 
+  template <int dim, int spacedim>
   void
-  PropertyPool::deallocate_properties_array(Handle &handle)
+  PropertyPool<dim, spacedim>::deallocate_properties_array(Handle &handle)
   {
     Assert(
       handle != invalid_handle,
@@ -109,18 +118,29 @@ namespace Particles
 
 
 
+  template <int dim, int spacedim>
   void
-  PropertyPool::reserve(const std::size_t size)
+  PropertyPool<dim, spacedim>::reserve(const std::size_t size)
   {
     properties.reserve(size * n_properties);
   }
 
 
 
+  template <int dim, int spacedim>
   unsigned int
-  PropertyPool::n_properties_per_slot() const
+  PropertyPool<dim, spacedim>::n_properties_per_slot() const
   {
     return n_properties;
   }
+
+
+  // Instantiate the class for all reasonable template arguments
+  template class PropertyPool<1, 1>;
+  template class PropertyPool<1, 2>;
+  template class PropertyPool<1, 3>;
+  template class PropertyPool<2, 2>;
+  template class PropertyPool<2, 3>;
+  template class PropertyPool<3, 3>;
 } // namespace Particles
 DEAL_II_NAMESPACE_CLOSE

--- a/tests/particles/particle_03.cc
+++ b/tests/particles/particle_03.cc
@@ -29,8 +29,8 @@ void
 test()
 {
   {
-    const unsigned int      n_properties_per_particle = 3;
-    Particles::PropertyPool pool(n_properties_per_particle);
+    const unsigned int           n_properties_per_particle = 3;
+    Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<2> position;
     position(0) = 0.3;

--- a/tests/particles/particle_06.cc
+++ b/tests/particles/particle_06.cc
@@ -29,8 +29,8 @@ void
 test()
 {
   {
-    const unsigned int      n_properties_per_particle = 3;
-    Particles::PropertyPool pool(n_properties_per_particle);
+    const unsigned int                     n_properties_per_particle = 3;
+    Particles::PropertyPool<dim, spacedim> pool(n_properties_per_particle);
 
     Point<spacedim> position;
 

--- a/tests/particles/particle_07.cc
+++ b/tests/particles/particle_07.cc
@@ -29,8 +29,8 @@ void
 test()
 {
   {
-    const unsigned int      n_properties_per_particle = 3;
-    Particles::PropertyPool pool(n_properties_per_particle);
+    const unsigned int           n_properties_per_particle = 3;
+    Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<2> position;
     position(0) = 0.3;

--- a/tests/particles/particle_iterator_01.cc
+++ b/tests/particles/particle_iterator_01.cc
@@ -31,8 +31,8 @@ void
 test()
 {
   {
-    const unsigned int      n_properties_per_particle = 3;
-    Particles::PropertyPool pool(n_properties_per_particle);
+    const unsigned int           n_properties_per_particle = 3;
+    Particles::PropertyPool<dim> pool(n_properties_per_particle);
 
     Point<dim> position;
     position(0) = 0.3;

--- a/tests/particles/property_pool_01.cc
+++ b/tests/particles/property_pool_01.cc
@@ -29,9 +29,12 @@ void
 test()
 {
   {
-    Particles::PropertyPool pool(1);
+    const int dim      = 2;
+    const int spacedim = 2;
 
-    typename Particles::PropertyPool::Handle handle =
+    Particles::PropertyPool<dim, spacedim> pool(1);
+
+    typename Particles::PropertyPool<dim, spacedim>::Handle handle =
       pool.allocate_properties_array();
 
     pool.get_properties(handle)[0] = 2.5;

--- a/tests/particles/property_pool_02.cc
+++ b/tests/particles/property_pool_02.cc
@@ -29,10 +29,13 @@ void
 test()
 {
   {
-    const unsigned int      n_properties = 3;
-    Particles::PropertyPool pool(n_properties);
+    const int dim      = 2;
+    const int spacedim = 2;
 
-    typename Particles::PropertyPool::Handle handle =
+    const unsigned int                     n_properties = 3;
+    Particles::PropertyPool<dim, spacedim> pool(n_properties);
+
+    typename Particles::PropertyPool<dim, spacedim>::Handle handle =
       pool.allocate_properties_array();
 
     pool.get_properties(handle)[0] = 1.2;

--- a/tests/serialization/particle_01.cc
+++ b/tests/serialization/particle_01.cc
@@ -34,10 +34,10 @@ test()
     Point<spacedim> location;
     Point<dim>      reference_location;
 
-    location[spacedim - 1]      = 0.3;
-    reference_location[dim - 1] = 0.5;
-    const unsigned int      id  = 6;
-    Particles::PropertyPool property_pool(2);
+    location[spacedim - 1]                    = 0.3;
+    reference_location[dim - 1]               = 0.5;
+    const unsigned int                     id = 6;
+    Particles::PropertyPool<dim, spacedim> property_pool(2);
 
     Particles::Particle<dim, spacedim> particle(location,
                                                 reference_location,
@@ -65,7 +65,7 @@ test()
     std::istringstream            iss(oss.str());
     boost::archive::text_iarchive ia(iss, boost::archive::no_header);
 
-    Particles::PropertyPool property_pool(2);
+    Particles::PropertyPool<dim, spacedim> property_pool(2);
 
     Particles::Particle<dim, spacedim> particle;
     particle.set_property_pool(property_pool);


### PR DESCRIPTION
Follow-up to #11314 and in pursuance of #11206: I'd like to also store particle locations and reference locations in `PropertyPool`, and for that it needs to have template arguments. I'm working on storing the data, but let's get this simple patch out of the way already.