### PR TITLE
Rename zero_out_ghosts() to zero_out_ghost_values()

### DIFF
--- a/doc/news/changes/incompatibilities/20210104Munch
+++ b/doc/news/changes/incompatibilities/20210104Munch
@@ -1,0 +1,4 @@
+Deprecated: All `LinearAlgebra::distributed::Vector::zero_out_ghosts()` has been deprecated. 
+Use `LinearAlgebra::distributed::Vector::zero_out_ghost_values()` instead.
+<br>
+(Peter Munch, 2021/01/04)

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -508,7 +508,7 @@ namespace Step48
     data_out.write_vtu_with_pvtu_record(
       "./", "solution", timestep_number, MPI_COMM_WORLD, 3);
 
-    solution.zero_out_ghosts();
+    solution.zero_out_ghost_values();
   }
 
 

--- a/examples/step-67/step-67.cc
+++ b/examples/step-67/step-67.cc
@@ -1544,7 +1544,7 @@ namespace Euler_DG
     FEEvaluation<dim, degree, degree + 1, dim + 2, Number> phi(data, 0, 1);
     MatrixFreeOperators::CellwiseInverseMassMatrix<dim, degree, dim + 2, Number>
       inverse(phi);
-    solution.zero_out_ghosts();
+    solution.zero_out_ghost_values();
     for (unsigned int cell = 0; cell < data.n_cell_batches(); ++cell)
       {
         phi.reinit(cell);

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -502,7 +502,7 @@ namespace Step68
   template <int dim>
   void ParticleTracking<dim>::interpolate_function_to_field()
   {
-    velocity_field.zero_out_ghosts();
+    velocity_field.zero_out_ghost_values();
     VectorTools::interpolate(mapping, fluid_dh, velocity, velocity_field);
     velocity_field.update_ghost_values();
   }

--- a/include/deal.II/distributed/solution_transfer.h
+++ b/include/deal.II/distributed/solution_transfer.h
@@ -120,7 +120,7 @@ namespace parallel
      * LinearAlgebra::distributed::Vector allows writing into ghost elements.
      * For a ghosted vector the interpolation step can be accomplished via
      * @code
-     * interpolated_solution.zero_out_ghosts();
+     * interpolated_solution.zero_out_ghost_values();
      * soltrans.interpolate(interpolated_solution);
      * interpolated_solution.update_ghost_values();
      * @endcode

--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1885,7 +1885,7 @@ namespace internal
           if (vec.in_local_range(idx))
             vec(idx) = 0.;
         }
-      vec.zero_out_ghosts();
+      vec.zero_out_ghost_values();
     }
 
 #ifdef DEAL_II_COMPILER_CUDA_AWARE
@@ -1930,7 +1930,7 @@ namespace internal
 
       Utilities::CUDA::free(constrained_local_dofs_device);
 
-      vec.zero_out_ghosts();
+      vec.zero_out_ghost_values();
     }
 #endif
 
@@ -2174,7 +2174,7 @@ namespace internal
     // TODO: the in vector might already have all elements. need to find a
     // way to efficiently avoid the copy then
     const_cast<LinearAlgebra::distributed::Vector<number> &>(vec)
-      .zero_out_ghosts();
+      .zero_out_ghost_values();
     output.reinit(locally_owned_elements,
                   needed_elements,
                   vec.get_mpi_communicator());

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -348,9 +348,23 @@ namespace LinearAlgebra
        * After calling this method, read access to ghost elements of the
        * vector is forbidden and an exception is thrown. Only write access to
        * ghost elements is allowed in this state.
+       *
+       * @deprecated Use zero_out_ghost_values() instead.
+       */
+      DEAL_II_DEPRECATED_EARLY void
+      zero_out_ghosts() const;
+
+
+      /**
+       * This method zeros the entries on ghost dofs, but does not touch
+       * locally owned DoFs.
+       *
+       * After calling this method, read access to ghost elements of the
+       * vector is forbidden and an exception is thrown. Only write access to
+       * ghost elements is allowed in this state.
        */
       void
