### PR TITLE
Use default constructed linear mapping.

### DIFF
--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -527,8 +527,12 @@ ParsedConvergenceTable::error_from_exact(const DoFHandler<dim, spacedim> &dh,
                                          const Function<spacedim> &exact,
                                          const Function<spacedim> *weight)
 {
-  error_from_exact(
-    StaticMappingQ1<dim, spacedim>::mapping, dh, solution, exact, weight);
+  error_from_exact(ReferenceCell::get_default_linear_mapping(
+                     dh.get_triangulation()),
+                   dh,
+                   solution,
+                   exact,
+                   weight);
 }
 
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2292,7 +2292,8 @@ namespace FETools
                 q_points_coarse[q](j) = q_points_fine[q](j);
             Quadrature<dim> q_coarse(q_points_coarse, fine.get_JxW_values());
             FEValues<dim, spacedim> coarse(
-              StaticMappingQ1<dim, spacedim>::mapping,
+              ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+                coarse_cell->reference_cell_type()),
               fe,
               q_coarse,
               update_values);

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1055,7 +1055,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(StaticMappingQ1<dim, spacedim>::mapping,
+  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+             dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1125,7 +1126,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(StaticMappingQ1<dim, spacedim>::mapping,
+  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+             dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1370,7 +1372,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(StaticMappingQ1<dim, spacedim>::mapping,
+  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+             dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1404,7 +1407,8 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(StaticMappingQ1<dim, spacedim>::mapping,
+  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+             dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -689,7 +689,8 @@ namespace MatrixCreator
                      const Function<spacedim, number> *const coefficient,
                      const AffineConstraints<number> &       constraints)
   {
-    create_mass_matrix(StaticMappingQ1<dim, spacedim>::mapping,
+    create_mass_matrix(ReferenceCell::get_default_linear_mapping(
+                         dof.get_triangulation()),
                        dof,
                        q,
                        matrix,
@@ -766,7 +767,8 @@ namespace MatrixCreator
                      const Function<spacedim, number> *const coefficient,
                      const AffineConstraints<number> &       constraints)
   {
-    create_mass_matrix(StaticMappingQ1<dim, spacedim>::mapping,
+    create_mass_matrix(ReferenceCell::get_default_linear_mapping(
+                         dof.get_triangulation()),
                        dof,
                        q,
                        matrix,
@@ -1728,7 +1730,8 @@ namespace MatrixCreator
     const Function<spacedim, number> *const a,
     std::vector<unsigned int>               component_mapping)
   {
-    create_boundary_mass_matrix(StaticMappingQ1<dim, spacedim>::mapping,
+    create_boundary_mass_matrix(ReferenceCell::get_default_linear_mapping(
+                                  dof.get_triangulation()),
                                 dof,
                                 q,
                                 matrix,
@@ -1917,7 +1920,8 @@ namespace MatrixCreator
                         const Function<spacedim> *const  coefficient,
                         const AffineConstraints<double> &constraints)
   {
-    create_laplace_matrix(StaticMappingQ1<dim, spacedim>::mapping,
+    create_laplace_matrix(ReferenceCell::get_default_linear_mapping(
+                            dof.get_triangulation()),
                           dof,
                           q,
                           matrix,
@@ -1993,7 +1997,8 @@ namespace MatrixCreator
                         const Function<spacedim> *const  coefficient,
                         const AffineConstraints<double> &constraints)
   {
-    create_laplace_matrix(StaticMappingQ1<dim, spacedim>::mapping,
+    create_laplace_matrix(ReferenceCell::get_default_linear_mapping(
+                            dof.get_triangulation()),
                           dof,
                           q,
                           matrix,

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -466,7 +466,8 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     const ComponentMask &                      component_mask)
   {
-    interpolate_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+                                  dof.get_triangulation()),
                                 dof,
                                 boundary_component,
                                 boundary_function,
@@ -485,7 +486,8 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     const ComponentMask &                      component_mask)
   {
-    interpolate_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+                                  dof.get_triangulation()),
                                 dof,
                                 function_map,
                                 boundary_values,
@@ -598,7 +600,8 @@ namespace VectorTools
     AffineConstraints<number> &       constraints,
     const ComponentMask &             component_mask)
   {
-    interpolate_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+                                  dof.get_triangulation()),
                                 dof,
                                 boundary_component,
                                 boundary_function,
@@ -617,7 +620,8 @@ namespace VectorTools
     AffineConstraints<number> &constraints,
     const ComponentMask &      component_mask)
   {
-    interpolate_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+                                  dof.get_triangulation()),
                                 dof,
                                 function_map,
                                 constraints,
@@ -883,7 +887,8 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     std::vector<unsigned int>                  component_mapping)
   {
-    project_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    project_boundary_values(ReferenceCell::get_default_linear_mapping(
+                              dof.get_triangulation()),
                             dof,
                             boundary_functions,
                             q,
@@ -973,7 +978,8 @@ namespace VectorTools
     AffineConstraints<number> &constraints,
     std::vector<unsigned int>  component_mapping)
   {
-    project_boundary_values(StaticMappingQ1<dim, spacedim>::mapping,
+    project_boundary_values(ReferenceCell::get_default_linear_mapping(
+                              dof.get_triangulation()),
                             dof,
                             boundary_functions,
                             q,

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -531,7 +531,8 @@ namespace VectorTools
     VectorType &                                               vec,
     const ComponentMask &                                      component_mask)
   {
-    interpolate(StaticMappingQ1<dim, spacedim>::mapping,
+    interpolate(ReferenceCell::get_default_linear_mapping(
+                  dof.get_triangulation()),
                 dof,
                 function,
                 vec,

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -197,8 +197,12 @@ namespace VectorTools
                      const VectorType &               v,
                      const unsigned int               component)
   {
-    return compute_mean_value(
-      StaticMappingQ1<dim, spacedim>::mapping, dof, quadrature, v, component);
+    return compute_mean_value(ReferenceCell::get_default_linear_mapping(
+                                dof.get_triangulation()),
+                              dof,
+                              quadrature,
+                              v,
+                              component);
   }
 } // namespace VectorTools
 

--- a/include/deal.II/numerics/vector_tools_point_gradient.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.templates.h
@@ -49,7 +49,8 @@ namespace VectorTools
       &gradients)
   {
     if (dof.has_hp_capabilities() == false)
-      point_gradient(StaticMappingQ1<dim, spacedim>::mapping,
+      point_gradient(ReferenceCell::get_default_linear_mapping(
+                       dof.get_triangulation()),
                      dof,
                      fe_function,
                      point,
@@ -70,7 +71,8 @@ namespace VectorTools
                  const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
-      return point_gradient(StaticMappingQ1<dim, spacedim>::mapping,
+      return point_gradient(ReferenceCell::get_default_linear_mapping(
+                              dof.get_triangulation()),
                             dof,
                             fe_function,
                             point);

--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -48,7 +48,8 @@ namespace VectorTools
               Vector<typename VectorType::value_type> &value)
   {
     if (dof.has_hp_capabilities() == false)
-      point_value(StaticMappingQ1<dim, spacedim>::mapping,
+      point_value(ReferenceCell::get_default_linear_mapping(
+                    dof.get_triangulation()),
                   dof,
                   fe_function,
                   point,
@@ -69,7 +70,8 @@ namespace VectorTools
               const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
-      return point_value(StaticMappingQ1<dim, spacedim>::mapping,
+      return point_value(ReferenceCell::get_default_linear_mapping(
+                           dof.get_triangulation()),
                          dof,
                          fe_function,
                          point);
@@ -323,7 +325,8 @@ namespace VectorTools
         p,
         rhs_vector);
     else
-      create_point_source_vector(StaticMappingQ1<dim, spacedim>::mapping,
+      create_point_source_vector(ReferenceCell::get_default_linear_mapping(
+                                   dof_handler.get_triangulation()),
                                  dof_handler,
                                  p,
                                  rhs_vector);
@@ -429,7 +432,8 @@ namespace VectorTools
         orientation,
         rhs_vector);
     else
-      create_point_source_vector(StaticMappingQ1<dim, spacedim>::mapping,
+      create_point_source_vector(ReferenceCell::get_default_linear_mapping(
+                                   dof_handler.get_triangulation()),
                                  dof_handler,
                                  p,
                                  orientation,

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -887,7 +887,7 @@ namespace VectorTools
            ExcMessage("Please specify the mapping explicitly "
                       "when building with MSVC!"));
 #else
-    project(StaticMappingQ1<dim, spacedim>::mapping,
+    project(ReferenceCell::get_default_linear_mapping(dof.get_triangulation()),
             dof,
             constraints,
             quadrature,

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -470,7 +470,8 @@ namespace VectorTools
     VectorType &                                               rhs_vector,
     const AffineConstraints<typename VectorType::value_type> & constraints)
   {
-    create_right_hand_side(StaticMappingQ1<dim, spacedim>::mapping,
+    create_right_hand_side(ReferenceCell::get_default_linear_mapping(
+                             dof_handler.get_triangulation()),
                            dof_handler,
                            quadrature,
                            rhs_function,


### PR DESCRIPTION
Follow-up to #11520 . These places are unambiguously correct and, moreover, are now also correct for non-quad/hex meshes where they weren't before.

/rebuild