### PR TITLE
Store particle locations in the PropertyPool

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -480,16 +480,6 @@ namespace Particles
     static PropertyPool<dim, spacedim> global_property_pool;
 
     /**
-     * Current particle location.
-     */
-    Point<spacedim> location;
-
-    /**
-     * Current particle location in the reference cell.
-     */
-    Point<dim> reference_location;
-
-    /**
      * Globally unique ID of particle.
      */
     types::particle_index id;
@@ -568,7 +558,7 @@ namespace Particles
   inline void
   Particle<dim, spacedim>::set_location(const Point<spacedim> &new_loc)
   {
-    location = new_loc;
+    property_pool->set_location(property_pool_handle, new_loc);
   }
 
 
@@ -577,7 +567,7 @@ namespace Particles
   inline const Point<spacedim> &
   Particle<dim, spacedim>::get_location() const
   {
-    return location;
+    return property_pool->get_location(property_pool_handle);
   }
 
 
@@ -586,7 +576,7 @@ namespace Particles
   inline void
   Particle<dim, spacedim>::set_reference_location(const Point<dim> &new_loc)
   {
-    reference_location = new_loc;
+    property_pool->set_reference_location(property_pool_handle, new_loc);
   }
 
 
@@ -595,7 +585,7 @@ namespace Particles
   inline const Point<dim> &
   Particle<dim, spacedim>::get_reference_location() const
   {
-    return reference_location;
+    return property_pool->get_reference_location(property_pool_handle);
   }
 
 
@@ -637,6 +627,9 @@ namespace Particles
     const typename PropertyPool<dim, spacedim>::Handle new_handle =
       new_property_pool.register_particle();
 
+    const Point<spacedim> location           = get_location();
+    const Point<dim>      reference_location = get_reference_location();
+
     if (/* old pool */ has_properties())
       {
         ArrayView<const double> old_properties = this->get_properties();
@@ -652,9 +645,13 @@ namespace Particles
 
 
     // Then set the pointer to the property pool we want to use. Also set the
-    // handle to any properties, if we have copied any above.
+    // handle to any properties.
     property_pool        = &new_property_pool;
     property_pool_handle = new_handle;
+
+    // Now also store the saved locations
+    set_location(location);
+    set_reference_location(reference_location);
   }
 
 

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -83,28 +83,26 @@ namespace Particles
   PropertyPool<dim, spacedim>::register_particle()
   {
     Handle handle = invalid_handle;
-    if (n_properties > 0)
+    if (currently_available_handles.size() > 0)
       {
-        if (currently_available_handles.size() > 0)
-          {
-            handle = currently_available_handles.back();
-            currently_available_handles.pop_back();
-          }
-        else
-          {
-            handle = locations.size();
-
-            // Append new slots to the end of the arrays. Initialize with
-            // invalid points.
-            locations.resize(locations.size() + 1,
-                             numbers::signaling_nan<Point<spacedim>>());
-            reference_locations.resize(reference_locations.size() + 1,
-                                       numbers::signaling_nan<Point<dim>>());
-
-            // In contrast, initialize properties by zero.
-            properties.resize(properties.size() + n_properties, 0.0);
-          }
+        handle = currently_available_handles.back();
+        currently_available_handles.pop_back();
       }
+    else
+      {
+        handle = locations.size();
+
+        locations.resize(locations.size() + 1);
+        reference_locations.resize(reference_locations.size() + 1);
+        properties.resize(properties.size() + n_properties);
+      }
+
+    // Then initialize whatever slot we have taken with invalid locations,
+    // but initialize properties with zero.
+    set_location(handle, numbers::signaling_nan<Point<spacedim>>());
+    set_reference_location(handle, numbers::signaling_nan<Point<dim>>());
+    for (double &x : get_properties(handle))
+      x = 0;
 
     return handle;
   }

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -14,6 +14,8 @@
 // ---------------------------------------------------------------------
 
 
+#include <deal.II/base/signaling_nan.h>
+
 #include <deal.II/particles/property_pool.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -61,6 +63,12 @@ namespace Particles
       }
 
     // Clear vectors and ensure deallocation of memory
+    locations.clear();
+    locations.shrink_to_fit();
+
+    reference_locations.clear();
+    reference_locations.shrink_to_fit();
+
     properties.clear();
     properties.shrink_to_fit();
 
@@ -84,7 +92,16 @@ namespace Particles
           }
         else
           {
-            handle = properties.size() / n_properties;
+            handle = locations.size();
+
+            // Append new slots to the end of the arrays. Initialize with
+            // invalid points.
+            locations.resize(locations.size() + 1,
+                             numbers::signaling_nan<Point<spacedim>>());
+            reference_locations.resize(reference_locations.size() + 1,
+                                       numbers::signaling_nan<Point<dim>>());
+
+            // In contrast, initialize properties by zero.
             properties.resize(properties.size() + n_properties, 0.0);
           }
       }
@@ -122,6 +139,8 @@ namespace Particles
   void
   PropertyPool<dim, spacedim>::reserve(const std::size_t size)
   {
+    locations.reserve(size);
+    reference_locations.reserve(size);
     properties.reserve(size * n_properties);
   }
 


### PR DESCRIPTION
This is the next step in #11206. It adds the interface to also store locations/reference locations in the property pool (but doesn't use that yet -- coming up soon). In order to do that, though, one always has to have a property pool associated with each particle, even if that particle doesn't actually store any "properties" (we can then call the locations these particles' only "properties"). So I now have a global pool that every newly created particle attaches to, and when a particle is inserted into a `ParticleHandler`, we switch to that `ParticleHandler`'s property pool.

/rebuild