### PR TITLE
Generalize MGTwoLevelTransfer for simplex meshes

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -239,7 +239,12 @@ private:
     std::vector<Number> weights;
 
     /**
-     * 1D prolongation matrix.
+     * Prolongation matrix for non-tensor-product elements.
+     */
+    AlignedVector<VectorizedArray<Number>> prolongation_matrix;
+
+    /**
+     * 1D prolongation matrix for tensor-product elements.
      */
     AlignedVector<VectorizedArray<Number>> prolongation_matrix_1d;
 

--- a/tests/multigrid-global-coarsening/multigrid_a_01.cc
+++ b/tests/multigrid-global-coarsening/multigrid_a_01.cc
@@ -151,9 +151,6 @@ main(int argc, char **argv)
     for (unsigned int degree = 2; degree <= 4; ++degree)
       test<2>(n_refinements, degree, false /*quadrilateral*/);
 
-  return 0; // TODO: enable simplex test once MGTwoLevelTransfer works for
-            // simplex meshes
-
   for (unsigned int n_refinements = 2; n_refinements <= 4; ++n_refinements)
     for (unsigned int degree = 2; degree <= 2; ++degree)
       test<2>(n_refinements, degree, true /*triangle*/);

--- a/tests/multigrid-global-coarsening/multigrid_a_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
+++ b/tests/multigrid-global-coarsening/multigrid_a_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
@@ -8,3 +8,6 @@ DEAL:0::2 4 3 quad 3
 DEAL:0::2 2 4 quad 3
 DEAL:0::2 3 4 quad 3
 DEAL:0::2 4 4 quad 3
+DEAL:0::2 2 2 tri  3
+DEAL:0::2 2 3 tri  3
+DEAL:0::2 2 4 tri  3

--- a/tests/multigrid-global-coarsening/multigrid_p_01.cc
+++ b/tests/multigrid-global-coarsening/multigrid_p_01.cc
@@ -154,9 +154,6 @@ main(int argc, char **argv)
     for (unsigned int degree = 2; degree <= 4; ++degree)
       test<2>(n_refinements, degree, false /*quadrilateral*/);
 
-  return 0; // TODO: enable simplex test once MGTwoLevelTransfer works for
-            // simplex meshes
-
   for (unsigned int n_refinements = 2; n_refinements <= 4; ++n_refinements)
     for (unsigned int degree = 2; degree <= 2; ++degree)
       test<2>(n_refinements, degree, true /*triangle*/);

--- a/tests/multigrid-global-coarsening/multigrid_p_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
+++ b/tests/multigrid-global-coarsening/multigrid_p_01.mpirun=1.with_trilinos=true.with_simplex_support=on.output
@@ -8,3 +8,6 @@ DEAL:0::2 4 3 quad 3
 DEAL:0::2 2 4 quad 3
 DEAL:0::2 3 4 quad 3
 DEAL:0::2 4 4 quad 3
+DEAL:0::2 2 2 tri  3
+DEAL:0::2 2 3 tri  3
+DEAL:0::2 2 4 tri  3


### PR DESCRIPTION
~Should be quite easy~. Introduce a second d-dimensional projection matrix:
https://github.com/dealii/dealii/blob/3679ade256b019723697e86847ebcbac70b1899f/include/deal.II/multigrid/mg_transfer_global_coarsening.h#L174-L177

and specialize the evaluation kernels just like in `FEEvaluation` for the general case.

Depends on ~#11426, #11428~, #11422, and ~#11436~.