### PR TITLE
Hide the ability to create ReferenceCell objects from users.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -42,6 +42,29 @@ class ScalarPolynomialsBase;
  */
 namespace ReferenceCell
 {
+  class Type;
+
+  namespace internal
+  {
+    /**
+     * A helper function to create a ReferenceCell::Type object from an
+     * integer. ReferenceCell::Type objects are "singletons" (actually,
+     * "multitons" -- there are multiple, but they are only a handful and
+     * these are all that can be used). What is then necessary is to
+     * have a way to create these with their internal id to distinguish
+     * the few possible ones in existence. We could do this via a public
+     * constructor of ReferenceCell::Type, but that would allow users to
+     * create ones outside the range we envision, and we don't want to do
+     * that. Rather, the constructor that takes an integer is made `private`
+     * but we have this one function in an internal namespace that is a friend
+     * of the class and can be used to create the objects.
+     */
+    Type
+    make_reference_cell_from_int(const std::uint8_t kind);
+  } // namespace internal
+
+
+
   /**
    * A type that describes the kinds of reference cells that can be used.
    * This includes quadrilaterals and hexahedra (i.e., "hypercubes"),
@@ -65,12 +88,6 @@ namespace ReferenceCell
      * Default constructor. Initialize this object as an invalid object.
      */
     constexpr Type();
-
-    /**
-     * Constructor.
-     */
-    constexpr Type(const std::uint8_t kind);
-
 
     /**
      * Return true if the object is a Vertex, Line, Quad, or Hex.
@@ -181,6 +198,21 @@ namespace ReferenceCell
      * The variable that stores what this object actually corresponds to.
      */
     std::uint8_t kind;
+
+    /**
+     * Constructor. This is the constructor used to create the different
+     * `static` member variables of this class. It is `private` but can
+     * be called by a function in an internal namespace that is a `friend`
+     * of this class.
+     */
+    constexpr Type(const std::uint8_t kind);
+
+    /**
+     * A kind of constructor -- not quite private because it can be
+     * called by anyone, but at least hidden in an internal namespace.
+     */
+    friend Type
+    internal::make_reference_cell_from_int(const std::uint8_t);
   };
 
 

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -309,7 +309,8 @@ namespace parallel
     // transform back and store result
     this->reference_cell_types.clear();
     for (const auto &i : reference_cell_types_ui)
-      this->reference_cell_types.emplace_back(static_cast<std::uint8_t>(i));
+      this->reference_cell_types.emplace_back(
+        ReferenceCell::internal::make_reference_cell_from_int(i));
   }
 
 

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -45,7 +45,7 @@ namespace ReferenceCell
 
       // Call the private constructor, which we can from here because this
       // function is a 'friend'.
-      return dealii::ReferenceCell::Type(kind);
+      return {kind};
     }
   } // namespace internal
 

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -30,17 +30,31 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+
 namespace ReferenceCell
 {
-  const Type Type::Vertex  = Type(0);
-  const Type Type::Line    = Type(1);
-  const Type Type::Tri     = Type(2);
-  const Type Type::Quad    = Type(3);
-  const Type Type::Tet     = Type(4);
-  const Type Type::Pyramid = Type(5);
-  const Type Type::Wedge   = Type(6);
-  const Type Type::Hex     = Type(7);
-  const Type Type::Invalid = Type(static_cast<std::uint8_t>(-1));
+  namespace internal
+  {
+    dealii::ReferenceCell::Type
+    make_reference_cell_from_int(const std::uint8_t kind)
+    {
+      // Call the private constructor, which we can from here because this
+      // function is a 'friend'.
+      return dealii::ReferenceCell::Type(kind);
+    }
+  } // namespace internal
+
+
+  const Type Type::Vertex  = internal::make_reference_cell_from_int(0);
+  const Type Type::Line    = internal::make_reference_cell_from_int(1);
+  const Type Type::Tri     = internal::make_reference_cell_from_int(2);
+  const Type Type::Quad    = internal::make_reference_cell_from_int(3);
+  const Type Type::Tet     = internal::make_reference_cell_from_int(4);
+  const Type Type::Pyramid = internal::make_reference_cell_from_int(5);
+  const Type Type::Wedge   = internal::make_reference_cell_from_int(6);
+  const Type Type::Hex     = internal::make_reference_cell_from_int(7);
+  const Type Type::Invalid =
+    internal::make_reference_cell_from_int(static_cast<std::uint8_t>(-1));
 
 
   template <int dim, int spacedim>

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -38,6 +38,11 @@ namespace ReferenceCell
     dealii::ReferenceCell::Type
     make_reference_cell_from_int(const std::uint8_t kind)
     {
+      // Make sure these are the only indices from which objects can be
+      // created.
+      Assert((kind == static_cast<std::uint8_t>(-1)) || (kind < 8),
+             ExcInternalError());
+
       // Call the private constructor, which we can from here because this
       // function is a 'friend'.
       return dealii::ReferenceCell::Type(kind);


### PR DESCRIPTION
Another follow-up to #11544.

The idea here is that users should not know, and should not be able to affect, what the numeric value is that corresponds to certain reference cell objects. For example, it should not matter at all that `Quad` has value `3` internally. In other words, what I want to achieve is that the class acts like an `enum` whose elements are not explicitly assigned values and, more importantly, for which it is not possible to create any object other than the predefined reference cell types.

The way to generally do this is make the constructor of the class `private` so that it is not possible to create these objects with specific numeric values -- the only way you're ever going to get an object of type `ReferenceCell::Type` is to use one of the pre-defined ones.

That leaves the issue of how the predefined objects are actually created. For singleton classes there is a standard way to do this but that doesn't work here because we don't want to use an `instance()` function as is usually done. Rather, I use a function that's hidden in an `internal` namespace and that is marked as `friend`. That achieves the same goal: For all intents and purposes, users will not be able to create these kinds of objects of their own, and will (as is my intent) have to use the pre-defined ones. The fact that I didn't have to change any code in the rest of the library validates this kind of design.

/rebuild