### PR TITLE
Generalize p::d::SolutionTransfer for p::f::Triangulation

### DIFF
--- a/doc/news/changes/minor/20210118PasqualeAfrica-2
+++ b/doc/news/changes/minor/20210118PasqualeAfrica-2
@@ -1,0 +1,3 @@
+New: implemented p::f::Triangulation::load()/save() for use with p::d::SolutionTransfer.
+<br>
+(Pasquale Claudio Africa, Peter Munch, 2021/01/18)

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -246,13 +246,14 @@ namespace parallel
        * must be empty before calling this function.
        *
        * You need to load with the same number of MPI processes that
-       * you saved with. Cell-based data that was saved with
-       * register_data_attach() can be read in with notify_ready_to_unpack()
-       * after calling load().
+       * you saved with, hence autopartition is disabled.
+       *
+       * Cell-based data that was saved with register_data_attach() can be read
+       * in with notify_ready_to_unpack() after calling load().
        */
       virtual void
       load(const std::string &filename,
-           const bool         autopartition = true) override;
+           const bool         autopartition = false) override;
 
     private:
       virtual unsigned int

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -52,7 +52,7 @@ namespace
    *
    * Given that the elements of @p dof_values are stored in consecutive
    * locations, we can just memcpy them. Since floating point values don't
-   * compress well, we also forgo the compression the default
+   * compress well, we also waive the compression that the default
    * Utilities::pack() and Utilities::unpack() functions offer.
    */
   template <typename value_type>
