### PR TITLE
Do not inspect an object that has been moved from.

### DIFF
--- a/tests/particles/particle_03.cc
+++ b/tests/particles/particle_03.cc
@@ -66,9 +66,6 @@ test()
 
     const Particles::Particle<2> moved_particle(std::move(particle));
 
-    deallog << "Old particle has properties after move: "
-            << particle.has_properties() << std::endl;
-
     deallog << "Moved particle properties: "
             << std::vector<double>(moved_particle.get_properties().begin(),
                                    moved_particle.get_properties().end())

--- a/tests/particles/particle_03.output
+++ b/tests/particles/particle_03.output
@@ -2,6 +2,5 @@
 DEAL::Particle properties: 0.150000 0.450000 0.750000
 DEAL::Copy particle properties: 0.150000 0.450000 0.750000
 DEAL::Old particle has properties before move: 1
-DEAL::Old particle has properties after move: 0
 DEAL::Moved particle properties: 0.150000 0.450000 0.750000
 DEAL::OK


### PR DESCRIPTION
Objects that have been moved from are considered invalid. We shouldn't be inspecting their properties.

Found while working on #11206.

/rebuild