### PR TITLE
Utility grid generator function `hyper_line` for tests.

### DIFF
--- a/tests/hp/error_prediction_01.cc
+++ b/tests/hp/error_prediction_01.cc
@@ -23,7 +23,6 @@
 
 #include <deal.II/fe/fe_q.h>
 
-#include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 
 #include <deal.II/hp/fe_collection.h>
@@ -36,25 +35,16 @@
 
 #include "../tests.h"
 
+#include "../test_grids.h"
 
 
 template <int dim>
 void
 test()
 {
-  const unsigned int n_cells = 4;
-
   // ----- setup -----
-  Triangulation<dim>        tria;
-  std::vector<unsigned int> rep(dim, 1);
-  rep[0] = n_cells;
-  Point<dim> p1, p2;
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      p1[d] = 0;
-      p2[d] = (d == 0) ? n_cells : 1;
-    }
-  GridGenerator::subdivided_hyper_rectangle(tria, rep, p1, p2);
+  Triangulation<dim> tria;
+  TestGrids::hyper_line(tria, 4);
 
   tria.begin_active()->set_refine_flag();
   tria.execute_coarsening_and_refinement();

--- a/tests/mpi/error_predictor_01.cc
+++ b/tests/mpi/error_predictor_01.cc
@@ -27,11 +27,11 @@
 
 #include <deal.II/fe/fe_q.h>
 
-#include <deal.II/grid/grid_generator.h>
-
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 
 template <int dim>
@@ -40,19 +40,9 @@ test()
 {
   const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
-  const unsigned int n_cells = 4;
-
   // ------ setup ------
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
-  std::vector<unsigned int>                 rep(dim, 1);
-  rep[0] = n_cells;
-  Point<dim> p1, p2;
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      p1[d] = 0;
-      p2[d] = (d == 0) ? n_cells : 1;
-    }
-  GridGenerator::subdivided_hyper_rectangle(tria, rep, p1, p2);
+  TestGrids::hyper_line(tria, 4);
 
   {
     auto first = tria.begin(0);

--- a/tests/mpi/error_predictor_02.cc
+++ b/tests/mpi/error_predictor_02.cc
@@ -27,11 +27,11 @@
 
 #include <deal.II/fe/fe_q.h>
 
-#include <deal.II/grid/grid_generator.h>
-
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 
 template <int dim>
@@ -40,19 +40,9 @@ test()
 {
   const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
 
-  const unsigned int n_cells = 4;
-
   // ------ setup ------
   parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
-  std::vector<unsigned int>                 rep(dim, 1);
-  rep[0] = n_cells;
-  Point<dim> p1, p2;
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      p1[d] = 0;
-      p2[d] = (d == 0) ? n_cells : 1;
-    }
-  GridGenerator::subdivided_hyper_rectangle(tria, rep, p1, p2);
+  TestGrids::hyper_line(tria, 4);
 
   for (auto cell = tria.begin(0); cell != tria.end(0); ++cell)
     if (cell->id().to_string() == "0_0:" || cell->id().to_string() == "1_0:")

--- a/tests/particles/particle_handler_14.cc
+++ b/tests/particles/particle_handler_14.cc
@@ -23,32 +23,21 @@
 
 #include <deal.II/fe/mapping_q.h>
 
-#include <deal.II/grid/grid_generator.h>
-
 #include <deal.II/particles/particle_handler.h>
 
 #include "../tests.h"
+
+#include "../test_grids.h"
+
 
 template <int dim, int spacedim>
 void
 test()
 {
   parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+  TestGrids::hyper_line(tr, 2);
 
   MappingQ<dim, spacedim> mapping(1);
-
-  // setup triangulation
-  const unsigned int n_cells = 2;
-
-  std::vector<unsigned int> rep(dim, 1);
-  rep[0] = n_cells;
-  Point<dim> p1, p2;
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      p1[d] = 0;
-      p2[d] = (d == 0) ? n_cells : 1;
-    }
-  GridGenerator::subdivided_hyper_rectangle(tr, rep, p1, p2);
 
   // setup one particle in first cell
   Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);

--- a/tests/sharedtria/hp_choose_p_over_h.cc
+++ b/tests/sharedtria/hp_choose_p_over_h.cc
@@ -25,12 +25,12 @@
 
 #include <deal.II/fe/fe_q.h>
 
-#include <deal.II/grid/grid_generator.h>
-
 #include <deal.II/hp/fe_collection.h>
 #include <deal.II/hp/refinement.h>
 
 #include "../tests.h"
+
+#include "../test_grids.h"
 
 
 template <int dim>
@@ -38,8 +38,6 @@ void
 test()
 {
   // setup
-  const unsigned int n_cells = 2;
-
   parallel::shared::Triangulation<dim> tr(
     MPI_COMM_WORLD,
     ::Triangulation<dim>::none,
@@ -52,15 +50,7 @@ test()
                              Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD));
   });
 
