### PR TITLE
Make code slightly easier to read.

### DIFF
--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -69,60 +69,52 @@ namespace Simplex
         {
           // We don't really have dim = 1 support for simplex elements yet, but
           // its convenient for populating the face array
+          Assert(degree <= 2, ExcNotImplemented());
           if (degree >= 1)
             {
               unit_points.emplace_back(0.0);
               unit_points.emplace_back(1.0);
-            }
-          if (degree == 2)
-            {
-              unit_points.emplace_back(0.5);
-            }
-          if (degree > 2)
-            {
-              Assert(false, ExcNotImplemented());
+
+              if (degree == 2)
+                unit_points.emplace_back(0.5);
             }
         }
       else if (dim == 2)
         {
+          Assert(degree <= 2, ExcNotImplemented());
           if (degree >= 1)
             {
               unit_points.emplace_back(0.0, 0.0);
               unit_points.emplace_back(1.0, 0.0);
               unit_points.emplace_back(0.0, 1.0);
-            }
-          if (degree == 2)
-            {
-              unit_points.emplace_back(0.5, 0.0);
-              unit_points.emplace_back(0.5, 0.5);
-              unit_points.emplace_back(0.0, 0.5);
-            }
-          if (degree > 3)
-            {
-              Assert(false, ExcNotImplemented());
+
+              if (degree == 2)
+                {
+                  unit_points.emplace_back(0.5, 0.0);
+                  unit_points.emplace_back(0.5, 0.5);
+                  unit_points.emplace_back(0.0, 0.5);
+                }
             }
         }
       else if (dim == 3)
         {
+          Assert(degree <= 2, ExcNotImplemented());
           if (degree >= 1)
             {
               unit_points.emplace_back(0.0, 0.0, 0.0);
               unit_points.emplace_back(1.0, 0.0, 0.0);
               unit_points.emplace_back(0.0, 1.0, 0.0);
               unit_points.emplace_back(0.0, 0.0, 1.0);
-            }
-          if (degree == 2)
-            {
-              unit_points.emplace_back(0.5, 0.0, 0.0);
-              unit_points.emplace_back(0.5, 0.5, 0.0);
-              unit_points.emplace_back(0.0, 0.5, 0.0);
-              unit_points.emplace_back(0.0, 0.0, 0.5);
-              unit_points.emplace_back(0.5, 0.0, 0.5);
-              unit_points.emplace_back(0.0, 0.5, 0.5);
-            }
-          if (degree == 3)
-            {
-              Assert(false, ExcNotImplemented());
+
+              if (degree == 2)
+                {
+                  unit_points.emplace_back(0.5, 0.0, 0.0);
+                  unit_points.emplace_back(0.5, 0.5, 0.0);
+                  unit_points.emplace_back(0.0, 0.5, 0.0);
+                  unit_points.emplace_back(0.0, 0.0, 0.5);
+                  unit_points.emplace_back(0.5, 0.0, 0.5);
+                  unit_points.emplace_back(0.0, 0.5, 0.5);
+                }
             }
         }
       else


### PR DESCRIPTION
Reading through #11516 by @drwells , I found myself confused by the fact that some of the `if` statements were `>`, others `==`. I initially thought they were mutually exclusive and could have been written as `else if`, but they are in fact nested.

Reflect this in the code, and move the assertion to a place where we can actually show the condition that's tested in the error message.

/rebuild