### PR TITLE
Nicely format exception texts.

### DIFF
--- a/doc/news/changes/minor/20210125WolfgangBangerth
+++ b/doc/news/changes/minor/20210125WolfgangBangerth
@@ -1,0 +1,4 @@
+Improved: Exception texts are now formatted and broken to fixed-length
+lines, rather than flowing to arbitrary lengths.
+<br>
+(Wolfgang Bangerth, 2021/01/25)

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -321,10 +321,25 @@ ExceptionBase::generate_message() const
                 << "--------------------------------------------------------"
                 << std::endl;
 
-      // print out general data
+      // Print out general data
       print_exc_data(converter);
-      // print out exception specific data
-      print_info(converter);
+
+      // Print out exception specific data. Put this into another stringstream
+      // object for now so that we can break long lines and print them in a
+      // more easily read way
+      {
+        std::ostringstream message;
+        print_info(message);
+
+        const auto message_in_lines =
+          Utilities::break_text_into_lines(message.str(), 70);
+
+        // Put the message into the stream that will be output.
+        for (const auto &line : message_in_lines)
+          converter << "    " << line << '\n';
+      }
+
+
       print_stack_trace(converter);
 
       if (!deal_II_exceptions::internals::get_additional_assert_output()

--- a/tests/base/exception_nothrow.debug.output
+++ b/tests/base/exception_nothrow.debug.output
@@ -5,10 +5,20 @@ DEAL::
 An error occurred in file <exception_nothrow.cc> in function
     int main()
 The violated condition was: 
-    1==2
+    1 == 2
 Additional information: 
-    This exception -- which is used in many places in the library -- usually indicates that some condition which the author of the code thought must be satisfied at a certain point in an algorithm, is not fulfilled. An example would be that the first part of an algorithm sorts elements of an array in ascending order, and a second part of the algorithm later encounters an element that is not larger than the previous one.
-
-There is usually not very much you can do if you encounter such an exception since it indicates an error in deal.II, not in your own program. Try to come up with the smallest possible program that still demonstrates the error and contact the deal.II mailing lists with it to obtain help.
+    This exception -- which is used in many places in the library --
+    usually indicates that some condition which the author of the code
+    thought must be satisfied at a certain point in an algorithm, is not
+    fulfilled. An example would be that the first part of an algorithm
+    sorts elements of an array in ascending order, and a second part of
+    the algorithm later encounters an element that is not larger than the
+    previous one.
+    
+    There is usually not very much you can do if you encounter such an
+    exception since it indicates an error in deal.II, not in your own
+    program. Try to come up with the smallest possible program that still
+    demonstrates the error and contact the deal.II mailing lists with it
+    to obtain help.
 --------------------------------------------------------
 

--- a/tests/base/unsubscribe_subscriptor.debug.output
+++ b/tests/base/unsubscribe_subscriptor.debug.output
@@ -7,7 +7,8 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
-    No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+    No subscriber with identifier <b> subscribes to this object of class
+    N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
 --------------------------------------------------------
 
 DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything about the supplied pointer!")
@@ -18,6 +19,7 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 
-    This Subscriptor object does not know anything about the supplied pointer!
+    This Subscriptor object does not know anything about the supplied
+    pointer!
 --------------------------------------------------------
 

--- a/tests/parameter_handler/parameter_handler_19.debug.output
+++ b/tests/parameter_handler/parameter_handler_19.debug.output
@@ -7,7 +7,8 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     subsection_path.size() != 0
 Additional information: 
-    You can't leave a subsection if you are already at the top level of the subsection hierarchy.
+    You can't leave a subsection if you are already at the top level of
+    the subsection hierarchy.
 --------------------------------------------------------
 
 DEAL::
@@ -22,7 +23,8 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     subsection_path.size() != 0
 Additional information: 
-    You can't leave a subsection if you are already at the top level of the subsection hierarchy.
+    You can't leave a subsection if you are already at the top level of
+    the subsection hierarchy.
 --------------------------------------------------------
 
 DEAL::

--- a/tests/parameter_handler/parameter_handler_25.output
+++ b/tests/parameter_handler/parameter_handler_25.output
@@ -5,9 +5,9 @@ DEAL::
 --------------------------------------------------------
 An error occurred in file <parameter_handler.cc> in function
     void dealii::ParameterHandler::set(const string&, const string&)
-The violated condition was:
+The violated condition was: 
     false
-Additional information:
+Additional information: 
     You can't ask for entry <Precison> you have not yet declared.
 --------------------------------------------------------
 
@@ -15,14 +15,17 @@ DEAL::
 --------------------------------------------------------
 An error occurred in file <parameter_handler.cc> in function
     void dealii::ParameterHandler::assert_that_entries_have_been_set() const
-The violated condition was:
+The violated condition was: 
     entries_wrongly_not_set.size() == 0
-Additional information:
-    Not all entries of the parameter handler that were declared with `has_to_be_set = true` have been set. The following parameters
-
-  General.Precision
-  General.dim
-
- have not been set. A possible reason might be that you did not add these parameter to the input file or that their spelling is not correct.
+Additional information: 
+    Not all entries of the parameter handler that were declared with
+    `has_to_be_set = true` have been set. The following parameters
+    
+    General.Precision
+    General.dim
+    
+    have not been set. A possible reason might be that you did not add
+    these parameter to the input file or that their spelling is not
+    correct.
 --------------------------------------------------------
 

--- a/tests/parameter_handler/parameter_handler_26.output
+++ b/tests/parameter_handler/parameter_handler_26.output
@@ -5,14 +5,17 @@ DEAL::
 --------------------------------------------------------
 An error occurred in file <parameter_handler.cc> in function
     void dealii::ParameterHandler::assert_that_entries_have_been_set() const
-The violated condition was:
+The violated condition was: 
     entries_wrongly_not_set.size() == 0
-Additional information:
-    Not all entries of the parameter handler that were declared with `has_to_be_set = true` have been set. The following parameters
-
-  General.Precision
-  General.dim
-
- have not been set. A possible reason might be that you did not add these parameter to the input file or that their spelling is not correct.
+Additional information: 
+    Not all entries of the parameter handler that were declared with
+    `has_to_be_set = true` have been set. The following parameters
+    
+    General.Precision
+    General.dim
+    
+    have not been set. A possible reason might be that you did not add
+    these parameter to the input file or that their spelling is not
+    correct.
 --------------------------------------------------------
 


### PR DESCRIPTION
We have quite a lot of exceptions now that have very long text descriptions. These are often hard to read because the text is not written in any formatted way. But that's easy to work around -- we even have a function already that breaks text as appropriate.

With this patch, we get this kind of output:
```
--------------------------------------------------------
An error occurred in line <3150> of file </home/bangerth/p/deal.II/1/dealii/source/dofs/dof_handler.cc> in function
    void dealii::DoFHandler<dim, spacedim>::create_active_fe_table() [with int dim = 2; int spacedim = 2]
The violated condition was: 
    this->hp_cell_active_fe_indices[level].size() == this->tria->n_raw_cells(level) && this->hp_cell_future_fe_indices[level].size() == this->tria->n_raw_cells(level)
Additional information: 
    This exception -- which is used in many places in the library --
    usually indicates that some condition which the author of the code
    thought must be satisfied at a certain point in an algorithm, is not
    fulfilled. An example would be that the first part of an algorithm
    sorts elements of an array in ascending order, and a second part of
    the algorithm later encounters an element that is not larger than the
    previous one.
    
    There is usually not very much you can do if you encounter such an
    exception since it indicates an error in deal.II, not in your own
    program. Try to come up with the smallest possible program that still
    demonstrates the error and contact the deal.II mailing lists with it
    to obtain help.

Stacktrace:
-----------
#0  /home/bangerth/p/deal.II/1/install/lib/libdeal_II.g.so.9.3.0-pre: dealii::DoFHandler<2, 2>::create_active_fe_table()
...
```

/rebuild