### PR TITLE
Python wrappers for simplex and mixed meshes

### DIFF
--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -28,6 +28,7 @@ namespace python
 {
   class PointWrapper;
   class TriangulationWrapper;
+  class CellTypeWrapper;
 
   class CellAccessorWrapper
   {
@@ -183,6 +184,11 @@ namespace python
      */
     unsigned int
     vertex_index(const unsigned int i) const;
+
+    /*! @copydoc TriaAccessor::reference_cell_type
+     */
+    CellTypeWrapper
+    reference_cell_type() const;
 
     /*! @copydoc TriaAccessor::n_vertices
      */

--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -184,6 +184,21 @@ namespace python
     unsigned int
     vertex_index(const unsigned int i) const;
 
+    /*! @copydoc TriaAccessor::n_vertices
+     */
+    unsigned int
+    n_vertices() const;
+
+    /*! @copydoc TriaAccessor::n_lines
+     */
+    unsigned int
+    n_lines() const;
+
+    /*! @copydoc TriaAccessor::n_faces
+     */
+    unsigned int
+    n_faces() const;
+
     /**
      * Exception.
      */

--- a/contrib/python-bindings/include/reference_cell_wrapper.h
+++ b/contrib/python-bindings/include/reference_cell_wrapper.h
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_reference_cell_wrapper_h
+#define dealii_reference_cell_wrapper_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/grid/reference_cell.h>
+
+#include <boost/python.hpp>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  class CellTypeWrapper
+  {
+  public:
+    /**
+     * Copy constructor.
+     */
+    CellTypeWrapper(const CellTypeWrapper &other);
+
+    /**
+     * Constructor. Takes a CellKinds enum field and creates a Type class.
+     */
+    CellTypeWrapper(const ReferenceCell::Type::CellKinds &kind);
+
+    /**
+     * Constructor. Takes a CellKinds enum field and creates a Type class.
+     */
+    CellTypeWrapper(const ReferenceCell::Type &cell_type_in);
+
+    /**
+     * Constructor for an empty object.
+     */
+    CellTypeWrapper();
+
+    /**
+     * Destructor.
+     */
+    ~CellTypeWrapper();
+
+    ReferenceCell::Type::CellKinds
+    cell_kind() const;
+
+  private:
+    ReferenceCell::Type cell_type;
+  };
+
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/contrib/python-bindings/include/tria_accessor_wrapper.h
+++ b/contrib/python-bindings/include/tria_accessor_wrapper.h
@@ -105,6 +105,21 @@ namespace python
     double
     measure() const;
 
+    /*! @copydoc TriaAccessor::n_vertices
+     */
+    unsigned int
+    n_vertices() const;
+
+    /*! @copydoc TriaAccessor::n_lines
+     */
+    unsigned int
+    n_lines() const;
+
+    /*! @copydoc TriaAccessor::n_faces
+     */
+    unsigned int
+    n_faces() const;
+
     /**
      * Exception.
      */

--- a/contrib/python-bindings/include/triangulation_wrapper.h
+++ b/contrib/python-bindings/include/triangulation_wrapper.h
@@ -274,6 +274,11 @@ namespace python
     void
     transform(boost::python::object &transformation);
 
+    /*! @copydoc GridGenerator::convert_hypercube_to_simplex_mesh
+     */
+    void
+    convert_hypercube_to_simplex_mesh(TriangulationWrapper &tria_out);
+
     /*! @copydoc GridTools::find_active_cell_around_point
      */
     CellAccessorWrapper

--- a/contrib/python-bindings/source/CMakeLists.txt
+++ b/contrib/python-bindings/source/CMakeLists.txt
@@ -38,6 +38,7 @@ SET(_src
   export_mapping.cc
   export_manifold.cc
   export_quadrature.cc
+  export_reference_cell.cc
   cell_accessor_wrapper.cc
   tria_accessor_wrapper.cc
   point_wrapper.cc
@@ -45,6 +46,7 @@ SET(_src
   mapping_wrapper.cc
   manifold_wrapper.cc
   quadrature_wrapper.cc
+  reference_cell_wrapper.cc
   )
 
 FOREACH(_build ${DEAL_II_BUILD_TYPES})

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -17,6 +17,7 @@
 
 #include <cell_accessor_wrapper.h>
 #include <point_wrapper.h>
+#include <reference_cell_wrapper.h>
 #include <tria_accessor_wrapper.h>
 #include <triangulation_wrapper.h>
 
@@ -793,6 +794,17 @@ namespace python
       return internal::cell_cast<2, 3>(cell_accessor)->n_faces();
     else
       return internal::cell_cast<3, 3>(cell_accessor)->n_faces();
+  }
+
+  CellTypeWrapper
+  CellAccessorWrapper::reference_cell_type() const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::cell_cast<2, 2>(cell_accessor)->reference_cell_type();
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::cell_cast<2, 3>(cell_accessor)->reference_cell_type();
+    else
+      return internal::cell_cast<3, 3>(cell_accessor)->reference_cell_type();
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -796,6 +796,8 @@ namespace python
       return internal::cell_cast<3, 3>(cell_accessor)->n_faces();
   }
 
+
+
   CellTypeWrapper
   CellAccessorWrapper::reference_cell_type() const
   {

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -756,6 +756,45 @@ namespace python
       return internal::cell_cast<3, 3>(cell_accessor)->vertex_index(i);
   }
 
+
+
+  unsigned int
+  CellAccessorWrapper::n_vertices() const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::cell_cast<2, 2>(cell_accessor)->n_vertices();
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::cell_cast<2, 3>(cell_accessor)->n_vertices();
+    else
+      return internal::cell_cast<3, 3>(cell_accessor)->n_vertices();
+  }
+
+
+
+  unsigned int
+  CellAccessorWrapper::n_lines() const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::cell_cast<2, 2>(cell_accessor)->n_lines();
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::cell_cast<2, 3>(cell_accessor)->n_lines();
+    else
+      return internal::cell_cast<3, 3>(cell_accessor)->n_lines();
+  }
+
+
+
+  unsigned int
+  CellAccessorWrapper::n_faces() const
+  {
+    if ((dim == 2) && (spacedim == 2))
+      return internal::cell_cast<2, 2>(cell_accessor)->n_faces();
+    else if ((dim == 2) && (spacedim == 3))
+      return internal::cell_cast<2, 3>(cell_accessor)->n_faces();
+    else
+      return internal::cell_cast<3, 3>(cell_accessor)->n_faces();
+  }
+
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -16,6 +16,7 @@
 #include <boost/python.hpp>
 
 #include <cell_accessor_wrapper.h>
