### PR TITLE
Fix BoundingBox's Container ctor.

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -23,14 +23,6 @@
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 
-DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <boost/geometry/algorithms/envelope.hpp>
-#include <boost/geometry/geometries/multi_point.hpp>
-#if DEAL_II_BOOST_VERSION_GTE(1, 75, 0)
-#  include <boost/geometry/strategies/envelope/cartesian.hpp>
-#endif
-DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
-
 DEAL_II_NAMESPACE_OPEN
 
 /**
@@ -164,6 +156,18 @@ public:
    */
   const std::pair<Point<spacedim, Number>, Point<spacedim, Number>> &
   get_boundary_points() const;
+
+  /**
+   * Test for equality.
+   */
+  bool
+  operator==(const BoundingBox<spacedim, Number> &box) const;
+
+  /**
+   * Test for inequality.
+   */
+  bool
+  operator!=(const BoundingBox<spacedim, Number> &box) const;
 
   /**
    * Check if the current object and @p other_bbox are neighbors, i.e. if the boxes
@@ -407,10 +411,46 @@ template <int spacedim, typename Number>
 template <class Container>
 inline BoundingBox<spacedim, Number>::BoundingBox(const Container &points)
 {
-  boost::geometry::envelope(
-    boost::geometry::model::multi_point<Point<spacedim, Number>>(points.begin(),
-                                                                 points.end()),
-    *this);
+  // Use the default constructor in case points is empty instead of setting
+  // things to +oo and -oo
+  if (points.size() > 0)
+    {
+      auto &min = boundary_points.first;
+      auto &max = boundary_points.second;
+      std::fill(min.begin_raw(),
+                min.end_raw(),
+                std::numeric_limits<Number>::infinity());
+      std::fill(max.begin_raw(),
+                max.end_raw(),
+                -std::numeric_limits<Number>::infinity());
+
+      for (const Point<spacedim, Number> &point : points)
+        for (unsigned int d = 0; d < spacedim; ++d)
+          {
+            min[d] = std::min(min[d], point[d]);
+            max[d] = std::max(max[d], point[d]);
+          }
+    }
+}
+
+
+
+template <int spacedim, typename Number>
+inline bool
+BoundingBox<spacedim, Number>::
+operator==(const BoundingBox<spacedim, Number> &box) const
+{
+  return boundary_points == box.boundary_points;
+}
+
+
+
+template <int spacedim, typename Number>
+inline bool
+BoundingBox<spacedim, Number>::
+operator!=(const BoundingBox<spacedim, Number> &box) const
+{
+  return boundary_points != box.boundary_points;
 }
 
 

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -29,6 +29,8 @@
 #include <deal.II/grid/tria_iterator_base.h>
 #include <deal.II/grid/tria_iterator_selector.h>
 
+#include <boost/container/small_vector.hpp>
+
 #include <utility>
 
 

--- a/tests/base/bounding_box_1.cc
+++ b/tests/base/bounding_box_1.cc
@@ -67,6 +67,16 @@ test_bounding_box()
             << " is inside: " << b.point_inside(test_points[i]) << std::endl;
 
   deallog << std::endl;
+
+  // Verify that we get the same box when we use all those points together
+  {
+    test_points.push_back(boundaries.first);
+    test_points.push_back(boundaries.second);
+
+    BoundingBox<spacedim> b2(test_points);
+    deallog << "Boxes should be equal : " << (b2 == b) << std::endl;
+  }
+
   test_points.clear();
 
   // To create outside points we take a non-convex combination
@@ -86,6 +96,13 @@ test_bounding_box()
   for (unsigned int i = 0; i < test_points.size(); ++i)
     deallog << test_points[i]
             << " is inside: " << b.point_inside(test_points[i]) << std::endl;
+
+  // Similarly, verify that we get different boxes since some points are
+  // outside:
+  {
+    BoundingBox<spacedim> b2(test_points);
+    deallog << "Boxes should not be equal : " << (b2 != b) << std::endl;
+  }
   deallog << std::endl;
 }
 

--- a/tests/base/bounding_box_1.output
+++ b/tests/base/bounding_box_1.output
@@ -15,12 +15,14 @@ DEAL::0.440000 is inside: 1
 DEAL::0.320000 is inside: 1
 DEAL::0.200000 is inside: 1
 DEAL::
+DEAL::Boxes should be equal : 1
 DEAL::Points outside:
 DEAL::-2.50000 is inside: 0
 DEAL::5.00000 is inside: 0
 DEAL::-7.50000 is inside: 0
 DEAL::10.0000 is inside: 0
 DEAL::-12.5000 is inside: 0
+DEAL::Boxes should not be equal : 1
 DEAL::
 DEAL::
 DEAL::Test for dimension 2
@@ -38,12 +40,14 @@ DEAL::0.440000 0.640000 is inside: 1
 DEAL::0.320000 0.320000 is inside: 1
 DEAL::0.200000 0.00000 is inside: 1
 DEAL::
+DEAL::Boxes should be equal : 1
 DEAL::Points outside:
 DEAL::-2.50000 -4.00000 is inside: 0
 DEAL::5.00000 8.00000 is inside: 0
 DEAL::-7.50000 -12.0000 is inside: 0
 DEAL::10.0000 16.0000 is inside: 0
 DEAL::-12.5000 -20.0000 is inside: 0
+DEAL::Boxes should not be equal : 1
 DEAL::
 DEAL::
 DEAL::Test for dimension 3
@@ -61,12 +65,14 @@ DEAL::0.440000 0.640000 0.840000 is inside: 1
 DEAL::0.320000 0.320000 0.320000 is inside: 1
 DEAL::0.200000 0.00000 -0.200000 is inside: 1
 DEAL::
+DEAL::Boxes should be equal : 1
 DEAL::Points outside:
 DEAL::-2.50000 -4.00000 -5.50000 is inside: 0
 DEAL::5.00000 8.00000 11.0000 is inside: 0
 DEAL::-7.50000 -12.0000 -16.5000 is inside: 0
 DEAL::10.0000 16.0000 22.0000 is inside: 0
 DEAL::-12.5000 -20.0000 -27.5000 is inside: 0
+DEAL::Boxes should not be equal : 1
 DEAL::
 DEAL::
 DEAL::Test for dimension 3, unitary box


### PR DESCRIPTION
I get inscrutably long boost errors right now (which was partially fixed in 13bc2f8a021) about boost not being able to figure out type conversions. Lets just roll our own BoundingBox function to fix the problem here and with other versions of boost.

While I was here I implemented == and != and added a test.