### PR TITLE
Return points by value.

### DIFF
--- a/include/deal.II/particles/particle.h
+++ b/include/deal.II/particles/particle.h
@@ -280,7 +280,7 @@ namespace Particles
      *
      * @return The location of this particle.
      */
-    const Point<spacedim> &
+    Point<spacedim>
     get_location() const;
 
     /**
@@ -306,7 +306,7 @@ namespace Particles
     /**
      * Return the reference location of this particle in its current cell.
      */
-    const Point<dim> &
+    Point<dim>
     get_reference_location() const;
 
     /**
@@ -555,7 +555,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<spacedim> &
+  inline Point<spacedim>
   Particle<dim, spacedim>::get_location() const
   {
     return location;
@@ -573,7 +573,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<dim> &
+  inline Point<dim>
   Particle<dim, spacedim>::get_reference_location() const
   {
     return reference_location;

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -84,7 +84,7 @@ namespace Particles
      *
      * @return The location of this particle.
      */
-    const Point<spacedim> &
+    Point<spacedim>
     get_location() const;
 
     /**
@@ -110,7 +110,7 @@ namespace Particles
     /**
      * Return the reference location of this particle in its current cell.
      */
-    const Point<dim> &
+    Point<dim>
     get_reference_location() const;
 
     /**
@@ -337,7 +337,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<spacedim> &
+  inline Point<spacedim>
   ParticleAccessor<dim, spacedim>::get_location() const
   {
     Assert(particle != map->end(), ExcInternalError());
@@ -360,7 +360,7 @@ namespace Particles
 
 
   template <int dim, int spacedim>
-  inline const Point<dim> &
+  inline Point<dim>
   ParticleAccessor<dim, spacedim>::get_reference_location() const
   {
     Assert(particle != map->end(), ExcInternalError());


### PR DESCRIPTION
For the purposes of returned arguments, we frequently return `Point<dim>` objects by-value rather than `const` reference. That's because they are small and easily scalarized by compilers. Do the same for the functions that return locations in the particle interfaces.

See #11206.

/rebuild