### PR TITLE
Rename ReferenceCell::Type to class ReferenceCell.

### DIFF
--- a/contrib/python-bindings/include/reference_cell_wrapper.h
+++ b/contrib/python-bindings/include/reference_cell_wrapper.h
@@ -40,9 +40,9 @@ namespace python
     CellTypeWrapper(const std::uint8_t &kind);
 
     /**
-     * Constructor. Takes a ReferenceCell::Type object and creates a Type class.
+     * Constructor. Takes a ReferenceCell object and creates a Type class.
      */
-    CellTypeWrapper(const ReferenceCell::Type &cell_type_in);
+    CellTypeWrapper(const ReferenceCell &cell_type_in);
 
     /**
      * Constructor for an empty object.
@@ -58,7 +58,7 @@ namespace python
     cell_kind() const;
 
   private:
-    ReferenceCell::Type cell_type;
+    ReferenceCell cell_type;
   };
 
 } // namespace python

--- a/contrib/python-bindings/source/reference_cell_wrapper.cc
+++ b/contrib/python-bindings/source/reference_cell_wrapper.cc
@@ -35,12 +35,12 @@ namespace python
 
   CellTypeWrapper::CellTypeWrapper(const std::uint8_t &kind)
   {
-    cell_type = ReferenceCell::internal::make_reference_cell_from_int(kind);
+    cell_type = internal::ReferenceCell::make_reference_cell_from_int(kind);
   }
 
 
 
-  CellTypeWrapper::CellTypeWrapper(const ReferenceCell::Type &cell_type_in)
+  CellTypeWrapper::CellTypeWrapper(const ReferenceCell &cell_type_in)
   {
     cell_type = cell_type_in;
   }

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -324,7 +324,7 @@ namespace DataOutBase
     /**
      * Reference-cell type of the underlying cell of this patch.
      */
-    ReferenceCell::Type reference_cell_type;
+    ReferenceCell reference_cell_type;
 
     /**
      * Default constructor. Sets #n_subdivisions to one, #points_are_available
@@ -474,7 +474,7 @@ namespace DataOutBase
     /**
      * Reference-cell type of the underlying cell of this patch.
      */
-    ReferenceCell::Type reference_cell_type;
+    ReferenceCell reference_cell_type;
 
     /**
      * Default constructor. Sets #points_are_available
@@ -3333,7 +3333,7 @@ public:
    * If the entry is not valid, this returns an empty string.
    *
    * @deprecated Use the overload taking an `unsigned int` and a
-   * `const ReferenceCell::Type &` instead.
+   * `const ReferenceCell &` instead.
    */
   DEAL_II_DEPRECATED
   std::string
@@ -3344,8 +3344,8 @@ public:
    * If the entry is not valid, this returns an empty string.
    */
   std::string
-  get_xdmf_content(const unsigned int         indent_level,
-                   const ReferenceCell::Type &reference_cell_type) const;
+  get_xdmf_content(const unsigned int   indent_level,
+                   const ReferenceCell &reference_cell_type) const;
 
 private:
   /**

--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -527,8 +527,7 @@ ParsedConvergenceTable::error_from_exact(const DoFHandler<dim, spacedim> &dh,
                                          const Function<spacedim> &exact,
                                          const Function<spacedim> *weight)
 {
-  error_from_exact(ReferenceCell::get_default_linear_mapping(
-                     dh.get_triangulation()),
+  error_from_exact(get_default_linear_mapping(dh.get_triangulation()),
                    dh,
                    solution,
                    exact,

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -106,10 +106,10 @@ public:
    * doc for this class.
    */
   static void
-  project_to_face(const ReferenceCell::Type reference_cell_type,
-                  const SubQuadrature &     quadrature,
-                  const unsigned int        face_no,
-                  std::vector<Point<dim>> & q_points);
+  project_to_face(const ReferenceCell      reference_cell_type,
+                  const SubQuadrature &    quadrature,
+                  const unsigned int       face_no,
+                  std::vector<Point<dim>> &q_points);
 
   /**
    * Compute the cell quadrature formula corresponding to using
@@ -129,9 +129,9 @@ public:
    * the general doc for this class.
    */
   static Quadrature<dim>
-  project_to_face(const ReferenceCell::Type reference_cell_type,
-                  const SubQuadrature &     quadrature,
-                  const unsigned int        face_no);
+  project_to_face(const ReferenceCell  reference_cell_type,
+                  const SubQuadrature &quadrature,
+                  const unsigned int   face_no);
 
   /**
    * Compute the quadrature points on the cell if the given quadrature formula
@@ -164,7 +164,7 @@ public:
    * same as those of the original rule.
    */
   static void
