### PR TITLE
Move the get_*mapping() functions into ReferenceCell::Type.

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -526,26 +526,26 @@ FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
   const UpdateFlags                   update_flags)
   : n_quadrature_points(quadrature.size())
   , internal_fe_face_values(
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values(
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_face_values_neighbor(
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values_neighbor(
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1608,8 +1608,7 @@ namespace FETools
     ReferenceCell::make_triangulation(reference_cell_type, tr);
 
     const auto &mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        reference_cell_type);
+      reference_cell_type.template get_default_linear_mapping<dim, spacedim>();
 
     // Choose a Gauss quadrature rule that is exact up to degree 2n-1
     const unsigned int degree =
@@ -1822,8 +1821,8 @@ namespace FETools
         const unsigned int degree = fe.degree;
 
         const auto &mapping =
-          ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-            reference_cell_type);
+          reference_cell_type
+            .template get_default_linear_mapping<dim, spacedim>();
         const auto &q_fine =
           ReferenceCell::get_gauss_type_quadrature<dim>(reference_cell_type,
                                                         degree + 1);
@@ -2291,8 +2290,8 @@ namespace FETools
                 q_points_coarse[q](j) = q_points_fine[q](j);
             Quadrature<dim> q_coarse(q_points_coarse, fine.get_JxW_values());
             FEValues<dim, spacedim> coarse(
-              ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-                coarse_cell->reference_cell_type()),
+              coarse_cell->reference_cell_type()
+                .template get_default_linear_mapping<dim, spacedim>(),
               fe,
               q_coarse,
               update_values);

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -83,7 +83,9 @@ public:
  *
  * @note The use of this object should be avoided since it is only applicable
  *   in cases where a mesh consists exclusively of quadrilaterals or hexahedra.
- *   Use ReferenceCell::get_default_linear_mapping() instead.
+ *   Use
+ * `ReferenceCell::Type::get_hypercube<dim>().get_default_linear_mapping()`
+ *   instead.
  */
 template <int dim, int spacedim = dim>
 struct StaticMappingQ1

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -176,8 +176,8 @@ namespace GridTools
   double
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
-           ReferenceCell::Type::get_hypercube<dim>()
-             .template get_default_linear_mapping<dim, spacedim>());
+           (ReferenceCell::Type::get_hypercube<dim>()
+              .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Return an approximation of the diameter of the smallest active cell of a
@@ -194,8 +194,8 @@ namespace GridTools
   minimal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Return an approximation of the diameter of the largest active cell of a
@@ -212,8 +212,8 @@ namespace GridTools
   maximal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Given a list of vertices (typically obtained using
@@ -1044,8 +1044,8 @@ namespace GridTools
   extract_used_vertices(
     const Triangulation<dim, spacedim> &container,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Find and return the index of the closest vertex to a given point in the
@@ -1872,8 +1872,8 @@ namespace GridTools
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Compute a globally unique index for each vertex and hanging node

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -176,8 +176,8 @@ namespace GridTools
   double
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
-           ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-             ReferenceCell::Type::get_hypercube<dim>()));
+           ReferenceCell::Type::get_hypercube<dim>()
+             .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Return an approximation of the diameter of the smallest active cell of a
@@ -194,8 +194,8 @@ namespace GridTools
   minimal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Return an approximation of the diameter of the largest active cell of a
@@ -212,8 +212,8 @@ namespace GridTools
   maximal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Given a list of vertices (typically obtained using
@@ -1044,8 +1044,8 @@ namespace GridTools
   extract_used_vertices(
     const Triangulation<dim, spacedim> &container,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Find and return the index of the closest vertex to a given point in the
@@ -1872,8 +1872,8 @@ namespace GridTools
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Compute a globally unique index for each vertex and hanging node

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -76,8 +76,8 @@ namespace GridTools
      */
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
-            ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-              ReferenceCell::Type::get_hypercube<dim>()));
+            ReferenceCell::Type::get_hypercube<dim>()
+              .template get_default_linear_mapping<dim, spacedim>());
 
     /**
      * Destructor.

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -76,8 +76,8 @@ namespace GridTools
      */
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
-            ReferenceCell::Type::get_hypercube<dim>()
-              .template get_default_linear_mapping<dim, spacedim>());
+            (ReferenceCell::Type::get_hypercube<dim>()
+               .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
      * Destructor.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -174,6 +174,34 @@ namespace ReferenceCell
                                   const unsigned int      orientation) const;
 
     /**
+     * Return a default mapping of degree @p degree matching the current
+     * reference cell. If this reference cell is a hypercube, then the returned
+     * mapping is a MappingQGeneric; otherwise, it is an object of type
+     * MappingFE initialized with Simplex::FE_P (if the reference cell is a
+     * triangle or tetrahedron), with Simplex::FE_PyramidP (if the reference
+     * cell is a pyramid), or with Simplex::FE_WedgeP (if the reference cell is
+     * a wedge).
+     */
+    template <int dim, int spacedim>
+    std::unique_ptr<Mapping<dim, spacedim>>
+    get_default_mapping(const unsigned int degree) const;
+
+    /**
+     * Return a default linear mapping matching the current reference cell.
+     * If this reference cell is a hypercube, then the returned mapping
+     * is a MappingQ1; otherwise, it is an object of type MappingFE
+     * initialized with Simplex::FE_P (if the reference cell is a triangle or
+     * tetrahedron), with Simplex::FE_PyramidP (if the reference cell is a
+     * pyramid), or with Simplex::FE_WedgeP (if the reference cell is a wedge).
+     * In other words, the term "linear" in the name of the function has to be
+     * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
+     * coordinate directions.
+     */
+    template <int dim, int spacedim>
+    const Mapping<dim, spacedim> &
+    get_default_linear_mapping() const;
+
+    /**
      * Return a text representation of the reference cell represented by the
      * current object.
      */
