### PR TITLE
Use linear Q1 mapping even in places where we know that that may be wrong

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -525,22 +525,38 @@ FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
   const Quadrature<dim - 1> &         quadrature,
   const UpdateFlags                   update_flags)
   : n_quadrature_points(quadrature.size())
-  , internal_fe_face_values(StaticMappingQ1<dim, spacedim>::mapping,
-                            fe,
-                            quadrature,
-                            update_flags)
-  , internal_fe_subface_values(StaticMappingQ1<dim, spacedim>::mapping,
-                               fe,
-                               quadrature,
-                               update_flags)
-  , internal_fe_face_values_neighbor(StaticMappingQ1<dim, spacedim>::mapping,
-                                     fe,
-                                     quadrature,
-                                     update_flags)
-  , internal_fe_subface_values_neighbor(StaticMappingQ1<dim, spacedim>::mapping,
-                                        fe,
-                                        quadrature,
-                                        update_flags)
+  , internal_fe_face_values(
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature,
+      update_flags)
+  , internal_fe_subface_values(
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature,
+      update_flags)
+  , internal_fe_face_values_neighbor(
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature,
+      update_flags)
+  , internal_fe_subface_values_neighbor(
+      // TODO: We should query the default mapping for the kind of cell
+      // represented by 'fe' and 'q':
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)),
+      fe,
+      quadrature,
+      update_flags)
   , fe_face_values(nullptr)
   , fe_face_values_neighbor(nullptr)
 {}

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -526,34 +526,26 @@ FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
   const UpdateFlags                   update_flags)
   : n_quadrature_points(quadrature.size())
   , internal_fe_face_values(
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values(
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature,
       update_flags)
   , internal_fe_face_values_neighbor(
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values_neighbor(
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature,
       update_flags)

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2265,14 +2265,10 @@ namespace FETools
         tr.begin_active()->set_refine_flag(RefinementCase<dim>(ref_case));
         tr.execute_coarsening_and_refinement();
 
-        FEValues<dim, spacedim> fine(
-          // TODO: We should query the default mapping for the kind of cell
-          // represented by 'fe' and 'q':
-          ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-            ReferenceCell::get_hypercube(dim)),
-          fe,
-          q_fine,
-          update_quadrature_points | update_JxW_values | update_values);
+        FEValues<dim, spacedim> fine(fe,
+                                     q_fine,
+                                     update_quadrature_points |
+                                       update_JxW_values | update_values);
 
         typename Triangulation<dim, spacedim>::cell_iterator coarse_cell =
           tr.begin(0);

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2265,11 +2265,14 @@ namespace FETools
         tr.begin_active()->set_refine_flag(RefinementCase<dim>(ref_case));
         tr.execute_coarsening_and_refinement();
 
-        FEValues<dim, spacedim> fine(StaticMappingQ1<dim, spacedim>::mapping,
-                                     fe,
-                                     q_fine,
-                                     update_quadrature_points |
-                                       update_JxW_values | update_values);
+        FEValues<dim, spacedim> fine(
+          // TODO: We should query the default mapping for the kind of cell
+          // represented by 'fe' and 'q':
+          ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+            ReferenceCell::get_hypercube(dim)),
+          fe,
+          q_fine,
+          update_quadrature_points | update_JxW_values | update_values);
 
         typename Triangulation<dim, spacedim>::cell_iterator coarse_cell =
           tr.begin(0);

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -176,7 +176,8 @@ namespace GridTools
   double
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
-           (StaticMappingQ1<dim, spacedim>::mapping));
+           ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+             ReferenceCell::get_hypercube(dim)));
 
   /**
    * Return an approximation of the diameter of the smallest active cell of a
@@ -190,9 +191,11 @@ namespace GridTools
    */
   template <int dim, int spacedim>
   double
