### PR TITLE
Turn get_hypercube/simple() into templates. Move them into ReferenceCell::Type

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -602,7 +602,8 @@ template <int dim>
 Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
   const Quadrature<dim - 1> &quadrature)
 {
-  return project_to_all_faces(ReferenceCell::get_hypercube<dim>(), quadrature);
+  return project_to_all_faces(ReferenceCell::Type::get_hypercube<dim>(),
+                              quadrature);
 }
 
 

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -602,7 +602,7 @@ template <int dim>
 Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
   const Quadrature<dim - 1> &quadrature)
 {
-  return project_to_all_faces(ReferenceCell::get_hypercube(dim), quadrature);
+  return project_to_all_faces(ReferenceCell::get_hypercube<dim>(), quadrature);
 }
 
 

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -178,7 +178,7 @@ protected:
       update_flags,
       mapping,
       hp::QCollection<dim - 1>(QProjector<dim - 1>::project_to_all_children(
-        ReferenceCell::get_hypercube(dim - 1), quadrature)),
+        ReferenceCell::get_hypercube<dim - 1>(), quadrature)),
       output_data);
   }
 

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -178,7 +178,7 @@ protected:
       update_flags,
       mapping,
       hp::QCollection<dim - 1>(QProjector<dim - 1>::project_to_all_children(
-        ReferenceCell::get_hypercube<dim - 1>(), quadrature)),
+        ReferenceCell::Type::get_hypercube<dim - 1>(), quadrature)),
       output_data);
   }
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -177,7 +177,7 @@ namespace GridTools
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
            ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-             ReferenceCell::get_hypercube<dim>()));
+             ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Return an approximation of the diameter of the smallest active cell of a
@@ -195,7 +195,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Return an approximation of the diameter of the largest active cell of a
@@ -213,7 +213,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Given a list of vertices (typically obtained using
@@ -1045,7 +1045,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &container,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Find and return the index of the closest vertex to a given point in the
@@ -1873,7 +1873,7 @@ namespace GridTools
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Compute a globally unique index for each vertex and hanging node
@@ -3261,7 +3261,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::get_hypercube<dim>(),
+                         ReferenceCell::Type::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this line has children
@@ -3281,7 +3281,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::get_hypercube<dim>(),
+                         ReferenceCell::Type::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this face has hanging nodes

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -177,7 +177,7 @@ namespace GridTools
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
            ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-             ReferenceCell::get_hypercube(dim)));
+             ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Return an approximation of the diameter of the smallest active cell of a
@@ -195,7 +195,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Return an approximation of the diameter of the largest active cell of a
@@ -213,7 +213,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Given a list of vertices (typically obtained using
@@ -1045,7 +1045,7 @@ namespace GridTools
     const Triangulation<dim, spacedim> &container,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Find and return the index of the closest vertex to a given point in the
@@ -1873,7 +1873,7 @@ namespace GridTools
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Compute a globally unique index for each vertex and hanging node
@@ -3261,7 +3261,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::get_hypercube(dim),
+                         ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this line has children
@@ -3281,7 +3281,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::get_hypercube(dim),
+                         ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this face has hanging nodes

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -77,7 +77,7 @@ namespace GridTools
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
             ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-              ReferenceCell::get_hypercube(dim)));
+              ReferenceCell::get_hypercube<dim>()));
 
     /**
      * Destructor.

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -77,7 +77,7 @@ namespace GridTools
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
             ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-              ReferenceCell::get_hypercube<dim>()));
+              ReferenceCell::Type::get_hypercube<dim>()));
 
     /**
      * Destructor.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -62,6 +62,25 @@ namespace ReferenceCell
     static const Type Invalid;
 
     /**
+     * Return the correct simplex reference cell type for the given dimension
+     * `dim`. Depending on the template argument `dim`, this function returns a
+     * reference to either Vertex, Tri, or Tet.
+     */
+    template <int dim>
+    static constexpr const Type &
+    get_simplex();
+
+
+    /**
+     * Return the correct hypercube reference cell type for the given dimension
+     * `dim`. Depending on the template argument `dim`, this function returns a
+     * reference to either Vertex, Quad, or Hex.
+     */
+    template <int dim>
+    static constexpr const Type &
+    get_hypercube();
+
+    /**
      * Default constructor. Initialize this object as an invalid object.
      */
     constexpr Type();
@@ -362,13 +381,11 @@ namespace ReferenceCell
     return "Invalid";
   }
 
-  /**
-   * Return the correct simplex reference cell type for the given dimension
-   * @p dim.
-   */
+
+
   template <int dim>
-  inline const Type &
-  get_simplex()
+  inline constexpr const Type &
+  Type::get_simplex()
   {
     switch (dim)
       {
@@ -386,13 +403,11 @@ namespace ReferenceCell
       }
   }
 
-  /**
-   * Return the correct hypercube reference cell type for the given dimension
-   * @p dim.
-   */
+
+
   template <int dim>