@@ -692,33 +720,6 @@ namespace ReferenceCell
   void
   make_triangulation(const Type &                  reference_cell,
                      Triangulation<dim, spacedim> &tria);
-
-  /**
-   * Return a default mapping of degree @ degree matching the given reference
-   * cell. If this reference cell is a hypercube, then the returned mapping is a
-   * MappingQGeneric; otherwise, it is an object of type MappingFE initialized
-   * with Simplex::FE_P (if the reference cell is a triangle and tetrahedron),
-   * with Simplex::FE_PyramidP (if the reference cell is a pyramid), or with
-   * Simplex::FE_WedgeP (if the reference cell is a wedge).
-   */
-  template <int dim, int spacedim>
-  std::unique_ptr<Mapping<dim, spacedim>>
-  get_default_mapping(const Type &reference_cell, const unsigned int degree);
-
-  /**
-   * Return a default linear mapping matching the given reference cell.
-   * If this reference cell is a hypercube, then the returned mapping
-   * is a MappingQ1; otherwise, it is an object of type MappingFE
-   * initialized with Simplex::FE_P (if the reference cell is a triangle and
-   * tetrahedron), with Simplex::FE_PyramidP (if the reference cell is a
-   * pyramid), or with Simplex::FE_WedgeP (if the reference cell is a wedge). In
-   * other words, the term "linear" in the name of the function has to be
-   * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
-   * coordinate directions.
-   */
-  template <int dim, int spacedim>
-  const Mapping<dim, spacedim> &
-  get_default_linear_mapping(const Type &reference_cell);
 
   /**
    * Return a default linear mapping that works for the given triangulation.

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1055,7 +1055,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+  estimate(ReferenceCell::get_default_linear_mapping(
              dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
@@ -1126,7 +1126,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+  estimate(ReferenceCell::get_default_linear_mapping(
              dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
@@ -1372,7 +1372,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+  estimate(ReferenceCell::get_default_linear_mapping(
              dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
@@ -1407,7 +1407,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
+  estimate(ReferenceCell::get_default_linear_mapping(
              dof_handler.get_triangulation()),
            dof_handler,
            quadrature,

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -280,8 +280,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * This function does the same as the
@@ -303,8 +303,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Compute the constraints that correspond to boundary conditions of the
@@ -332,8 +332,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
    * Same as above for homogeneous tangential-flux constraints.
@@ -351,8 +351,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::Type::get_hypercube<dim>()
-        .template get_default_linear_mapping<dim, spacedim>());
+      (ReferenceCell::Type::get_hypercube<dim>()
+         .template get_default_linear_mapping<dim, spacedim>()));
 
   //@}
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -280,8 +280,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * This function does the same as the
@@ -303,8 +303,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Compute the constraints that correspond to boundary conditions of the
@@ -332,8 +332,8 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   /**
    * Same as above for homogeneous tangential-flux constraints.
@@ -351,8 +351,8 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        ReferenceCell::Type::get_hypercube<dim>()));
+      ReferenceCell::Type::get_hypercube<dim>()
+        .template get_default_linear_mapping<dim, spacedim>());
 
   //@}
 } // namespace VectorTools

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -653,8 +653,9 @@ namespace VectorTools
       {
         const Quadrature<dim> quad(fe.get_unit_support_points());
 
-        const auto map_q = ReferenceCell::get_default_mapping<dim, spacedim>(
-          fe.reference_cell_type(), fe.degree);
+        const auto map_q =
+          fe.reference_cell_type().template get_default_mapping<dim, spacedim>(
+            fe.degree);
         FEValues<dim, spacedim>              fe_v(*map_q,
                                      fe,
                                      quad,

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -69,8 +69,8 @@ namespace Particles
       const std::vector<Point<dim>> &     particle_reference_locations,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::Type::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()
+          .template get_default_linear_mapping<dim, spacedim>());
 
     /**
      * A function that generates one particle at a random location in cell @p cell and with
@@ -108,8 +108,8 @@ namespace Particles
       const types::particle_index                                        id,
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::Type::get_hypercube<dim>()));
+        ReferenceCell::Type::get_hypercube<dim>()
+          .template get_default_linear_mapping<dim, spacedim>());
 
     /**
      * A function that generates particles randomly in the domain with a
@@ -164,8 +164,8 @@ namespace Particles
       const types::particle_index         n_particles_to_create,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::Type::get_hypercube<dim>()),
+        ReferenceCell::Type::get_hypercube<dim>()
+          .template get_default_linear_mapping<dim, spacedim>(),
       const unsigned int random_number_seed = 5432);
 
 
@@ -211,8 +211,8 @@ namespace Particles
         &                             global_bounding_boxes,
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::Type::get_hypercube<dim>()),
+        ReferenceCell::Type::get_hypercube<dim>()
+          .template get_default_linear_mapping<dim, spacedim>(),
       const ComponentMask &                   components = ComponentMask(),
       const std::vector<std::vector<double>> &properties = {});
 
@@ -249,16 +249,15 @@ namespace Particles
      */
     template <int dim, int spacedim = dim>
     void