-  minimal_cell_diameter(const Triangulation<dim, spacedim> &triangulation,
-                        const Mapping<dim, spacedim> &      mapping =
-                          (StaticMappingQ1<dim, spacedim>::mapping));
+  minimal_cell_diameter(
+    const Triangulation<dim, spacedim> &triangulation,
+    const Mapping<dim, spacedim> &      mapping =
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Return an approximation of the diameter of the largest active cell of a
@@ -206,9 +209,11 @@ namespace GridTools
    */
   template <int dim, int spacedim>
   double
-  maximal_cell_diameter(const Triangulation<dim, spacedim> &triangulation,
-                        const Mapping<dim, spacedim> &      mapping =
-                          (StaticMappingQ1<dim, spacedim>::mapping));
+  maximal_cell_diameter(
+    const Triangulation<dim, spacedim> &triangulation,
+    const Mapping<dim, spacedim> &      mapping =
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Given a list of vertices (typically obtained using
@@ -1036,9 +1041,11 @@ namespace GridTools
    */
   template <int dim, int spacedim>
   std::map<unsigned int, Point<spacedim>>
-  extract_used_vertices(const Triangulation<dim, spacedim> &container,
-                        const Mapping<dim, spacedim> &      mapping =
-                          StaticMappingQ1<dim, spacedim>::mapping);
+  extract_used_vertices(
+    const Triangulation<dim, spacedim> &container,
+    const Mapping<dim, spacedim> &      mapping =
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Find and return the index of the closest vertex to a given point in the
@@ -1865,7 +1872,8 @@ namespace GridTools
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
-      StaticMappingQ1<dim, spacedim>::mapping);
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Compute a globally unique index for each vertex and hanging node

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -76,7 +76,8 @@ namespace GridTools
      */
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
-            StaticMappingQ1<dim, spacedim>::mapping);
+            ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+              ReferenceCell::get_hypercube(dim)));
 
     /**
      * Destructor.

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -280,7 +280,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      StaticMappingQ1<dim, spacedim>::mapping);
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * This function does the same as the
@@ -302,7 +303,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      StaticMappingQ1<dim, spacedim>::mapping);
+      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Compute the constraints that correspond to boundary conditions of the
@@ -330,7 +332,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      StaticMappingQ1<dim, spacedim>::mapping);
+      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   /**
    * Same as above for homogeneous tangential-flux constraints.
@@ -348,7 +351,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      StaticMappingQ1<dim, spacedim>::mapping);
+      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+        ReferenceCell::get_hypercube(dim)));
 
   //@}
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -303,7 +303,7 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
         ReferenceCell::get_hypercube(dim)));
 
   /**
@@ -332,7 +332,7 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
         ReferenceCell::get_hypercube(dim)));
 
   /**
@@ -351,7 +351,7 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim,spacedim>(
+      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
         ReferenceCell::get_hypercube(dim)));
 
   //@}

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -69,7 +69,8 @@ namespace Particles
       const std::vector<Point<dim>> &     particle_reference_locations,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        StaticMappingQ1<dim, spacedim>::mapping);
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)));
 
     /**
      * A function that generates one particle at a random location in cell @p cell and with
@@ -107,7 +108,8 @@ namespace Particles
       const types::particle_index                                        id,
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
-        StaticMappingQ1<dim, spacedim>::mapping);
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)));
 
     /**
      * A function that generates particles randomly in the domain with a
@@ -162,7 +164,8 @@ namespace Particles
       const types::particle_index         n_particles_to_create,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        StaticMappingQ1<dim, spacedim>::mapping,
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)),
       const unsigned int random_number_seed = 5432);
 
 
@@ -202,14 +205,16 @@ namespace Particles
      */
     template <int dim, int spacedim = dim>
     void
-    dof_support_points(const DoFHandler<dim, spacedim> &dof_handler,
-                       const std::vector<std::vector<BoundingBox<spacedim>>>
-                         &                             global_bounding_boxes,
-                       ParticleHandler<dim, spacedim> &particle_handler,
-                       const Mapping<dim, spacedim> &  mapping =
-                         StaticMappingQ1<dim, spacedim>::mapping,
-                       const ComponentMask &components = ComponentMask(),
-                       const std::vector<std::vector<double>> &properties = {});
+    dof_support_points(
+      const DoFHandler<dim, spacedim> &dof_handler,
+      const std::vector<std::vector<BoundingBox<spacedim>>>
+        &                             global_bounding_boxes,
+      ParticleHandler<dim, spacedim> &particle_handler,
+      const Mapping<dim, spacedim> &  mapping =
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)),
+      const ComponentMask &                   components = ComponentMask(),
+      const std::vector<std::vector<double>> &properties = {});
 
     /**
      * A function that generates particles at the locations of the quadrature
@@ -244,14 +249,16 @@ namespace Particles
      */
     template <int dim, int spacedim = dim>
     void
-    quadrature_points(const Triangulation<dim, spacedim> &triangulation,
-                      const Quadrature<dim> &             quadrature,
-                      const std::vector<std::vector<BoundingBox<spacedim>>>
-                        &                             global_bounding_boxes,
-                      ParticleHandler<dim, spacedim> &particle_handler,
-                      const Mapping<dim, spacedim> &  mapping =
-                        StaticMappingQ1<dim, spacedim>::mapping,
-                      const std::vector<std::vector<double>> &properties = {});
+    quadrature_points(
+      const Triangulation<dim, spacedim> &triangulation,
+      const Quadrature<dim> &             quadrature,
+      const std::vector<std::vector<BoundingBox<spacedim>>>
+        &                             global_bounding_boxes,
+      ParticleHandler<dim, spacedim> &particle_handler,
+      const Mapping<dim, spacedim> &  mapping =
+        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+          ReferenceCell::get_hypercube(dim)),
+      const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles
 


### PR DESCRIPTION
This is the counter-part to #11538, follow-up to #11520. I'm replacing uses of `StaticMappingQ1` by `ReferenceCell::get_default_linear_mapping<dim, spacedim>(ReferenceCell::get_hypercube(dim))`, but in contexts where I don't know whether that is actually correct (e.g., in default arguments). It is exactly as correct/wrong as it was before, but it points to the right direction.

I'd like to merge this so as to make progress.

/rebuild