-  project_to_subface(const ReferenceCell::Type      reference_cell_type,
+  project_to_subface(const ReferenceCell            reference_cell_type,
                      const SubQuadrature &          quadrature,
                      const unsigned int             face_no,
                      const unsigned int             subface_no,
@@ -206,7 +206,7 @@ public:
    * version of this function that takes the reference cell type instead.
    */
   static Quadrature<dim>
-  project_to_subface(const ReferenceCell::Type      reference_cell_type,
+  project_to_subface(const ReferenceCell            reference_cell_type,
                      const SubQuadrature &          quadrature,
                      const unsigned int             face_no,
                      const unsigned int             subface_no,
@@ -253,7 +253,7 @@ public:
    * each face, in order to cope possibly different orientations of the mesh.
    */
   static Quadrature<dim>
-  project_to_all_faces(const ReferenceCell::Type       reference_cell_type,
+  project_to_all_faces(const ReferenceCell             reference_cell_type,
                        const hp::QCollection<dim - 1> &quadrature);
 
   /**
@@ -261,7 +261,7 @@ public:
    * formula on all faces.
    */
   static Quadrature<dim>
-  project_to_all_faces(const ReferenceCell::Type  reference_cell_type,
+  project_to_all_faces(const ReferenceCell        reference_cell_type,
                        const Quadrature<dim - 1> &quadrature);
 
   /**
@@ -298,8 +298,8 @@ public:
    * in FESubfaceValues.
    */
   static Quadrature<dim>
-  project_to_all_subfaces(const ReferenceCell::Type reference_cell_type,
-                          const SubQuadrature &     quadrature);
+  project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+                          const SubQuadrature &quadrature);
 
   /**
    * Project a given quadrature formula to a child of a cell. You may want to
@@ -330,9 +330,9 @@ public:
    * GeometryInfo<dim>::children_per_cell.
    */
   static Quadrature<dim>
-  project_to_child(const ReferenceCell::Type reference_cell_type,
-                   const Quadrature<dim> &   quadrature,
-                   const unsigned int        child_no);
+  project_to_child(const ReferenceCell    reference_cell_type,
+                   const Quadrature<dim> &quadrature,
+                   const unsigned int     child_no);
 
   /**
    * Project a quadrature rule to all children of a cell. Similarly to
@@ -360,8 +360,8 @@ public:
    * refinement of the cell.
    */
   static Quadrature<dim>
-  project_to_all_children(const ReferenceCell::Type reference_cell_type,
-                          const Quadrature<dim> &   quadrature);
+  project_to_all_children(const ReferenceCell    reference_cell_type,
+                          const Quadrature<dim> &quadrature);
 
   /**
    * Project the one dimensional rule <tt>quadrature</tt> to the straight line
@@ -381,10 +381,10 @@ public:
    * connecting the points <tt>p1</tt> and <tt>p2</tt>.
    */
   static Quadrature<dim>
-  project_to_line(const ReferenceCell::Type reference_cell_type,
-                  const Quadrature<1> &     quadrature,
-                  const Point<dim> &        p1,
-                  const Point<dim> &        p2);
+  project_to_line(const ReferenceCell  reference_cell_type,
+                  const Quadrature<1> &quadrature,
+                  const Point<dim> &   p1,
+                  const Point<dim> &   p2);
 
   /**
    * Since the project_to_all_faces() and project_to_all_subfaces() functions
@@ -447,19 +447,19 @@ public:
      * onto the faces) has.
      */
     static DataSetDescriptor
-    face(const ReferenceCell::Type reference_cell_type,
-         const unsigned int        face_no,
-         const bool                face_orientation,
-         const bool                face_flip,
-         const bool                face_rotation,
-         const unsigned int        n_quadrature_points);
+    face(const ReferenceCell reference_cell_type,
+         const unsigned int  face_no,
+         const bool          face_orientation,
+         const bool          face_flip,
+         const bool          face_rotation,
+         const unsigned int  n_quadrature_points);
 
     /**
      * Like the above function but taking a quadrature collection, enabling
      * that each face might have different number of quadrature points.
      */
     static DataSetDescriptor
-    face(const ReferenceCell::Type       reference_cell_type,
+    face(const ReferenceCell             reference_cell_type,
          const unsigned int              face_no,
          const bool                      face_orientation,
          const bool                      face_flip,
@@ -505,7 +505,7 @@ public:
      * Through the last argument anisotropic refinement can be respected.
      */
     static DataSetDescriptor
-    subface(const ReferenceCell::Type        reference_cell_type,
+    subface(const ReferenceCell              reference_cell_type,
             const unsigned int               face_no,
             const unsigned int               subface_no,
             const bool                       face_orientation,
@@ -579,14 +579,13 @@ template <int dim>
 Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
   const Quadrature<dim - 1> &quadrature)
 {
-  return project_to_all_faces(ReferenceCell::Type::get_hypercube<dim>(),
-                              quadrature);
+  return project_to_all_faces(ReferenceCell::get_hypercube<dim>(), quadrature);
 }
 
 
 template <int dim>
 Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
-  const ReferenceCell::Type  reference_cell_type,
+  const ReferenceCell        reference_cell_type,
   const Quadrature<dim - 1> &quadrature)
 {
   return project_to_all_faces(reference_cell_type,
@@ -606,7 +605,7 @@ QProjector<1>::project_to_face(const Quadrature<0> &,
                                std::vector<Point<1>> &);
 template <>
 void
-QProjector<1>::project_to_face(const ReferenceCell::Type reference_cell_type,
+QProjector<1>::project_to_face(const ReferenceCell reference_cell_type,
                                const Quadrature<0> &,
                                const unsigned int,
                                std::vector<Point<1>> &);
@@ -617,10 +616,10 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
                                std::vector<Point<2>> &q_points);
 template <>
 void
-QProjector<2>::project_to_face(const ReferenceCell::Type reference_cell_type,
-                               const Quadrature<1> &     quadrature,
-                               const unsigned int        face_no,
-                               std::vector<Point<2>> &   q_points);
+QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
+                               const Quadrature<1> &  quadrature,
+                               const unsigned int     face_no,
+                               std::vector<Point<2>> &q_points);
 template <>
 void
 QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
@@ -628,16 +627,15 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
                                std::vector<Point<3>> &q_points);
 template <>
 void
-QProjector<3>::project_to_face(const ReferenceCell::Type reference_cell_type,
-                               const Quadrature<2> &     quadrature,
-                               const unsigned int        face_no,
-                               std::vector<Point<3>> &   q_points);
+QProjector<3>::project_to_face(const ReferenceCell    reference_cell_type,
+                               const Quadrature<2> &  quadrature,
+                               const unsigned int     face_no,
+                               std::vector<Point<3>> &q_points);
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_faces(
-  const ReferenceCell::Type reference_cell_type,
-  const hp::QCollection<0> &quadrature);
+QProjector<1>::project_to_all_faces(const ReferenceCell reference_cell_type,
+                                    const hp::QCollection<0> &quadrature);
 
 
 template <>
@@ -649,7 +647,7 @@ QProjector<1>::project_to_subface(const Quadrature<0> &,
                                   const RefinementCase<0> &);
 template <>
 void
-QProjector<1>::project_to_subface(const ReferenceCell::Type reference_cell_type,
+QProjector<1>::project_to_subface(const ReferenceCell reference_cell_type,
                                   const Quadrature<0> &,
                                   const unsigned int,
                                   const unsigned int,
@@ -664,11 +662,11 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                                   const RefinementCase<1> &);
 template <>
 void
-QProjector<2>::project_to_subface(const ReferenceCell::Type reference_cell_type,
-                                  const Quadrature<1> &     quadrature,
-                                  const unsigned int        face_no,
-                                  const unsigned int        subface_no,
-                                  std::vector<Point<2>> &   q_points,
+QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
+                                  const Quadrature<1> &  quadrature,
+                                  const unsigned int     face_no,
+                                  const unsigned int     subface_no,
+                                  std::vector<Point<2>> &q_points,
                                   const RefinementCase<1> &);
 template <>
 void
@@ -679,21 +677,20 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
                                   const RefinementCase<2> &face_ref_case);
 template <>
 void
-QProjector<3>::project_to_subface(const ReferenceCell::Type reference_cell_type,
-                                  const Quadrature<2> &     quadrature,
-                                  const unsigned int        face_no,
-                                  const unsigned int        subface_no,
-                                  std::vector<Point<3>> &   q_points,
-                                  const RefinementCase<2> & face_ref_case);
+QProjector<3>::project_to_subface(const ReferenceCell      reference_cell_type,
+                                  const Quadrature<2> &    quadrature,
+                                  const unsigned int       face_no,
+                                  const unsigned int       subface_no,
+                                  std::vector<Point<3>> &  q_points,
+                                  const RefinementCase<2> &face_ref_case);
 
 template <>
 Quadrature<1>
 QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature);
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_subfaces(
-  const ReferenceCell::Type reference_cell_type,
-  const Quadrature<0> &     quadrature);
+QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+                                       const Quadrature<0> &quadrature);
 
 
 #endif // DOXYGEN

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -288,7 +288,7 @@ private:
   /**
    * Reference cell type.
    */
-  const ReferenceCell::Type cell_type;
+  const ReferenceCell cell_type;
 
   /**
    * Number of unique quads. If all quads have the same type, the value is
@@ -495,7 +495,7 @@ public:
    * underlying geometric entity can be specified.
    */
   FiniteElementData(const std::vector<unsigned int> &dofs_per_object,
-                    const ReferenceCell::Type        cell_type,
+                    const ReferenceCell              cell_type,
                     const unsigned int               n_components,
                     const unsigned int               degree,
                     const Conformity                 conformity = unknown,
@@ -508,7 +508,7 @@ public:
    * is particular useful for cells with triangles and quadrilaterals as faces.
    */
   FiniteElementData(const internal::GenericDoFsPerObject &data,
-                    const ReferenceCell::Type             cell_type,
+                    const ReferenceCell                   cell_type,
                     const unsigned int                    n_components,
                     const unsigned int                    degree,
                     const Conformity                      conformity = unknown,
@@ -519,7 +519,7 @@ public:
    * example, whether the element's reference cell is a square or
    * triangle, or similar choices in higher dimensions.
    */
-  ReferenceCell::Type
+  ReferenceCell
   reference_cell_type() const;
 
   /**
@@ -686,7 +686,7 @@ namespace internal
   internal::GenericDoFsPerObject
   expand(const unsigned int               dim,
          const std::vector<unsigned int> &dofs_per_object,
-         const ReferenceCell::Type        cell_type);
+         const dealii::ReferenceCell      cell_type);
 } // namespace internal
 
 
@@ -745,7 +745,7 @@ namespace FiniteElementDomination
 
 
 template <int dim>
-inline ReferenceCell::Type
+inline ReferenceCell
 FiniteElementData<dim>::reference_cell_type() const
 {
   return cell_type;

--- a/include/deal.II/fe/fe_nothing.h
+++ b/include/deal.II/fe/fe_nothing.h
@@ -145,9 +145,9 @@ public:
    * $Q_1$ field will be forced to become zero at this interface. See also the
    * discussion in the general documentation of this class.
    */
-  FE_Nothing(const ReferenceCell::Type &type,
-             const unsigned int         n_components = 1,
-             const bool                 dominate     = false);
+  FE_Nothing(const ReferenceCell &type,
+             const unsigned int   n_components = 1,
+             const bool           dominate     = false);
 
   /**
    * Same as above but for a hypercube reference-cell type.

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -178,7 +178,7 @@ protected:
       update_flags,
       mapping,
       hp::QCollection<dim - 1>(QProjector<dim - 1>::project_to_all_children(
-        ReferenceCell::Type::get_hypercube<dim - 1>(), quadrature)),
+        ReferenceCell::get_hypercube<dim - 1>(), quadrature)),
       output_data);
   }
 

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -235,8 +235,7 @@ namespace FETools
       // one, taking into account multiplicities, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           ReferenceCell::internal::Info::get_cell(
-             fes.front()->reference_cell_type())
+           dealii::internal::Info::get_cell(fes.front()->reference_cell_type())
              .vertex_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -258,8 +257,7 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           ReferenceCell::internal::Info::get_cell(
-             fes.front()->reference_cell_type())
+           dealii::internal::Info::get_cell(fes.front()->reference_cell_type())
              .line_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -283,7 +281,7 @@ namespace FETools
       for (unsigned int quad_number = 0;
            quad_number < (dim == 2 ?
                             1 :
-                            (dim == 3 ? ReferenceCell::internal::Info::get_cell(
+                            (dim == 3 ? dealii::internal::Info::get_cell(
                                           fes.front()->reference_cell_type())
                                           .n_faces() :
                                         0));
@@ -428,8 +426,7 @@ namespace FETools
       // base elements, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           ReferenceCell::internal::Info::get_cell(
-             fes.front()->reference_cell_type())
+           dealii::internal::Info::get_cell(fes.front()->reference_cell_type())
              .vertex_indices())
         {
           unsigned int comp_start = 0;
@@ -463,8 +460,7 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           ReferenceCell::internal::Info::get_cell(
-             fes.front()->reference_cell_type())
+           dealii::internal::Info::get_cell(fes.front()->reference_cell_type())
              .line_indices())
         {
           unsigned int comp_start = 0;
@@ -500,7 +496,7 @@ namespace FETools
       for (unsigned int quad_number = 0;
            quad_number < (dim == 2 ?
                             1 :
-                            (dim == 3 ? ReferenceCell::internal::Info::get_cell(
+                            (dim == 3 ? dealii::internal::Info::get_cell(
                                           fes.front()->reference_cell_type())
                                           .n_faces() :
                                         0));
@@ -673,7 +669,7 @@ namespace FETools
       // vertex, etc
       total_index = 0;
       for (const unsigned int vertex_number :
-           ReferenceCell::internal::Info::get_cell(fe.reference_cell_type())
+           dealii::internal::Info::get_cell(fe.reference_cell_type())
              .vertex_indices())
         {
           unsigned int comp_start = 0;
@@ -716,7 +712,7 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           ReferenceCell::internal::Info::get_cell(fe.reference_cell_type())
+           dealii::internal::Info::get_cell(fe.reference_cell_type())
              .line_indices())
         {
           unsigned int comp_start = 0;
@@ -762,7 +758,7 @@ namespace FETools
       for (unsigned int quad_number = 0;
            quad_number < (dim == 2 ?
                             1 :
-                            (dim == 3 ? ReferenceCell::internal::Info::get_cell(
+                            (dim == 3 ? dealii::internal::Info::get_cell(
                                           fe.reference_cell_type())
                                           .n_faces() :
                                         0));
@@ -872,8 +868,7 @@ namespace FETools
       unsigned int total_index = 0;
       for (unsigned int vertex_number = 0;
            vertex_number <
-           ReferenceCell::internal::Info::get_face(fe.reference_cell_type(),
-                                                   face_no)
+           dealii::internal::Info::get_face(fe.reference_cell_type(), face_no)
              .n_vertices();
            ++vertex_number)
         {
@@ -932,8 +927,7 @@ namespace FETools
       // 2. Lines
       for (unsigned int line_number = 0;
            line_number <
-           ReferenceCell::internal::Info::get_face(fe.reference_cell_type(),
-                                                   face_no)
+           dealii::internal::Info::get_face(fe.reference_cell_type(), face_no)
              .n_lines();
            ++line_number)
         {
@@ -1598,7 +1592,7 @@ namespace FETools
     const unsigned int n1 = fe1.n_dofs_per_cell();
     const unsigned int n2 = fe2.n_dofs_per_cell();
 
-    const ReferenceCell::Type reference_cell_type = fe1.reference_cell_type();
+    const ReferenceCell reference_cell_type = fe1.reference_cell_type();
 
     Assert(fe1.reference_cell_type() == fe2.reference_cell_type(),
            ExcNotImplemented());
@@ -1808,8 +1802,7 @@ namespace FETools
                    ExcDimensionMismatch(matrices[i].m(), n));
           }
 
-        const ReferenceCell::Type reference_cell_type =
-          fe.reference_cell_type();
+        const ReferenceCell reference_cell_type = fe.reference_cell_type();
 
         // Set up meshes, one with a single
         // reference cell and refine it once
@@ -1998,9 +1991,9 @@ namespace FETools
     {
       unsigned int face_dof = 0;
       for (unsigned int i = 0;
-           i < ReferenceCell::internal::Info::get_face(fe.reference_cell_type(),
-                                                       face_no)
-                 .n_vertices();
+           i <
+           dealii::internal::Info::get_face(fe.reference_cell_type(), face_no)
+             .n_vertices();
            ++i)
         {
           const unsigned int offset_c =
@@ -2017,9 +2010,10 @@ namespace FETools
             }
         }
 
-      for (unsigned int i = 1; i <= ReferenceCell::internal::Info::get_face(
-                                      fe.reference_cell_type(), face_no)
-                                      .n_lines();
+      for (unsigned int i = 1;
+           i <=
+           dealii::internal::Info::get_face(fe.reference_cell_type(), face_no)
+             .n_lines();
            ++i)
         {
           const unsigned int offset_c =

--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -406,7 +406,7 @@ public:
    * in @p cell_type.
    */
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const = 0;
+  is_compatible_with(const ReferenceCell &cell_type) const = 0;
 
   /**
    * @name Mapping points between reference and real cells

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -89,7 +89,7 @@ public:
   preserves_vertex_locations() const override;
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * @name Mapping points between reference and real cells

--- a/include/deal.II/fe/mapping_fe.h
+++ b/include/deal.II/fe/mapping_fe.h
@@ -86,7 +86,7 @@ public:
 
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * Always returns @p true because the default implementation of functions in

--- a/include/deal.II/fe/mapping_fe_field.h
+++ b/include/deal.II/fe/mapping_fe_field.h
@@ -211,7 +211,7 @@ public:
   preserves_vertex_locations() const override;
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * Return the mapped vertices of a cell.

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -80,7 +80,7 @@ public:
   preserves_vertex_locations() const override;
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * @name Mapping points between reference and real cells
@@ -441,7 +441,7 @@ MappingManifold<dim, spacedim>::preserves_vertex_locations() const
 template <int dim, int spacedim>
 bool
 MappingManifold<dim, spacedim>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   if (cell_type.get_dimension() != dim)
     return false; // TODO: or is this an error?

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -125,7 +125,7 @@ public:
                      &cell) const override;
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * Transform the point @p p on the unit cell to the point @p p_real on the

--- a/include/deal.II/fe/mapping_q1.h
+++ b/include/deal.II/fe/mapping_q1.h
@@ -84,7 +84,7 @@ public:
  * @note The use of this object should be avoided since it is only applicable
  *   in cases where a mesh consists exclusively of quadrilaterals or hexahedra.
  *   Use
- * `ReferenceCell::Type::get_hypercube<dim>().get_default_linear_mapping()`
+ * `ReferenceCell::get_hypercube<dim>().get_default_linear_mapping()`
  *   instead.
  */
 template <int dim, int spacedim = dim>

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -171,7 +171,7 @@ public:
                      &cell) const override;
 
   virtual bool
-  is_compatible_with(const ReferenceCell::Type &cell_type) const override;
+  is_compatible_with(const ReferenceCell &cell_type) const override;
 
   /**
    * @name Mapping points between reference and real cells

--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -70,14 +70,14 @@ namespace internal
       /**
        * Geometric entity type of the @p e-th sub-entity of dimension @p d.
        */
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const
       {
         Assert(false, ExcNotImplemented());
         (void)d;
         (void)e;
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       /**
@@ -150,17 +150,17 @@ namespace internal
         return {};
       }
 
-      ReferenceCell::Type
+      dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -204,20 +204,20 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 2)
-          return ReferenceCell::Type::Tri;
+          return dealii::ReferenceCell::Tri;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -261,20 +261,20 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 2)
-          return ReferenceCell::Type::Quad;
+          return dealii::ReferenceCell::Quad;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -326,23 +326,23 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return ReferenceCell::Type::Tet;
+          return dealii::ReferenceCell::Tet;
 
         if (d == 2)
-          return ReferenceCell::Type::Tri;
+          return dealii::ReferenceCell::Tri;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -437,25 +437,25 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return ReferenceCell::Type::Pyramid;
+          return dealii::ReferenceCell::Pyramid;
 
         if (d == 2 && e == 0)
-          return ReferenceCell::Type::Quad;
+          return dealii::ReferenceCell::Quad;
         else if (d == 2)
-          return ReferenceCell::Type::Tri;
+          return dealii::ReferenceCell::Tri;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -563,25 +563,25 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return ReferenceCell::Type::Wedge;
+          return dealii::ReferenceCell::Wedge;
 
         if (d == 2 && e > 1)
-          return ReferenceCell::Type::Quad;
+          return dealii::ReferenceCell::Quad;
         else if (d == 2)
-          return ReferenceCell::Type::Tri;
+          return dealii::ReferenceCell::Tri;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -691,23 +691,23 @@ namespace internal
         return {};
       }
 
-      virtual ReferenceCell::Type
+      virtual dealii::ReferenceCell
       type_of_entity(const unsigned int d, const unsigned int e) const override
       {
         (void)e;
 
         if (d == 3)
-          return ReferenceCell::Type::Hex;
+          return dealii::ReferenceCell::Hex;
 
         if (d == 2)
-          return ReferenceCell::Type::Quad;
+          return dealii::ReferenceCell::Quad;
 
         if (d == 1)
-          return ReferenceCell::Type::Line;
+          return dealii::ReferenceCell::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return ReferenceCell::Type::Vertex;
+        return dealii::ReferenceCell::Vertex;
       }
 
       unsigned int
@@ -820,8 +820,8 @@ namespace internal
     template <typename T = unsigned int>
     struct Connectivity
     {
-      Connectivity(const unsigned int                      dim,
-                   const std::vector<ReferenceCell::Type> &cell_types)
+      Connectivity(const unsigned int                        dim,
+                   const std::vector<dealii::ReferenceCell> &cell_types)
         : dim(dim)
         , cell_types(cell_types)
       {}
@@ -848,7 +848,7 @@ namespace internal
         return quad_orientation;
       }
 
-      inline std::vector<ReferenceCell::Type> &
+      inline std::vector<dealii::ReferenceCell> &
       entity_types(const unsigned int structdim)
       {
         if (structdim == dim)
@@ -861,7 +861,7 @@ namespace internal
         return quad_types;
       }
 
-      inline const std::vector<ReferenceCell::Type> &
+      inline const std::vector<dealii::ReferenceCell> &
       entity_types(const unsigned int structdim) const
       {
         if (structdim == dim)
@@ -913,8 +913,8 @@ namespace internal
       }
 
     private:
-      const unsigned int               dim;
-      std::vector<ReferenceCell::Type> cell_types;
+      const unsigned int                 dim;
+      std::vector<dealii::ReferenceCell> cell_types;
 
       CRS<T> line_vertices;
 
@@ -928,7 +928,7 @@ namespace internal
       CRS<T> cell_entities;
       CRS<T> neighbors;
 
-      std::vector<ReferenceCell::Type> quad_types;
+      std::vector<dealii::ReferenceCell> quad_types;
     };
 
 
@@ -998,7 +998,7 @@ namespace internal
     build_entity_templated(
       const unsigned int                                d,
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-      const std::vector<ReferenceCell::Type> &          cell_types_index,
+      const std::vector<dealii::ReferenceCell> &        cell_types_index,
       const CRS<unsigned int> &                         crs,
       CRS<unsigned int> &                               crs_d,        // result
       CRS<unsigned int> &                               crs_0,        // result
@@ -1038,7 +1038,7 @@ namespace internal
         keys; // key (sorted vertices), cell-entity index
 
       std::vector<std::array<unsigned int, key_length>> ad_entity_vertices;
-      std::vector<ReferenceCell::Type>                  ad_entity_types;
+      std::vector<dealii::ReferenceCell>                ad_entity_types;
       std::vector<std::array<unsigned int, key_length>> ad_compatibility;
 
       keys.reserve(n_entities);
@@ -1181,12 +1181,12 @@ namespace internal
     void
     build_entity(const unsigned int                                d,
                  const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-                 const std::vector<ReferenceCell::Type> &cell_types_index,
-                 const CRS<unsigned int> &               crs,
-                 CRS<unsigned int> &                     crs_d,
-                 CRS<unsigned int> &                     crs_0,
-                 std::vector<unsigned char> &            orientations,
-                 const FU &                              second_key_function)
+                 const std::vector<dealii::ReferenceCell> &cell_types_index,
+                 const CRS<unsigned int> &                 crs,
+                 CRS<unsigned int> &                       crs_d,
+                 CRS<unsigned int> &                       crs_0,
+                 std::vector<unsigned char> &              orientations,
+                 const FU &                                second_key_function)
     {
       std::size_t key_length = 0;
 
@@ -1242,7 +1242,7 @@ namespace internal
     void
     build_intersection(
       const std::vector<std::shared_ptr<CellTypeBase>> &cell_types,
-      const std::vector<ReferenceCell::Type> &          cell_types_index,
+      const std::vector<dealii::ReferenceCell> &        cell_types_index,
       const CRS<unsigned int> &                         con_cv,
       const CRS<unsigned int> &                         con_cl,
       const CRS<unsigned int> &                         con_lv,
@@ -1251,7 +1251,7 @@ namespace internal
       const std::vector<unsigned char> &                ori_cq,
       CRS<unsigned int> &                               con_ql,   // result
       std::vector<unsigned char> &                      ori_ql,   // result
-      std::vector<ReferenceCell::Type> &                quad_t_id // result
+      std::vector<dealii::ReferenceCell> &              quad_t_id // result
     )
     {
       // reset output
@@ -1357,8 +1357,8 @@ namespace internal
     Connectivity<T>
     build_connectivity(const unsigned int                                dim,
                        const std::vector<std::shared_ptr<CellTypeBase>> &cell_t,
-                       const std::vector<ReferenceCell::Type> &cell_t_id,
-                       const CRS<T> &                          con_cv)
+                       const std::vector<dealii::ReferenceCell> &cell_t_id,
+                       const CRS<T> &                            con_cv)
     {
       Connectivity<T> connectivity(dim, cell_t_id);
 
@@ -1449,25 +1449,25 @@ namespace internal
       std::vector<std::shared_ptr<CellTypeBase>> cell_types_impl(8);
 
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Line)]
+                        dealii::ReferenceCell::Line)]
         .reset(new CellTypeLine());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Tri)]
+                        dealii::ReferenceCell::Tri)]
         .reset(new CellTypeTri());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Quad)]
+                        dealii::ReferenceCell::Quad)]
         .reset(new CellTypeQuad());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Tet)]
+                        dealii::ReferenceCell::Tet)]
         .reset(new CellTypeTet());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Pyramid)]
+                        dealii::ReferenceCell::Pyramid)]
         .reset(new CellTypePyramid());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Wedge)]
+                        dealii::ReferenceCell::Wedge)]
         .reset(new CellTypeWedge());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        ReferenceCell::Type::Hex)]
+                        dealii::ReferenceCell::Hex)]
         .reset(new CellTypeHex());
 
       // determine cell types and process vertices
@@ -1484,16 +1484,17 @@ namespace internal
       cell_vertices_ptr.reserve(cells.size() + 1);
       cell_vertices_ptr.push_back(0);
 
-      std::vector<ReferenceCell::Type> cell_types_indices;
+      std::vector<dealii::ReferenceCell> cell_types_indices;
       cell_types_indices.reserve(cells.size());
 
       // loop over cells and create CRS
       for (const auto &cell : cells)
         {
-          const ReferenceCell::Type reference_cell_type =
-            ReferenceCell::Type::n_vertices_to_type(dim, cell.vertices.size());
+          const dealii::ReferenceCell reference_cell_type =
+            dealii::ReferenceCell::n_vertices_to_type(dim,
+                                                      cell.vertices.size());
 
-          Assert(reference_cell_type != ReferenceCell::Type::Invalid,
+          Assert(reference_cell_type != dealii::ReferenceCell::Invalid,
                  ExcNotImplemented());
           AssertIndexRange(static_cast<types::geometric_entity_type>(
                              reference_cell_type),

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -136,7 +136,7 @@ namespace GridGenerator
    */
   template <int dim, int spacedim>
   void
-  reference_cell(const ReferenceCell::Type &   reference_cell,
+  reference_cell(const ReferenceCell &         reference_cell,
                  Triangulation<dim, spacedim> &tria);
 
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -176,7 +176,7 @@ namespace GridTools
   double
   volume(const Triangulation<dim, spacedim> &tria,
          const Mapping<dim, spacedim> &      mapping =
-           (ReferenceCell::Type::get_hypercube<dim>()
+           (ReferenceCell::get_hypercube<dim>()
               .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -194,7 +194,7 @@ namespace GridTools
   minimal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -212,7 +212,7 @@ namespace GridTools
   maximal_cell_diameter(
     const Triangulation<dim, spacedim> &triangulation,
     const Mapping<dim, spacedim> &      mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -1044,7 +1044,7 @@ namespace GridTools
   extract_used_vertices(
     const Triangulation<dim, spacedim> &container,
     const Mapping<dim, spacedim> &      mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -1872,7 +1872,7 @@ namespace GridTools
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
     const Point<spacedim> &                                            position,
     const Mapping<dim, spacedim> &                                     mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -3272,7 +3272,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::Type::get_hypercube<dim>(),
+                         ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this line has children
@@ -3292,7 +3292,7 @@ namespace GridTools
                 !cell->face(face)->at_boundary())
               {
                 Assert(cell->reference_cell_type() ==
-                         ReferenceCell::Type::get_hypercube<dim>(),
+                         ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 
                 // this face has hanging nodes

--- a/include/deal.II/grid/grid_tools_cache.h
+++ b/include/deal.II/grid/grid_tools_cache.h
@@ -76,7 +76,7 @@ namespace GridTools
      */
     Cache(const Triangulation<dim, spacedim> &tria,
           const Mapping<dim, spacedim> &      mapping =
-            (ReferenceCell::Type::get_hypercube<dim>()
+            (ReferenceCell::get_hypercube<dim>()
                .template get_default_linear_mapping<dim, spacedim>()));
 
     /**

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -40,2172 +40,2166 @@ class ScalarPolynomialsBase;
 /**
  * A namespace for reference cells.
  */
-namespace ReferenceCell
-{
-  class Type;
+class ReferenceCell;
 
-  namespace internal
+namespace internal
+{
+  namespace ReferenceCell
   {
     /**
-     * A helper function to create a ReferenceCell::Type object from an
-     * integer. ReferenceCell::Type objects are "singletons" (actually,
+     * A helper function to create a ReferenceCell object from an
+     * integer. ReferenceCell objects are "singletons" (actually,
      * "multitons" -- there are multiple, but they are only a handful and
      * these are all that can be used). What is then necessary is to
      * have a way to create these with their internal id to distinguish
      * the few possible ones in existence. We could do this via a public
-     * constructor of ReferenceCell::Type, but that would allow users to
-     * create ones outside the range we envision, and we don't want to do
+     * constructor of ReferenceCell, but that would allow users
+     * to create ones outside the range we envision, and we don't want to do
      * that. Rather, the constructor that takes an integer is made `private`
      * but we have this one function in an internal namespace that is a friend
      * of the class and can be used to create the objects.
      */
-    Type
+    dealii::ReferenceCell
     make_reference_cell_from_int(const std::uint8_t kind);
-  } // namespace internal
+  } // namespace ReferenceCell
+} // namespace internal
 
 
+
+/**
+ * A type that describes the kinds of reference cells that can be used.
+ * This includes quadrilaterals and hexahedra (i.e., "hypercubes"),
+ * triangles and tetrahedra (simplices), and the pyramids and wedges
+ * necessary when using mixed 3d meshes.
+ */
+class ReferenceCell
+{
+public:
+  static const ReferenceCell Vertex;
+  static const ReferenceCell Line;
+  static const ReferenceCell Tri;
+  static const ReferenceCell Quad;
+  static const ReferenceCell Tet;
+  static const ReferenceCell Pyramid;
+  static const ReferenceCell Wedge;
+  static const ReferenceCell Hex;
+  static const ReferenceCell Invalid;
 
   /**
-   * A type that describes the kinds of reference cells that can be used.
-   * This includes quadrilaterals and hexahedra (i.e., "hypercubes"),
-   * triangles and tetrahedra (simplices), and the pyramids and wedges
-   * necessary when using mixed 3d meshes.
+   * Return the correct simplex reference cell type for the given dimension
+   * `dim`. Depending on the template argument `dim`, this function returns a
+   * reference to either Vertex, Tri, or Tet.
    */
-  class Type
-  {
-  public:
-    static const Type Vertex;
-    static const Type Line;
-    static const Type Tri;
-    static const Type Quad;
-    static const Type Tet;
-    static const Type Pyramid;
-    static const Type Wedge;
-    static const Type Hex;
-    static const Type Invalid;
-
-    /**
-     * Return the correct simplex reference cell type for the given dimension
-     * `dim`. Depending on the template argument `dim`, this function returns a
-     * reference to either Vertex, Tri, or Tet.
-     */
-    template <int dim>
-    static constexpr const Type &
-    get_simplex();
-
-    /**
-     * Return the correct hypercube reference cell type for the given dimension
-     * `dim`. Depending on the template argument `dim`, this function returns a
-     * reference to either Vertex, Quad, or Hex.
-     */
-    template <int dim>
-    static constexpr const Type &
-    get_hypercube();
-
-    /**
-     * Return the correct ReferenceCell::Type for a given structural dimension
-     * and number of vertices. For example, if `dim==2` and `n_vertices==4`,
-     * this function will return `Quad`. But if `dim==3` and `n_vertices==4`, it
-     * will return `Tri`.
-     */
-    static Type
-    n_vertices_to_type(const int dim, const unsigned int n_vertices);
-
-    /**
-     * Default constructor. Initialize this object as an invalid object.
-     */
-    constexpr Type();
-
-    /**
-     * Return true if the object is a Vertex, Line, Quad, or Hex.
-     */
-    bool
-    is_hyper_cube() const;
-
-    /**
-     * Return true if the object is a Vertex, Line, Tri, or Tet.
-     */
-    bool
-    is_simplex() const;
-
-    /**
-     * Return the dimension of the reference cell represented by the current
-     * object.
-     */
-    unsigned int
-    get_dimension() const;
-
-    /**
-     * Compute the value of the $i$-th linear shape function at location $\xi$
-     * for the current reference-cell type.
-     */
-    template <int dim>
-    double
-    d_linear_shape_function(const Point<dim> &xi, const unsigned int i) const;
-
-    /**
-     * Compute the gradient of the $i$-th linear shape function at location
-     * $\xi$ for the current reference-cell type.
-     */
-    template <int dim>
-    Tensor<1, dim>
-    d_linear_shape_function_gradient(const Point<dim> & xi,
-                                     const unsigned int i) const;
-
-    /*
-     * Return $i$-th unit tangential vector of a face of the reference cell.
-     * The vectors are arranged such that the
-     * cross product between the two vectors returns the unit normal vector.
-     *
-     * @pre $i$ must be between zero and `dim-1`.
-     */
-    template <int dim>
-    Tensor<1, dim>
-    unit_tangential_vectors(const unsigned int face_no,
-                            const unsigned int i) const;
-
-    /**
-     * Return the unit normal vector of a face of the reference cell.
-     */
-    template <int dim>
-    Tensor<1, dim>
-    unit_normal_vectors(const unsigned int face_no) const;
-
-    /**
-     * Determine the orientation of the current entity described by its
-     * vertices @p var_1 relative to an entity described by @p var_0.
-     */
-    template <typename T, std::size_t N>
-    unsigned char
-    compute_orientation(const std::array<T, N> &vertices_0,
-                        const std::array<T, N> &vertices_1) const;
-
-    /**
-     * Inverse function of compute_orientation().
-     */
-    template <typename T, std::size_t N>
-    std::array<T, N>
-    permute_according_orientation(const std::array<T, N> &vertices,
-                                  const unsigned int      orientation) const;
-
-    /**
-     * Return a default mapping of degree @p degree matching the current
-     * reference cell. If this reference cell is a hypercube, then the returned
-     * mapping is a MappingQGeneric; otherwise, it is an object of type
-     * MappingFE initialized with Simplex::FE_P (if the reference cell is a
-     * triangle or tetrahedron), with Simplex::FE_PyramidP (if the reference
-     * cell is a pyramid), or with Simplex::FE_WedgeP (if the reference cell is
-     * a wedge).
-     */
-    template <int dim, int spacedim>
-    std::unique_ptr<Mapping<dim, spacedim>>
-    get_default_mapping(const unsigned int degree) const;
-
-    /**
-     * Return a default linear mapping matching the current reference cell.
-     * If this reference cell is a hypercube, then the returned mapping
-     * is a MappingQ1; otherwise, it is an object of type MappingFE
-     * initialized with Simplex::FE_P (if the reference cell is a triangle or
-     * tetrahedron), with Simplex::FE_PyramidP (if the reference cell is a
-     * pyramid), or with Simplex::FE_WedgeP (if the reference cell is a wedge).
-     * In other words, the term "linear" in the name of the function has to be
-     * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
-     * coordinate directions.
-     */
-    template <int dim, int spacedim>
-    const Mapping<dim, spacedim> &
-    get_default_linear_mapping() const;
-
-    /**
-     * Return a Gauss-type quadrature matching the given reference cell (QGauss,
-     * Simplex::QGauss, Simplex::QGaussPyramid, Simplex::QGaussWedge).
-     *
-     * @param[in] n_points_1D The number of quadrature points in each direction
-     * (QGauss) or an indication of what polynomial degree needs to be
-     * integrated exactly for the other types.
-     */
-    template <int dim>
-    Quadrature<dim>
-    get_gauss_type_quadrature(const unsigned n_points_1D) const;
-
-    /**
-     * Return a quadrature rule with the support points of the given reference
-     * cell.
-     *
-     * @note The weights of the quadrature object are left unfilled.
-     */
-    template <int dim>
-    const Quadrature<dim> &
-    get_nodal_type_quadrature() const;
-
-    /**
-     * Return a text representation of the reference cell represented by the
-     * current object.
-     */
-    std::string
-    to_string() const;
-
-    /**
-     * Conversion operator to an integer.
-     */
-    constexpr operator std::uint8_t() const;
-
-    /**
-     * Operator for equality comparison.
-     */
-    constexpr bool
-    operator==(const Type &type) const;
-
-    /**
-     * Operator for inequality comparison.
-     */
-    constexpr bool
-    operator!=(const Type &type) const;
-
-    /**
-     * Write and read the data of this object from a stream for the purpose
-     * of serialization using the [BOOST serialization
-     * library](https://www.boost.org/doc/libs/1_74_0/libs/serialization/doc/index.html).
-     */
-    template <class Archive>
-    void
-    serialize(Archive &archive, const unsigned int /*version*/);
-
-    /**
-     * Return a vector of faces a @p vertex belongs to.
-     */
-    ArrayView<const unsigned int>
-    faces_for_given_vertex(const unsigned int vertex) const;
-
-  private:
-    /**
-     * The variable that stores what this object actually corresponds to.
-     */
-    std::uint8_t kind;
-
-    /**
-     * Constructor. This is the constructor used to create the different
-     * `static` member variables of this class. It is `private` but can
-     * be called by a function in an internal namespace that is a `friend`
-     * of this class.
-     */
-    constexpr Type(const std::uint8_t kind);
-
-    /**
-     * A kind of constructor -- not quite private because it can be
-     * called by anyone, but at least hidden in an internal namespace.
-     */
-    friend Type
-    internal::make_reference_cell_from_int(const std::uint8_t);
-  };
-
-
-
-  inline constexpr Type::Type()
-    : Type(static_cast<std::uint8_t>(-1))
-  {}
-
-
-
-  inline constexpr Type::Type(const std::uint8_t kind)
-    : kind(kind)
-  {}
-
-
-
-  inline constexpr Type::operator std::uint8_t() const
-  {
-    return kind;
-  }
-
-
-
-  inline constexpr bool
-  Type::operator==(const Type &type) const
-  {
-    return kind == type.kind;
-  }
-
-
-
-  inline constexpr bool
-  Type::operator!=(const Type &type) const
-  {
-    return kind != type.kind;
-  }
-
-
-
-  template <class Archive>
-  inline void
-  Type::serialize(Archive &archive, const unsigned int /*version*/)
-  {
-    archive &kind;
-  }
-
-
-
-  inline ArrayView<const unsigned int>
-  Type::faces_for_given_vertex(const unsigned int vertex) const
-  {
-    if (*this == Type::Line)
-      {
-        AssertIndexRange(vertex, GeometryInfo<1>::vertices_per_cell);
-        return {&GeometryInfo<2>::vertex_to_face[vertex][0], 1};
-      }
-    else if (*this == Type::Quad)
-      {
-        AssertIndexRange(vertex, GeometryInfo<2>::vertices_per_cell);
-        return {&GeometryInfo<2>::vertex_to_face[vertex][0], 2};
-      }
-    else if (*this == Type::Hex)
-      {
-        AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_cell);
-        return {&GeometryInfo<3>::vertex_to_face[vertex][0], 3};
-      }
-    else if (*this == Type::Tri)
-      {
-        AssertIndexRange(vertex, 3);
-        static const std::array<std::array<unsigned int, 2>, 3> table = {
-          {{{0, 2}}, {{0, 1}}, {{1, 2}}}};
-
-        return table[vertex];
-      }
-    else if (*this == Type::Tet)
-      {
-        AssertIndexRange(vertex, 4);
-        static const std::array<std::array<unsigned int, 3>, 4> table = {
-          {{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}}};
-
-        return table[vertex];
-      }
-    else if (*this == Type::Wedge)
-      {
-        AssertIndexRange(vertex, 6);
-        static const std::array<std::array<unsigned int, 3>, 6> table = {
-          {{{0, 2, 4}},
-           {{0, 2, 3}},
-           {{0, 3, 4}},
-           {{1, 2, 4}},
-           {{1, 2, 3}},
-           {{1, 3, 4}}}};
-
-        return table[vertex];
-      }
-    else if (*this == Type::Pyramid)
-      {
-        AssertIndexRange(vertex, 5);
-        static const unsigned int X = numbers::invalid_unsigned_int;
-        static const std::array<std::array<unsigned int, 4>, 5> table = {
-          {{{0, 1, 3, X}},
-           {{0, 2, 3, X}},
-           {{0, 1, 4, X}},
-           {{0, 2, 4, X}},
-           {{1, 2, 3, 4}}}};
-
-        return {&table[vertex][0], vertex == 4 ? 4u : 3u};
-      }
-
-    Assert(false, ExcNotImplemented());
-
-    return {};
-  }
-
-
-
-  inline bool
-  Type::is_hyper_cube() const
-  {
-    return (*this == Vertex || *this == Line || *this == Quad || *this == Hex);
-  }
-
-
-
-  inline bool
-  Type::is_simplex() const
-  {
-    return (*this == Vertex || *this == Line || *this == Tri || *this == Tet);
-  }
-
-
-
-  inline unsigned int
-  Type::get_dimension() const
-  {
-    if (*this == Vertex)
-      return 0;
-    else if (*this == Line)
-      return 1;
-    else if ((*this == Tri) || (*this == Quad))
-      return 2;
-    else if ((*this == Tet) || (*this == Pyramid) || (*this == Wedge) ||
-             (*this == Hex))
-      return 3;
-
-    Assert(false, ExcNotImplemented());
-    return numbers::invalid_unsigned_int;
-  }
-
-
-
   template <int dim>
-  inline constexpr const Type &
-  Type::get_simplex()
-  {
-    switch (dim)
-      {
-        case 0:
-          return Type::Vertex;
-        case 1:
-          return Type::Line;
-        case 2:
-          return Type::Tri;
-        case 3:
-          return Type::Tet;
-        default:
-          Assert(false, ExcNotImplemented());
-          return Type::Invalid;
-      }
-  }
-
-
-
-  template <int dim>
-  inline constexpr const Type &
-  Type::get_hypercube()
-  {
-    switch (dim)
-      {
-        case 0:
-          return Type::Vertex;
-        case 1:
-          return Type::Line;
-        case 2:
-          return Type::Quad;
-        case 3:
-          return Type::Hex;
-        default:
-          Assert(false, ExcNotImplemented());
-          return Type::Invalid;
-      }
-  }
-
-
-
-  inline Type
-  Type::n_vertices_to_type(const int dim, const unsigned int n_vertices)
-  {
-    AssertIndexRange(dim, 4);
-    AssertIndexRange(n_vertices, 9);
-
-    const auto X = Type::Invalid;
-    static const std::array<std::array<ReferenceCell::Type, 9>,
-                            4>
-      table = {
-        {// dim 0
-         {{X, Type::Vertex, X, X, X, X, X, X, X}},
-         // dim 1
-         {{X, X, Type::Line, X, X, X, X, X, X}},
-         // dim 2
-         {{X, X, X, Type::Tri, Type::Quad, X, X, X, X}},
-         // dim 3
-         {{X, X, X, X, Type::Tet, Type::Pyramid, Type::Wedge, X, Type::Hex}}}};
-    Assert(table[dim][n_vertices] != Type::Invalid,
-           ExcMessage("The combination of dim = " + std::to_string(dim) +
-                      " and n_vertices = " + std::to_string(n_vertices) +
-                      " does not correspond to a known reference cell type."));
-    return table[dim][n_vertices];
-  }
-
-
-
-  template <int dim>
-  inline double
-  Type::d_linear_shape_function(const Point<dim> & xi,
-                                const unsigned int i) const
-  {
-    AssertDimension(dim, get_dimension());
-    if (*this == get_hypercube<dim>())
-      return GeometryInfo<dim>::d_linear_shape_function(xi, i);
-
-    if (*this == Type::Tri) // see also Simplex::ScalarPolynomial::compute_value
-      {
-        switch (i)
-          {
-            case 0:
-              return 1.0 - xi[std::min(0, dim - 1)] - xi[std::min(1, dim - 1)];
-            case 1:
-              return xi[std::min(0, dim - 1)];
-            case 2:
-              return xi[std::min(1, dim - 1)];
-          }
-      }
-
-    if (*this == Type::Tet) // see also Simplex::ScalarPolynomial::compute_value
-      {
-        switch (i)
-          {
-            case 0:
-              return 1.0 - xi[std::min(0, dim - 1)] - xi[std::min(1, dim - 1)] -
-                     xi[std::min(2, dim - 1)];
-            case 1:
-              return xi[std::min(0, dim - 1)];
-            case 2:
-              return xi[std::min(1, dim - 1)];
-            case 3:
-              return xi[std::min(2, dim - 1)];
-          }
-      }
-
-    if (*this ==
-        Type::Wedge) // see also Simplex::ScalarWedgePolynomial::compute_value
-      {
-        return Type(Type::Tri).d_linear_shape_function<2>(
-                 Point<2>(xi[std::min(0, dim - 1)], xi[std::min(1, dim - 1)]),
-                 i % 3) *
-               Type(Type::Line)
-                 .d_linear_shape_function<1>(Point<1>(xi[std::min(2, dim - 1)]),
-                                             i / 3);
-      }
-
-    if (*this ==
-        Type::Pyramid) // see also
-                       // Simplex::ScalarPyramidPolynomial::compute_value
-      {
-        const double Q14 = 0.25;
-        double       ration;
-
-        const double r = xi[std::min(0, dim - 1)];
-        const double s = xi[std::min(1, dim - 1)];
-        const double t = xi[std::min(2, dim - 1)];
-
-        if (fabs(t - 1.0) > 1.0e-14)
-          {
-            ration = (r * s * t) / (1.0 - t);
-          }
-        else
-          {
-            ration = 0.0;
-          }
-
-        if (i == 0)
-          return Q14 * ((1.0 - r) * (1.0 - s) - t + ration);
-        if (i == 1)
-          return Q14 * ((1.0 + r) * (1.0 - s) - t - ration);
-        if (i == 2)
-          return Q14 * ((1.0 - r) * (1.0 + s) - t - ration);
-        if (i == 3)
-          return Q14 * ((1.0 + r) * (1.0 + s) - t + ration);
-        else
-          return t;
-      }
-
-    Assert(false, ExcNotImplemented());
-
-    return 0.0;
-  }
-
-
-
-  template <int dim>
-  inline Tensor<1, dim>
-  Type::d_linear_shape_function_gradient(const Point<dim> & xi,
-                                         const unsigned int i) const
-  {
-    AssertDimension(dim, get_dimension());
-    if (*this == get_hypercube<dim>())
-      return GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i);
-
-    if (*this == Type::Tri) // see also Simplex::ScalarPolynomial::compute_grad
-      {
-        switch (i)
-          {
-            case 0:
-              return Point<dim>(-1.0, -1.0);
-            case 1:
-              return Point<dim>(+1.0, +0.0);
-            case 2:
-              return Point<dim>(+0.0, +1.0);
-          }
-      }
-
-    Assert(false, ExcNotImplemented());
-
-    return Point<dim>(+0.0, +0.0, +0.0);
-  }
-
-
-  template <int dim>
-  inline Tensor<1, dim>
-  Type::unit_tangential_vectors(const unsigned int face_no,
-                                const unsigned int i) const
-  {
-    AssertDimension(dim, get_dimension());
-    AssertIndexRange(i, dim - 1);
-
-    if (*this == get_hypercube<dim>())
-      {
-        AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
-        return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
-      }
-    else if (*this == Type::Tri)
-      {
-        AssertIndexRange(face_no, 3);
-        static const std::array<Tensor<1, dim>, 3> table = {
-          {Point<dim>(1, 0),
-           Point<dim>(-std::sqrt(0.5), +std::sqrt(0.5)),
-           Point<dim>(0, -1)}};
-
-        return table[face_no];
-      }
-    else if (*this == Type::Tet)
-      {
-        AssertIndexRange(face_no, 4);
-        static const std::array<std::array<Tensor<1, dim>, 2>, 4> table = {
-          {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-           {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-           {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
-           {{Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
-                        +std::pow(1.0 / 3.0, 1.0 / 4.0),
-                        0),
-             Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
-                        0,
-                        +std::pow(1.0 / 3.0, 1.0 / 4.0))}}}};
-
-        return table[face_no][i];
-      }
-    else if (*this == Type::Wedge)
-      {
-        AssertIndexRange(face_no, 5);
-        static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
-          {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-           {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
-           {{Point<dim>(-1 / std::sqrt(2.0), +1 / std::sqrt(2.0), 0),
-             Point<dim>(0, 0, 1)}},
-           {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
-           {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}}}};
-
-        return table[face_no][i];
-      }
-    else if (*this == Type::Pyramid)
-      {
-        AssertIndexRange(face_no, 5);
-        static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
-          {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
-           {{Point<dim>(+1.0 / sqrt(2.0), 0, +1.0 / sqrt(2.0)),
-             Point<dim>(0, 1, 0)}},
-           {{Point<dim>(+1.0 / sqrt(2.0), 0, -1.0 / sqrt(2.0)),
-             Point<dim>(0, 1, 0)}},
-           {{Point<dim>(1, 0, 0),
-             Point<dim>(0, +1.0 / sqrt(2.0), +1.0 / sqrt(2.0))}},
-           {{Point<dim>(1, 0, 0),
-             Point<dim>(0, +1.0 / sqrt(2.0), -1.0 / sqrt(2.0))}}}};
-
-        return table[face_no][i];
-      }
-
-    Assert(false, ExcNotImplemented());
-
-    return {};
-  }
-
-
-
-  template <int dim>
-  inline Tensor<1, dim>
-  Type::unit_normal_vectors(const unsigned int face_no) const
-  {
-    AssertDimension(dim, this->get_dimension());
-
-    if (is_hyper_cube())
-      {
-        AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
-        return GeometryInfo<dim>::unit_normal_vector[face_no];
-      }
-    else if (dim == 2)
-      {
-        Assert(*this == Tri, ExcInternalError());
-
-        // Return the rotated vector
-        return cross_product_2d(unit_tangential_vectors<dim>(face_no, 0));
-      }
-    else if (dim == 3)
-      {
-        return cross_product_3d(unit_tangential_vectors<dim>(face_no, 0),
-                                unit_tangential_vectors<dim>(face_no, 1));
-      }
-
-    Assert(false, ExcNotImplemented());
-
-    return {};
-  }
+  static constexpr const ReferenceCell &
+  get_simplex();
 
   /**
-   * Return a default linear mapping that works for the given triangulation.
-   * Internally, this function calls the function above for the reference
-   * cell used by the given triangulation, assuming that the triangulation
-   * uses only a single cell type. If the triangulation uses mixed cell
-   * types, then this function will trigger an exception.
+   * Return the correct hypercube reference cell type for the given dimension
+   * `dim`. Depending on the template argument `dim`, this function returns a
+   * reference to either Vertex, Quad, or Hex.
+   */
+  template <int dim>
+  static constexpr const ReferenceCell &
+  get_hypercube();
+
+  /**
+   * Return the correct ReferenceCell for a given structural
+   * dimension and number of vertices. For example, if `dim==2` and
+   * `n_vertices==4`, this function will return `Quad`. But if `dim==3` and
+   * `n_vertices==4`, it will return `Tri`.
+   */
+  static ReferenceCell
+  n_vertices_to_type(const int dim, const unsigned int n_vertices);
+
+  /**
+   * Default constructor. Initialize this object as an invalid object.
+   */
+  constexpr ReferenceCell();
+
+  /**
+   * Return true if the object is a Vertex, Line, Quad, or Hex.
+   */
+  bool
+  is_hyper_cube() const;
+
+  /**
+   * Return true if the object is a Vertex, Line, Tri, or Tet.
+   */
+  bool
+  is_simplex() const;
+
+  /**
+   * Return the dimension of the reference cell represented by the current
+   * object.
+   */
+  unsigned int
+  get_dimension() const;
+
+  /**
+   * Compute the value of the $i$-th linear shape function at location $\xi$
+   * for the current reference-cell type.
+   */
+  template <int dim>
+  double
+  d_linear_shape_function(const Point<dim> &xi, const unsigned int i) const;
+
+  /**
+   * Compute the gradient of the $i$-th linear shape function at location
+   * $\xi$ for the current reference-cell type.
+   */
+  template <int dim>
+  Tensor<1, dim>
+  d_linear_shape_function_gradient(const Point<dim> & xi,
+                                   const unsigned int i) const;
+
+  /*
+   * Return $i$-th unit tangential vector of a face of the reference cell.
+   * The vectors are arranged such that the
+   * cross product between the two vectors returns the unit normal vector.
+   *
+   * @pre $i$ must be between zero and `dim-1`.
+   */
+  template <int dim>
+  Tensor<1, dim>
+  unit_tangential_vectors(const unsigned int face_no,
+                          const unsigned int i) const;
+
+  /**
+   * Return the unit normal vector of a face of the reference cell.
+   */
+  template <int dim>
+  Tensor<1, dim>
+  unit_normal_vectors(const unsigned int face_no) const;
+
+  /**
+   * Determine the orientation of the current entity described by its
+   * vertices @p var_1 relative to an entity described by @p var_0.
+   */
+  template <typename T, std::size_t N>
+  unsigned char
+  compute_orientation(const std::array<T, N> &vertices_0,
+                      const std::array<T, N> &vertices_1) const;
+
+  /**
+   * Inverse function of compute_orientation().
+   */
+  template <typename T, std::size_t N>
+  std::array<T, N>
+  permute_according_orientation(const std::array<T, N> &vertices,
+                                const unsigned int      orientation) const;
+
+  /**
+   * Return a default mapping of degree @p degree matching the current
+   * reference cell. If this reference cell is a hypercube, then the returned
+   * mapping is a MappingQGeneric; otherwise, it is an object of type
+   * MappingFE initialized with Simplex::FE_P (if the reference cell is a
+   * triangle or tetrahedron), with Simplex::FE_PyramidP (if the reference
+   * cell is a pyramid), or with Simplex::FE_WedgeP (if the reference cell is
+   * a wedge).
+   */
+  template <int dim, int spacedim>
+  std::unique_ptr<Mapping<dim, spacedim>>
+  get_default_mapping(const unsigned int degree) const;
+
+  /**
+   * Return a default linear mapping matching the current reference cell.
+   * If this reference cell is a hypercube, then the returned mapping
+   * is a MappingQ1; otherwise, it is an object of type MappingFE
+   * initialized with Simplex::FE_P (if the reference cell is a triangle or
+   * tetrahedron), with Simplex::FE_PyramidP (if the reference cell is a
+   * pyramid), or with Simplex::FE_WedgeP (if the reference cell is a wedge).
+   * In other words, the term "linear" in the name of the function has to be
+   * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
+   * coordinate directions.
    */
   template <int dim, int spacedim>
   const Mapping<dim, spacedim> &
-  get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation);
+  get_default_linear_mapping() const;
 
-  namespace internal
-  {
-    /**
-     * Check if the bit at position @p n in @p number is set.
-     */
-    inline static bool
-    get_bit(const unsigned char number, const unsigned int n)
+  /**
+   * Return a Gauss-type quadrature matching the given reference cell (QGauss,
+   * Simplex::QGauss, Simplex::QGaussPyramid, Simplex::QGaussWedge).
+   *
+   * @param[in] n_points_1D The number of quadrature points in each direction
+   * (QGauss) or an indication of what polynomial degree needs to be
+   * integrated exactly for the other types.
+   */
+  template <int dim>
+  Quadrature<dim>
+  get_gauss_type_quadrature(const unsigned n_points_1D) const;
+
+  /**
+   * Return a quadrature rule with the support points of the given reference
+   * cell.
+   *
+   * @note The weights of the quadrature object are left unfilled.
+   */
+  template <int dim>
+  const Quadrature<dim> &
+  get_nodal_type_quadrature() const;
+
+  /**
+   * Return a text representation of the reference cell represented by the
+   * current object.
+   */
+  std::string
+  to_string() const;
+
+  /**
+   * Conversion operator to an integer.
+   */
+  constexpr operator std::uint8_t() const;
+
+  /**
+   * Operator for equality comparison.
+   */
+  constexpr bool
+  operator==(const ReferenceCell &type) const;
+
+  /**
+   * Operator for inequality comparison.
+   */
+  constexpr bool
+  operator!=(const ReferenceCell &type) const;
+
+  /**
+   * Write and read the data of this object from a stream for the purpose
+   * of serialization using the [BOOST serialization
+   * library](https://www.boost.org/doc/libs/1_74_0/libs/serialization/doc/index.html).
+   */
+  template <class Archive>
+  void
+  serialize(Archive &archive, const unsigned int /*version*/);
+
+  /**
+   * Return a vector of faces a @p vertex belongs to.
+   */
+  ArrayView<const unsigned int>
+  faces_for_given_vertex(const unsigned int vertex) const;
+
+private:
+  /**
+   * The variable that stores what this object actually corresponds to.
+   */
+  std::uint8_t kind;
+
+  /**
+   * Constructor. This is the constructor used to create the different
+   * `static` member variables of this class. It is `private` but can
+   * be called by a function in an internal namespace that is a `friend`
+   * of this class.
+   */
+  constexpr ReferenceCell(const std::uint8_t kind);
+
+  /**
+   * A kind of constructor -- not quite private because it can be
+   * called by anyone, but at least hidden in an internal namespace.
+   */
+  friend ReferenceCell
+  internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
+};
+
+
+
+inline constexpr ReferenceCell::ReferenceCell()
+  : ReferenceCell(static_cast<std::uint8_t>(-1))
+{}
+
+
+
+inline constexpr ReferenceCell::ReferenceCell(const std::uint8_t kind)
+  : kind(kind)
+{}
+
+
+
+inline constexpr ReferenceCell::operator std::uint8_t() const
+{
+  return kind;
+}
+
+
+
+inline constexpr bool
+ReferenceCell::operator==(const ReferenceCell &type) const
+{
+  return kind == type.kind;
+}
+
+
+
+inline constexpr bool
+ReferenceCell::operator!=(const ReferenceCell &type) const
+{
+  return kind != type.kind;
+}
+
+
+
+template <class Archive>
+inline void
+ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)
+{
+  archive &kind;
+}
+
+
+
+inline ArrayView<const unsigned int>
+ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
+{
+  if (*this == ReferenceCell::Line)
     {
-      AssertIndexRange(n, 8);
+      AssertIndexRange(vertex, GeometryInfo<1>::vertices_per_cell);
+      return {&GeometryInfo<2>::vertex_to_face[vertex][0], 1};
+    }
+  else if (*this == ReferenceCell::Quad)
+    {
+      AssertIndexRange(vertex, GeometryInfo<2>::vertices_per_cell);
+      return {&GeometryInfo<2>::vertex_to_face[vertex][0], 2};
+    }
+  else if (*this == ReferenceCell::Hex)
+    {
+      AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_cell);
+      return {&GeometryInfo<3>::vertex_to_face[vertex][0], 3};
+    }
+  else if (*this == ReferenceCell::Tri)
+    {
+      AssertIndexRange(vertex, 3);
+      static const std::array<std::array<unsigned int, 2>, 3> table = {
+        {{{0, 2}}, {{0, 1}}, {{1, 2}}}};
 
-      // source:
-      // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
-      // "Checking a bit"
-      return (number >> n) & 1U;
+      return table[vertex];
+    }
+  else if (*this == ReferenceCell::Tet)
+    {
+      AssertIndexRange(vertex, 4);
+      static const std::array<std::array<unsigned int, 3>, 4> table = {
+        {{{0, 1, 2}}, {{0, 1, 3}}, {{0, 2, 3}}, {{1, 2, 3}}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCell::Wedge)
+    {
+      AssertIndexRange(vertex, 6);
+      static const std::array<std::array<unsigned int, 3>, 6> table = {
+        {{{0, 2, 4}},
+         {{0, 2, 3}},
+         {{0, 3, 4}},
+         {{1, 2, 4}},
+         {{1, 2, 3}},
+         {{1, 3, 4}}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCell::Pyramid)
+    {
+      AssertIndexRange(vertex, 5);
+      static const unsigned int X = numbers::invalid_unsigned_int;
+      static const std::array<std::array<unsigned int, 4>, 5> table = {
+        {{{0, 1, 3, X}},
+         {{0, 2, 3, X}},
+         {{0, 1, 4, X}},
+         {{0, 2, 4, X}},
+         {{1, 2, 3, 4}}}};
+
+      return {&table[vertex][0], vertex == 4 ? 4u : 3u};
     }
 
+  Assert(false, ExcNotImplemented());
+
+  return {};
+}
 
 
-    /**
-     * Set the bit at position @p n in @p number to value @p x.
-     */
-    inline static void
-    set_bit(unsigned char &number, const unsigned int n, const bool x)
+
+inline bool
+ReferenceCell::is_hyper_cube() const
+{
+  return (*this == Vertex || *this == Line || *this == Quad || *this == Hex);
+}
+
+
+
+inline bool
+ReferenceCell::is_simplex() const
+{
+  return (*this == Vertex || *this == Line || *this == Tri || *this == Tet);
+}
+
+
+
+inline unsigned int
+ReferenceCell::get_dimension() const
+{
+  if (*this == Vertex)
+    return 0;
+  else if (*this == Line)
+    return 1;
+  else if ((*this == Tri) || (*this == Quad))
+    return 2;
+  else if ((*this == Tet) || (*this == Pyramid) || (*this == Wedge) ||
+           (*this == Hex))
+    return 3;
+
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+template <int dim>
+inline constexpr const ReferenceCell &
+ReferenceCell::get_simplex()
+{
+  switch (dim)
     {
-      AssertIndexRange(n, 8);
+      case 0:
+        return ReferenceCell::Vertex;
+      case 1:
+        return ReferenceCell::Line;
+      case 2:
+        return ReferenceCell::Tri;
+      case 3:
+        return ReferenceCell::Tet;
+      default:
+        Assert(false, ExcNotImplemented());
+        return ReferenceCell::Invalid;
+    }
+}
 
-      // source:
-      // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
-      // "Changing the nth bit to x"
-      number ^= (-static_cast<unsigned char>(x) ^ number) & (1U << n);
+
+
+template <int dim>
+inline constexpr const ReferenceCell &
+ReferenceCell::get_hypercube()
+{
+  switch (dim)
+    {
+      case 0:
+        return ReferenceCell::Vertex;
+      case 1:
+        return ReferenceCell::Line;
+      case 2:
+        return ReferenceCell::Quad;
+      case 3:
+        return ReferenceCell::Hex;
+      default:
+        Assert(false, ExcNotImplemented());
+        return ReferenceCell::Invalid;
+    }
+}
+
+
+
+inline ReferenceCell
+ReferenceCell::n_vertices_to_type(const int dim, const unsigned int n_vertices)
+{
+  AssertIndexRange(dim, 4);
+  AssertIndexRange(n_vertices, 9);
+
+  const auto X = ReferenceCell::Invalid;
+  static const std::array<std::array<ReferenceCell, 9>,
+                          4>
+    table = {{// dim 0
+              {{X, ReferenceCell::Vertex, X, X, X, X, X, X, X}},
+              // dim 1
+              {{X, X, ReferenceCell::Line, X, X, X, X, X, X}},
+              // dim 2
+              {{X, X, X, ReferenceCell::Tri, ReferenceCell::Quad, X, X, X, X}},
+              // dim 3
+              {{X,
+                X,
+                X,
+                X,
+                ReferenceCell::Tet,
+                ReferenceCell::Pyramid,
+                ReferenceCell::Wedge,
+                X,
+                ReferenceCell::Hex}}}};
+  Assert(table[dim][n_vertices] != ReferenceCell::Invalid,
+         ExcMessage("The combination of dim = " + std::to_string(dim) +
+                    " and n_vertices = " + std::to_string(n_vertices) +
+                    " does not correspond to a known reference cell type."));
+  return table[dim][n_vertices];
+}
+
+
+
+template <int dim>
+inline double
+ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
+                                       const unsigned int i) const
+{
+  AssertDimension(dim, get_dimension());
+  if (*this == get_hypercube<dim>())
+    return GeometryInfo<dim>::d_linear_shape_function(xi, i);
+
+  if (*this ==
+      ReferenceCell::Tri) // see also Simplex::ScalarPolynomial::compute_value
+    {
+      switch (i)
+        {
+          case 0:
+            return 1.0 - xi[std::min(0, dim - 1)] - xi[std::min(1, dim - 1)];
+          case 1:
+            return xi[std::min(0, dim - 1)];
+          case 2:
+            return xi[std::min(1, dim - 1)];
+        }
     }
 
-    /**
-     * A namespace for geometric information on reference cells.
-     */
-    namespace Info
+  if (*this ==
+      ReferenceCell::Tet) // see also Simplex::ScalarPolynomial::compute_value
     {
-      /**
-       * Interface to be used in TriaAccessor/TriaCellAccessor to access
-       * sub-entities of dimension d' of geometric entities of dimension d, with
-       * 0<=d'<d<=3.
-       */
-      struct Base
-      {
-        /**
-         * Destructor.
-         */
-        virtual ~Base() = default;
-
-        /**
-         * Number of vertices.
-         */
-        virtual unsigned int
-        n_vertices() const
-        {
-          Assert(false, ExcNotImplemented());
-          return 0;
-        }
-
-        /**
-         * Number of lines.
-         */
-        virtual unsigned int
-        n_lines() const
-        {
-          Assert(false, ExcNotImplemented());
-          return 0;
-        }
-
-
-        /**
-         * Number of faces.
-         */
-        virtual unsigned int
-        n_faces() const
-        {
-          Assert(false, ExcNotImplemented());
-          return 0;
-        }
-
-        /**
-         * Return an object that can be thought of as an array containing all
-         * indices from zero to n_vertices().
-         */
-        inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
-        vertex_indices() const
-        {
-          return {0U, n_vertices()};
-        }
-
-        /**
-         * Return an object that can be thought of as an array containing all
-         * indices from zero to n_lines().
-         */
-        inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
-        line_indices() const
-        {
-          return {0U, n_lines()};
-        }
-
-        /**
-         * Return an object that can be thought of as an array containing all
-         * indices from zero to n_faces().
-         */
-        inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
-        face_indices() const
-        {
-          return {0U, n_faces()};
-        }
-
-        /**
-         * Standard decomposition of vertex index into face and face-vertex
-         * index.
-         */
-        virtual std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const
-        {
-          Assert(false, ExcNotImplemented());
-
-          (void)vertex;
-
-          return {{0u, 0u}};
-        }
-
-        /**
-         * Standard decomposition of line index into face and face-line index.
-         */
-        virtual std::array<unsigned int, 2>
-        standard_line_to_face_and_line_index(const unsigned int line) const
-        {
-          Assert(false, ExcNotImplemented());
-
-          (void)line;
-
-          return {{0, 0}};
-        }
-
-        /**
-         * Correct vertex index depending on face orientation.
-         */
-        virtual unsigned int
-        standard_to_real_face_vertex(const unsigned int  vertex,
-                                     const unsigned int  face,
-                                     const unsigned char face_orientation) const
-        {
-          Assert(false, ExcNotImplemented());
-
-          (void)vertex;
-          (void)face;
-          (void)face_orientation;
-
-          return 0;
-        }
-
-        /**
-         * Correct line index depending on face orientation.
-         */
-        virtual unsigned int
-        standard_to_real_face_line(const unsigned int  line,
-                                   const unsigned int  face,
-                                   const unsigned char face_orientation) const
-        {
-          Assert(false, ExcNotImplemented());
-
-          (void)line;
-          (void)face;
-          (void)face_orientation;
-
-          return 0;
-        }
-
-        /**
-         * Combine face and line orientation.
-         */
-        virtual bool
-        combine_face_and_line_orientation(
-          const unsigned int  line,
-          const unsigned char face_orientation,
-          const unsigned char line_orientation) const
-        {
-          Assert(false, ExcNotImplemented());
-
-          (void)line;
-          (void)face_orientation;
-          (void)line_orientation;
-
-          return true;
-        }
-
-        /**
-         * Return reference-cell type of face @p face_no.
-         */
-        virtual ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)face_no;
-
-          return ReferenceCell::Type::Invalid;
-        }
-
-        /**
-         * Map face line number to cell line number.
-         */
-        virtual unsigned int
-        face_to_cell_lines(const unsigned int  face,
-                           const unsigned int  line,
-                           const unsigned char face_orientation) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)face;
-          (void)line;
-          (void)face_orientation;
-
-          return 0;
-        }
-
-        /**
-         * Map face vertex number to cell vertex number.
-         */
-        virtual unsigned int
-        face_to_cell_vertices(const unsigned int  face,
-                              const unsigned int  vertex,
-                              const unsigned char face_orientation) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)face;
-          (void)vertex;
-          (void)face_orientation;
-
-          return 0;
-        }
-
-        /**
-         * Map an ExodusII vertex number to a deal.II vertex number.
-         */
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)vertex_n;
-
-          return 0;
-        }
-
-        /**
-         * Map an ExodusII face number to a deal.II face number.
-         */
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)face_n;
-
-          return 0;
-        }
-
-        /**
-         * Indices of child cells that are adjacent to a certain face of the
-         * mother cell.
-         */
-        virtual unsigned int
-        child_cell_on_face(const unsigned int face_n,
-                           const unsigned int subface_n) const
-        {
-          Assert(false, ExcNotImplemented());
-          (void)face_n;
-          (void)subface_n;
-
-          return numbers::invalid_unsigned_int;
-        }
-      };
-
-
-      /**
-       * Base class for tensor-product geometric entities.
-       */
-      template <int dim>
-      struct TensorProductBase : Base
-      {
-        unsigned int
-        n_vertices() const override
-        {
-          return GeometryInfo<dim>::vertices_per_cell;
-        }
-
-        unsigned int
-        n_lines() const override
-        {
-          return GeometryInfo<dim>::lines_per_cell;
-        }
-
-        unsigned int
-        n_faces() const override
-        {
-          return GeometryInfo<dim>::faces_per_cell;
-        }
-
-        unsigned int
-        face_to_cell_lines(const unsigned int  face,
-                           const unsigned int  line,
-                           const unsigned char face_orientation) const override
-        {
-          return GeometryInfo<dim>::face_to_cell_lines(
-            face,
-            line,
-            get_bit(face_orientation, 0),
-            get_bit(face_orientation, 2),
-            get_bit(face_orientation, 1));
-        }
-
-        unsigned int
-        face_to_cell_vertices(
-          const unsigned int  face,
-          const unsigned int  vertex,
-          const unsigned char face_orientation) const override
-        {
-          return GeometryInfo<dim>::face_to_cell_vertices(
-            face,
-            vertex,
-            get_bit(face_orientation, 0),
-            get_bit(face_orientation, 2),
-            get_bit(face_orientation, 1));
-        }
-      };
-
-
-
-      /*
-       * Vertex.
-       */
-      struct Vertex : public TensorProductBase<0>
-      {
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-          return ReferenceCell::Type::Invalid;
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          (void)face_n;
-          AssertIndexRange(face_n, n_faces());
-
-          return 0;
-        }
-      };
-
-
-
-      /*
-       * Line.
-       */
-      struct Line : public TensorProductBase<1>
-      {
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-          return ReferenceCell::Type::Vertex;
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          return vertex_n;
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          return face_n;
-        }
-      };
-
-
-
-      /**
-       * Triangle.
-       */
-      struct Tri : public Base
-      {
-        unsigned int
-        n_vertices() const override
-        {
-          return 3;
-        }
-
-        unsigned int
-        n_lines() const override
-        {
-          return 3;
-        }
-
-        unsigned int
-        n_faces() const override
-        {
-          return this->n_lines();
-        }
-
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          AssertIndexRange(vertex, 3);
-
-          static const std::array<std::array<unsigned int, 2>, 3> table = {
-            {{{0, 0}}, {{0, 1}}, {{1, 1}}}};
-
-          return table[vertex];
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char line_orientation) const override
-        {
-          (void)face;
-
-          static const std::array<std::array<unsigned int, 2>, 2> table = {
-            {{{1, 0}}, {{0, 1}}}};
-
-          return table[line_orientation][vertex];
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-
-          AssertIndexRange(face_no, n_faces());
-
-          return ReferenceCell::Type::Line;
-        }
-
-        unsigned int
-        face_to_cell_lines(const unsigned int  face,
-                           const unsigned int  line,
-                           const unsigned char face_orientation) const override
-        {
-          AssertIndexRange(face, n_faces());
-          AssertDimension(line, 0);
-
-          (void)line;
-          (void)face_orientation;
-
-          return face;
-        }
-
-        unsigned int
-        face_to_cell_vertices(
-          const unsigned int  face,
-          const unsigned int  vertex,
-          const unsigned char face_orientation) const override
-        {
-          static const std::array<std::array<unsigned int, 2>, 3> table = {
-            {{{0, 1}}, {{1, 2}}, {{2, 0}}}};
-
-          return table[face][face_orientation ? vertex : (1 - vertex)];
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          return vertex_n;
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          return face_n;
-        }
-
-        virtual unsigned int
-        child_cell_on_face(const unsigned int face_n,
-                           const unsigned int subface_n) const override
-        {
-          static constexpr unsigned int subcells[3][2] = {{0, 1},
-                                                          {1, 2},
-                                                          {2, 0}};
-
-          return subcells[face_n][subface_n];
-        }
-      };
-
-
-
-      /**
-       * Quad.
-       */
-      struct Quad : public TensorProductBase<2>
-      {
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          return GeometryInfo<2>::standard_quad_vertex_to_line_vertex_index(
-            vertex);
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char line_orientation) const override
-        {
-          (void)face;
-
-          return GeometryInfo<2>::standard_to_real_line_vertex(
-            vertex, line_orientation);
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-          return ReferenceCell::Type::Line;
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          constexpr std::array<unsigned int, 4> exodus_to_deal{{0, 1, 3, 2}};
-          return exodus_to_deal[vertex_n];
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          constexpr std::array<unsigned int, 4> exodus_to_deal{{2, 1, 3, 0}};
-          return exodus_to_deal[face_n];
-        }
-      };
-
-
-
-      /**
-       * Tet.
-       */
-      struct Tet : public Base
-      {
-        unsigned int
-        n_vertices() const override
-        {
-          return 4;
-        }
-
-        unsigned int
-        n_lines() const override
-        {
-          return 6;
-        }
-
-        unsigned int
-        n_faces() const override
-        {
-          return 4;
-        }
-
-        std::array<unsigned int, 2>
-        standard_line_to_face_and_line_index(
-          const unsigned int line) const override
-        {
-          static const std::array<unsigned int, 2> table[6] = {
-            {{0, 0}}, {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}};
-
-          return table[line];
-        }
-
-        unsigned int
-        standard_to_real_face_line(
-          const unsigned int  line,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          (void)face;
-
-          static const std::array<std::array<unsigned int, 3>, 6> table = {
-            {{{2, 1, 0}},
-             {{0, 1, 2}},
-             {{1, 0, 2}},
-             {{1, 2, 0}},
-             {{0, 2, 1}},
-             {{2, 0, 1}}}};
-
-          return table[face_orientation][line];
-        }
-
-        bool
-        combine_face_and_line_orientation(
-          const unsigned int  line,
-          const unsigned char face_orientation_raw,
-          const unsigned char line_orientation) const override
-        {
-          (void)line;
-          (void)face_orientation_raw;
-
-          return line_orientation;
-        }
-
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          AssertIndexRange(vertex, 4);
-
-          static const std::array<unsigned int, 2> table[4] = {{{0, 0}},
-                                                               {{0, 1}},
-                                                               {{0, 2}},
-                                                               {{1, 2}}};
-
-          return table[vertex];
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          AssertIndexRange(face_orientation, 6);
-          (void)face;
-
-          static const std::array<std::array<unsigned int, 3>, 6> table = {
-            {{{0, 2, 1}},
-             {{0, 1, 2}},
-             {{2, 1, 0}},
-             {{1, 2, 0}},
-             {{1, 0, 2}},
-             {{2, 0, 1}}}};
-
-          return table[face_orientation][vertex];
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-
-          AssertIndexRange(face_no, n_faces());
-
-          return ReferenceCell::Type::Tri;
-        }
-
-        unsigned int
-        face_to_cell_lines(const unsigned int  face,
-                           const unsigned int  line,
-                           const unsigned char face_orientation) const override
-        {
-          AssertIndexRange(face, n_faces());
-
-          const static std::array<std::array<unsigned int, 3>, 4> table = {
-            {{{0, 1, 2}}, {{0, 3, 4}}, {{2, 5, 3}}, {{1, 4, 5}}}};
-
-          return table[face][standard_to_real_face_line(
-            line, face, face_orientation)];
-        }
-
-        unsigned int
-        face_to_cell_vertices(
-          const unsigned int  face,
-          const unsigned int  vertex,
-          const unsigned char face_orientation) const override
-        {
-          static const std::array<std::array<unsigned int, 3>, 4> table = {
-            {{{0, 1, 2}}, {{1, 0, 3}}, {{0, 2, 3}}, {{2, 1, 3}}}};
-
-          return table[face][standard_to_real_face_vertex(
-            vertex, face, face_orientation)];
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          return vertex_n;
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          constexpr std::array<unsigned int, 4> exodus_to_deal{{1, 3, 2, 0}};
-          return exodus_to_deal[face_n];
-        }
-      };
-
-
-
-      /**
-       * Pyramid.
-       */
-      struct Pyramid : public Base
-      {
-        unsigned int
-        n_vertices() const override
-        {
-          return 5;
-        }
-
-        unsigned int
-        n_lines() const override
-        {
-          return 8;
-        }
-
-        unsigned int
-        n_faces() const override
-        {
-          return 5;
-        }
-
-        std::array<unsigned int, 2>
-        standard_line_to_face_and_line_index(
-          const unsigned int line) const override
-        {
-          static const std::array<unsigned int, 2> table[8] = {{{0, 0}},
-                                                               {{0, 1}},
-                                                               {{0, 2}},
-                                                               {{0, 3}},
-                                                               {{1, 2}},
-                                                               {{2, 1}},
-                                                               {{1, 1}},
-                                                               {{2, 2}}};
-
-          return table[line];
-        }
-
-        unsigned int
-        standard_to_real_face_line(
-          const unsigned int  line,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          if (face == 0) // QUAD
-            {
-              return GeometryInfo<3>::standard_to_real_face_line(
-                line,
-                get_bit(face_orientation, 0),
-                get_bit(face_orientation, 2),
-                get_bit(face_orientation, 1));
-            }
-          else // TRI
-            {
-              static const std::array<std::array<unsigned int, 3>, 6> table = {
-                {{{2, 1, 0}},
-                 {{0, 1, 2}},
-                 {{1, 0, 2}},
-                 {{1, 2, 0}},
-                 {{0, 2, 1}},
-                 {{2, 0, 1}}}};
-
-              return table[face_orientation][line];
-            }
-        }
-
-        bool
-        combine_face_and_line_orientation(
-          const unsigned int  line,
-          const unsigned char face_orientation_raw,
-          const unsigned char line_orientation) const override
-        {
-          (void)line;
-          (void)face_orientation_raw;
-
-          return line_orientation;
-        }
-
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          static const std::array<unsigned int, 2> table[5] = {
-            {{0, 0}}, {{0, 1}}, {{0, 2}}, {{0, 3}}, {{1, 2}}};
-
-          return table[vertex];
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          if (face == 0) // Quad
-            {
-              return GeometryInfo<3>::standard_to_real_face_vertex(
-                vertex,
-                get_bit(face_orientation, 0),
-                get_bit(face_orientation, 2),
-                get_bit(face_orientation, 1));
-            }
-          else // Tri
-            {
-              static const std::array<std::array<unsigned int, 3>, 6> table = {
-                {{{0, 2, 1}},
-                 {{0, 1, 2}},
-                 {{2, 1, 0}},
-                 {{1, 2, 0}},
-                 {{1, 0, 2}},
-                 {{2, 0, 1}}}};
-
-              return table[face_orientation][vertex];
-            }
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          AssertIndexRange(face_no, n_faces());
-
-          if (face_no == 0)
-            return ReferenceCell::Type::Quad;
-          else
-            return ReferenceCell::Type::Tri;
-        }
-
-        unsigned int
-        face_to_cell_vertices(
-          const unsigned int  face,
-          const unsigned int  vertex,
-          const unsigned char face_orientation) const override
-        {
-          AssertIndexRange(face, n_faces());
-          if (face == 0)
-            {
-              AssertIndexRange(vertex, 4);
-            }
-          else
-            {
-              AssertIndexRange(vertex, 3);
-            }
-          constexpr auto X = numbers::invalid_unsigned_int;
-          static const std::array<std::array<unsigned int, 4>, 5> table = {
-            {{{0, 1, 2, 3}},
-             {{0, 2, 4, X}},
-             {{3, 1, 4, X}},
-             {{1, 0, 4, X}},
-             {{2, 3, 4, X}}}};
-
-          return table[face][standard_to_real_face_vertex(
-            vertex, face, face_orientation)];
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          constexpr std::array<unsigned int, 5> exodus_to_deal{{0, 1, 3, 2, 4}};
-          return exodus_to_deal[vertex_n];
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          constexpr std::array<unsigned int, 5> exodus_to_deal{{3, 2, 4, 1, 0}};
-          return exodus_to_deal[face_n];
-        }
-      };
-
-
-
-      /**
-       * Wedge.
-       */
-      struct Wedge : public Base
-      {
-        unsigned int
-        n_vertices() const override
-        {
-          return 6;
-        }
-
-        unsigned int
-        n_lines() const override
-        {
-          return 9;
-        }
-
-        unsigned int
-        n_faces() const override
-        {
-          return 5;
-        }
-
-        std::array<unsigned int, 2>
-        standard_line_to_face_and_line_index(
-          const unsigned int line) const override
-        {
-          static const std::array<unsigned int, 2> table[9] = {{{0, 0}},
-                                                               {{0, 2}},
-                                                               {{0, 1}},
-                                                               {{1, 0}},
-                                                               {{1, 1}},
-                                                               {{1, 2}},
-                                                               {{2, 0}},
-                                                               {{2, 1}},
-                                                               {{3, 1}}};
-
-          return table[line];
-        }
-
-        unsigned int
-        standard_to_real_face_line(
-          const unsigned int  line,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          if (face > 1) // QUAD
-            {
-              return GeometryInfo<3>::standard_to_real_face_line(
-                line,
-                get_bit(face_orientation, 0),
-                get_bit(face_orientation, 2),
-                get_bit(face_orientation, 1));
-            }
-          else // TRI
-            {
-              static const std::array<std::array<unsigned int, 3>, 6> table = {
-                {{{2, 1, 0}},
-                 {{0, 1, 2}},
-                 {{1, 0, 2}},
-                 {{1, 2, 0}},
-                 {{0, 2, 1}},
-                 {{2, 0, 1}}}};
-
-              return table[face_orientation][line];
-            }
-        }
-
-        bool
-        combine_face_and_line_orientation(
-          const unsigned int  line,
-          const unsigned char face_orientation_raw,
-          const unsigned char line_orientation) const override
-        {
-          (void)line;
-          (void)face_orientation_raw;
-
-          return line_orientation;
-        }
-
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          static const std::array<std::array<unsigned int, 2>, 6> table = {
-            {{{0, 1}}, {{0, 0}}, {{0, 2}}, {{1, 0}}, {{1, 1}}, {{1, 2}}}};
-
-          return table[vertex];
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          if (face > 1) // QUAD
-            {
-              return GeometryInfo<3>::standard_to_real_face_vertex(
-                vertex,
-                get_bit(face_orientation, 0),
-                get_bit(face_orientation, 2),
-                get_bit(face_orientation, 1));
-            }
-          else // TRI
-            {
-              static const std::array<std::array<unsigned int, 3>, 6> table = {
-                {{{0, 2, 1}},
-                 {{0, 1, 2}},
-                 {{2, 1, 0}},
-                 {{1, 2, 0}},
-                 {{1, 0, 2}},
-                 {{2, 0, 1}}}};
-
-              return table[face_orientation][vertex];
-            }
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          AssertIndexRange(face_no, n_faces());
-
-          if (face_no > 1)
-            return ReferenceCell::Type::Quad;
-          else
-            return ReferenceCell::Type::Tri;
-        }
-
-        unsigned int
-        face_to_cell_vertices(
-          const unsigned int  face,
-          const unsigned int  vertex,
-          const unsigned char face_orientation) const override
-        {
-          AssertIndexRange(face, n_faces());
-          if (face < 2)
-            {
-              AssertIndexRange(vertex, 3);
-            }
-          else
-            {
-              AssertIndexRange(vertex, 4);
-            }
-          constexpr auto X = numbers::invalid_unsigned_int;
-          static const std::array<std::array<unsigned int, 4>, 6> table = {
-            {{{1, 0, 2, X}},
-             {{3, 4, 5, X}},
-             {{0, 1, 3, 4}},
-             {{1, 2, 4, 5}},
-             {{2, 0, 5, 3}}}};
-
-          return table[face][standard_to_real_face_vertex(
-            vertex, face, face_orientation)];
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          constexpr std::array<unsigned int, 6> exodus_to_deal{
-            {2, 1, 0, 5, 4, 3}};
-          return exodus_to_deal[vertex_n];
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          constexpr std::array<unsigned int, 6> exodus_to_deal{{3, 4, 2, 0, 1}};
-          return exodus_to_deal[face_n];
-        }
-      };
-
-
-
-      /**
-       * Hex.
-       */
-      struct Hex : public TensorProductBase<3>
-      {
-        std::array<unsigned int, 2>
-        standard_line_to_face_and_line_index(
-          const unsigned int line) const override
-        {
-          return GeometryInfo<3>::standard_hex_line_to_quad_line_index(line);
-        }
-
-        unsigned int
-        standard_to_real_face_line(
-          const unsigned int  line,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          (void)face;
-
-          return GeometryInfo<3>::standard_to_real_face_line(
-            line,
-            get_bit(face_orientation, 0),
-            get_bit(face_orientation, 2),
-            get_bit(face_orientation, 1));
-        }
-
-        bool
-        combine_face_and_line_orientation(
-          const unsigned int  line,
-          const unsigned char face_orientation_raw,
-          const unsigned char line_orientation) const override
-        {
-          static const bool bool_table[2][2][2][2] = {
-            {{{true, false},    // lines 0/1, face_orientation=false,
-                                // face_flip=false, face_rotation=false and true
-              {false, true}},   // lines 0/1, face_orientation=false,
-                                // face_flip=true, face_rotation=false and true
-             {{true, true},     // lines 0/1, face_orientation=true,
-                                // face_flip=false, face_rotation=false and true
-              {false, false}}}, // lines 0/1, face_orientation=true,
-                                // face_flip=true, face_rotation=false and true
-
-            {{{true, true}, // lines 2/3 ...
-              {false, false}},
-             {{true, false}, {false, true}}}};
-
-          const bool face_orientation = get_bit(face_orientation_raw, 0);
-          const bool face_flip        = get_bit(face_orientation_raw, 2);
-          const bool face_rotation    = get_bit(face_orientation_raw, 1);
-
-          return (
-            static_cast<bool>(line_orientation) ==
-            bool_table[line / 2][face_orientation][face_flip][face_rotation]);
-        }
-
-        std::array<unsigned int, 2>
-        standard_vertex_to_face_and_vertex_index(
-          const unsigned int vertex) const override
-        {
-          return GeometryInfo<3>::standard_hex_vertex_to_quad_vertex_index(
-            vertex);
-        }
-
-        unsigned int
-        standard_to_real_face_vertex(
-          const unsigned int  vertex,
-          const unsigned int  face,
-          const unsigned char face_orientation) const override
-        {
-          (void)face;
-
-          return GeometryInfo<3>::standard_to_real_face_vertex(
-            vertex,
-            get_bit(face_orientation, 0),
-            get_bit(face_orientation, 2),
-            get_bit(face_orientation, 1));
-        }
-
-        ReferenceCell::Type
-        face_reference_cell_type(const unsigned int face_no) const override
-        {
-          (void)face_no;
-          return ReferenceCell::Type::Quad;
-        }
-
-        virtual unsigned int
-        exodusii_vertex_to_deal_vertex(
-          const unsigned int vertex_n) const override
-        {
-          AssertIndexRange(vertex_n, n_vertices());
-          constexpr std::array<unsigned int, 8> exodus_to_deal{
-            {0, 1, 3, 2, 4, 5, 7, 6}};
-          return exodus_to_deal[vertex_n];
-        }
-
-        virtual unsigned int
-        exodusii_face_to_deal_face(const unsigned int face_n) const override
-        {
-          AssertIndexRange(face_n, n_faces());
-          constexpr std::array<unsigned int, 6> exodus_to_deal{
-            {2, 1, 3, 0, 4, 5}};
-          return exodus_to_deal[face_n];
-        }
-      };
-
-      /**
-       * Return for a given reference-cell type the right Info.
-       */
-      inline const ReferenceCell::internal::Info::Base &
-      get_cell(const ReferenceCell::Type &type)
-      {
-        static const std::
-          array<std::unique_ptr<ReferenceCell::internal::Info::Base>, 8>
-            gei{{std::make_unique<ReferenceCell::internal::Info::Vertex>(),
-                 std::make_unique<ReferenceCell::internal::Info::Line>(),
-                 std::make_unique<ReferenceCell::internal::Info::Tri>(),
-                 std::make_unique<ReferenceCell::internal::Info::Quad>(),
-                 std::make_unique<ReferenceCell::internal::Info::Tet>(),
-                 std::make_unique<ReferenceCell::internal::Info::Pyramid>(),
-                 std::make_unique<ReferenceCell::internal::Info::Wedge>(),
-                 std::make_unique<ReferenceCell::internal::Info::Hex>()}};
-        AssertIndexRange(static_cast<std::uint8_t>(type), 8);
-        return *gei[static_cast<std::uint8_t>(type)];
-      }
-
-      /**
-       * Return for a given reference-cell type @p and face number @p face_no the
-       * right Info of the @p face_no-th face.
-       */
-      inline const ReferenceCell::internal::Info::Base &
-      get_face(const ReferenceCell::Type &type, const unsigned int face_no)
-      {
-        return get_cell(get_cell(type).face_reference_cell_type(face_no));
-      }
-
-    } // namespace Info
-  }   // namespace internal
-
-
-
-  namespace internal
+      switch (i)
+        {
+          case 0:
+            return 1.0 - xi[std::min(0, dim - 1)] - xi[std::min(1, dim - 1)] -
+                   xi[std::min(2, dim - 1)];
+          case 1:
+            return xi[std::min(0, dim - 1)];
+          case 2:
+            return xi[std::min(1, dim - 1)];
+          case 3:
+            return xi[std::min(2, dim - 1)];
+        }
+    }
+
+  if (*this ==
+      ReferenceCell::Wedge) // see also
+                            // Simplex::ScalarWedgePolynomial::compute_value
+    {
+      return ReferenceCell(ReferenceCell::Tri)
+               .d_linear_shape_function<2>(Point<2>(xi[std::min(0, dim - 1)],
+                                                    xi[std::min(1, dim - 1)]),
+                                           i % 3) *
+             ReferenceCell(ReferenceCell::Line)
+               .d_linear_shape_function<1>(Point<1>(xi[std::min(2, dim - 1)]),
+                                           i / 3);
+    }
+
+  if (*this ==
+      ReferenceCell::Pyramid) // see also
+                              // Simplex::ScalarPyramidPolynomial::compute_value
+    {
+      const double Q14 = 0.25;
+      double       ration;
+
+      const double r = xi[std::min(0, dim - 1)];
+      const double s = xi[std::min(1, dim - 1)];
+      const double t = xi[std::min(2, dim - 1)];
+
+      if (fabs(t - 1.0) > 1.0e-14)
+        {
+          ration = (r * s * t) / (1.0 - t);
+        }
+      else
+        {
+          ration = 0.0;
+        }
+
+      if (i == 0)
+        return Q14 * ((1.0 - r) * (1.0 - s) - t + ration);
+      if (i == 1)
+        return Q14 * ((1.0 + r) * (1.0 - s) - t - ration);
+      if (i == 2)
+        return Q14 * ((1.0 - r) * (1.0 + s) - t - ration);
+      if (i == 3)
+        return Q14 * ((1.0 + r) * (1.0 + s) - t + ration);
+      else
+        return t;
+    }
+
+  Assert(false, ExcNotImplemented());
+
+  return 0.0;
+}
+
+
+
+template <int dim>
+inline Tensor<1, dim>
+ReferenceCell::d_linear_shape_function_gradient(const Point<dim> & xi,
+                                                const unsigned int i) const
+{
+  AssertDimension(dim, get_dimension());
+  if (*this == get_hypercube<dim>())
+    return GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i);
+
+  if (*this ==
+      ReferenceCell::Tri) // see also Simplex::ScalarPolynomial::compute_grad
+    {
+      switch (i)
+        {
+          case 0:
+            return Point<dim>(-1.0, -1.0);
+          case 1:
+            return Point<dim>(+1.0, +0.0);
+          case 2:
+            return Point<dim>(+0.0, +1.0);
+        }
+    }
+
+  Assert(false, ExcNotImplemented());
+
+  return Point<dim>(+0.0, +0.0, +0.0);
+}
+
+
+template <int dim>
+inline Tensor<1, dim>
+ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
+                                       const unsigned int i) const
+{
+  AssertDimension(dim, get_dimension());
+  AssertIndexRange(i, dim - 1);
+
+  if (*this == get_hypercube<dim>())
+    {
+      AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
+      return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
+    }
+  else if (*this == ReferenceCell::Tri)
+    {
+      AssertIndexRange(face_no, 3);
+      static const std::array<Tensor<1, dim>, 3> table = {
+        {Point<dim>(1, 0),
+         Point<dim>(-std::sqrt(0.5), +std::sqrt(0.5)),
+         Point<dim>(0, -1)}};
+
+      return table[face_no];
+    }
+  else if (*this == ReferenceCell::Tet)
+    {
+      AssertIndexRange(face_no, 4);
+      static const std::array<std::array<Tensor<1, dim>, 2>, 4> table = {
+        {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+         {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+         {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
+         {{Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
+                      +std::pow(1.0 / 3.0, 1.0 / 4.0),
+                      0),
+           Point<dim>(-std::pow(1.0 / 3.0, 1.0 / 4.0),
+                      0,
+                      +std::pow(1.0 / 3.0, 1.0 / 4.0))}}}};
+
+      return table[face_no][i];
+    }
+  else if (*this == ReferenceCell::Wedge)
+    {
+      AssertIndexRange(face_no, 5);
+      static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
+        {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+         {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}},
+         {{Point<dim>(-1 / std::sqrt(2.0), +1 / std::sqrt(2.0), 0),
+           Point<dim>(0, 0, 1)}},
+         {{Point<dim>(0, 0, 1), Point<dim>(0, 1, 0)}},
+         {{Point<dim>(1, 0, 0), Point<dim>(0, 0, 1)}}}};
+
+      return table[face_no][i];
+    }
+  else if (*this == ReferenceCell::Pyramid)
+    {
+      AssertIndexRange(face_no, 5);
+      static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
+        {{{Point<dim>(0, 1, 0), Point<dim>(1, 0, 0)}},
+         {{Point<dim>(+1.0 / sqrt(2.0), 0, +1.0 / sqrt(2.0)),
+           Point<dim>(0, 1, 0)}},
+         {{Point<dim>(+1.0 / sqrt(2.0), 0, -1.0 / sqrt(2.0)),
+           Point<dim>(0, 1, 0)}},
+         {{Point<dim>(1, 0, 0),
+           Point<dim>(0, +1.0 / sqrt(2.0), +1.0 / sqrt(2.0))}},
+         {{Point<dim>(1, 0, 0),
+           Point<dim>(0, +1.0 / sqrt(2.0), -1.0 / sqrt(2.0))}}}};
+
+      return table[face_no][i];
+    }
+
+  Assert(false, ExcNotImplemented());
+
+  return {};
+}
+
+
+
+template <int dim>
+inline Tensor<1, dim>
+ReferenceCell::unit_normal_vectors(const unsigned int face_no) const
+{
+  AssertDimension(dim, this->get_dimension());
+
+  if (is_hyper_cube())
+    {
+      AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
+      return GeometryInfo<dim>::unit_normal_vector[face_no];
+    }
+  else if (dim == 2)
+    {
+      Assert(*this == Tri, ExcInternalError());
+
+      // Return the rotated vector
+      return cross_product_2d(unit_tangential_vectors<dim>(face_no, 0));
+    }
+  else if (dim == 3)
+    {
+      return cross_product_3d(unit_tangential_vectors<dim>(face_no, 0),
+                              unit_tangential_vectors<dim>(face_no, 1));
+    }
+
+  Assert(false, ExcNotImplemented());
+
+  return {};
+}
+
+/**
+ * Return a default linear mapping that works for the given triangulation.
+ * Internally, this function calls the function above for the reference
+ * cell used by the given triangulation, assuming that the triangulation
+ * uses only a single cell type. If the triangulation uses mixed cell
+ * types, then this function will trigger an exception.
+ */
+template <int dim, int spacedim>
+const Mapping<dim, spacedim> &
+get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation);
+
+namespace internal
+{
+  /**
+   * Check if the bit at position @p n in @p number is set.
+   */
+  inline static bool
+  get_bit(const unsigned char number, const unsigned int n)
   {
-    template <typename T, std::size_t N>
-    class NoPermutation : public dealii::ExceptionBase
-    {
-    public:
-      /**
-       * Constructor.
-       */
-      NoPermutation(const ReferenceCell::Type &entity_type,
-                    const std::array<T, N> &   vertices_0,
-                    const std::array<T, N> &   vertices_1)
-        : entity_type(entity_type)
-        , vertices_0(vertices_0)
-        , vertices_1(vertices_1)
-      {}
+    AssertIndexRange(n, 8);
 
+    // source:
+    // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
+    // "Checking a bit"
+    return (number >> n) & 1U;
+  }
+
+
+
+  /**
+   * Set the bit at position @p n in @p number to value @p x.
+   */
+  inline static void
+  set_bit(unsigned char &number, const unsigned int n, const bool x)
+  {
+    AssertIndexRange(n, 8);
+
+    // source:
+    // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
+    // "Changing the nth bit to x"
+    number ^= (-static_cast<unsigned char>(x) ^ number) & (1U << n);
+  }
+
+  /**
+   * A namespace for geometric information on reference cells.
+   */
+  namespace Info
+  {
+    /**
+     * Interface to be used in TriaAccessor/TriaCellAccessor to access
+     * sub-entities of dimension d' of geometric entities of dimension d, with
+     * 0<=d'<d<=3.
+     */
+    struct Base
+    {
       /**
        * Destructor.
        */
-      virtual ~NoPermutation() noexcept override = default;
+      virtual ~Base() = default;
 
       /**
-       * Print error message to @p out.
+       * Number of vertices.
        */
-      virtual void
-      print_info(std::ostream &out) const override
+      virtual unsigned int
+      n_vertices() const
       {
-        out << "[";
-
-        const unsigned int n_vertices =
-          ReferenceCell::internal::Info::get_cell(entity_type).n_vertices();
-
-        for (unsigned int i = 0; i < n_vertices; ++i)
-          {
-            out << vertices_0[i];
-            if (i + 1 != n_vertices)
-              out << ",";
-          }
-
-        out << "] is not a permutation of [";
-
-        for (unsigned int i = 0; i < n_vertices; ++i)
-          {
-            out << vertices_1[i];
-            if (i + 1 != n_vertices)
-              out << ",";
-          }
-
-        out << "]." << std::endl;
+        Assert(false, ExcNotImplemented());
+        return 0;
       }
 
       /**
-       * Entity type.
+       * Number of lines.
        */
-      const ReferenceCell::Type entity_type;
+      virtual unsigned int
+      n_lines() const
+      {
+        Assert(false, ExcNotImplemented());
+        return 0;
+      }
+
 
       /**
-       * First set of values.
+       * Number of faces.
        */
-      const std::array<T, N> vertices_0;
+      virtual unsigned int
+      n_faces() const
+      {
+        Assert(false, ExcNotImplemented());
+        return 0;
+      }
 
       /**
-       * Second set of values.
+       * Return an object that can be thought of as an array containing all
+       * indices from zero to n_vertices().
        */
-      const std::array<T, N> vertices_1;
+      inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+      vertex_indices() const
+      {
+        return {0U, n_vertices()};
+      }
+
+      /**
+       * Return an object that can be thought of as an array containing all
+       * indices from zero to n_lines().
+       */
+      inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+      line_indices() const
+      {
+        return {0U, n_lines()};
+      }
+
+      /**
+       * Return an object that can be thought of as an array containing all
+       * indices from zero to n_faces().
+       */
+      inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+      face_indices() const
+      {
+        return {0U, n_faces()};
+      }
+
+      /**
+       * Standard decomposition of vertex index into face and face-vertex
+       * index.
+       */
+      virtual std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(const unsigned int vertex) const
+      {
+        Assert(false, ExcNotImplemented());
+
+        (void)vertex;
+
+        return {{0u, 0u}};
+      }
+
+      /**
+       * Standard decomposition of line index into face and face-line index.
+       */
+      virtual std::array<unsigned int, 2>
+      standard_line_to_face_and_line_index(const unsigned int line) const
+      {
+        Assert(false, ExcNotImplemented());
+
+        (void)line;
+
+        return {{0, 0}};
+      }
+
+      /**
+       * Correct vertex index depending on face orientation.
+       */
+      virtual unsigned int
+      standard_to_real_face_vertex(const unsigned int  vertex,
+                                   const unsigned int  face,
+                                   const unsigned char face_orientation) const
+      {
+        Assert(false, ExcNotImplemented());
+
+        (void)vertex;
+        (void)face;
+        (void)face_orientation;
+
+        return 0;
+      }
+
+      /**
+       * Correct line index depending on face orientation.
+       */
+      virtual unsigned int
+      standard_to_real_face_line(const unsigned int  line,
+                                 const unsigned int  face,
+                                 const unsigned char face_orientation) const
+      {
+        Assert(false, ExcNotImplemented());
+
+        (void)line;
+        (void)face;
+        (void)face_orientation;
+
+        return 0;
+      }
+
+      /**
+       * Combine face and line orientation.
+       */
+      virtual bool
+      combine_face_and_line_orientation(
+        const unsigned int  line,
+        const unsigned char face_orientation,
+        const unsigned char line_orientation) const
+      {
+        Assert(false, ExcNotImplemented());
+
+        (void)line;
+        (void)face_orientation;
+        (void)line_orientation;
+
+        return true;
+      }
+
+      /**
+       * Return reference-cell type of face @p face_no.
+       */
+      virtual dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)face_no;
+
+        return dealii::ReferenceCell::Invalid;
+      }
+
+      /**
+       * Map face line number to cell line number.
+       */
+      virtual unsigned int
+      face_to_cell_lines(const unsigned int  face,
+                         const unsigned int  line,
+                         const unsigned char face_orientation) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)face;
+        (void)line;
+        (void)face_orientation;
+
+        return 0;
+      }
+
+      /**
+       * Map face vertex number to cell vertex number.
+       */
+      virtual unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)face;
+        (void)vertex;
+        (void)face_orientation;
+
+        return 0;
+      }
+
+      /**
+       * Map an ExodusII vertex number to a deal.II vertex number.
+       */
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)vertex_n;
+
+        return 0;
+      }
+
+      /**
+       * Map an ExodusII face number to a deal.II face number.
+       */
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)face_n;
+
+        return 0;
+      }
+
+      /**
+       * Indices of child cells that are adjacent to a certain face of the
+       * mother cell.
+       */
+      virtual unsigned int
+      child_cell_on_face(const unsigned int face_n,
+                         const unsigned int subface_n) const
+      {
+        Assert(false, ExcNotImplemented());
+        (void)face_n;
+        (void)subface_n;
+
+        return numbers::invalid_unsigned_int;
+      }
     };
