### PR TITLE
Ensure exactly one newline at the end of each file.

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -75,3 +75,35 @@ process_changed "tests include source examples cmake/scripts contrib/python-bind
 
 process_changed "tests include source examples cmake/scripts contrib/python-bindings doc" \
   ".*\.(cc|h|cu|cuh|html|dox|txt)" remove_trailing_whitespace
+
+
+#
+# Ensure only a single newline at end of files
+#
+ensure_single_trailing_newline()
+{
+  f=$1
+
+  # Remove newlines at end of file
+  # Check that the current line only contains newlines
+  # If it doesn't match, print it
+  # If it does match and we're not at the end of the file,
+  # append the next line to the current line and repeat the check
+  # If it does match and we're at the end of the file,
+  # remove the line.
+  sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba' $f >$f.tmpi
+
+  # Then add a newline to the end of the file
+  # '$' denotes the end of file
+  # 'a\' appends the following text (which in this case is nothing)
+  # on a new line
+  sed -e '$a\' $f.tmpi >$f.tmp
+
+  diff -q $f $f.tmp >/dev/null || mv $f.tmp $f
+  rm -f $f.tmp $f.tmpi
+}
+export -f ensure_single_trailing_newline
+
+process_changed "tests include source examples cmake/scripts contrib/python-bindings doc" \
+  ".*\.(cc|h|cu|cuh|html|dox|txt)" ensure_single_trailing_newline
+


### PR DESCRIPTION
This is really @bobmyhill 's work, taken from https://github.com/geodynamics/aspect/pull/3963 . It turns out that, apparently, we don't have any files right now that either have no endline at the end, or have more than one endline at the end. I thought that was strange, but I checked that the script works as advertised, and so I'm adding it to the automatic indentation checks since we keep getting patches that have files without an endline at the end.

/rebuild