### PR TITLE
Move two static private functions into an internal namespace.

### DIFF
--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -535,29 +535,6 @@ public:
      */
     DataSetDescriptor(const unsigned int dataset_offset);
   };
-
-private:
-  /**
-   * Given a quadrature object in 2d, reflect all quadrature points at the
-   * main diagonal and return them with their original weights.
-   *
-   * This function is necessary for projecting a 2d quadrature rule onto the
-   * faces of a 3d cube, since there we need both orientations.
-   */
-  static Quadrature<2>
-  reflect(const Quadrature<2> &q);
-
-  /**
-   * Given a quadrature object in 2d, rotate all quadrature points by @p
-   * n_times * 90 degrees counterclockwise and return them with their original
-   * weights.
-   *
-   * This function is necessary for projecting a 2d quadrature rule onto the
-   * faces of a 3d cube, since there we need all rotations to account for
-   * face_flip and face_rotation of non-standard faces.
-   */
-  static Quadrature<2>
-  rotate(const Quadrature<2> &q, const unsigned int n_times);
 };
 
 /*@}*/

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -27,52 +27,55 @@ namespace internal
 {
   namespace QProjector
   {
-    Quadrature<2>
-    reflect(const Quadrature<2> &q)
+    namespace
     {
-      // Take the points and reflect them by the diagonal
-      std::vector<Point<2>> q_points(q.get_points());
-      for (Point<2> &p : q_points)
-        std::swap(p[0], p[1]);
+      Quadrature<2>
+      reflect(const Quadrature<2> &q)
+      {
+        // Take the points and reflect them by the diagonal
+        std::vector<Point<2>> q_points(q.get_points());
+        for (Point<2> &p : q_points)
+          std::swap(p[0], p[1]);
 
-      return Quadrature<2>(q_points, q.get_weights());
-    }
+        return Quadrature<2>(q_points, q.get_weights());
+      }
 
 
-    Quadrature<2>
-    rotate(const Quadrature<2> &q, const unsigned int n_times)
-    {
-      std::vector<Point<2>> q_points(q.size());
-      for (unsigned int i = 0; i < q.size(); ++i)
-        {
-          switch (n_times % 4)
-            {
-              case 0:
-                // 0 degree. the point remains as it is.
-                q_points[i] = q.point(i);
-                break;
+      Quadrature<2>
+      rotate(const Quadrature<2> &q, const unsigned int n_times)
+      {
+        std::vector<Point<2>> q_points(q.size());
+        for (unsigned int i = 0; i < q.size(); ++i)
+          {
+            switch (n_times % 4)
+              {
+                case 0:
+                  // 0 degree. the point remains as it is.
+                  q_points[i] = q.point(i);
+                  break;
 
-              case 1:
-                // 90 degree counterclockwise
-                q_points[i][0] = 1.0 - q.point(i)[1];
-                q_points[i][1] = q.point(i)[0];
-                break;
-              case 2:
-                // 180 degree counterclockwise
-                q_points[i][0] = 1.0 - q.point(i)[0];
-                q_points[i][1] = 1.0 - q.point(i)[1];
-                break;
-              case 3:
-                // 270 degree counterclockwise
-                q_points[i][0] = q.point(i)[1];
-                q_points[i][1] = 1.0 - q.point(i)[0];
-                break;
-            }
-        }
+                case 1:
+                  // 90 degree counterclockwise
+                  q_points[i][0] = 1.0 - q.point(i)[1];
+                  q_points[i][1] = q.point(i)[0];
+                  break;
+                case 2:
+                  // 180 degree counterclockwise
+                  q_points[i][0] = 1.0 - q.point(i)[0];
+                  q_points[i][1] = 1.0 - q.point(i)[1];
+                  break;
+                case 3:
+                  // 270 degree counterclockwise
+                  q_points[i][0] = q.point(i)[1];
+                  q_points[i][1] = 1.0 - q.point(i)[0];
+                  break;
+              }
+          }
 
-      return Quadrature<2>(q_points, q.get_weights());
-    }
-  } // namespace QProjector
+        return Quadrature<2>(q_points, q.get_weights());
+      }
+    } // namespace
+  }   // namespace QProjector
 } // namespace internal
 
 

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -23,53 +23,58 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int dim>
-Quadrature<2>
-QProjector<dim>::reflect(const Quadrature<2> &q)
+namespace internal
 {
-  // Take the points and reflect them by the diagonal
-  std::vector<Point<2>> q_points(q.get_points());
-  for (Point<2> &p : q_points)
-    std::swap(p[0], p[1]);
-
-  return Quadrature<2>(q_points, q.get_weights());
-}
-
-
-template <int dim>
-Quadrature<2>
-QProjector<dim>::rotate(const Quadrature<2> &q, const unsigned int n_times)
-{
-  std::vector<Point<2>> q_points(q.size());
-  for (unsigned int i = 0; i < q.size(); ++i)
+  namespace QProjector
+  {
+    Quadrature<2>
+    reflect(const Quadrature<2> &q)
     {
-      switch (n_times % 4)
-        {
-          case 0:
-            // 0 degree. the point remains as it is.
-            q_points[i] = q.point(i);
-            break;
+      // Take the points and reflect them by the diagonal
+      std::vector<Point<2>> q_points(q.get_points());
+      for (Point<2> &p : q_points)
+        std::swap(p[0], p[1]);
 
-          case 1:
-            // 90 degree counterclockwise
-            q_points[i][0] = 1.0 - q.point(i)[1];
-            q_points[i][1] = q.point(i)[0];
-            break;
-          case 2:
-            // 180 degree counterclockwise
-            q_points[i][0] = 1.0 - q.point(i)[0];
-            q_points[i][1] = 1.0 - q.point(i)[1];
-            break;
-          case 3:
-            // 270 degree counterclockwise
-            q_points[i][0] = q.point(i)[1];
-            q_points[i][1] = 1.0 - q.point(i)[0];
-            break;
-        }
+      return Quadrature<2>(q_points, q.get_weights());
     }
 
-  return Quadrature<2>(q_points, q.get_weights());
-}
+
+    Quadrature<2>
+    rotate(const Quadrature<2> &q, const unsigned int n_times)
+    {
+      std::vector<Point<2>> q_points(q.size());
+      for (unsigned int i = 0; i < q.size(); ++i)
+        {
+          switch (n_times % 4)
+            {
+              case 0:
+                // 0 degree. the point remains as it is.
+                q_points[i] = q.point(i);
+                break;
+
+              case 1:
+                // 90 degree counterclockwise
+                q_points[i][0] = 1.0 - q.point(i)[1];
+                q_points[i][1] = q.point(i)[0];
+                break;
+              case 2:
+                // 180 degree counterclockwise
+                q_points[i][0] = 1.0 - q.point(i)[0];
+                q_points[i][1] = 1.0 - q.point(i)[1];
+                break;
+              case 3:
+                // 270 degree counterclockwise
+                q_points[i][0] = q.point(i)[1];
+                q_points[i][1] = 1.0 - q.point(i)[0];
+                break;
+            }
+        }
+
+      return Quadrature<2>(q_points, q.get_weights());
+    }
+  } // namespace QProjector
+} // namespace internal
+
 
 
 template <>