-  } // namespace internal
+
+
+    /**
+     * Base class for tensor-product geometric entities.
+     */
+    template <int dim>
+    struct TensorProductBase : Base
+    {
+      unsigned int
+      n_vertices() const override
+      {
+        return GeometryInfo<dim>::vertices_per_cell;
+      }
+
+      unsigned int
+      n_lines() const override
+      {
+        return GeometryInfo<dim>::lines_per_cell;
+      }
+
+      unsigned int
+      n_faces() const override
+      {
+        return GeometryInfo<dim>::faces_per_cell;
+      }
+
+      unsigned int
+      face_to_cell_lines(const unsigned int  face,
+                         const unsigned int  line,
+                         const unsigned char face_orientation) const override
+      {
+        return GeometryInfo<dim>::face_to_cell_lines(
+          face,
+          line,
+          get_bit(face_orientation, 0),
+          get_bit(face_orientation, 2),
+          get_bit(face_orientation, 1));
+      }
+
+      unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const override
+      {
+        return GeometryInfo<dim>::face_to_cell_vertices(
+          face,
+          vertex,
+          get_bit(face_orientation, 0),
+          get_bit(face_orientation, 2),
+          get_bit(face_orientation, 1));
+      }
+    };
 
 
 
+    /*
+     * Vertex.
+     */
+    struct Vertex : public TensorProductBase<0>
+    {
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+        return dealii::ReferenceCell::Invalid;
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        (void)face_n;
+        AssertIndexRange(face_n, n_faces());
+
+        return 0;
+      }
+    };
+
+
+
+    /*
+     * Line.
+     */
+    struct Line : public TensorProductBase<1>
+    {
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+        return dealii::ReferenceCell::Vertex;
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        return vertex_n;
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        return face_n;
+      }
+    };
+
+
+
+    /**
+     * Triangle.
+     */
+    struct Tri : public Base
+    {
+      unsigned int
+      n_vertices() const override
+      {
+        return 3;
+      }
+
+      unsigned int
+      n_lines() const override
+      {
+        return 3;
+      }
+
+      unsigned int
+      n_faces() const override
+      {
+        return this->n_lines();
+      }
+
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        AssertIndexRange(vertex, 3);
+
+        static const std::array<std::array<unsigned int, 2>, 3> table = {
+          {{{0, 0}}, {{0, 1}}, {{1, 1}}}};
+
+        return table[vertex];
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char line_orientation) const override
+      {
+        (void)face;
+
+        static const std::array<std::array<unsigned int, 2>, 2> table = {
+          {{{1, 0}}, {{0, 1}}}};
+
+        return table[line_orientation][vertex];
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+
+        AssertIndexRange(face_no, n_faces());
+
+        return dealii::ReferenceCell::Line;
+      }
+
+      unsigned int
+      face_to_cell_lines(const unsigned int  face,
+                         const unsigned int  line,
+                         const unsigned char face_orientation) const override
+      {
+        AssertIndexRange(face, n_faces());
+        AssertDimension(line, 0);
+
+        (void)line;
+        (void)face_orientation;
+
+        return face;
+      }
+
+      unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const override
+      {
+        static const std::array<std::array<unsigned int, 2>, 3> table = {
+          {{{0, 1}}, {{1, 2}}, {{2, 0}}}};
+
+        return table[face][face_orientation ? vertex : (1 - vertex)];
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        return vertex_n;
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        return face_n;
+      }
+
+      virtual unsigned int
+      child_cell_on_face(const unsigned int face_n,
+                         const unsigned int subface_n) const override
+      {
+        static constexpr unsigned int subcells[3][2] = {{0, 1}, {1, 2}, {2, 0}};
+
+        return subcells[face_n][subface_n];
+      }
+    };
+
+
+
+    /**
+     * Quad.
+     */
+    struct Quad : public TensorProductBase<2>
+    {
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        return GeometryInfo<2>::standard_quad_vertex_to_line_vertex_index(
+          vertex);
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char line_orientation) const override
+      {
+        (void)face;
+
+        return GeometryInfo<2>::standard_to_real_line_vertex(vertex,
+                                                             line_orientation);
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+        return dealii::ReferenceCell::Line;
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        constexpr std::array<unsigned int, 4> exodus_to_deal{{0, 1, 3, 2}};
+        return exodus_to_deal[vertex_n];
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        constexpr std::array<unsigned int, 4> exodus_to_deal{{2, 1, 3, 0}};
+        return exodus_to_deal[face_n];
+      }
+    };
+
+
+
+    /**
+     * Tet.
+     */
+    struct Tet : public Base
+    {
+      unsigned int
+      n_vertices() const override
+      {
+        return 4;
+      }
+
+      unsigned int
+      n_lines() const override
+      {
+        return 6;
+      }
+
+      unsigned int
+      n_faces() const override
+      {
+        return 4;
+      }
+
+      std::array<unsigned int, 2>
+      standard_line_to_face_and_line_index(
+        const unsigned int line) const override
+      {
+        static const std::array<unsigned int, 2> table[6] = {
+          {{0, 0}}, {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}};
+
+        return table[line];
+      }
+
+      unsigned int
+      standard_to_real_face_line(
+        const unsigned int  line,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        (void)face;
+
+        static const std::array<std::array<unsigned int, 3>, 6> table = {
+          {{{2, 1, 0}},
+           {{0, 1, 2}},
+           {{1, 0, 2}},
+           {{1, 2, 0}},
+           {{0, 2, 1}},
+           {{2, 0, 1}}}};
+
+        return table[face_orientation][line];
+      }
+
+      bool
+      combine_face_and_line_orientation(
+        const unsigned int  line,
+        const unsigned char face_orientation_raw,
+        const unsigned char line_orientation) const override
+      {
+        (void)line;
+        (void)face_orientation_raw;
+
+        return line_orientation;
+      }
+
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        AssertIndexRange(vertex, 4);
+
+        static const std::array<unsigned int, 2> table[4] = {{{0, 0}},
+                                                             {{0, 1}},
+                                                             {{0, 2}},
+                                                             {{1, 2}}};
+
+        return table[vertex];
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        AssertIndexRange(face_orientation, 6);
+        (void)face;
+
+        static const std::array<std::array<unsigned int, 3>, 6> table = {
+          {{{0, 2, 1}},
+           {{0, 1, 2}},
+           {{2, 1, 0}},
+           {{1, 2, 0}},
+           {{1, 0, 2}},
+           {{2, 0, 1}}}};
+
+        return table[face_orientation][vertex];
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+
+        AssertIndexRange(face_no, n_faces());
+
+        return dealii::ReferenceCell::Tri;
+      }
+
+      unsigned int
+      face_to_cell_lines(const unsigned int  face,
+                         const unsigned int  line,
+                         const unsigned char face_orientation) const override
+      {
+        AssertIndexRange(face, n_faces());
+
+        const static std::array<std::array<unsigned int, 3>, 4> table = {
+          {{{0, 1, 2}}, {{0, 3, 4}}, {{2, 5, 3}}, {{1, 4, 5}}}};
+
+        return table[face]
+                    [standard_to_real_face_line(line, face, face_orientation)];
+      }
+
+      unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const override
+      {
+        static const std::array<std::array<unsigned int, 3>, 4> table = {
+          {{{0, 1, 2}}, {{1, 0, 3}}, {{0, 2, 3}}, {{2, 1, 3}}}};
+
+        return table[face][standard_to_real_face_vertex(
+          vertex, face, face_orientation)];
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        return vertex_n;
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        constexpr std::array<unsigned int, 4> exodus_to_deal{{1, 3, 2, 0}};
+        return exodus_to_deal[face_n];
+      }
+    };
+
+
+
+    /**
+     * Pyramid.
+     */
+    struct Pyramid : public Base
+    {
+      unsigned int
+      n_vertices() const override
+      {
+        return 5;
+      }
+
+      unsigned int
+      n_lines() const override
+      {
+        return 8;
+      }
+
+      unsigned int
+      n_faces() const override
+      {
+        return 5;
+      }
+
+      std::array<unsigned int, 2>
+      standard_line_to_face_and_line_index(
+        const unsigned int line) const override
+      {
+        static const std::array<unsigned int, 2> table[8] = {{{0, 0}},
+                                                             {{0, 1}},
+                                                             {{0, 2}},
+                                                             {{0, 3}},
+                                                             {{1, 2}},
+                                                             {{2, 1}},
+                                                             {{1, 1}},
+                                                             {{2, 2}}};
+
+        return table[line];
+      }
+
+      unsigned int
+      standard_to_real_face_line(
+        const unsigned int  line,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        if (face == 0) // QUAD
+          {
+            return GeometryInfo<3>::standard_to_real_face_line(
+              line,
+              get_bit(face_orientation, 0),
+              get_bit(face_orientation, 2),
+              get_bit(face_orientation, 1));
+          }
+        else // TRI
+          {
+            static const std::array<std::array<unsigned int, 3>, 6> table = {
+              {{{2, 1, 0}},
+               {{0, 1, 2}},
+               {{1, 0, 2}},
+               {{1, 2, 0}},
+               {{0, 2, 1}},
+               {{2, 0, 1}}}};
+
+            return table[face_orientation][line];
+          }
+      }
+
+      bool
+      combine_face_and_line_orientation(
+        const unsigned int  line,
+        const unsigned char face_orientation_raw,
+        const unsigned char line_orientation) const override
+      {
+        (void)line;
+        (void)face_orientation_raw;
+
+        return line_orientation;
+      }
+
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        static const std::array<unsigned int, 2> table[5] = {
+          {{0, 0}}, {{0, 1}}, {{0, 2}}, {{0, 3}}, {{1, 2}}};
+
+        return table[vertex];
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        if (face == 0) // Quad
+          {
+            return GeometryInfo<3>::standard_to_real_face_vertex(
+              vertex,
+              get_bit(face_orientation, 0),
+              get_bit(face_orientation, 2),
+              get_bit(face_orientation, 1));
+          }
+        else // Tri
+          {
+            static const std::array<std::array<unsigned int, 3>, 6> table = {
+              {{{0, 2, 1}},
+               {{0, 1, 2}},
+               {{2, 1, 0}},
+               {{1, 2, 0}},
+               {{1, 0, 2}},
+               {{2, 0, 1}}}};
+
+            return table[face_orientation][vertex];
+          }
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        AssertIndexRange(face_no, n_faces());
+
+        if (face_no == 0)
+          return dealii::ReferenceCell::Quad;
+        else
+          return dealii::ReferenceCell::Tri;
+      }
+
+      unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const override
+      {
+        AssertIndexRange(face, n_faces());
+        if (face == 0)
+          {
+            AssertIndexRange(vertex, 4);
+          }
+        else
+          {
+            AssertIndexRange(vertex, 3);
+          }
+        constexpr auto X = numbers::invalid_unsigned_int;
+        static const std::array<std::array<unsigned int, 4>, 5> table = {
+          {{{0, 1, 2, 3}},
+           {{0, 2, 4, X}},
+           {{3, 1, 4, X}},
+           {{1, 0, 4, X}},
+           {{2, 3, 4, X}}}};
+
+        return table[face][standard_to_real_face_vertex(
+          vertex, face, face_orientation)];
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        constexpr std::array<unsigned int, 5> exodus_to_deal{{0, 1, 3, 2, 4}};
+        return exodus_to_deal[vertex_n];
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        constexpr std::array<unsigned int, 5> exodus_to_deal{{3, 2, 4, 1, 0}};
+        return exodus_to_deal[face_n];
+      }
+    };
+
+
+
+    /**
+     * Wedge.
+     */
+    struct Wedge : public Base
+    {
+      unsigned int
+      n_vertices() const override
+      {
+        return 6;
+      }
+
+      unsigned int
+      n_lines() const override
+      {
+        return 9;
+      }
+
+      unsigned int
+      n_faces() const override
+      {
+        return 5;
+      }
+
+      std::array<unsigned int, 2>
+      standard_line_to_face_and_line_index(
+        const unsigned int line) const override
+      {
+        static const std::array<unsigned int, 2> table[9] = {{{0, 0}},
+                                                             {{0, 2}},
+                                                             {{0, 1}},
+                                                             {{1, 0}},
+                                                             {{1, 1}},
+                                                             {{1, 2}},
+                                                             {{2, 0}},
+                                                             {{2, 1}},
+                                                             {{3, 1}}};
+
+        return table[line];
+      }
+
+      unsigned int
+      standard_to_real_face_line(
+        const unsigned int  line,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        if (face > 1) // QUAD
+          {
+            return GeometryInfo<3>::standard_to_real_face_line(
+              line,
+              get_bit(face_orientation, 0),
+              get_bit(face_orientation, 2),
+              get_bit(face_orientation, 1));
+          }
+        else // TRI
+          {
+            static const std::array<std::array<unsigned int, 3>, 6> table = {
+              {{{2, 1, 0}},
+               {{0, 1, 2}},
+               {{1, 0, 2}},
+               {{1, 2, 0}},
+               {{0, 2, 1}},
+               {{2, 0, 1}}}};
+
+            return table[face_orientation][line];
+          }
+      }
+
+      bool
+      combine_face_and_line_orientation(
+        const unsigned int  line,
+        const unsigned char face_orientation_raw,
+        const unsigned char line_orientation) const override
+      {
+        (void)line;
+        (void)face_orientation_raw;
+
+        return line_orientation;
+      }
+
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        static const std::array<std::array<unsigned int, 2>, 6> table = {
+          {{{0, 1}}, {{0, 0}}, {{0, 2}}, {{1, 0}}, {{1, 1}}, {{1, 2}}}};
+
+        return table[vertex];
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        if (face > 1) // QUAD
+          {
+            return GeometryInfo<3>::standard_to_real_face_vertex(
+              vertex,
+              get_bit(face_orientation, 0),
+              get_bit(face_orientation, 2),
+              get_bit(face_orientation, 1));
+          }
+        else // TRI
+          {
+            static const std::array<std::array<unsigned int, 3>, 6> table = {
+              {{{0, 2, 1}},
+               {{0, 1, 2}},
+               {{2, 1, 0}},
+               {{1, 2, 0}},
+               {{1, 0, 2}},
+               {{2, 0, 1}}}};
+
+            return table[face_orientation][vertex];
+          }
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        AssertIndexRange(face_no, n_faces());
+
+        if (face_no > 1)
+          return dealii::ReferenceCell::Quad;
+        else
+          return dealii::ReferenceCell::Tri;
+      }
+
+      unsigned int
+      face_to_cell_vertices(const unsigned int  face,
+                            const unsigned int  vertex,
+                            const unsigned char face_orientation) const override
+      {
+        AssertIndexRange(face, n_faces());
+        if (face < 2)
+          {
+            AssertIndexRange(vertex, 3);
+          }
+        else
+          {
+            AssertIndexRange(vertex, 4);
+          }
+        constexpr auto X = numbers::invalid_unsigned_int;
+        static const std::array<std::array<unsigned int, 4>, 6> table = {
+          {{{1, 0, 2, X}},
+           {{3, 4, 5, X}},
+           {{0, 1, 3, 4}},
+           {{1, 2, 4, 5}},
+           {{2, 0, 5, 3}}}};
+
+        return table[face][standard_to_real_face_vertex(
+          vertex, face, face_orientation)];
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        constexpr std::array<unsigned int, 6> exodus_to_deal{
+          {2, 1, 0, 5, 4, 3}};
+        return exodus_to_deal[vertex_n];
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        constexpr std::array<unsigned int, 6> exodus_to_deal{{3, 4, 2, 0, 1}};
+        return exodus_to_deal[face_n];
+      }
+    };
+
+
+
+    /**
+     * Hex.
+     */
+    struct Hex : public TensorProductBase<3>
+    {
+      std::array<unsigned int, 2>
+      standard_line_to_face_and_line_index(
+        const unsigned int line) const override
+      {
+        return GeometryInfo<3>::standard_hex_line_to_quad_line_index(line);
+      }
+
+      unsigned int
+      standard_to_real_face_line(
+        const unsigned int  line,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        (void)face;
+
+        return GeometryInfo<3>::standard_to_real_face_line(
+          line,
+          get_bit(face_orientation, 0),
+          get_bit(face_orientation, 2),
+          get_bit(face_orientation, 1));
+      }
+
+      bool
+      combine_face_and_line_orientation(
+        const unsigned int  line,
+        const unsigned char face_orientation_raw,
+        const unsigned char line_orientation) const override
+      {
+        static const bool bool_table[2][2][2][2] = {
+          {{{true, false},    // lines 0/1, face_orientation=false,
+                              // face_flip=false, face_rotation=false and true
+            {false, true}},   // lines 0/1, face_orientation=false,
+                              // face_flip=true, face_rotation=false and true
+           {{true, true},     // lines 0/1, face_orientation=true,
+                              // face_flip=false, face_rotation=false and true
+            {false, false}}}, // lines 0/1, face_orientation=true,
+                              // face_flip=true, face_rotation=false and true
+
+          {{{true, true}, // lines 2/3 ...
+            {false, false}},
+           {{true, false}, {false, true}}}};
+
+        const bool face_orientation = get_bit(face_orientation_raw, 0);
+        const bool face_flip        = get_bit(face_orientation_raw, 2);
+        const bool face_rotation    = get_bit(face_orientation_raw, 1);
+
+        return (
+          static_cast<bool>(line_orientation) ==
+          bool_table[line / 2][face_orientation][face_flip][face_rotation]);
+      }
+
+      std::array<unsigned int, 2>
+      standard_vertex_to_face_and_vertex_index(
+        const unsigned int vertex) const override
+      {
+        return GeometryInfo<3>::standard_hex_vertex_to_quad_vertex_index(
+          vertex);
+      }
+
+      unsigned int
+      standard_to_real_face_vertex(
+        const unsigned int  vertex,
+        const unsigned int  face,
+        const unsigned char face_orientation) const override
+      {
+        (void)face;
+
+        return GeometryInfo<3>::standard_to_real_face_vertex(
+          vertex,
+          get_bit(face_orientation, 0),
+          get_bit(face_orientation, 2),
+          get_bit(face_orientation, 1));
+      }
+
+      dealii::ReferenceCell
+      face_reference_cell_type(const unsigned int face_no) const override
+      {
+        (void)face_no;
+        return dealii::ReferenceCell::Quad;
+      }
+
+      virtual unsigned int
+      exodusii_vertex_to_deal_vertex(const unsigned int vertex_n) const override
+      {
+        AssertIndexRange(vertex_n, n_vertices());
+        constexpr std::array<unsigned int, 8> exodus_to_deal{
+          {0, 1, 3, 2, 4, 5, 7, 6}};
+        return exodus_to_deal[vertex_n];
+      }
+
+      virtual unsigned int
+      exodusii_face_to_deal_face(const unsigned int face_n) const override
+      {
+        AssertIndexRange(face_n, n_faces());
+        constexpr std::array<unsigned int, 6> exodus_to_deal{
+          {2, 1, 3, 0, 4, 5}};
+        return exodus_to_deal[face_n];
+      }
+    };
+
+    /**
+     * Return for a given reference-cell type the right Info.
+     */
+    inline const internal::Info::Base &
+    get_cell(const dealii::ReferenceCell &type)
+    {
+      static const std::array<std::unique_ptr<internal::Info::Base>, 8> gei{
+        {std::make_unique<internal::Info::Vertex>(),
+         std::make_unique<internal::Info::Line>(),
+         std::make_unique<internal::Info::Tri>(),
+         std::make_unique<internal::Info::Quad>(),
+         std::make_unique<internal::Info::Tet>(),
+         std::make_unique<internal::Info::Pyramid>(),
+         std::make_unique<internal::Info::Wedge>(),
+         std::make_unique<internal::Info::Hex>()}};
+      AssertIndexRange(static_cast<std::uint8_t>(type), 8);
+      return *gei[static_cast<std::uint8_t>(type)];
+    }
+
+    /**
+     * Return for a given reference-cell type @p and face number @p face_no the
+     * right Info of the @p face_no-th face.
+     */
+    inline const internal::Info::Base &
+    get_face(const dealii::ReferenceCell &type, const unsigned int face_no)
+    {
+      return get_cell(get_cell(type).face_reference_cell_type(face_no));
+    }
+
+  } // namespace Info
+} // namespace internal
+
+
+
+namespace internal
+{
   template <typename T, std::size_t N>
-  inline unsigned char
-  Type::compute_orientation(const std::array<T, N> &vertices_0,
-                            const std::array<T, N> &vertices_1) const
+  class NoPermutation : public dealii::ExceptionBase
   {
-    AssertIndexRange(
-      ReferenceCell::internal::Info::get_cell(*this).n_vertices(), N + 1);
-    if (*this == ReferenceCell::Type::Line)
-      {
-        const std::array<T, 2> i{{vertices_0[0], vertices_0[1]}};
-        const std::array<T, 2> j{{vertices_1[0], vertices_1[1]}};
+  public:
+    /**
+     * Constructor.
+     */
+    NoPermutation(const dealii::ReferenceCell &entity_type,
+                  const std::array<T, N> &     vertices_0,
+                  const std::array<T, N> &     vertices_1)
+      : entity_type(entity_type)
+      , vertices_0(vertices_0)
+      , vertices_1(vertices_1)
+    {}
 
-        // line_orientation=true
-        if (i == std::array<T, 2>{{j[0], j[1]}})
-          return 1;
+    /**
+     * Destructor.
+     */
+    virtual ~NoPermutation() noexcept override = default;
 
-        // line_orientation=false
-        if (i == std::array<T, 2>{{j[1], j[0]}})
-          return 0;
-      }
-    else if (*this == ReferenceCell::Type::Tri)
-      {
-        const std::array<T, 3> i{{vertices_0[0], vertices_0[1], vertices_0[2]}};
-        const std::array<T, 3> j{{vertices_1[0], vertices_1[1], vertices_1[2]}};
+    /**
+     * Print error message to @p out.
+     */
+    virtual void
+    print_info(std::ostream &out) const override
+    {
+      out << "[";
 
-        // face_orientation=true, face_rotation=false, face_flip=false
-        if (i == std::array<T, 3>{{j[0], j[1], j[2]}})
-          return 1;
+      const unsigned int n_vertices =
+        internal::Info::get_cell(entity_type).n_vertices();
 
-        // face_orientation=true, face_rotation=true, face_flip=false
-        if (i == std::array<T, 3>{{j[1], j[2], j[0]}})
-          return 3;
+      for (unsigned int i = 0; i < n_vertices; ++i)
+        {
+          out << vertices_0[i];
+          if (i + 1 != n_vertices)
+            out << ",";
+        }
 
-        // face_orientation=true, face_rotation=false, face_flip=true
-        if (i == std::array<T, 3>{{j[2], j[0], j[1]}})
-          return 5;
+      out << "] is not a permutation of [";
 
-        // face_orientation=false, face_rotation=false, face_flip=false
-        if (i == std::array<T, 3>{{j[0], j[2], j[1]}})
-          return 0;
+      for (unsigned int i = 0; i < n_vertices; ++i)
+        {
+          out << vertices_1[i];
+          if (i + 1 != n_vertices)
+            out << ",";
+        }
 
-        // face_orientation=false, face_rotation=true, face_flip=false
-        if (i == std::array<T, 3>{{j[2], j[1], j[0]}})
-          return 2;
+      out << "]." << std::endl;
+    }
 
-        // face_orientation=false, face_rotation=false, face_flip=true
-        if (i == std::array<T, 3>{{j[1], j[0], j[2]}})
-          return 4;
-      }
-    else if (*this == ReferenceCell::Type::Quad)
-      {
-        const std::array<T, 4> i{
-          {vertices_0[0], vertices_0[1], vertices_0[2], vertices_0[3]}};
-        const std::array<T, 4> j{
-          {vertices_1[0], vertices_1[1], vertices_1[2], vertices_1[3]}};
+    /**
+     * Entity type.
+     */
+    const dealii::ReferenceCell entity_type;
 
-        // face_orientation=true, face_rotation=false, face_flip=false
-        if (i == std::array<T, 4>{{j[0], j[1], j[2], j[3]}})
-          return 1;
+    /**
+     * First set of values.
+     */
+    const std::array<T, N> vertices_0;
 
-        // face_orientation=true, face_rotation=true, face_flip=false
-        if (i == std::array<T, 4>{{j[2], j[0], j[3], j[1]}})
-          return 3;
-
-        // face_orientation=true, face_rotation=false, face_flip=true
-        if (i == std::array<T, 4>{{j[3], j[2], j[1], j[0]}})
-          return 5;
-
-        // face_orientation=true, face_rotation=true, face_flip=true
-        if (i == std::array<T, 4>{{j[1], j[3], j[0], j[2]}})
-          return 7;
-
-        // face_orientation=false, face_rotation=false, face_flip=false
-        if (i == std::array<T, 4>{{j[0], j[2], j[1], j[3]}})
-          return 0;
-
-        // face_orientation=false, face_rotation=true, face_flip=false
-        if (i == std::array<T, 4>{{j[2], j[3], j[0], j[1]}})
-          return 2;
-
-        // face_orientation=false, face_rotation=false, face_flip=true
-        if (i == std::array<T, 4>{{j[3], j[1], j[2], j[0]}})
-          return 4;
-
-        // face_orientation=false, face_rotation=true, face_flip=true
-        if (i == std::array<T, 4>{{j[1], j[0], j[3], j[2]}})
-          return 6;
-      }
-
-    Assert(false,
-           (internal::NoPermutation<T, N>(*this, vertices_0, vertices_1)));
-
-    return -1;
-  }
+    /**
+     * Second set of values.
+     */
+    const std::array<T, N> vertices_1;
+  };
+} // namespace internal
 
 
 
