### PR TITLE
Rename some member functions of PropertyPool, also member variables of Particle

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -483,7 +483,7 @@ namespace Particles
     /**
      * A handle to all particle properties
      */
-    typename PropertyPool<dim, spacedim>::Handle properties;
+    typename PropertyPool<dim, spacedim>::Handle property_pool_handle;
   };
 
   /* ---------------------- inline and template functions ------------------ */
@@ -523,7 +523,7 @@ namespace Particles
   {
     unsigned int n_properties = 0;
     if ((property_pool != nullptr) &&
-        (properties != PropertyPool<dim, spacedim>::invalid_handle))
+        (property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle))
       n_properties = get_properties().size();
 
     ar &location &reference_location &id &n_properties;
@@ -600,7 +600,7 @@ namespace Particles
     typename PropertyPool<dim, spacedim>::Handle new_handle =
       PropertyPool<dim, spacedim>::invalid_handle;
     if (property_pool != nullptr &&
-        properties != PropertyPool<dim, spacedim>::invalid_handle)
+        property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle)
       {
         new_handle = new_property_pool.register_particle();
 
@@ -615,14 +615,14 @@ namespace Particles
     // If the particle currently has a reference to properties, then
     // release those.
     if (property_pool != nullptr &&
-        properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deregister_particle(properties);
+        property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle)
+      property_pool->deregister_particle(property_pool_handle);
 
 
     // Then set the pointer to the property pool we want to use. Also set the
     // handle to any properties, if we have copied any above.
-    property_pool = &new_property_pool;
-    properties    = new_handle;
+    property_pool        = &new_property_pool;
+    property_pool_handle = new_handle;
   }
 
 
@@ -633,7 +633,7 @@ namespace Particles
   {
     Assert(has_properties(), ExcInternalError());
 
-    return property_pool->get_properties(properties);
+    return property_pool->get_properties(property_pool_handle);
   }
 
 
@@ -643,7 +643,8 @@ namespace Particles
   Particle<dim, spacedim>::has_properties() const
   {
     return (property_pool != nullptr) &&
-           (properties != PropertyPool<dim, spacedim>::invalid_handle);
+           (property_pool_handle !=
+            PropertyPool<dim, spacedim>::invalid_handle);
   }
 
 } // namespace Particles

