### PR TITLE
Cancelling workflow for github actions.

### DIFF
--- a/.github/workflows/cancelling.yml
+++ b/.github/workflows/cancelling.yml
@@ -1,0 +1,20 @@
+name: Cancelling
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: ['requested']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel duplicate workflow runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: duplicates
+          cancelFutureDuplicates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          notifyPRCancel: true
+          skipEventTypes: '["push", "schedule"]'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,12 +7,7 @@ on:
 jobs:
   build-master-docker:
     runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-          access_token: ${{ github.token }}
-          
+    steps:          
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This should inspect the workflow status, and cancel all duplicate workflows, speeding up our CI builds. 

This happens, for example, when you push a new commit to an open PR. All the running workflows will be stopped, and only the latest one survive.