-  template <typename T, std::size_t N>
-  inline std::array<T, N>
-  Type::permute_according_orientation(const std::array<T, N> &vertices,
-                                      const unsigned int      orientation) const
-  {
-    std::array<T, 4> temp;
+template <typename T, std::size_t N>
+inline unsigned char
+ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
+                                   const std::array<T, N> &vertices_1) const
+{
+  AssertIndexRange(internal::Info::get_cell(*this).n_vertices(), N + 1);
+  if (*this == ReferenceCell::Line)
+    {
+      const std::array<T, 2> i{{vertices_0[0], vertices_0[1]}};
+      const std::array<T, 2> j{{vertices_1[0], vertices_1[1]}};
 
-    if (*this == ReferenceCell::Type::Line)
-      {
-        switch (orientation)
-          {
-            case 1:
-              temp = {{vertices[0], vertices[1]}};
-              break;
-            case 0:
-              temp = {{vertices[1], vertices[0]}};
-              break;
-            default:
-              Assert(false, ExcNotImplemented());
-          }
-      }
-    else if (*this == ReferenceCell::Type::Tri)
-      {
-        switch (orientation)
-          {
-            case 1:
-              temp = {{vertices[0], vertices[1], vertices[2]}};
-              break;
-            case 3:
-              temp = {{vertices[1], vertices[2], vertices[0]}};
-              break;
-            case 5:
-              temp = {{vertices[2], vertices[0], vertices[1]}};
-              break;
-            case 0:
-              temp = {{vertices[0], vertices[2], vertices[1]}};
-              break;
-            case 2:
-              temp = {{vertices[2], vertices[1], vertices[0]}};
-              break;
-            case 4:
-              temp = {{vertices[1], vertices[0], vertices[2]}};
-              break;
-            default:
-              Assert(false, ExcNotImplemented());
-          }
-      }
-    else if (*this == ReferenceCell::Type::Quad)
-      {
-        switch (orientation)
-          {
-            case 1:
-              temp = {{vertices[0], vertices[1], vertices[2], vertices[3]}};
-              break;
-            case 3:
-              temp = {{vertices[2], vertices[0], vertices[3], vertices[1]}};
-              break;
-            case 5:
-              temp = {{vertices[3], vertices[2], vertices[1], vertices[0]}};
-              break;
-            case 7:
-              temp = {{vertices[1], vertices[3], vertices[0], vertices[2]}};
-              break;
-            case 0:
-              temp = {{vertices[0], vertices[2], vertices[1], vertices[3]}};
-              break;
-            case 2:
-              temp = {{vertices[2], vertices[3], vertices[0], vertices[1]}};
-              break;
-            case 4:
-              temp = {{vertices[3], vertices[1], vertices[2], vertices[0]}};
-              break;
-            case 6:
-              temp = {{vertices[1], vertices[0], vertices[3], vertices[2]}};
-              break;
-            default:
-              Assert(false, ExcNotImplemented());
-          }
-      }
-    else
-      {
-        AssertThrow(false, ExcNotImplemented());
-      }
+      // line_orientation=true
+      if (i == std::array<T, 2>{{j[0], j[1]}})
+        return 1;
 
-    std::array<T, N> temp_;
-    std::copy_n(temp.begin(), N, temp_.begin());
+      // line_orientation=false
+      if (i == std::array<T, 2>{{j[1], j[0]}})
+        return 0;
+    }
+  else if (*this == ReferenceCell::Tri)
+    {
+      const std::array<T, 3> i{{vertices_0[0], vertices_0[1], vertices_0[2]}};
+      const std::array<T, 3> j{{vertices_1[0], vertices_1[1], vertices_1[2]}};
 
-    return temp_;
-  }
+      // face_orientation=true, face_rotation=false, face_flip=false
+      if (i == std::array<T, 3>{{j[0], j[1], j[2]}})
+        return 1;
 
-} // namespace ReferenceCell
+      // face_orientation=true, face_rotation=true, face_flip=false
+      if (i == std::array<T, 3>{{j[1], j[2], j[0]}})
+        return 3;
+
+      // face_orientation=true, face_rotation=false, face_flip=true
+      if (i == std::array<T, 3>{{j[2], j[0], j[1]}})
+        return 5;
+
+      // face_orientation=false, face_rotation=false, face_flip=false
+      if (i == std::array<T, 3>{{j[0], j[2], j[1]}})
+        return 0;
+
+      // face_orientation=false, face_rotation=true, face_flip=false
+      if (i == std::array<T, 3>{{j[2], j[1], j[0]}})
+        return 2;
+
+      // face_orientation=false, face_rotation=false, face_flip=true
+      if (i == std::array<T, 3>{{j[1], j[0], j[2]}})
+        return 4;
+    }
+  else if (*this == ReferenceCell::Quad)
+    {
+      const std::array<T, 4> i{
+        {vertices_0[0], vertices_0[1], vertices_0[2], vertices_0[3]}};
+      const std::array<T, 4> j{
+        {vertices_1[0], vertices_1[1], vertices_1[2], vertices_1[3]}};
+
+      // face_orientation=true, face_rotation=false, face_flip=false
+      if (i == std::array<T, 4>{{j[0], j[1], j[2], j[3]}})
+        return 1;
+
+      // face_orientation=true, face_rotation=true, face_flip=false
+      if (i == std::array<T, 4>{{j[2], j[0], j[3], j[1]}})
+        return 3;
+
+      // face_orientation=true, face_rotation=false, face_flip=true
+      if (i == std::array<T, 4>{{j[3], j[2], j[1], j[0]}})
+        return 5;
+
+      // face_orientation=true, face_rotation=true, face_flip=true
+      if (i == std::array<T, 4>{{j[1], j[3], j[0], j[2]}})
+        return 7;
+
+      // face_orientation=false, face_rotation=false, face_flip=false
+      if (i == std::array<T, 4>{{j[0], j[2], j[1], j[3]}})
+        return 0;
+
+      // face_orientation=false, face_rotation=true, face_flip=false
+      if (i == std::array<T, 4>{{j[2], j[3], j[0], j[1]}})
+        return 2;
+
+      // face_orientation=false, face_rotation=false, face_flip=true
+      if (i == std::array<T, 4>{{j[3], j[1], j[2], j[0]}})
+        return 4;
+
+      // face_orientation=false, face_rotation=true, face_flip=true
+      if (i == std::array<T, 4>{{j[1], j[0], j[3], j[2]}})
+        return 6;
+    }
+
+  Assert(false, (internal::NoPermutation<T, N>(*this, vertices_0, vertices_1)));
+
+  return -1;
+}
+
+
+
+template <typename T, std::size_t N>
+inline std::array<T, N>
+ReferenceCell::permute_according_orientation(
+  const std::array<T, N> &vertices,
+  const unsigned int      orientation) const
+{
+  std::array<T, 4> temp;
+
+  if (*this == ReferenceCell::Line)
+    {
+      switch (orientation)
+        {
+          case 1:
+            temp = {{vertices[0], vertices[1]}};
+            break;
+          case 0:
+            temp = {{vertices[1], vertices[0]}};
+            break;
+          default:
+            Assert(false, ExcNotImplemented());
+        }
+    }
+  else if (*this == ReferenceCell::Tri)
+    {
+      switch (orientation)
+        {
+          case 1:
+            temp = {{vertices[0], vertices[1], vertices[2]}};
+            break;
+          case 3:
+            temp = {{vertices[1], vertices[2], vertices[0]}};
+            break;
+          case 5:
+            temp = {{vertices[2], vertices[0], vertices[1]}};
+            break;
+          case 0:
+            temp = {{vertices[0], vertices[2], vertices[1]}};
+            break;
+          case 2:
+            temp = {{vertices[2], vertices[1], vertices[0]}};
+            break;
+          case 4:
+            temp = {{vertices[1], vertices[0], vertices[2]}};
+            break;
+          default:
+            Assert(false, ExcNotImplemented());
+        }
+    }
+  else if (*this == ReferenceCell::Quad)
+    {
+      switch (orientation)
+        {
+          case 1:
+            temp = {{vertices[0], vertices[1], vertices[2], vertices[3]}};
+            break;
+          case 3:
+            temp = {{vertices[2], vertices[0], vertices[3], vertices[1]}};
+            break;
+          case 5:
+            temp = {{vertices[3], vertices[2], vertices[1], vertices[0]}};
+            break;
+          case 7:
+            temp = {{vertices[1], vertices[3], vertices[0], vertices[2]}};
+            break;
+          case 0:
+            temp = {{vertices[0], vertices[2], vertices[1], vertices[3]}};
+            break;
+          case 2:
+            temp = {{vertices[2], vertices[3], vertices[0], vertices[1]}};
+            break;
+          case 4:
+            temp = {{vertices[3], vertices[1], vertices[2], vertices[0]}};
+            break;
+          case 6:
+            temp = {{vertices[1], vertices[0], vertices[3], vertices[2]}};
+            break;
+          default:
+            Assert(false, ExcNotImplemented());
+        }
+    }
+  else
+    {
+      AssertThrow(false, ExcNotImplemented());
+    }
+
+  std::array<T, N> temp_;
+  std::copy_n(temp.begin(), N, temp_.begin());
+
+  return temp_;
+}
 
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3388,7 +3388,7 @@ public:
    * Return vector filled with the used reference-cell types of this
    * triangulation.
    */
