### PR TITLE
Provide correct mappings to function calls.

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2149,10 +2149,11 @@ namespace GridGenerator
 
     // Check that the order of the vertices makes sense, i.e., the volume of the
     // cell is positive.
-    Assert(GridTools::volume(tria) > 0.,
-           ExcMessage(
-             "The volume of the cell is not greater than zero. "
-             "This could be due to the wrong ordering of the vertices."));
+    Assert(
+      GridTools::volume(tria, ReferenceCell::get_default_linear_mapping(tria)) >
+        0.,
+      ExcMessage("The volume of the cell is not greater than zero. "
+                 "This could be due to the wrong ordering of the vertices."));
   }
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1033,7 +1033,7 @@ namespace Particles
 
           const unsigned int closest_vertex =
             GridTools::find_closest_vertex_of_cell<dim, spacedim>(
-              current_cell, out_particle->get_location());
+              current_cell, out_particle->get_location(), *mapping);
           Tensor<1, spacedim> vertex_to_particle =
             out_particle->get_location() - current_cell->vertex(closest_vertex);
           vertex_to_particle /= vertex_to_particle.norm();


### PR DESCRIPTION
The `GridTools` functions being called have default arguments. In the case of the call in `grid_generator.cc`, the default argument is only correct if the mesh is a hypercube mesh, and we would presumably fail otherwise.

In the case of the call in `particle_handler.cc`, I believe that the omission of the mapping is an actual bug. @gassmoeller @luca-heltai 

/rebuild