### PR TITLE
Add a filter=output attribute to output files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,37 @@
-/.github/ export-ignore
-/cmake/scripts/run_test.sh text eol=lf
+#
+# do not include the following files in tarballs created via git-export:
+#
+
+.clang-format export-ignore
+.clang-tidy export-ignore
+.codecov.yml export-ignore
 /contrib/ci/ export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+Jenkinsfile export-ignore
+.mailmap export-ignore
+.travis.yml export-ignore
+
+/.github/ export-ignore
+
 /tests/* export-ignore
 /tests/CMakeLists.txt -export-ignore
 /tests/quick_tests -export-ignore
 /tests/run_test.cmake -export-ignore
 /tests/tests.h -export-ignore
-/tests/**/*output text eol=lf
-.clang-format export-ignore
-.clang-tidy export-ignore
-.codecov.yml export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.mailmap export-ignore
-.travis.yml export-ignore
-Jenkinsfile export-ignore
+
+#
+# MSVC compatiblity
+#
+
+/cmake/scripts/run_test.sh text eol=lf
+/tests/**/*.output* text eol=lf
+
+#
+# Declare a number of filter attributes
+#
+
+tests/**/*.output filter=test-output
+bundled/**/* filter=bundled-files
+bundled/CMakeLists.txt -filter=bundled-files
+bundled/setup_bundled.cmake -filter=bundled-files


### PR DESCRIPTION
This change alone does nothing but helps to set up custom smudge/clean
filters for some files in the repository.

For example, one can set up the following filters in `.git/config` (1, 2):

```
[filter "test-output"]
        clean = zstd -d
        smudge = zstd -z
        required

[filter "bundled-files"]
        clean = zstd -d
        smudge = zstd -z
        required
```

git will then compress all files that had been tagged with "test-output"
and "bundled-files" via zstd saving some discspace.

A couple of comments:

1/ For very good reason it is not possible to automatically add this
   configuration to the repository - git tries very hard to prevent remote
   code execution exploits when handling repositories

2/ I don't see any benefit in changing everyones workflow to handle
   compressed (test output) files.

   But adding filter annotations alone doesn't do anything. So why not
   adding the attributes and let everyone be happy? :-)

3/ This obviously requires an additional hook to decompress test output
   files if we want the testsuite to still function. A possible route is to add
   an override with an environment variable to "preprocess" output
   files prior to comparing with numdiff.


(1) It is recommended to make sure that clean and smudge are projections.
    So it might be best to write a small wrapper ensuring this...

(2) These two filters reduce the size of the working directory by 228M
    (369M bundled + tests down to 140M)

In reference to #11375