### PR TITLE
Let ReferenceCell::get_nodal_type_quadrature() return a 'const' reference

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -732,7 +732,7 @@ namespace ReferenceCell
    * @note The weights are not filled.
    */
   template <int dim>
-  Quadrature<dim> &
+  const Quadrature<dim> &
   get_nodal_type_quadrature(const Type &reference_cell);
 
   namespace internal

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -223,7 +223,7 @@ namespace ReferenceCell
   }
 
   template <int dim>
-  Quadrature<dim> &
+  const Quadrature<dim> &
   get_nodal_type_quadrature(const Type &reference_cell)
   {
     AssertDimension(dim, reference_cell.get_dimension());
@@ -237,22 +237,26 @@ namespace ReferenceCell
 
     if (reference_cell == get_hypercube(dim))
       {
-        static Quadrature<dim> quadrature = create_quadrature(reference_cell);
+        static const Quadrature<dim> quadrature =
+          create_quadrature(reference_cell);
         return quadrature;
       }
     else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
       {
-        static Quadrature<dim> quadrature = create_quadrature(reference_cell);
+        static const Quadrature<dim> quadrature =
+          create_quadrature(reference_cell);
         return quadrature;
       }
     else if (reference_cell == Type::Pyramid)
       {
-        static Quadrature<dim> quadrature = create_quadrature(reference_cell);
+        static const Quadrature<dim> quadrature =
+          create_quadrature(reference_cell);
         return quadrature;
       }
     else if (reference_cell == Type::Wedge)
       {
-        static Quadrature<dim> quadrature = create_quadrature(reference_cell);
+        static const Quadrature<dim> quadrature =
+          create_quadrature(reference_cell);
         return quadrature;
       }
     else

--- a/source/grid/reference_cell.inst.in
+++ b/source/grid/reference_cell.inst.in
@@ -38,6 +38,6 @@ for (deal_II_dimension : DIMENSIONS)
   {
     template Quadrature<deal_II_dimension> get_gauss_type_quadrature(
       const Type &reference_cell, const unsigned n_points_1D);
-    template Quadrature<deal_II_dimension> &get_nodal_type_quadrature(
+    template const Quadrature<deal_II_dimension> &get_nodal_type_quadrature(
       const Type &reference_cell);
   }


### PR DESCRIPTION
It already returns a reference to a `static` local variable of a function, but that's dangerous because in principle one can change that object and subsequent calls to that function will then return something we didn't really want.

/rebuild