### PR TITLE
Get rid of the PolynomialType template argument of FE_Q_Base.

### DIFF
--- a/doc/news/changes/incompatibilities/20210203Bangerth
+++ b/doc/news/changes/incompatibilities/20210203Bangerth
@@ -1,0 +1,7 @@
+Changed: The FE_Q_Base class took a description of the polynomial
+space as a template argument. But that is not necessary: It is
+entirely sufficient to pass this information to the constructor in the
+form of a regular constructor argument. This has been changed, and the
+class has therefore lost its first template argument.
+<br>
+(Wolfgang Bangerth, 2021/02/03)

--- a/include/deal.II/fe/fe_bernstein.h
+++ b/include/deal.II/fe/fe_bernstein.h
@@ -60,8 +60,7 @@ DEAL_II_NAMESPACE_OPEN
  */
 
 template <int dim, int spacedim = dim>
-class FE_Bernstein
-  : public FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>
+class FE_Bernstein : public FE_Q_Base<dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_q.h
+++ b/include/deal.II/fe/fe_q.h
@@ -545,7 +545,7 @@ DEAL_II_NAMESPACE_OPEN
  * <td align="center"> </td> </tr> </table>
  */
 template <int dim, int spacedim = dim>
-class FE_Q : public FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>
+class FE_Q : public FE_Q_Base<dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -34,18 +34,16 @@ DEAL_II_NAMESPACE_OPEN
  * functional as a stand-alone. The completion of definitions is left to the
  * derived classes.
  */
