### PR TITLE
Removed ansi flag from intel compiler setup

### DIFF
--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -46,11 +46,6 @@ ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-fpic")
 ENABLE_IF_LINKS(DEAL_II_LINKER_FLAGS "-Wl,--as-needed")
 
 #
-# Set ansi mode:
-#
-ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-ansi")
-
-#
 # Enable verbose warnings:
 #
 ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS "-w2")


### PR DESCRIPTION
Small PR to remove -ansi flag from intel compiler, which conflicts with c++14 and thus does not allow for configuration.