-  std::vector<unsigned int> rep(dim, 1);
-  rep[0] = n_cells;
-  Point<dim> p1, p2;
-  for (unsigned int d = 0; d < dim; ++d)
-    {
-      p1[d] = 0;
-      p2[d] = (d == 0) ? n_cells : 1;
-    }
-  GridGenerator::subdivided_hyper_rectangle(tr, rep, p1, p2);
+  TestGrids::hyper_line(tr, 2);
   tr.refine_global(1);
 
   hp::FECollection<dim> fes;

--- a/tests/test_grids.h
+++ b/tests/test_grids.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2006 - 2018 by the deal.II authors
+// Copyright (C) 2006 - 2020 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -13,10 +13,14 @@
 //
 // ---------------------------------------------------------------------
 
+#include <deal.II/base/point.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
 #include <deal.II/grid/tria_accessor.h>
 #include <deal.II/grid/tria_iterator.h>
+
+#include <vector>
 
 #include "tests.h"
 
@@ -39,23 +43,21 @@
  * <tr><td>#star_shaped(tr,2,true)</td><td>method is robust if more than
  * usual cells meet in one vertex and local refinement exceeds one
  * level</td></tr>
+ * <tr><td>#hyper_line(tr,n)</td><td>aligns n unit cells in
+ * x-direction</td></tr>
  * </table>
  */
 namespace TestGrids
 {
   /**
-   * Generate grids based on
-   * hypercube. These meshes have a
-   * regular geometry and topology.
+   * Generate grids based on hypercube. These meshes have a regular geometry and
+   * topology.
    *
-   * @param <tt>refinement</tt>
-   * denotes the number of refinement
-   * steps of the root cell.
+   * @param <tt>refinement</tt> denotes the number of refinement steps of the
+   * root cell.
    *
-   * @param if <tt>local</tt> is
-   * <tt>true</tt>, refine only the
-   * cell containing the corner with
-   * only negative coordinates.
+   * @param if <tt>local</tt> is <tt>true</tt>, refine only the cell containing
+   * the corner with only negative coordinates.
    */
   template <int dim>
   void
@@ -96,42 +98,62 @@ namespace TestGrids
   }
 
   /**
-   * Create a star-shaped mesh,
-   * having more than the average
-   * <tt>2<sup>dim</sup></tt> cells
-   * in the central vertex.
+   * Create a star-shaped mesh, having more than the average
+   * <tt>2<sup>dim</sup></tt> cells in the central vertex.
    *
-   * @param <tt>refinement</tt>
-   * denotes the number of refinement
+   * @param <tt>refinement</tt> denotes the number of refinement
    * steps of the root mesh.
    *
-   * @param if <tt>local</tt> is
-   * <tt>true</tt>, refine only one
-   * of the coarse cells.
+   * @param if <tt>local</tt> is <tt>true</tt>, refine only one of
+   * the coarse cells.
    */
   template <int dim>
   void
   star_shaped(Triangulation<dim> &tr,
               unsigned int        refinement = 0,
               bool                local      = false);
+
   /**
-   * Local refinement of every other
-   * cell in a checkerboard fashion.
+   * Local refinement of every other cell in a checkerboard fashion.
    */
   template <int dim>
   void
   checkers(Triangulation<dim> &tr);
+
   /**
-   * Islands of local refinement
+   * Islands of local refinement.
    */
   template <int dim>
   void
   islands(Triangulation<dim> &tr);
+
   /**
-   * Local refinement with an
-   * unrefined hole.
+   * Local refinement with an unrefined hole.
    */
   template <int dim>
   void
   laguna(Triangulation<dim> &tr);
+
+  /**
+   * Generates grid with @p n_cells unit cells $[0,1]^d$ aligned in the
+   * x-coordinate direction.
+   *
+   * The domain this grid represents covers $[0,n_cells] \times [0,1]^{d-1}$.
+   * Thus, integer division of the x-cordinate $x // 1$ on any point in this
+   * triangulation gives you the index of the cell the point is located in.
+   */
+  template <int dim, int spacedim>
+  void
+  hyper_line(Triangulation<dim, spacedim> &tr, const int n_cells)
+  {
+    std::vector<unsigned int> repetitions(dim, 1);
+    repetitions[0] = n_cells;
+    Point<dim> p1, p2;
+    for (unsigned int d = 0; d < dim; ++d)
+      {
+        p1[d] = 0;
+        p2[d] = (d == 0) ? n_cells : 1;
+      }
+    GridGenerator::subdivided_hyper_rectangle(tr, repetitions, p1, p2);
+  }
 } // namespace TestGrids

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -418,6 +418,7 @@ filter_out_small_numbers(const Number number, const double tolerance)
     return number;
 }
 
+
 // ---------------- Functions used in initializing subsystems -----------------
 
 


### PR DESCRIPTION
I keep re-using the same grid generation code snippet for many tests.

I thought this would make a nice addition to the utility functions for the testsuite. This suggestion is not versatile enough to be part of the `GridGenerator` namespace, so I thought it would be best suited in `tests/test.h`. What do you think?

EDIT: I have just spotted `tests/test_grids.h` and moved it there. I think this is a good place to keep it there.