### PR TITLE
Introduce ReferenceCell::get_default_linear_mapping() with triangulation argument. Use it.

### DIFF
--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -80,6 +80,10 @@ public:
  * these contexts throughout the library, this class defines a static $Q_1$
  * mapping object. This object can then be used in all of those places where
  * such an object is needed.
+ *
+ * @note The use of this object should be avoided since it is only applicable
+ *   in cases where a mesh consists exclusively of quadrilaterals or hexahedra.
+ *   Use ReferenceCell::get_default_linear_mapping() instead.
  */
 template <int dim, int spacedim = dim>
 struct StaticMappingQ1

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -340,12 +340,30 @@ namespace ReferenceCell
                      Triangulation<dim, spacedim> &tria);
 
   /**
-   * Return a default linear mapping matching the given reference cell
-   * (MappingQ1 for hypercube cells and MappingFE else).
+   * Return a default linear mapping matching the given reference cell.
+   * If this reference cell is a hypercube, then the returned mapping
+   * is a MappingQ1; otherwise, it is an object of type MappingFE
+   * initialized with Simplex::FE_P (if the reference cell is a triangle and
+   * tetrahedron), with Simplex::FE_PyramidP (if the reference cell is a
+   * pyramid), or with Simplex::FE_WedgeP (if the reference cell is a wedge). In
+   * other words, the term "linear" in the name of the function has to be
+   * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
+   * coordinate directions.
    */
   template <int dim, int spacedim>
   const Mapping<dim, spacedim> &
   get_default_linear_mapping(const Type &reference_cell);
