### PR TITLE
Make unit_normal_vectors() a member of ReferenceCell::Type.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -157,6 +157,13 @@ namespace ReferenceCell
                             const unsigned int i) const;
 
     /**
+     * Return the unit normal vector of a face of the reference cell.
+     */
+    template <int dim>
+    Tensor<1, dim>
+    unit_normal_vectors(const unsigned int face_no) const;
+
+    /**
      * Determine the orientation of the current entity described by its
      * vertices @p var_1 relative to an entity described by @p var_0.
      */
@@ -674,27 +681,26 @@ namespace ReferenceCell
     return {};
   }
 
-  /**
-   * Return the unit normal vector of a face of the reference cell.
-   */
+
+
   template <int dim>
   inline Tensor<1, dim>
-  unit_normal_vectors(const Type &reference_cell, const unsigned int face_no)
+  Type::unit_normal_vectors(const unsigned int face_no) const
   {
-    AssertDimension(dim, reference_cell.get_dimension());
+    AssertDimension(dim, this->get_dimension());
 
-    if (reference_cell == Type::get_hypercube<dim>())
+    if (is_hyper_cube())
       {
         AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
         return GeometryInfo<dim>::unit_normal_vector[face_no];
       }
     else if (dim == 2)
       {
-        const auto tangential =
-          reference_cell.unit_tangential_vectors<dim>(face_no, 0);
+        Assert(*this == Tri, ExcInternalError());
+
+        const auto tangential = unit_tangential_vectors<dim>(face_no, 0);
 
         Tensor<1, dim> result;
-
         result[0] = tangential[1];
         result[1] = -tangential[0];
 
@@ -702,9 +708,8 @@ namespace ReferenceCell
       }
     else if (dim == 3)
       {
-        return cross_product_3d(
-          reference_cell.unit_tangential_vectors<dim>(face_no, 0),
-          reference_cell.unit_tangential_vectors<dim>(face_no, 1));
+        return cross_product_3d(unit_tangential_vectors<dim>(face_no, 0),
+                                unit_tangential_vectors<dim>(face_no, 1));
       }
 
     Assert(false, ExcNotImplemented());

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -20,6 +20,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/template_constraints.h>
+#include <deal.II/base/types.h>
 #include <deal.II/base/work_stream.h>
 
 #include <deal.II/grid/filtered_iterator.h>

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -33,8 +33,7 @@ test(const ReferenceCell::Type &reference_cell)
   for (const auto face_no :
        ReferenceCell::internal::Info::get_cell(reference_cell).face_indices())
     {
-      deallog << ReferenceCell::unit_normal_vectors<dim>(reference_cell,
-                                                         face_no)
+      deallog << reference_cell.template unit_normal_vectors<dim>(face_no)
               << std::endl;
 
       for (unsigned int i = 0; i < dim - 1; ++i)


### PR DESCRIPTION
Following up on #11544. The similar `unit_tangent_vector()` already is a member.

/rebuild