-    quadrature_points(
-      const Triangulation<dim, spacedim> &triangulation,
-      const Quadrature<dim> &             quadrature,
-      const std::vector<std::vector<BoundingBox<spacedim>>>
-        &                             global_bounding_boxes,
-      ParticleHandler<dim, spacedim> &particle_handler,
-      const Mapping<dim, spacedim> &  mapping =
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          ReferenceCell::Type::get_hypercube<dim>()),
-      const std::vector<std::vector<double>> &properties = {});
+    quadrature_points(const Triangulation<dim, spacedim> &triangulation,
+                      const Quadrature<dim> &             quadrature,
+                      const std::vector<std::vector<BoundingBox<spacedim>>>
+                        &                             global_bounding_boxes,
+                      ParticleHandler<dim, spacedim> &particle_handler,
+                      const Mapping<dim, spacedim> &  mapping =
+                        ReferenceCell::Type::get_hypercube<dim>()
+                          .template get_default_linear_mapping<dim, spacedim>(),
+                      const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles
 

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -69,8 +69,8 @@ namespace Particles
       const std::vector<Point<dim>> &     particle_reference_locations,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        ReferenceCell::Type::get_hypercube<dim>()
-          .template get_default_linear_mapping<dim, spacedim>());
+        (ReferenceCell::Type::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
      * A function that generates one particle at a random location in cell @p cell and with
@@ -108,8 +108,8 @@ namespace Particles
       const types::particle_index                                        id,
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
-        ReferenceCell::Type::get_hypercube<dim>()
-          .template get_default_linear_mapping<dim, spacedim>());
+        (ReferenceCell::Type::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
      * A function that generates particles randomly in the domain with a
@@ -164,8 +164,8 @@ namespace Particles
       const types::particle_index         n_particles_to_create,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        ReferenceCell::Type::get_hypercube<dim>()
-          .template get_default_linear_mapping<dim, spacedim>(),
+        (ReferenceCell::Type::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()),
       const unsigned int random_number_seed = 5432);
 
 
