### PR TITLE
Move two free functions into class ReferenceCell.

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -1164,9 +1164,8 @@ namespace internal
             {
               col_d[offset_i] = counter;
               orientations[offset_i] =
-                ReferenceCell::compute_orientation(ad_entity_types[offset_i],
-                                                   ad_entity_vertices[offset_i],
-                                                   ref_indices);
+                ad_entity_types[offset_i].compute_orientation(
+                  ad_entity_vertices[offset_i], ref_indices);
             }
         }
       ptr_0.push_back(col_0.size());

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -647,10 +647,8 @@ QProjector<3>::project_to_all_faces(
     [](const auto &face, const auto &orientation) -> std::vector<Point<3>> {
     std::array<Point<3>, 3> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
-    const auto temp =
-      ReferenceCell::permute_according_orientation(ReferenceCell::Type::Tri,
-                                                   vertices,
-                                                   orientation);
+    const auto temp = ReferenceCell::Type(ReferenceCell::Type::Tri)
+                        .permute_according_orientation(vertices, orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -659,10 +657,8 @@ QProjector<3>::project_to_all_faces(
     [](const auto &face, const auto &orientation) -> std::vector<Point<3>> {
     std::array<Point<3>, 4> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
-    const auto temp =
-      ReferenceCell::permute_according_orientation(ReferenceCell::Type::Quad,
-                                                   vertices,
-                                                   orientation);
+    const auto temp = ReferenceCell::Type(ReferenceCell::Type::Quad)
+                        .permute_according_orientation(vertices, orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -76,8 +76,7 @@ FE_Nothing<dim, spacedim>::get_name() const
 
   std::vector<std::string> name_components;
   if (this->reference_cell_type() != ReferenceCell::get_hypercube(dim))
-    name_components.push_back(
-      ReferenceCell::to_string(this->reference_cell_type()));
+    name_components.push_back(this->reference_cell_type().to_string());
   if (this->n_components() > 1)
     name_components.push_back(std::to_string(this->n_components()));
   if (dominate)

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -158,17 +158,17 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
       for (unsigned int i = 0; i < n_faces; ++i)
         {
           unit_tangentials[i].resize(n_original_q_points);
-          std::fill(unit_tangentials[i].begin(),
-                    unit_tangentials[i].end(),
-                    ReferenceCell::unit_tangential_vectors<dim>(
-                      reference_cell_type, i, 0));
+          std::fill(
+            unit_tangentials[i].begin(),
+            unit_tangentials[i].end(),
+            reference_cell_type.template unit_tangential_vectors<dim>(i, 0));
           if (dim > 2)
             {
               unit_tangentials[n_faces + i].resize(n_original_q_points);
               std::fill(unit_tangentials[n_faces + i].begin(),
                         unit_tangentials[n_faces + i].end(),
-                        ReferenceCell::unit_tangential_vectors<dim>(
-                          reference_cell_type, i, 1));
+                        reference_cell_type
+                          .template unit_tangential_vectors<dim>(i, 1));
             }
         }
     }
@@ -871,9 +871,8 @@ MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe)
   for (unsigned int point = 0; point < n_points; ++point)
     for (unsigned int i = 0; i < n_shape_functions; ++i)
       mapping_support_point_weights(point, i) =
-        ReferenceCell::d_linear_shape_function(reference_cell_type,
-                                               mapping_support_points[point],
-                                               i);
+        reference_cell_type.d_linear_shape_function(
+          mapping_support_points[point], i);
 }
 
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -580,16 +580,16 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
               data.unit_tangentials[i].resize(n_original_q_points);
               std::fill(data.unit_tangentials[i].begin(),
                         data.unit_tangentials[i].end(),
-                        ReferenceCell::unit_tangential_vectors<dim>(
-                          reference_cell_type, i, 0));
+                        reference_cell_type
+                          .template unit_tangential_vectors<dim>(i, 0));
               if (dim > 2)
                 {
                   data.unit_tangentials[n_faces + i].resize(
                     n_original_q_points);
                   std::fill(data.unit_tangentials[n_faces + i].begin(),
                             data.unit_tangentials[n_faces + i].end(),
-                            ReferenceCell::unit_tangential_vectors<dim>(
-                              reference_cell_type, i, 1));
+                            reference_cell_type
+                              .template unit_tangential_vectors<dim>(i, 1));
                 }
             }
         }

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -913,16 +913,17 @@ FlatManifold<dim, spacedim>::normal_vector(
     {
       Point<spacedim> F;
       for (const unsigned int v : face->vertex_indices())
-        F += face->vertex(v) * ReferenceCell::d_linear_shape_function(
-                                 face_reference_cell_type, xi, v);
+        F += face->vertex(v) *
+             face_reference_cell_type.d_linear_shape_function(xi, v);
 
       for (unsigned int i = 0; i < facedim; ++i)
         {
           grad_F[i] = 0;
           for (const unsigned int v : face->vertex_indices())
             grad_F[i] +=
-              face->vertex(v) * ReferenceCell::d_linear_shape_function_gradient(
-                                  face_reference_cell_type, xi, v)[i];
+              face->vertex(v) *
+              face_reference_cell_type.d_linear_shape_function_gradient(xi,
+                                                                        v)[i];
         }
 
       Tensor<1, facedim> J;

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -37,7 +37,7 @@ namespace ReferenceCell
   make_triangulation(const Type &                  reference_cell,
                      Triangulation<dim, spacedim> &tria)
   {
-    AssertDimension(dim, get_dimension(reference_cell));
+    AssertDimension(dim, reference_cell.get_dimension());
 
     if (reference_cell == get_hypercube(dim))
       {
@@ -110,7 +110,7 @@ namespace ReferenceCell
   std::unique_ptr<Mapping<dim, spacedim>>
   get_default_mapping(const Type &reference_cell, const unsigned int degree)
   {
-    AssertDimension(dim, get_dimension(reference_cell));
+    AssertDimension(dim, reference_cell.get_dimension());
 
     if (reference_cell == get_hypercube(dim))
       return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
@@ -136,7 +136,7 @@ namespace ReferenceCell
   const Mapping<dim, spacedim> &
   get_default_linear_mapping(const Type &reference_cell)
   {
-    AssertDimension(dim, get_dimension(reference_cell));
+    AssertDimension(dim, reference_cell.get_dimension());
 
     if (reference_cell == get_hypercube(dim))
       {
@@ -195,7 +195,7 @@ namespace ReferenceCell
   get_gauss_type_quadrature(const Type &   reference_cell,
                             const unsigned n_points_1D)
   {
-    AssertDimension(dim, get_dimension(reference_cell));
+    AssertDimension(dim, reference_cell.get_dimension());
 
     if (reference_cell == get_hypercube(dim))
       return QGauss<dim>(n_points_1D);
@@ -215,7 +215,7 @@ namespace ReferenceCell
   Quadrature<dim> &
   get_nodal_type_quadrature(const Type &reference_cell)
   {
-    AssertDimension(dim, get_dimension(reference_cell));
+    AssertDimension(dim, reference_cell.get_dimension());
 
     const auto create_quadrature = [](const Type &reference_cell) {
       Triangulation<dim> tria;

--- a/tests/simplex/orientation_01.cc
+++ b/tests/simplex/orientation_01.cc
@@ -33,10 +33,9 @@ test(const ReferenceCell::Type type, const unsigned int n_orientations)
       for (unsigned int i = 0; i < n_points; ++i)
         origin[i] = i;
 
-      const auto permuted =
-        ReferenceCell::permute_according_orientation(type, origin, o);
+      const auto permuted = type.permute_according_orientation(origin, o);
       const unsigned int origin_back =
-        ReferenceCell::compute_orientation(type, permuted, origin);
+        type.compute_orientation(permuted, origin);
 
       AssertDimension(o, origin_back);
     }

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -43,12 +43,14 @@ test(const unsigned int orientation)
   }
 
   {
-    const auto &face     = dummy.begin()->face(face_no);
-    const auto  permuted = ReferenceCell::permute_according_orientation(
-      ReferenceCell::Type::Tri,
-      std::array<unsigned int, 3>{
-        {face->vertex_index(0), face->vertex_index(1), face->vertex_index(2)}},
-      orientation);
+    const auto &face = dummy.begin()->face(face_no);
+    const auto  permuted =
+      ReferenceCell::Type(ReferenceCell::Type::Tri)
+        .permute_according_orientation(
+          std::array<unsigned int, 3>{{face->vertex_index(0),
+                                       face->vertex_index(1),
+                                       face->vertex_index(2)}},
+          orientation);
 
     auto direction =
       cross_product_3d(vertices[permuted[1]] - vertices[permuted[0]],

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -33,9 +33,7 @@ test(const ReferenceCell::Type &reference_cell)
   for (const auto face_no :
        ReferenceCell::internal::Info::get_cell(reference_cell).face_indices())
     {
-      deallog << ReferenceCell::unit_normal_vectors<dim>(reference_cell,
-                                                         face_no)
-              << std::endl;
+      deallog << reference_cell.unit_normal_vectors<dim>(face_no) << std::endl;
 
       for (unsigned int i = 0; i < dim - 1; ++i)
         deallog << ReferenceCell::unit_tangential_vectors<dim>(reference_cell,

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -33,12 +33,13 @@ test(const ReferenceCell::Type &reference_cell)
   for (const auto face_no :
        ReferenceCell::internal::Info::get_cell(reference_cell).face_indices())
     {
-      deallog << reference_cell.unit_normal_vectors<dim>(face_no) << std::endl;
+      deallog << ReferenceCell::unit_normal_vectors<dim>(reference_cell,
+                                                         face_no)
+              << std::endl;
 
       for (unsigned int i = 0; i < dim - 1; ++i)
-        deallog << ReferenceCell::unit_tangential_vectors<dim>(reference_cell,
-                                                               face_no,
-                                                               i)
+        deallog << reference_cell.template unit_tangential_vectors<dim>(face_no,
+                                                                        i)
                 << std::endl;
     }
   deallog << std::endl;


### PR DESCRIPTION
@peterrum -- this is the sort of follow-up I have in mind for #11544. It moves two of the current free functions into the `ReferenceCell::Type` class. There are plenty more to come, but I thought I'd show what I have in mind. (The first two commits are from #11544 and will be dropped once that is merged.)