-template <class PolynomialType,
-          int dim      = PolynomialType::dimension,
-          int spacedim = dim>
+template <int dim, int spacedim = dim>
 class FE_Q_Base : public FE_Poly<dim, spacedim>
 {
 public:
   /**
    * Constructor.
    */
-  FE_Q_Base(const PolynomialType &        poly_space,
-            const FiniteElementData<dim> &fe_data,
-            const std::vector<bool> &     restriction_is_additive_flags);
+  FE_Q_Base(const ScalarPolynomialsBase<dim> &poly_space,
+            const FiniteElementData<dim> &    fe_data,
+            const std::vector<bool> &         restriction_is_additive_flags);
 
   /**
    * Return the matrix interpolating from the given finite element to the
@@ -330,7 +328,7 @@ protected:
   struct Implementation;
 
   // Declare implementation friend.
-  friend struct FE_Q_Base<PolynomialType, dim, spacedim>::Implementation;
+  friend struct FE_Q_Base<dim, spacedim>::Implementation;
 
 private:
   /**

--- a/include/deal.II/fe/fe_q_bubbles.h
+++ b/include/deal.II/fe/fe_q_bubbles.h
@@ -88,8 +88,7 @@ DEAL_II_NAMESPACE_OPEN
  * the bubble enrichments in the middle of the cell.
  */
 template <int dim, int spacedim = dim>
-class FE_Q_Bubbles
-  : public FE_Q_Base<TensorProductPolynomialsBubbles<dim>, dim, spacedim>
+class FE_Q_Bubbles : public FE_Q_Base<dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_q_dg0.h
+++ b/include/deal.II/fe/fe_q_dg0.h
@@ -235,8 +235,7 @@ DEAL_II_NAMESPACE_OPEN
  * </ul>
  */
 template <int dim, int spacedim = dim>
-class FE_Q_DG0
-  : public FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>
+class FE_Q_DG0 : public FE_Q_Base<dim, spacedim>
 {
 public:
   /**

--- a/include/deal.II/fe/fe_q_iso_q1.h
+++ b/include/deal.II/fe/fe_q_iso_q1.h
@@ -108,11 +108,7 @@ DEAL_II_NAMESPACE_OPEN
  * FE_Q_iso_Q1 with more than one subdivision does have less coupling.
  */
 template <int dim, int spacedim = dim>
-class FE_Q_iso_Q1
-  : public FE_Q_Base<
-      TensorProductPolynomials<dim, Polynomials::PiecewisePolynomial<double>>,
-      dim,
-      spacedim>
+class FE_Q_iso_Q1 : public FE_Q_Base<dim, spacedim>
 {
 public:
   /**

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -36,13 +36,13 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FE_Bernstein<dim, spacedim>::FE_Bernstein(const unsigned int degree)
-  : FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>(
-      this->renumber_bases(degree),
-      FiniteElementData<dim>(this->get_dpo_vector(degree),
-                             1,
-                             degree,
-                             FiniteElementData<dim>::H1),
-      std::vector<bool>(1, false))
+  : FE_Q_Base<dim, spacedim>(this->renumber_bases(degree),
+                             FiniteElementData<dim>(this->get_dpo_vector(
+                                                      degree),
+                                                    1,
+                                                    degree,
+                                                    FiniteElementData<dim>::H1),
+                             std::vector<bool>(1, false))
 {}
 
 

--- a/source/fe/fe_q.cc
+++ b/source/fe/fe_q.cc
@@ -44,7 +44,7 @@ namespace internal
           return QGaussLobatto<1>(degree + 1).get_points();
         else
           {
-            using FEQ = dealii::FE_Q_Base<TensorProductPolynomials<1>, 1, 1>;
+            using FEQ = dealii::FE_Q_Base<1, 1>;
             AssertThrow(false, FEQ::ExcFEQCannotHaveDegree0());
           }
         return std::vector<Point<1>>();
@@ -57,7 +57,7 @@ namespace internal
 
 template <int dim, int spacedim>
 FE_Q<dim, spacedim>::FE_Q(const unsigned int degree)
-  : FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>(
+  : FE_Q_Base<dim, spacedim>(
       TensorProductPolynomials<dim>(
         Polynomials::generate_complete_Lagrange_basis(
           internal::FE_Q::get_QGaussLobatto_points(degree))),
@@ -74,7 +74,7 @@ FE_Q<dim, spacedim>::FE_Q(const unsigned int degree)
 
 template <int dim, int spacedim>
 FE_Q<dim, spacedim>::FE_Q(const Quadrature<1> &points)
-  : FE_Q_Base<TensorProductPolynomials<dim>, dim, spacedim>(
+  : FE_Q_Base<dim, spacedim>(
       TensorProductPolynomials<dim>(
         Polynomials::generate_complete_Lagrange_basis(points.get_points())),
       FiniteElementData<dim>(this->get_dpo_vector(points.size() - 1),

--- a/source/fe/fe_q_base.inst.in
+++ b/source/fe/fe_q_base.inst.in
@@ -18,19 +18,6 @@
 for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
-    template class FE_Q_Base<TensorProductPolynomials<deal_II_dimension>,
-                             deal_II_dimension,
-                             deal_II_space_dimension>;
-    template class FE_Q_Base<TensorProductPolynomialsConst<deal_II_dimension>,
-                             deal_II_dimension,
-                             deal_II_space_dimension>;
-    template class FE_Q_Base<TensorProductPolynomialsBubbles<deal_II_dimension>,
-                             deal_II_dimension,
-                             deal_II_space_dimension>;
-    template class FE_Q_Base<
-      TensorProductPolynomials<deal_II_dimension,
-                               Polynomials::PiecewisePolynomial<double>>,
-      deal_II_dimension,
-      deal_II_space_dimension>;
+    template class FE_Q_Base<deal_II_dimension, deal_II_space_dimension>;
 #endif
   }

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -186,15 +186,14 @@ namespace internal
 
 template <int dim, int spacedim>
 FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const unsigned int q_degree)
-  : FE_Q_Base<TensorProductPolynomialsBubbles<dim>, dim, spacedim>(
-      TensorProductPolynomialsBubbles<dim>(
-        Polynomials::generate_complete_Lagrange_basis(
-          QGaussLobatto<1>(q_degree + 1).get_points())),
-      FiniteElementData<dim>(get_dpo_vector(q_degree),
-                             1,
-                             q_degree + 1,
-                             FiniteElementData<dim>::H1),
-      get_riaf_vector(q_degree))
+  : FE_Q_Base<dim, spacedim>(TensorProductPolynomialsBubbles<dim>(
+                               Polynomials::generate_complete_Lagrange_basis(
+                                 QGaussLobatto<1>(q_degree + 1).get_points())),
+                             FiniteElementData<dim>(get_dpo_vector(q_degree),
+                                                    1,
+                                                    q_degree + 1,
+                                                    FiniteElementData<dim>::H1),
+                             get_riaf_vector(q_degree))
   , n_bubbles((q_degree <= 1) ? 1 : dim)
 {
   Assert(q_degree > 0,
@@ -226,7 +225,7 @@ FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const unsigned int q_degree)
 
 template <int dim, int spacedim>
 FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const Quadrature<1> &points)
-  : FE_Q_Base<TensorProductPolynomialsBubbles<dim>, dim, spacedim>(
+  : FE_Q_Base<dim, spacedim>(
       TensorProductPolynomialsBubbles<dim>(
         Polynomials::generate_complete_Lagrange_basis(points.get_points())),
       FiniteElementData<dim>(get_dpo_vector(points.size() - 1),
@@ -455,8 +454,8 @@ FE_Q_Bubbles<dim, spacedim>::has_support_on_face(
   if (shape_index >= this->n_dofs_per_cell() - n_bubbles)
     return false;
   else
-    return FE_Q_Base<TensorProductPolynomialsBubbles<dim>, dim, spacedim>::
-      has_support_on_face(shape_index, face_index);
+    return FE_Q_Base<dim, spacedim>::has_support_on_face(shape_index,
+                                                         face_index);
 }
 
 

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -33,15 +33,14 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const unsigned int degree)
-  : FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>(
-      TensorProductPolynomialsConst<dim>(
-        Polynomials::generate_complete_Lagrange_basis(
-          QGaussLobatto<1>(degree + 1).get_points())),
-      FiniteElementData<dim>(get_dpo_vector(degree),
-                             1,
-                             degree,
-                             FiniteElementData<dim>::L2),
-      get_riaf_vector(degree))
+  : FE_Q_Base<dim, spacedim>(TensorProductPolynomialsConst<dim>(
+                               Polynomials::generate_complete_Lagrange_basis(
+                                 QGaussLobatto<1>(degree + 1).get_points())),
+                             FiniteElementData<dim>(get_dpo_vector(degree),
+                                                    1,
+                                                    degree,
+                                                    FiniteElementData<dim>::L2),
+                             get_riaf_vector(degree))
 {
   Assert(degree > 0,
          ExcMessage("This element can only be used for polynomial degrees "
@@ -61,7 +60,7 @@ FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const unsigned int degree)
 
 template <int dim, int spacedim>
 FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const Quadrature<1> &points)
-  : FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>(
+  : FE_Q_Base<dim, spacedim>(
       TensorProductPolynomialsConst<dim>(
         Polynomials::generate_complete_Lagrange_basis(points.get_points())),
       FiniteElementData<dim>(get_dpo_vector(points.size() - 1),
@@ -226,8 +225,8 @@ FE_Q_DG0<dim, spacedim>::get_interpolation_matrix(
          ExcDimensionMismatch(interpolation_matrix.m(),
                               x_source_fe.n_dofs_per_cell()));
 
-  this->FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>::
-    get_interpolation_matrix(x_source_fe, interpolation_matrix);
+  this->FE_Q_Base<dim, spacedim>::get_interpolation_matrix(
+    x_source_fe, interpolation_matrix);
 }
 
 
@@ -267,8 +266,8 @@ FE_Q_DG0<dim, spacedim>::has_support_on_face(
   if (shape_index == this->n_dofs_per_cell() - 1)
     return true;
   else
-    return FE_Q_Base<TensorProductPolynomialsConst<dim>, dim, spacedim>::
-      has_support_on_face(shape_index, face_index);
+    return FE_Q_Base<dim, spacedim>::has_support_on_face(shape_index,
+                                                         face_index);
 }
 
 

--- a/source/fe/fe_q_iso_q1.cc
+++ b/source/fe/fe_q_iso_q1.cc
@@ -32,10 +32,7 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FE_Q_iso_Q1<dim, spacedim>::FE_Q_iso_Q1(const unsigned int subdivisions)
-  : FE_Q_Base<
-      TensorProductPolynomials<dim, Polynomials::PiecewisePolynomial<double>>,
-      dim,
-      spacedim>(
+  : FE_Q_Base<dim, spacedim>(
       TensorProductPolynomials<dim, Polynomials::PiecewisePolynomial<double>>(
         Polynomials::generate_complete_Lagrange_basis_on_subdivisions(
           subdivisions,


### PR DESCRIPTION
This is similar to what @GrahamBenHarper did in #8597 and #8711. In short, there is no good reason why the `FE_Q_Base` class should have the polynomial space description as a *template argument*, as opposed to just taking an object as a regular argument in the constructor. Indeed, removing this template argument is not overly complicated, and probably also saves us some compile time and disk space.

Related to #1973.

@marcfehling -- FYI, as discussed earlier.

/rebuild