### PR TITLE
Minor change to CellWeights exception handling.

### DIFF
--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -171,9 +171,10 @@ namespace parallel
   {
     // Check if we are still working with the correct combination of
     // Triangulation and DoFHandler.
-    AssertThrow(&triangulation == &(dof_handler.get_triangulation()),
-                ExcMessage(
-                  "Triangulation associated with the DoFHandler has changed!"));
+    Assert(&triangulation == &(dof_handler.get_triangulation()),
+           ExcMessage(
+             "Triangulation associated with the DoFHandler has changed!"));
+    (void)triangulation;
 
     // Convert cell type from Triangulation to DoFHandler to be able
     // to access the information about the degrees of freedom.

--- a/tests/mpi/hp_cell_weights_01.cc
+++ b/tests/mpi/hp_cell_weights_01.cc
@@ -105,12 +105,14 @@ test()
     {
       tria.repartition();
     }
-  catch (ExcMessage &)
+  catch (const ExceptionBase &e)
     {
-      deallog << "Triangulation changed" << std::endl;
+      deallog << e.get_exc_name() << std::endl;
     }
 #else
-  deallog << "Triangulation changed" << std::endl;
+  deallog
+    << "ExcMessage(\"Triangulation associated with the DoFHandler has changed!\")"
+    << std::endl;
 #endif
 
   // make sure no processor is hanging
@@ -125,6 +127,8 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
+
+  deal_II_exceptions::disable_abort_on_exception();
 
   deallog.push("2d");
   test<2>();

--- a/tests/mpi/hp_cell_weights_01.with_p4est=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_01.with_p4est=true.mpirun=2.output
@@ -3,25 +3,25 @@ DEAL:0:2d::Number of cells before repartitioning: 8
 DEAL:0:2d::  Cumulative dofs per cell: 64
 DEAL:0:2d::Number of cells after repartitioning: 4
 DEAL:0:2d::  Cumulative dofs per cell: 48
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 32
 DEAL:0:3d::  Cumulative dofs per cell: 464
 DEAL:0:3d::Number of cells after repartitioning: 24
 DEAL:0:3d::  Cumulative dofs per cell: 400
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
 DEAL:1:2d::  Cumulative dofs per cell: 32
 DEAL:1:2d::Number of cells after repartitioning: 12
 DEAL:1:2d::  Cumulative dofs per cell: 48
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 32
 DEAL:1:3d::  Cumulative dofs per cell: 256
 DEAL:1:3d::Number of cells after repartitioning: 40
 DEAL:1:3d::  Cumulative dofs per cell: 320
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 

--- a/tests/mpi/hp_cell_weights_02.cc
+++ b/tests/mpi/hp_cell_weights_02.cc
@@ -111,12 +111,14 @@ test()
     {
       tria.repartition();
     }
-  catch (ExcMessage &)
+  catch (const ExceptionBase &e)
     {
-      deallog << "Triangulation changed" << std::endl;
+      deallog << e.get_exc_name() << std::endl;
     }
 #else
-  deallog << "Triangulation changed" << std::endl;
+  deallog
+    << "ExcMessage(\"Triangulation associated with the DoFHandler has changed!\")"
+    << std::endl;
 #endif
 
   // make sure no processor is hanging
@@ -131,6 +133,8 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
+
+  deal_II_exceptions::disable_abort_on_exception();
 
   deallog.push("2d");
   test<2>();

--- a/tests/mpi/hp_cell_weights_02.with_p4est=true.mpirun=3.output
+++ b/tests/mpi/hp_cell_weights_02.with_p4est=true.mpirun=3.output
@@ -3,26 +3,26 @@ DEAL:0:2d::Number of cells before repartitioning: 20
 DEAL:0:2d::  Cumulative dofs per cell: 140
 DEAL:0:2d::Number of cells after repartitioning: 12
 DEAL:0:2d::  Cumulative dofs per cell: 108
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 168
 DEAL:0:3d::  Cumulative dofs per cell: 1848
 DEAL:0:3d::Number of cells after repartitioning: 128
 DEAL:0:3d::  Cumulative dofs per cell: 1528
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 24
 DEAL:1:2d::  Cumulative dofs per cell: 96
 DEAL:1:2d::Number of cells after repartitioning: 28
 DEAL:1:2d::  Cumulative dofs per cell: 112
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 176
 DEAL:1:3d::  Cumulative dofs per cell: 1408
 DEAL:1:3d::Number of cells after repartitioning: 192
 DEAL:1:3d::  Cumulative dofs per cell: 1536
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 
 
@@ -30,12 +30,12 @@ DEAL:2:2d::Number of cells before repartitioning: 20
 DEAL:2:2d::  Cumulative dofs per cell: 80
 DEAL:2:2d::Number of cells after repartitioning: 24
 DEAL:2:2d::  Cumulative dofs per cell: 96
-DEAL:2:2d::Triangulation changed
+DEAL:2:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:2:2d::OK
 DEAL:2:3d::Number of cells before repartitioning: 168
 DEAL:2:3d::  Cumulative dofs per cell: 1344
 DEAL:2:3d::Number of cells after repartitioning: 192
 DEAL:2:3d::  Cumulative dofs per cell: 1536
-DEAL:2:3d::Triangulation changed
+DEAL:2:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:2:3d::OK
 

--- a/tests/mpi/hp_cell_weights_03.cc
+++ b/tests/mpi/hp_cell_weights_03.cc
@@ -116,12 +116,14 @@ test()
     {
       tria.execute_coarsening_and_refinement();
     }
-  catch (ExcMessage &)
+  catch (const ExceptionBase &e)
     {
-      deallog << "Triangulation changed" << std::endl;
+      deallog << e.get_exc_name() << std::endl;
     }
 #else
-  deallog << "Triangulation changed" << std::endl;
+  deallog
+    << "ExcMessage(\"Triangulation associated with the DoFHandler has changed!\")"
+    << std::endl;
 #endif
 
   // make sure no processor is hanging
@@ -136,6 +138,8 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
+
+  deal_II_exceptions::disable_abort_on_exception();
 
   deallog.push("2d");
   test<2>();

--- a/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output
@@ -3,25 +3,25 @@ DEAL:0:2d::Number of cells before repartitioning: 8
 DEAL:0:2d::  Cumulative dofs per cell: 32
 DEAL:0:2d::Number of cells after repartitioning: 13
 DEAL:0:2d::  Cumulative dofs per cell: 52
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 33
 DEAL:0:3d::  Cumulative dofs per cell: 264
 DEAL:0:3d::Number of cells after repartitioning: 47
 DEAL:0:3d::  Cumulative dofs per cell: 376
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
 DEAL:1:2d::  Cumulative dofs per cell: 64
 DEAL:1:2d::Number of cells after repartitioning: 3
 DEAL:1:2d::  Cumulative dofs per cell: 44
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 31
 DEAL:1:3d::  Cumulative dofs per cell: 456
 DEAL:1:3d::Number of cells after repartitioning: 17
 DEAL:1:3d::  Cumulative dofs per cell: 344
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 

--- a/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output.1
+++ b/tests/mpi/hp_cell_weights_03.with_mpi=true.with_metis=true.mpirun=2.output.1
@@ -3,25 +3,25 @@ DEAL:0:2d::Number of cells before repartitioning: 8
 DEAL:0:2d::  Cumulative dofs per cell: 64
 DEAL:0:2d::Number of cells after repartitioning: 13
 DEAL:0:2d::  Cumulative dofs per cell: 52
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 32
 DEAL:0:3d::  Cumulative dofs per cell: 256
 DEAL:0:3d::Number of cells after repartitioning: 47
 DEAL:0:3d::  Cumulative dofs per cell: 376
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
 DEAL:1:2d::  Cumulative dofs per cell: 32
 DEAL:1:2d::Number of cells after repartitioning: 3
 DEAL:1:2d::  Cumulative dofs per cell: 44
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 32
 DEAL:1:3d::  Cumulative dofs per cell: 464
 DEAL:1:3d::Number of cells after repartitioning: 17
 DEAL:1:3d::  Cumulative dofs per cell: 344
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 

--- a/tests/mpi/hp_cell_weights_04.cc
+++ b/tests/mpi/hp_cell_weights_04.cc
@@ -118,12 +118,14 @@ test()
     {
       tria.execute_coarsening_and_refinement();
     }
-  catch (ExcMessage &)
+  catch (const ExceptionBase &e)
     {
-      deallog << "Triangulation changed" << std::endl;
+      deallog << e.get_exc_name() << std::endl;
     }
 #else
-  deallog << "Triangulation changed" << std::endl;
+  deallog
+    << "ExcMessage(\"Triangulation associated with the DoFHandler has changed!\")"
+    << std::endl;
 #endif
 
   // make sure no processor is hanging
@@ -138,6 +140,8 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
   MPILogInitAll                    log;
+
+  deal_II_exceptions::disable_abort_on_exception();
 
   deallog.push("2d");
   test<2>();

--- a/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output
+++ b/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output
@@ -3,25 +3,25 @@ DEAL:0:2d::Number of cells before repartitioning: 8
 DEAL:0:2d::  Cumulative dofs per cell: 32
 DEAL:0:2d::Number of cells after repartitioning: 13
 DEAL:0:2d::  Cumulative dofs per cell: 52
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 33
 DEAL:0:3d::  Cumulative dofs per cell: 264
 DEAL:0:3d::Number of cells after repartitioning: 47
 DEAL:0:3d::  Cumulative dofs per cell: 376
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
 DEAL:1:2d::  Cumulative dofs per cell: 64
 DEAL:1:2d::Number of cells after repartitioning: 3
 DEAL:1:2d::  Cumulative dofs per cell: 44
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 31
 DEAL:1:3d::  Cumulative dofs per cell: 456
 DEAL:1:3d::Number of cells after repartitioning: 17
 DEAL:1:3d::  Cumulative dofs per cell: 344
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 

--- a/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output.1
+++ b/tests/mpi/hp_cell_weights_04.with_mpi=true.with_metis=true.mpirun=2.output.1
@@ -3,25 +3,25 @@ DEAL:0:2d::Number of cells before repartitioning: 8
 DEAL:0:2d::  Cumulative dofs per cell: 64
 DEAL:0:2d::Number of cells after repartitioning: 13
 DEAL:0:2d::  Cumulative dofs per cell: 52
-DEAL:0:2d::Triangulation changed
+DEAL:0:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:2d::OK
 DEAL:0:3d::Number of cells before repartitioning: 32
 DEAL:0:3d::  Cumulative dofs per cell: 256
 DEAL:0:3d::Number of cells after repartitioning: 47
 DEAL:0:3d::  Cumulative dofs per cell: 376
-DEAL:0:3d::Triangulation changed
+DEAL:0:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:0:3d::OK
 
 DEAL:1:2d::Number of cells before repartitioning: 8
 DEAL:1:2d::  Cumulative dofs per cell: 32
 DEAL:1:2d::Number of cells after repartitioning: 3
 DEAL:1:2d::  Cumulative dofs per cell: 44
-DEAL:1:2d::Triangulation changed
+DEAL:1:2d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:2d::OK
 DEAL:1:3d::Number of cells before repartitioning: 32
 DEAL:1:3d::  Cumulative dofs per cell: 464
 DEAL:1:3d::Number of cells after repartitioning: 17
 DEAL:1:3d::  Cumulative dofs per cell: 344
-DEAL:1:3d::Triangulation changed
+DEAL:1:3d::ExcMessage("Triangulation associated with the DoFHandler has changed!")
 DEAL:1:3d::OK
 


### PR DESCRIPTION
I only used `AssertThrow` in #8687 to catch the exceptions in tests. This is what I had initially in mind.