+#include <reference_cell_wrapper.h>
 #include <triangulation_wrapper.h>
 
 DEAL_II_NAMESPACE_OPEN
@@ -151,6 +152,11 @@ namespace python
 
 
 
+  const char reference_cell_type_docstring[] =
+    " Reference cell type of the current cell).                          \n";
+
+
+
   const char n_vertices_docstring[] =
     " Number of vertices.                                                \n";
 
@@ -254,6 +260,10 @@ namespace python
            &CellAccessorWrapper::vertex_index,
            vertex_index_docstring,
            boost::python::args("self", "vertex"))
+      .def("reference_cell_type",
+           &CellAccessorWrapper::reference_cell_type,
+           reference_cell_type_docstring,
+           boost::python::args("self"))
       .def("n_vertices",
            &CellAccessorWrapper::n_vertices,
            n_vertices_docstring,

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -150,6 +150,21 @@ namespace python
     " for activity of a cell).                                           \n";
 
 
+
+  const char n_vertices_docstring[] =
+    " Number of vertices.                                                \n";
+
+
+
+  const char n_lines_docstring[] =
+    " Number of lines.                                                   \n";
+
+
+
+  const char n_faces_docstring[] =
+    " Number of faces.                                                   \n";
+
+
   void
   export_cell_accessor()
   {
@@ -238,7 +253,19 @@ namespace python
       .def("vertex_index",
            &CellAccessorWrapper::vertex_index,
            vertex_index_docstring,
-           boost::python::args("self", "vertex"));
+           boost::python::args("self", "vertex"))
+      .def("n_vertices",
+           &CellAccessorWrapper::n_vertices,
+           n_vertices_docstring,
+           boost::python::args("self"))
+      .def("n_lines",
+           &CellAccessorWrapper::n_lines,
+           n_lines_docstring,
+           boost::python::args("self"))
+      .def("n_faces",
+           &CellAccessorWrapper::n_faces,
+           n_faces_docstring,
+           boost::python::args("self"));
   }
 } // namespace python
 

