### PR TITLE
Replace deprecated CellId::to_cell().

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -4103,7 +4103,7 @@ namespace GridTools
           for (unsigned int c = 0; c < static_cast<unsigned int>(n_cells); ++c)
             {
               const auto cell =
-                CellId(cell_data_to_send[idx][c]).to_cell(*tria);
+                tria->create_cell_iterator(CellId(cell_data_to_send[idx][c]));
 
               MeshCellIteratorType                mesh_it(tria,
                                            cell->level(),
@@ -4176,7 +4176,7 @@ namespace GridTools
           for (unsigned int c = 0; c < cellinfo.cell_ids.size(); ++c, ++data)
             {
               const typename Triangulation<dim, spacedim>::cell_iterator
-                tria_cell = cellinfo.cell_ids[c].to_cell(*tria);
+                tria_cell = tria->create_cell_iterator(cellinfo.cell_ids[c]);
 
               MeshCellIteratorType cell(tria,
                                         tria_cell->level(),

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -551,7 +551,8 @@ namespace internal
             for (auto cell_id : i.second)
               {
                 typename MeshType::cell_iterator cell(
-                  *cell_id_translator.to_cell_id(cell_id).to_cell(tria_dst),
+                  *tria_dst.create_cell_iterator(
+                    cell_id_translator.to_cell_id(cell_id)),
                   &dof_handler_dst);
 
                 cell->get_dof_indices(indices);
@@ -580,8 +581,8 @@ namespace internal
           {
             const auto cell_id = cell_id_translator.to_cell_id(id);
 
-            typename MeshType::cell_iterator cell_(*cell_id.to_cell(tria_dst),
-                                                   &dof_handler_dst);
+            typename MeshType::cell_iterator cell_(
+              *tria_dst.create_cell_iterator(cell_id), &dof_handler_dst);
 
             cell_->get_dof_indices(indices);
 
@@ -695,7 +696,8 @@ namespace internal
           if (is_cell_locally_owned)
             {
               (typename MeshType::cell_iterator(
-                 *cell->id().to_cell(mesh_fine.get_triangulation()),
+                 *mesh_fine.get_triangulation().create_cell_iterator(
+                   cell->id()),
                  &mesh_fine))
                 ->get_dof_indices(dof_indices);
             }
@@ -732,7 +734,8 @@ namespace internal
           if (is_cell_locally_owned)
             {
               (typename MeshType::cell_iterator(
-                 *cell->id().to_cell(mesh_fine.get_triangulation()),
+                 *mesh_fine.get_triangulation().create_cell_iterator(
+                   cell->id()),
                  &mesh_fine))
                 ->child(c)
                 ->get_dof_indices(dof_indices);

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5222,7 +5222,8 @@ namespace GridTools
         std::vector<typename Triangulation<dim, spacedim>::active_cell_iterator>
           cell_iter(n_cells);
         for (unsigned int c = 0; c < n_cells; ++c)
-          cell_iter[c] = cell_ids[c].to_cell(cache.get_triangulation());
+          cell_iter[c] =
+            cache.get_triangulation().create_cell_iterator(cell_ids[c]);
 
         internal::DistributedComputePointLocations::merge_into_point_locations(
           cell_iter,

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1533,7 +1533,7 @@ namespace Particles
         recv_data_it = static_cast<const char *>(recv_data_it) + cellid_size;
 
         const typename Triangulation<dim, spacedim>::active_cell_iterator cell =
-          id.to_cell(*triangulation);
+          triangulation->create_cell_iterator(id);
 
         typename std::multimap<internal::LevelInd,
                                Particle<dim, spacedim>>::iterator


### PR DESCRIPTION
Follow-up to #11365. We missed a few occurrences of the now deprecated function inside the library.