### PR TITLE
Add missing include file for SUNDIALS

### DIFF
--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -23,6 +23,8 @@
 
 #    include <sundials/sundials_nvector.h>
 
+#    include <memory>
+
 DEAL_II_NAMESPACE_OPEN
 
 #    ifndef DOXYGEN


### PR DESCRIPTION
`NVectorView` uses `std::unique_ptr`.