--- a/contrib/python-bindings/source/export_reference_cell.cc
+++ b/contrib/python-bindings/source/export_reference_cell.cc
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2016 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <boost/python.hpp>
+
+#include <reference_cell_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  const char cell_kind_docstring[] =
+    "Return geometric type of the corresponding reference cell.               \n";
+
+
+  void
+  export_reference_cell()
+  {
+    boost::python::enum_<ReferenceCell::Type::CellKinds>("CellKinds")
+      .value("Vertex", ReferenceCell::Type::Vertex)
+      .value("Line", ReferenceCell::Type::Line)
+      .value("Tri", ReferenceCell::Type::Tri)
+      .value("Quad", ReferenceCell::Type::Quad)
+      .value("Tet", ReferenceCell::Type::Tet)
+      .value("Pyramid", ReferenceCell::Type::Pyramid)
+      .value("Wedge", ReferenceCell::Type::Wedge)
+      .value("Hex", ReferenceCell::Type::Hex)
+      .value("Invalid", ReferenceCell::Type::Invalid);
+
+    boost::python::class_<CellTypeWrapper>(
+      "CellType",
+      boost::python::init<ReferenceCell::Type::CellKinds>(
+        boost::python::args("kind")))
+      .add_property("kind", &CellTypeWrapper::cell_kind, cell_kind_docstring);
+  }
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/export_triangulation.cc
+++ b/contrib/python-bindings/source/export_triangulation.cc
@@ -479,6 +479,13 @@ namespace python
     "Return the diameter of the largest active cell of a triangulation.    \n";
 
 
+
+  const char convert_hypercube_to_simplex_mesh_docstring[] =
+    "Convert a triangulation consisting only of hypercube cells            \n"
+    "(quadrilaterals, hexahedra) to a triangulation only consisting of     \n"
+    "simplices (triangles, tetrahedra).                                    \n";
+
+
   void
   export_triangulation()
   {
@@ -665,6 +672,10 @@ namespace python
            &TriangulationWrapper::transform,
            transform_docstring,
            boost::python::args("self", "transformation"))
+      .def("convert_hypercube_to_simplex_mesh",
+           &TriangulationWrapper::convert_hypercube_to_simplex_mesh,
+           convert_hypercube_to_simplex_mesh_docstring,
+           boost::python::args("self", "tria_out"))
       .def("find_active_cell_around_point",
            &TriangulationWrapper::find_active_cell_around_point,
            find_active_cell_around_point_overloads(

--- a/contrib/python-bindings/source/reference_cell_wrapper.cc
+++ b/contrib/python-bindings/source/reference_cell_wrapper.cc
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#include <deal.II/grid/reference_cell.h>
+
+#include <reference_cell_wrapper.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace python
+{
+  CellTypeWrapper::CellTypeWrapper()
+  {}
+
+
+
+  CellTypeWrapper::CellTypeWrapper(const CellTypeWrapper &other)
+  {
+    cell_type = other.cell_type;
+  }
+
+
+
+  CellTypeWrapper::CellTypeWrapper(const ReferenceCell::Type::CellKinds &kind)
+  {
+    cell_type = kind;
+  }
+
+
+
+  CellTypeWrapper::CellTypeWrapper(const ReferenceCell::Type &cell_type_in)
+  {
+    cell_type = cell_type_in;
+  }
+
+
+
+  CellTypeWrapper::~CellTypeWrapper()
+  {}
+
+
+
+  ReferenceCell::Type::CellKinds
+  CellTypeWrapper::cell_kind() const
+  {
+    std::uint8_t kind = (std::uint8_t)cell_type;
+    return static_cast<ReferenceCell::Type::CellKinds>(kind);
+  }
+
+} // namespace python
+
+DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/tria_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/tria_accessor_wrapper.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2016 - 2020 by the deal.II authors
+// Copyright (C) 2021 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //
@@ -417,8 +417,18 @@ namespace python
       return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_vertices();
     else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
       return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_vertices();
-    else
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 3, 3>(tria_accessor)->n_vertices();
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 2))
       return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_vertices();
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 3))
+      return internal::tria_accessor_cast<3, 3, 3>(tria_accessor)->n_vertices();
+    else
+      {
+        AssertThrow(false,
+                    ExcMessage("Wrong structdim-dim-spacedim combination."));
+        return -1;
+      }
   }
 
 