-      zero_out_ghosts() const;
+      zero_out_ghost_values() const;
 
       /**
        * Return if this Vector contains ghost elements.

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -379,8 +379,17 @@ namespace LinearAlgebra
     void
     BlockVector<Number>::zero_out_ghosts() const
     {
+      this->zero_out_ghost_values();
+    }
+
+
+
+    template <typename Number>
+    void
+    BlockVector<Number>::zero_out_ghost_values() const
+    {
       for (unsigned int block = 0; block < this->n_blocks(); ++block)
-        this->block(block).zero_out_ghosts();
+        this->block(block).zero_out_ghost_values();
     }
 
 

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -134,7 +134,7 @@ namespace LinearAlgebra
      * This vector can take two different states with respect to ghost
      * elements:
      * <ul>
-     * <li> After creation and whenever zero_out_ghosts() is called (or
+     * <li> After creation and whenever zero_out_ghost_values() is called (or
      * <code>operator= (0.)</code>), the vector does only allow writing into
      * ghost elements but not reading from ghost elements.
      * <li> After a call to update_ghost_values(), the vector does not allow
@@ -515,7 +515,7 @@ namespace LinearAlgebra
        * operation. However, global reduction operations like norms or the
        * inner product will always ignore ghost elements in order to avoid
        * counting the ghost data more than once. To allow writing to ghost
-       * elements again, call zero_out_ghosts().
+       * elements again, call zero_out_ghost_values().
        *
        * @see
        * @ref GlossGhostedVector "vectors with ghost elements"
@@ -605,9 +605,22 @@ namespace LinearAlgebra
        * After calling this method, read access to ghost elements of the
        * vector is forbidden and an exception is thrown. Only write access to
        * ghost elements is allowed in this state.
+       *
+       * @deprecated Use zero_out_ghost_values() instead.
+       */
+      DEAL_II_DEPRECATED_EARLY void
+      zero_out_ghosts() const;
+
+      /**
+       * This method zeros the entries on ghost dofs, but does not touch
+       * locally owned DoFs.
+       *
+       * After calling this method, read access to ghost elements of the
+       * vector is forbidden and an exception is thrown. Only write access to
+       * ghost elements is allowed in this state.
        */
       void
