### PR TITLE
ARKode: remove/deprecate unused functionality

### DIFF
--- a/doc/news/changes/incompatibilities/20210201Proell
+++ b/doc/news/changes/incompatibilities/20210201Proell
@@ -1,0 +1,3 @@
+Deprecated: ARKode does no longer need a `reinit_vector` function.
+<br>
+(Sebastian Proell, 2021/02/01)

--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -280,10 +280,8 @@ namespace SUNDIALS
    * $z_j$ where $j < i$). Additional information on the specific predictor
    * algorithms implemented in ARKode is provided in ARKode documentation.
    *
-   * The user has to provide the implementation of the following
-   *`std::function`s:
-   *  - reinit_vector()
-   * and either one or both of
+   * The user has to provide the implementation of at least one (or both) of the
+   * following `std::function`s:
    *  - implicit_function()
    *  - explicit_function()
    *
@@ -363,12 +361,7 @@ namespace SUNDIALS
    *
    * SUNDIALS::ARKode<VectorType> ode;
    *
-   * ode.reinit_vector = [] (VectorType&v)
-   * {
-   *   v.reinit(2);
-   * };
-   *
-   * double kappa = 1.0;
+   * const double kappa = 1.0;
    *
    * ode.explicit_function = [kappa] (double,
    *                                  const VectorType &y,
@@ -634,9 +627,14 @@ namespace SUNDIALS
     get_arkode_memory() const;
 
     /**
-     * A function object that users need to supply and that is intended to
-     * reinit the given vector.
+     * A function object that was used to `reinit` the given vector. Setting
+     * this field does no longer have any effect and all auxiliary vectors are
+     * reinit-ed automatically based on the user-supplied vector in solve_ode().
+     *
+     * @deprecated This function is no longer used and can be safely removed in
+     *   user code.
      */
+    DEAL_II_DEPRECATED
     std::function<void(VectorType &)> reinit_vector;
 
     /**
@@ -1373,19 +1371,12 @@ namespace SUNDIALS
     /**
      * Constructor.
      *
-     * @param solver The ARKode solver that uses this operator
      * @param A_data Data required by @p a_times_fn
      * @param a_times_fn A function pointer to the function that computes A*v
      */
-    SundialsOperator(ARKode<VectorType> &solver,
-                     void *              A_data,
-                     ATimesFn            a_times_fn);
+    SundialsOperator(void *A_data, ATimesFn a_times_fn);
 
   private:
-    /**
-     * Reference to the ARKode object that uses this SundialsOperator.
-     */
-    ARKode<VectorType> &solver;
     /**
      * Data necessary to evaluate a_times_fn.
      */
@@ -1421,23 +1412,14 @@ namespace SUNDIALS
     /**
      * Constructor.
      *
-     * @param solver The ARKode solver that uses this operator
      * @param P_data Data required by @p p_solve_fn
      * @param p_solve_fn A function pointer to the function that computes A*v
      * @param tol Tolerance, that an iterative solver should use to judge
      *   convergence
      */
-    SundialsPreconditioner(ARKode<VectorType> &solver,
-                           void *              P_data,
-                           PSolveFn            p_solve_fn,
-                           double              tol);
+    SundialsPreconditioner(void *P_data, PSolveFn p_solve_fn, double tol);
 
   private:
-    /**
-     * Reference to the ARKode object that uses this SundialsPreconditioner.
-     */
-    ARKode<VectorType> &solver;
-
     /**
      * Data necessary to calls p_solve_fn
      */

--- a/tests/sundials/arkode_01.cc
+++ b/tests/sundials/arkode_01.cc
@@ -76,8 +76,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) { v.reinit(2); };
-
   double kappa = 1.0;
 
   ode.explicit_function =

--- a/tests/sundials/arkode_02.cc
+++ b/tests/sundials/arkode_02.cc
@@ -69,8 +69,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) { v.reinit(2); };
-
   double kappa = 1.0;
 
   ode.implicit_function =

--- a/tests/sundials/arkode_03.cc
+++ b/tests/sundials/arkode_03.cc
@@ -72,11 +72,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) {
-    // Three independent variables
-    v.reinit(3);
-  };
-
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
 

--- a/tests/sundials/arkode_04.cc
+++ b/tests/sundials/arkode_04.cc
@@ -72,11 +72,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) {
-    // Three independent variables
-    v.reinit(3);
-  };
-
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.

--- a/tests/sundials/arkode_05.cc
+++ b/tests/sundials/arkode_05.cc
@@ -72,11 +72,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) {
-    // Three independent variables
-    v.reinit(3);
-  };
-
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.

--- a/tests/sundials/arkode_06.cc
+++ b/tests/sundials/arkode_06.cc
@@ -79,11 +79,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) {
-    // Three independent variables
-    v.reinit(3);
-  };
-
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.

--- a/tests/sundials/arkode_07.cc
+++ b/tests/sundials/arkode_07.cc
@@ -79,11 +79,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) {
-    // Three independent variables
-    v.reinit(3);
-  };
-
   // Parameters
   double u0 = 3.9, v0 = 1.1, w0 = 2.8, a = 1.2, b = 2.5, eps = 1e-5;
   // Explicit jacobian.

--- a/tests/sundials/arkode_08.cc
+++ b/tests/sundials/arkode_08.cc
@@ -69,8 +69,6 @@ main(int argc, char **argv)
 
   SUNDIALS::ARKode<VectorType> ode(data);
 
-  ode.reinit_vector = [&](VectorType &v) { v.reinit(2); };
-
   // Explicit jacobian = stiffness matrix
   FullMatrix<double> K(2, 2);
   K(0, 0) = K(1, 1) = 0.5;


### PR DESCRIPTION
- remove internal solver reference in operators
 - deprecate now obsolete `reinit_vector`: not sure if this is the best way. I guess the attribute doesn't work on member variables. It still has documentary value though. Or should I just delete the member?

@luca-heltai 