### PR TITLE
Assert type of coarse grid in p:d:T

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2179,6 +2179,12 @@ namespace parallel
           Assert(false, ExcInternalError());
         }
 
+      Assert(
+        this->all_reference_cell_types_are_hyper_cube(),
+        ExcMessage(
+          "The class parallel::distributed::Triangulation only supports meshes "
+          "consisting only of hypercube-like cells."));
+
       // note that now we have some content in the p4est objects and call the
       // functions that do the actual work (which are dimension dependent, so
       // separate)


### PR DESCRIPTION
This PR introduces asserts when simplex grid generators (```subdivided_hyper_rectangle_with_simplices``` and ```subdivided_hyper_cube_with_simplices```) are called with a ```parallel::distributed``` triangulation, which is currently not (yet) supported. This assert might be also relevant for other code locations related to the simplex support.

It is my first PR involving changes in the code, so feel free to point out general remarks, if there are some.

@peterrum: FYI