-      zero_out_ghosts() const;
+      zero_out_ghost_values() const;
 
       /**
        * Return whether the vector currently is in a state where ghost values

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -537,7 +537,7 @@ namespace LinearAlgebra
       if (omit_zeroing_entries == false)
         this->operator=(Number());
       else
-        zero_out_ghosts();
+        zero_out_ghost_values();
     }
 
 
@@ -598,7 +598,7 @@ namespace LinearAlgebra
       if (omit_zeroing_entries == false)
         this->operator=(Number());
       else
-        zero_out_ghosts();
+        zero_out_ghost_values();
 
       // do not reallocate import_data directly, but only upon request. It
       // is only used as temporary storage for compress() and
@@ -846,7 +846,7 @@ namespace LinearAlgebra
       if (must_update_ghost_values)
         update_ghost_values();
       else
-        zero_out_ghosts();
+        zero_out_ghost_values();
       return *this;
     }
 
@@ -916,6 +916,15 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::zero_out_ghosts() const
+    {
+      this->zero_out_ghost_values();
+    }
+
+
+
+    template <typename Number, typename MemorySpaceType>
+    void
+    Vector<Number, MemorySpaceType>::zero_out_ghost_values() const
     {
       if (data.values != nullptr)
         std::fill_n(data.values.get() + partitioner->local_size(),
@@ -1420,7 +1429,7 @@ namespace LinearAlgebra
       // if we call Vector::operator=0, we want to zero out all the entries
       // plus ghosts.
       if (s == Number())
-        zero_out_ghosts();
+        zero_out_ghost_values();
 
       return *this;
     }

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -1218,7 +1218,7 @@ namespace CUDAWrappers
                 }
             dst.compress(VectorOperation::add);
           }
-        src.zero_out_ghosts();
+        src.zero_out_ghost_values();
       }
     else
       {

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3797,7 +3797,7 @@ namespace internal
       if (ghosts_were_set == true)
         return;
 
-      vec.zero_out_ghosts();
+      vec.zero_out_ghost_values();
     }
 
 

--- a/include/deal.II/multigrid/mg_transfer.templates.h
+++ b/include/deal.II/multigrid/mg_transfer.templates.h
@@ -531,7 +531,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_from_mg(
       // In this case, we can simply copy the local range. To avoid having
       // stray data in ghost entries of the destination, make sure to clear
       // them here.
-      dst.zero_out_ghosts();
+      dst.zero_out_ghost_values();
       AssertDimension(src[src.max_level()].local_size(), dst.local_size());
       dst.copy_locally_owned_data_from(src[src.max_level()]);
       return;
@@ -544,7 +544,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::copy_from_mg(
       Assert(copy_indices_global_mine.back().empty(), ExcInternalError());
       const LinearAlgebra::distributed::Vector<Number> &src_level =
         src[src.max_level()];
-      dst.zero_out_ghosts();
+      dst.zero_out_ghost_values();
       for (unsigned int i = 0; i < copy_indices.back().n_cols(); ++i)
         dst.local_element(i) =
           src_level.local_element(copy_indices.back()(1, i));
@@ -602,7 +602,7 @@ MGLevelGlobalTransfer<LinearAlgebra::distributed::Vector<Number>>::
   // attention, since they belong to the coarse level, but have fine level
   // basis functions
 
-  dst.zero_out_ghosts();
+  dst.zero_out_ghost_values();
   for (unsigned int level = src.min_level(); level <= src.max_level(); ++level)
     {
       // the ghosted vector should already have the correct local size (but

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -1742,8 +1742,8 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::prolongate(
         }
     }
 
-  this->vec_coarse.zero_out_ghosts(); // clear ghost values; else compress in
-                                      // do_restrict_add does not work
+  this->vec_coarse.zero_out_ghost_values(); // clear ghost values; else compress
+                                            // in do_restrict_add does not work
 
   if (schemes.size() > 0 && schemes.front().fine_element_is_continuous)
     this->vec_fine.compress(VectorOperation::add);

--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -253,7 +253,7 @@ MGTransferMatrixFree<dim, Number>::prolongate(
     dst.copy_locally_owned_data_from(this->ghosted_level_vector[to_level]);
 
   if (src_inplace == true)
-    src.zero_out_ghosts();
+    src.zero_out_ghost_values();
 }
 
 
@@ -330,7 +330,7 @@ MGTransferMatrixFree<dim, Number>::restrict_and_add(
     dst += dst_vec;
 
   if (src_inplace == true)
-    src.zero_out_ghosts();
+    src.zero_out_ghost_values();
 }
 
 

--- a/tests/cuda/parallel_vector_15.cu
+++ b/tests/cuda/parallel_vector_15.cu
@@ -77,12 +77,12 @@ test()
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
 
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   w = v;
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
 
-  w.zero_out_ghosts();
+  w.zero_out_ghost_values();
   w = v;
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
@@ -92,7 +92,7 @@ test()
   if (myid == 0)
     deallog << "x has ghost elements: " << x.has_ghost_elements() << std::endl;
 
-  x.zero_out_ghosts();
+  x.zero_out_ghost_values();
   if (myid == 0)
     deallog << "x has ghost elements: " << x.has_ghost_elements() << std::endl;
 

--- a/tests/cuda/parallel_vector_16.cu
+++ b/tests/cuda/parallel_vector_16.cu
@@ -78,7 +78,7 @@ test()
   v.update_ghost_values();
   v.print(deallog.get_file_stream(), 12, false, false);
 
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   double *    values_dev  = v.get_values();
   const auto &partitioner = v.get_partitioner();
   set_value<<<1, 1>>>(values_dev,

--- a/tests/cuda/parallel_vector_22.cu
+++ b/tests/cuda/parallel_vector_22.cu
@@ -106,7 +106,7 @@ test()
           << std::endl;
 
   // ghosts are set to zero
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
 
   // minimize
   v.compress(VectorOperation::min);
@@ -119,7 +119,7 @@ test()
           << std::endl;
 
   // set ghost dof on non-owning processors and minimize
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   if (myid == 0)
     set_value<<<1, 1>>>(v.get_values(), partitioner->global_to_local(1), -1.);
   v.compress(VectorOperation::min);
@@ -132,7 +132,7 @@ test()
           << std::endl;
 
   // set vector to 1, zeros in ghosts except on owner where -1. is set
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v = 1.0;
   if (myid == 0)
     set_value<<<1, 1>>>(v.get_values(), partitioner->global_to_local(1), -1.);
@@ -150,7 +150,7 @@ test()
 
   // however, if the ghost value is set on all processors, the
   // maximum is -1:
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v = 1.0;
   set_value<<<1, 1>>>(v.get_values(), partitioner->global_to_local(1), -1.);
   v.compress(VectorOperation::max);
@@ -162,7 +162,7 @@ test()
 
   // what happens in case max is called two times and all values were smaller
   // than zero
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v = -1.0;
   set_value<<<1, 1>>>(v.get_values(), partitioner->global_to_local(1), -1.);
   v.compress(VectorOperation::max);

--- a/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
+++ b/tests/dofs/dof_tools_extract_dofs_with_support_contained_within_04.cc
@@ -122,8 +122,8 @@ test()
   sparse_rhs.reinit(locally_owned_set, locally_relevant_set, MPI_COMM_WORLD);
   rhs.reinit(locally_owned_set, locally_relevant_set, MPI_COMM_WORLD);
 
-  sparse_rhs.zero_out_ghosts();
-  rhs.zero_out_ghosts();
+  sparse_rhs.zero_out_ghost_values();
+  rhs.zero_out_ghost_values();
 
   // assemble RHS which has a local support:
   const std::function<double(const Point<dim> &)> rhs_func =

--- a/tests/matrix_free/compare_faces_by_cells.cc
+++ b/tests/matrix_free/compare_faces_by_cells.cc
@@ -97,7 +97,7 @@ public:
     LinearAlgebra::distributed::Vector<number> &result) const
   {
     int dummy;
-    result.zero_out_ghosts();
+    result.zero_out_ghost_values();
     data.cell_loop(&LaplaceOperator::local_diagonal_by_cell,
                    this,
                    result,

--- a/tests/matrix_free/loop_boundary.cc
+++ b/tests/matrix_free/loop_boundary.cc
@@ -133,7 +133,7 @@ do_test(const unsigned int n_refine, const bool overlap_communication)
                                matrix_free.n_inner_face_batches() +
                                  matrix_free.n_boundary_face_batches()));
   ref.compress(VectorOperation::add);
-  in.zero_out_ghosts();
+  in.zero_out_ghost_values();
 
   std::function<void(const MatrixFree<dim> &,
                      LinearAlgebra::distributed::Vector<double> &,
@@ -209,7 +209,7 @@ do_test(const unsigned int n_refine, const bool overlap_communication)
             in,
             std::make_pair(0U, matrix_free.n_cell_batches()));
   ref.compress(VectorOperation::add);
-  in.zero_out_ghosts();
+  in.zero_out_ghost_values();
 
   matrix_free.cell_loop(cell_func, test, in, true);
   test -= ref;

--- a/tests/matrix_free/multigrid_dg_sip_01.cc
+++ b/tests/matrix_free/multigrid_dg_sip_01.cc
@@ -132,7 +132,7 @@ public:
         dst_copy = dst;
         dst.swap(dst_copy);
       }
-    dst.zero_out_ghosts();
+    dst.zero_out_ghost_values();
     data.loop(&LaplaceOperator::local_apply,
               &LaplaceOperator::local_apply_face,
               &LaplaceOperator::local_apply_boundary,

--- a/tests/matrix_free/multigrid_dg_sip_02.cc
+++ b/tests/matrix_free/multigrid_dg_sip_02.cc
@@ -135,7 +135,7 @@ public:
         dst_copy = dst;
         dst.swap(dst_copy);
       }
-    dst.zero_out_ghosts();
+    dst.zero_out_ghost_values();
     data.loop(&LaplaceOperator::local_apply,
               &LaplaceOperator::local_apply_face,
               &LaplaceOperator::local_apply_boundary,

--- a/tests/mpi/parallel_block_vector_02.cc
+++ b/tests/mpi/parallel_block_vector_02.cc
@@ -87,7 +87,7 @@ test()
     AssertDimension(i + 1, (unsigned int)w.block(i)(1));
 
   // zero out ghosts, now all processors except processor 1 should have 0.
-  w.zero_out_ghosts();
+  w.zero_out_ghost_values();
   for (unsigned int i = 0; i < 3; ++i)
     if (myid == 0)
       {

--- a/tests/mpi/parallel_block_vector_13.cc
+++ b/tests/mpi/parallel_block_vector_13.cc
@@ -91,7 +91,7 @@ test()
     AssertDimension(i + 1, (unsigned int)w.block(i)(1));
 
   // zero out ghosts, now all processors except processor 1 should have 0.
-  w.zero_out_ghosts();
+  w.zero_out_ghost_values();
   for (unsigned int i = 0; i < n_blocks; ++i)
     if (myid == 0)
       {

--- a/tests/mpi/parallel_vector_15.cc
+++ b/tests/mpi/parallel_vector_15.cc
@@ -75,12 +75,12 @@ test()
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
 
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   w = v;
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
 
-  w.zero_out_ghosts();
+  w.zero_out_ghost_values();
   w = v;
   if (myid == 0)
     deallog << "w has ghost elements: " << w.has_ghost_elements() << std::endl;
@@ -90,7 +90,7 @@ test()
   if (myid == 0)
     deallog << "x has ghost elements: " << x.has_ghost_elements() << std::endl;
 
-  x.zero_out_ghosts();
+  x.zero_out_ghost_values();
   if (myid == 0)
     deallog << "x has ghost elements: " << x.has_ghost_elements() << std::endl;
 

--- a/tests/mpi/parallel_vector_16.cc
+++ b/tests/mpi/parallel_vector_16.cc
@@ -76,7 +76,7 @@ test()
   Assert(v(min_index + 39) == min_index + 39, ExcInternalError());
   Assert(v(min_index + 38) == min_index + 38, ExcInternalError());
 
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v(min_index + 38) = min_index;
   v(min_index + 39) = min_index * 2;
   v(min_index + 41) = min_index + 7;

--- a/tests/mpi/parallel_vector_22.cc
+++ b/tests/mpi/parallel_vector_22.cc
@@ -75,7 +75,7 @@ test()
           << "ghost entry after max from owner: " << v(1) << std::endl;
 
   // ghosts are set to zero
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
 
   // minimize
   v.compress(VectorOperation::min);
@@ -86,7 +86,7 @@ test()
           << "ghost entry after min from zero: " << v(1) << std::endl;
 
   // set ghost dof on non-owning processors and minimize
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   if (!myid)
     v(1) = -1.;
   v.compress(VectorOperation::min);
@@ -97,7 +97,7 @@ test()
           << "ghost entry after min from : " << v(1) << std::endl;
 
   // set vector to 1, zeros in ghosts except on owner where -1. is set
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v = 1.0;
   if (!myid)
     v(1) = -1.0;
@@ -113,7 +113,7 @@ test()
 
   // however, if the ghost value is set on all processors, the
   // maximum is -1:
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v    = 1.0;
   v(1) = -1.0;
   v.compress(VectorOperation::max);
@@ -123,7 +123,7 @@ test()
 
   // what happens in case max is called two times and all values were smaller
   // than zero
-  v.zero_out_ghosts();
+  v.zero_out_ghost_values();
   v    = -1.0;
   v(1) = -1.0;
   v.compress(VectorOperation::max);

--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -129,7 +129,7 @@ do_project(const parallel::distributed::Triangulation<dim> &triangulation,
   for (unsigned int q = 0; q <= p + 2 - order_difference; ++q)
     {
       // project the function
-      projection.zero_out_ghosts();
+      projection.zero_out_ghost_values();
       VectorTools::project(dof_handler,
                            constraints,
                            QGauss<dim>(p + 2),


### PR DESCRIPTION
The asymmetric of `update_ghost_values()` and `zero_out_ghosts()` only leads to confusion. I would suggest to also rename `has_ghost_elements()` to `has_ghost_values()`.

FYI @mschreter 