-  const std::vector<ReferenceCell::Type> &
+  const std::vector<ReferenceCell> &
   get_reference_cell_types() const;
 
   /**
@@ -3511,7 +3511,7 @@ protected:
    * Vector caching all reference-cell types of the given triangulation
    * (also in the distributed case).
    */
-  std::vector<ReferenceCell::Type> reference_cell_types;
+  std::vector<ReferenceCell> reference_cell_types;
 
   /**
    * Write a bool vector to the given stream, writing a pre- and a postfix

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1636,7 +1636,7 @@ public:
   /**
    * Reference cell type of the current object.
    */
-  ReferenceCell::Type
+  ReferenceCell
   reference_cell_type() const;
 
   /**
@@ -1691,7 +1691,7 @@ protected:
    * Return additional information related to the current geometric entity
    * type.
    */
-  inline const ReferenceCell::internal::Info::Base &
+  inline const internal::Info::Base &
   reference_cell_info() const;
 
 private:
@@ -2717,7 +2717,7 @@ public:
   /**
    * Reference cell type of the current object.
    */
-  ReferenceCell::Type
+  ReferenceCell
   reference_cell_type() const;
 
   /**

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -54,22 +54,22 @@ namespace internal
                                            GeometryInfo<dim>::vertices_per_cell>
         vertices)
     {
-      const ReferenceCell::Type reference_cell_type =
-        ReferenceCell::Type::n_vertices_to_type(dim, vertices.size());
+      const dealii::ReferenceCell reference_cell_type =
+        dealii::ReferenceCell::n_vertices_to_type(dim, vertices.size());
 
-      if (reference_cell_type == ReferenceCell::Type::Line)
+      if (reference_cell_type == dealii::ReferenceCell::Line)
         // Return the distance between the two vertices
         return (vertices[1] - vertices[0]).norm();
-      else if (reference_cell_type == ReferenceCell::Type::Tri)
+      else if (reference_cell_type == dealii::ReferenceCell::Tri)
         // Return the longest of the three edges
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm(),
                          (vertices[2] - vertices[0]).norm()});
-      else if (reference_cell_type == ReferenceCell::Type::Quad)
+      else if (reference_cell_type == dealii::ReferenceCell::Quad)
         // Return the longer one of the two diagonals of the quadrilateral
         return std::max({(vertices[3] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm()});
-      else if (reference_cell_type == ReferenceCell::Type::Tet)
+      else if (reference_cell_type == dealii::ReferenceCell::Tet)
         // Return the longest of the six edges of the tetrahedron
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[0]).norm(),
@@ -77,7 +77,7 @@ namespace internal
                          (vertices[3] - vertices[0]).norm(),
                          (vertices[3] - vertices[1]).norm(),
                          (vertices[3] - vertices[2]).norm()});
-      else if (reference_cell_type == ReferenceCell::Type::Pyramid)
+      else if (reference_cell_type == dealii::ReferenceCell::Pyramid)
         // Return ...
         return std::max({// the longest diagonal of the quadrilateral base
                          // of the pyramid or ...
@@ -89,7 +89,7 @@ namespace internal
                          (vertices[4] - vertices[1]).norm(),
                          (vertices[4] - vertices[2]).norm(),
                          (vertices[4] - vertices[3]).norm()});
-      else if (reference_cell_type == ReferenceCell::Type::Wedge)
+      else if (reference_cell_type == dealii::ReferenceCell::Wedge)
         // Return ...
         return std::max({// the longest of the 2*3=6 diagonals of the three
                          // quadrilateral sides of the wedge or ...
@@ -107,7 +107,7 @@ namespace internal
                          (vertices[4] - vertices[3]).norm(),
                          (vertices[5] - vertices[4]).norm(),
                          (vertices[5] - vertices[3]).norm()});
-      else if (reference_cell_type == ReferenceCell::Type::Hex)
+      else if (reference_cell_type == dealii::ReferenceCell::Hex)
         // Return the longest of the four diagonals of the hexahedron
         return std::max({(vertices[7] - vertices[0]).norm(),
                          (vertices[6] - vertices[1]).norm(),
@@ -689,7 +689,7 @@ namespace internal
       face_orientation(const TriaAccessor<3, 3, 3> &accessor,
                        const unsigned int           face)
       {
-        return ReferenceCell::internal::get_bit(
+        return internal::get_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           0 /*=orientation_bit*/);
@@ -739,7 +739,7 @@ namespace internal
                    ->face_orientations.size(),
                ExcInternalError());
 
-        return ReferenceCell::internal::get_bit(
+        return internal::get_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           2 /*=flip_bit*/);
@@ -775,7 +775,7 @@ namespace internal
                    ->face_orientations.size(),
                ExcInternalError());
 
-        return ReferenceCell::internal::get_bit(
+        return internal::get_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           1 /*=rotation_bit*/);
@@ -873,7 +873,7 @@ namespace internal
                  accessor.tria->levels[accessor.present_level]
                    ->face_orientations.size(),
                ExcInternalError());
-        ReferenceCell::internal::set_bit(
+        internal::set_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           0 /*=orientation_bit*/,
@@ -906,7 +906,7 @@ namespace internal
                    ->face_orientations.size(),
                ExcInternalError());
 
-        ReferenceCell::internal::set_bit(
+        internal::set_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           2 /*=flip_bit*/,
@@ -939,7 +939,7 @@ namespace internal
                    ->face_orientations.size(),
                ExcInternalError());
 