--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -602,7 +602,7 @@ namespace Particles
     if (property_pool != nullptr &&
         properties != PropertyPool<dim, spacedim>::invalid_handle)
       {
-        new_handle = new_property_pool.allocate_properties_array();
+        new_handle = new_property_pool.register_particle();
 
         ArrayView<double> old_properties = this->get_properties();
         ArrayView<double> new_properties =
@@ -616,7 +616,7 @@ namespace Particles
     // release those.
     if (property_pool != nullptr &&
         properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deallocate_properties_array(properties);
+      property_pool->deregister_particle(properties);
 
 
     // Then set the pointer to the property pool we want to use. Also set the

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -82,24 +82,19 @@ namespace Particles
     clear();
 
     /**
-     * Return a new handle that allows accessing the reserved particle
-     * properties. If the number of properties is zero this will return an
-     * invalid handle. Handles can be copied, but after deallocating one
-     * of the copied handles using any of the other copies will cause
-     * undefined behavior.
+     * Return a new handle that allows a particle to store information such as
+     * properties and locations. This also allocated memory in this PropertyPool
+     * variable.
      */
     Handle
-    allocate_properties_array();
+    register_particle();
 
     /**
-     * Mark the properties corresponding to the handle @p handle as
-     * deleted and invalidate the @p handle. Calling this function
-     * more than once for the same handle (e.g. by calling it again
-     * with a copy of the previously invalidated handle) causes
-     * undefined behavior.
+     * Return a handle obtained by register_particle() and mark the memory
+     * allocated for storing the particle's data as free for re-use.
      */
     void
-    deallocate_properties_array(Handle &handle);
+    deregister_particle(Handle &handle);
 
     /**
      * Return an ArrayView to the properties that correspond to the given

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -55,7 +55,7 @@ namespace Particles
   {
     if (particle.has_properties())
       {
-        properties = property_pool->allocate_properties_array();
+        properties = property_pool->register_particle();
         const ArrayView<double> my_properties =
           property_pool->get_properties(properties);
         const ArrayView<const double> their_properties =
@@ -87,7 +87,7 @@ namespace Particles
 
     property_pool = new_property_pool;
     if (property_pool != nullptr)
-      properties = property_pool->allocate_properties_array();
+      properties = property_pool->register_particle();
     else
       properties = PropertyPool<dim, spacedim>::invalid_handle;
 
@@ -132,7 +132,7 @@ namespace Particles
 
         if (particle.has_properties())
           {
-            properties = property_pool->allocate_properties_array();
+            properties = property_pool->register_particle();
             const ArrayView<const double> their_properties =
               particle.get_properties();
             const ArrayView<double> my_properties =
@@ -178,7 +178,7 @@ namespace Particles
   {
     if (property_pool != nullptr &&
         properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deallocate_properties_array(properties);
+      property_pool->deregister_particle(properties);
   }
 
   template <int dim, int spacedim>
@@ -187,7 +187,7 @@ namespace Particles
   {
     if (property_pool != nullptr &&
         properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deallocate_properties_array(properties);
+      property_pool->deregister_particle(properties);
   }
 
 
@@ -278,7 +278,7 @@ namespace Particles
 
     // If we haven't allocated memory yet, do so now
     if (properties == PropertyPool<dim, spacedim>::invalid_handle)
-      properties = property_pool->allocate_properties_array();
+      properties = property_pool->register_particle();
 
     const ArrayView<double> property_values =
       property_pool->get_properties(properties);
@@ -309,7 +309,7 @@ namespace Particles
     // If this particle has no properties yet, allocate and initialize them.
     if (properties == PropertyPool<dim, spacedim>::invalid_handle)
       {
-        properties = property_pool->allocate_properties_array();
+        properties = property_pool->register_particle();
 
         ArrayView<double> my_properties =
           property_pool->get_properties(properties);

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -27,7 +27,7 @@ namespace Particles
     , reference_location(numbers::signaling_nan<Point<dim>>())
     , id(0)
     , property_pool(nullptr)
-    , properties(PropertyPool<dim, spacedim>::invalid_handle)
+    , property_pool_handle(PropertyPool<dim, spacedim>::invalid_handle)
   {}
 
 
@@ -40,7 +40,7 @@ namespace Particles
     , reference_location(reference_location)
     , id(id)
     , property_pool(nullptr)
-    , properties(PropertyPool<dim, spacedim>::invalid_handle)
+    , property_pool_handle(PropertyPool<dim, spacedim>::invalid_handle)
   {}
 
 
@@ -51,13 +51,13 @@ namespace Particles
     , reference_location(particle.get_reference_location())
     , id(particle.get_id())
     , property_pool(particle.property_pool)
-    , properties(PropertyPool<dim, spacedim>::invalid_handle)
+    , property_pool_handle(PropertyPool<dim, spacedim>::invalid_handle)
   {
     if (particle.has_properties())
       {
-        properties = property_pool->register_particle();
+        property_pool_handle = property_pool->register_particle();
         const ArrayView<double> my_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
         const ArrayView<const double> their_properties =
           particle.get_properties();
 
@@ -87,15 +87,15 @@ namespace Particles
 
     property_pool = new_property_pool;
     if (property_pool != nullptr)
-      properties = property_pool->register_particle();
+      property_pool_handle = property_pool->register_particle();
     else
-      properties = PropertyPool<dim, spacedim>::invalid_handle;
+      property_pool_handle = PropertyPool<dim, spacedim>::invalid_handle;
 
     // See if there are properties to load
     if (has_properties())
       {
         const ArrayView<double> particle_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
         const unsigned int size = particle_properties.size();
         for (unsigned int i = 0; i < size; ++i)
           particle_properties[i] = *pdata++;
@@ -112,9 +112,9 @@ namespace Particles
     , reference_location(std::move(particle.reference_location))
     , id(std::move(particle.id))
     , property_pool(std::move(particle.property_pool))
-    , properties(std::move(particle.properties))
+    , property_pool_handle(std::move(particle.property_pool_handle))
   {
-    particle.properties = PropertyPool<dim, spacedim>::invalid_handle;
+    particle.property_pool_handle = PropertyPool<dim, spacedim>::invalid_handle;
   }
 
 
@@ -132,18 +132,18 @@ namespace Particles
 
         if (particle.has_properties())
           {
-            properties = property_pool->register_particle();
+            property_pool_handle = property_pool->register_particle();
             const ArrayView<const double> their_properties =
               particle.get_properties();
             const ArrayView<double> my_properties =
-              property_pool->get_properties(properties);
+              property_pool->get_properties(property_pool_handle);
 
             std::copy(their_properties.begin(),
                       their_properties.end(),
                       my_properties.begin());
           }
         else
-          properties = PropertyPool<dim, spacedim>::invalid_handle;
+          property_pool_handle = PropertyPool<dim, spacedim>::invalid_handle;
       }
     return *this;
   }
@@ -157,16 +157,17 @@ namespace Particles
   {
     if (this != &particle)
       {
-        location           = particle.location;
-        reference_location = particle.reference_location;
-        id                 = particle.id;
-        property_pool      = particle.property_pool;
-        properties         = particle.properties;
+        location             = particle.location;
+        reference_location   = particle.reference_location;
+        id                   = particle.id;
+        property_pool        = particle.property_pool;
+        property_pool_handle = particle.property_pool_handle;
 
         // We stole the rhs's properties, so we need to invalidate
         // the handle the rhs holds lest it releases the memory that
         // we still reference here.
-        particle.properties = PropertyPool<dim, spacedim>::invalid_handle;
+        particle.property_pool_handle =
+          PropertyPool<dim, spacedim>::invalid_handle;
       }
     return *this;
   }
@@ -177,17 +178,19 @@ namespace Particles
   Particle<dim, spacedim>::~Particle()
   {
     if (property_pool != nullptr &&
-        properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deregister_particle(properties);
+        property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle)
+      property_pool->deregister_particle(property_pool_handle);
   }
+
+
 
   template <int dim, int spacedim>
   void
   Particle<dim, spacedim>::free_properties()
   {
     if (property_pool != nullptr &&
-        properties != PropertyPool<dim, spacedim>::invalid_handle)
-      property_pool->deregister_particle(properties);
+        property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle)
+      property_pool->deregister_particle(property_pool_handle);
   }
 
 
@@ -213,7 +216,7 @@ namespace Particles
     if (has_properties())
       {
         const ArrayView<double> particle_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
         for (unsigned int i = 0; i < particle_properties.size(); ++i, ++pdata)
           *pdata = particle_properties[i];
       }
@@ -241,7 +244,7 @@ namespace Particles
     if (has_properties())
       {
         const ArrayView<double> particle_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
         const unsigned int size = particle_properties.size();
         for (unsigned int i = 0; i < size; ++i)
           particle_properties[i] = *pdata++;
@@ -261,7 +264,7 @@ namespace Particles
     if (has_properties())
       {
         const ArrayView<double> particle_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
         size += sizeof(double) * particle_properties.size();
       }
     return size;
@@ -277,11 +280,11 @@ namespace Particles
     Assert(property_pool != nullptr, ExcInternalError());
 
     // If we haven't allocated memory yet, do so now
-    if (properties == PropertyPool<dim, spacedim>::invalid_handle)
-      properties = property_pool->register_particle();
+    if (property_pool_handle == PropertyPool<dim, spacedim>::invalid_handle)
+      property_pool_handle = property_pool->register_particle();
 
     const ArrayView<double> property_values =
-      property_pool->get_properties(properties);
+      property_pool->get_properties(property_pool_handle);
 
     Assert(new_properties.size() == property_values.size(),
            ExcMessage(
@@ -307,17 +310,17 @@ namespace Particles
     Assert(property_pool != nullptr, ExcInternalError());
 
     // If this particle has no properties yet, allocate and initialize them.
-    if (properties == PropertyPool<dim, spacedim>::invalid_handle)
+    if (property_pool_handle == PropertyPool<dim, spacedim>::invalid_handle)
       {
-        properties = property_pool->register_particle();
+        property_pool_handle = property_pool->register_particle();
 
         ArrayView<double> my_properties =
-          property_pool->get_properties(properties);
+          property_pool->get_properties(property_pool_handle);
 
         std::fill(my_properties.begin(), my_properties.end(), 0.0);
       }
 
-    return property_pool->get_properties(properties);
+    return property_pool->get_properties(property_pool_handle);
   }
 } // namespace Particles
 

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -72,7 +72,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   typename PropertyPool<dim, spacedim>::Handle
-  PropertyPool<dim, spacedim>::allocate_properties_array()
+  PropertyPool<dim, spacedim>::register_particle()
   {
     Handle handle = invalid_handle;
     if (n_properties > 0)
@@ -96,7 +96,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   void
-  PropertyPool<dim, spacedim>::deallocate_properties_array(Handle &handle)
+  PropertyPool<dim, spacedim>::deregister_particle(Handle &handle)
   {
     Assert(
       handle != invalid_handle,

--- a/tests/particles/property_pool_01.cc
+++ b/tests/particles/property_pool_01.cc
@@ -35,14 +35,14 @@ test()
     Particles::PropertyPool<dim, spacedim> pool(1);
 
     typename Particles::PropertyPool<dim, spacedim>::Handle handle =
-      pool.allocate_properties_array();
+      pool.register_particle();
 
     pool.get_properties(handle)[0] = 2.5;
 
     deallog << "Pool properties: " << pool.get_properties(handle)[0]
             << std::endl;
 
-    pool.deallocate_properties_array(handle);
+    pool.deregister_particle(handle);
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/property_pool_02.cc
+++ b/tests/particles/property_pool_02.cc
@@ -36,7 +36,7 @@ test()
     Particles::PropertyPool<dim, spacedim> pool(n_properties);
 
     typename Particles::PropertyPool<dim, spacedim>::Handle handle =
-      pool.allocate_properties_array();
+      pool.register_particle();
 
     pool.get_properties(handle)[0] = 1.2;
     pool.get_properties(handle)[1] = 2.5;
@@ -50,7 +50,7 @@ test()
 
     deallog << std::endl;
 
-    pool.deallocate_properties_array(handle);
+    pool.deregister_particle(handle);
   }
 
   deallog << "OK" << std::endl;


### PR DESCRIPTION
The next step towards #11206: If we want to store locations in the `PropertyPool`, it is no longer accurate to name its member functions after "properties". Instead, call them `(de)register_particle()`, and name the corresponding handle in the `Particle` class just "handle".

Strictly speaking, these kinds of changes are incompatible. I suspect that in reality, few people actually use `PropertyPool` in user codes. But I will write a detailed changelog entry when we've settled on the final interface.