### PR TITLE
Fix missing 'spacedim' template argument.

### DIFF
--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -317,10 +317,11 @@ namespace VectorTools
                              Vector<double> &                 rhs_vector)
   {
     if (dof_handler.has_hp_capabilities())
-      create_point_source_vector(hp::StaticMappingQ1<dim>::mapping_collection,
-                                 dof_handler,
-                                 p,
-                                 rhs_vector);
+      create_point_source_vector(
+        hp::StaticMappingQ1<dim, spacedim>::mapping_collection,
+        dof_handler,
+        p,
+        rhs_vector);
     else
       create_point_source_vector(StaticMappingQ1<dim, spacedim>::mapping,
                                  dof_handler,
@@ -421,11 +422,12 @@ namespace VectorTools
                              Vector<double> &                 rhs_vector)
   {
     if (dof_handler.has_hp_capabilities())
-      create_point_source_vector(hp::StaticMappingQ1<dim>::mapping_collection,
-                                 dof_handler,
-                                 p,
-                                 orientation,
-                                 rhs_vector);
+      create_point_source_vector(
+        hp::StaticMappingQ1<dim, spacedim>::mapping_collection,
+        dof_handler,
+        p,
+        orientation,
+        rhs_vector);
     else
       create_point_source_vector(StaticMappingQ1<dim, spacedim>::mapping,
                                  dof_handler,


### PR DESCRIPTION
Just a missing `, spacedim` in two places. I guess these functions were simply never instantiated for `dim != spacedim`, so this wasn't wrong, but if we ever plan on instantiating these functions for `dim < spacedim`, then this fix will be necessary one way or the other.

/rebuild