### PR TITLE
Update grid/cell_id_08 output.

### DIFF
--- a/tests/grid/cell_id_08.cc
+++ b/tests/grid/cell_id_08.cc
@@ -74,8 +74,8 @@ benchmark(const unsigned int n_global_refinements)
     for (const auto &cell : tria.active_cell_iterators())
       cell_ids.push_back(cell->id());
   }
-  deallog << "Creation successful." << std::endl
-          << "  Number of CellId objects: " << cell_ids.size() << std::endl;
+  deallog << "Creation successful." << std::endl;
+  std::cout << "Number of CellId objects: " << cell_ids.size() << std::endl;
 
 
   //
@@ -106,7 +106,8 @@ benchmark(const unsigned int n_global_refinements)
                 ExcMessage("Serialization with boost binary archives failed."));
     deallog << "Serialization with boost binary archives successful."
             << std::endl;
-    std::cout << "  Buffer size in bytes: " << size_in_bytes(buffer)
+    std::cout << "Buffer size in bytes with ..."
+              << "  boost binary_archive : " << size_in_bytes(buffer)
               << std::endl;
   }
 
@@ -144,7 +145,7 @@ benchmark(const unsigned int n_global_refinements)
     AssertThrow(cell_ids == deserialized,
                 ExcMessage("Serialization with Utilities failed."));
     deallog << "Serialization with Utilities successful." << std::endl;
-    std::cout << "  Buffer size in bytes: " << size_in_bytes(buffer)
+    std::cout << "  Utilities            : " << size_in_bytes(buffer)
               << std::endl;
   }
 
@@ -173,7 +174,7 @@ benchmark(const unsigned int n_global_refinements)
                 ExcMessage("Serialization with binary representation failed."));
     deallog << "Serialization with binary representation successful."
             << std::endl;
-    std::cout << "  Buffer size in bytes: " << size_in_bytes(buffer)
+    std::cout << "  binary representation: " << size_in_bytes(buffer)
               << std::endl;
   }
 

--- a/tests/grid/cell_id_08.output
+++ b/tests/grid/cell_id_08.output
@@ -1,6 +1,5 @@
 
 DEAL::Creation successful.
-DEAL::  Number of CellId objects: 256
 DEAL::Serialization with boost binary archives successful.
 DEAL::Serialization with Utilities successful.
 DEAL::Serialization with binary representation successful.


### PR DESCRIPTION
Follow-up to #11425.

Restructures the output of test `grid/cell_id_08.cc` and puts it into better context.

@bangerth -- I don't think we should just get rid of these lines in this test. If someone decides to continue to work on `CellId` or serialization, this test could be used to easily check the results of these changes. It would help to make this test more prominent in this regard. Would it make sense to move this to `dealii/performance-benchmarks`?