@@ -430,8 +440,18 @@ namespace python
       return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_lines();
     else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
       return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_lines();
-    else
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 3, 3>(tria_accessor)->n_lines();
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 2))
       return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_lines();
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 3))
+      return internal::tria_accessor_cast<3, 3, 3>(tria_accessor)->n_lines();
+    else
+      {
+        AssertThrow(false,
+                    ExcMessage("Wrong structdim-dim-spacedim combination."));
+        return -1;
+      }
   }
 
 
@@ -441,10 +461,16 @@ namespace python
   {
     if ((dim == 2) && (spacedim == 2) && (structdim == 1))
       return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_faces();
-    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
-      return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_faces();
-    else
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 2))
       return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_faces();
+    else if ((dim == 3) && (spacedim == 3) && (structdim == 3))
+      return internal::tria_accessor_cast<3, 3, 3>(tria_accessor)->n_faces();
+    else
+      {
+        AssertThrow(false,
+                    ExcMessage("Wrong structdim-dim-spacedim combination."));
+        return -1;
+      }
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/tria_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/tria_accessor_wrapper.cc
@@ -171,6 +171,14 @@ namespace python
           tria_accessor);
       return accessor->measure();
     }
+
+    template <int structdim, int dim, int spacedim>
+    const TriaAccessor<structdim, dim, spacedim> *
+    tria_accessor_cast(const void *tria_accessor)
+    {
+      return static_cast<const TriaAccessor<structdim, dim, spacedim> *>(
+        tria_accessor);
+    }
   } // namespace internal
 
 
@@ -398,6 +406,45 @@ namespace python
       return internal::measure<1, 2, 3>(tria_accessor);
     else
       return internal::measure<2, 3, 3>(tria_accessor);
+  }
+
+
+
+  unsigned int
+  TriaAccessorWrapper::n_vertices() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_vertices();
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_vertices();
+    else
+      return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_vertices();
+  }
+
+
+
+  unsigned int
+  TriaAccessorWrapper::n_lines() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_lines();
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_lines();
+    else
+      return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_lines();
+  }
+
+
+
+  unsigned int
+  TriaAccessorWrapper::n_faces() const
+  {
+    if ((dim == 2) && (spacedim == 2) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 2>(tria_accessor)->n_faces();
+    else if ((dim == 2) && (spacedim == 3) && (structdim == 1))
+      return internal::tria_accessor_cast<1, 2, 3>(tria_accessor)->n_faces();
+    else
+      return internal::tria_accessor_cast<2, 3, 3>(tria_accessor)->n_faces();
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -1549,6 +1549,7 @@ namespace python
   }
 
 
+
   void
   TriangulationWrapper::convert_hypercube_to_simplex_mesh(
     TriangulationWrapper &tria_out)
@@ -1567,6 +1568,7 @@ namespace python
       internal::convert_hypercube_to_simplex_mesh<3, 3>(triangulation,
                                                         tria_out);
   }
+
 
 
   void

--- a/contrib/python-bindings/source/triangulation_wrapper.cc
+++ b/contrib/python-bindings/source/triangulation_wrapper.cc
@@ -557,6 +557,21 @@ namespace python
 
     template <int dim, int spacedim>
     void
