### PR TITLE
step-26: Reset time and timestep_number during pre refinement steps

### DIFF
--- a/doc/news/changes/minor/20210105CPraveen
+++ b/doc/news/changes/minor/20210105CPraveen
@@ -1,0 +1,3 @@
+Fixed: Reset time and timestep_number during pre refinement steps in step-26.
+<br>
+(Praveen Chandrashekar, 2021/01/05)

--- a/examples/step-26/step-26.cc
+++ b/examples/step-26/step-26.cc
@@ -205,9 +205,7 @@ namespace Step26
   HeatEquation<dim>::HeatEquation()
     : fe(1)
     , dof_handler(triangulation)
-    , time(0.0)
     , time_step(1. / 500)
-    , timestep_number(0)
     , theta(0.5)
   {}
 
@@ -456,6 +454,9 @@ namespace Step26
     Vector<double> forcing_terms;
 
   start_time_iteration:
+
+    time            = 0.0;
+    timestep_number = 0;
 
     tmp.reinit(solution.size());
     forcing_terms.reinit(solution.size());


### PR DESCRIPTION
Otherwise, the pre-refinement is performed only once. See https://github.com/dealii/dealii/issues/10715