-  inline const Type &
-  get_hypercube()
+  inline constexpr const Type &
+  Type::get_hypercube()
   {
     switch (dim)
       {
@@ -640,7 +655,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       {
         AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
         return GeometryInfo<dim>::unit_normal_vector[face_no];

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -366,8 +366,9 @@ namespace ReferenceCell
    * Return the correct simplex reference cell type for the given dimension
    * @p dim.
    */
-  inline Type
-  get_simplex(const unsigned int dim)
+  template <int dim>
+  inline const Type &
+  get_simplex()
   {
     switch (dim)
       {
@@ -389,8 +390,9 @@ namespace ReferenceCell
    * Return the correct hypercube reference cell type for the given dimension
    * @p dim.
    */
-  inline Type
-  get_hypercube(const unsigned int dim)
+  template <int dim>
+  inline const Type &
+  get_hypercube()
   {
     switch (dim)
       {
@@ -445,7 +447,7 @@ namespace ReferenceCell
                                 const unsigned int i) const
   {
     AssertDimension(dim, get_dimension());
-    if (*this == get_hypercube(dim))
+    if (*this == get_hypercube<dim>())
       return GeometryInfo<dim>::d_linear_shape_function(xi, i);
 
     if (*this == Type::Tri) // see also Simplex::ScalarPolynomial::compute_value
@@ -533,7 +535,7 @@ namespace ReferenceCell
                                          const unsigned int i) const
   {
     AssertDimension(dim, get_dimension());
-    if (*this == get_hypercube(dim))
+    if (*this == get_hypercube<dim>())
       return GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i);
 
     if (*this == Type::Tri) // see also Simplex::ScalarPolynomial::compute_grad
@@ -563,7 +565,7 @@ namespace ReferenceCell
     AssertDimension(dim, get_dimension());
     AssertIndexRange(i, dim - 1);
 
-    if (*this == get_hypercube(dim))
+    if (*this == get_hypercube<dim>())
       {
         AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
         return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
@@ -638,7 +640,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       {
         AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
         return GeometryInfo<dim>::unit_normal_vector[face_no];

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1756,7 +1756,8 @@ namespace internal
         Assert(index < dim, ExcInternalError());
 
         if ((reference_cell_type == ReferenceCell::Type::Invalid ||
-             reference_cell_type == ReferenceCell::get_hypercube(dim)) == false)
+             reference_cell_type == ReferenceCell::get_hypercube<dim>()) ==
+            false)
           {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
             return index;

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1756,8 +1756,8 @@ namespace internal
         Assert(index < dim, ExcInternalError());
 
         if ((reference_cell_type == ReferenceCell::Type::Invalid ||
-             reference_cell_type == ReferenceCell::get_hypercube<dim>()) ==
-            false)
+             reference_cell_type ==
+               ReferenceCell::Type::get_hypercube<dim>()) == false)
           {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
             return index;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1481,7 +1481,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
              ++fe_no)
           shape_info_dummy(c, fe_no).reinit(
             dof_handlers[no]->get_fe(fe_no).reference_cell_type() ==
-                ReferenceCell::get_hypercube(dim) ?
+                ReferenceCell::get_hypercube<dim>() ?
               quad :
               quad_simplex,
             dof_handlers[no]->get_fe(fe_no),

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1481,7 +1481,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
              ++fe_no)
           shape_info_dummy(c, fe_no).reinit(
             dof_handlers[no]->get_fe(fe_no).reference_cell_type() ==
-                ReferenceCell::get_hypercube<dim>() ?
+                ReferenceCell::Type::get_hypercube<dim>() ?
               quad :
               quad_simplex,
             dof_handlers[no]->get_fe(fe_no),

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -317,7 +317,7 @@ namespace internal
           try
             {
               const auto reference_cell_type =
-                ReferenceCell::get_simplex<dim>();
+                ReferenceCell::Type::get_simplex<dim>();
 
               const auto quad_face  = get_face_quadrature(quad);
               this->n_q_points_face = quad_face.size();

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -316,7 +316,8 @@ namespace internal
 
           try
             {
-              const auto reference_cell_type = ReferenceCell::get_simplex(dim);
+              const auto reference_cell_type =
+                ReferenceCell::get_simplex<dim>();
 
               const auto quad_face  = get_face_quadrature(quad);
               this->n_q_points_face = quad_face.size();

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -281,7 +281,7 @@ namespace VectorTools
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * This function does the same as the
@@ -304,7 +304,7 @@ namespace VectorTools
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Compute the constraints that correspond to boundary conditions of the
@@ -333,7 +333,7 @@ namespace VectorTools
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   /**
    * Same as above for homogeneous tangential-flux constraints.
@@ -352,7 +352,7 @@ namespace VectorTools
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()));
 
   //@}
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -281,7 +281,7 @@ namespace VectorTools
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * This function does the same as the
@@ -304,7 +304,7 @@ namespace VectorTools
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Compute the constraints that correspond to boundary conditions of the
@@ -333,7 +333,7 @@ namespace VectorTools
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   /**
    * Same as above for homogeneous tangential-flux constraints.
@@ -352,7 +352,7 @@ namespace VectorTools
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
       ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::get_hypercube(dim)));
+        ReferenceCell::get_hypercube<dim>()));
 
   //@}
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -184,7 +184,7 @@ namespace VectorTools
       Quadrature<dim> quadrature_mf;
 
       if (dof.get_fe(0).reference_cell_type() ==
-          ReferenceCell::get_hypercube<dim>())
+          ReferenceCell::Type::get_hypercube<dim>())
         quadrature_mf = QGauss<dim>(dof.get_fe().degree + 2);
       else
         // TODO: since we have currently only implemented a handful quadrature

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -184,7 +184,7 @@ namespace VectorTools
       Quadrature<dim> quadrature_mf;
 
       if (dof.get_fe(0).reference_cell_type() ==
-          ReferenceCell::get_hypercube(dim))
+          ReferenceCell::get_hypercube<dim>())
         quadrature_mf = QGauss<dim>(dof.get_fe().degree + 2);
       else
         // TODO: since we have currently only implemented a handful quadrature

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -70,7 +70,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube<dim>()));
+          ReferenceCell::Type::get_hypercube<dim>()));
 
     /**
      * A function that generates one particle at a random location in cell @p cell and with
@@ -109,7 +109,7 @@ namespace Particles
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube<dim>()));
+          ReferenceCell::Type::get_hypercube<dim>()));
 
     /**
      * A function that generates particles randomly in the domain with a
@@ -165,7 +165,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube<dim>()),
+          ReferenceCell::Type::get_hypercube<dim>()),
       const unsigned int random_number_seed = 5432);
 
 
@@ -212,7 +212,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube<dim>()),
+          ReferenceCell::Type::get_hypercube<dim>()),
       const ComponentMask &                   components = ComponentMask(),
       const std::vector<std::vector<double>> &properties = {});
 
@@ -257,7 +257,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube<dim>()),
+          ReferenceCell::Type::get_hypercube<dim>()),
       const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -70,7 +70,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)));
+          ReferenceCell::get_hypercube<dim>()));
 
     /**
      * A function that generates one particle at a random location in cell @p cell and with
@@ -109,7 +109,7 @@ namespace Particles
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)));
+          ReferenceCell::get_hypercube<dim>()));
 
     /**
      * A function that generates particles randomly in the domain with a
@@ -165,7 +165,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)),
+          ReferenceCell::get_hypercube<dim>()),
       const unsigned int random_number_seed = 5432);
 
 
@@ -212,7 +212,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)),
+          ReferenceCell::get_hypercube<dim>()),
       const ComponentMask &                   components = ComponentMask(),
       const std::vector<std::vector<double>> &properties = {});
 
@@ -257,7 +257,7 @@ namespace Particles
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
         ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::get_hypercube(dim)),
+          ReferenceCell::get_hypercube<dim>()),
       const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -294,7 +294,7 @@ namespace DataOutBase
                                         n_data_sets,
                                       patch.data.n_rows()));
           Assert(patch.reference_cell_type !=
-                     ReferenceCell::get_hypercube<dim>() ||
+                     ReferenceCell::Type::get_hypercube<dim>() ||
                    (n_data_sets == 0) ||
                    (patch.data.n_cols() ==
                     Utilities::fixed_power<dim>(n_subdivisions + 1)),
@@ -616,7 +616,8 @@ namespace
 
     if (write_higher_order_cells)
       {
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell_type ==
+            ReferenceCell::Type::get_hypercube<dim>())
           {
             const std::array<unsigned int, 4> cell_type_by_dim{
               {VTK_VERTEX,
@@ -667,7 +668,8 @@ namespace
         vtk_cell_id[0] = VTK_PYRAMID;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+    else if (patch.reference_cell_type ==
+             ReferenceCell::Type::get_hypercube<dim>())
       {
         const std::array<unsigned int, 4> cell_type_by_dim{
           {VTK_VERTEX, VTK_LINE, VTK_QUAD, VTK_HEXAHEDRON}};
@@ -679,7 +681,8 @@ namespace
         Assert(false, ExcNotImplemented());
       }
 
-    if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>() ||
+    if (patch.reference_cell_type !=
+          ReferenceCell::Type::get_hypercube<dim>() ||
         write_higher_order_cells)
       vtk_cell_id[2] = patch.data.n_cols();
     else
@@ -915,7 +918,8 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formula doesn't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell_type ==
+            ReferenceCell::Type::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             n_cells += Utilities::fixed_power<dim>(patch.n_subdivisions);
@@ -946,7 +950,8 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formulas don't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell_type ==
+            ReferenceCell::Type::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
 
@@ -1862,7 +1867,7 @@ namespace DataOutBase
     : patch_index(no_neighbor)
     , n_subdivisions(1)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube<dim>())
+    , reference_cell_type(ReferenceCell::Type::get_hypercube<dim>())
   // all the other data has a constructor of its own, except for the "neighbors"
   // field, which we set to invalid values.
   {
@@ -1964,7 +1969,7 @@ namespace DataOutBase
   Patch<0, spacedim>::Patch()
     : patch_index(no_neighbor)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube<0>())
+    , reference_cell_type(ReferenceCell::Type::get_hypercube<0>())
   {
     Assert(spacedim <= 3, ExcNotImplemented());
   }
@@ -2627,7 +2632,8 @@ namespace DataOutBase
         // special treatment of simplices since they are not subdivided, such
         // that no new nodes have to be created, but the precomputed ones can be
         // used
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell_type !=
+            ReferenceCell::Type::get_hypercube<dim>())
           {
             Point<spacedim> node;
 
@@ -2671,7 +2677,8 @@ namespace DataOutBase
     for (const auto &patch : patches)
       {
         // special treatment of simplices since they are not subdivided
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell_type !=
+            ReferenceCell::Type::get_hypercube<dim>())
           {
             out.write_cell_single(count++,
                                   first_vertex_of_patch,
@@ -8647,16 +8654,16 @@ XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
     {
       case 0:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::get_hypercube<0>());
+                                ReferenceCell::Type::get_hypercube<0>());
       case 1:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::get_hypercube<1>());
+                                ReferenceCell::Type::get_hypercube<1>());
       case 2:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::get_hypercube<2>());
+                                ReferenceCell::Type::get_hypercube<2>());
       case 3:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::get_hypercube<3>());
+                                ReferenceCell::Type::get_hypercube<3>());
       default:
         Assert(false, ExcNotImplemented());
     }

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -294,7 +294,7 @@ namespace DataOutBase
                                         n_data_sets,
                                       patch.data.n_rows()));
           Assert(patch.reference_cell_type !=
-                     ReferenceCell::get_hypercube(dim) ||
+                     ReferenceCell::get_hypercube<dim>() ||
                    (n_data_sets == 0) ||
                    (patch.data.n_cols() ==
                     Utilities::fixed_power<dim>(n_subdivisions + 1)),
@@ -616,7 +616,7 @@ namespace
 
     if (write_higher_order_cells)
       {
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             const std::array<unsigned int, 4> cell_type_by_dim{
               {VTK_VERTEX,
@@ -667,7 +667,7 @@ namespace
         vtk_cell_id[0] = VTK_PYRAMID;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+    else if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
       {
         const std::array<unsigned int, 4> cell_type_by_dim{
           {VTK_VERTEX, VTK_LINE, VTK_QUAD, VTK_HEXAHEDRON}};
@@ -679,7 +679,7 @@ namespace
         Assert(false, ExcNotImplemented());
       }
 
-    if (patch.reference_cell_type != ReferenceCell::get_hypercube(dim) ||
+    if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>() ||
         write_higher_order_cells)
       vtk_cell_id[2] = patch.data.n_cols();
     else
@@ -915,7 +915,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formula doesn't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             n_cells += Utilities::fixed_power<dim>(patch.n_subdivisions);
@@ -946,7 +946,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formulas don't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube(dim))
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
 
@@ -1862,7 +1862,7 @@ namespace DataOutBase
     : patch_index(no_neighbor)
     , n_subdivisions(1)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube(dim))
+    , reference_cell_type(ReferenceCell::get_hypercube<dim>())
   // all the other data has a constructor of its own, except for the "neighbors"
   // field, which we set to invalid values.
   {
@@ -1964,7 +1964,7 @@ namespace DataOutBase
   Patch<0, spacedim>::Patch()
     : patch_index(no_neighbor)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube(0))
+    , reference_cell_type(ReferenceCell::get_hypercube<0>())
   {
     Assert(spacedim <= 3, ExcNotImplemented());
   }
@@ -2627,7 +2627,7 @@ namespace DataOutBase
         // special treatment of simplices since they are not subdivided, such
         // that no new nodes have to be created, but the precomputed ones can be
         // used
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube(dim))
+        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
           {
             Point<spacedim> node;
 
@@ -2671,7 +2671,7 @@ namespace DataOutBase
     for (const auto &patch : patches)
       {
         // special treatment of simplices since they are not subdivided
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube(dim))
+        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
           {
             out.write_cell_single(count++,
                                   first_vertex_of_patch,
@@ -8643,8 +8643,25 @@ namespace
 std::string
 XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
 {
-  return get_xdmf_content(indent_level,
-                          ReferenceCell::get_hypercube(dimension));
+  switch (dimension)
+    {
+      case 0:
+        return get_xdmf_content(indent_level,
+                                ReferenceCell::get_hypercube<0>());
+      case 1:
+        return get_xdmf_content(indent_level,
+                                ReferenceCell::get_hypercube<1>());
+      case 2:
+        return get_xdmf_content(indent_level,
+                                ReferenceCell::get_hypercube<2>());
+      case 3:
+        return get_xdmf_content(indent_level,
+                                ReferenceCell::get_hypercube<3>());
+      default:
+        Assert(false, ExcNotImplemented());
+    }
+
+  return "";
 }
 
 

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -1159,7 +1159,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
                                   const unsigned int     child_no)
 {
-  return project_to_child(ReferenceCell::get_hypercube(dim),
+  return project_to_child(ReferenceCell::get_hypercube<dim>(),
                           quadrature,
                           child_no);
 }
@@ -1172,7 +1172,7 @@ QProjector<dim>::project_to_child(const ReferenceCell::Type reference_cell_type,
                                   const Quadrature<dim> &   quadrature,
                                   const unsigned int        child_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1202,7 +1202,8 @@ template <int dim>
 Quadrature<dim>
 QProjector<dim>::project_to_all_children(const Quadrature<dim> &quadrature)
 {
-  return project_to_all_children(ReferenceCell::get_hypercube(dim), quadrature);
+  return project_to_all_children(ReferenceCell::get_hypercube<dim>(),
+                                 quadrature);
 }
 
 
@@ -1213,7 +1214,7 @@ QProjector<dim>::project_to_all_children(
   const ReferenceCell::Type reference_cell_type,
   const Quadrature<dim> &   quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1245,7 +1246,10 @@ QProjector<dim>::project_to_line(const Quadrature<1> &quadrature,
                                  const Point<dim> &   p1,
                                  const Point<dim> &   p2)
 {
-  return project_to_line(ReferenceCell::get_hypercube(dim), quadrature, p1, p2);
+  return project_to_line(ReferenceCell::get_hypercube<dim>(),
+                         quadrature,
+                         p1,
+                         p2);
 }
 
 
@@ -1257,7 +1261,7 @@ QProjector<dim>::project_to_line(const ReferenceCell::Type reference_cell_type,
                                  const Point<dim> &        p1,
                                  const Point<dim> &        p2)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1286,7 +1290,7 @@ QProjector<dim>::DataSetDescriptor::face(const unsigned int face_no,
                                          const bool         face_rotation,
                                          const unsigned int n_quadrature_points)
 {
-  return face(ReferenceCell::get_hypercube(dim),
+  return face(ReferenceCell::get_hypercube<dim>(),
               face_no,
               face_orientation,
               face_flip,
@@ -1319,7 +1323,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1438,7 +1442,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1901,7 +1905,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_face(const SubQuadrature &quadrature,
                                  const unsigned int   face_no)
 {
-  return project_to_face(ReferenceCell::get_hypercube(dim),
+  return project_to_face(ReferenceCell::get_hypercube<dim>(),
                          quadrature,
                          face_no);
 }
@@ -1914,7 +1918,7 @@ QProjector<dim>::project_to_face(const ReferenceCell::Type reference_cell_type,
                                  const SubQuadrature &     quadrature,
                                  const unsigned int        face_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1932,7 +1936,7 @@ QProjector<dim>::project_to_subface(const SubQuadrature &          quadrature,
                                     const unsigned int             subface_no,
                                     const RefinementCase<dim - 1> &ref_case)
 {
-  return project_to_subface(ReferenceCell::get_hypercube(dim),
+  return project_to_subface(ReferenceCell::get_hypercube<dim>(),
                             quadrature,
                             face_no,
                             subface_no,
@@ -1950,7 +1954,7 @@ QProjector<dim>::project_to_subface(
   const unsigned int             subface_no,
   const RefinementCase<dim - 1> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube(dim),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -1159,7 +1159,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
                                   const unsigned int     child_no)
 {
-  return project_to_child(ReferenceCell::get_hypercube<dim>(),
+  return project_to_child(ReferenceCell::Type::get_hypercube<dim>(),
                           quadrature,
                           child_no);
 }
@@ -1172,7 +1172,7 @@ QProjector<dim>::project_to_child(const ReferenceCell::Type reference_cell_type,
                                   const Quadrature<dim> &   quadrature,
                                   const unsigned int        child_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1202,7 +1202,7 @@ template <int dim>
 Quadrature<dim>
 QProjector<dim>::project_to_all_children(const Quadrature<dim> &quadrature)
 {
-  return project_to_all_children(ReferenceCell::get_hypercube<dim>(),
+  return project_to_all_children(ReferenceCell::Type::get_hypercube<dim>(),
                                  quadrature);
 }
 
@@ -1214,7 +1214,7 @@ QProjector<dim>::project_to_all_children(
   const ReferenceCell::Type reference_cell_type,
   const Quadrature<dim> &   quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1246,7 +1246,7 @@ QProjector<dim>::project_to_line(const Quadrature<1> &quadrature,
                                  const Point<dim> &   p1,
                                  const Point<dim> &   p2)
 {
-  return project_to_line(ReferenceCell::get_hypercube<dim>(),
+  return project_to_line(ReferenceCell::Type::get_hypercube<dim>(),
                          quadrature,
                          p1,
                          p2);
@@ -1261,7 +1261,7 @@ QProjector<dim>::project_to_line(const ReferenceCell::Type reference_cell_type,
                                  const Point<dim> &        p1,
                                  const Point<dim> &        p2)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1290,7 +1290,7 @@ QProjector<dim>::DataSetDescriptor::face(const unsigned int face_no,
                                          const bool         face_rotation,
                                          const unsigned int n_quadrature_points)
 {
-  return face(ReferenceCell::get_hypercube<dim>(),
+  return face(ReferenceCell::Type::get_hypercube<dim>(),
               face_no,
               face_orientation,
               face_flip,
@@ -1323,7 +1323,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1442,7 +1442,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1905,7 +1905,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_face(const SubQuadrature &quadrature,
                                  const unsigned int   face_no)
 {
-  return project_to_face(ReferenceCell::get_hypercube<dim>(),
+  return project_to_face(ReferenceCell::Type::get_hypercube<dim>(),
                          quadrature,
                          face_no);
 }
@@ -1918,7 +1918,7 @@ QProjector<dim>::project_to_face(const ReferenceCell::Type reference_cell_type,
                                  const SubQuadrature &     quadrature,
                                  const unsigned int        face_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1936,7 +1936,7 @@ QProjector<dim>::project_to_subface(const SubQuadrature &          quadrature,
                                     const unsigned int             subface_no,
                                     const RefinementCase<dim - 1> &ref_case)
 {
-  return project_to_subface(ReferenceCell::get_hypercube<dim>(),
+  return project_to_subface(ReferenceCell::Type::get_hypercube<dim>(),
                             quadrature,
                             face_no,
                             subface_no,
@@ -1954,7 +1954,7 @@ QProjector<dim>::project_to_subface(
   const unsigned int             subface_no,
   const RefinementCase<dim - 1> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -381,7 +381,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
   const unsigned int         n_edge_points = reference_edge_quadrature.size();
   const Quadrature<dim - 1> &edge_quadrature =
     QProjector<dim - 1>::project_to_all_faces(
-      ReferenceCell::get_hypercube<dim - 1>(), reference_edge_quadrature);
+      ReferenceCell::Type::get_hypercube<dim - 1>(), reference_edge_quadrature);
 
   if (order > 0)
     {
@@ -414,7 +414,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::get_hypercube<dim - 1>(),
+                  ReferenceCell::Type::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,
@@ -515,7 +515,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::get_hypercube<dim - 1>(),
+                  ReferenceCell::Type::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -380,9 +380,8 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
   const QGauss<1>            reference_edge_quadrature(order + 1);
   const unsigned int         n_edge_points = reference_edge_quadrature.size();
   const Quadrature<dim - 1> &edge_quadrature =
-    QProjector<dim - 1>::project_to_all_faces(ReferenceCell::get_hypercube(dim -
-                                                                           1),
-                                              reference_edge_quadrature);
+    QProjector<dim - 1>::project_to_all_faces(
+      ReferenceCell::get_hypercube<dim - 1>(), reference_edge_quadrature);
 
   if (order > 0)
     {
@@ -415,7 +414,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::get_hypercube(dim - 1),
+                  ReferenceCell::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,
@@ -516,7 +515,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::get_hypercube(dim - 1),
+                  ReferenceCell::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -51,7 +51,7 @@ FE_Nothing<dim, spacedim>::FE_Nothing(const ReferenceCell::Type &type,
 template <int dim, int spacedim>
 FE_Nothing<dim, spacedim>::FE_Nothing(const unsigned int n_components,
                                       const bool         dominate)
-  : FE_Nothing<dim, spacedim>(ReferenceCell::get_hypercube<dim>(),
+  : FE_Nothing<dim, spacedim>(ReferenceCell::Type::get_hypercube<dim>(),
                               n_components,
                               dominate)
 {}
@@ -75,7 +75,7 @@ FE_Nothing<dim, spacedim>::get_name() const
   namebuf << "FE_Nothing<" << Utilities::dim_string(dim, spacedim) << ">(";
 
   std::vector<std::string> name_components;
-  if (this->reference_cell_type() != ReferenceCell::get_hypercube<dim>())
+  if (this->reference_cell_type() != ReferenceCell::Type::get_hypercube<dim>())
     name_components.push_back(this->reference_cell_type().to_string());
   if (this->n_components() > 1)
     name_components.push_back(std::to_string(this->n_components()));

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -51,7 +51,7 @@ FE_Nothing<dim, spacedim>::FE_Nothing(const ReferenceCell::Type &type,
 template <int dim, int spacedim>
 FE_Nothing<dim, spacedim>::FE_Nothing(const unsigned int n_components,
                                       const bool         dominate)
-  : FE_Nothing<dim, spacedim>(ReferenceCell::get_hypercube(dim),
+  : FE_Nothing<dim, spacedim>(ReferenceCell::get_hypercube<dim>(),
                               n_components,
                               dominate)
 {}
@@ -75,7 +75,7 @@ FE_Nothing<dim, spacedim>::get_name() const
   namebuf << "FE_Nothing<" << Utilities::dim_string(dim, spacedim) << ">(";
 
   std::vector<std::string> name_components;
-  if (this->reference_cell_type() != ReferenceCell::get_hypercube(dim))
+  if (this->reference_cell_type() != ReferenceCell::get_hypercube<dim>())
     name_components.push_back(this->reference_cell_type().to_string());
   if (this->n_components() > 1)
     name_components.push_back(std::to_string(this->n_components()));

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -263,22 +263,22 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
 
         // line 5: use line 9
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube(dim - 1), qline, 0, 0, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 6: use line 10
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube(dim - 1), qline, 0, 1, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 7: use line 13
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube(dim - 1), qline, 2, 0, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
         // line 8: use line 14
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube(dim - 1), qline, 2, 1, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
 
@@ -291,7 +291,7 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
                ++subface)
             {
               QProjector<dim - 1>::project_to_subface(
-                ReferenceCell::get_hypercube(dim - 1),
+                ReferenceCell::get_hypercube<dim - 1>(),
                 qline,
                 face,
                 subface,

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -263,22 +263,22 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
 
         // line 5: use line 9
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 0, p_line);
+          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 0, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 6: use line 10
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 1, p_line);
+          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 0, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 7: use line 13
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 0, p_line);
+          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 2, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
         // line 8: use line 14
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 1, p_line);
+          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 2, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
 
@@ -291,7 +291,7 @@ struct FE_Q_Base<PolynomialType, xdim, xspacedim>::Implementation
                ++subface)
             {
               QProjector<dim - 1>::project_to_subface(
-                ReferenceCell::get_hypercube<dim - 1>(),
+                ReferenceCell::Type::get_hypercube<dim - 1>(),
                 qline,
                 face,
                 subface,

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -117,9 +117,8 @@ MappingCartesian<dim, spacedim>::get_face_data(
   AssertDimension(quadrature.size(), 1);
 
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
-    std::make_unique<InternalData>(
-      QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
-                                            quadrature[0]));
+    std::make_unique<InternalData>(QProjector<dim>::project_to_all_faces(
+      ReferenceCell::Type::get_hypercube<dim>(), quadrature[0]));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
@@ -144,7 +143,7 @@ MappingCartesian<dim, spacedim>::get_subface_data(
 {
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(QProjector<dim>::project_to_all_subfaces(
-      ReferenceCell::get_hypercube<dim>(), quadrature));
+      ReferenceCell::Type::get_hypercube<dim>(), quadrature));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
@@ -227,7 +226,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
-        ReferenceCell::get_hypercube<dim>(),
+        ReferenceCell::Type::get_hypercube<dim>(),
         face_no,
         cell->face_orientation(face_no),
         cell->face_flip(face_no),
@@ -260,7 +259,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
-        ReferenceCell::get_hypercube<dim>(),
+        ReferenceCell::Type::get_hypercube<dim>(),
         face_no,
         sub_no,
         cell->face_orientation(face_no),

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -118,7 +118,7 @@ MappingCartesian<dim, spacedim>::get_face_data(
 
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(
-      QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube(dim),
+      QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
                                             quadrature[0]));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
@@ -144,7 +144,7 @@ MappingCartesian<dim, spacedim>::get_subface_data(
 {
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(QProjector<dim>::project_to_all_subfaces(
-      ReferenceCell::get_hypercube(dim), quadrature));
+      ReferenceCell::get_hypercube<dim>(), quadrature));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
@@ -227,7 +227,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
-        ReferenceCell::get_hypercube(dim),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         cell->face_orientation(face_no),
         cell->face_flip(face_no),
@@ -260,7 +260,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
-        ReferenceCell::get_hypercube(dim),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         sub_no,
         cell->face_orientation(face_no),

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -625,7 +625,7 @@ MappingFEField<dim, spacedim, VectorType, void>::get_face_data(
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
   const Quadrature<dim> q(
-    QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube(dim),
+    QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
                                           quadrature[0]));
   this->compute_face_data(update_flags, q, quadrature[0].size(), data);
 
@@ -642,9 +642,8 @@ MappingFEField<dim, spacedim, VectorType, void>::get_subface_data(
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
-  const Quadrature<dim> q(
-    QProjector<dim>::project_to_all_subfaces(ReferenceCell::get_hypercube(dim),
-                                             quadrature));
+  const Quadrature<dim> q(QProjector<dim>::project_to_all_subfaces(
+    ReferenceCell::get_hypercube<dim>(), quadrature));
   this->compute_face_data(update_flags, q, quadrature.size(), data);
 
   return data_ptr;
@@ -1695,25 +1694,25 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_face_values(
 
   update_internal_dofs(cell, data);
 
-  internal::MappingFEFieldImplementation::do_fill_fe_face_values<dim,
-                                                                 spacedim,
-                                                                 VectorType>(
-    *this,
-    cell,
-    face_no,
-    numbers::invalid_unsigned_int,
-    QProjector<dim>::DataSetDescriptor::face(ReferenceCell::get_hypercube(dim),
-                                             face_no,
-                                             cell->face_orientation(face_no),
-                                             cell->face_flip(face_no),
-                                             cell->face_rotation(face_no),
-                                             quadrature[0].size()),
-    quadrature[0],
-    data,
-    euler_dof_handler->get_fe(),
-    fe_mask,
-    fe_to_real,
-    output_data);
+  internal::MappingFEFieldImplementation::
+    do_fill_fe_face_values<dim, spacedim, VectorType>(
+      *this,
+      cell,
+      face_no,
+      numbers::invalid_unsigned_int,
+      QProjector<dim>::DataSetDescriptor::face(
+        ReferenceCell::get_hypercube<dim>(),
+        face_no,
+        cell->face_orientation(face_no),
+        cell->face_flip(face_no),
+        cell->face_rotation(face_no),
+        quadrature[0].size()),
+      quadrature[0],
+      data,
+      euler_dof_handler->get_fe(),
+      fe_mask,
+      fe_to_real,
+      output_data);
 }
 
 
@@ -1736,28 +1735,27 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_subface_values(
 
   update_internal_dofs(cell, data);
 
-  internal::MappingFEFieldImplementation::do_fill_fe_face_values<dim,
-                                                                 spacedim,
-                                                                 VectorType>(
-    *this,
-    cell,
-    face_no,
-    numbers::invalid_unsigned_int,
-    QProjector<dim>::DataSetDescriptor::subface(ReferenceCell::get_hypercube(
-                                                  dim),
-                                                face_no,
-                                                subface_no,
-                                                cell->face_orientation(face_no),
-                                                cell->face_flip(face_no),
-                                                cell->face_rotation(face_no),
-                                                quadrature.size(),
-                                                cell->subface_case(face_no)),
-    quadrature,
-    data,
-    euler_dof_handler->get_fe(),
-    fe_mask,
-    fe_to_real,
-    output_data);
+  internal::MappingFEFieldImplementation::
+    do_fill_fe_face_values<dim, spacedim, VectorType>(
+      *this,
+      cell,
+      face_no,
+      numbers::invalid_unsigned_int,
+      QProjector<dim>::DataSetDescriptor::subface(
+        ReferenceCell::get_hypercube<dim>(),
+        face_no,
+        subface_no,
+        cell->face_orientation(face_no),
+        cell->face_flip(face_no),
+        cell->face_rotation(face_no),
+        quadrature.size(),
+        cell->subface_case(face_no)),
+      quadrature,
+      data,
+      euler_dof_handler->get_fe(),
+      fe_mask,
+      fe_to_real,
+      output_data);
 }
 
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -624,9 +624,8 @@ MappingFEField<dim, spacedim, VectorType, void>::get_face_data(
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
-  const Quadrature<dim> q(
-    QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
-                                          quadrature[0]));
+  const Quadrature<dim> q(QProjector<dim>::project_to_all_faces(
+    ReferenceCell::Type::get_hypercube<dim>(), quadrature[0]));
   this->compute_face_data(update_flags, q, quadrature[0].size(), data);
 
   return data_ptr;
@@ -643,7 +642,7 @@ MappingFEField<dim, spacedim, VectorType, void>::get_subface_data(
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
   const Quadrature<dim> q(QProjector<dim>::project_to_all_subfaces(
-    ReferenceCell::get_hypercube<dim>(), quadrature));
+    ReferenceCell::Type::get_hypercube<dim>(), quadrature));
   this->compute_face_data(update_flags, q, quadrature.size(), data);
 
   return data_ptr;
@@ -1701,7 +1700,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_face_values(
       face_no,
       numbers::invalid_unsigned_int,
       QProjector<dim>::DataSetDescriptor::face(
-        ReferenceCell::get_hypercube<dim>(),
+        ReferenceCell::Type::get_hypercube<dim>(),
         face_no,
         cell->face_orientation(face_no),
         cell->face_flip(face_no),
@@ -1742,7 +1741,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_subface_values(
       face_no,
       numbers::invalid_unsigned_int,
       QProjector<dim>::DataSetDescriptor::subface(
-        ReferenceCell::get_hypercube<dim>(),
+        ReferenceCell::Type::get_hypercube<dim>(),
         face_no,
         subface_no,
         cell->face_orientation(face_no),

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -292,7 +292,8 @@ MappingManifold<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
+                         ReferenceCell::Type::get_hypercube<dim>(),
+                         quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -311,7 +312,7 @@ MappingManifold<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::get_hypercube<dim>(), quadrature),
+                         ReferenceCell::Type::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1228,7 +1229,7 @@ MappingManifold<dim, spacedim>::fill_fe_face_values(
     face_no,
     numbers::invalid_unsigned_int,
     QProjector<dim>::DataSetDescriptor::face(
-      ReferenceCell::get_hypercube<dim>(),
+      ReferenceCell::Type::get_hypercube<dim>(),
       face_no,
       cell->face_orientation(face_no),
       cell->face_flip(face_no),
@@ -1263,7 +1264,7 @@ MappingManifold<dim, spacedim>::fill_fe_subface_values(
     face_no,
     subface_no,
     QProjector<dim>::DataSetDescriptor::subface(
-      ReferenceCell::get_hypercube<dim>(),
+      ReferenceCell::Type::get_hypercube<dim>(),
       face_no,
       subface_no,
       cell->face_orientation(face_no),

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -292,7 +292,7 @@ MappingManifold<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::get_hypercube(dim), quadrature[0]),
+                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -311,7 +311,7 @@ MappingManifold<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::get_hypercube(dim), quadrature),
+                         ReferenceCell::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1227,12 +1227,13 @@ MappingManifold<dim, spacedim>::fill_fe_face_values(
     cell,
     face_no,
     numbers::invalid_unsigned_int,
-    QProjector<dim>::DataSetDescriptor::face(ReferenceCell::get_hypercube(dim),
-                                             face_no,
-                                             cell->face_orientation(face_no),
-                                             cell->face_flip(face_no),
-                                             cell->face_rotation(face_no),
-                                             quadrature[0].size()),
+    QProjector<dim>::DataSetDescriptor::face(
+      ReferenceCell::get_hypercube<dim>(),
+      face_no,
+      cell->face_orientation(face_no),
+      cell->face_flip(face_no),
+      cell->face_rotation(face_no),
+      quadrature[0].size()),
     quadrature[0],
     data,
     output_data);
@@ -1261,15 +1262,15 @@ MappingManifold<dim, spacedim>::fill_fe_subface_values(
     cell,
     face_no,
     subface_no,
-    QProjector<dim>::DataSetDescriptor::subface(ReferenceCell::get_hypercube(
-                                                  dim),
-                                                face_no,
-                                                subface_no,
-                                                cell->face_orientation(face_no),
-                                                cell->face_flip(face_no),
-                                                cell->face_rotation(face_no),
-                                                quadrature.size(),
-                                                cell->subface_case(face_no)),
+    QProjector<dim>::DataSetDescriptor::subface(
+      ReferenceCell::get_hypercube<dim>(),
+      face_no,
+      subface_no,
+      cell->face_orientation(face_no),
+      cell->face_flip(face_no),
+      cell->face_rotation(face_no),
+      quadrature.size(),
+      cell->subface_case(face_no)),
     quadrature,
     data,
     output_data);

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -885,7 +885,8 @@ MappingQGeneric<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
+                         ReferenceCell::Type::get_hypercube<dim>(),
+                         quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -904,7 +905,7 @@ MappingQGeneric<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::get_hypercube<dim>(), quadrature),
+                         ReferenceCell::Type::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1170,7 +1171,7 @@ MappingQGeneric<dim, spacedim>::fill_fe_face_values(
     face_no,
     numbers::invalid_unsigned_int,
     QProjector<dim>::DataSetDescriptor::face(
-      ReferenceCell::get_hypercube<dim>(),
+      ReferenceCell::Type::get_hypercube<dim>(),
       face_no,
       cell->face_orientation(face_no),
       cell->face_flip(face_no),
@@ -1218,7 +1219,7 @@ MappingQGeneric<dim, spacedim>::fill_fe_subface_values(
     face_no,
     subface_no,
     QProjector<dim>::DataSetDescriptor::subface(
-      ReferenceCell::get_hypercube<dim>(),
+      ReferenceCell::Type::get_hypercube<dim>(),
       face_no,
       subface_no,
       cell->face_orientation(face_no),

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -885,7 +885,7 @@ MappingQGeneric<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::get_hypercube(dim), quadrature[0]),
+                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -904,7 +904,7 @@ MappingQGeneric<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::get_hypercube(dim), quadrature),
+                         ReferenceCell::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1169,12 +1169,13 @@ MappingQGeneric<dim, spacedim>::fill_fe_face_values(
     cell,
     face_no,
     numbers::invalid_unsigned_int,
-    QProjector<dim>::DataSetDescriptor::face(ReferenceCell::get_hypercube(dim),
-                                             face_no,
-                                             cell->face_orientation(face_no),
-                                             cell->face_flip(face_no),
-                                             cell->face_rotation(face_no),
-                                             quadrature[0].size()),
+    QProjector<dim>::DataSetDescriptor::face(
+      ReferenceCell::get_hypercube<dim>(),
+      face_no,
+      cell->face_orientation(face_no),
+      cell->face_flip(face_no),
+      cell->face_rotation(face_no),
+      quadrature[0].size()),
     quadrature[0],
     data,
     output_data);
@@ -1216,15 +1217,15 @@ MappingQGeneric<dim, spacedim>::fill_fe_subface_values(
     cell,
     face_no,
     subface_no,
-    QProjector<dim>::DataSetDescriptor::subface(ReferenceCell::get_hypercube(
-                                                  dim),
-                                                face_no,
-                                                subface_no,
-                                                cell->face_orientation(face_no),
-                                                cell->face_flip(face_no),
-                                                cell->face_rotation(face_no),
-                                                quadrature.size(),
-                                                cell->subface_case(face_no)),
+    QProjector<dim>::DataSetDescriptor::subface(
+      ReferenceCell::get_hypercube<dim>(),
+      face_no,
+      subface_no,
+      cell->face_orientation(face_no),
+      cell->face_flip(face_no),
+      cell->face_rotation(face_no),
+      quadrature.size(),
+      cell->subface_case(face_no)),
     quadrature,
     data,
     output_data);

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -895,7 +895,7 @@ FlatManifold<dim, spacedim>::normal_vector(
 
   const auto face_reference_cell_type = face->reference_cell_type();
 
-  if (face_reference_cell_type == ReferenceCell::get_hypercube<facedim>())
+  if (face_reference_cell_type == ReferenceCell::Type::get_hypercube<facedim>())
     {
       for (unsigned int i = 0; i < facedim; ++i)
         xi[i] = 1. / 2;

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -895,7 +895,7 @@ FlatManifold<dim, spacedim>::normal_vector(
 
   const auto face_reference_cell_type = face->reference_cell_type();
 
-  if (face_reference_cell_type == ReferenceCell::get_hypercube(facedim))
+  if (face_reference_cell_type == ReferenceCell::get_hypercube<facedim>())
     {
       for (unsigned int i = 0; i < facedim; ++i)
         xi[i] = 1. / 2;

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -50,7 +50,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       {
         GridGenerator::hyper_cube(tria, 0, 1);
       }
@@ -123,7 +123,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
     else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
       return std::make_unique<MappingFE<dim, spacedim>>(
@@ -149,7 +149,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       {
         return StaticMappingQ1<dim, spacedim>::mapping;
       }
@@ -208,7 +208,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       return QGauss<dim>(n_points_1D);
     else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
       return Simplex::QGauss<dim>(n_points_1D);
@@ -235,7 +235,7 @@ namespace ReferenceCell
       return Quadrature<dim>(tria.get_vertices());
     };
 
-    if (reference_cell == get_hypercube(dim))
+    if (reference_cell == get_hypercube<dim>())
       {
         static Quadrature<dim> quadrature = create_quadrature(reference_cell);
         return quadrature;

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -50,7 +50,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       {
         GridGenerator::hyper_cube(tria, 0, 1);
       }
@@ -123,7 +123,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
     else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
       return std::make_unique<MappingFE<dim, spacedim>>(
@@ -149,7 +149,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       {
         return StaticMappingQ1<dim, spacedim>::mapping;
       }
@@ -208,7 +208,7 @@ namespace ReferenceCell
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       return QGauss<dim>(n_points_1D);
     else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
       return Simplex::QGauss<dim>(n_points_1D);
@@ -221,6 +221,8 @@ namespace ReferenceCell
 
     return Quadrature<dim>(); // never reached
   }
+
+
 
   template <int dim>
   Quadrature<dim> &
@@ -235,7 +237,7 @@ namespace ReferenceCell
       return Quadrature<dim>(tria.get_vertices());
     };
 
-    if (reference_cell == get_hypercube<dim>())
+    if (reference_cell == Type::get_hypercube<dim>())
       {
         static Quadrature<dim> quadrature = create_quadrature(reference_cell);
         return quadrature;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13535,7 +13535,7 @@ Triangulation<dim, spacedim>::all_reference_cell_types_are_hyper_cube() const
 {
   return (this->reference_cell_types.size() == 0) ||
          (this->reference_cell_types.size() == 1 &&
-          this->reference_cell_types[0] == ReferenceCell::get_hypercube(dim));
+          this->reference_cell_types[0] == ReferenceCell::get_hypercube<dim>());
 }
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13535,7 +13535,8 @@ Triangulation<dim, spacedim>::all_reference_cell_types_are_hyper_cube() const
 {
   return (this->reference_cell_types.size() == 0) ||
          (this->reference_cell_types.size() == 1 &&
-          this->reference_cell_types[0] == ReferenceCell::get_hypercube<dim>());
+          this->reference_cell_types[0] ==
+            ReferenceCell::Type::get_hypercube<dim>());
 }
 
 

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -165,7 +165,8 @@ namespace MGTools
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
 
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
+        Assert(fe.reference_cell_type() ==
+                 ReferenceCell::Type::get_hypercube<dim>(),
                ExcNotImplemented());
 
         unsigned int increment =
@@ -345,7 +346,8 @@ namespace MGTools
 
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
+        Assert(fe.reference_cell_type() ==
+                 ReferenceCell::Type::get_hypercube<dim>(),
                ExcNotImplemented());
 
         Assert(couplings.n_rows() == fe.n_components(),

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -165,7 +165,7 @@ namespace MGTools
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
 
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube(dim),
+        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         unsigned int increment =
@@ -345,7 +345,7 @@ namespace MGTools
 
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube(dim),
+        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         Assert(couplings.n_rows() == fe.n_components(),

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -148,7 +148,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
        (cell_and_index->first->at_boundary() ||
         (DoFHandlerType::dimension != DoFHandlerType::space_dimension))) ||
       (cell_and_index->first->reference_cell_type() !=
-       ReferenceCell::get_hypercube<dim>()))
+       ReferenceCell::Type::get_hypercube<dim>()))
     {
       Assert(patch.space_dim == DoFHandlerType::space_dimension,
              ExcInternalError());

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -148,7 +148,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
        (cell_and_index->first->at_boundary() ||
         (DoFHandlerType::dimension != DoFHandlerType::space_dimension))) ||
       (cell_and_index->first->reference_cell_type() !=
-       ReferenceCell::get_hypercube(dim)))
+       ReferenceCell::get_hypercube<dim>()))
     {
       Assert(patch.space_dim == DoFHandlerType::space_dimension,
              ExcInternalError());

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -47,7 +47,7 @@ process(const std::vector<Point<spacedim>> &vertices,
 
   AssertDimension(reference_cell_types.size(), 1);
 
-  if (reference_cell_types[0] == ReferenceCell::get_simplex(dim))
+  if (reference_cell_types[0] == ReferenceCell::get_simplex<dim>())
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_P<dim>(1));
   else if (reference_cell_types[0] == ReferenceCell::Type::Wedge)
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_WedgeP<dim>(1));

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -47,7 +47,7 @@ process(const std::vector<Point<spacedim>> &vertices,
 
   AssertDimension(reference_cell_types.size(), 1);
 
-  if (reference_cell_types[0] == ReferenceCell::get_simplex<dim>())
+  if (reference_cell_types[0] == ReferenceCell::Type::get_simplex<dim>())
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_P<dim>(1));
   else if (reference_cell_types[0] == ReferenceCell::Type::Wedge)
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_WedgeP<dim>(1));


### PR DESCRIPTION
With the exception of a single place (the one in `data_out_base.cc`), we always know the space dimension statically -- so we can turn the current argument to `get_hypercube(int)` and `get_simplex(int)` into a template argument and stick with our usual style. This has the advantage that the compiler will optimize away the entire implementation of the function to just returning a reference to an object known at compile time. No more run-time comparisons.

While there also move the function into `ReferenceCell::Type`. 

Follow-up to #11544.

/rebuild