+    convert_hypercube_to_simplex_mesh(void *                triangulation,
+                                      TriangulationWrapper &tria_out)
+    {
+      Triangulation<dim, spacedim> *tria =
+        static_cast<Triangulation<dim, spacedim> *>(triangulation);
+      Triangulation<dim, spacedim> *tria_2 =
+        static_cast<Triangulation<dim, spacedim> *>(
+          tria_out.get_triangulation());
+      GridGenerator::convert_hypercube_to_simplex_mesh(*tria, *tria_2);
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
     replicate_triangulation(TriangulationWrapper &     tria_in,
                             const boost::python::list &extents,
                             void *                     tria_out)
@@ -1534,6 +1549,25 @@ namespace python
   }
 
 
+  void
+  TriangulationWrapper::convert_hypercube_to_simplex_mesh(
+    TriangulationWrapper &tria_out)
+  {
+    AssertThrow(
+      (tria_out.get_dim() == dim) && (tria_out.get_spacedim() == spacedim),
+      ExcMessage("The output Triangulation must be of the same dimension"));
+
+    if ((dim == 2) && (spacedim == 2))
+      internal::convert_hypercube_to_simplex_mesh<2, 2>(triangulation,
+                                                        tria_out);
+    else if ((dim == 2) && (spacedim == 3))
+      internal::convert_hypercube_to_simplex_mesh<2, 3>(triangulation,
+                                                        tria_out);
+    else
+      internal::convert_hypercube_to_simplex_mesh<3, 3>(triangulation,
+                                                        tria_out);
+  }
+
 
   void
   TriangulationWrapper::extrude_triangulation(
@@ -1978,6 +2012,7 @@ namespace python
     else
       AssertThrow(false, ExcMessage("Dimension needs to be 2D or 3D."));
   }
+
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE

--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -37,6 +37,8 @@ namespace python
   export_manifold();
   void
   export_quadrature();
+  void
+  export_reference_cell();
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE
@@ -65,6 +67,7 @@ BOOST_PYTHON_MODULE(Debug)
   // message is printed.
   dealii::deal_II_exceptions::disable_abort_on_exception();
 
+  dealii::python::export_reference_cell();
   dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();
@@ -85,6 +88,7 @@ BOOST_PYTHON_MODULE(Release)
   doc_options.enable_py_signatures();
   doc_options.disable_cpp_signatures();
 
+  dealii::python::export_reference_cell();
   dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();

--- a/contrib/python-bindings/tests/triangulation_wrapper.py
+++ b/contrib/python-bindings/tests/triangulation_wrapper.py
@@ -438,6 +438,18 @@ class TestTriangulationWrapper(unittest.TestCase):
                 self.assertTrue(cell.center().distance(cell_ret.center()) < 1e-8)
 
 
+    def test_simplex(self):
+        for dim in self.dim:
+            triangulation_hex = self.build_hyper_cube_triangulation(dim)
+            triangulation_simplex = Triangulation(dim[0], dim[1])
+            triangulation_hex.convert_hypercube_to_simplex_mesh(triangulation_simplex)
+
+            if dim[0] == '3D':
+                self.assertTrue(triangulation_simplex.n_active_cells() == 24)
+            else:
+                self.assertTrue(triangulation_simplex.n_active_cells() == 8)
+
+
     def test_save_load(self):
         for dim in self.dim:
             triangulation_1 = self.build_hyper_cube_triangulation(dim)

--- a/doc/news/changes/minor/20210118AlexanderGrayver
+++ b/doc/news/changes/minor/20210118AlexanderGrayver
@@ -1,0 +1,3 @@
+New: Added python wrappers to enable support for simplex and mixed meshes.
+<br>
+(Alexander Grayver, 2021/01/18)


### PR DESCRIPTION
Now you can query geometry and reference cell type from within python. Additionally, adds a wrapper for `GridGenerator::convert_hypercube_to_simplex_mesh`.

Related to #11508 