@@ -891,25 +896,28 @@ QProjector<3>::project_to_all_faces(
                 mutation = quadrature_f;
                 break;
               case 1:
-                mutation = rotate(quadrature_f, 1);
+                mutation = internal::QProjector::rotate(quadrature_f, 1);
                 break;
               case 2:
-                mutation = rotate(quadrature_f, 2);
+                mutation = internal::QProjector::rotate(quadrature_f, 2);
                 break;
               case 3:
-                mutation = rotate(quadrature_f, 3);
+                mutation = internal::QProjector::rotate(quadrature_f, 3);
                 break;
               case 4:
-                mutation = reflect(quadrature_f);
+                mutation = internal::QProjector::reflect(quadrature_f);
                 break;
               case 5:
-                mutation = rotate(reflect(quadrature_f), 3);
+                mutation = internal::QProjector::rotate(
+                  internal::QProjector::reflect(quadrature_f), 3);
                 break;
               case 6:
-                mutation = rotate(reflect(quadrature_f), 2);
+                mutation = internal::QProjector::rotate(
+                  internal::QProjector::reflect(quadrature_f), 2);
                 break;
               case 7:
-                mutation = rotate(reflect(quadrature_f), 1);
+                mutation = internal::QProjector::rotate(
+                  internal::QProjector::reflect(quadrature_f), 1);
                 break;
               default:
                 Assert(false, ExcInternalError())
@@ -1065,15 +1073,15 @@ QProjector<3>::project_to_all_subfaces(
   Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
 
   const unsigned int dim         = 3;
-  SubQuadrature      q_reflected = reflect(quadrature);
+  SubQuadrature      q_reflected = internal::QProjector::reflect(quadrature);
   SubQuadrature      q[8]        = {quadrature,
-                        rotate(quadrature, 1),
-                        rotate(quadrature, 2),
-                        rotate(quadrature, 3),
+                        internal::QProjector::rotate(quadrature, 1),
+                        internal::QProjector::rotate(quadrature, 2),
+                        internal::QProjector::rotate(quadrature, 3),
                         q_reflected,
-                        rotate(q_reflected, 3),
-                        rotate(q_reflected, 2),
-                        rotate(q_reflected, 1)};
+                        internal::QProjector::rotate(q_reflected, 3),
+                        internal::QProjector::rotate(q_reflected, 2),
+                        internal::QProjector::rotate(q_reflected, 1)};
 
   const unsigned int n_points = quadrature.size(),
                      n_faces  = GeometryInfo<dim>::faces_per_cell,


### PR DESCRIPTION
`QProjector` is a funny class because it has no members. It's really just a namespace with a template argument, and at one point in the future I'll just make it a namespace indeed. For now, let's move two of the `static private` member functions into an internal namespace.

/rebuild