### PR TITLE
Compile subdivided_hyper_rectangle_with_simplices ...

### DIFF
--- a/include/deal.II/simplex/grid_generator.h
+++ b/include/deal.II/simplex/grid_generator.h
@@ -27,8 +27,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-
 namespace GridGenerator
 {
   /**
@@ -76,8 +74,6 @@ namespace GridGenerator
                                        const bool         colorize = false);
 
 } // namespace GridGenerator
-
-#endif
 
 DEAL_II_NAMESPACE_CLOSE
 

--- a/source/simplex/grid_generator.cc
+++ b/source/simplex/grid_generator.cc
@@ -19,8 +19,6 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-
 namespace GridGenerator
 {
   template <int dim, int spacedim>
@@ -32,6 +30,9 @@ namespace GridGenerator
     const Point<dim> &               p2,
     const bool                       colorize)
   {
+#ifndef DEAL_II_WITH_SIMPLEX_SUPPORT
+    Assert(false, ExcNeedsSimplexSupport());
+#endif
     AssertDimension(dim, spacedim);
 
     AssertThrow(colorize == false, ExcNotImplemented());
@@ -206,8 +207,6 @@ namespace GridGenerator
       }
   }
 } // namespace GridGenerator
-
-#endif
 
 // explicit instantiations
 #include "grid_generator.inst"

--- a/source/simplex/grid_generator.inst.in
+++ b/source/simplex/grid_generator.inst.in
@@ -15,8 +15,6 @@
 
 
 
-#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
-
 for (deal_II_dimension : DIMENSIONS)
   {
     template void GridGenerator::subdivided_hyper_rectangle_with_simplices(
@@ -33,5 +31,3 @@ for (deal_II_dimension : DIMENSIONS)
       const double       p2,
       const bool         colorize);
   }
-
-#endif


### PR DESCRIPTION
... even without DEAL_II_WITH_SIMPLEX_SUPPORT enabled and add an assert.

This was the only place we use to disable the compilation of simplex-related functions, passing the responsibility to the user, who want to build their user code with and without simplex support,  to also add ifdefs.

FYI @mschreter @JPmoep