### PR TITLE
Permit conversion of triangulations with multiple levels to simplices.

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -145,10 +145,8 @@ namespace GridGenerator
    * @param tria The triangulation to create. It needs to be empty upon
    * calling this function.
    *
-   * @param repetitions A vector of @p dim positive values denoting the number
-   * of cells to generate in that direction. For example, the first component of
-   * the vector specifies the number of cells in the x-direction, the second
-   * component specifies that for the y-direction for dim=2.
+   * @param repetitions The number of cells to place in each coordinate
+   * direction.
    *
    * @param left Lower bound for the interval used to create the hyper cube.
    *

--- a/tests/simplex/conv_hex_to_simplex.cc
+++ b/tests/simplex/conv_hex_to_simplex.cc
@@ -40,7 +40,8 @@ template <int dim, int spacedim>
 void
 create_triangulation(Triangulation<dim, spacedim> &triangulation)
 {
-  GridGenerator::subdivided_hyper_cube(triangulation, 4);
+  GridGenerator::hyper_cube(triangulation);
+  triangulation.refine_global(2);
 }
 
 template <int dim>
@@ -59,20 +60,23 @@ check_file() // for dim = spaceim
 
   // make each cell a different material id
   unsigned int m_id = 0;
-  for (const auto &cell : in_tria)
+  for (const auto &cell : in_tria.active_cell_iterators())
     {
-      cell.set_material_id(m_id++);
+      cell->set_material_id(m_id++);
     }
+
+  //  TODO - there is some horrible bug here where m_id = 21 at this point but
+  //  it should be just 16.
 
   // set different boundary ids and output
   unsigned int b_id = 0;
-  for (const auto &cell : in_tria)
+  for (const auto &cell : in_tria.active_cell_iterators())
     {
       for (const auto f : cell.face_indices())
         {
-          if (cell.face(f)->at_boundary())
+          if (cell->face(f)->at_boundary())
             {
-              cell.face(f)->set_boundary_id(b_id);
+              cell->face(f)->set_boundary_id(b_id);
               b_id++;
             }
         }


### PR DESCRIPTION
I thought this would be straightforward, but trying to write this patch exposed a weird bug where it looks like `Triangulation<2, 3.::active_cell_iterators()` returns the entire set of iterators, not just the active ones.