-        ReferenceCell::internal::set_bit(
+        internal::set_bit(
           accessor.tria->levels[accessor.present_level]->face_orientations
             [accessor.present_index * GeometryInfo<3>::faces_per_cell + face],
           1 /*=rotation_bit*/,
@@ -1086,13 +1086,13 @@ TriaAccessor<structdim, dim, spacedim>::vertex_iterator(
 
 
 template <int structdim, int dim, int spacedim>
-inline ReferenceCell::Type
+inline ReferenceCell
 TriaAccessor<structdim, dim, spacedim>::reference_cell_type() const
 {
   if (structdim == 0)
-    return ReferenceCell::Type::Vertex;
+    return ReferenceCell::Vertex;
   else if (structdim == 1)
-    return ReferenceCell::Type::Line;
+    return ReferenceCell::Line;
   else if (structdim == dim)
     return this->tria->levels[this->present_level]
       ->reference_cell_type[this->present_index];
@@ -2248,15 +2248,15 @@ TriaAccessor<structdim, dim, spacedim>::face_indices() const
 
 
 template <int structdim, int dim, int spacedim>
-inline const ReferenceCell::internal::Info::Base &
+inline const internal::Info::Base &
 TriaAccessor<structdim, dim, spacedim>::reference_cell_info() const
 {
   if (structdim == 0)
-    return ReferenceCell::internal::Info::get_cell(ReferenceCell::Type::Vertex);
+    return internal::Info::get_cell(ReferenceCell::Vertex);
   else if (structdim == 1)
-    return ReferenceCell::internal::Info::get_cell(ReferenceCell::Type::Line);
+    return internal::Info::get_cell(ReferenceCell::Line);
   else
-    return ReferenceCell::internal::Info::get_cell(this->reference_cell_type());
+    return internal::Info::get_cell(this->reference_cell_type());
 }
 
 
@@ -3110,10 +3110,10 @@ TriaAccessor<0, 1, spacedim>::used() const
 
 
 template <int spacedim>
-inline ReferenceCell::Type
+inline ReferenceCell
 TriaAccessor<0, 1, spacedim>::reference_cell_type() const
 {
-  return ReferenceCell::Type::Vertex;
+  return ReferenceCell::Vertex;
 }
 
 

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -77,7 +77,7 @@ namespace internal
        *
        * @note Used only for dim=3.
        */
-      std::vector<ReferenceCell::Type> quad_reference_cell_type;
+      std::vector<dealii::ReferenceCell> quad_reference_cell_type;
 
       /**
        * The TriaObject containing the data of lines.

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -222,7 +222,7 @@ namespace internal
        *
        * @note Used only for dim=2 and dim=3.
        */
-      std::vector<ReferenceCell::Type> reference_cell_type;
+      std::vector<dealii::ReferenceCell> reference_cell_type;
 
       /**
        * Determine an estimate for the memory consumption (in bytes) of this

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1748,16 +1748,16 @@ namespace internal
       template <int dim>
       unsigned int
       reorder_face_derivative_indices(
-        const unsigned int        face_no,
-        const unsigned int        index,
-        const ReferenceCell::Type reference_cell_type =
-          ReferenceCell::Type::Invalid)
+        const unsigned int          face_no,
+        const unsigned int          index,
+        const dealii::ReferenceCell reference_cell_type =
+          dealii::ReferenceCell::Invalid)
       {
         Assert(index < dim, ExcInternalError());
 
-        if ((reference_cell_type == ReferenceCell::Type::Invalid ||
+        if ((reference_cell_type == dealii::ReferenceCell::Invalid ||
              reference_cell_type ==
-               ReferenceCell::Type::get_hypercube<dim>()) == false)
+               dealii::ReferenceCell::get_hypercube<dim>()) == false)
           {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
             return index;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1481,7 +1481,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
              ++fe_no)
           shape_info_dummy(c, fe_no).reinit(
             dof_handlers[no]->get_fe(fe_no).reference_cell_type() ==
-                ReferenceCell::Type::get_hypercube<dim>() ?
+                ReferenceCell::get_hypercube<dim>() ?
               quad :
               quad_simplex,
             dof_handlers[no]->get_fe(fe_no),

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -316,16 +316,15 @@ namespace internal
 
           try
             {
-              const auto reference_cell_type =
-                ReferenceCell::Type::get_simplex<dim>();
+              const dealii::ReferenceCell reference_cell_type =
+                dealii::ReferenceCell::get_simplex<dim>();
 
               const auto quad_face  = get_face_quadrature(quad);
               this->n_q_points_face = quad_face.size();
 
               const unsigned int n_face_orientations = dim == 2 ? 2 : 6;
               const unsigned int n_faces =
-                ReferenceCell::internal::Info::get_cell(reference_cell_type)
-                  .n_faces();
+                dealii::internal::Info::get_cell(reference_cell_type).n_faces();
 
               const auto projected_quad_face =
                 QProjector<dim>::project_to_all_faces(reference_cell_type,

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -232,17 +232,17 @@ namespace internal
               {
                 const auto reference_cell_type = (*fe)[i].reference_cell_type();
 
-                if ((reference_cell_type == ReferenceCell::Type::Vertex) ||
-                    (reference_cell_type == ReferenceCell::Type::Line) ||
-                    (reference_cell_type == ReferenceCell::Type::Quad) ||
-                    (reference_cell_type == ReferenceCell::Type::Hex))
+                if ((reference_cell_type == dealii::ReferenceCell::Vertex) ||
+                    (reference_cell_type == dealii::ReferenceCell::Line) ||
+                    (reference_cell_type == dealii::ReferenceCell::Quad) ||
+                    (reference_cell_type == dealii::ReferenceCell::Hex))
                   needs_hypercube_setup |= true;
-                else if ((reference_cell_type == ReferenceCell::Type::Tri) ||
-                         (reference_cell_type == ReferenceCell::Type::Tet))
+                else if ((reference_cell_type == dealii::ReferenceCell::Tri) ||
+                         (reference_cell_type == dealii::ReferenceCell::Tet))
                   needs_simplex_setup |= true;
-                else if (reference_cell_type == ReferenceCell::Type::Wedge)
+                else if (reference_cell_type == dealii::ReferenceCell::Wedge)
                   needs_wedge_setup |= true;
-                else if (reference_cell_type == ReferenceCell::Type::Pyramid)
+                else if (reference_cell_type == dealii::ReferenceCell::Pyramid)
                   needs_pyramid_setup |= true;
                 else
                   Assert(false, ExcNotImplemented());
@@ -322,21 +322,23 @@ namespace internal
                         (*finite_elements[i])[j].reference_cell_type();
 
                       if ((reference_cell_type ==
-                           ReferenceCell::Type::Vertex) ||
-                          (reference_cell_type == ReferenceCell::Type::Line) ||
-                          (reference_cell_type == ReferenceCell::Type::Quad) ||
-                          (reference_cell_type == ReferenceCell::Type::Hex))
+                           dealii::ReferenceCell::Vertex) ||
+                          (reference_cell_type ==
+                           dealii::ReferenceCell::Line) ||
+                          (reference_cell_type ==
+                           dealii::ReferenceCell::Quad) ||
+                          (reference_cell_type == dealii::ReferenceCell::Hex))
                         quadrature.push_back(*quadrature_hypercube);
                       else if ((reference_cell_type ==
-                                ReferenceCell::Type::Tri) ||
+                                dealii::ReferenceCell::Tri) ||
                                (reference_cell_type ==
-                                ReferenceCell::Type::Tet))
+                                dealii::ReferenceCell::Tet))
                         quadrature.push_back(*quadrature_simplex);
                       else if (reference_cell_type ==
-                               ReferenceCell::Type::Wedge)
+                               dealii::ReferenceCell::Wedge)
                         quadrature.push_back(*quadrature_wedge);
                       else if (reference_cell_type ==
-                               ReferenceCell::Type::Pyramid)
+                               dealii::ReferenceCell::Pyramid)
                         quadrature.push_back(*quadrature_pyramid);
                       else
                         Assert(false, ExcNotImplemented());

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -1055,8 +1055,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping(
-             dof_handler.get_triangulation()),
+  estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1126,8 +1125,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id  material_id,
   const Strategy            strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping(
-             dof_handler.get_triangulation()),
+  estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1372,8 +1370,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping(
-             dof_handler.get_triangulation()),
+  estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,
@@ -1407,8 +1404,7 @@ KellyErrorEstimator<dim, spacedim>::estimate(
   const types::material_id                material_id,
   const Strategy                          strategy)
 {
-  estimate(ReferenceCell::get_default_linear_mapping(
-             dof_handler.get_triangulation()),
+  estimate(get_default_linear_mapping(dof_handler.get_triangulation()),
            dof_handler,
            quadrature,
            neumann_bc,

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -689,8 +689,7 @@ namespace MatrixCreator
                      const Function<spacedim, number> *const coefficient,
                      const AffineConstraints<number> &       constraints)
   {
-    create_mass_matrix(ReferenceCell::get_default_linear_mapping(
-                         dof.get_triangulation()),
+    create_mass_matrix(get_default_linear_mapping(dof.get_triangulation()),
                        dof,
                        q,
                        matrix,
@@ -767,8 +766,7 @@ namespace MatrixCreator
                      const Function<spacedim, number> *const coefficient,
                      const AffineConstraints<number> &       constraints)
   {
-    create_mass_matrix(ReferenceCell::get_default_linear_mapping(
-                         dof.get_triangulation()),
+    create_mass_matrix(get_default_linear_mapping(dof.get_triangulation()),
                        dof,
                        q,
                        matrix,
@@ -1730,7 +1728,7 @@ namespace MatrixCreator
     const Function<spacedim, number> *const a,
     std::vector<unsigned int>               component_mapping)
   {
-    create_boundary_mass_matrix(ReferenceCell::get_default_linear_mapping(
+    create_boundary_mass_matrix(get_default_linear_mapping(
                                   dof.get_triangulation()),
                                 dof,
                                 q,
@@ -1920,8 +1918,7 @@ namespace MatrixCreator
                         const Function<spacedim> *const  coefficient,
                         const AffineConstraints<double> &constraints)
   {
-    create_laplace_matrix(ReferenceCell::get_default_linear_mapping(
-                            dof.get_triangulation()),
+    create_laplace_matrix(get_default_linear_mapping(dof.get_triangulation()),
                           dof,
                           q,
                           matrix,
@@ -1997,8 +1994,7 @@ namespace MatrixCreator
                         const Function<spacedim> *const  coefficient,
                         const AffineConstraints<double> &constraints)
   {
-    create_laplace_matrix(ReferenceCell::get_default_linear_mapping(
-                            dof.get_triangulation()),
+    create_laplace_matrix(get_default_linear_mapping(dof.get_triangulation()),
                           dof,
                           q,
                           matrix,

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -466,7 +466,7 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     const ComponentMask &                      component_mask)
   {
-    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+    interpolate_boundary_values(get_default_linear_mapping(
                                   dof.get_triangulation()),
                                 dof,
                                 boundary_component,
@@ -486,7 +486,7 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     const ComponentMask &                      component_mask)
   {
-    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+    interpolate_boundary_values(get_default_linear_mapping(
                                   dof.get_triangulation()),
                                 dof,
                                 function_map,
@@ -600,7 +600,7 @@ namespace VectorTools
     AffineConstraints<number> &       constraints,
     const ComponentMask &             component_mask)
   {
-    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+    interpolate_boundary_values(get_default_linear_mapping(
                                   dof.get_triangulation()),
                                 dof,
                                 boundary_component,
@@ -620,7 +620,7 @@ namespace VectorTools
     AffineConstraints<number> &constraints,
     const ComponentMask &      component_mask)
   {
-    interpolate_boundary_values(ReferenceCell::get_default_linear_mapping(
+    interpolate_boundary_values(get_default_linear_mapping(
                                   dof.get_triangulation()),
                                 dof,
                                 function_map,
@@ -887,8 +887,7 @@ namespace VectorTools
     std::map<types::global_dof_index, number> &boundary_values,
     std::vector<unsigned int>                  component_mapping)
   {
-    project_boundary_values(ReferenceCell::get_default_linear_mapping(
-                              dof.get_triangulation()),
+    project_boundary_values(get_default_linear_mapping(dof.get_triangulation()),
                             dof,
                             boundary_functions,
                             q,
@@ -978,8 +977,7 @@ namespace VectorTools
     AffineConstraints<number> &constraints,
     std::vector<unsigned int>  component_mapping)
   {
-    project_boundary_values(ReferenceCell::get_default_linear_mapping(
-                              dof.get_triangulation()),
+    project_boundary_values(get_default_linear_mapping(dof.get_triangulation()),
                             dof,
                             boundary_functions,
                             q,

--- a/include/deal.II/numerics/vector_tools_constraints.h
+++ b/include/deal.II/numerics/vector_tools_constraints.h
@@ -280,7 +280,7 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -303,7 +303,7 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -332,7 +332,7 @@ namespace VectorTools
       &                           function_map,
     AffineConstraints<double> &   constraints,
     const Mapping<dim, spacedim> &mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   /**
@@ -351,7 +351,7 @@ namespace VectorTools
     const std::set<types::boundary_id> &boundary_ids,
     AffineConstraints<double> &         constraints,
     const Mapping<dim, spacedim> &      mapping =
-      (ReferenceCell::Type::get_hypercube<dim>()
+      (ReferenceCell::get_hypercube<dim>()
          .template get_default_linear_mapping<dim, spacedim>()));
 
   //@}

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -531,8 +531,7 @@ namespace VectorTools
     VectorType &                                               vec,
     const ComponentMask &                                      component_mask)
   {
-    interpolate(ReferenceCell::get_default_linear_mapping(
-                  dof.get_triangulation()),
+    interpolate(get_default_linear_mapping(dof.get_triangulation()),
                 dof,
                 function,
                 vec,

--- a/include/deal.II/numerics/vector_tools_mean_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_mean_value.templates.h
@@ -197,7 +197,7 @@ namespace VectorTools
                      const VectorType &               v,
                      const unsigned int               component)
   {
-    return compute_mean_value(ReferenceCell::get_default_linear_mapping(
+    return compute_mean_value(get_default_linear_mapping(
                                 dof.get_triangulation()),
                               dof,
                               quadrature,

--- a/include/deal.II/numerics/vector_tools_point_gradient.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_gradient.templates.h
@@ -49,8 +49,7 @@ namespace VectorTools
       &gradients)
   {
     if (dof.has_hp_capabilities() == false)
-      point_gradient(ReferenceCell::get_default_linear_mapping(
-                       dof.get_triangulation()),
+      point_gradient(get_default_linear_mapping(dof.get_triangulation()),
                      dof,
                      fe_function,
                      point,
@@ -71,8 +70,7 @@ namespace VectorTools
                  const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
-      return point_gradient(ReferenceCell::get_default_linear_mapping(
-                              dof.get_triangulation()),
+      return point_gradient(get_default_linear_mapping(dof.get_triangulation()),
                             dof,
                             fe_function,
                             point);

--- a/include/deal.II/numerics/vector_tools_point_value.templates.h
+++ b/include/deal.II/numerics/vector_tools_point_value.templates.h
@@ -48,8 +48,7 @@ namespace VectorTools
               Vector<typename VectorType::value_type> &value)
   {
     if (dof.has_hp_capabilities() == false)
-      point_value(ReferenceCell::get_default_linear_mapping(
-                    dof.get_triangulation()),
+      point_value(get_default_linear_mapping(dof.get_triangulation()),
                   dof,
                   fe_function,
                   point,
@@ -70,8 +69,7 @@ namespace VectorTools
               const Point<spacedim> &          point)
   {
     if (dof.has_hp_capabilities() == false)
-      return point_value(ReferenceCell::get_default_linear_mapping(
-                           dof.get_triangulation()),
+      return point_value(get_default_linear_mapping(dof.get_triangulation()),
                          dof,
                          fe_function,
                          point);
@@ -325,7 +323,7 @@ namespace VectorTools
         p,
         rhs_vector);
     else
-      create_point_source_vector(ReferenceCell::get_default_linear_mapping(
+      create_point_source_vector(get_default_linear_mapping(
                                    dof_handler.get_triangulation()),
                                  dof_handler,
                                  p,
@@ -432,7 +430,7 @@ namespace VectorTools
         orientation,
         rhs_vector);
     else
-      create_point_source_vector(ReferenceCell::get_default_linear_mapping(
+      create_point_source_vector(get_default_linear_mapping(
                                    dof_handler.get_triangulation()),
                                  dof_handler,
                                  p,

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -184,7 +184,7 @@ namespace VectorTools
       Quadrature<dim> quadrature_mf;
 
       if (dof.get_fe(0).reference_cell_type() ==
-          ReferenceCell::Type::get_hypercube<dim>())
+          ReferenceCell::get_hypercube<dim>())
         quadrature_mf = QGauss<dim>(dof.get_fe().degree + 2);
       else
         // TODO: since we have currently only implemented a handful quadrature
@@ -887,7 +887,7 @@ namespace VectorTools
            ExcMessage("Please specify the mapping explicitly "
                       "when building with MSVC!"));
 #else
-    project(ReferenceCell::get_default_linear_mapping(dof.get_triangulation()),
+    project(get_default_linear_mapping(dof.get_triangulation()),
             dof,
             constraints,
             quadrature,

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -470,7 +470,7 @@ namespace VectorTools
     VectorType &                                               rhs_vector,
     const AffineConstraints<typename VectorType::value_type> & constraints)
   {
-    create_right_hand_side(ReferenceCell::get_default_linear_mapping(
+    create_right_hand_side(get_default_linear_mapping(
                              dof_handler.get_triangulation()),
                            dof_handler,
                            quadrature,

--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -69,7 +69,7 @@ namespace Particles
       const std::vector<Point<dim>> &     particle_reference_locations,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        (ReferenceCell::Type::get_hypercube<dim>()
+        (ReferenceCell::get_hypercube<dim>()
            .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
@@ -108,7 +108,7 @@ namespace Particles
       const types::particle_index                                        id,
       std::mt19937 &                random_number_generator,
       const Mapping<dim, spacedim> &mapping =
-        (ReferenceCell::Type::get_hypercube<dim>()
+        (ReferenceCell::get_hypercube<dim>()
            .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
@@ -164,7 +164,7 @@ namespace Particles
       const types::particle_index         n_particles_to_create,
       ParticleHandler<dim, spacedim> &    particle_handler,
       const Mapping<dim, spacedim> &      mapping =
-        (ReferenceCell::Type::get_hypercube<dim>()
+        (ReferenceCell::get_hypercube<dim>()
            .template get_default_linear_mapping<dim, spacedim>()),
       const unsigned int random_number_seed = 5432);
 
@@ -211,7 +211,7 @@ namespace Particles
         &                             global_bounding_boxes,
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
-        (ReferenceCell::Type::get_hypercube<dim>()
+        (ReferenceCell::get_hypercube<dim>()
            .template get_default_linear_mapping<dim, spacedim>()),
       const ComponentMask &                   components = ComponentMask(),
       const std::vector<std::vector<double>> &properties = {});
@@ -256,7 +256,7 @@ namespace Particles
         &                             global_bounding_boxes,
       ParticleHandler<dim, spacedim> &particle_handler,
       const Mapping<dim, spacedim> &  mapping =
-        (ReferenceCell::Type::get_hypercube<dim>()
+        (ReferenceCell::get_hypercube<dim>()
            .template get_default_linear_mapping<dim, spacedim>()),
       const std::vector<std::vector<double>> &properties = {});
   } // namespace Generators

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -294,7 +294,7 @@ namespace DataOutBase
                                         n_data_sets,
                                       patch.data.n_rows()));
           Assert(patch.reference_cell_type !=
-                     ReferenceCell::Type::get_hypercube<dim>() ||
+                     ReferenceCell::get_hypercube<dim>() ||
                    (n_data_sets == 0) ||
                    (patch.data.n_cols() ==
                     Utilities::fixed_power<dim>(n_subdivisions + 1)),
@@ -616,8 +616,7 @@ namespace
 
     if (write_higher_order_cells)
       {
-        if (patch.reference_cell_type ==
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             const std::array<unsigned int, 4> cell_type_by_dim{
               {VTK_VERTEX,
@@ -627,7 +626,7 @@ namespace
             vtk_cell_id[0] = cell_type_by_dim[dim];
             vtk_cell_id[1] = 1;
           }
-        else if (patch.reference_cell_type == ReferenceCell::Type::Tri)
+        else if (patch.reference_cell_type == ReferenceCell::Tri)
           {
             vtk_cell_id[0] = VTK_LAGRANGE_TRIANGLE;
             vtk_cell_id[1] = 1;
@@ -637,44 +636,43 @@ namespace
             Assert(false, ExcNotImplemented());
           }
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Tri &&
+    else if (patch.reference_cell_type == ReferenceCell::Tri &&
              patch.data.n_cols() == 3)
       {
         vtk_cell_id[0] = VTK_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Tri &&
+    else if (patch.reference_cell_type == ReferenceCell::Tri &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Tet &&
+    else if (patch.reference_cell_type == ReferenceCell::Tet &&
              patch.data.n_cols() == 4)
       {
         vtk_cell_id[0] = VTK_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Tet &&
+    else if (patch.reference_cell_type == ReferenceCell::Tet &&
              patch.data.n_cols() == 10)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Wedge &&
+    else if (patch.reference_cell_type == ReferenceCell::Wedge &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_WEDGE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Type::Pyramid &&
+    else if (patch.reference_cell_type == ReferenceCell::Pyramid &&
              patch.data.n_cols() == 5)
       {
         vtk_cell_id[0] = VTK_PYRAMID;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type ==
-             ReferenceCell::Type::get_hypercube<dim>())
+    else if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
       {
         const std::array<unsigned int, 4> cell_type_by_dim{
           {VTK_VERTEX, VTK_LINE, VTK_QUAD, VTK_HEXAHEDRON}};
@@ -686,8 +684,7 @@ namespace
         Assert(false, ExcNotImplemented());
       }
 
-    if (patch.reference_cell_type !=
-          ReferenceCell::Type::get_hypercube<dim>() ||
+    if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>() ||
         write_higher_order_cells)
       vtk_cell_id[2] = patch.data.n_cols();
     else
@@ -923,8 +920,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formula doesn't hold for non-tensor products.
-        if (patch.reference_cell_type ==
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             n_cells += Utilities::fixed_power<dim>(patch.n_subdivisions);
@@ -932,8 +928,8 @@ namespace
         else
           {
             Assert(patch.n_subdivisions == 1, ExcNotImplemented());
-            const auto &info = ReferenceCell::internal::Info::get_cell(
-              patch.reference_cell_type);
+            const auto &info =
+              internal::Info::get_cell(patch.reference_cell_type);
             n_nodes += info.n_vertices();
             n_cells += 1;
           }
@@ -955,8 +951,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formulas don't hold for non-tensor products.
-        if (patch.reference_cell_type ==
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
 
@@ -1872,7 +1867,7 @@ namespace DataOutBase
     : patch_index(no_neighbor)
     , n_subdivisions(1)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::Type::get_hypercube<dim>())
+    , reference_cell_type(ReferenceCell::get_hypercube<dim>())
   // all the other data has a constructor of its own, except for the "neighbors"
   // field, which we set to invalid values.
   {
@@ -1974,7 +1969,7 @@ namespace DataOutBase
   Patch<0, spacedim>::Patch()
     : patch_index(no_neighbor)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::Type::get_hypercube<0>())
+    , reference_cell_type(ReferenceCell::get_hypercube<0>())
   {
     Assert(spacedim <= 3, ExcNotImplemented());
   }
@@ -2637,8 +2632,7 @@ namespace DataOutBase
         // special treatment of simplices since they are not subdivided, such
         // that no new nodes have to be created, but the precomputed ones can be
         // used
-        if (patch.reference_cell_type !=
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
           {
             Point<spacedim> node;
 
@@ -2682,8 +2676,7 @@ namespace DataOutBase
     for (const auto &patch : patches)
       {
         // special treatment of simplices since they are not subdivided
-        if (patch.reference_cell_type !=
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
           {
             out.write_cell_single(count++,
                                   first_vertex_of_patch,
@@ -2735,8 +2728,7 @@ namespace DataOutBase
 
     for (const auto &patch : patches)
       {
-        if (patch.reference_cell_type !=
-            ReferenceCell::Type::get_hypercube<dim>())
+        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
           {
             connectivity.resize(patch.data.n_cols());
 
@@ -7749,7 +7741,7 @@ DataOutBase::write_hdf5_parallel(
   Assert(patches.size() > 0, ExcNoPatches());
 
   const auto &cell_info =
-    ReferenceCell::internal::Info::get_cell(patches[0].reference_cell_type);
+    internal::Info::get_cell(patches[0].reference_cell_type);
 
   hid_t h5_mesh_file_id = -1, h5_solution_file_id, file_plist_id, plist_id;
   hid_t node_dataspace, node_dataset, node_file_dataspace,
@@ -8677,16 +8669,16 @@ XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
     {
       case 0:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::Type::get_hypercube<0>());
+                                ReferenceCell::get_hypercube<0>());
       case 1:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::Type::get_hypercube<1>());
+                                ReferenceCell::get_hypercube<1>());
       case 2:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::Type::get_hypercube<2>());
+                                ReferenceCell::get_hypercube<2>());
       case 3:
         return get_xdmf_content(indent_level,
-                                ReferenceCell::Type::get_hypercube<3>());
+                                ReferenceCell::get_hypercube<3>());
       default:
         Assert(false, ExcNotImplemented());
     }
@@ -8697,9 +8689,8 @@ XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
 
 
 std::string
-XDMFEntry::get_xdmf_content(
-  const unsigned int         indent_level,
-  const ReferenceCell::Type &reference_cell_type) const
+XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
+                            const ReferenceCell &reference_cell_type) const
 {
   if (!valid)
     return "";
@@ -8731,19 +8722,19 @@ XDMFEntry::get_xdmf_content(
            << "\" NodesPerElement=\"2\">\n";
       else if (dimension == 2)
         {
-          Assert(reference_cell_type == ReferenceCell::Type::Quad ||
-                   reference_cell_type == ReferenceCell::Type::Tri,
+          Assert(reference_cell_type == ReferenceCell::Quad ||
+                   reference_cell_type == ReferenceCell::Tri,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell_type == ReferenceCell::Type::Quad)
+          if (reference_cell_type == ReferenceCell::Quad)
             {
               ss << "Quadrilateral"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell_type == ReferenceCell::Type::Tri)
+          else // if (reference_cell_type == ReferenceCell::Tri)
             {
               ss << "Triangle"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
@@ -8753,19 +8744,19 @@ XDMFEntry::get_xdmf_content(
         }
       else if (dimension == 3)
         {
-          Assert(reference_cell_type == ReferenceCell::Type::Hex ||
-                   reference_cell_type == ReferenceCell::Type::Tet,
+          Assert(reference_cell_type == ReferenceCell::Hex ||
+                   reference_cell_type == ReferenceCell::Tet,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell_type == ReferenceCell::Type::Hex)
+          if (reference_cell_type == ReferenceCell::Hex)
             {
               ss << "Hexahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell_type == ReferenceCell::Type::Tet)
+          else // if (reference_cell_type == ReferenceCell::Tet)
             {
               ss << "Tetrahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -86,19 +86,19 @@ QProjector<1>::project_to_face(const Quadrature<0> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<1>> &q_points)
 {
-  project_to_face(ReferenceCell::Type::Line, quadrature, face_no, q_points);
+  project_to_face(ReferenceCell::Line, quadrature, face_no, q_points);
 }
 
 
 
 template <>
 void
-QProjector<1>::project_to_face(const ReferenceCell::Type reference_cell_type,
+QProjector<1>::project_to_face(const ReferenceCell reference_cell_type,
                                const Quadrature<0> &,
                                const unsigned int     face_no,
                                std::vector<Point<1>> &q_points)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Line, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 1;
@@ -116,24 +116,24 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<2>> &q_points)
 {
-  project_to_face(ReferenceCell::Type::Quad, quadrature, face_no, q_points);
+  project_to_face(ReferenceCell::Quad, quadrature, face_no, q_points);
 }
 
 
 
 template <>
 void
-QProjector<2>::project_to_face(const ReferenceCell::Type reference_cell_type,
-                               const Quadrature<1> &     quadrature,
-                               const unsigned int        face_no,
-                               std::vector<Point<2>> &   q_points)
+QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
+                               const Quadrature<1> &  quadrature,
+                               const unsigned int     face_no,
+                               std::vector<Point<2>> &q_points)
 {
   const unsigned int dim = 2;
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell_type == ReferenceCell::Type::Tri)
+  if (reference_cell_type == ReferenceCell::Tri)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -154,7 +154,7 @@ QProjector<2>::project_to_face(const ReferenceCell::Type reference_cell_type,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell_type == ReferenceCell::Type::Quad)
+  else if (reference_cell_type == ReferenceCell::Quad)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -189,19 +189,19 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  project_to_face(ReferenceCell::Type::Hex, quadrature, face_no, q_points);
+  project_to_face(ReferenceCell::Hex, quadrature, face_no, q_points);
 }
 
 
 
 template <>
 void
-QProjector<3>::project_to_face(const ReferenceCell::Type reference_cell_type,
-                               const Quadrature<2> &     quadrature,
-                               const unsigned int        face_no,
-                               std::vector<Point<3>> &   q_points)
+QProjector<3>::project_to_face(const ReferenceCell    reference_cell_type,
+                               const Quadrature<2> &  quadrature,
+                               const unsigned int     face_no,
+                               std::vector<Point<3>> &q_points)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 3;
@@ -252,26 +252,22 @@ QProjector<1>::project_to_subface(const Quadrature<0> &    quadrature,
                                   std::vector<Point<1>> &  q_points,
                                   const RefinementCase<0> &ref_case)
 {
-  project_to_subface(ReferenceCell::Type::Line,
-                     quadrature,
-                     face_no,
-                     subface_no,
-                     q_points,
-                     ref_case);
+  project_to_subface(
+    ReferenceCell::Line, quadrature, face_no, subface_no, q_points, ref_case);
 }
 
 
 
 template <>
 void
-QProjector<1>::project_to_subface(const ReferenceCell::Type reference_cell_type,
+QProjector<1>::project_to_subface(const ReferenceCell reference_cell_type,
                                   const Quadrature<0> &,
                                   const unsigned int face_no,
                                   const unsigned int,
                                   std::vector<Point<1>> &q_points,
                                   const RefinementCase<0> &)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Line, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 1;
@@ -291,23 +287,19 @@ QProjector<2>::project_to_subface(const Quadrature<1> &    quadrature,
                                   std::vector<Point<2>> &  q_points,
                                   const RefinementCase<1> &ref_case)
 {
-  project_to_subface(ReferenceCell::Type::Quad,
-                     quadrature,
-                     face_no,
-                     subface_no,
-                     q_points,
-                     ref_case);
+  project_to_subface(
+    ReferenceCell::Quad, quadrature, face_no, subface_no, q_points, ref_case);
 }
 
 
 
 template <>
 void
-QProjector<2>::project_to_subface(const ReferenceCell::Type reference_cell_type,
-                                  const Quadrature<1> &     quadrature,
-                                  const unsigned int        face_no,
-                                  const unsigned int        subface_no,
-                                  std::vector<Point<2>> &   q_points,
+QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
+                                  const Quadrature<1> &  quadrature,
+                                  const unsigned int     face_no,
+                                  const unsigned int     subface_no,
+                                  std::vector<Point<2>> &q_points,
                                   const RefinementCase<1> &)
 {
   const unsigned int dim = 2;
@@ -317,7 +309,7 @@ QProjector<2>::project_to_subface(const ReferenceCell::Type reference_cell_type,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell_type == ReferenceCell::Type::Tri)
+  if (reference_cell_type == ReferenceCell::Tri)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -371,7 +363,7 @@ QProjector<2>::project_to_subface(const ReferenceCell::Type reference_cell_type,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell_type == ReferenceCell::Type::Quad)
+  else if (reference_cell_type == ReferenceCell::Quad)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -453,26 +445,22 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  project_to_subface(ReferenceCell::Type::Hex,
-                     quadrature,
-                     face_no,
-                     subface_no,
-                     q_points,
-                     ref_case);
+  project_to_subface(
+    ReferenceCell::Hex, quadrature, face_no, subface_no, q_points, ref_case);
 }
 
 
 
 template <>
 void
-QProjector<3>::project_to_subface(const ReferenceCell::Type reference_cell_type,
-                                  const Quadrature<2> &     quadrature,
-                                  const unsigned int        face_no,
-                                  const unsigned int        subface_no,
-                                  std::vector<Point<3>> &   q_points,
-                                  const RefinementCase<2> & ref_case)
+QProjector<3>::project_to_subface(const ReferenceCell      reference_cell_type,
+                                  const Quadrature<2> &    quadrature,
+                                  const unsigned int       face_no,
+                                  const unsigned int       subface_no,
+                                  std::vector<Point<3>> &  q_points,
+                                  const RefinementCase<2> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 3;
@@ -555,12 +543,11 @@ QProjector<3>::project_to_subface(const ReferenceCell::Type reference_cell_type,
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_faces(
-  const ReferenceCell::Type reference_cell_type,
-  const hp::QCollection<0> &quadrature)
+QProjector<1>::project_to_all_faces(const ReferenceCell reference_cell_type,
+                                    const hp::QCollection<0> &quadrature)
 {
   AssertDimension(quadrature.size(), 1);
-  Assert(reference_cell_type == ReferenceCell::Type::Line, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 1;
@@ -602,19 +589,18 @@ QProjector<1>::project_to_all_faces(
 
 template <>
 Quadrature<2>
-QProjector<2>::project_to_all_faces(
-  const ReferenceCell::Type reference_cell_type,
-  const hp::QCollection<1> &quadrature)
+QProjector<2>::project_to_all_faces(const ReferenceCell reference_cell_type,
+                                    const hp::QCollection<1> &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Type::Tri)
+  if (reference_cell_type == ReferenceCell::Tri)
     {
       const auto support_points_line =
         [](const auto &face, const auto &orientation) -> std::vector<Point<2>> {
         std::array<Point<2>, 2> vertices;
         std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
         const auto temp =
-          ReferenceCell::Type(ReferenceCell::Type::Line)
-            .permute_according_orientation(vertices, orientation);
+          ReferenceCell::Line.permute_according_orientation(vertices,
+                                                            orientation);
         return std::vector<Point<2>>(temp.begin(),
                                      temp.begin() + face.first.size());
       };
@@ -673,7 +659,7 @@ QProjector<2>::project_to_all_faces(
       return {points, weights};
     }
 
-  Assert(reference_cell_type == ReferenceCell::Type::Quad, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -726,17 +712,15 @@ QProjector<2>::project_to_all_faces(
 
 template <>
 Quadrature<3>
-QProjector<3>::project_to_all_faces(
-  const ReferenceCell::Type reference_cell_type,
-  const hp::QCollection<2> &quadrature)
+QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
+                                    const hp::QCollection<2> &quadrature)
 {
   const auto support_points_tri =
     [](const auto &face, const auto &orientation) -> std::vector<Point<3>> {
     std::array<Point<3>, 3> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Type::Tri.permute_according_orientation(vertices,
-                                                             orientation);
+      ReferenceCell::Tri.permute_according_orientation(vertices, orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -746,8 +730,7 @@ QProjector<3>::project_to_all_faces(
     std::array<Point<3>, 4> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Type::Quad.permute_according_orientation(vertices,
-                                                              orientation);
+      ReferenceCell::Quad.permute_according_orientation(vertices, orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -857,7 +840,7 @@ QProjector<3>::project_to_all_faces(
     return Quadrature<3>(points, weights);
   };
 
-  if (reference_cell_type == ReferenceCell::Type::Tet)
+  if (reference_cell_type == ReferenceCell::Tet)
     {
       // reference faces (defined by its support points and its area)
       // note: the area is later not used as a scaling factor but recomputed
@@ -881,7 +864,7 @@ QProjector<3>::project_to_all_faces(
 
       return process(faces);
     }
-  else if (reference_cell_type == ReferenceCell::Type::Wedge)
+  else if (reference_cell_type == ReferenceCell::Wedge)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(1.0, 0.0, 0.0),
@@ -910,7 +893,7 @@ QProjector<3>::project_to_all_faces(
 
       return process(faces);
     }
-  else if (reference_cell_type == ReferenceCell::Type::Pyramid)
+  else if (reference_cell_type == ReferenceCell::Pyramid)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(-1.0, -1.0, 0.0),
@@ -939,7 +922,7 @@ QProjector<3>::project_to_all_faces(
     }
 
 
-  Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
 
   const unsigned int dim = 3;
 
@@ -1036,18 +1019,17 @@ template <>
 Quadrature<1>
 QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Type::Line, quadrature);
+  return project_to_all_subfaces(ReferenceCell::Line, quadrature);
 }
 
 
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_subfaces(
-  const ReferenceCell::Type reference_cell_type,
-  const Quadrature<0> &     quadrature)
+QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+                                       const Quadrature<0> &quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Line, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
   (void)reference_cell_type;
 
   const unsigned int dim = 1;
@@ -1091,15 +1073,14 @@ QProjector<1>::project_to_all_subfaces(
 
 template <>
 Quadrature<2>
-QProjector<2>::project_to_all_subfaces(
-  const ReferenceCell::Type reference_cell_type,
-  const SubQuadrature &     quadrature)
+QProjector<2>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+                                       const SubQuadrature &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Type::Tri ||
-      reference_cell_type == ReferenceCell::Type::Tet)
+  if (reference_cell_type == ReferenceCell::Tri ||
+      reference_cell_type == ReferenceCell::Tet)
     return Quadrature<2>(); // nothing to do
 
-  Assert(reference_cell_type == ReferenceCell::Type::Quad, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -1145,22 +1126,21 @@ template <>
 Quadrature<2>
 QProjector<2>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Type::Quad, quadrature);
+  return project_to_all_subfaces(ReferenceCell::Quad, quadrature);
 }
 
 
 
 template <>
 Quadrature<3>
-QProjector<3>::project_to_all_subfaces(
-  const ReferenceCell::Type reference_cell_type,
-  const SubQuadrature &     quadrature)
+QProjector<3>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+                                       const SubQuadrature &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Type::Tri ||
-      reference_cell_type == ReferenceCell::Type::Tet)
+  if (reference_cell_type == ReferenceCell::Tri ||
+      reference_cell_type == ReferenceCell::Tet)
     return Quadrature<3>(); // nothing to do
 
-  Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
 
   const unsigned int dim         = 3;
   SubQuadrature      q_reflected = internal::QProjector::reflect(quadrature);
@@ -1238,7 +1218,7 @@ template <>
 Quadrature<3>
 QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Type::Hex, quadrature);
+  return project_to_all_subfaces(ReferenceCell::Hex, quadrature);
 }
 
 
@@ -1249,7 +1229,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
                                   const unsigned int     child_no)
 {
-  return project_to_child(ReferenceCell::Type::get_hypercube<dim>(),
+  return project_to_child(ReferenceCell::get_hypercube<dim>(),
                           quadrature,
                           child_no);
 }
@@ -1258,11 +1238,11 @@ QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_child(const ReferenceCell::Type reference_cell_type,
-                                  const Quadrature<dim> &   quadrature,
-                                  const unsigned int        child_no)
+QProjector<dim>::project_to_child(const ReferenceCell    reference_cell_type,
+                                  const Quadrature<dim> &quadrature,
+                                  const unsigned int     child_no)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1292,7 +1272,7 @@ template <int dim>
 Quadrature<dim>
 QProjector<dim>::project_to_all_children(const Quadrature<dim> &quadrature)
 {
-  return project_to_all_children(ReferenceCell::Type::get_hypercube<dim>(),
+  return project_to_all_children(ReferenceCell::get_hypercube<dim>(),
                                  quadrature);
 }
 
@@ -1301,10 +1281,10 @@ QProjector<dim>::project_to_all_children(const Quadrature<dim> &quadrature)
 template <int dim>
 Quadrature<dim>
 QProjector<dim>::project_to_all_children(
-  const ReferenceCell::Type reference_cell_type,
-  const Quadrature<dim> &   quadrature)
+  const ReferenceCell    reference_cell_type,
+  const Quadrature<dim> &quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1336,7 +1316,7 @@ QProjector<dim>::project_to_line(const Quadrature<1> &quadrature,
                                  const Point<dim> &   p1,
                                  const Point<dim> &   p2)
 {
-  return project_to_line(ReferenceCell::Type::get_hypercube<dim>(),
+  return project_to_line(ReferenceCell::get_hypercube<dim>(),
                          quadrature,
                          p1,
                          p2);
@@ -1346,12 +1326,12 @@ QProjector<dim>::project_to_line(const Quadrature<1> &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_line(const ReferenceCell::Type reference_cell_type,
-                                 const Quadrature<1> &     quadrature,
-                                 const Point<dim> &        p1,
-                                 const Point<dim> &        p2)
+QProjector<dim>::project_to_line(const ReferenceCell  reference_cell_type,
+                                 const Quadrature<1> &quadrature,
+                                 const Point<dim> &   p1,
+                                 const Point<dim> &   p2)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -1380,7 +1360,7 @@ QProjector<dim>::DataSetDescriptor::face(const unsigned int face_no,
                                          const bool         face_rotation,
                                          const unsigned int n_quadrature_points)
 {
-  return face(ReferenceCell::Type::get_hypercube<dim>(),
+  return face(ReferenceCell::get_hypercube<dim>(),
               face_no,
               face_orientation,
               face_flip,
@@ -1393,15 +1373,15 @@ QProjector<dim>::DataSetDescriptor::face(const unsigned int face_no,
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
 QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell::Type reference_cell_type,
-  const unsigned int        face_no,
-  const bool                face_orientation,
-  const bool                face_flip,
-  const bool                face_rotation,
-  const unsigned int        n_quadrature_points)
+  const ReferenceCell reference_cell_type,
+  const unsigned int  face_no,
+  const bool          face_orientation,
+  const bool          face_flip,
+  const bool          face_rotation,
+  const unsigned int  n_quadrature_points)
 {
-  if (reference_cell_type == ReferenceCell::Type::Tri ||
-      reference_cell_type == ReferenceCell::Type::Tet)
+  if (reference_cell_type == ReferenceCell::Tri ||
+      reference_cell_type == ReferenceCell::Tet)
     {
       if (dim == 2)
         return {(2 * face_no + face_orientation) * n_quadrature_points};
@@ -1413,7 +1393,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1481,17 +1461,17 @@ QProjector<dim>::DataSetDescriptor::face(
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
 QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell::Type       reference_cell_type,
+  const ReferenceCell             reference_cell_type,
   const unsigned int              face_no,
   const bool                      face_orientation,
   const bool                      face_flip,
   const bool                      face_rotation,
   const hp::QCollection<dim - 1> &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Type::Tri ||
-      reference_cell_type == ReferenceCell::Type::Tet ||
-      reference_cell_type == ReferenceCell::Type::Wedge ||
-      reference_cell_type == ReferenceCell::Type::Pyramid)
+  if (reference_cell_type == ReferenceCell::Tri ||
+      reference_cell_type == ReferenceCell::Tet ||
+      reference_cell_type == ReferenceCell::Wedge ||
+      reference_cell_type == ReferenceCell::Pyramid)
     {
       unsigned int offset = 0;
 
@@ -1503,13 +1483,12 @@ QProjector<dim>::DataSetDescriptor::face(
         {8, 6, 6, 6, 6}};
 
       const auto &scale =
-        (reference_cell_type == ReferenceCell::Type::Tri) ?
+        (reference_cell_type == ReferenceCell::Tri) ?
           scale_tri :
-          ((reference_cell_type == ReferenceCell::Type::Tet) ?
+          ((reference_cell_type == ReferenceCell::Tet) ?
              scale_tet :
-             ((reference_cell_type == ReferenceCell::Type::Wedge) ?
-                scale_wedge :
-                scale_pyramid));
+             ((reference_cell_type == ReferenceCell::Wedge) ? scale_wedge :
+                                                              scale_pyramid));
 
       if (quadrature.size() == 1)
         offset = scale[0] * quadrature[0].size() * face_no;
@@ -1532,7 +1511,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1618,16 +1597,16 @@ QProjector<dim>::DataSetDescriptor::face(
 template <>
 QProjector<1>::DataSetDescriptor
 QProjector<1>::DataSetDescriptor::subface(
-  const ReferenceCell::Type reference_cell_type,
-  const unsigned int        face_no,
-  const unsigned int        subface_no,
+  const ReferenceCell reference_cell_type,
+  const unsigned int  face_no,
+  const unsigned int  subface_no,
   const bool,
   const bool,
   const bool,
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<1>)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Line, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
   (void)reference_cell_type;
 
   Assert(face_no < GeometryInfo<1>::faces_per_cell, ExcInternalError());
@@ -1651,7 +1630,7 @@ QProjector<1>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<1> ref_case)
 {
-  return subface(ReferenceCell::Type::Line,
+  return subface(ReferenceCell::Line,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1666,16 +1645,16 @@ QProjector<1>::DataSetDescriptor::subface(
 template <>
 QProjector<2>::DataSetDescriptor
 QProjector<2>::DataSetDescriptor::subface(
-  const ReferenceCell::Type reference_cell_type,
-  const unsigned int        face_no,
-  const unsigned int        subface_no,
+  const ReferenceCell reference_cell_type,
+  const unsigned int  face_no,
+  const unsigned int  subface_no,
   const bool,
   const bool,
   const bool,
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<2>)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::Quad, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
   (void)reference_cell_type;
 
   Assert(face_no < GeometryInfo<2>::faces_per_cell, ExcInternalError());
@@ -1699,7 +1678,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<2> ref_case)
 {
-  return subface(ReferenceCell::Type::Quad,
+  return subface(ReferenceCell::Quad,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1713,7 +1692,7 @@ QProjector<2>::DataSetDescriptor::subface(
 template <>
 QProjector<3>::DataSetDescriptor
 QProjector<3>::DataSetDescriptor::subface(
-  const ReferenceCell::Type      reference_cell_type,
+  const ReferenceCell            reference_cell_type,
   const unsigned int             face_no,
   const unsigned int             subface_no,
   const bool                     face_orientation,
@@ -1724,7 +1703,7 @@ QProjector<3>::DataSetDescriptor::subface(
 {
   const unsigned int dim = 3;
 
-  Assert(reference_cell_type == ReferenceCell::Type::Hex, ExcNotImplemented());
+  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
   (void)reference_cell_type;
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1978,7 +1957,7 @@ QProjector<3>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<3> ref_case)
 {
-  return subface(ReferenceCell::Type::Hex,
+  return subface(ReferenceCell::Hex,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1995,7 +1974,7 @@ Quadrature<dim>
 QProjector<dim>::project_to_face(const SubQuadrature &quadrature,
                                  const unsigned int   face_no)
 {
-  return project_to_face(ReferenceCell::Type::get_hypercube<dim>(),
+  return project_to_face(ReferenceCell::get_hypercube<dim>(),
                          quadrature,
                          face_no);
 }
@@ -2004,11 +1983,11 @@ QProjector<dim>::project_to_face(const SubQuadrature &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_face(const ReferenceCell::Type reference_cell_type,
-                                 const SubQuadrature &     quadrature,
-                                 const unsigned int        face_no)
+QProjector<dim>::project_to_face(const ReferenceCell  reference_cell_type,
+                                 const SubQuadrature &quadrature,
+                                 const unsigned int   face_no)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 
@@ -2026,7 +2005,7 @@ QProjector<dim>::project_to_subface(const SubQuadrature &          quadrature,
                                     const unsigned int             subface_no,
                                     const RefinementCase<dim - 1> &ref_case)
 {
-  return project_to_subface(ReferenceCell::Type::get_hypercube<dim>(),
+  return project_to_subface(ReferenceCell::get_hypercube<dim>(),
                             quadrature,
                             face_no,
                             subface_no,
@@ -2037,14 +2016,13 @@ QProjector<dim>::project_to_subface(const SubQuadrature &          quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_subface(
-  const ReferenceCell::Type      reference_cell_type,
-  const SubQuadrature &          quadrature,
-  const unsigned int             face_no,
-  const unsigned int             subface_no,
-  const RefinementCase<dim - 1> &ref_case)
+QProjector<dim>::project_to_subface(const ReferenceCell  reference_cell_type,
+                                    const SubQuadrature &quadrature,
+                                    const unsigned int   face_no,
+                                    const unsigned int   subface_no,
+                                    const RefinementCase<dim - 1> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::Type::get_hypercube<dim>(),
+  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
   (void)reference_cell_type;
 

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -294,7 +294,7 @@ namespace parallel
     // run algorithm for locally-owned cells
     dealii::Triangulation<dim, spacedim>::update_reference_cell_types();
 
-    // translate ReferenceCell::Type to unsigned int (needed by
+    // translate ReferenceCell to unsigned int (needed by
     // Utilities::MPI::compute_set_union)
     std::vector<unsigned int> reference_cell_types_ui;
 
@@ -310,7 +310,7 @@ namespace parallel
     this->reference_cell_types.clear();
     for (const auto &i : reference_cell_types_ui)
       this->reference_cell_types.emplace_back(
-        ReferenceCell::internal::make_reference_cell_from_int(i));
+        dealii::internal::ReferenceCell::make_reference_cell_from_int(i));
   }
 
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -838,7 +838,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell_type() ==
-                                   ReferenceCell::Type::Quad],
+                                   dealii::ReferenceCell::Quad],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)
@@ -1595,7 +1595,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell_type() ==
-                                   ReferenceCell::Type::Quad],
+                                   dealii::ReferenceCell::Quad],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -690,10 +690,9 @@ namespace DoFTools
                 const auto reference_cell_type = cell->reference_cell_type();
 
                 const auto &cell_rc =
-                  ReferenceCell::internal::Info::get_cell(reference_cell_type);
+                  dealii::internal::Info::get_cell(reference_cell_type);
                 const auto &face_rc =
-                  ReferenceCell::internal::Info::get_face(reference_cell_type,
-                                                          face);
+                  dealii::internal::Info::get_face(reference_cell_type, face);
 
                 const unsigned int n_vertices_per_cell = cell_rc.n_vertices();
                 const unsigned int n_lines_per_cell    = cell_rc.n_lines();

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -156,12 +156,13 @@ FiniteElement<dim, spacedim>::FiniteElement(
 
       for (unsigned int f = 0; f < this->n_unique_quads(); ++f)
         {
-          adjust_quad_dof_index_for_face_orientation_table[f] = Table<2, int>(
-            this->n_dofs_per_quad(f),
-            ReferenceCell::internal::Info::get_cell(this->reference_cell_type())
-                  .face_reference_cell_type(f) == ReferenceCell::Type::Quad ?
-              8 :
-              6);
+          adjust_quad_dof_index_for_face_orientation_table[f] =
+            Table<2, int>(this->n_dofs_per_quad(f),
+                          internal::Info::get_cell(this->reference_cell_type())
+                                .face_reference_cell_type(f) ==
+                              ReferenceCell::Quad ?
+                            8 :
+                            6);
           adjust_quad_dof_index_for_face_orientation_table[f].fill(0);
         }
     }
@@ -572,7 +573,7 @@ FiniteElement<dim, spacedim>::face_to_cell_index(const unsigned int face_index,
                                                  const bool face_rotation) const
 {
   const auto &refence_cell =
-    ReferenceCell::internal::Info::get_cell(this->reference_cell_type());
+    internal::Info::get_cell(this->reference_cell_type());
 
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, refence_cell.n_faces());
@@ -685,8 +686,8 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   Assert(adjust_quad_dof_index_for_face_orientation_table
              [this->n_unique_quads() == 1 ? 0 : face]
                .n_elements() ==
-           (ReferenceCell::internal::Info::get_cell(this->reference_cell_type())
-                  .face_reference_cell_type(face) == ReferenceCell::Type::Quad ?
+           (internal::Info::get_cell(this->reference_cell_type())
+                  .face_reference_cell_type(face) == ReferenceCell::Quad ?
               8 :
               6) *
              this->n_dofs_per_quad(face),

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -24,7 +24,7 @@ namespace internal
   internal::GenericDoFsPerObject
   expand(const unsigned int               dim,
          const std::vector<unsigned int> &dofs_per_object,
-         const ReferenceCell::Type        cell_type)
+         const dealii::ReferenceCell      cell_type)
   {
     internal::GenericDoFsPerObject result;
 
@@ -54,15 +54,13 @@ namespace internal
 
     // first_line_index
     const unsigned int first_line_index =
-      (ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-       dofs_per_vertex);
+      (internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex);
     result.object_index[1][0] = first_line_index;
 
     // first_quad_index
     const unsigned int first_quad_index =
       (first_line_index +
-       ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
-         dofs_per_line);
+       internal::Info::get_cell(cell_type).n_lines() * dofs_per_line);
     result.object_index[2][0] = first_quad_index;
 
     // first_hex_index
@@ -70,49 +68,37 @@ namespace internal
       (first_quad_index +
        (dim == 2 ?
           1 :
-          (dim == 3 ?
-             ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
-             0)) *
+          (dim == 3 ? internal::Info::get_cell(cell_type).n_faces() : 0)) *
          dofs_per_quad);
 
     // first_face_line_index
     result.first_object_index_on_face[1][0] =
-      (ReferenceCell::internal::Info::get_face(cell_type, face_no)
-         .n_vertices() *
+      (internal::Info::get_face(cell_type, face_no).n_vertices() *
        dofs_per_vertex);
 
     // first_face_quad_index
     result.first_object_index_on_face[2][0] =
       ((dim == 3 ?
-          ReferenceCell::internal::Info::get_face(cell_type, face_no)
-              .n_vertices() *
+          internal::Info::get_face(cell_type, face_no).n_vertices() *
             dofs_per_vertex :
-          ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-            dofs_per_vertex) +
-       ReferenceCell::internal::Info::get_face(cell_type, face_no).n_lines() *
-         dofs_per_line);
+          internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex) +
+       internal::Info::get_face(cell_type, face_no).n_lines() * dofs_per_line);
 
     // dofs_per_face
     result.dofs_per_object_inclusive[dim - 1][0] =
-      (ReferenceCell::internal::Info::get_face(cell_type, face_no)
-           .n_vertices() *
+      (internal::Info::get_face(cell_type, face_no).n_vertices() *
          dofs_per_vertex +
-       ReferenceCell::internal::Info::get_face(cell_type, face_no).n_lines() *
-         dofs_per_line +
+       internal::Info::get_face(cell_type, face_no).n_lines() * dofs_per_line +
        (dim == 3 ? 1 : 0) * dofs_per_quad);
 
 
     // dofs_per_cell
     result.dofs_per_object_inclusive[dim][0] =
-      (ReferenceCell::internal::Info::get_cell(cell_type).n_vertices() *
-         dofs_per_vertex +
-       ReferenceCell::internal::Info::get_cell(cell_type).n_lines() *
-         dofs_per_line +
+      (internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex +
+       internal::Info::get_cell(cell_type).n_lines() * dofs_per_line +
        (dim == 2 ?
           1 :
-          (dim == 3 ?
-             ReferenceCell::internal::Info::get_cell(cell_type).n_faces() :
-             0)) *
+          (dim == 3 ? internal::Info::get_cell(cell_type).n_faces() : 0)) *
          dofs_per_quad +
        (dim == 3 ? 1 : 0) * dofs_per_hex);
 
@@ -128,11 +114,10 @@ FiniteElementData<dim>::FiniteElementData(
   const Conformity                 conformity,
   const BlockIndices &             block_indices)
   : FiniteElementData(dofs_per_object,
-                      dim == 0 ?
-                        ReferenceCell::Type::Vertex :
-                        (dim == 1 ? ReferenceCell::Type::Line :
-                                    (dim == 2 ? ReferenceCell::Type::Quad :
-                                                ReferenceCell::Type::Hex)),
+                      dim == 0 ? ReferenceCell::Vertex :
+                                 (dim == 1 ? ReferenceCell::Line :
+                                             (dim == 2 ? ReferenceCell::Quad :
+                                                         ReferenceCell::Hex)),
                       n_components,
                       degree,
                       conformity,
@@ -142,7 +127,7 @@ FiniteElementData<dim>::FiniteElementData(
 template <int dim>
 FiniteElementData<dim>::FiniteElementData(
   const std::vector<unsigned int> &dofs_per_object,
-  const ReferenceCell::Type        cell_type,
+  const ReferenceCell              cell_type,
   const unsigned int               n_components,
   const unsigned int               degree,
   const Conformity                 conformity,
@@ -158,7 +143,7 @@ FiniteElementData<dim>::FiniteElementData(
 template <int dim>
 FiniteElementData<dim>::FiniteElementData(
   const internal::GenericDoFsPerObject &data,
-  const ReferenceCell::Type             cell_type,
+  const ReferenceCell                   cell_type,
   const unsigned int                    n_components,
   const unsigned int                    degree,
   const Conformity                      conformity,

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -381,7 +381,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
   const unsigned int         n_edge_points = reference_edge_quadrature.size();
   const Quadrature<dim - 1> &edge_quadrature =
     QProjector<dim - 1>::project_to_all_faces(
-      ReferenceCell::Type::get_hypercube<dim - 1>(), reference_edge_quadrature);
+      ReferenceCell::get_hypercube<dim - 1>(), reference_edge_quadrature);
 
   if (order > 0)
     {
@@ -414,7 +414,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::Type::get_hypercube<dim - 1>(),
+                  ReferenceCell::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,
@@ -515,7 +515,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
                                                          q_point] =
               edge_quadrature.point(
                 QProjector<dim - 1>::DataSetDescriptor::face(
-                  ReferenceCell::Type::get_hypercube<dim - 1>(),
+                  ReferenceCell::get_hypercube<dim - 1>(),
                   line,
                   true,
                   false,

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -22,9 +22,9 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-FE_Nothing<dim, spacedim>::FE_Nothing(const ReferenceCell::Type &type,
-                                      const unsigned int         n_components,
-                                      const bool                 dominate)
+FE_Nothing<dim, spacedim>::FE_Nothing(const ReferenceCell &type,
+                                      const unsigned int   n_components,
+                                      const bool           dominate)
   : FiniteElement<dim, spacedim>(
       FiniteElementData<dim>(std::vector<unsigned>(dim + 1, 0),
                              type,
@@ -51,7 +51,7 @@ FE_Nothing<dim, spacedim>::FE_Nothing(const ReferenceCell::Type &type,
 template <int dim, int spacedim>
 FE_Nothing<dim, spacedim>::FE_Nothing(const unsigned int n_components,
                                       const bool         dominate)
-  : FE_Nothing<dim, spacedim>(ReferenceCell::Type::get_hypercube<dim>(),
+  : FE_Nothing<dim, spacedim>(ReferenceCell::get_hypercube<dim>(),
                               n_components,
                               dominate)
 {}
@@ -75,7 +75,7 @@ FE_Nothing<dim, spacedim>::get_name() const
   namebuf << "FE_Nothing<" << Utilities::dim_string(dim, spacedim) << ">(";
 
   std::vector<std::string> name_components;
-  if (this->reference_cell_type() != ReferenceCell::Type::get_hypercube<dim>())
+  if (this->reference_cell_type() != ReferenceCell::get_hypercube<dim>())
     name_components.push_back(this->reference_cell_type().to_string());
   if (this->n_components() > 1)
     name_components.push_back(std::to_string(this->n_components()));

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -263,22 +263,22 @@ struct FE_Q_Base<xdim, xspacedim>::Implementation
 
         // line 5: use line 9
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 0, 0, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 6: use line 10
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 0, 1, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 0, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0.5, 0));
         // line 7: use line 13
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 2, 0, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 0, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
         // line 8: use line 14
         QProjector<dim - 1>::project_to_subface(
-          ReferenceCell::Type::get_hypercube<dim - 1>(), qline, 2, 1, p_line);
+          ReferenceCell::get_hypercube<dim - 1>(), qline, 2, 1, p_line);
         for (unsigned int i = 0; i < n; ++i)
           constraint_points.push_back(p_line[i] + Point<dim - 1>(0, 0.5));
 
@@ -291,7 +291,7 @@ struct FE_Q_Base<xdim, xspacedim>::Implementation
                ++subface)
             {
               QProjector<dim - 1>::project_to_subface(
-                ReferenceCell::Type::get_hypercube<dim - 1>(),
+                ReferenceCell::get_hypercube<dim - 1>(),
                 qline,
                 face,
                 subface,

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -121,11 +121,12 @@ namespace internal
             dealii::DoFHandler<dim, spacedim> dh(tr);
             dh.distribute_dofs(fe);
 
-            dealii::FEValues<dim, spacedim> fine(
-              ReferenceCell::get_default_linear_mapping(tr),
-              fe,
-              *q_fine,
-              update_quadrature_points | update_JxW_values | update_values);
+            dealii::FEValues<dim, spacedim> fine(get_default_linear_mapping(tr),
+                                                 fe,
+                                                 *q_fine,
+                                                 update_quadrature_points |
+                                                   update_JxW_values |
+                                                   update_values);
 
             const unsigned int n_dofs = dh.n_dofs();
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4637,8 +4637,7 @@ FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
 {
   Assert(quadrature.size() == 1 ||
            quadrature.size() ==
-             ReferenceCell::internal::Info::get_cell(fe.reference_cell_type())
-               .n_faces(),
+             internal::Info::get_cell(fe.reference_cell_type()).n_faces(),
          ExcInternalError());
 }
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -73,7 +73,7 @@ MappingCartesian<dim, spacedim>::preserves_vertex_locations() const
 template <int dim, int spacedim>
 bool
 MappingCartesian<dim, spacedim>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   Assert(dim == cell_type.get_dimension(),
          ExcMessage("The dimension of your mapping (" +
@@ -134,8 +134,9 @@ MappingCartesian<dim, spacedim>::get_face_data(
   AssertDimension(quadrature.size(), 1);
 
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
-    std::make_unique<InternalData>(QProjector<dim>::project_to_all_faces(
-      ReferenceCell::Type::get_hypercube<dim>(), quadrature[0]));
+    std::make_unique<InternalData>(
+      QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
+                                            quadrature[0]));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
@@ -160,7 +161,7 @@ MappingCartesian<dim, spacedim>::get_subface_data(
 {
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(QProjector<dim>::project_to_all_subfaces(
-      ReferenceCell::Type::get_hypercube<dim>(), quadrature));
+      ReferenceCell::get_hypercube<dim>(), quadrature));
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
 
   // verify that we have computed the transitive hull of the required
@@ -243,7 +244,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
-        ReferenceCell::Type::get_hypercube<dim>(),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         cell->face_orientation(face_no),
         cell->face_flip(face_no),
@@ -276,7 +277,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
   if (data.update_each & update_quadrature_points)
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
-        ReferenceCell::Type::get_hypercube<dim>(),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         sub_no,
         cell->face_orientation(face_no),

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -153,7 +153,7 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
       // Compute tangentials to the unit cell.
       const auto reference_cell_type = this->fe.reference_cell_type();
       const auto n_faces =
-        ReferenceCell::internal::Info::get_cell(reference_cell_type).n_faces();
+        internal::Info::get_cell(reference_cell_type).n_faces();
 
       for (unsigned int i = 0; i < n_faces; ++i)
         {
@@ -863,7 +863,7 @@ MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe)
 
   const unsigned int n_points = mapping_support_points.size();
   const unsigned int n_shape_functions =
-    ReferenceCell::internal::Info::get_cell(reference_cell_type).n_vertices();
+    internal::Info::get_cell(reference_cell_type).n_vertices();
 
   this->mapping_support_point_weights =
     Table<2, double>(n_points, n_shape_functions);
@@ -2312,7 +2312,7 @@ MappingFE<dim, spacedim>::get_bounding_box(
 template <int dim, int spacedim>
 bool
 MappingFE<dim, spacedim>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   Assert(dim == cell_type.get_dimension(),
          ExcMessage("The dimension of your mapping (" +

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -349,7 +349,7 @@ MappingFEField<dim, spacedim, VectorType, void>::preserves_vertex_locations()
 template <int dim, int spacedim, typename VectorType>
 bool
 MappingFEField<dim, spacedim, VectorType, void>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   Assert(dim == cell_type.get_dimension(),
          ExcMessage("The dimension of your mapping (" +
@@ -592,8 +592,7 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
           const auto reference_cell_type =
             this->euler_dof_handler->get_fe().reference_cell_type();
           const auto n_faces =
-            ReferenceCell::internal::Info::get_cell(reference_cell_type)
-              .n_faces();
+            internal::Info::get_cell(reference_cell_type).n_faces();
 
           // Compute tangentials to the unit cell.
           for (unsigned int i = 0; i < n_faces; ++i)
@@ -645,8 +644,9 @@ MappingFEField<dim, spacedim, VectorType, void>::get_face_data(
   std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase> data_ptr =
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
-  const Quadrature<dim> q(QProjector<dim>::project_to_all_faces(
-    ReferenceCell::Type::get_hypercube<dim>(), quadrature[0]));
+  const Quadrature<dim> q(
+    QProjector<dim>::project_to_all_faces(ReferenceCell::get_hypercube<dim>(),
+                                          quadrature[0]));
   this->compute_face_data(update_flags, q, quadrature[0].size(), data);
 
   return data_ptr;
@@ -663,7 +663,7 @@ MappingFEField<dim, spacedim, VectorType, void>::get_subface_data(
     std::make_unique<InternalData>(euler_dof_handler->get_fe(), fe_mask);
   auto &                data = dynamic_cast<InternalData &>(*data_ptr);
   const Quadrature<dim> q(QProjector<dim>::project_to_all_subfaces(
-    ReferenceCell::Type::get_hypercube<dim>(), quadrature));
+    ReferenceCell::get_hypercube<dim>(), quadrature));
   this->compute_face_data(update_flags, q, quadrature.size(), data);
 
   return data_ptr;
@@ -1727,7 +1727,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_face_values(
       face_no,
       numbers::invalid_unsigned_int,
       QProjector<dim>::DataSetDescriptor::face(
-        ReferenceCell::Type::get_hypercube<dim>(),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         cell->face_orientation(face_no),
         cell->face_flip(face_no),
@@ -1768,7 +1768,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_subface_values(
       face_no,
       numbers::invalid_unsigned_int,
       QProjector<dim>::DataSetDescriptor::subface(
-        ReferenceCell::Type::get_hypercube<dim>(),
+        ReferenceCell::get_hypercube<dim>(),
         face_no,
         subface_no,
         cell->face_orientation(face_no),
@@ -2091,9 +2091,8 @@ MappingFEField<dim, spacedim, VectorType, void>::transform_real_to_unit_cell(
   Point<dim> initial_p_unit;
   try
     {
-      initial_p_unit =
-        ReferenceCell::get_default_linear_mapping(cell->get_triangulation())
-          .transform_real_to_unit_cell(cell, p);
+      initial_p_unit = get_default_linear_mapping(cell->get_triangulation())
+                         .transform_real_to_unit_cell(cell, p);
     }
   catch (const typename Mapping<dim, spacedim>::ExcTransformationFailed &)
     {

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -292,8 +292,7 @@ MappingManifold<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::Type::get_hypercube<dim>(),
-                         quadrature[0]),
+                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -312,7 +311,7 @@ MappingManifold<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::Type::get_hypercube<dim>(), quadrature),
+                         ReferenceCell::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1229,7 +1228,7 @@ MappingManifold<dim, spacedim>::fill_fe_face_values(
     face_no,
     numbers::invalid_unsigned_int,
     QProjector<dim>::DataSetDescriptor::face(
-      ReferenceCell::Type::get_hypercube<dim>(),
+      ReferenceCell::get_hypercube<dim>(),
       face_no,
       cell->face_orientation(face_no),
       cell->face_flip(face_no),
@@ -1264,7 +1263,7 @@ MappingManifold<dim, spacedim>::fill_fe_subface_values(
     face_no,
     subface_no,
     QProjector<dim>::DataSetDescriptor::subface(
-      ReferenceCell::Type::get_hypercube<dim>(),
+      ReferenceCell::get_hypercube<dim>(),
       face_no,
       subface_no,
       cell->face_orientation(face_no),

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -562,7 +562,7 @@ MappingQ<dim, spacedim>::get_bounding_box(
 template <int dim, int spacedim>
 bool
 MappingQ<dim, spacedim>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   if (cell_type.get_dimension() != dim)
     return false; // TODO: or is this an error?

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -885,8 +885,7 @@ MappingQGeneric<dim, spacedim>::get_face_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_faces(
-                         ReferenceCell::Type::get_hypercube<dim>(),
-                         quadrature[0]),
+                         ReferenceCell::get_hypercube<dim>(), quadrature[0]),
                        quadrature[0].size());
 
   return data_ptr;
@@ -905,7 +904,7 @@ MappingQGeneric<dim, spacedim>::get_subface_data(
   auto &data = dynamic_cast<InternalData &>(*data_ptr);
   data.initialize_face(this->requires_update_flags(update_flags),
                        QProjector<dim>::project_to_all_subfaces(
-                         ReferenceCell::Type::get_hypercube<dim>(), quadrature),
+                         ReferenceCell::get_hypercube<dim>(), quadrature),
                        quadrature.size());
 
   return data_ptr;
@@ -1171,7 +1170,7 @@ MappingQGeneric<dim, spacedim>::fill_fe_face_values(
     face_no,
     numbers::invalid_unsigned_int,
     QProjector<dim>::DataSetDescriptor::face(
-      ReferenceCell::Type::get_hypercube<dim>(),
+      ReferenceCell::get_hypercube<dim>(),
       face_no,
       cell->face_orientation(face_no),
       cell->face_flip(face_no),
@@ -1219,7 +1218,7 @@ MappingQGeneric<dim, spacedim>::fill_fe_subface_values(
     face_no,
     subface_no,
     QProjector<dim>::DataSetDescriptor::subface(
-      ReferenceCell::Type::get_hypercube<dim>(),
+      ReferenceCell::get_hypercube<dim>(),
       face_no,
       subface_no,
       cell->face_orientation(face_no),
@@ -1655,7 +1654,7 @@ MappingQGeneric<dim, spacedim>::get_bounding_box(
 template <int dim, int spacedim>
 bool
 MappingQGeneric<dim, spacedim>::is_compatible_with(
-  const ReferenceCell::Type &cell_type) const
+  const ReferenceCell &cell_type) const
 {
   if (cell_type.get_dimension() != dim)
     return false; // TODO: or is this an error?

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1717,16 +1717,16 @@ namespace GridGenerator
 
   template <int dim, int spacedim>
   void
-  reference_cell(const ReferenceCell::Type &   reference_cell,
+  reference_cell(const ReferenceCell &         reference_cell,
                  Triangulation<dim, spacedim> &tria)
   {
     AssertDimension(dim, reference_cell.get_dimension());
 
-    if (reference_cell == ReferenceCell::Type::get_hypercube<dim>())
+    if (reference_cell == ReferenceCell::get_hypercube<dim>())
       {
         GridGenerator::hyper_cube(tria, 0, 1);
       }
-    else if ((dim == 2) && (reference_cell == ReferenceCell::Type::Tri))
+    else if ((dim == 2) && (reference_cell == ReferenceCell::Tri))
       {
         const std::vector<Point<spacedim>> vertices = {
           Point<spacedim>(),               // the origin
@@ -1739,7 +1739,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Type::Tet))
+    else if ((dim == 3) && (reference_cell == ReferenceCell::Tet))
       {
         AssertDimension(spacedim, 3);
 
@@ -1751,7 +1751,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Type::Pyramid))
+    else if ((dim == 3) && (reference_cell == ReferenceCell::Pyramid))
       {
         AssertDimension(spacedim, 3);
 
@@ -1767,7 +1767,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Type::Wedge))
+    else if ((dim == 3) && (reference_cell == ReferenceCell::Wedge))
       {
         AssertDimension(spacedim, 3);
 
@@ -2149,11 +2149,10 @@ namespace GridGenerator
 
     // Check that the order of the vertices makes sense, i.e., the volume of the
     // cell is positive.
-    Assert(
-      GridTools::volume(tria, ReferenceCell::get_default_linear_mapping(tria)) >
-        0.,
-      ExcMessage("The volume of the cell is not greater than zero. "
-                 "This could be due to the wrong ordering of the vertices."));
+    Assert(GridTools::volume(tria, get_default_linear_mapping(tria)) > 0.,
+           ExcMessage(
+             "The volume of the cell is not greater than zero. "
+             "This could be due to the wrong ordering of the vertices."));
   }
 
 

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -271,7 +271,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #if deal_II_dimension <= deal_II_space_dimension
       template void
       reference_cell<deal_II_dimension, deal_II_space_dimension>(
-        const ReferenceCell::Type &,
+        const ReferenceCell &,
         Triangulation<deal_II_dimension, deal_II_space_dimension> &);
 
       template void

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3042,7 +3042,7 @@ namespace
 {
   // Convert ExodusII strings to cell types. Use the number of nodes per element
   // to disambiguate some cases.
-  ReferenceCell::Type
+  ReferenceCell
   exodusii_name_to_type(const std::string &type_name,
                         const int          n_nodes_per_element)
   {
@@ -3063,28 +3063,28 @@ namespace
                       type_name_2.end());
 
     if (type_name_2 == "TRI" || type_name_2 == "TRIANGLE")
-      return ReferenceCell::Type::Tri;
+      return ReferenceCell::Tri;
     else if (type_name_2 == "QUAD" || type_name_2 == "QUADRILATERAL")
-      return ReferenceCell::Type::Quad;
+      return ReferenceCell::Quad;
     else if (type_name_2 == "SHELL")
       {
         if (n_nodes_per_element == 3)
-          return ReferenceCell::Type::Tri;
+          return ReferenceCell::Tri;
         else
-          return ReferenceCell::Type::Quad;
+          return ReferenceCell::Quad;
       }
     else if (type_name_2 == "TET" || type_name_2 == "TETRA" ||
              type_name_2 == "TETRAHEDRON")
-      return ReferenceCell::Type::Tet;
+      return ReferenceCell::Tet;
     else if (type_name_2 == "PYRA" || type_name_2 == "PYRAMID")
-      return ReferenceCell::Type::Pyramid;
+      return ReferenceCell::Pyramid;
     else if (type_name_2 == "WEDGE")
-      return ReferenceCell::Type::Wedge;
+      return ReferenceCell::Wedge;
     else if (type_name_2 == "HEX" || type_name_2 == "HEXAHEDRON")
-      return ReferenceCell::Type::Hex;
+      return ReferenceCell::Hex;
 
     Assert(false, ExcNotImplemented());
-    return ReferenceCell::Type::Invalid;
+    return ReferenceCell::Invalid;
   }
 
   // Associate deal.II boundary ids with sidesets (a face can be in multiple
@@ -3192,11 +3192,10 @@ namespace
             // Record the b_or_m_id of the current face.
             const unsigned int   local_face_n = face_id % max_faces_per_cell;
             const CellData<dim> &cell = cells[face_id / max_faces_per_cell];
-            const ReferenceCell::Type cell_type =
-              ReferenceCell::Type::n_vertices_to_type(dim,
-                                                      cell.vertices.size());
+            const ReferenceCell  cell_type =
+              ReferenceCell::n_vertices_to_type(dim, cell.vertices.size());
             const ReferenceCell::internal::Info::Base &info =
-              ReferenceCell::internal::Info::get_cell(cell_type);
+              internal::Info::get_cell(cell_type);
             const unsigned int deal_face_n =
               info.exodusii_face_to_deal_face(local_face_n);
             const ReferenceCell::internal::Info::Base &face_info =
@@ -3345,10 +3344,10 @@ GridIn<dim, spacedim>::read_exodusii(
                           &n_faces_per_element,
                           &n_attributes_per_element);
       AssertThrowExodusII(ierr);
-      const ReferenceCell::Type type =
+      const ReferenceCell type =
         exodusii_name_to_type(string_temp.data(), n_nodes_per_element);
       const ReferenceCell::internal::Info::Base &info =
-        ReferenceCell::internal::Info::get_cell(type);
+        internal::Info::get_cell(type);
       // The number of nodes per element may be larger than what we want to
       // read - for example, if the Exodus file contains a QUAD9 element, we
       // only want to read the first four values and ignore the rest.

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3441,16 +3441,16 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
             out << ' ';
             const auto reference_cell_type = cell->reference_cell_type();
 
-            if ((reference_cell_type == ReferenceCell::Type::Vertex) ||
-                (reference_cell_type == ReferenceCell::Type::Line) ||
-                (reference_cell_type == ReferenceCell::Type::Quad) ||
-                (reference_cell_type == ReferenceCell::Type::Hex))
+            if ((reference_cell_type == ReferenceCell::Vertex) ||
+                (reference_cell_type == ReferenceCell::Line) ||
+                (reference_cell_type == ReferenceCell::Quad) ||
+                (reference_cell_type == ReferenceCell::Hex))
               out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[i]);
-            else if ((reference_cell_type == ReferenceCell::Type::Tri) ||
-                     (reference_cell_type == ReferenceCell::Type::Tet) ||
-                     (reference_cell_type == ReferenceCell::Type::Wedge))
+            else if ((reference_cell_type == ReferenceCell::Tri) ||
+                     (reference_cell_type == ReferenceCell::Tet) ||
+                     (reference_cell_type == ReferenceCell::Wedge))
               out << cell->vertex_index(i);
-            else if (reference_cell_type == ReferenceCell::Type::Pyramid)
+            else if (reference_cell_type == ReferenceCell::Pyramid)
               {
                 static const std::array<unsigned int, 5> permutation_table{
                   {0, 1, 3, 2, 4}};
@@ -4274,7 +4274,7 @@ namespace internal
           Quadrature<dim - 1> quadrature(boundary_points, dummy_weights);
 
           q_projector =
-            QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Quad,
+            QProjector<dim>::project_to_all_faces(dealii::ReferenceCell::Quad,
                                                   quadrature);
         }
 

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -415,8 +415,7 @@ namespace GridTools
                                 const double                   tolerance)
   {
     return find_active_cell_around_point<dim, MeshType, spacedim>(
-             ReferenceCell::get_default_linear_mapping(
-               mesh.get_triangulation()),
+             get_default_linear_mapping(mesh.get_triangulation()),
              mesh,
              p,
              marked_vertices,

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -895,7 +895,7 @@ FlatManifold<dim, spacedim>::normal_vector(
 
   const auto face_reference_cell_type = face->reference_cell_type();
 
-  if (face_reference_cell_type == ReferenceCell::Type::get_hypercube<facedim>())
+  if (face_reference_cell_type == ReferenceCell::get_hypercube<facedim>())
     {
       for (unsigned int i = 0; i < facedim; ++i)
         xi[i] = 1. / 2;

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -31,11 +31,11 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace ReferenceCell
+namespace internal
 {
-  namespace internal
+  namespace ReferenceCell
   {
-    dealii::ReferenceCell::Type
+    dealii::ReferenceCell
     make_reference_cell_from_int(const std::uint8_t kind)
     {
       // Make sure these are the only indices from which objects can be
@@ -47,203 +47,211 @@ namespace ReferenceCell
       // function is a 'friend'.
       return {kind};
     }
-  } // namespace internal
+  } // namespace ReferenceCell
+} // namespace internal
 
 
-  const Type Type::Vertex  = internal::make_reference_cell_from_int(0);
-  const Type Type::Line    = internal::make_reference_cell_from_int(1);
-  const Type Type::Tri     = internal::make_reference_cell_from_int(2);
-  const Type Type::Quad    = internal::make_reference_cell_from_int(3);
-  const Type Type::Tet     = internal::make_reference_cell_from_int(4);
-  const Type Type::Pyramid = internal::make_reference_cell_from_int(5);
-  const Type Type::Wedge   = internal::make_reference_cell_from_int(6);
-  const Type Type::Hex     = internal::make_reference_cell_from_int(7);
-  const Type Type::Invalid =
-    internal::make_reference_cell_from_int(static_cast<std::uint8_t>(-1));
+const ReferenceCell ReferenceCell::Vertex =
+  internal::ReferenceCell::make_reference_cell_from_int(0);
+const ReferenceCell ReferenceCell::Line =
+  internal::ReferenceCell::make_reference_cell_from_int(1);
+const ReferenceCell ReferenceCell::Tri =
+  internal::ReferenceCell::make_reference_cell_from_int(2);
+const ReferenceCell ReferenceCell::Quad =
+  internal::ReferenceCell::make_reference_cell_from_int(3);
+const ReferenceCell ReferenceCell::Tet =
+  internal::ReferenceCell::make_reference_cell_from_int(4);
+const ReferenceCell ReferenceCell::Pyramid =
+  internal::ReferenceCell::make_reference_cell_from_int(5);
+const ReferenceCell ReferenceCell::Wedge =
+  internal::ReferenceCell::make_reference_cell_from_int(6);
+const ReferenceCell ReferenceCell::Hex =
+  internal::ReferenceCell::make_reference_cell_from_int(7);
+const ReferenceCell ReferenceCell::Invalid =
+  internal::ReferenceCell::make_reference_cell_from_int(
+    static_cast<std::uint8_t>(-1));
 
 
 
-  std::string
-  Type::to_string() const
-  {
-    if (*this == Vertex)
-      return "Vertex";
-    else if (*this == Line)
-      return "Line";
-    else if (*this == Tri)
-      return "Tri";
-    else if (*this == Quad)
-      return "Quad";
-    else if (*this == Tet)
-      return "Tet";
-    else if (*this == Pyramid)
-      return "Pyramid";
-    else if (*this == Wedge)
-      return "Wedge";
-    else if (*this == Hex)
-      return "Hex";
-    else if (*this == Invalid)
-      return "Invalid";
+std::string
+ReferenceCell::to_string() const
+{
+  if (*this == Vertex)
+    return "Vertex";
+  else if (*this == Line)
+    return "Line";
+  else if (*this == Tri)
+    return "Tri";
+  else if (*this == Quad)
+    return "Quad";
+  else if (*this == Tet)
+    return "Tet";
+  else if (*this == Pyramid)
+    return "Pyramid";
+  else if (*this == Wedge)
+    return "Wedge";
+  else if (*this == Hex)
+    return "Hex";
+  else if (*this == Invalid)
+    return "Invalid";
 
+  Assert(false, ExcNotImplemented());
+
+  return "Invalid";
+}
+
+
+
+template <int dim, int spacedim>
+std::unique_ptr<Mapping<dim, spacedim>>
+ReferenceCell::get_default_mapping(const unsigned int degree) const
+{
+  AssertDimension(dim, get_dimension());
+
+  if (is_hyper_cube())
+    return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
+  else if (is_simplex())
+    return std::make_unique<MappingFE<dim, spacedim>>(
+      Simplex::FE_P<dim, spacedim>(degree));
+  else if (*this == ReferenceCell::Pyramid)
+    return std::make_unique<MappingFE<dim, spacedim>>(
+      Simplex::FE_PyramidP<dim, spacedim>(degree));
+  else if (*this == ReferenceCell::Wedge)
+    return std::make_unique<MappingFE<dim, spacedim>>(
+      Simplex::FE_WedgeP<dim, spacedim>(degree));
+  else
+    {
+      Assert(false, ExcNotImplemented());
+    }
+
+  return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
+}
+
+
+
+template <int dim, int spacedim>
+const Mapping<dim, spacedim> &
+ReferenceCell::get_default_linear_mapping() const
+{
+  AssertDimension(dim, get_dimension());
+
+  if (is_hyper_cube())
+    {
+      return StaticMappingQ1<dim, spacedim>::mapping;
+    }
+  else if (is_simplex())
+    {
+      static const MappingFE<dim, spacedim> mapping(
+        Simplex::FE_P<dim, spacedim>(1));
+      return mapping;
+    }
+  else if (*this == ReferenceCell::Pyramid)
+    {
+      static const MappingFE<dim, spacedim> mapping(
+        Simplex::FE_PyramidP<dim, spacedim>(1));
+      return mapping;
+    }
+  else if (*this == ReferenceCell::Wedge)
+    {
+      static const MappingFE<dim, spacedim> mapping(
+        Simplex::FE_WedgeP<dim, spacedim>(1));
+      return mapping;
+    }
+  else
+    {
+      Assert(false, ExcNotImplemented());
+    }
+
+  return StaticMappingQ1<dim, spacedim>::mapping; // never reached
+}
+
+
+
+template <int dim, int spacedim>
+const Mapping<dim, spacedim> &
+get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
+{
+  const auto &reference_cell_types = triangulation.get_reference_cell_types();
+  Assert(reference_cell_types.size() == 1,
+         ExcMessage(
+           "This function can only work for triangulations that "
+           "use only a single cell type -- for example, only triangles "
+           "or only quadrilaterals. For mixed meshes, there is no "
+           "single linear mapping object that can be used for all "
+           "cells of the triangulation. The triangulation you are "
+           "passing to this function uses multiple cell types."));
+
+  return reference_cell_types.front()
+    .template get_default_linear_mapping<dim, spacedim>();
+}
+
+
+
+template <int dim>
+Quadrature<dim>
+ReferenceCell::get_gauss_type_quadrature(const unsigned n_points_1D) const
+{
+  AssertDimension(dim, get_dimension());
+
+  if (is_hyper_cube())
+    return QGauss<dim>(n_points_1D);
+  else if (is_simplex())
+    return Simplex::QGauss<dim>(n_points_1D);
+  else if (*this == ReferenceCell::Pyramid)
+    return Simplex::QGaussPyramid<dim>(n_points_1D);
+  else if (*this == ReferenceCell::Wedge)
+    return Simplex::QGaussWedge<dim>(n_points_1D);
+  else
     Assert(false, ExcNotImplemented());
 
-    return "Invalid";
-  }
+  return Quadrature<dim>(); // never reached
+}
 
 
 
-  template <int dim, int spacedim>
-  std::unique_ptr<Mapping<dim, spacedim>>
-  Type::get_default_mapping(const unsigned int degree) const
-  {
-    AssertDimension(dim, get_dimension());
+template <int dim>
+const Quadrature<dim> &
+ReferenceCell::get_nodal_type_quadrature() const
+{
+  AssertDimension(dim, get_dimension());
 
-    if (is_hyper_cube())
-      return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
-    else if (is_simplex())
-      return std::make_unique<MappingFE<dim, spacedim>>(
-        Simplex::FE_P<dim, spacedim>(degree));
-    else if (*this == Type::Pyramid)
-      return std::make_unique<MappingFE<dim, spacedim>>(
-        Simplex::FE_PyramidP<dim, spacedim>(degree));
-    else if (*this == Type::Wedge)
-      return std::make_unique<MappingFE<dim, spacedim>>(
-        Simplex::FE_WedgeP<dim, spacedim>(degree));
-    else
-      {
-        Assert(false, ExcNotImplemented());
-      }
+  // A function that is used to fill a quadrature object of the
+  // desired type the first time we encounter a particular
+  // reference cell
+  const auto create_quadrature = [](const ReferenceCell &reference_cell) {
+    Triangulation<dim> tria;
+    GridGenerator::reference_cell(reference_cell, tria);
 
-    return std::make_unique<MappingQGeneric<dim, spacedim>>(degree);
-  }
+    return Quadrature<dim>(tria.get_vertices());
+  };
 
+  if (is_hyper_cube())
+    {
+      static const Quadrature<dim> quadrature = create_quadrature(*this);
+      return quadrature;
+    }
+  else if (is_simplex())
+    {
+      static const Quadrature<dim> quadrature = create_quadrature(*this);
+      return quadrature;
+    }
+  else if (*this == ReferenceCell::Pyramid)
+    {
+      static const Quadrature<dim> quadrature = create_quadrature(*this);
+      return quadrature;
+    }
+  else if (*this == ReferenceCell::Wedge)
+    {
+      static const Quadrature<dim> quadrature = create_quadrature(*this);
+      return quadrature;
+    }
+  else
+    Assert(false, ExcNotImplemented());
 
-
-  template <int dim, int spacedim>
-  const Mapping<dim, spacedim> &
-  Type::get_default_linear_mapping() const
-  {
-    AssertDimension(dim, get_dimension());
-
-    if (is_hyper_cube())
-      {
-        return StaticMappingQ1<dim, spacedim>::mapping;
-      }
-    else if (is_simplex())
-      {
-        static const MappingFE<dim, spacedim> mapping(
-          Simplex::FE_P<dim, spacedim>(1));
-        return mapping;
-      }
-    else if (*this == Type::Pyramid)
-      {
-        static const MappingFE<dim, spacedim> mapping(
-          Simplex::FE_PyramidP<dim, spacedim>(1));
-        return mapping;
-      }
-    else if (*this == Type::Wedge)
-      {
-        static const MappingFE<dim, spacedim> mapping(
-          Simplex::FE_WedgeP<dim, spacedim>(1));
-        return mapping;
-      }
-    else
-      {
-        Assert(false, ExcNotImplemented());
-      }
-
-    return StaticMappingQ1<dim, spacedim>::mapping; // never reached
-  }
-
-
-
-  template <int dim, int spacedim>
-  const Mapping<dim, spacedim> &
-  get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
-  {
-    const auto &reference_cell_types = triangulation.get_reference_cell_types();
-    Assert(reference_cell_types.size() == 1,
-           ExcMessage(
-             "This function can only work for triangulations that "
-             "use only a single cell type -- for example, only triangles "
-             "or only quadrilaterals. For mixed meshes, there is no "
-             "single linear mapping object that can be used for all "
-             "cells of the triangulation. The triangulation you are "
-             "passing to this function uses multiple cell types."));
-
-    return reference_cell_types.front()
-      .template get_default_linear_mapping<dim, spacedim>();
-  }
-
-
-
-  template <int dim>
-  Quadrature<dim>
-  Type::get_gauss_type_quadrature(const unsigned n_points_1D) const
-  {
-    AssertDimension(dim, get_dimension());
-
-    if (is_hyper_cube())
-      return QGauss<dim>(n_points_1D);
-    else if (is_simplex())
-      return Simplex::QGauss<dim>(n_points_1D);
-    else if (*this == Type::Pyramid)
-      return Simplex::QGaussPyramid<dim>(n_points_1D);
-    else if (*this == Type::Wedge)
-      return Simplex::QGaussWedge<dim>(n_points_1D);
-    else
-      Assert(false, ExcNotImplemented());
-
-    return Quadrature<dim>(); // never reached
-  }
-
-
-
-  template <int dim>
-  const Quadrature<dim> &
-  Type::get_nodal_type_quadrature() const
-  {
-    AssertDimension(dim, get_dimension());
-
-    // A function that is used to fill a quadrature object of the
-    // desired type the first time we encounter a particular
-    // reference cell
-    const auto create_quadrature = [](const Type &reference_cell) {
-      Triangulation<dim> tria;
-      GridGenerator::reference_cell(reference_cell, tria);
-
-      return Quadrature<dim>(tria.get_vertices());
-    };
-
-    if (is_hyper_cube())
-      {
-        static const Quadrature<dim> quadrature = create_quadrature(*this);
-        return quadrature;
-      }
-    else if (is_simplex())
-      {
-        static const Quadrature<dim> quadrature = create_quadrature(*this);
-        return quadrature;
-      }
-    else if (*this == Type::Pyramid)
-      {
-        static const Quadrature<dim> quadrature = create_quadrature(*this);
-        return quadrature;
-      }
-    else if (*this == Type::Wedge)
-      {
-        static const Quadrature<dim> quadrature = create_quadrature(*this);
-        return quadrature;
-      }
-    else
-      Assert(false, ExcNotImplemented());
-
-    static const Quadrature<dim> dummy;
-    return dummy; // never reached
-  }
+  static const Quadrature<dim> dummy;
+  return dummy; // never reached
+}
 
 #include "reference_cell.inst"
-
-} // namespace ReferenceCell
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/reference_cell.inst.in
+++ b/source/grid/reference_cell.inst.in
@@ -18,10 +18,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #if deal_II_dimension <= deal_II_space_dimension
     template std::unique_ptr<
       Mapping<deal_II_dimension, deal_II_space_dimension>>
-    Type::get_default_mapping(const unsigned int degree) const;
+    ReferenceCell::get_default_mapping(const unsigned int degree) const;
 
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
-      &Type::get_default_linear_mapping() const;
+      &ReferenceCell::get_default_linear_mapping() const;
 
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
       &get_default_linear_mapping(
@@ -32,8 +32,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 
 for (deal_II_dimension : DIMENSIONS)
   {
-    template Quadrature<deal_II_dimension> Type::get_gauss_type_quadrature(
-      const unsigned n_points_1D) const;
+    template Quadrature<deal_II_dimension>
+    ReferenceCell::get_gauss_type_quadrature(const unsigned n_points_1D) const;
     template const Quadrature<deal_II_dimension>
-      &Type::get_nodal_type_quadrature() const;
+      &ReferenceCell::get_nodal_type_quadrature() const;
   }

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1182,7 +1182,7 @@ namespace internal
           tria_faces.quad_reference_cell_type.insert(
             tria_faces.quad_reference_cell_type.end(),
             new_size - tria_faces.quad_reference_cell_type.size(),
-            ReferenceCell::Type::Quad);
+            dealii::ReferenceCell::Quad);
         }
     }
 
@@ -1308,8 +1308,8 @@ namespace internal
               tria_level.reference_cell_type.insert(
                 tria_level.reference_cell_type.end(),
                 total_cells - tria_level.reference_cell_type.size(),
-                tria_level.dim == 2 ? ReferenceCell::Type::Quad :
-                                      ReferenceCell::Type::Hex);
+                tria_level.dim == 2 ? dealii::ReferenceCell::Quad :
+                                      dealii::ReferenceCell::Hex);
             }
         }
     }
@@ -2668,8 +2668,8 @@ namespace internal
         if (dim == 3 && structdim == 2)
           {
             // quad entity types
-            faces.quad_reference_cell_type.assign(size,
-                                                  ReferenceCell::Type::Invalid);
+            faces.quad_reference_cell_type.assign(
+              size, dealii::ReferenceCell::Invalid);
 
             // quad line orientations
             faces.quads_line_orientations.assign(size * faces_per_cell, -1);
@@ -2705,7 +2705,7 @@ namespace internal
 
         level.neighbors.assign(size * faces_per_cell, {-1, -1});
 
-        level.reference_cell_type.assign(size, ReferenceCell::Type::Invalid);
+        level.reference_cell_type.assign(size, dealii::ReferenceCell::Invalid);
 
         if (orientation_needed)
           level.face_orientations.assign(size * faces_per_cell, -1);
@@ -4110,14 +4110,14 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
-                  if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+                  if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
                     {
                       needed_cells += 4;
                       needed_vertices += 0;
                       n_single_lines += 3;
                     }
                   else if (cell->reference_cell_type() ==
-                           ReferenceCell::Type::Quad)
+                           dealii::ReferenceCell::Quad)
                     {
                       needed_cells += 4;
                       needed_vertices += 1;
@@ -4270,9 +4270,9 @@ namespace internal
 
           unsigned int n_new_vertices = 0;
 
-          if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
             n_new_vertices = 6;
-          else if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
             n_new_vertices = 9;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4286,7 +4286,7 @@ namespace internal
               new_vertices[cell->n_vertices() + line_no] =
                 cell->line(line_no)->child(0)->vertex_index(1);
 
-          if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+          if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
             {
               while (triangulation.vertices_used[next_unused_vertex] == true)
                 ++next_unused_vertex;
@@ -4325,12 +4325,12 @@ namespace internal
           unsigned int lmin = 0;
           unsigned int lmax = 0;
 
-          if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
             {
               lmin = 6;
               lmax = 9;
             }
-          else if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
             {
               lmin = 8;
               lmax = 12;
@@ -4355,7 +4355,7 @@ namespace internal
 
           if (true)
             {
-              if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+              if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
                 {
                   // add lines in the right order [TODO: clean up]
                   const auto ref = [&](const unsigned int face_no,
@@ -4390,7 +4390,8 @@ namespace internal
                   new_lines[8]->set_bounding_object_indices(
                     {new_vertices[5], new_vertices[3]});
                 }
-              else if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+              else if (cell->reference_cell_type() ==
+                       dealii::ReferenceCell::Quad)
                 {
                   unsigned int l = 0;
                   for (const unsigned int face_no : cell->face_indices())
@@ -4432,9 +4433,9 @@ namespace internal
 
           unsigned int n_children = 0;
 
-          if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
             n_children = 4;
-          else if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
             n_children = 4;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4453,7 +4454,7 @@ namespace internal
             }
 
           if ((dim == 2) &&
-              (cell->reference_cell_type() == ReferenceCell::Type::Tri))
+              (cell->reference_cell_type() == dealii::ReferenceCell::Tri))
             {
               subcells[0]->set_bounding_object_indices({new_lines[0]->index(),
                                                         new_lines[8]->index(),
@@ -4504,7 +4505,7 @@ namespace internal
               // * GeometryInfo<2>::faces_per_cell + 0] = 0;
             }
           else if ((dim == 2) &&
-                   (cell->reference_cell_type() == ReferenceCell::Type::Quad))
+                   (cell->reference_cell_type() == dealii::ReferenceCell::Quad))
             {
               subcells[0]->set_bounding_object_indices(
                 {new_lines[0]->index(),
@@ -4586,7 +4587,7 @@ namespace internal
                                   cell);
 
                   if (cell->reference_cell_type() ==
-                        ReferenceCell::Type::Quad &&
+                        dealii::ReferenceCell::Quad &&
                       check_for_distorted_cells &&
                       has_distorted_children<dim, spacedim>(cell))
                     cells_with_distorted_children.distorted_cells.push_back(
@@ -13506,12 +13507,12 @@ template <int dim, int spacedim>
 void
 Triangulation<dim, spacedim>::update_reference_cell_types()
 {
-  std::set<ReferenceCell::Type> reference_cell_types_set;
+  std::set<ReferenceCell> reference_cell_types_set;
   for (auto cell : active_cell_iterators())
     if (cell->is_locally_owned())
       reference_cell_types_set.insert(cell->reference_cell_type());
 
-  std::vector<ReferenceCell::Type> reference_cell_types(
+  std::vector<ReferenceCell> reference_cell_types(
     reference_cell_types_set.begin(), reference_cell_types_set.end());
 
   this->reference_cell_types = reference_cell_types;
@@ -13520,7 +13521,7 @@ Triangulation<dim, spacedim>::update_reference_cell_types()
 
 
 template <int dim, int spacedim>
-const std::vector<ReferenceCell::Type> &
+const std::vector<ReferenceCell> &
 Triangulation<dim, spacedim>::get_reference_cell_types() const
 {
   return this->reference_cell_types;
@@ -13534,8 +13535,7 @@ Triangulation<dim, spacedim>::all_reference_cell_types_are_hyper_cube() const
 {
   return (this->reference_cell_types.size() == 0) ||
          (this->reference_cell_types.size() == 1 &&
-          this->reference_cell_types[0] ==
-            ReferenceCell::Type::get_hypercube<dim>());
+          this->reference_cell_types[0] == ReferenceCell::get_hypercube<dim>());
 }
 
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2845,7 +2845,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
     {
       case 2:
         {
-          if (this->reference_cell_type() == ReferenceCell::Type::Tri)
+          if (this->reference_cell_type() == ReferenceCell::Tri)
             {
               const auto neighbor_cell = this->neighbor(face);
 
@@ -2868,8 +2868,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
                   (1 - subface) :
                   subface;
 
-              const auto &info = ReferenceCell::internal::Info::get_cell(
-                ReferenceCell::Type::Tri);
+              const auto &info = internal::Info::get_cell(ReferenceCell::Tri);
               const unsigned int neighbor_child_index =
                 info.child_cell_on_face(neighbor_face, neighbor_subface);
               TriaIterator<CellAccessor<dim, spacedim>> sub_neighbor =
@@ -2883,7 +2882,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
               return sub_neighbor;
             }
-          else if (this->reference_cell_type() == ReferenceCell::Type::Quad)
+          else if (this->reference_cell_type() == ReferenceCell::Quad)
             {
               const unsigned int neighbor_neighbor =
                 this->neighbor_of_neighbor(face);
@@ -2923,7 +2922,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
       case 3:
         {
-          if (this->reference_cell_type() == ReferenceCell::Type::Hex)
+          if (this->reference_cell_type() == ReferenceCell::Hex)
             {
               // this function returns the neighbor's
               // child on a given face and

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -165,8 +165,7 @@ namespace MGTools
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
 
-        Assert(fe.reference_cell_type() ==
-                 ReferenceCell::Type::get_hypercube<dim>(),
+        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         unsigned int increment =
@@ -346,8 +345,7 @@ namespace MGTools
 
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
-        Assert(fe.reference_cell_type() ==
-                 ReferenceCell::Type::get_hypercube<dim>(),
+        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         Assert(couplings.n_rows() == fe.n_components(),

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -148,7 +148,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
        (cell_and_index->first->at_boundary() ||
         (DoFHandlerType::dimension != DoFHandlerType::space_dimension))) ||
       (cell_and_index->first->reference_cell_type() !=
-       ReferenceCell::Type::get_hypercube<dim>()))
+       ReferenceCell::get_hypercube<dim>()))
     {
       Assert(patch.space_dim == DoFHandlerType::space_dimension,
              ExcInternalError());

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -154,8 +154,8 @@ namespace Simplex
       if (dim == 1)
         return {};
 
-      const auto &info = ReferenceCell::internal::Info::get_cell(
-        dim == 2 ? ReferenceCell::Type::Tri : ReferenceCell::Type::Tet);
+      const auto &info = internal::Info::get_cell(
+        dim == 2 ? ReferenceCell::Tri : ReferenceCell::Tet);
       std::vector<std::vector<Point<dim - 1>>> unit_face_points;
 
       // all faces have the same support points
@@ -310,9 +310,7 @@ namespace Simplex
       else
         Assert(false, ExcNotImplemented());
 
-      return internal::expand(3,
-                              {{0, 0, 0, n_dofs}},
-                              ReferenceCell::Type::Wedge);
+      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCell::Wedge);
     }
 
     /**
@@ -353,9 +351,7 @@ namespace Simplex
       else
         Assert(false, ExcNotImplemented());
 
-      return internal::expand(3,
-                              {{0, 0, 0, n_dofs}},
-                              ReferenceCell::Type::Pyramid);
+      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCell::Pyramid);
     }
   } // namespace
 
@@ -369,27 +365,26 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         BarycentricPolynomials<dim>::get_fe_p_basis(degree),
         FiniteElementData<dim>(dpo_vector,
-                               dim == 2 ? ReferenceCell::Type::Tri :
-                                          ReferenceCell::Type::Tet,
+                               dim == 2 ? ReferenceCell::Tri :
+                                          ReferenceCell::Tet,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(FiniteElementData<dim>(dpo_vector,
-                                                 dim == 2 ?
-                                                   ReferenceCell::Type::Tri :
-                                                   ReferenceCell::Type::Tet,
+                                                 dim == 2 ? ReferenceCell::Tri :
+                                                            ReferenceCell::Tet,
                                                  1,
                                                  degree)
                             .dofs_per_cell,
                           true),
-        std::vector<ComponentMask>(
-          FiniteElementData<dim>(dpo_vector,
-                                 dim == 2 ? ReferenceCell::Type::Tri :
-                                            ReferenceCell::Type::Tet,
-                                 1,
-                                 degree)
-            .dofs_per_cell,
-          std::vector<bool>(1, true)))
+        std::vector<ComponentMask>(FiniteElementData<dim>(dpo_vector,
+                                                          dim == 2 ?
+                                                            ReferenceCell::Tri :
+                                                            ReferenceCell::Tet,
+                                                          1,
+                                                          degree)
+                                     .dofs_per_cell,
+                                   std::vector<bool>(1, true)))
   {
     this->unit_support_points = unit_support_points_fe_poly<dim>(degree);
     // Discontinuous elements don't have face support points
@@ -962,16 +957,16 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         Simplex::ScalarWedgePolynomial<dim>(degree),
         FiniteElementData<dim>(dpos,
-                               ReferenceCell::Type::Wedge,
+                               ReferenceCell::Wedge,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Type::Wedge, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCell::Wedge, 1, degree)
             .dofs_per_cell,
           true),
         std::vector<ComponentMask>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Type::Wedge, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCell::Wedge, 1, degree)
             .dofs_per_cell,
           std::vector<bool>(1, true)))
   {
@@ -1196,16 +1191,16 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         Simplex::ScalarPyramidPolynomial<dim>(degree),
         FiniteElementData<dim>(dpos,
-                               ReferenceCell::Type::Pyramid,
+                               ReferenceCell::Pyramid,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Type::Pyramid, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCell::Pyramid, 1, degree)
             .dofs_per_cell,
           true),
         std::vector<ComponentMask>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Type::Pyramid, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCell::Pyramid, 1, degree)
             .dofs_per_cell,
           std::vector<bool>(1, true)))
   {
@@ -1619,7 +1614,7 @@ namespace Simplex
       // basis.
       const auto polys = get_basis<dim>(degree);
       return FiniteElementData<dim>(get_dpo_vector<dim>(degree),
-                                    ReferenceCell::Type::get_simplex<dim>(),
+                                    ReferenceCell::get_simplex<dim>(),
                                     1, // n_components
                                     polys.degree(),
                                     FiniteElementData<dim>::H1);

--- a/tests/hp/fe_nothing_22.cc
+++ b/tests/hp/fe_nothing_22.cc
@@ -39,25 +39,25 @@ test()
           << std::endl;
   if (dim == 2)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Quad, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Quad, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Tri, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Tri, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
     }
   if (dim == 3)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Hex, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Hex, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Tet, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Tet, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Wedge, 1, false) ==
-                  FE_Nothing<dim>(ReferenceCell::Type::Pyramid, 1, false))
+      deallog << (FE_Nothing<dim>(ReferenceCell::Wedge, 1, false) ==
+                  FE_Nothing<dim>(ReferenceCell::Pyramid, 1, false))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Type::Wedge, 3) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Wedge, 3) ==
                   FE_Nothing<dim>(3))
               << std::endl;
     }

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -47,9 +47,9 @@ process(const std::vector<Point<spacedim>> &vertices,
 
   AssertDimension(reference_cell_types.size(), 1);
 
-  if (reference_cell_types[0] == ReferenceCell::Type::get_simplex<dim>())
+  if (reference_cell_types[0] == ReferenceCell::get_simplex<dim>())
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_P<dim>(1));
-  else if (reference_cell_types[0] == ReferenceCell::Type::Wedge)
+  else if (reference_cell_types[0] == ReferenceCell::Wedge)
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_WedgeP<dim>(1));
   else
     AssertThrow(false, ExcNotImplemented());

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -84,9 +84,9 @@ test(const FiniteElement<dim, spacedim> &fe_0,
       if (cell->is_locally_owned() == false)
         continue;
 
-      if (cell->reference_cell_type() == ReferenceCell::Type::Tri)
+      if (cell->reference_cell_type() == ReferenceCell::Tri)
         cell->set_active_fe_index(0);
-      else if (cell->reference_cell_type() == ReferenceCell::Type::Quad)
+      else if (cell->reference_cell_type() == ReferenceCell::Quad)
         cell->set_active_fe_index(1);
       else
         Assert(false, ExcNotImplemented());

--- a/tests/simplex/fe_lib_01.cc
+++ b/tests/simplex/fe_lib_01.cc
@@ -30,7 +30,7 @@ test(const FiniteElement<dim, spacedim> &fe)
   deallog << fe.get_name() << ": " << std::endl;
 
   const auto &reference_cell =
-    ReferenceCell::internal::Info::get_cell(fe.reference_cell_type());
+    internal::Info::get_cell(fe.reference_cell_type());
 
   deallog << "  n_dofs_per_vertex(): " << fe.n_dofs_per_vertex() << std::endl;
   deallog << "  n_dofs_per_line():   " << fe.n_dofs_per_line() << std::endl;

--- a/tests/simplex/fe_p_bubbles_02.cc
+++ b/tests/simplex/fe_p_bubbles_02.cc
@@ -44,14 +44,14 @@ compute_nodal_quadrature(const FiniteElement<dim, spacedim> &fe)
   Assert(fe.n_blocks() == 1, ExcNotImplemented());
   Assert(fe.n_components() == 1, ExcNotImplemented());
 
-  const ReferenceCell::Type type = fe.reference_cell_type();
+  const ReferenceCell type = fe.reference_cell_type();
 
   const Quadrature<dim> q_gauss =
     type.get_gauss_type_quadrature<dim>(fe.tensor_degree() + 1);
   Triangulation<dim, spacedim> tria;
   GridGenerator::reference_cell(type, tria);
   const Mapping<dim, spacedim> &mapping =
-    ReferenceCell::get_default_linear_mapping<dim, spacedim>(type);
+    get_default_linear_mapping<dim, spacedim>(type);
 
   auto                    cell = tria.begin_active();
   FEValues<dim, spacedim> fe_values(mapping,
@@ -110,13 +110,13 @@ test_interpolate()
 
           Simplex::FE_P_Bubbles<dim, spacedim> fe(degree);
 
-          const ReferenceCell::Type type = fe.reference_cell_type();
+          const ReferenceCell       type = fe.reference_cell_type();
           DoFHandler<dim, spacedim> dh(tria);
           dh.distribute_dofs(fe);
           deallog << "number of dofs = " << dh.n_dofs() << std::endl;
 
           const Mapping<dim, spacedim> &map =
-            ReferenceCell::get_default_linear_mapping<dim, spacedim>(type);
+            get_default_linear_mapping<dim, spacedim>(type);
 
           Vector<double> solution(dh.n_dofs());
           VectorTools::interpolate(map, dh, func, solution);
@@ -175,7 +175,7 @@ test_lumped_project()
 
           Simplex::FE_P_Bubbles<dim, spacedim> fe(degree);
 
-          const ReferenceCell::Type type = fe.reference_cell_type();
+          const ReferenceCell       type = fe.reference_cell_type();
           DoFHandler<dim, spacedim> dh(tria);
           dh.distribute_dofs(fe);
           deallog << "number of dofs = " << dh.n_dofs() << std::endl;
@@ -187,7 +187,7 @@ test_lumped_project()
           Vector<double> consistent_rhs(dh.n_dofs());
 
           const Mapping<dim, spacedim> &map =
-            ReferenceCell::get_default_linear_mapping<dim, spacedim>(type);
+            get_default_linear_mapping<dim, spacedim>(type);
 
           FEValues<dim> lumped_fev(map,
                                    fe,

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -157,8 +157,8 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell_type() == ReferenceCell::Type::Tri ||
-        cell->reference_cell_type() == ReferenceCell::Type::Tet)
+    if (cell->reference_cell_type() == ReferenceCell::Tri ||
+        cell->reference_cell_type() == ReferenceCell::Tet)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -260,8 +260,8 @@ test(const unsigned version, const unsigned int degree)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell_type() == ReferenceCell::Type::Tri ||
-        cell->reference_cell_type() == ReferenceCell::Type::Tet)
+    if (cell->reference_cell_type() == ReferenceCell::Tri ||
+        cell->reference_cell_type() == ReferenceCell::Tet)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/orientation_01.cc
+++ b/tests/simplex/orientation_01.cc
@@ -24,7 +24,7 @@
 
 template <unsigned int n_points>
 void
-test(const ReferenceCell::Type type, const unsigned int n_orientations)
+test(const ReferenceCell type, const unsigned int n_orientations)
 {
   for (unsigned int o = 0; o < n_orientations; ++o)
     {
@@ -46,9 +46,9 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Type::Line, 2);
-  test<3>(ReferenceCell::Type::Tri, 3);
-  test<4>(ReferenceCell::Type::Quad, 4);
+  test<2>(ReferenceCell::Line, 2);
+  test<3>(ReferenceCell::Tri, 3);
+  test<4>(ReferenceCell::Quad, 4);
 
   deallog << "OK!" << std::endl;
 }

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -30,7 +30,7 @@ test(const unsigned int orientation)
 
 
   Triangulation<3> dummy, tria;
-  GridGenerator::reference_cell(ReferenceCell::Type::Tet, dummy);
+  GridGenerator::reference_cell(ReferenceCell::Tet, dummy);
 
   auto vertices = dummy.get_vertices();
 
@@ -46,7 +46,7 @@ test(const unsigned int orientation)
   {
     const auto &face = dummy.begin()->face(face_no);
     const auto  permuted =
-      ReferenceCell::Type(ReferenceCell::Type::Tri)
+      ReferenceCell(ReferenceCell::Tri)
         .permute_according_orientation(
           std::array<unsigned int, 3>{{face->vertex_index(0),
                                        face->vertex_index(1),
@@ -97,8 +97,9 @@ test(const unsigned int orientation)
   for (const auto l : face->line_indices())
     {
       const unsigned int l_ =
-        ReferenceCell::internal::Info::Tet().standard_to_real_face_line(
-          l, face_no, orientation);
+        internal::Info::Tet().standard_to_real_face_line(l,
+                                                         face_no,
+                                                         orientation);
 
       std::array<unsigned int, 2> a = {
         {face->line(l_)->vertex_index(0), face->line(l_)->vertex_index(1)}};

--- a/tests/simplex/q_projection_01.cc
+++ b/tests/simplex/q_projection_01.cc
@@ -41,7 +41,7 @@ test<2>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Tri, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCell::Tri, quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation) {
@@ -50,13 +50,12 @@ test<2>(const unsigned int n_points)
             << ":" << std::endl;
     for (unsigned int
            q = 0,
-           i =
-             QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Type::Tri,
-                                                      face_no,
-                                                      face_orientation,
-                                                      false,
-                                                      false,
-                                                      quad_ref.size());
+           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Tri,
+                                                        face_no,
+                                                        face_orientation,
+                                                        false,
+                                                        false,
+                                                        quad_ref.size());
          q < quad_ref.size();
          ++q, ++i)
       {
@@ -83,7 +82,7 @@ test<3>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Tet, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCell::Tet, quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation,
@@ -96,13 +95,12 @@ test<3>(const unsigned int n_points)
             << std::endl;
     for (unsigned int
            q = 0,
-           i =
-             QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Type::Tet,
-                                                      face_no,
-                                                      face_orientation,
-                                                      face_flip,
-                                                      face_rotation,
-                                                      quad_ref.size());
+           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Tet,
+                                                        face_no,
+                                                        face_orientation,
+                                                        face_flip,
+                                                        face_rotation,
+                                                        quad_ref.size());
          q < quad_ref.size();
          ++q, ++i)
       {

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -27,10 +27,10 @@ using namespace dealii;
 
 template <int dim>
 void
-test(const ReferenceCell::Type &reference_cell)
+test(const ReferenceCell &reference_cell)
 {
-  const auto  kind = ReferenceCell::Type(reference_cell);
-  const auto &info = ReferenceCell::internal::Info::get_cell(reference_cell);
+  const auto  kind = ReferenceCell(reference_cell);
+  const auto &info = internal::Info::get_cell(reference_cell);
 
   for (const auto v : info.vertex_indices())
     {
@@ -49,11 +49,11 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Type::Line);
-  test<2>(ReferenceCell::Type::Tri);
-  test<2>(ReferenceCell::Type::Quad);
-  test<3>(ReferenceCell::Type::Tet);
-  test<3>(ReferenceCell::Type::Pyramid);
-  test<3>(ReferenceCell::Type::Wedge);
-  test<3>(ReferenceCell::Type::Hex);
+  test<2>(ReferenceCell::Line);
+  test<2>(ReferenceCell::Tri);
+  test<2>(ReferenceCell::Quad);
+  test<3>(ReferenceCell::Tet);
+  test<3>(ReferenceCell::Pyramid);
+  test<3>(ReferenceCell::Wedge);
+  test<3>(ReferenceCell::Hex);
 }

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -28,10 +28,10 @@ using namespace dealii;
 
 template <int dim>
 void
-test(const ReferenceCell::Type &reference_cell)
+test(const ReferenceCell &reference_cell)
 {
   for (const auto face_no :
-       ReferenceCell::internal::Info::get_cell(reference_cell).face_indices())
+       internal::Info::get_cell(reference_cell).face_indices())
     {
       deallog << reference_cell.template unit_normal_vectors<dim>(face_no)
               << std::endl;
@@ -51,10 +51,10 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Type::Tri);
-  test<2>(ReferenceCell::Type::Quad);
-  test<3>(ReferenceCell::Type::Tet);
-  test<3>(ReferenceCell::Type::Pyramid);
-  test<3>(ReferenceCell::Type::Wedge);
-  test<3>(ReferenceCell::Type::Hex);
+  test<2>(ReferenceCell::Tri);
+  test<2>(ReferenceCell::Quad);
+  test<3>(ReferenceCell::Tet);
+  test<3>(ReferenceCell::Pyramid);
+  test<3>(ReferenceCell::Wedge);
+  test<3>(ReferenceCell::Hex);
 }

--- a/tests/simplex/variable_face_quadratures_01.cc
+++ b/tests/simplex/variable_face_quadratures_01.cc
@@ -75,19 +75,14 @@ test<2>()
                                             QGauss<dim - 1>(4));
 
     const auto quad =
-      QProjector<dim>::project_to_all_faces(ReferenceCell::Type::Quad,
-                                            quad_ref);
+      QProjector<dim>::project_to_all_faces(ReferenceCell::Quad, quad_ref);
 
     const auto print = [&](const unsigned int face_no) {
       deallog << "face_no=" << face_no << ":" << std::endl;
-      for (unsigned int q = 0,
-                        i = QProjector<dim>::DataSetDescriptor::face(
-                          ReferenceCell::Type::Quad,
-                          face_no,
-                          false,
-                          false,
-                          false,
-                          quad_ref);
+      for (unsigned int
+             q = 0,
+             i = QProjector<dim>::DataSetDescriptor::face(
+               ReferenceCell::Quad, face_no, false, false, false, quad_ref);
            q < quad_ref[face_no].size();
            ++q, ++i)
         {


### PR DESCRIPTION
This is what I was really aiming at with #11544: Just name the class `ReferenceCell`. This is quite a large patch, and probably terribly boring to look through if anyone actually wanted to do that. So here is the skinny:

* Previously, we had `namespace ReferenceCell` and in it `class Type`. I moved the class out of the namespace and because there was nothing left in it, removed the namespace. Then I renamed the class `ReferenceCell`. 
* I used a script to replace `ReferenceCell::Type` in all places to `ReferenceCell`. 
* We had a namespace `ReferenceCell::internal` which is now simply `internal`. I put one function into a nested `namespace internal::ReferenceCell` (and will move the `Info` classes there too at a later point), and this leads to issues in all places where we refer to `ReferenceCell` in `internal` namespaces because that symbol now finds `namespace internal::ReferenceCell` before `class dealii::ReferenceCell`, so I needed to namespace-qualify the name with `dealii::` in all of these places.

Nothing I do here changes any functionality, nor was it difficult. It was just tedious to do, and will be tedious to review. I appreciate whoever wants to take on that task -- I've got a couple more follow-up patches already queued up.

/rebuild