### PR TITLE
MappingInfo: convert quadrature to face-quadrature rules

### DIFF
--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -392,7 +392,7 @@ namespace internal
                   quad[my_q][q].get_tensor_basis()[0], update_default);
             }
 
-          face_data[my_q].descriptor.resize(n_hp_quads);
+          face_data[my_q].descriptor.reserve(n_hp_quads * 2);
           for (unsigned int hpq = 0; hpq < n_hp_quads; ++hpq)
             {
               bool flag = quad[my_q][hpq].is_tensor_product();
@@ -405,28 +405,29 @@ namespace internal
               if (flag == false)
                 {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-                  try
+                  for (const auto &quad_face :
+                       get_unique_face_quadratures(quad[my_q][hpq]))
                     {
-                      const auto quad_face =
-                        get_face_quadrature(quad[my_q][hpq]);
-                      face_data[my_q].descriptor[hpq].initialize(
+                      face_data[my_q].descriptor.resize(
+                        face_data[my_q].descriptor.size() + 1);
+                      face_data[my_q].descriptor.back().initialize(
                         quad_face, update_default);
-                    }
-                  catch (...)
-                    {
-                      // TODO: nothing to do for now for wedges and pyramids.
                     }
 #else
                   Assert(false, ExcNotImplemented());
 #endif
                 }
               else
-                face_data[my_q].descriptor[hpq].initialize(
-                  quad[my_q][hpq].get_tensor_basis()[0],
-                  update_flags_boundary_faces);
+                {
+                  face_data[my_q].descriptor.resize(
+                    face_data[my_q].descriptor.size() + 1);
+                  face_data[my_q].descriptor.back().initialize(
+                    quad[my_q][hpq].get_tensor_basis()[0],
+                    update_flags_boundary_faces);
+                }
             }
 
-          face_data_by_cells[my_q].descriptor.resize(n_hp_quads);
+          face_data_by_cells[my_q].descriptor.reserve(n_hp_quads * 2);
           for (unsigned int hpq = 0; hpq < n_hp_quads; ++hpq)
             {
               bool flag = quad[my_q][hpq].is_tensor_product();
@@ -439,24 +440,25 @@ namespace internal
               if (flag == false)
                 {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-                  try
+                  for (const auto &quad_face :
+                       get_unique_face_quadratures(quad[my_q][hpq]))
                     {
-                      const auto quad_face =
-                        get_face_quadrature(quad[my_q][hpq]);
-                      face_data_by_cells[my_q].descriptor[hpq].initialize(
+                      face_data_by_cells[my_q].descriptor.resize(
+                        face_data_by_cells[my_q].descriptor.size() + 1);
+                      face_data_by_cells[my_q].descriptor.back().initialize(
                         quad_face, update_default);
-                    }
-                  catch (...)
-                    {
-                      // TODO: nothing to do for now for wedges and pyramids.
                     }
 #else
                   Assert(false, ExcNotImplemented());
 #endif
                 }
               else
-                face_data_by_cells[my_q].descriptor[hpq].initialize(
-                  quad[my_q][hpq].get_tensor_basis()[0], update_default);
+                {
+                  face_data_by_cells[my_q].descriptor.resize(
+                    face_data_by_cells[my_q].descriptor.size() + 1);
+                  face_data_by_cells[my_q].descriptor.back().initialize(
+                    quad[my_q][hpq].get_tensor_basis()[0], update_default);
+                }
             }
         }
 

--- a/include/deal.II/matrix_free/util.h
+++ b/include/deal.II/matrix_free/util.h
@@ -45,6 +45,30 @@ namespace internal
       return Quadrature<dim - 1>();
     }
 
+    template <int dim>
+    inline std::vector<Quadrature<dim - 1>>
+    get_unique_face_quadratures(const Quadrature<dim> &quad)
+    {
+      if (dim == 2 || dim == 3)
+        for (unsigned int i = 1; i <= 3; ++i)
+          if (quad == Simplex::QGauss<dim>(i))
+            return {{Simplex::QGauss<dim - 1>(i)}};
+
+      if (dim == 3)
+        for (unsigned int i = 1; i <= 3; ++i)
+          if (quad == Simplex::QGaussWedge<dim>(i))
+            return {{QGauss<dim - 1>(i), Simplex::QGauss<dim - 1>(i)}};
+
+      if (dim == 3)
+        for (unsigned int i = 1; i <= 2; ++i)
+          if (quad == Simplex::QGaussPyramid<dim>(i))
+            return {{QGauss<dim - 1>(i), Simplex::QGauss<dim - 1>(i)}};
+
+      AssertThrow(false, ExcNotImplemented());
+
+      return {{QGauss<dim - 1>(1)}};
+    }
+
   } // end of namespace MatrixFreeFunctions
 } // end of namespace internal
 


### PR DESCRIPTION
Add to `face_data[my_q].descriptor` more quadrature rules (in the case of wedges/pyramids 2). 

Follow up PR-s, will split up face ranges according to the face types and introduce a logic to access the correct face-quadrature rule depending on the face type.