@@ -211,8 +211,8 @@ namespace Particles
         &                             global_bounding_boxes,
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
-        ReferenceCell::Type::get_hypercube<dim>()
-          .template get_default_linear_mapping<dim, spacedim>(),
+        (ReferenceCell::Type::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()),
       const ComponentMask &                   components = ComponentMask(),
       const std::vector<std::vector<double>> &properties = {});
 
@@ -249,15 +249,16 @@ namespace Particles
      */
     template <int dim, int spacedim = dim>
     void
-    quadrature_points(const Triangulation<dim, spacedim> &triangulation,
-                      const Quadrature<dim> &             quadrature,
-                      const std::vector<std::vector<BoundingBox<spacedim>>>
-                        &                             global_bounding_boxes,
-                      ParticleHandler<dim, spacedim> &particle_handler,
-                      const Mapping<dim, spacedim> &  mapping =
-                        ReferenceCell::Type::get_hypercube<dim>()
-                          .template get_default_linear_mapping<dim, spacedim>(),
-                      const std::vector<std::vector<double>> &properties = {});
+    quadrature_points(
+      const Triangulation<dim, spacedim> &triangulation,
+      const Quadrature<dim> &             quadrature,
+      const std::vector<std::vector<BoundingBox<spacedim>>>
+        &                             global_bounding_boxes,
+      ParticleHandler<dim, spacedim> &particle_handler,
+      const Mapping<dim, spacedim> &  mapping =
+        (ReferenceCell::Type::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()),
+      const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators
 } // namespace Particles
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4388,8 +4388,8 @@ FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
       q.size(),
       fe.n_dofs_per_cell(),
       update_default,
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe)
   , quadrature(q)
 {
@@ -4714,8 +4714,8 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature)
 {
@@ -4946,8 +4946,8 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        fe.reference_cell_type()),
+      fe.reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature)
 {

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -179,19 +179,19 @@ namespace ReferenceCell
 
   template <int dim, int spacedim>
   std::unique_ptr<Mapping<dim, spacedim>>
-  get_default_mapping(const Type &reference_cell, const unsigned int degree)
+  Type::get_default_mapping(const unsigned int degree) const
   {
-    AssertDimension(dim, reference_cell.get_dimension());
+    AssertDimension(dim, get_dimension());
 
-    if (reference_cell == Type::get_hypercube<dim>())
+    if (*this == Type::get_hypercube<dim>())
       return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
-    else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
+    else if (*this == Type::Tri || *this == Type::Tet)
       return std::make_unique<MappingFE<dim, spacedim>>(
         Simplex::FE_P<dim, spacedim>(degree));
-    else if (reference_cell == Type::Pyramid)
+    else if (*this == Type::Pyramid)
       return std::make_unique<MappingFE<dim, spacedim>>(
         Simplex::FE_PyramidP<dim, spacedim>(degree));
-    else if (reference_cell == Type::Wedge)
+    else if (*this == Type::Wedge)
       return std::make_unique<MappingFE<dim, spacedim>>(
         Simplex::FE_WedgeP<dim, spacedim>(degree));
     else
@@ -203,29 +203,30 @@ namespace ReferenceCell
   }
 
 
+
   template <int dim, int spacedim>
   const Mapping<dim, spacedim> &
-  get_default_linear_mapping(const Type &reference_cell)
+  Type::get_default_linear_mapping() const
   {
-    AssertDimension(dim, reference_cell.get_dimension());
+    AssertDimension(dim, get_dimension());
 
-    if (reference_cell == Type::get_hypercube<dim>())
+    if (*this == Type::get_hypercube<dim>())
       {
         return StaticMappingQ1<dim, spacedim>::mapping;
       }
-    else if (reference_cell == Type::Tri || reference_cell == Type::Tet)
+    else if (*this == Type::Tri || *this == Type::Tet)
       {
         static const MappingFE<dim, spacedim> mapping(
           Simplex::FE_P<dim, spacedim>(1));
         return mapping;
       }
-    else if (reference_cell == Type::Pyramid)
+    else if (*this == Type::Pyramid)
       {
         static const MappingFE<dim, spacedim> mapping(
           Simplex::FE_PyramidP<dim, spacedim>(1));
         return mapping;
       }
-    else if (reference_cell == Type::Wedge)
+    else if (*this == Type::Wedge)
       {
         static const MappingFE<dim, spacedim> mapping(
           Simplex::FE_WedgeP<dim, spacedim>(1));
@@ -255,8 +256,8 @@ namespace ReferenceCell
              "cells of the triangulation. The triangulation you are "
              "passing to this function uses multiple cell types."));
 
-    return get_default_linear_mapping<dim, spacedim>(
-      reference_cell_types.front());
+    return reference_cell_types.front()
+      .template get_default_linear_mapping<dim, spacedim>();
   }
 
 

