### PR TITLE
Test alternative path in QProjector

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -887,8 +887,14 @@ namespace ReferenceCell
         standard_line_to_face_and_line_index(
           const unsigned int line) const override
         {
-          static const std::array<unsigned int, 2> table[6] = {
-            {{0, 0}}, {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}};
+          static const std::array<unsigned int, 2> table[8] = {{{0, 0}},
+                                                               {{0, 1}},
+                                                               {{0, 2}},
+                                                               {{0, 3}},
+                                                               {{1, 2}},
+                                                               {{2, 1}},
+                                                               {{1, 1}},
+                                                               {{2, 2}}};
 
           return table[line];
         }

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -693,7 +693,7 @@ QProjector<3>::project_to_all_faces(
       }
   };
 
-  const auto process = [&](const auto faces) {
+  const auto process = [&](const auto &faces) {
     // new (projected) quadrature points and weights
     std::vector<Point<3>> points;
     std::vector<double>   weights;
@@ -825,14 +825,19 @@ QProjector<3>::project_to_all_faces(
   else if (reference_cell_type == ReferenceCell::Type::Wedge)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
-        {{{{Point<3>(0.0, 1.0, 0.0),
+        {{{{Point<3>(1.0, 0.0, 0.0),
+            Point<3>(0.0, 0.0, 0.0),
+            Point<3>(0.0, 1.0, 0.0)}},
+          0.5},
+         {{{Point<3>(0.0, 0.0, 1.0),
+            Point<3>(1.0, 0.0, 1.0),
+            Point<3>(0.0, 1.0, 1.0)}},
+          0.5},
+         {{{Point<3>(0.0, 0.0, 0.0),
             Point<3>(1.0, 0.0, 0.0),
-            Point<3>(0.0, 0.0, 0.0)}},
-          0.5},
-         {{{Point<3>(1.0, 0.0, 1.0),
-            Point<3>(0.0, 1.0, 1.0),
-            Point<3>(0.0, 0.0, 1.0)}},
-          0.5},
+            Point<3>(0.0, 0.0, 1.0),
+            Point<3>(1.0, 0.0, 1.0)}},
+          1.0},
          {{{Point<3>(1.0, 0.0, 0.0),
             Point<3>(0.0, 1.0, 0.0),
             Point<3>(1.0, 0.0, 1.0),
@@ -842,11 +847,6 @@ QProjector<3>::project_to_all_faces(
             Point<3>(0.0, 0.0, 0.0),
             Point<3>(0.0, 1.0, 1.0),
             Point<3>(0.0, 0.0, 1.0)}},
-          1.0},
-         {{{Point<3>(0.0, 0.0, 0.0),
-            Point<3>(1.0, 0.0, 0.0),
-            Point<3>(0.0, 0.0, 1.0),
-            Point<3>(1.0, 0.0, 1.0)}},
           1.0}}};
 
       return process(faces);

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -282,8 +282,8 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
             unit_tangentials[6].emplace_back(t1);
 
           // face 2
-          t1[d0] = -1 / std::sqrt(2.0);
-          t1[d1] = +1 / std::sqrt(2.0);
+          t1[d0] = 1;
+          t1[d1] = 0;
           t1[d2] = 0;
           for (unsigned int i = 0; i < n_original_q_points; i++)
             unit_tangentials[2].emplace_back(t1);
@@ -296,30 +296,30 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
             unit_tangentials[7].emplace_back(t1);
 
           // face 3
-          t1[d0] = +0;
-          t1[d1] = +0;
-          t1[d2] = +1;
+          t1[d0] = -1 / std::sqrt(2.0);
+          t1[d1] = +1 / std::sqrt(2.0);
+          t1[d2] = 0;
           for (unsigned int i = 0; i < n_original_q_points; i++)
             unit_tangentials[3].emplace_back(t1);
 
           // face 3
-          t1[d0] = +0;
-          t1[d1] = +1;
-          t1[d2] = +0;
+          t1[d0] = 0;
+          t1[d1] = 0;
+          t1[d2] = 1;
           for (unsigned int i = 0; i < n_original_q_points; i++)
             unit_tangentials[8].emplace_back(t1);
 
           // face 4
-          t1[d0] = 1;
-          t1[d1] = 0;
-          t1[d2] = 0;
+          t1[d0] = +0;
+          t1[d1] = +0;
+          t1[d2] = +1;
           for (unsigned int i = 0; i < n_original_q_points; i++)
             unit_tangentials[4].emplace_back(t1);
 
           // face 4
-          t1[d0] = 0;
-          t1[d1] = 0;
-          t1[d2] = 1;
+          t1[d0] = +0;
+          t1[d1] = +1;
+          t1[d2] = +0;
           for (unsigned int i = 0; i < n_original_q_points; i++)
             unit_tangentials[9].emplace_back(t1);
         }

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -511,12 +511,12 @@ namespace Simplex
 
     if (degree == 1)
       {
+        this->unit_support_points.emplace_back(0.0, 0.0, 0.0);
         this->unit_support_points.emplace_back(1.0, 0.0, 0.0);
         this->unit_support_points.emplace_back(0.0, 1.0, 0.0);
-        this->unit_support_points.emplace_back(0.0, 0.0, 0.0);
+        this->unit_support_points.emplace_back(0.0, 0.0, 1.0);
         this->unit_support_points.emplace_back(1.0, 0.0, 1.0);
         this->unit_support_points.emplace_back(0.0, 1.0, 1.0);
-        this->unit_support_points.emplace_back(0.0, 0.0, 1.0);
       }
   }
 

--- a/tests/simplex/poisson_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
+++ b/tests/simplex/poisson_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
@@ -25,9 +25,9 @@ DEAL::   with 134 CG iterations needed to obtain convergence
 DEAL::
 DEAL::Solve problem on WEDGE mesh:
 DEAL::   on parallel::fullydistributed::Triangulation
-DEAL:cg::Starting value 0.0561953
-DEAL:cg::Convergence step 197 value 8.61398e-13
-DEAL::   with 197 CG iterations needed to obtain convergence
+DEAL:cg::Starting value 0.0576447
+DEAL:cg::Convergence step 196 value 8.95502e-13
+DEAL::   with 196 CG iterations needed to obtain convergence
 DEAL::
 DEAL::Solve problem on PYRAMID mesh:
 DEAL::   on parallel::fullydistributed::Triangulation

--- a/tests/simplex/poisson_01.mpirun=4.with_trilinos=true.with_simplex_support=on.output
+++ b/tests/simplex/poisson_01.mpirun=4.with_trilinos=true.with_simplex_support=on.output
@@ -25,9 +25,9 @@ DEAL::   with 134 CG iterations needed to obtain convergence
 DEAL::
 DEAL::Solve problem on WEDGE mesh:
 DEAL::   on parallel::fullydistributed::Triangulation
-DEAL:cg::Starting value 0.0561953
-DEAL:cg::Convergence step 197 value 8.60684e-13
-DEAL::   with 197 CG iterations needed to obtain convergence
+DEAL:cg::Starting value 0.0576447
+DEAL:cg::Convergence step 196 value 8.89749e-13
+DEAL::   with 196 CG iterations needed to obtain convergence
 DEAL::
 DEAL::Solve problem on PYRAMID mesh:
 DEAL::   on parallel::fullydistributed::Triangulation


### PR DESCRIPTION
The first commit is from #11419.

This PR enables in theory that also for quad and hex the new, more general code path in `QProjector` is used. It should give some confidence that the new implementation works. However, it is disabled for now for two reason: 1) projection onto the faces of hypercube-like cells is trivial and 2) in many of the places of the library a certain order of the face quadrature points is needed (since `QProjector::DataSetDescriptor::face` is not used consistently). I would, nevertheless, appreciate if we could merge this PR, since the change enables to test me offline the routine with a larger set of old tests (in particular the matrix-free tests).