### PR TITLE
Adjusted settings for default FESeries::Legendre object.

### DIFF
--- a/include/deal.II/numerics/smoothness_estimator.h
+++ b/include/deal.II/numerics/smoothness_estimator.h
@@ -228,10 +228,10 @@ namespace SmoothnessEstimator
      * the default configuration for smoothness estimation purposes.
      *
      * For each finite element of the provided @p fe_collection, we use as many
-     * modes as its polynomial degree plus one, since we start with the first
-     * Legendre polynomial which is just a constant. Further for each element,
-     * we use a Gaussian quadrature designed to yield exact results for the
-     * highest order Legendre polynomial used.
+     * modes as its polynomial degree plus two. This includes the first Legendre
+     * polynomial which is just a constant. Further for each element, we use a
+     * Gaussian quadrature designed to yield exact results for the highest order
+     * Legendre polynomial used.
      */
     template <int dim, int spacedim>
     FESeries::Legendre<dim, spacedim>

--- a/source/numerics/smoothness_estimator.cc
+++ b/source/numerics/smoothness_estimator.cc
@@ -290,9 +290,13 @@ namespace SmoothnessEstimator
     default_fe_series(const hp::FECollection<dim, spacedim> &fe_collection)
     {
       // Default number of coefficients per direction.
+      //
+      // With a number of modes equal to the polynomial degree plus two for each
+      // finite element, the smoothness estimation algorithm tends to produce
+      // stable results.
       std::vector<unsigned int> n_coefficients_per_direction;
       for (unsigned int i = 0; i < fe_collection.size(); ++i)
-        n_coefficients_per_direction.push_back(fe_collection[i].degree + 1);
+        n_coefficients_per_direction.push_back(fe_collection[i].degree + 2);
 
       // Default quadrature collection.
       //


### PR DESCRIPTION
After #11471, I was curious to see how Legendre coefficient decay strategy performs on `step-27`. Again, I could observe how the refinement behavior changes with an increasing number of modes, and we were again one mode short until results converge.

This PR suggests to use `degree + 2` modes for each finite element, which would mean that we cut off the Legendre series after a Legendre polynomial with `degree + 1`.

I currently have no explanation why this additional mode is necessary for both Fourier and Legendre strategies, but let us consider them for the sake of their robustness.