### PR TITLE
Let Particle::get_(reference_)location() return by-value rather than reference

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -279,7 +279,7 @@ namespace Particles
      *
      * @return The location of this particle.
      */
-    const Point<spacedim> &
+    Point<spacedim>
     get_location() const;
 
     /**
@@ -305,7 +305,7 @@ namespace Particles
     /**
      * Return the reference location of this particle in its current cell.
      */
-    const Point<dim> &
+    Point<dim>
     get_reference_location() const;
 
     /**
@@ -545,7 +545,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<spacedim> &
+  inline Point<spacedim>
   Particle<dim, spacedim>::get_location() const
   {
     return location;
@@ -563,7 +563,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<dim> &
+  inline Point<dim>
   Particle<dim, spacedim>::get_reference_location() const
   {
     return reference_location;

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -84,7 +84,7 @@ namespace Particles
      *
      * @return The location of this particle.
      */
-    const Point<spacedim> &
+    Point<spacedim>
     get_location() const;
 
     /**
@@ -110,7 +110,7 @@ namespace Particles
     /**
      * Return the reference location of this particle in its current cell.
      */
-    const Point<dim> &
+    Point<dim>
     get_reference_location() const;
 
     /**
@@ -337,7 +337,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<spacedim> &
+  inline Point<spacedim>
   ParticleAccessor<dim, spacedim>::get_location() const
   {
     Assert(particle != map->end(), ExcInternalError());
@@ -360,7 +360,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<dim> &
+  inline Point<dim>
   ParticleAccessor<dim, spacedim>::get_reference_location() const
   {
     Assert(particle != map->end(), ExcInternalError());


### PR DESCRIPTION
More prep work for moving locations from `Particle` to `PropertyPool`: Let some functions return points by value, rather than by reference. These are objects easily scalarized by compilers, so this might even lead to marginally better code.

In reference to #11206.

/rebuild