### PR TITLE
Added missing header for boost 1.75.0.

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -26,6 +26,9 @@
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <boost/geometry/algorithms/envelope.hpp>
 #include <boost/geometry/geometries/multi_point.hpp>
+#if DEAL_II_BOOST_VERSION_GTE(1, 75, 0)
+#  include <boost/geometry/strategies/envelope/cartesian.hpp>
+#endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -238,6 +238,13 @@
 #define DEAL_II_BOOST_VERSION_MINOR @Boost_MINOR_VERSION@
 #define DEAL_II_BOOST_VERSION_SUBMINOR @Boost_SUBMINOR_VERSION@
 
+#define DEAL_II_BOOST_VERSION_GTE(major,minor,subminor) \
+ ((DEAL_II_BOOST_VERSION_MAJOR * 100000 + \
+    DEAL_II_BOOST_VERSION_MINOR * 100 + \
+     DEAL_II_BOOST_VERSION_SUBMINOR) \
+    >= \
+    (major)*100000 + (minor)*100 + (subminor))
+
 /*
  * Gmsh:
  */


### PR DESCRIPTION
Fixes #11379.

In `boost 1.75.0` the structure for the geometry module has been changed. We require an additional header file to be able to continue using the deal.II implementation of `BoundingBox`.

@awulkiew -- I bet that this incompatibility was not intentional. Could it be that there is a header file missing in the backwards compatible part of the geometry module?