### PR TITLE
Use both quadratic element and quadrature mapping in simplex/step-38

### DIFF
--- a/tests/simplex/step-38.cc
+++ b/tests/simplex/step-38.cc
@@ -63,7 +63,7 @@ namespace Step38
   class LaplaceBeltramiProblem
   {
   public:
-    LaplaceBeltramiProblem(const unsigned degree = 1);
+    LaplaceBeltramiProblem(const unsigned degree = 2);
     void
     run();
 
@@ -274,7 +274,7 @@ namespace Step38
     system_matrix = 0;
     system_rhs    = 0;
 #ifdef USE_SIMPLEX
-    const Simplex::QGauss<dim> quadrature_formula(2 * fe.degree);
+    const Simplex::QGauss<dim> quadrature_formula(fe.degree + 1);
 #else
     const QGauss<dim> quadrature_formula(2 * fe.degree);
 #endif
@@ -379,7 +379,7 @@ namespace Step38
                                       Solution<spacedim>(),
                                       difference_per_cell,
 #ifdef USE_SIMPLEX
-                                      Simplex::QGauss<dim>(2 * fe.degree + 1),
+                                      Simplex::QGauss<dim>(fe.degree + 1),
 #else
                                       QGauss<dim>(2 * fe.degree +
                                                   1), // This also works on
@@ -412,7 +412,7 @@ main()
     {
       using namespace Step38;
 
-      LaplaceBeltramiProblem<3> laplace_beltrami(1);
+      LaplaceBeltramiProblem<3> laplace_beltrami;
       laplace_beltrami.run();
     }
   catch (std::exception &exc)

--- a/tests/simplex/step-38.with_simplex_support=on.output
+++ b/tests/simplex/step-38.with_simplex_support=on.output
@@ -1,3 +1,3 @@
 Surface mesh has 10240 cells.
-Surface mesh has 5185 degrees of freedom.
-H1 error = 0.384717
+Surface mesh has 20609 degrees of freedom.
+H1 error = 0.00932553


### PR DESCRIPTION
According to https://github.com/dealii/dealii/pull/11569#discussion_r559045899, this is a test for #11563. Now the default order of the FE element and mapping is set to be 2 in simplex/step-38.