### PR TITLE
Prepare for storing particle locations in the PropertyPool.

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -486,6 +486,8 @@ namespace Particles
     typename PropertyPool<dim, spacedim>::Handle property_pool_handle;
   };
 
+
+
   /* ---------------------- inline and template functions ------------------ */
 
   template <int dim, int spacedim>
@@ -495,7 +497,12 @@ namespace Particles
   {
     unsigned int n_properties = 0;
 
+    Point<spacedim> location;
+    Point<dim>      reference_location;
     ar &location &reference_location &id &n_properties;
+
+    set_location(location);
+    set_reference_location(reference_location);
 
     if (n_properties > 0)
       {
@@ -525,6 +532,9 @@ namespace Particles
     if ((property_pool != nullptr) &&
         (property_pool_handle != PropertyPool<dim, spacedim>::invalid_handle))
       n_properties = get_properties().size();
+
+    Point<spacedim> location           = get_location();
+    Point<dim>      reference_location = get_reference_location();
 
     ar &location &reference_location &id &n_properties;
 

--- a/source/particles/particle.cc
+++ b/source/particles/particle.cc
@@ -79,11 +79,15 @@ namespace Particles
     id                  = *id_data++;
     const double *pdata = reinterpret_cast<const double *>(id_data);
 
+    Point<spacedim> location;
     for (unsigned int i = 0; i < spacedim; ++i)
       location(i) = *pdata++;
+    set_location(location);
 
+    Point<dim> reference_location;
     for (unsigned int i = 0; i < dim; ++i)
       reference_location(i) = *pdata++;
+    set_reference_location(reference_location);
 
     property_pool = new_property_pool;
     if (property_pool != nullptr)
@@ -206,11 +210,11 @@ namespace Particles
 
     // Write location data
     for (unsigned int i = 0; i < spacedim; ++i, ++pdata)
-      *pdata = location(i);
+      *pdata = get_location()[i];
 
     // Write reference location data
     for (unsigned int i = 0; i < dim; ++i, ++pdata)
-      *pdata = reference_location(i);
+      *pdata = get_reference_location()[i];
 
     // Write property data
     if (has_properties())
@@ -225,6 +229,7 @@ namespace Particles
   }
 
 
+
   template <int dim, int spacedim>
   void
   Particle<dim, spacedim>::update_particle_data(const void *&data)
@@ -234,11 +239,15 @@ namespace Particles
     id                  = *id_data++;
     const double *pdata = reinterpret_cast<const double *>(id_data);
 
+    Point<spacedim> location;
     for (unsigned int i = 0; i < spacedim; ++i)
       location(i) = *pdata++;
+    set_location(location);
 
+    Point<dim> reference_location;
     for (unsigned int i = 0; i < dim; ++i)
       reference_location(i) = *pdata++;
+    set_reference_location(reference_location);
 
     // See if there are properties to load
     if (has_properties())
@@ -252,6 +261,7 @@ namespace Particles
 
     data = static_cast<const void *>(pdata);
   }
+
 
 
   template <int dim, int spacedim>


### PR DESCRIPTION
If this data is no longer stored in the particle itself, we need to slightly adjust the code that serializes/deserializes particles. As is, this patch is a no-op but it's going to reduce the size of any follow-up patches that actually move the storage location.

In reference to #11206.

/rebuild