@@ -121,8 +121,9 @@ namespace parallel
       , handle(numbers::invalid_unsigned_int)
     {
       Assert(
-        (dynamic_cast<const parallel::distributed::
-                        Triangulation<dim, DoFHandlerType::space_dimension> *>(
+        (dynamic_cast<const parallel::DistributedTriangulationBase<
+           dim,
+           DoFHandlerType::space_dimension> *>(
            &dof_handler->get_triangulation()) != nullptr),
         ExcMessage(
           "parallel::distributed::SolutionTransfer requires a parallel::distributed::Triangulation object."));
@@ -147,12 +148,11 @@ namespace parallel
     SolutionTransfer<dim, VectorType, DoFHandlerType>::register_data_attach()
     {
       // TODO: casting away constness is bad
-      parallel::distributed::Triangulation<dim, DoFHandlerType::space_dimension>
-        *tria = (dynamic_cast<parallel::distributed::Triangulation<
-                   dim,
-                   DoFHandlerType::space_dimension> *>(
-          const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
-                       *>(&dof_handler->get_triangulation())));
+      auto *tria = (dynamic_cast<parallel::DistributedTriangulationBase<
+                      dim,
+                      DoFHandlerType::space_dimension> *>(
+        const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
+                     *>(&dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
       handle = tria->register_data_attach(
@@ -232,12 +232,11 @@ namespace parallel
              ExcDimensionMismatch(input_vectors.size(), all_out.size()));
 
       // TODO: casting away constness is bad
-      parallel::distributed::Triangulation<dim, DoFHandlerType::space_dimension>
-        *tria = (dynamic_cast<parallel::distributed::Triangulation<
-                   dim,
-                   DoFHandlerType::space_dimension> *>(
-          const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
-                       *>(&dof_handler->get_triangulation())));
+      auto *tria = (dynamic_cast<parallel::DistributedTriangulationBase<
+                      dim,
+                      DoFHandlerType::space_dimension> *>(
+        const_cast<dealii::Triangulation<dim, DoFHandlerType::space_dimension>
+                     *>(&dof_handler->get_triangulation())));
       Assert(tria != nullptr, ExcInternalError());
 
       tria->notify_ready_to_unpack(

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1427,7 +1427,7 @@ namespace parallel
       Assert(
         this->cell_attached_data.n_attached_deserialize == 0,
         ExcMessage(
-          "not all SolutionTransfer's got deserialized after the last load()"));
+          "Not all SolutionTransfer objects have been deserialized after the last call to load()."));
       Assert(this->n_cells() > 0,
              ExcMessage("Can not save() an empty Triangulation."));
 

--- a/tests/fullydistributed_grids/save_load_01.cc
+++ b/tests/fullydistributed_grids/save_load_01.cc
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2008 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test fullydistributed::Triangulation::load()/save().
+// Create a triangulation, save it and load it.
+// The initial and the loaded triangulations must be the same.
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_description.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include "./tests.h"
+
+using namespace dealii;
+
+template <int dim, typename TriangulationType>
+void
+test(TriangulationType &triangulation)
+{
+  const std::string filename = "save_load_" + std::to_string(dim) + "d_out";
+
+  triangulation.save(filename);
+  deallog.push("save");
+  print_statistics(triangulation, false);
+  deallog.pop();
+
+  triangulation.clear();
+
+  triangulation.load(filename);
+  deallog.push("load");
+  print_statistics(triangulation, false);
+  deallog.pop();
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d");
+  {
+    constexpr int dim = 2;
+
+    parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(3);
+
+    const auto description = TriangulationDescription::Utilities::
+      create_description_from_triangulation(triangulation, MPI_COMM_WORLD);
+
+    parallel::fullydistributed::Triangulation<dim> triangulation_pft(
+      MPI_COMM_WORLD);
+    triangulation_pft.create_triangulation(description);
+
+    test<dim>(triangulation_pft);
+  }
+  deallog.pop();
+
+  deallog.push("3d");
+  {
+    constexpr int dim = 3;
+
+    parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(3);
+
+    const auto description = TriangulationDescription::Utilities::
+      create_description_from_triangulation(triangulation, MPI_COMM_WORLD);
+
+    parallel::fullydistributed::Triangulation<dim> triangulation_pft(
+      MPI_COMM_WORLD);
+    triangulation_pft.create_triangulation(description);
+
+    test<dim>(triangulation_pft);
+  }
+  deallog.pop();
+}

--- a/tests/fullydistributed_grids/save_load_01.mpirun=1.output
+++ b/tests/fullydistributed_grids/save_load_01.mpirun=1.output
@@ -1,0 +1,17 @@
+
+DEAL:0:2d:save::n_levels:                  4
+DEAL:0:2d:save::n_cells:                   85
+DEAL:0:2d:save::n_active_cells:            64
+DEAL:0:2d:save::
+DEAL:0:2d:load::n_levels:                  4
+DEAL:0:2d:load::n_cells:                   85
+DEAL:0:2d:load::n_active_cells:            64
+DEAL:0:2d:load::
+DEAL:0:3d:save::n_levels:                  4
+DEAL:0:3d:save::n_cells:                   585
+DEAL:0:3d:save::n_active_cells:            512
+DEAL:0:3d:save::
+DEAL:0:3d:load::n_levels:                  4
+DEAL:0:3d:load::n_cells:                   585
+DEAL:0:3d:load::n_active_cells:            512
+DEAL:0:3d:load::

--- a/tests/fullydistributed_grids/save_load_01.mpirun=4.output
+++ b/tests/fullydistributed_grids/save_load_01.mpirun=4.output
@@ -1,0 +1,71 @@
+
+DEAL:0:2d:save::n_levels:                  4
+DEAL:0:2d:save::n_cells:                   57
+DEAL:0:2d:save::n_active_cells:            43
+DEAL:0:2d:save::
+DEAL:0:2d:load::n_levels:                  4
+DEAL:0:2d:load::n_cells:                   57
+DEAL:0:2d:load::n_active_cells:            43
+DEAL:0:2d:load::
+DEAL:0:3d:save::n_levels:                  4
+DEAL:0:3d:save::n_cells:                   361
+DEAL:0:3d:save::n_active_cells:            316
+DEAL:0:3d:save::
+DEAL:0:3d:load::n_levels:                  4
+DEAL:0:3d:load::n_cells:                   361
+DEAL:0:3d:load::n_active_cells:            316
+DEAL:0:3d:load::
+
+DEAL:1:2d:save::n_levels:                  4
+DEAL:1:2d:save::n_cells:                   57
+DEAL:1:2d:save::n_active_cells:            43
+DEAL:1:2d:save::
+DEAL:1:2d:load::n_levels:                  4
+DEAL:1:2d:load::n_cells:                   57
+DEAL:1:2d:load::n_active_cells:            43
+DEAL:1:2d:load::
+DEAL:1:3d:save::n_levels:                  4
+DEAL:1:3d:save::n_cells:                   361
+DEAL:1:3d:save::n_active_cells:            316
+DEAL:1:3d:save::
+DEAL:1:3d:load::n_levels:                  4
+DEAL:1:3d:load::n_cells:                   361
+DEAL:1:3d:load::n_active_cells:            316
+DEAL:1:3d:load::
+
+
+DEAL:2:2d:save::n_levels:                  4
+DEAL:2:2d:save::n_cells:                   57
+DEAL:2:2d:save::n_active_cells:            43
+DEAL:2:2d:save::
+DEAL:2:2d:load::n_levels:                  4
+DEAL:2:2d:load::n_cells:                   57
+DEAL:2:2d:load::n_active_cells:            43
+DEAL:2:2d:load::
+DEAL:2:3d:save::n_levels:                  4
+DEAL:2:3d:save::n_cells:                   361
+DEAL:2:3d:save::n_active_cells:            316
+DEAL:2:3d:save::
+DEAL:2:3d:load::n_levels:                  4
+DEAL:2:3d:load::n_cells:                   361
+DEAL:2:3d:load::n_active_cells:            316
+DEAL:2:3d:load::
+
+
+DEAL:3:2d:save::n_levels:                  4
+DEAL:3:2d:save::n_cells:                   57
+DEAL:3:2d:save::n_active_cells:            43
+DEAL:3:2d:save::
+DEAL:3:2d:load::n_levels:                  4
+DEAL:3:2d:load::n_cells:                   57
+DEAL:3:2d:load::n_active_cells:            43
+DEAL:3:2d:load::
+DEAL:3:3d:save::n_levels:                  4
+DEAL:3:3d:save::n_cells:                   361
+DEAL:3:3d:save::n_active_cells:            316
+DEAL:3:3d:save::
+DEAL:3:3d:load::n_levels:                  4
+DEAL:3:3d:load::n_cells:                   361
+DEAL:3:3d:load::n_active_cells:            316
+DEAL:3:3d:load::
+

--- a/tests/fullydistributed_grids/solution_transfer_01.cc
+++ b/tests/fullydistributed_grids/solution_transfer_01.cc
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2008 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test distributed solution transfer with fullydistributed triangulations.
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/solution_transfer.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria_description.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+template <int dim>
+class InterpolationFunction : public Function<dim>
+{
+public:
+  InterpolationFunction()
+    : Function<dim>(1)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    return p.norm();
+  }
+};
+
+template <int dim, typename TriangulationType>
+void
+test(TriangulationType &triangulation)
+{
+  DoFHandler<dim> dof_handler(triangulation);
+  dof_handler.distribute_dofs(FE_Q<dim>(2));
+
+  IndexSet locally_relevant_dofs;
+  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+
+  using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+  std::shared_ptr<Utilities::MPI::Partitioner> partitioner =
+    std::make_shared<Utilities::MPI::Partitioner>(
+      dof_handler.locally_owned_dofs(), locally_relevant_dofs, MPI_COMM_WORLD);
+
+  VectorType vector(partitioner);
+
+  VectorTools::interpolate(dof_handler, InterpolationFunction<dim>(), vector);
+  vector.update_ghost_values();
+
+  VectorType vector_loaded(partitioner);
+
+  const std::string filename =
+    "solution_transfer_" + std::to_string(dim) + "d_out";
+
+  {
+    parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
+      dof_handler);
+    solution_transfer.prepare_for_serialization(vector);
+
+    triangulation.save(filename);
+  }
+
+  triangulation.clear();
+
+  {
+    triangulation.load(filename);
+
+    parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
+      dof_handler);
+    solution_transfer.deserialize(vector_loaded);
+
+    vector_loaded.update_ghost_values();
+  }
+
+  // Verify that error is 0.
+  VectorType error(vector);
+  error.add(-1, vector_loaded);
+
+  deallog << (error.linfty_norm() < 1e-16 ? "PASSED" : "FAILED") << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  deallog.push("2d");
+  {
+    constexpr int dim = 2;
+
+    parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(3);
+
+    const auto description = TriangulationDescription::Utilities::
+      create_description_from_triangulation(triangulation, MPI_COMM_WORLD);
+
+    parallel::fullydistributed::Triangulation<dim> triangulation_pft(
+      MPI_COMM_WORLD);
+    triangulation_pft.create_triangulation(description);
+
+    test<dim>(triangulation_pft);
+  }
+  deallog.pop();
+
+  deallog.push("3d");
+  {
+    constexpr int dim = 3;
+
+    parallel::distributed::Triangulation<dim> triangulation(MPI_COMM_WORLD);
+    GridGenerator::hyper_cube(triangulation);
+    triangulation.refine_global(3);
+
+    const auto description = TriangulationDescription::Utilities::
+      create_description_from_triangulation(triangulation, MPI_COMM_WORLD);
+
+    parallel::fullydistributed::Triangulation<dim> triangulation_pft(
+      MPI_COMM_WORLD);
+    triangulation_pft.create_triangulation(description);
+
+    test<dim>(triangulation_pft);
+  }
+  deallog.pop();
+}

--- a/tests/fullydistributed_grids/solution_transfer_01.mpirun=1.output
+++ b/tests/fullydistributed_grids/solution_transfer_01.mpirun=1.output
@@ -1,0 +1,3 @@
+
+DEAL:2d::PASSED
+DEAL:3d::PASSED

--- a/tests/fullydistributed_grids/solution_transfer_01.mpirun=4.output
+++ b/tests/fullydistributed_grids/solution_transfer_01.mpirun=4.output
@@ -1,0 +1,3 @@
+
+DEAL:2d::PASSED
+DEAL:3d::PASSED


### PR DESCRIPTION
**Warning**: depends on #1580.

Here is a summary of changes:
- `p::f::T::load()/save()` methods have been implemented for (de-)serializing `p::f::Triangulation`s (with @peterrum) and cell-attached data (from) to file.
- The pure virtual `update_cell_relations()` method has been overridden.

Remark: the new abstract interface of `DataTransfer` and `update_cell_relations()` (implemented in #1580) is possibly ready for a future implementation of data transfer across p::f::T refinement/coarsening (through the flags `CELL_PERSIST`, `CELL_REFINE`, `CELL_COARSEN`, `CELL_INVALID`).