### PR TITLE
Change the loop of the bounding lines in set_all_manifold_ids

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1959,8 +1959,8 @@ TriaAccessor<structdim, dim, spacedim>::set_all_manifold_ids(
         break;
 
       case 2:
-        // for quads also set manifold_id of bounding lines
-        for (unsigned int i = 0; i < 4; ++i)
+        // for quads/simplices also set manifold_id of bounding lines
+        for (unsigned int i = 0; i < this->n_lines(); ++i)
           this->line(i)->set_manifold_id(manifold_ind);
         break;
       default:


### PR DESCRIPTION
According to #11535, the loop in `TriaAccessor<structdim, dim, spacedim>::set_all_manifold_ids` should also work for simplices (and for general polygon as well).