### PR TITLE
Use the correct mapping for a finite element.

### DIFF
--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4388,10 +4388,8 @@ FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
       q.size(),
       fe.n_dofs_per_cell(),
       update_default,
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe)
   , quadrature(q)
 {
@@ -4716,10 +4714,8 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature)
 {
@@ -4950,10 +4946,8 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      // TODO: We should query the default mapping for the kind of cell
-      // represented by 'fe' and 'q':
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)),
+        fe.reference_cell_type()),
       fe,
       quadrature)
 {

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -74,16 +74,13 @@ namespace MeshWorker
     const UpdateFlags &                 update_flags,
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags)
-    : ScratchData(
-        // TODO: We should query the default mapping for the kind of cell
-        // represented by 'fe' and 'q':
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)),
-        fe,
-        quadrature,
-        update_flags,
-        face_quadrature,
-        face_update_flags)
+    : ScratchData(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+                    fe.reference_cell_type()),
+                  fe,
+                  quadrature,
+                  update_flags,
+                  face_quadrature,
+                  face_update_flags)
   {}
 
 
@@ -97,18 +94,15 @@ namespace MeshWorker
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags,
     const UpdateFlags &                 neighbor_face_update_flags)
-    : ScratchData(
-        // TODO: We should query the default mapping for the kind of cell
-        // represented by 'fe' and 'q':
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)),
-        fe,
-        quadrature,
-        update_flags,
-        neighbor_update_flags,
-        face_quadrature,
-        face_update_flags,
-        neighbor_face_update_flags)
+    : ScratchData(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+                    fe.reference_cell_type()),
+                  fe,
+                  quadrature,
+                  update_flags,
+                  neighbor_update_flags,
+                  face_quadrature,
+                  face_update_flags,
+                  neighbor_face_update_flags)
   {}
 
 


### PR DESCRIPTION
Follow-up to #11520 and #11540. Fixes the TODO places introduced in #11520 since @peterrum told me how to query the reference cell -- I had looked into class `FiniteElement` and not found it there, but it turns out to be in class `FiniteElementData`.

/rebuild