### PR TITLE
MatrixFree: introduce FaceToCellTopology::face_type

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2549,7 +2549,7 @@ namespace internal
       if (data.element_type == MatrixFreeFunctions::tensor_none)
         {
           const unsigned int n_dofs     = data.dofs_per_component_on_cell;
-          const unsigned int n_q_points = data.n_q_points_face;
+          const unsigned int n_q_points = data.n_q_points_faces[face_no];
           const auto         shape_info = data.data.front();
 
           using Eval = EvaluatorTensorProduct<evaluate_general,
@@ -2704,7 +2704,7 @@ namespace internal
       if (data.element_type == MatrixFreeFunctions::tensor_none)
         {
           const unsigned int n_dofs     = data.dofs_per_component_on_cell;
-          const unsigned int n_q_points = data.n_q_points_face;
+          const unsigned int n_q_points = data.n_q_points_faces[face_no];
           const auto         shape_info = data.data.front();
 
           using Eval = EvaluatorTensorProduct<evaluate_general,

--- a/include/deal.II/matrix_free/face_info.h
+++ b/include/deal.II/matrix_free/face_info.h
@@ -111,6 +111,12 @@ namespace internal
       unsigned char face_orientation;
 
       /**
+       * Reference-cell type of the given face: 0 for line or quadrilateral,
+       * 1 for triangle.
+       */
+      unsigned char face_type;
+
+      /**
        * Return the memory consumption of the present data structure.
        */
       std::size_t

--- a/include/deal.II/matrix_free/face_setup_internal.h
+++ b/include/deal.II/matrix_free/face_setup_internal.h
@@ -780,6 +780,9 @@ namespace internal
                         info.cells_exterior[0] = numbers::invalid_unsigned_int;
                         info.interior_face_no  = f;
                         info.exterior_face_no  = dcell->face(f)->boundary_id();
+                        info.face_type =
+                          dcell->face(f)->reference_cell() !=
+                          dealii::ReferenceCells::get_hypercube<dim - 1>();
                         info.subface_index =
                           GeometryInfo<dim>::max_children_per_cell;
                         info.face_orientation = 0;
@@ -959,6 +962,9 @@ namespace internal
       else
         info.exterior_face_no = cell->neighbor_face_no(face_no);
 
+      info.face_type = cell->face(face_no)->reference_cell() !=
+                       dealii::ReferenceCells::get_hypercube<dim - 1>();
+
       info.subface_index = GeometryInfo<dim>::max_children_per_cell;
       Assert(neighbor->level() <= cell->level(), ExcInternalError());
       if (cell->level() > neighbor->level())
@@ -1037,6 +1043,8 @@ namespace internal
         return false;
       if (face1.face_orientation != face2.face_orientation)
         return false;
+      if (face1.face_type != face2.face_type)
+        return false;
 
       if (active_fe_indices.size() > 0)
         {
@@ -1072,6 +1080,12 @@ namespace internal
       operator()(const FaceToCellTopology<length> &face1,
                  const FaceToCellTopology<length> &face2) const
       {
+        // check if active FE indices match
+        if (face1.face_type < face2.face_type)
+          return true;
+        else if (face1.face_type > face2.face_type)
+          return false;
+
         // check if active FE indices match
         if (active_fe_indices.size() > 0)
           {
@@ -1187,6 +1201,7 @@ namespace internal
             new_faces(face_comparator);
           for (const auto &face_type : faces_type)
             {
+              macro_face.face_type = faces_in[face_type[0]].face_type;
               macro_face.interior_face_no =
                 faces_in[face_type[0]].interior_face_no;
               macro_face.exterior_face_no =

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -298,7 +298,8 @@ protected:
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index);
+    const unsigned int active_quad_index,
+    const unsigned int face_type);
 
   /**
    * Constructor that comes with reduced functionality and works similar as
@@ -1143,7 +1144,8 @@ protected:
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index);
+    const unsigned int active_quad_index,
+    const unsigned int face_type);
 
   /**
    * Constructor that comes with reduced functionality and works similar as
@@ -1428,7 +1430,8 @@ protected:
     const unsigned int n_q_points,
     const bool         is_interior_face  = true,
     const unsigned int active_fe_index   = numbers::invalid_unsigned_int,
-    const unsigned int active_quad_index = numbers::invalid_unsigned_int);
+    const unsigned int active_quad_index = numbers::invalid_unsigned_int,
+    const unsigned int face_type         = numbers::invalid_unsigned_int);
 
   /**
    * Constructor with reduced functionality for similar usage of FEEvaluation
@@ -1565,7 +1568,8 @@ protected:
     const unsigned int n_q_points,
     const bool         is_interior_face  = true,
     const unsigned int active_fe_index   = numbers::invalid_unsigned_int,
-    const unsigned int active_quad_index = numbers::invalid_unsigned_int);
+    const unsigned int active_quad_index = numbers::invalid_unsigned_int,
+    const unsigned int face_type         = numbers::invalid_unsigned_int);
 
   /**
    * Constructor with reduced functionality for similar usage of FEEvaluation
@@ -1726,7 +1730,8 @@ protected:
     const unsigned int n_q_points,
     const bool         is_interior_face  = true,
     const unsigned int active_fe_index   = numbers::invalid_unsigned_int,
-    const unsigned int active_quad_index = numbers::invalid_unsigned_int);
+    const unsigned int active_quad_index = numbers::invalid_unsigned_int,
+    const unsigned int face_type         = numbers::invalid_unsigned_int);
 
   /**
    * Constructor with reduced functionality for similar usage of FEEvaluation
@@ -1872,7 +1877,8 @@ protected:
     const unsigned int                                n_q_points,
     const bool                                        is_interior_face = true,
     const unsigned int active_fe_index   = numbers::invalid_unsigned_int,
-    const unsigned int active_quad_index = numbers::invalid_unsigned_int);
+    const unsigned int active_quad_index = numbers::invalid_unsigned_int,
+    const unsigned int face_type         = numbers::invalid_unsigned_int);
 
   /**
    * Constructor with reduced functionality for similar usage of FEEvaluation
@@ -3069,6 +3075,9 @@ public:
    * DoFHandler/AffineConstraints pair the given evaluator should be attached
    * to.
    *
+   * @param face_type In the case of a face, indicate its reference-cell type
+   * (0 for line or quadrilateral 1 for triangle).
+   *
    * @param active_quad_index If matrix_free was set up with hp::Collection
    * objects, this parameter selects the appropriate number of the quadrature
    * formula.
@@ -3080,7 +3089,8 @@ public:
     const unsigned int                                  quad_no          = 0,
     const unsigned int first_selected_component                          = 0,
     const unsigned int active_fe_index   = numbers::invalid_unsigned_int,
-    const unsigned int active_quad_index = numbers::invalid_unsigned_int);
+    const unsigned int active_quad_index = numbers::invalid_unsigned_int,
+    const unsigned int face_type         = numbers::invalid_unsigned_int);
 
   /**
    * Constructor. Takes all data stored in MatrixFree for a given face range,
@@ -3342,7 +3352,8 @@ inline FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index_in,
-    const unsigned int active_quad_index_in)
+    const unsigned int active_quad_index_in,
+    const unsigned int face_type)
   : scratch_data_array(data_in.acquire_scratch_data())
   , quad_no(quad_no_in)
   , matrix_info(&data_in)
@@ -3366,7 +3377,12 @@ inline FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>::
            active_quad_index_in :
            std::min<unsigned int>(active_fe_index,
                                   mapping_data->descriptor.size() - 1)))
-  , descriptor(&mapping_data->descriptor[active_quad_index])
+  , descriptor(
+      &mapping_data->descriptor
+         [is_face ?
+            (active_quad_index * std::max<unsigned int>(1, dim - 1) +
+             (face_type == numbers::invalid_unsigned_int ? 0 : face_type)) :
+            active_quad_index])
   , n_quadrature_points(descriptor->n_q_points)
   , data(&data_in.get_shape_info(
       dof_no,
@@ -4019,7 +4035,8 @@ inline FEEvaluationBase<dim,
                    const unsigned int n_q_points,
                    const bool         is_interior_face,
                    const unsigned int active_fe_index,
-                   const unsigned int active_quad_index)
+                   const unsigned int active_quad_index,
+                   const unsigned int face_type)
   : FEEvaluationBaseData<dim, Number, is_face, VectorizedArrayType>(
       data_in,
       dof_no,
@@ -4029,7 +4046,8 @@ inline FEEvaluationBase<dim,
       n_q_points,
       is_interior_face,
       active_fe_index,
-      active_quad_index)
+      active_quad_index,
+      face_type)
   , n_fe_components(data_in.get_dof_info(dof_no).start_components.back())
   , dof_values_initialized(false)
   , values_quad_initialized(false)
@@ -6159,7 +6177,8 @@ inline FEEvaluationAccess<dim,
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index)
+    const unsigned int active_quad_index,
+    const unsigned int face_type)
   : FEEvaluationBase<dim, n_components_, Number, is_face, VectorizedArrayType>(
       data_in,
       dof_no,
@@ -6169,7 +6188,8 @@ inline FEEvaluationAccess<dim,
       n_q_points,
       is_interior_face,
       active_fe_index,
-      active_quad_index)
+      active_quad_index,
+      face_type)
 {}
 
 
@@ -6265,7 +6285,8 @@ inline FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index)
+    const unsigned int active_quad_index,
+    const unsigned int face_type)
   : FEEvaluationBase<dim, 1, Number, is_face, VectorizedArrayType>(
       data_in,
       dof_no,
@@ -6275,7 +6296,8 @@ inline FEEvaluationAccess<dim, 1, Number, is_face, VectorizedArrayType>::
       n_q_points,
       is_interior_face,
       active_fe_index,
-      active_quad_index)
+      active_quad_index,
+      face_type)
 {}
 
 
@@ -6576,7 +6598,8 @@ inline FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
     const unsigned int n_q_points,
     const bool         is_interior_face,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index)
+    const unsigned int active_quad_index,
+    const unsigned int face_type)
   : FEEvaluationBase<dim, dim, Number, is_face, VectorizedArrayType>(
       data_in,
       dof_no,
@@ -6586,7 +6609,8 @@ inline FEEvaluationAccess<dim, dim, Number, is_face, VectorizedArrayType>::
       n_q_points,
       is_interior_face,
       active_fe_index,
-      active_quad_index)
+      active_quad_index,
+      face_type)
 {}
 
 
@@ -6985,7 +7009,8 @@ inline FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
                      const unsigned int n_q_points,
                      const bool         is_interior_face,
                      const unsigned int active_fe_index,
-                     const unsigned int active_quad_index)
+                     const unsigned int active_quad_index,
+                     const unsigned int face_type)
   : FEEvaluationBase<1, 1, Number, is_face, VectorizedArrayType>(
       data_in,
       dof_no,
@@ -6995,7 +7020,8 @@ inline FEEvaluationAccess<1, 1, Number, is_face, VectorizedArrayType>::
       n_q_points,
       is_interior_face,
       active_fe_index,
-      active_quad_index)
+      active_quad_index,
+      face_type)
 {}
 
 
@@ -8412,7 +8438,8 @@ inline FEFaceEvaluation<dim,
     const unsigned int                                  quad_no,
     const unsigned int first_selected_component,
     const unsigned int active_fe_index,
-    const unsigned int active_quad_index)
+    const unsigned int active_quad_index,
+    const unsigned int face_type)
   : BaseClass(matrix_free,
               dof_no,
               first_selected_component,
@@ -8421,7 +8448,8 @@ inline FEFaceEvaluation<dim,
               static_n_q_points,
               is_interior_face,
               active_fe_index,
-              active_quad_index)
+              active_quad_index,
+              face_type)
   , dofs_per_component(this->data->dofs_per_component_on_cell)
   , dofs_per_cell(this->data->dofs_per_component_on_cell * n_components_)
   , n_q_points(this->n_quadrature_points)
@@ -8454,7 +8482,9 @@ inline FEFaceEvaluation<dim,
                      quad_no,
                      first_selected_component,
                      matrix_free.get_face_active_fe_index(range,
-                                                          is_interior_face))
+                                                          is_interior_face),
+                     numbers::invalid_unsigned_int,
+                     matrix_free.get_face_info(range.first).face_type)
 {}
 
 

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1843,8 +1843,6 @@ namespace internal
 #ifndef DEAL_II_WITH_SIMPLEX_SUPPORT
               // currently only non-hp-case...
               AssertDimension(mapping_in.size(), 1);
-              AssertDimension(mapping_info.face_data[my_q].descriptor.size(),
-                              1);
 #endif
 
               // We assume that we have the faces sorted by the active FE

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -93,10 +93,9 @@ namespace internal
 
       const auto fe_poly = dynamic_cast<const FE_Poly<dim, dim> *>(&fe);
 
-      if (dynamic_cast<const FE_SimplexP<dim, dim> *>(&fe) != nullptr ||
-          dynamic_cast<const FE_SimplexDGP<dim, dim> *>(&fe) != nullptr ||
-          dynamic_cast<const FE_WedgeP<dim, dim> *>(&fe) != nullptr ||
-          dynamic_cast<const FE_PyramidP<dim, dim> *>(&fe) != nullptr)
+      if (dynamic_cast<const FE_SimplexPoly<dim, dim> *>(&fe) != nullptr ||
+          dynamic_cast<const FE_Wedge<dim, dim> *>(&fe) != nullptr ||
+          dynamic_cast<const FE_Pyramid<dim, dim> *>(&fe) != nullptr)
         {
           scalar_lexicographic.resize(fe.n_dofs_per_cell());
           for (unsigned int i = 0; i < scalar_lexicographic.size(); ++i)


### PR DESCRIPTION
This PR introduces a new `FaceToCellTopology::face_type`:
https://github.com/dealii/dealii/blob/5c47e535302b535ef510f1dca2aad2bc946581ee/include/deal.II/matrix_free/face_info.h#L113

Face ranges are partitioned now also according the face type:
https://github.com/dealii/dealii/blob/5c47e535302b535ef510f1dca2aad2bc946581ee/include/deal.II/matrix_free/matrix_free.h#L1490-L1496
https://github.com/dealii/dealii/blob/5c47e535302b535ef510f1dca2aad2bc946581ee/include/deal.II/matrix_free/matrix_free.h#L1504-L1509

The face type is passed to the constructor of `FEEvaluationBaseData` to select the correct `descriptor`:
https://github.com/dealii/dealii/blob/5c47e535302b535ef510f1dca2aad2bc946581ee/include/deal.II/matrix_free/fe_evaluation.h#L3370-L3375
selecting between the quadrature rules of a triangle or quad in the case of 3D.

@kronbichler What do you think? Any concerns? Do you see a way how to simplify this procedure. From a `FE(Face)Evaluation` perspective, they should be ready for wedges/pyramids (once the underlying kernels are extended to use a newer version of `ShapeInfo`). Now the relevant info has to be set up in `MappingInfo` (PR #11400 and a modified version of #11387) and `ShapeInfo` (PR #11372).

depends on #11400