### PR TITLE
Consistent nonlocal access error messages

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1218,8 +1218,8 @@ namespace LinearAlgebra
         << "You tried to access element " << arg1
         << " of a distributed vector, but this element is not "
         << "stored on the current processor. Note: The range of "
-        << "locally owned elements is " << arg2 << " to " << arg3
-        << ", and there are " << arg4 << " ghost elements "
+        << "locally owned elements is [" << arg2 << "," << arg3
+        << "], and there are " << arg4 << " ghost elements "
         << "that this vector can access."
         << "\n\n"
         << "A common source for this kind of problem is that you "
@@ -1589,7 +1589,7 @@ namespace LinearAlgebra
           partitioner->ghost_indices().is_element(global_index),
         ExcAccessToNonLocalElement(global_index,
                                    partitioner->local_range().first,
-                                   partitioner->local_range().second,
+                                   partitioner->local_range().second - 1,
                                    partitioner->ghost_indices().n_elements()));
       // do not allow reading a vector which is not in ghost mode
       Assert(partitioner->in_local_range(global_index) ||
@@ -1613,7 +1613,7 @@ namespace LinearAlgebra
           partitioner->ghost_indices().is_element(global_index),
         ExcAccessToNonLocalElement(global_index,
                                    partitioner->local_range().first,
-                                   partitioner->local_range().second,
+                                   partitioner->local_range().second - 1,
                                    partitioner->ghost_indices().n_elements()));
       // we would like to prevent reading ghosts from a vector that does not
       // have them imported, but this is not possible because we might be in a

--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -179,8 +179,8 @@ namespace PETScWrappers
         int,
         int,
         << "You tried to access element " << arg1
-        << " of a distributed vector, but only elements " << arg2 << " through "
-        << arg3 << " are stored locally and can be accessed."
+        << " of a distributed vector, but only elements in range [" << arg2
+        << "," << arg3 << "] are stored locally and can be accessed."
         << "\n\n"
         << "A common source for this kind of problem is that you "
         << "are passing a 'fully distributed' vector into a function "

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -1830,9 +1830,9 @@ namespace TrilinosWrappers
                    size_type,
                    << "You tried to access element (" << arg1 << "/" << arg2
                    << ")"
-                   << " of a distributed matrix, but only rows " << arg3
-                   << " through " << arg4
-                   << " are stored locally and can be accessed.");
+                   << " of a distributed matrix, but only rows in range ["
+                   << arg3 << "," << arg4
+                   << "] are stored locally and can be accessed.");
 
     /**
      * Exception

--- a/include/deal.II/lac/trilinos_sparsity_pattern.h
+++ b/include/deal.II/lac/trilinos_sparsity_pattern.h
@@ -969,9 +969,9 @@ namespace TrilinosWrappers
                    size_type,
                    << "You tried to access element (" << arg1 << "/" << arg2
                    << ")"
-                   << " of a distributed matrix, but only rows " << arg3
-                   << " through " << arg4
-                   << " are stored locally and can be accessed.");
+                   << " of a distributed matrix, but only rows in range ["
+                   << arg3 << "," << arg4
+                   << "] are stored locally and can be accessed.");
 
     /**
      * Exception

--- a/include/deal.II/lac/trilinos_vector.h
+++ b/include/deal.II/lac/trilinos_vector.h
@@ -1278,9 +1278,8 @@ namespace TrilinosWrappers
         << " of a distributed vector, but this element is not stored "
         << "on the current processor. Note: There are " << arg2
         << " elements stored "
-        << "on the current processor from within the range " << arg3
-        << " through " << arg4
-        << " but Trilinos vectors need not store contiguous "
+        << "on the current processor from within the range [" << arg3 << ","
+        << arg4 << "] but Trilinos vectors need not store contiguous "
         << "ranges on each processor, and not every element in "
         << "this range may in fact be stored locally."
         << "\n\n"

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -1184,7 +1184,7 @@ namespace TrilinosWrappers
       {
         Assert(false,
                ExcAccessToNonLocalElement(
-                 i, j, local_range().first, local_range().second));
+                 i, j, local_range().first, local_range().second - 1));
       }
     else
       {


### PR DESCRIPTION
Exception message for L:d:V when nonlocal element was accessed was misleading. Also adapted the message for the other parallel vectors. The passed range was already "correct"  in some places and is now consistently taken to be the inclusive range.

@peterrum as discussed.