### PR TITLE
ARKode with L:d:(Block)Vector

### DIFF
--- a/doc/news/changes/minor/20210131Proell
+++ b/doc/news/changes/minor/20210131Proell
@@ -1,0 +1,5 @@
+New: SUNDIALS N_Vector module now directly operates on different deal.II vectors without internally
+creating copies.
+In particular, ARKode can now also be used with LinearAlgebra::distributed::(Block)Vector.
+<br>
+(Sebastian Proell, 2021/01/31)

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -24,6 +24,8 @@
 #  include <deal.II/base/utilities.h>
 
 #  include <deal.II/lac/block_vector.h>
+#  include <deal.II/lac/la_parallel_block_vector.h>
+#  include <deal.II/lac/la_parallel_vector.h>
 #  ifdef DEAL_II_WITH_TRILINOS
 #    include <deal.II/lac/trilinos_parallel_block_vector.h>
 #    include <deal.II/lac/trilinos_vector.h>
@@ -1016,12 +1018,22 @@ namespace SUNDIALS
   template class ARKode<Vector<double>>;
   template class ARKode<BlockVector<double>>;
 
+  template class ARKode<LinearAlgebra::distributed::Vector<double>>;
+  template class ARKode<LinearAlgebra::distributed::BlockVector<double>>;
+
 #  if DEAL_II_SUNDIALS_VERSION_GTE(4, 0, 0)
   template struct SundialsOperator<Vector<double>>;
   template struct SundialsOperator<BlockVector<double>>;
+  template struct SundialsOperator<LinearAlgebra::distributed::Vector<double>>;
+  template struct SundialsOperator<
+    LinearAlgebra::distributed::BlockVector<double>>;
 
   template struct SundialsPreconditioner<Vector<double>>;
   template struct SundialsPreconditioner<BlockVector<double>>;
+  template struct SundialsPreconditioner<
+    LinearAlgebra::distributed::Vector<double>>;
+  template struct SundialsPreconditioner<
+    LinearAlgebra::distributed::BlockVector<double>>;
 #  endif
 
 #  ifdef DEAL_II_WITH_MPI
@@ -1045,11 +1057,11 @@ namespace SUNDIALS
   template class ARKode<PETScWrappers::MPI::BlockVector>;
 
 #        if DEAL_II_SUNDIALS_VERSION_GTE(4, 0, 0)
-  template class SundialsOperator<PETScWrappers::MPI::Vector>;
-  template class SundialsOperator<PETScWrappers::MPI::BlockVector>;
+  template struct SundialsOperator<PETScWrappers::MPI::Vector>;
+  template struct SundialsOperator<PETScWrappers::MPI::BlockVector>;
 
-  template class SundialsPreconditioner<PETScWrappers::MPI::Vector>;
-  template class SundialsPreconditioner<PETScWrappers::MPI::BlockVector>;
+  template struct SundialsPreconditioner<PETScWrappers::MPI::Vector>;
+  template struct SundialsPreconditioner<PETScWrappers::MPI::BlockVector>;
 #        endif
 #      endif // PETSC_USE_COMPLEX
 #    endif   // DEAL_II_WITH_PETSC

--- a/tests/sundials/arkode_03.cc
+++ b/tests/sundials/arkode_03.cc
@@ -16,14 +16,14 @@
 #include <deal.II/base/parameter_handler.h>
 
 #include <deal.II/lac/full_matrix.h>
-#include <deal.II/lac/vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
 
 #include <deal.II/sundials/arkode.h>
 
 #include "../tests.h"
 
 
-// Test implicit-explicit time stepper, no jacobian.
+// Test implicit-explicit time stepper, no jacobian. Use L:d:V (in serial)
 // Brusselator benchmark
 
 /**
@@ -54,7 +54,7 @@ main(int argc, char **argv)
   Utilities::MPI::MPI_InitFinalize mpi_initialization(
     argc, argv, numbers::invalid_unsigned_int);
 
-  typedef Vector<double> VectorType;
+  using VectorType = LinearAlgebra::distributed::Vector<double>;
 
   ParameterHandler                             prm;
   SUNDIALS::ARKode<VectorType>::AdditionalData data;
@@ -108,7 +108,7 @@ main(int argc, char **argv)
     return 0;
   };
 
-  Vector<double> y(3);
+  VectorType y(3);
   y[0] = u0;
   y[1] = v0;
   y[2] = w0;


### PR DESCRIPTION
Compile ARKode with the L:d: vectors.

One ARKode test is now using a L:d:V. Functionality of the internal N_Vector module for all vector types is already tested with #11395 and its follow-ups.

@luca-heltai @peterrum