### PR TITLE
Avoid warning about unused variable in particle.h

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -517,8 +517,7 @@ namespace Particles
             std::to_string(properties.size()) +
             " properties. Deserializing a particle only works for matching property sizes."));
 
-        ar &boost::serialization::make_array(get_properties().data(),
-                                             n_properties);
+        ar &boost::serialization::make_array(properties.data(), n_properties);
       }
   }
 


### PR DESCRIPTION
Should fix https://cdash.43-1.org/viewBuildError.php?type=1&buildid=14930.