--- a/source/grid/reference_cell.inst.in
+++ b/source/grid/reference_cell.inst.in
@@ -22,10 +22,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 
     template std::unique_ptr<
       Mapping<deal_II_dimension, deal_II_space_dimension>>
-    get_default_mapping(const Type &reference_cell, const unsigned int degree);
+    Type::get_default_mapping(const unsigned int degree) const;
 
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
-      &get_default_linear_mapping(const Type &reference_cell);
+      &Type::get_default_linear_mapping() const;
 
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
       &get_default_linear_mapping(

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -9611,9 +9611,9 @@ namespace internal
                         // to check it, transform to the unit cell
                         // with a linear mapping
                         const Point<dim> new_unit =
-                          ReferenceCell::get_default_linear_mapping<dim,
-                                                                    spacedim>(
-                            cell->reference_cell_type())
+                          cell->reference_cell_type()
+                            .template get_default_linear_mapping<dim,
+                                                                 spacedim>()
                             .transform_real_to_unit_cell(cell, new_bound);
 
                         // Now, we have to calculate the distance from

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1857,8 +1857,8 @@ CellAccessor<3>::point_inside(const Point<3> &p) const
     {
       const TriaRawIterator<CellAccessor<dim, spacedim>> cell_iterator(*this);
       return (GeometryInfo<dim>::is_inside_unit_cell(
-        ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-          reference_cell_type())
+        reference_cell_type()
+          .template get_default_linear_mapping<dim, spacedim>()
           .transform_real_to_unit_cell(cell_iterator, p)));
     }
   catch (const Mapping<dim, spacedim>::ExcTransformationFailed &)

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -74,8 +74,8 @@ namespace MeshWorker
     const UpdateFlags &                 update_flags,
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags)
-    : ScratchData(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-                    fe.reference_cell_type()),
+    : ScratchData(fe.reference_cell_type()
+                    .template get_default_linear_mapping<dim, spacedim>(),
                   fe,
                   quadrature,
                   update_flags,
@@ -94,8 +94,8 @@ namespace MeshWorker
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags,
     const UpdateFlags &                 neighbor_face_update_flags)
-    : ScratchData(ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-                    fe.reference_cell_type()),
+    : ScratchData(fe.reference_cell_type()
+                    .template get_default_linear_mapping<dim, spacedim>(),
                   fe,
                   quadrature,
                   update_flags,

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -1101,8 +1101,8 @@ namespace DerivativeApproximation
   {
     // just call the respective function with Q1 mapping
     approximate_derivative_tensor(
-      ReferenceCell::get_default_linear_mapping<dim, spacedim>(
-        cell->reference_cell_type()),
+      cell->reference_cell_type()
+        .template get_default_linear_mapping<dim, spacedim>(),
       dof,
       solution,
       cell,


### PR DESCRIPTION
Follow-up to #11544. Moving more free functions into the class. This one was a bit of a nuisance because of all of the changes to be made elsewhere, but it was worth it.

/rebuild