+
+  /**
+   * Return a default linear mapping that works for the given triangulation.
+   * Internally, this function calls the function above for the reference
+   * cell used by the given triangulation, assuming that the triangulation
+   * uses only a single cell type. If the triangulation uses mixed cell
+   * types, then this function will trigger an exception.
+   */
+  template <int dim, int spacedim>
+  const Mapping<dim, spacedim> &
+  get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation);
 
   /**
    * Return a Gauss-type quadrature matching the given reference cell(QGauss,

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -122,7 +122,7 @@ namespace internal
             dh.distribute_dofs(fe);
 
             dealii::FEValues<dim, spacedim> fine(
-              StaticMappingQ1<dim, spacedim>::mapping,
+              ReferenceCell::get_default_linear_mapping(tr),
               fe,
               *q_fine,
               update_quadrature_points | update_JxW_values | update_values);

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4384,11 +4384,15 @@ template <int dim, int spacedim>
 FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
                                   const Quadrature<dim> &             q,
                                   const UpdateFlags update_flags)
-  : FEValuesBase<dim, spacedim>(q.size(),
-                                fe.n_dofs_per_cell(),
-                                update_default,
-                                StaticMappingQ1<dim, spacedim>::mapping,
-                                fe)
+  : FEValuesBase<dim, spacedim>(
+      q.size(),
+      fe.n_dofs_per_cell(),
+      update_default,
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe)
   , quadrature(q)
 {
   initialize(update_flags);
@@ -4709,11 +4713,15 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   const FiniteElement<dim, spacedim> &fe,
   const hp::QCollection<dim - 1> &    quadrature,
   const UpdateFlags                   update_flags)
-  : FEFaceValuesBase<dim, spacedim>(fe.n_dofs_per_cell(),
-                                    update_flags,
-                                    StaticMappingQ1<dim, spacedim>::mapping,
-                                    fe,
-                                    quadrature)
+  : FEFaceValuesBase<dim, spacedim>(
+      fe.n_dofs_per_cell(),
+      update_flags,
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature)
 {
   initialize(update_flags);
 }
@@ -4939,11 +4947,15 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   const FiniteElement<dim, spacedim> &fe,
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
-  : FEFaceValuesBase<dim, spacedim>(fe.n_dofs_per_cell(),
-                                    update_flags,
-                                    StaticMappingQ1<dim, spacedim>::mapping,
-                                    fe,
-                                    quadrature)
+  : FEFaceValuesBase<dim, spacedim>(
+      fe.n_dofs_per_cell(),
+      update_flags,
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature)
 {
   initialize(update_flags);
 }

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -2084,8 +2084,8 @@ MappingFEField<dim, spacedim, VectorType, void>::transform_real_to_unit_cell(
   try
     {
       initial_p_unit =
-        StaticMappingQ1<dim, spacedim>::mapping.transform_real_to_unit_cell(
-          cell, p);
+        ReferenceCell::get_default_linear_mapping(cell->get_triangulation())
+          .transform_real_to_unit_cell(cell, p);
     }
   catch (const typename Mapping<dim, spacedim>::ExcTransformationFailed &)
     {

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -419,7 +419,8 @@ namespace GridTools
                                 const double                   tolerance)
   {
     return find_active_cell_around_point<dim, MeshType, spacedim>(
-             StaticMappingQ1<dim, spacedim>::mapping,
+             ReferenceCell::get_default_linear_mapping(
+               mesh.get_triangulation()),
              mesh,
              p,
              marked_vertices,
@@ -2379,6 +2380,7 @@ namespace GridTools
   {
     using MATCH_T =
       std::array<unsigned int, GeometryInfo<3>::vertices_per_face>;
+
     static inline std::bitset<3>
     lookup(const MATCH_T &matching)
     {

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -140,6 +140,26 @@ namespace ReferenceCell
 
 
 
+  template <int dim, int spacedim>
+  const Mapping<dim, spacedim> &
+  get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
+  {
+    const auto &reference_cell_types = triangulation.get_reference_cell_types();
+    Assert(reference_cell_types.size() == 1,
+           ExcMessage(
+             "This function can only work for triangulations that "
+             "use only a single cell type -- for example, only triangles "
+             "or only quadrilaterals. For mixed meshes, there is no "
+             "single linear mapping object that can be used for all "
+             "cells of the triangulation. The triangulation you are "
+             "passing to this function uses multiple cell types."));
+
+    return get_default_linear_mapping<dim, spacedim>(
+      reference_cell_types.front());
+  }
+
+
+
   template <int dim>
   Quadrature<dim>
   get_gauss_type_quadrature(const Type &   reference_cell,

--- a/source/grid/reference_cell.inst.in
+++ b/source/grid/reference_cell.inst.in
@@ -23,6 +23,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
       &get_default_linear_mapping(const Type &reference_cell);
 
+    template const Mapping<deal_II_dimension, deal_II_space_dimension>
+      &get_default_linear_mapping(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation);
 #endif
   }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9607,9 +9607,11 @@ namespace internal
                         // one.
                         const Point<spacedim> new_bound = face->center(true);
                         // to check it, transform to the unit cell
-                        // with Q1Mapping
+                        // with a linear mapping
                         const Point<dim> new_unit =
-                          StaticMappingQ1<dim, spacedim>::mapping
+                          ReferenceCell::get_default_linear_mapping<dim,
+                                                                    spacedim>(
+                            cell->reference_cell_type())
                             .transform_real_to_unit_cell(cell, new_bound);
 
                         // Now, we have to calculate the distance from

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1859,8 +1859,9 @@ CellAccessor<3>::point_inside(const Point<3> &p) const
     {
       const TriaRawIterator<CellAccessor<dim, spacedim>> cell_iterator(*this);
       return (GeometryInfo<dim>::is_inside_unit_cell(
-        StaticMappingQ1<dim, spacedim>::mapping.transform_real_to_unit_cell(
-          cell_iterator, p)));
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          reference_cell_type())
+          .transform_real_to_unit_cell(cell_iterator, p)));
     }
   catch (const Mapping<dim, spacedim>::ExcTransformationFailed &)
     {

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -74,12 +74,16 @@ namespace MeshWorker
     const UpdateFlags &                 update_flags,
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags)
-    : ScratchData(StaticMappingQ1<dim, spacedim>::mapping,
-                  fe,
-                  quadrature,
-                  update_flags,
-                  face_quadrature,
-                  face_update_flags)
+    : ScratchData(
+        // TODO: We should query the default mapping for the kind of cell
+        // represented by 'fe' and 'q':
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)),
+        fe,
+        quadrature,
+        update_flags,
+        face_quadrature,
+        face_update_flags)
   {}
 
 
@@ -93,14 +97,18 @@ namespace MeshWorker
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags,
     const UpdateFlags &                 neighbor_face_update_flags)
-    : ScratchData(StaticMappingQ1<dim, spacedim>::mapping,
-                  fe,
-                  quadrature,
-                  update_flags,
-                  neighbor_update_flags,
-                  face_quadrature,
-                  face_update_flags,
-                  neighbor_face_update_flags)
+    : ScratchData(
+        // TODO: We should query the default mapping for the kind of cell
+        // represented by 'fe' and 'q':
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)),
+        fe,
+        quadrature,
+        update_flags,
+        neighbor_update_flags,
+        face_quadrature,
+        face_update_flags,
+        neighbor_face_update_flags)
   {}
 
 

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -25,6 +25,7 @@
 
 #include <deal.II/grid/filtered_iterator.h>
 #include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/reference_cell.h>
 #include <deal.II/grid/tria_iterator.h>
 
 #include <deal.II/hp/fe_collection.h>
@@ -1099,12 +1100,14 @@ namespace DerivativeApproximation
     const unsigned int  component)
   {
     // just call the respective function with Q1 mapping
-    approximate_derivative_tensor(StaticMappingQ1<dim, spacedim>::mapping,
-                                  dof,
-                                  solution,
-                                  cell,
-                                  derivative,
-                                  component);
+    approximate_derivative_tensor(
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        cell->reference_cell_type()),
+      dof,
+      solution,
+      cell,
+      derivative,
+      component);
   }
 
 


### PR DESCRIPTION
A better approach than #11512. This also changes all uses of `StaticMappingQ1` in `source/` to the new function -- fixing a few potential bugs in the process, and leaving some TODOs that can't be addressed with the current finite element and quadrature interfaces. I'll convert `include/` later, but wanted to put this out here already for discussion.

/rebuild