### PR TITLE
Rename variables named 'reference_cell_type' to 'reference_cell'.

### DIFF
--- a/contrib/python-bindings/include/cell_accessor_wrapper.h
+++ b/contrib/python-bindings/include/cell_accessor_wrapper.h
@@ -185,10 +185,10 @@ namespace python
     unsigned int
     vertex_index(const unsigned int i) const;
 
-    /*! @copydoc TriaAccessor::reference_cell_type
+    /*! @copydoc TriaAccessor::reference_cell
      */
     CellTypeWrapper
-    reference_cell_type() const;
+    reference_cell() const;
 
     /*! @copydoc TriaAccessor::n_vertices
      */

--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -799,14 +799,14 @@ namespace python
 
 
   CellTypeWrapper
-  CellAccessorWrapper::reference_cell_type() const
+  CellAccessorWrapper::reference_cell() const
   {
     if ((dim == 2) && (spacedim == 2))
-      return internal::cell_cast<2, 2>(cell_accessor)->reference_cell_type();
+      return internal::cell_cast<2, 2>(cell_accessor)->reference_cell();
     else if ((dim == 2) && (spacedim == 3))
-      return internal::cell_cast<2, 3>(cell_accessor)->reference_cell_type();
+      return internal::cell_cast<2, 3>(cell_accessor)->reference_cell();
     else
-      return internal::cell_cast<3, 3>(cell_accessor)->reference_cell_type();
+      return internal::cell_cast<3, 3>(cell_accessor)->reference_cell();
   }
 
 } // namespace python

--- a/contrib/python-bindings/source/export_cell_accessor.cc
+++ b/contrib/python-bindings/source/export_cell_accessor.cc
@@ -152,8 +152,8 @@ namespace python
 
 
 
-  const char reference_cell_type_docstring[] =
-    " Reference cell type of the current cell).                          \n";
+  const char reference_cell_docstring[] =
+    " Reference cell of the current cell).                               \n";
 
 
 
@@ -260,9 +260,9 @@ namespace python
            &CellAccessorWrapper::vertex_index,
            vertex_index_docstring,
            boost::python::args("self", "vertex"))
-      .def("reference_cell_type",
-           &CellAccessorWrapper::reference_cell_type,
-           reference_cell_type_docstring,
+      .def("reference_cell",
+           &CellAccessorWrapper::reference_cell,
+           reference_cell_docstring,
            boost::python::args("self"))
       .def("n_vertices",
            &CellAccessorWrapper::n_vertices,

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -324,7 +324,7 @@ namespace DataOutBase
     /**
      * Reference-cell type of the underlying cell of this patch.
      */
-    ReferenceCell reference_cell_type;
+    ReferenceCell reference_cell;
 
     /**
      * Default constructor. Sets #n_subdivisions to one, #points_are_available
@@ -474,7 +474,7 @@ namespace DataOutBase
     /**
      * Reference-cell type of the underlying cell of this patch.
      */
-    ReferenceCell reference_cell_type;
+    ReferenceCell reference_cell;
 
     /**
      * Default constructor. Sets #points_are_available
@@ -3345,7 +3345,7 @@ public:
    */
   std::string
   get_xdmf_content(const unsigned int   indent_level,
-                   const ReferenceCell &reference_cell_type) const;
+                   const ReferenceCell &reference_cell) const;
 
 private:
   /**

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -106,7 +106,7 @@ public:
    * doc for this class.
    */
   static void
-  project_to_face(const ReferenceCell      reference_cell_type,
+  project_to_face(const ReferenceCell      reference_cell,
                   const SubQuadrature &    quadrature,
                   const unsigned int       face_no,
                   std::vector<Point<dim>> &q_points);
@@ -129,7 +129,7 @@ public:
    * the general doc for this class.
    */
   static Quadrature<dim>
-  project_to_face(const ReferenceCell  reference_cell_type,
+  project_to_face(const ReferenceCell  reference_cell,
                   const SubQuadrature &quadrature,
                   const unsigned int   face_no);
 
@@ -164,7 +164,7 @@ public:
    * same as those of the original rule.
    */
   static void
-  project_to_subface(const ReferenceCell            reference_cell_type,
+  project_to_subface(const ReferenceCell            reference_cell,
                      const SubQuadrature &          quadrature,
                      const unsigned int             face_no,
                      const unsigned int             subface_no,
@@ -206,7 +206,7 @@ public:
    * version of this function that takes the reference cell type instead.
    */
   static Quadrature<dim>
-  project_to_subface(const ReferenceCell            reference_cell_type,
+  project_to_subface(const ReferenceCell            reference_cell,
                      const SubQuadrature &          quadrature,
                      const unsigned int             face_no,
                      const unsigned int             subface_no,
@@ -253,7 +253,7 @@ public:
    * each face, in order to cope possibly different orientations of the mesh.
    */
   static Quadrature<dim>
-  project_to_all_faces(const ReferenceCell             reference_cell_type,
+  project_to_all_faces(const ReferenceCell             reference_cell,
                        const hp::QCollection<dim - 1> &quadrature);
 
   /**
@@ -261,7 +261,7 @@ public:
    * formula on all faces.
    */
   static Quadrature<dim>
-  project_to_all_faces(const ReferenceCell        reference_cell_type,
+  project_to_all_faces(const ReferenceCell        reference_cell,
                        const Quadrature<dim - 1> &quadrature);
 
   /**
@@ -298,7 +298,7 @@ public:
    * in FESubfaceValues.
    */
   static Quadrature<dim>
-  project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+  project_to_all_subfaces(const ReferenceCell  reference_cell,
                           const SubQuadrature &quadrature);
 
   /**
@@ -330,7 +330,7 @@ public:
    * GeometryInfo<dim>::children_per_cell.
    */
   static Quadrature<dim>
-  project_to_child(const ReferenceCell    reference_cell_type,
+  project_to_child(const ReferenceCell    reference_cell,
                    const Quadrature<dim> &quadrature,
                    const unsigned int     child_no);
 
@@ -360,7 +360,7 @@ public:
    * refinement of the cell.
    */
   static Quadrature<dim>
-  project_to_all_children(const ReferenceCell    reference_cell_type,
+  project_to_all_children(const ReferenceCell    reference_cell,
                           const Quadrature<dim> &quadrature);
 
   /**
@@ -381,7 +381,7 @@ public:
    * connecting the points <tt>p1</tt> and <tt>p2</tt>.
    */
   static Quadrature<dim>
-  project_to_line(const ReferenceCell  reference_cell_type,
+  project_to_line(const ReferenceCell  reference_cell,
                   const Quadrature<1> &quadrature,
                   const Point<dim> &   p1,
                   const Point<dim> &   p2);
@@ -447,7 +447,7 @@ public:
      * onto the faces) has.
      */
     static DataSetDescriptor
-    face(const ReferenceCell reference_cell_type,
+    face(const ReferenceCell reference_cell,
          const unsigned int  face_no,
          const bool          face_orientation,
          const bool          face_flip,
@@ -459,7 +459,7 @@ public:
      * that each face might have different number of quadrature points.
      */
     static DataSetDescriptor
-    face(const ReferenceCell             reference_cell_type,
+    face(const ReferenceCell             reference_cell,
          const unsigned int              face_no,
          const bool                      face_orientation,
          const bool                      face_flip,
@@ -505,7 +505,7 @@ public:
      * Through the last argument anisotropic refinement can be respected.
      */
     static DataSetDescriptor
-    subface(const ReferenceCell              reference_cell_type,
+    subface(const ReferenceCell              reference_cell,
             const unsigned int               face_no,
             const unsigned int               subface_no,
             const bool                       face_orientation,
@@ -585,10 +585,10 @@ Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
 
 template <int dim>
 Quadrature<dim> inline QProjector<dim>::project_to_all_faces(
-  const ReferenceCell        reference_cell_type,
+  const ReferenceCell        reference_cell,
   const Quadrature<dim - 1> &quadrature)
 {
-  return project_to_all_faces(reference_cell_type,
+  return project_to_all_faces(reference_cell,
                               hp::QCollection<dim - 1>(quadrature));
 }
 
@@ -605,7 +605,7 @@ QProjector<1>::project_to_face(const Quadrature<0> &,
                                std::vector<Point<1>> &);
 template <>
 void
-QProjector<1>::project_to_face(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_face(const ReferenceCell reference_cell,
                                const Quadrature<0> &,
                                const unsigned int,
                                std::vector<Point<1>> &);
@@ -616,7 +616,7 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
                                std::vector<Point<2>> &q_points);
 template <>
 void
-QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
+QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
                                const Quadrature<1> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<2>> &q_points);
@@ -627,14 +627,14 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
                                std::vector<Point<3>> &q_points);
 template <>
 void
-QProjector<3>::project_to_face(const ReferenceCell    reference_cell_type,
+QProjector<3>::project_to_face(const ReferenceCell    reference_cell,
                                const Quadrature<2> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points);
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_faces(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<0> &quadrature);
 
 
@@ -647,7 +647,7 @@ QProjector<1>::project_to_subface(const Quadrature<0> &,
                                   const RefinementCase<0> &);
 template <>
 void
-QProjector<1>::project_to_subface(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_subface(const ReferenceCell reference_cell,
                                   const Quadrature<0> &,
                                   const unsigned int,
                                   const unsigned int,
@@ -662,7 +662,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &  quadrature,
                                   const RefinementCase<1> &);
 template <>
 void
-QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
+QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
                                   const Quadrature<1> &  quadrature,
                                   const unsigned int     face_no,
                                   const unsigned int     subface_no,
@@ -677,7 +677,7 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
                                   const RefinementCase<2> &face_ref_case);
 template <>
 void
-QProjector<3>::project_to_subface(const ReferenceCell      reference_cell_type,
+QProjector<3>::project_to_subface(const ReferenceCell      reference_cell,
                                   const Quadrature<2> &    quadrature,
                                   const unsigned int       face_no,
                                   const unsigned int       subface_no,
@@ -689,7 +689,7 @@ Quadrature<1>
 QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature);
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const Quadrature<0> &quadrature);
 
 

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -375,10 +375,10 @@ namespace parallel
     update_number_cache();
 
     /**
-     * @copydoc dealii::Triangulation::update_reference_cell_types()
+     * @copydoc dealii::Triangulation::update_reference_cells()
      */
     void
-    update_reference_cell_types() override;
+    update_reference_cells() override;
 
     /**
      * Reset global active cell indices and global level cell indices.

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2760,7 +2760,7 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::get_fe() const
   const auto &fe = this->dof_handler->get_fe(active_fe_index());
 
   Assert(
-    this->reference_cell_type() == fe.reference_cell_type(),
+    this->reference_cell() == fe.reference_cell(),
     ExcMessage(
       "The reference-cell type of the cell does not match the one of the finite element!"));
 

--- a/include/deal.II/fe/fe_base.h
+++ b/include/deal.II/fe/fe_base.h
@@ -520,7 +520,7 @@ public:
    * triangle, or similar choices in higher dimensions.
    */
   ReferenceCell
-  reference_cell_type() const;
+  reference_cell() const;
 
   /**
    * Number of unique quads. If all quads have the same type, the value is
@@ -746,7 +746,7 @@ namespace FiniteElementDomination
 
 template <int dim>
 inline ReferenceCell
-FiniteElementData<dim>::reference_cell_type() const
+FiniteElementData<dim>::reference_cell() const
 {
   return cell_type;
 }

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -526,26 +526,22 @@ FEInterfaceValues<dim, spacedim>::FEInterfaceValues(
   const UpdateFlags                   update_flags)
   : n_quadrature_points(quadrature.size())
   , internal_fe_face_values(
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values(
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_face_values_neighbor(
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)
   , internal_fe_subface_values_neighbor(
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature,
       update_flags)

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -363,7 +363,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // faces are stored contiguously)
 
   const auto offset =
-    QProjector<dim>::DataSetDescriptor::face(this->reference_cell_type(),
+    QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
                                              face_no,
                                              cell->face_orientation(face_no),
                                              cell->face_flip(face_no),
@@ -453,7 +453,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // sub-faces are stored contiguously)
 
   const auto offset =
-    QProjector<dim>::DataSetDescriptor::subface(this->reference_cell_type(),
+    QProjector<dim>::DataSetDescriptor::subface(this->reference_cell(),
                                                 face_no,
                                                 sub_no,
                                                 cell->face_orientation(face_no),

--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -1490,21 +1490,21 @@ namespace internal
       // loop over cells and create CRS
       for (const auto &cell : cells)
         {
-          const dealii::ReferenceCell reference_cell_type =
+          const dealii::ReferenceCell reference_cell =
             dealii::ReferenceCell::n_vertices_to_type(dim,
                                                       cell.vertices.size());
 
-          Assert(reference_cell_type != dealii::ReferenceCell::Invalid,
+          Assert(reference_cell != dealii::ReferenceCell::Invalid,
                  ExcNotImplemented());
           AssertIndexRange(static_cast<types::geometric_entity_type>(
-                             reference_cell_type),
+                             reference_cell),
                            cell_types_impl.size());
           Assert(cell_types_impl[static_cast<types::geometric_entity_type>(
-                                   reference_cell_type)]
+                                   reference_cell)]
                      .get() != nullptr,
                  ExcNotImplemented());
 
-          cell_types_indices.push_back(reference_cell_type);
+          cell_types_indices.push_back(reference_cell);
 
           // create CRS of vertices (to remove template argument dim)
           for (const auto &vertex : cell.vertices)

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3271,7 +3271,7 @@ namespace GridTools
             if (cell->face(face)->has_children() &&
                 !cell->face(face)->at_boundary())
               {
-                Assert(cell->reference_cell_type() ==
+                Assert(cell->reference_cell() ==
                          ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 
@@ -3291,7 +3291,7 @@ namespace GridTools
             if (cell->face(face)->has_children() &&
                 !cell->face(face)->at_boundary())
               {
-                Assert(cell->reference_cell_type() ==
+                Assert(cell->reference_cell() ==
                          ReferenceCell::get_hypercube<dim>(),
                        ExcNotImplemented());
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -957,7 +957,7 @@ namespace internal
        * Return reference-cell type of face @p face_no.
        */
       virtual dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const
+      face_reference_cell(const unsigned int face_no) const
       {
         Assert(false, ExcNotImplemented());
         (void)face_no;
@@ -1097,7 +1097,7 @@ namespace internal
     struct Vertex : public TensorProductBase<0>
     {
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
         return dealii::ReferenceCell::Invalid;
@@ -1121,7 +1121,7 @@ namespace internal
     struct Line : public TensorProductBase<1>
     {
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
         return dealii::ReferenceCell::Vertex;
@@ -1194,7 +1194,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
 
@@ -1280,7 +1280,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
         return dealii::ReferenceCell::Line;
@@ -1404,7 +1404,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
 
@@ -1575,7 +1575,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         AssertIndexRange(face_no, n_faces());
 
@@ -1749,7 +1749,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         AssertIndexRange(face_no, n_faces());
 
@@ -1885,7 +1885,7 @@ namespace internal
       }
 
       dealii::ReferenceCell
-      face_reference_cell_type(const unsigned int face_no) const override
+      face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
         return dealii::ReferenceCell::Quad;
@@ -1936,7 +1936,7 @@ namespace internal
     inline const internal::Info::Base &
     get_face(const dealii::ReferenceCell &type, const unsigned int face_no)
     {
-      return get_cell(get_cell(type).face_reference_cell_type(face_no));
+      return get_cell(get_cell(type).face_reference_cell(face_no));
     }
 
   } // namespace Info

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3389,14 +3389,14 @@ public:
    * triangulation.
    */
   const std::vector<ReferenceCell> &
-  get_reference_cell_types() const;
+  get_reference_cells() const;
 
   /**
    * Indicate if the triangulation only consists of hypercube-like cells, i.e.,
    * lines, quadrilaterals, or hexahedra.
    */
   bool
-  all_reference_cell_types_are_hyper_cube() const;
+  all_reference_cells_are_hyper_cube() const;
 
 #ifdef DOXYGEN
   /**
@@ -3511,7 +3511,7 @@ protected:
    * Vector caching all reference-cell types of the given triangulation
    * (also in the distributed case).
    */
-  std::vector<ReferenceCell> reference_cell_types;
+  std::vector<ReferenceCell> reference_cells;
 
   /**
    * Write a bool vector to the given stream, writing a pre- and a postfix
@@ -3550,10 +3550,10 @@ protected:
   update_periodic_face_map();
 
   /**
-   * Update the internal reference_cell_types vector.
+   * Update the internal reference_cells vector.
    */
   virtual void
-  update_reference_cell_types();
+  update_reference_cells();
 
 
 private:

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1639,7 +1639,7 @@ public:
    * Reference cell type of the current object.
    */
   ReferenceCell
-  reference_cell_type() const;
+  reference_cell() const;
 
   /**
    * Number of vertices.
@@ -2720,7 +2720,7 @@ public:
    * Reference cell type of the current object.
    */
   ReferenceCell
-  reference_cell_type() const;
+  reference_cell() const;
 
   /**
    * Number of vertices.

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -54,22 +54,22 @@ namespace internal
                                            GeometryInfo<dim>::vertices_per_cell>
         vertices)
     {
-      const dealii::ReferenceCell reference_cell_type =
+      const dealii::ReferenceCell reference_cell =
         dealii::ReferenceCell::n_vertices_to_type(dim, vertices.size());
 
-      if (reference_cell_type == dealii::ReferenceCell::Line)
+      if (reference_cell == dealii::ReferenceCell::Line)
         // Return the distance between the two vertices
         return (vertices[1] - vertices[0]).norm();
-      else if (reference_cell_type == dealii::ReferenceCell::Tri)
+      else if (reference_cell == dealii::ReferenceCell::Tri)
         // Return the longest of the three edges
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm(),
                          (vertices[2] - vertices[0]).norm()});
-      else if (reference_cell_type == dealii::ReferenceCell::Quad)
+      else if (reference_cell == dealii::ReferenceCell::Quad)
         // Return the longer one of the two diagonals of the quadrilateral
         return std::max({(vertices[3] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm()});
-      else if (reference_cell_type == dealii::ReferenceCell::Tet)
+      else if (reference_cell == dealii::ReferenceCell::Tet)
         // Return the longest of the six edges of the tetrahedron
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[0]).norm(),
@@ -77,7 +77,7 @@ namespace internal
                          (vertices[3] - vertices[0]).norm(),
                          (vertices[3] - vertices[1]).norm(),
                          (vertices[3] - vertices[2]).norm()});
-      else if (reference_cell_type == dealii::ReferenceCell::Pyramid)
+      else if (reference_cell == dealii::ReferenceCell::Pyramid)
         // Return ...
         return std::max({// the longest diagonal of the quadrilateral base
                          // of the pyramid or ...
@@ -89,7 +89,7 @@ namespace internal
                          (vertices[4] - vertices[1]).norm(),
                          (vertices[4] - vertices[2]).norm(),
                          (vertices[4] - vertices[3]).norm()});
-      else if (reference_cell_type == dealii::ReferenceCell::Wedge)
+      else if (reference_cell == dealii::ReferenceCell::Wedge)
         // Return ...
         return std::max({// the longest of the 2*3=6 diagonals of the three
                          // quadrilateral sides of the wedge or ...
@@ -107,7 +107,7 @@ namespace internal
                          (vertices[4] - vertices[3]).norm(),
                          (vertices[5] - vertices[4]).norm(),
                          (vertices[5] - vertices[3]).norm()});
-      else if (reference_cell_type == dealii::ReferenceCell::Hex)
+      else if (reference_cell == dealii::ReferenceCell::Hex)
         // Return the longest of the four diagonals of the hexahedron
         return std::max({(vertices[7] - vertices[0]).norm(),
                          (vertices[6] - vertices[1]).norm(),
@@ -1087,7 +1087,7 @@ TriaAccessor<structdim, dim, spacedim>::vertex_iterator(
 
 template <int structdim, int dim, int spacedim>
 inline ReferenceCell
-TriaAccessor<structdim, dim, spacedim>::reference_cell_type() const
+TriaAccessor<structdim, dim, spacedim>::reference_cell() const
 {
   if (structdim == 0)
     return ReferenceCell::Vertex;
@@ -1095,9 +1095,9 @@ TriaAccessor<structdim, dim, spacedim>::reference_cell_type() const
     return ReferenceCell::Line;
   else if (structdim == dim)
     return this->tria->levels[this->present_level]
-      ->reference_cell_type[this->present_index];
+      ->reference_cell[this->present_index];
   else
-    return this->tria->faces->quad_reference_cell_type[this->present_index];
+    return this->tria->faces->quad_reference_cell[this->present_index];
 }
 
 
@@ -2256,7 +2256,7 @@ TriaAccessor<structdim, dim, spacedim>::reference_cell_info() const
   else if (structdim == 1)
     return internal::Info::get_cell(ReferenceCell::Line);
   else
-    return internal::Info::get_cell(this->reference_cell_type());
+    return internal::Info::get_cell(this->reference_cell());
 }
 
 
@@ -3111,7 +3111,7 @@ TriaAccessor<0, 1, spacedim>::used() const
 
 template <int spacedim>
 inline ReferenceCell
-TriaAccessor<0, 1, spacedim>::reference_cell_type() const
+TriaAccessor<0, 1, spacedim>::reference_cell() const
 {
   return ReferenceCell::Vertex;
 }

--- a/include/deal.II/grid/tria_faces.h
+++ b/include/deal.II/grid/tria_faces.h
@@ -77,7 +77,7 @@ namespace internal
        *
        * @note Used only for dim=3.
        */
-      std::vector<dealii::ReferenceCell> quad_reference_cell_type;
+      std::vector<dealii::ReferenceCell> quad_reference_cell;
 
       /**
        * The TriaObject containing the data of lines.
@@ -115,7 +115,7 @@ namespace internal
         ar &lines;
 
       if (dim == 3)
-        ar &quads &lines &quads_line_orientations &quad_reference_cell_type;
+        ar &quads &lines &quads_line_orientations &quad_reference_cell;
     }
   } // namespace TriangulationImplementation
 } // namespace internal

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -222,7 +222,7 @@ namespace internal
        *
        * @note Used only for dim=2 and dim=3.
        */
-      std::vector<dealii::ReferenceCell> reference_cell_type;
+      std::vector<dealii::ReferenceCell> reference_cell;
 
       /**
        * Determine an estimate for the memory consumption (in bytes) of this
@@ -265,7 +265,7 @@ namespace internal
         ar &face_orientations;
 
       if (dim == 2 || dim == 3)
-        ar &reference_cell_type;
+        ar &reference_cell;
     }
 
   } // namespace TriangulationImplementation

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1750,14 +1750,14 @@ namespace internal
       reorder_face_derivative_indices(
         const unsigned int          face_no,
         const unsigned int          index,
-        const dealii::ReferenceCell reference_cell_type =
+        const dealii::ReferenceCell reference_cell =
           dealii::ReferenceCell::Invalid)
       {
         Assert(index < dim, ExcInternalError());
 
-        if ((reference_cell_type == dealii::ReferenceCell::Invalid ||
-             reference_cell_type ==
-               dealii::ReferenceCell::get_hypercube<dim>()) == false)
+        if ((reference_cell == dealii::ReferenceCell::Invalid ||
+             reference_cell == dealii::ReferenceCell::get_hypercube<dim>()) ==
+            false)
           {
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
             return index;
@@ -1954,7 +1954,7 @@ namespace internal
                                   reorder_face_derivative_indices<dim>(
                                     faces[face].interior_face_no,
                                     e,
-                                    cell_it->reference_cell_type());
+                                    cell_it->reference_cell());
                                 face_data.general_jac[q][d][e][v] =
                                   inv_jac[d][ee];
                               }
@@ -2102,7 +2102,7 @@ namespace internal
                                   reorder_face_derivative_indices<dim>(
                                     faces[face].exterior_face_no,
                                     e,
-                                    cell_it->reference_cell_type());
+                                    cell_it->reference_cell());
                                 face_data.general_jac[n_q_points + q][d][e][v] =
                                   inv_jac[d][ee];
                               }

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1480,7 +1480,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
              fe_no < dof_handlers[no]->get_fe_collection().size();
              ++fe_no)
           shape_info_dummy(c, fe_no).reinit(
-            dof_handlers[no]->get_fe(fe_no).reference_cell_type() ==
+            dof_handlers[no]->get_fe(fe_no).reference_cell() ==
                 ReferenceCell::get_hypercube<dim>() ?
               quad :
               quad_simplex,

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -316,7 +316,7 @@ namespace internal
 
           try
             {
-              const dealii::ReferenceCell reference_cell_type =
+              const dealii::ReferenceCell reference_cell =
                 dealii::ReferenceCell::get_simplex<dim>();
 
               const auto quad_face  = get_face_quadrature(quad);
@@ -324,10 +324,10 @@ namespace internal
 
               const unsigned int n_face_orientations = dim == 2 ? 2 : 6;
               const unsigned int n_faces =
-                dealii::internal::Info::get_cell(reference_cell_type).n_faces();
+                dealii::internal::Info::get_cell(reference_cell).n_faces();
 
               const auto projected_quad_face =
-                QProjector<dim>::project_to_all_faces(reference_cell_type,
+                QProjector<dim>::project_to_all_faces(reference_cell,
                                                       quad_face);
 
               shape_values_face.reinit(
@@ -341,7 +341,7 @@ namespace internal
                   {
                     const auto offset =
                       QProjector<dim>::DataSetDescriptor::face(
-                        reference_cell_type,
+                        reference_cell,
                         f,
                         (o ^ 1) & 1,  // face_orientation
                         (o >> 1) & 1, // face_flip

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -230,19 +230,19 @@ namespace internal
           for (const auto &fe : finite_elements)
             for (unsigned int i = 0; i < fe->size(); ++i)
               {
-                const auto reference_cell_type = (*fe)[i].reference_cell_type();
+                const auto reference_cell = (*fe)[i].reference_cell();
 
-                if ((reference_cell_type == dealii::ReferenceCell::Vertex) ||
-                    (reference_cell_type == dealii::ReferenceCell::Line) ||
-                    (reference_cell_type == dealii::ReferenceCell::Quad) ||
-                    (reference_cell_type == dealii::ReferenceCell::Hex))
+                if ((reference_cell == dealii::ReferenceCell::Vertex) ||
+                    (reference_cell == dealii::ReferenceCell::Line) ||
+                    (reference_cell == dealii::ReferenceCell::Quad) ||
+                    (reference_cell == dealii::ReferenceCell::Hex))
                   needs_hypercube_setup |= true;
-                else if ((reference_cell_type == dealii::ReferenceCell::Tri) ||
-                         (reference_cell_type == dealii::ReferenceCell::Tet))
+                else if ((reference_cell == dealii::ReferenceCell::Tri) ||
+                         (reference_cell == dealii::ReferenceCell::Tet))
                   needs_simplex_setup |= true;
-                else if (reference_cell_type == dealii::ReferenceCell::Wedge)
+                else if (reference_cell == dealii::ReferenceCell::Wedge)
                   needs_wedge_setup |= true;
-                else if (reference_cell_type == dealii::ReferenceCell::Pyramid)
+                else if (reference_cell == dealii::ReferenceCell::Pyramid)
                   needs_pyramid_setup |= true;
                 else
                   Assert(false, ExcNotImplemented());
@@ -318,27 +318,20 @@ namespace internal
 
                   for (unsigned int j = 0; j < finite_elements[i]->size(); ++j)
                     {
-                      const auto reference_cell_type =
-                        (*finite_elements[i])[j].reference_cell_type();
+                      const auto reference_cell =
+                        (*finite_elements[i])[j].reference_cell();
 
-                      if ((reference_cell_type ==
-                           dealii::ReferenceCell::Vertex) ||
-                          (reference_cell_type ==
-                           dealii::ReferenceCell::Line) ||
-                          (reference_cell_type ==
-                           dealii::ReferenceCell::Quad) ||
-                          (reference_cell_type == dealii::ReferenceCell::Hex))
+                      if ((reference_cell == dealii::ReferenceCell::Vertex) ||
+                          (reference_cell == dealii::ReferenceCell::Line) ||
+                          (reference_cell == dealii::ReferenceCell::Quad) ||
+                          (reference_cell == dealii::ReferenceCell::Hex))
                         quadrature.push_back(*quadrature_hypercube);
-                      else if ((reference_cell_type ==
-                                dealii::ReferenceCell::Tri) ||
-                               (reference_cell_type ==
-                                dealii::ReferenceCell::Tet))
+                      else if ((reference_cell == dealii::ReferenceCell::Tri) ||
+                               (reference_cell == dealii::ReferenceCell::Tet))
                         quadrature.push_back(*quadrature_simplex);
-                      else if (reference_cell_type ==
-                               dealii::ReferenceCell::Wedge)
+                      else if (reference_cell == dealii::ReferenceCell::Wedge)
                         quadrature.push_back(*quadrature_wedge);
-                      else if (reference_cell_type ==
-                               dealii::ReferenceCell::Pyramid)
+                      else if (reference_cell == dealii::ReferenceCell::Pyramid)
                         quadrature.push_back(*quadrature_pyramid);
                       else
                         Assert(false, ExcNotImplemented());

--- a/include/deal.II/numerics/vector_tools_interpolate.templates.h
+++ b/include/deal.II/numerics/vector_tools_interpolate.templates.h
@@ -653,7 +653,7 @@ namespace VectorTools
         const Quadrature<dim> quad(fe.get_unit_support_points());
 
         const auto map_q =
-          fe.reference_cell_type().template get_default_mapping<dim, spacedim>(
+          fe.reference_cell().template get_default_mapping<dim, spacedim>(
             fe.degree);
         FEValues<dim, spacedim>              fe_v(*map_q,
                                      fe,

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -183,8 +183,7 @@ namespace VectorTools
 
       Quadrature<dim> quadrature_mf;
 
-      if (dof.get_fe(0).reference_cell_type() ==
-          ReferenceCell::get_hypercube<dim>())
+      if (dof.get_fe(0).reference_cell() == ReferenceCell::get_hypercube<dim>())
         quadrature_mf = QGauss<dim>(dof.get_fe().degree + 2);
       else
         // TODO: since we have currently only implemented a handful quadrature

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -293,8 +293,7 @@ namespace DataOutBase
                                         (n_data_sets + spacedim) :
                                         n_data_sets,
                                       patch.data.n_rows()));
-          Assert(patch.reference_cell_type !=
-                     ReferenceCell::get_hypercube<dim>() ||
+          Assert(patch.reference_cell != ReferenceCell::get_hypercube<dim>() ||
                    (n_data_sets == 0) ||
                    (patch.data.n_cols() ==
                     Utilities::fixed_power<dim>(n_subdivisions + 1)),
@@ -616,7 +615,7 @@ namespace
 
     if (write_higher_order_cells)
       {
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell == ReferenceCell::get_hypercube<dim>())
           {
             const std::array<unsigned int, 4> cell_type_by_dim{
               {VTK_VERTEX,
@@ -626,7 +625,7 @@ namespace
             vtk_cell_id[0] = cell_type_by_dim[dim];
             vtk_cell_id[1] = 1;
           }
-        else if (patch.reference_cell_type == ReferenceCell::Tri)
+        else if (patch.reference_cell == ReferenceCell::Tri)
           {
             vtk_cell_id[0] = VTK_LAGRANGE_TRIANGLE;
             vtk_cell_id[1] = 1;
@@ -636,43 +635,43 @@ namespace
             Assert(false, ExcNotImplemented());
           }
       }
-    else if (patch.reference_cell_type == ReferenceCell::Tri &&
+    else if (patch.reference_cell == ReferenceCell::Tri &&
              patch.data.n_cols() == 3)
       {
         vtk_cell_id[0] = VTK_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Tri &&
+    else if (patch.reference_cell == ReferenceCell::Tri &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Tet &&
+    else if (patch.reference_cell == ReferenceCell::Tet &&
              patch.data.n_cols() == 4)
       {
         vtk_cell_id[0] = VTK_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Tet &&
+    else if (patch.reference_cell == ReferenceCell::Tet &&
              patch.data.n_cols() == 10)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Wedge &&
+    else if (patch.reference_cell == ReferenceCell::Wedge &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_WEDGE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::Pyramid &&
+    else if (patch.reference_cell == ReferenceCell::Pyramid &&
              patch.data.n_cols() == 5)
       {
         vtk_cell_id[0] = VTK_PYRAMID;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+    else if (patch.reference_cell == ReferenceCell::get_hypercube<dim>())
       {
         const std::array<unsigned int, 4> cell_type_by_dim{
           {VTK_VERTEX, VTK_LINE, VTK_QUAD, VTK_HEXAHEDRON}};
@@ -684,7 +683,7 @@ namespace
         Assert(false, ExcNotImplemented());
       }
 
-    if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>() ||
+    if (patch.reference_cell != ReferenceCell::get_hypercube<dim>() ||
         write_higher_order_cells)
       vtk_cell_id[2] = patch.data.n_cols();
     else
@@ -920,7 +919,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formula doesn't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
             n_cells += Utilities::fixed_power<dim>(patch.n_subdivisions);
@@ -928,8 +927,7 @@ namespace
         else
           {
             Assert(patch.n_subdivisions == 1, ExcNotImplemented());
-            const auto &info =
-              internal::Info::get_cell(patch.reference_cell_type);
+            const auto &info = internal::Info::get_cell(patch.reference_cell);
             n_nodes += info.n_vertices();
             n_cells += 1;
           }
@@ -951,7 +949,7 @@ namespace
     for (const auto &patch : patches)
       {
         // The following formulas don't hold for non-tensor products.
-        if (patch.reference_cell_type == ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell == ReferenceCell::get_hypercube<dim>())
           {
             n_nodes += Utilities::fixed_power<dim>(patch.n_subdivisions + 1);
 
@@ -1867,7 +1865,7 @@ namespace DataOutBase
     : patch_index(no_neighbor)
     , n_subdivisions(1)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube<dim>())
+    , reference_cell(ReferenceCell::get_hypercube<dim>())
   // all the other data has a constructor of its own, except for the "neighbors"
   // field, which we set to invalid values.
   {
@@ -1945,7 +1943,7 @@ namespace DataOutBase
     std::swap(n_subdivisions, other_patch.n_subdivisions);
     data.swap(other_patch.data);
     std::swap(points_are_available, other_patch.points_are_available);
-    std::swap(reference_cell_type, other_patch.reference_cell_type);
+    std::swap(reference_cell, other_patch.reference_cell);
   }
 
 
@@ -1969,7 +1967,7 @@ namespace DataOutBase
   Patch<0, spacedim>::Patch()
     : patch_index(no_neighbor)
     , points_are_available(false)
-    , reference_cell_type(ReferenceCell::get_hypercube<0>())
+    , reference_cell(ReferenceCell::get_hypercube<0>())
   {
     Assert(spacedim <= 3, ExcNotImplemented());
   }
@@ -2632,7 +2630,7 @@ namespace DataOutBase
         // special treatment of simplices since they are not subdivided, such
         // that no new nodes have to be created, but the precomputed ones can be
         // used
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell != ReferenceCell::get_hypercube<dim>())
           {
             Point<spacedim> node;
 
@@ -2676,7 +2674,7 @@ namespace DataOutBase
     for (const auto &patch : patches)
       {
         // special treatment of simplices since they are not subdivided
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell != ReferenceCell::get_hypercube<dim>())
           {
             out.write_cell_single(count++,
                                   first_vertex_of_patch,
@@ -2728,7 +2726,7 @@ namespace DataOutBase
 
     for (const auto &patch : patches)
       {
-        if (patch.reference_cell_type != ReferenceCell::get_hypercube<dim>())
+        if (patch.reference_cell != ReferenceCell::get_hypercube<dim>())
           {
             connectivity.resize(patch.data.n_cols());
 
@@ -7510,7 +7508,7 @@ DataOutInterface<dim, spacedim>::write_xdmf_file(
 
       for (it = entries.begin(); it != entries.end(); ++it)
         {
-          xdmf_file << it->get_xdmf_content(3, patches[0].reference_cell_type);
+          xdmf_file << it->get_xdmf_content(3, patches[0].reference_cell);
         }
 
       xdmf_file << "    </Grid>\n";
@@ -7740,8 +7738,7 @@ DataOutBase::write_hdf5_parallel(
   // patches
   Assert(patches.size() > 0, ExcNoPatches());
 
-  const auto &cell_info =
-    internal::Info::get_cell(patches[0].reference_cell_type);
+  const auto &cell_info = internal::Info::get_cell(patches[0].reference_cell);
 
   hid_t h5_mesh_file_id = -1, h5_solution_file_id, file_plist_id, plist_id;
   hid_t node_dataspace, node_dataset, node_file_dataspace,
@@ -8690,7 +8687,7 @@ XDMFEntry::get_xdmf_content(const unsigned int indent_level) const
 
 std::string
 XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
-                            const ReferenceCell &reference_cell_type) const
+                            const ReferenceCell &reference_cell) const
 {
   if (!valid)
     return "";
@@ -8722,19 +8719,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
            << "\" NodesPerElement=\"2\">\n";
       else if (dimension == 2)
         {
-          Assert(reference_cell_type == ReferenceCell::Quad ||
-                   reference_cell_type == ReferenceCell::Tri,
+          Assert(reference_cell == ReferenceCell::Quad ||
+                   reference_cell == ReferenceCell::Tri,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell_type == ReferenceCell::Quad)
+          if (reference_cell == ReferenceCell::Quad)
             {
               ss << "Quadrilateral"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell_type == ReferenceCell::Tri)
+          else // if (reference_cell == ReferenceCell::Tri)
             {
               ss << "Triangle"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
@@ -8744,19 +8741,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
         }
       else if (dimension == 3)
         {
-          Assert(reference_cell_type == ReferenceCell::Hex ||
-                   reference_cell_type == ReferenceCell::Tet,
+          Assert(reference_cell == ReferenceCell::Hex ||
+                   reference_cell == ReferenceCell::Tet,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell_type == ReferenceCell::Hex)
+          if (reference_cell == ReferenceCell::Hex)
             {
               ss << "Hexahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell_type == ReferenceCell::Tet)
+          else // if (reference_cell == ReferenceCell::Tet)
             {
               ss << "Tetrahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -93,13 +93,13 @@ QProjector<1>::project_to_face(const Quadrature<0> &  quadrature,
 
 template <>
 void
-QProjector<1>::project_to_face(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_face(const ReferenceCell reference_cell,
                                const Quadrature<0> &,
                                const unsigned int     face_no,
                                std::vector<Point<1>> &q_points)
 {
-  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 1;
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
@@ -123,7 +123,7 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
 
 template <>
 void
-QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
+QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
                                const Quadrature<1> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<2>> &q_points)
@@ -133,7 +133,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell_type == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Tri)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -154,7 +154,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell_type,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell_type == ReferenceCell::Quad)
+  else if (reference_cell == ReferenceCell::Quad)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -196,13 +196,13 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
 
 template <>
 void
-QProjector<3>::project_to_face(const ReferenceCell    reference_cell_type,
+QProjector<3>::project_to_face(const ReferenceCell    reference_cell,
                                const Quadrature<2> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 3;
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
@@ -260,15 +260,15 @@ QProjector<1>::project_to_subface(const Quadrature<0> &    quadrature,
 
 template <>
 void
-QProjector<1>::project_to_subface(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_subface(const ReferenceCell reference_cell,
                                   const Quadrature<0> &,
                                   const unsigned int face_no,
                                   const unsigned int,
                                   std::vector<Point<1>> &q_points,
                                   const RefinementCase<0> &)
 {
-  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 1;
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
@@ -295,7 +295,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &    quadrature,
 
 template <>
 void
-QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
+QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
                                   const Quadrature<1> &  quadrature,
                                   const unsigned int     face_no,
                                   const unsigned int     subface_no,
@@ -309,7 +309,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell_type == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Tri)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -363,7 +363,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell_type,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell_type == ReferenceCell::Quad)
+  else if (reference_cell == ReferenceCell::Quad)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -453,15 +453,15 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
 
 template <>
 void
-QProjector<3>::project_to_subface(const ReferenceCell      reference_cell_type,
+QProjector<3>::project_to_subface(const ReferenceCell      reference_cell,
                                   const Quadrature<2> &    quadrature,
                                   const unsigned int       face_no,
                                   const unsigned int       subface_no,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 3;
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
@@ -543,12 +543,12 @@ QProjector<3>::project_to_subface(const ReferenceCell      reference_cell_type,
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_faces(const ReferenceCell reference_cell_type,
+QProjector<1>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<0> &quadrature)
 {
   AssertDimension(quadrature.size(), 1);
-  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 1;
 
@@ -589,10 +589,10 @@ QProjector<1>::project_to_all_faces(const ReferenceCell reference_cell_type,
 
 template <>
 Quadrature<2>
-QProjector<2>::project_to_all_faces(const ReferenceCell reference_cell_type,
+QProjector<2>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<1> &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Tri)
     {
       const auto support_points_line =
         [](const auto &face, const auto &orientation) -> std::vector<Point<2>> {
@@ -659,7 +659,7 @@ QProjector<2>::project_to_all_faces(const ReferenceCell reference_cell_type,
       return {points, weights};
     }
 
-  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -712,7 +712,7 @@ QProjector<2>::project_to_all_faces(const ReferenceCell reference_cell_type,
 
 template <>
 Quadrature<3>
-QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
+QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<2> &quadrature)
 {
   const auto support_points_tri =
@@ -840,7 +840,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
     return Quadrature<3>(points, weights);
   };
 
-  if (reference_cell_type == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Tet)
     {
       // reference faces (defined by its support points and its area)
       // note: the area is later not used as a scaling factor but recomputed
@@ -864,7 +864,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
 
       return process(faces);
     }
-  else if (reference_cell_type == ReferenceCell::Wedge)
+  else if (reference_cell == ReferenceCell::Wedge)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(1.0, 0.0, 0.0),
@@ -893,7 +893,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
 
       return process(faces);
     }
-  else if (reference_cell_type == ReferenceCell::Pyramid)
+  else if (reference_cell == ReferenceCell::Pyramid)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(-1.0, -1.0, 0.0),
@@ -922,7 +922,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell reference_cell_type,
     }
 
 
-  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
 
   const unsigned int dim = 3;
 
@@ -1026,11 +1026,11 @@ QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature)
 
 template <>
 Quadrature<1>
-QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const Quadrature<0> &quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  (void)reference_cell;
 
   const unsigned int dim = 1;
 
@@ -1073,14 +1073,14 @@ QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
 
 template <>
 Quadrature<2>
-QProjector<2>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+QProjector<2>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Tri ||
-      reference_cell_type == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Tri ||
+      reference_cell == ReferenceCell::Tet)
     return Quadrature<2>(); // nothing to do
 
-  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -1133,14 +1133,14 @@ QProjector<2>::project_to_all_subfaces(const SubQuadrature &quadrature)
 
 template <>
 Quadrature<3>
-QProjector<3>::project_to_all_subfaces(const ReferenceCell  reference_cell_type,
+QProjector<3>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Tri ||
-      reference_cell_type == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Tri ||
+      reference_cell == ReferenceCell::Tet)
     return Quadrature<3>(); // nothing to do
 
-  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
 
   const unsigned int dim         = 3;
   SubQuadrature      q_reflected = internal::QProjector::reflect(quadrature);
@@ -1238,13 +1238,13 @@ QProjector<dim>::project_to_child(const Quadrature<dim> &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_child(const ReferenceCell    reference_cell_type,
+QProjector<dim>::project_to_child(const ReferenceCell    reference_cell,
                                   const Quadrature<dim> &quadrature,
                                   const unsigned int     child_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
-  (void)reference_cell_type;
+  (void)reference_cell;
 
   AssertIndexRange(child_no, GeometryInfo<dim>::max_children_per_cell);
 
@@ -1280,13 +1280,12 @@ QProjector<dim>::project_to_all_children(const Quadrature<dim> &quadrature)
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_all_children(
-  const ReferenceCell    reference_cell_type,
-  const Quadrature<dim> &quadrature)
+QProjector<dim>::project_to_all_children(const ReferenceCell    reference_cell,
+                                         const Quadrature<dim> &quadrature)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
-  (void)reference_cell_type;
+  (void)reference_cell;
 
   const unsigned int n_points   = quadrature.size(),
                      n_children = GeometryInfo<dim>::max_children_per_cell;
@@ -1326,14 +1325,14 @@ QProjector<dim>::project_to_line(const Quadrature<1> &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_line(const ReferenceCell  reference_cell_type,
+QProjector<dim>::project_to_line(const ReferenceCell  reference_cell,
                                  const Quadrature<1> &quadrature,
                                  const Point<dim> &   p1,
                                  const Point<dim> &   p2)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
-  (void)reference_cell_type;
+  (void)reference_cell;
 
   const unsigned int      n = quadrature.size();
   std::vector<Point<dim>> points(n);
@@ -1372,16 +1371,15 @@ QProjector<dim>::DataSetDescriptor::face(const unsigned int face_no,
 
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
-QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell reference_cell_type,
-  const unsigned int  face_no,
-  const bool          face_orientation,
-  const bool          face_flip,
-  const bool          face_rotation,
-  const unsigned int  n_quadrature_points)
+QProjector<dim>::DataSetDescriptor::face(const ReferenceCell reference_cell,
+                                         const unsigned int  face_no,
+                                         const bool          face_orientation,
+                                         const bool          face_flip,
+                                         const bool          face_rotation,
+                                         const unsigned int n_quadrature_points)
 {
-  if (reference_cell_type == ReferenceCell::Tri ||
-      reference_cell_type == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Tri ||
+      reference_cell == ReferenceCell::Tet)
     {
       if (dim == 2)
         return {(2 * face_no + face_orientation) * n_quadrature_points};
@@ -1393,7 +1391,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1461,17 +1459,17 @@ QProjector<dim>::DataSetDescriptor::face(
 template <int dim>
 typename QProjector<dim>::DataSetDescriptor
 QProjector<dim>::DataSetDescriptor::face(
-  const ReferenceCell             reference_cell_type,
+  const ReferenceCell             reference_cell,
   const unsigned int              face_no,
   const bool                      face_orientation,
   const bool                      face_flip,
   const bool                      face_rotation,
   const hp::QCollection<dim - 1> &quadrature)
 {
-  if (reference_cell_type == ReferenceCell::Tri ||
-      reference_cell_type == ReferenceCell::Tet ||
-      reference_cell_type == ReferenceCell::Wedge ||
-      reference_cell_type == ReferenceCell::Pyramid)
+  if (reference_cell == ReferenceCell::Tri ||
+      reference_cell == ReferenceCell::Tet ||
+      reference_cell == ReferenceCell::Wedge ||
+      reference_cell == ReferenceCell::Pyramid)
     {
       unsigned int offset = 0;
 
@@ -1483,12 +1481,12 @@ QProjector<dim>::DataSetDescriptor::face(
         {8, 6, 6, 6, 6}};
 
       const auto &scale =
-        (reference_cell_type == ReferenceCell::Tri) ?
+        (reference_cell == ReferenceCell::Tri) ?
           scale_tri :
-          ((reference_cell_type == ReferenceCell::Tet) ?
+          ((reference_cell == ReferenceCell::Tet) ?
              scale_tet :
-             ((reference_cell_type == ReferenceCell::Wedge) ? scale_wedge :
-                                                              scale_pyramid));
+             ((reference_cell == ReferenceCell::Wedge) ? scale_wedge :
+                                                         scale_pyramid));
 
       if (quadrature.size() == 1)
         offset = scale[0] * quadrature[0].size() * face_no;
@@ -1511,7 +1509,7 @@ QProjector<dim>::DataSetDescriptor::face(
         }
     }
 
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1597,7 +1595,7 @@ QProjector<dim>::DataSetDescriptor::face(
 template <>
 QProjector<1>::DataSetDescriptor
 QProjector<1>::DataSetDescriptor::subface(
-  const ReferenceCell reference_cell_type,
+  const ReferenceCell reference_cell,
   const unsigned int  face_no,
   const unsigned int  subface_no,
   const bool,
@@ -1606,8 +1604,8 @@ QProjector<1>::DataSetDescriptor::subface(
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<1>)
 {
-  Assert(reference_cell_type == ReferenceCell::Line, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  (void)reference_cell;
 
   Assert(face_no < GeometryInfo<1>::faces_per_cell, ExcInternalError());
   Assert(subface_no < GeometryInfo<1>::max_children_per_face,
@@ -1645,7 +1643,7 @@ QProjector<1>::DataSetDescriptor::subface(
 template <>
 QProjector<2>::DataSetDescriptor
 QProjector<2>::DataSetDescriptor::subface(
-  const ReferenceCell reference_cell_type,
+  const ReferenceCell reference_cell,
   const unsigned int  face_no,
   const unsigned int  subface_no,
   const bool,
@@ -1654,8 +1652,8 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<2>)
 {
-  Assert(reference_cell_type == ReferenceCell::Quad, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
+  (void)reference_cell;
 
   Assert(face_no < GeometryInfo<2>::faces_per_cell, ExcInternalError());
   Assert(subface_no < GeometryInfo<2>::max_children_per_face,
@@ -1692,7 +1690,7 @@ QProjector<2>::DataSetDescriptor::subface(
 template <>
 QProjector<3>::DataSetDescriptor
 QProjector<3>::DataSetDescriptor::subface(
-  const ReferenceCell            reference_cell_type,
+  const ReferenceCell            reference_cell,
   const unsigned int             face_no,
   const unsigned int             subface_no,
   const bool                     face_orientation,
@@ -1703,8 +1701,8 @@ QProjector<3>::DataSetDescriptor::subface(
 {
   const unsigned int dim = 3;
 
-  Assert(reference_cell_type == ReferenceCell::Hex, ExcNotImplemented());
-  (void)reference_cell_type;
+  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  (void)reference_cell;
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
   Assert(subface_no < GeometryInfo<dim>::max_children_per_face,
@@ -1983,13 +1981,13 @@ QProjector<dim>::project_to_face(const SubQuadrature &quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_face(const ReferenceCell  reference_cell_type,
+QProjector<dim>::project_to_face(const ReferenceCell  reference_cell,
                                  const SubQuadrature &quadrature,
                                  const unsigned int   face_no)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
-  (void)reference_cell_type;
+  (void)reference_cell;
 
   std::vector<Point<dim>> points(quadrature.size());
   project_to_face(quadrature, face_no, points);
@@ -2016,15 +2014,15 @@ QProjector<dim>::project_to_subface(const SubQuadrature &          quadrature,
 
 template <int dim>
 Quadrature<dim>
-QProjector<dim>::project_to_subface(const ReferenceCell  reference_cell_type,
+QProjector<dim>::project_to_subface(const ReferenceCell  reference_cell,
                                     const SubQuadrature &quadrature,
                                     const unsigned int   face_no,
                                     const unsigned int   subface_no,
                                     const RefinementCase<dim - 1> &ref_case)
 {
-  Assert(reference_cell_type == ReferenceCell::get_hypercube<dim>(),
+  Assert(reference_cell == ReferenceCell::get_hypercube<dim>(),
          ExcNotImplemented());
-  (void)reference_cell_type;
+  (void)reference_cell;
 
   std::vector<Point<dim>> points(quadrature.size());
   project_to_subface(quadrature, face_no, subface_no, points, ref_case);

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1179,7 +1179,7 @@ namespace parallel
         }
 
       Assert(
-        this->all_reference_cell_types_are_hyper_cube(),
+        this->all_reference_cells_are_hyper_cube(),
         ExcMessage(
           "The class parallel::distributed::Triangulation only supports meshes "
           "consisting only of hypercube-like cells."));

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -289,27 +289,27 @@ namespace parallel
 
   template <int dim, int spacedim>
   void
-  TriangulationBase<dim, spacedim>::update_reference_cell_types()
+  TriangulationBase<dim, spacedim>::update_reference_cells()
   {
     // run algorithm for locally-owned cells
-    dealii::Triangulation<dim, spacedim>::update_reference_cell_types();
+    dealii::Triangulation<dim, spacedim>::update_reference_cells();
 
     // translate ReferenceCell to unsigned int (needed by
     // Utilities::MPI::compute_set_union)
-    std::vector<unsigned int> reference_cell_types_ui;
+    std::vector<unsigned int> reference_cells_ui;
 
-    for (const auto &i : this->reference_cell_types)
-      reference_cell_types_ui.push_back(static_cast<unsigned int>(i));
+    for (const auto &i : this->reference_cells)
+      reference_cells_ui.push_back(static_cast<unsigned int>(i));
 
     // create union
-    reference_cell_types_ui =
-      Utilities::MPI::compute_set_union(reference_cell_types_ui,
+    reference_cells_ui =
+      Utilities::MPI::compute_set_union(reference_cells_ui,
                                         this->mpi_communicator);
 
     // transform back and store result
-    this->reference_cell_types.clear();
-    for (const auto &i : reference_cell_types_ui)
-      this->reference_cell_types.emplace_back(
+    this->reference_cells.clear();
+    for (const auto &i : reference_cells_ui)
+      this->reference_cells.emplace_back(
         dealii::internal::ReferenceCell::make_reference_cell_from_int(i));
   }
 

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -837,7 +837,7 @@ namespace internal
                                 dof_handler.get_fe(other_fe_index),
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
-                                  [cell->quad(q)->reference_cell_type() ==
+                                  [cell->quad(q)->reference_cell() ==
                                    dealii::ReferenceCell::Quad],
                                 most_dominating_fe_index_face_no);
 
@@ -1594,7 +1594,7 @@ namespace internal
                                 dof_handler.get_fe(other_fe_index),
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
-                                  [cell->quad(q)->reference_cell_type() ==
+                                  [cell->quad(q)->reference_cell() ==
                                    dealii::ReferenceCell::Quad],
                                 most_dominating_fe_index_face_no);
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -687,12 +687,12 @@ namespace DoFTools
               {
                 const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
-                const auto reference_cell_type = cell->reference_cell_type();
+                const auto reference_cell = cell->reference_cell();
 
                 const auto &cell_rc =
-                  dealii::internal::Info::get_cell(reference_cell_type);
+                  dealii::internal::Info::get_cell(reference_cell);
                 const auto &face_rc =
-                  dealii::internal::Info::get_face(reference_cell_type, face);
+                  dealii::internal::Info::get_face(reference_cell, face);
 
                 const unsigned int n_vertices_per_cell = cell_rc.n_vertices();
                 const unsigned int n_lines_per_cell    = cell_rc.n_lines();

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -158,9 +158,8 @@ FiniteElement<dim, spacedim>::FiniteElement(
         {
           adjust_quad_dof_index_for_face_orientation_table[f] =
             Table<2, int>(this->n_dofs_per_quad(f),
-                          internal::Info::get_cell(this->reference_cell_type())
-                                .face_reference_cell_type(f) ==
-                              ReferenceCell::Quad ?
+                          internal::Info::get_cell(this->reference_cell())
+                                .face_reference_cell(f) == ReferenceCell::Quad ?
                             8 :
                             6);
           adjust_quad_dof_index_for_face_orientation_table[f].fill(0);
@@ -572,8 +571,7 @@ FiniteElement<dim, spacedim>::face_to_cell_index(const unsigned int face_index,
                                                  const bool face_flip,
                                                  const bool face_rotation) const
 {
-  const auto &refence_cell =
-    internal::Info::get_cell(this->reference_cell_type());
+  const auto &refence_cell = internal::Info::get_cell(this->reference_cell());
 
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, refence_cell.n_faces());
@@ -686,8 +684,8 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   Assert(adjust_quad_dof_index_for_face_orientation_table
              [this->n_unique_quads() == 1 ? 0 : face]
                .n_elements() ==
-           (internal::Info::get_cell(this->reference_cell_type())
-                  .face_reference_cell_type(face) == ReferenceCell::Quad ?
+           (internal::Info::get_cell(this->reference_cell())
+                  .face_reference_cell(face) == ReferenceCell::Quad ?
               8 :
               6) *
              this->n_dofs_per_quad(face),
@@ -1295,8 +1293,8 @@ FiniteElement<dim, spacedim>::get_face_data(
 {
   return get_data(flags,
                   mapping,
-                  QProjector<dim>::project_to_all_faces(
-                    this->reference_cell_type(), quadrature),
+                  QProjector<dim>::project_to_all_faces(this->reference_cell(),
+                                                        quadrature),
                   output_data);
 }
 
@@ -1314,8 +1312,8 @@ FiniteElement<dim, spacedim>::get_face_data(
 {
   return get_data(flags,
                   mapping,
-                  QProjector<dim>::project_to_all_faces(
-                    this->reference_cell_type(), quadrature),
+                  QProjector<dim>::project_to_all_faces(this->reference_cell(),
+                                                        quadrature),
                   output_data);
 }
 
@@ -1396,7 +1394,7 @@ FiniteElement<dim, spacedim>::get_subface_data(
   return get_data(flags,
                   mapping,
                   QProjector<dim>::project_to_all_subfaces(
-                    this->reference_cell_type(), quadrature),
+                    this->reference_cell(), quadrature),
                   output_data);
 }
 

--- a/source/fe/fe_abf.cc
+++ b/source/fe/fe_abf.cc
@@ -220,7 +220,7 @@ FE_ABF<dim>::initialize_support_points(const unsigned int deg)
         }
 
       Quadrature<dim> faces =
-        QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+        QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                               face_points);
       for (; current < GeometryInfo<dim>::faces_per_cell * n_face_points;
            ++current)
@@ -348,9 +348,7 @@ FE_ABF<dim>::initialize_restriction()
       // in the quadrature points
       // of a full face.
       Quadrature<dim> q_face =
-        QProjector<dim>::project_to_face(this->reference_cell_type(),
-                                         q_base,
-                                         face);
+        QProjector<dim>::project_to_face(this->reference_cell(), q_base, face);
       // Store shape values, since the
       // evaluation suffers if not
       // ordered by point
@@ -369,7 +367,7 @@ FE_ABF<dim>::initialize_restriction()
           // evaluated on the subface
           // only.
           Quadrature<dim> q_sub = QProjector<dim>::project_to_subface(
-            this->reference_cell_type(), q_base, face, sub);
+            this->reference_cell(), q_base, face, sub);
           const unsigned int child = GeometryInfo<dim>::child_cell_on_face(
             RefinementCase<dim>::isotropic_refinement, face, sub);
 
@@ -451,7 +449,7 @@ FE_ABF<dim>::initialize_restriction()
        ++child)
     {
       Quadrature<dim> q_sub =
-        QProjector<dim>::project_to_child(this->reference_cell_type(),
+        QProjector<dim>::project_to_child(this->reference_cell(),
                                           q_cell,
                                           child);
 
@@ -613,12 +611,7 @@ FE_ABF<dim>::convert_generalized_support_point_values_to_dof_values(
           // TODO: Check what the face_orientation, face_flip and face_rotation
           // have to be in 3D
           unsigned int k = QProjector<dim>::DataSetDescriptor::face(
-            this->reference_cell_type(),
-            face,
-            false,
-            false,
-            false,
-            n_face_points);
+            this->reference_cell(), face, false, false, false, n_face_points);
           for (unsigned int i = 0; i < boundary_weights_abf.size(1); ++i)
             nodal_values[start_abf_dofs + i] +=
               n_orient * boundary_weights_abf(k + fp, i) *

--- a/source/fe/fe_bdm.cc
+++ b/source/fe/fe_bdm.cc
@@ -365,14 +365,13 @@ FE_BDM<dim>::initialize_support_points(const unsigned int deg)
   this->generalized_support_points.resize(npoints);
 
   Quadrature<dim> faces =
-    QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
-                                          face_points);
+    QProjector<dim>::project_to_all_faces(this->reference_cell(), face_points);
   for (unsigned int k = 0;
        k < face_points.size() * GeometryInfo<dim>::faces_per_cell;
        ++k)
     this->generalized_support_points[k] = faces.point(
       k +
-      QProjector<dim>::DataSetDescriptor::face(this->reference_cell_type(),
+      QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
                                                0,
                                                true,
                                                false,

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -155,10 +155,10 @@ FE_Bernstein<dim, spacedim>::get_subface_interpolation_matrix(
       // be done for the face orientation flag in 3D.
       const Quadrature<dim> subface_quadrature =
         subface == numbers::invalid_unsigned_int ?
-          QProjector<dim>::project_to_face(this->reference_cell_type(),
+          QProjector<dim>::project_to_face(this->reference_cell(),
                                            quad_face_support,
                                            0) :
-          QProjector<dim>::project_to_subface(this->reference_cell_type(),
+          QProjector<dim>::project_to_subface(this->reference_cell(),
                                               quad_face_support,
                                               0,
                                               subface);

--- a/source/fe/fe_nedelec.cc
+++ b/source/fe/fe_nedelec.cc
@@ -284,7 +284,7 @@ FE_Nedelec<2>::initialize_support_points(const unsigned int order)
   const unsigned int    n_boundary_points =
     GeometryInfo<dim>::lines_per_cell * n_edge_points;
   const Quadrature<dim> edge_quadrature =
-    QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+    QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                           reference_edge_quadrature);
 
   this->generalized_face_support_points[face_no].resize(n_edge_points);
@@ -311,14 +311,14 @@ FE_Nedelec<2>::initialize_support_points(const unsigned int order)
           for (unsigned int line = 0; line < GeometryInfo<dim>::lines_per_cell;
                ++line)
             this->generalized_support_points[line * n_edge_points + q_point] =
-              edge_quadrature.point(QProjector<dim>::DataSetDescriptor::face(
-                                      this->reference_cell_type(),
-                                      line,
-                                      true,
-                                      false,
-                                      false,
-                                      n_edge_points) +
-                                    q_point);
+              edge_quadrature.point(
+                QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
+                                                         line,
+                                                         true,
+                                                         false,
+                                                         false,
+                                                         n_edge_points) +
+                q_point);
 
           for (unsigned int i = 0; i < order; ++i)
             boundary_weights(q_point, i) =
@@ -342,14 +342,14 @@ FE_Nedelec<2>::initialize_support_points(const unsigned int order)
            ++line)
         for (unsigned int q_point = 0; q_point < n_edge_points; ++q_point)
           this->generalized_support_points[line * n_edge_points + q_point] =
-            edge_quadrature.point(QProjector<dim>::DataSetDescriptor::face(
-                                    this->reference_cell_type(),
-                                    line,
-                                    true,
-                                    false,
-                                    false,
-                                    n_edge_points) +
-                                  q_point);
+            edge_quadrature.point(
+              QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
+                                                       line,
+                                                       true,
+                                                       false,
+                                                       false,
+                                                       n_edge_points) +
+              q_point);
     }
 }
 
@@ -474,7 +474,7 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
         }
 
       const Quadrature<dim> &face_quadrature =
-        QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+        QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                               reference_face_quadrature);
 
       for (const unsigned int face : GeometryInfo<dim>::face_indices())
@@ -483,14 +483,14 @@ FE_Nedelec<3>::initialize_support_points(const unsigned int order)
             this->generalized_support_points[face * n_face_points + q_point +
                                              GeometryInfo<dim>::lines_per_cell *
                                                n_edge_points] =
-              face_quadrature.point(QProjector<dim>::DataSetDescriptor::face(
-                                      this->reference_cell_type(),
-                                      face,
-                                      true,
-                                      false,
-                                      false,
-                                      n_face_points) +
-                                    q_point);
+              face_quadrature.point(
+                QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
+                                                         face,
+                                                         true,
+                                                         false,
+                                                         false,
+                                                         n_face_points) +
+                q_point);
           }
 
       // Create support points in the interior.

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -2061,21 +2061,21 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
   // This will fill in the missing items in the InternalData
   // (fe_internal/fe_data) which was not filled in by get_data.
   fill_edge_values(cell,
-                   QProjector<dim>::project_to_all_faces(
-                     this->reference_cell_type(), quadrature[0]),
+                   QProjector<dim>::project_to_all_faces(this->reference_cell(),
+                                                         quadrature[0]),
                    fe_data);
   if (dim == 3 && this->degree > 1)
     {
       fill_face_values(cell,
                        QProjector<dim>::project_to_all_faces(
-                         this->reference_cell_type(), quadrature[0]),
+                         this->reference_cell(), quadrature[0]),
                        fe_data);
     }
 
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature[0].size();
   const auto         offset =
-    QProjector<dim>::DataSetDescriptor::face(this->reference_cell_type(),
+    QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
                                              face_no,
                                              cell->face_orientation(face_no),
                                              cell->face_flip(face_no),

--- a/source/fe/fe_nothing.cc
+++ b/source/fe/fe_nothing.cc
@@ -75,8 +75,8 @@ FE_Nothing<dim, spacedim>::get_name() const
   namebuf << "FE_Nothing<" << Utilities::dim_string(dim, spacedim) << ">(";
 
   std::vector<std::string> name_components;
-  if (this->reference_cell_type() != ReferenceCell::get_hypercube<dim>())
-    name_components.push_back(this->reference_cell_type().to_string());
+  if (this->reference_cell() != ReferenceCell::get_hypercube<dim>())
+    name_components.push_back(this->reference_cell().to_string());
   if (this->n_components() > 1)
     name_components.push_back(std::to_string(this->n_components()));
   if (dominate)

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -266,7 +266,7 @@ FE_P1NC::fill_fe_face_values(
 
   // compute on the face
   const Quadrature<2> quadrature_on_face =
-    QProjector<2>::project_to_face(this->reference_cell_type(),
+    QProjector<2>::project_to_face(this->reference_cell(),
                                    quadrature[0],
                                    face_no);
 
@@ -313,7 +313,7 @@ FE_P1NC::fill_fe_subface_values(
 
   // compute on the subface
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
-    this->reference_cell_type(), quadrature, face_no, sub_no);
+    this->reference_cell(), quadrature, face_no, sub_no);
 
   if (flags & update_values)
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -972,7 +972,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
   // faces are stored contiguously)
 
   const auto offset =
-    QProjector<dim>::DataSetDescriptor::face(this->reference_cell_type(),
+    QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
                                              face_no,
                                              cell->face_orientation(face_no),
                                              cell->face_flip(face_no),
@@ -1599,7 +1599,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
   // to take (all data sets for all
   // sub-faces are stored contiguously)
   const auto offset =
-    QProjector<dim>::DataSetDescriptor::subface(this->reference_cell_type(),
+    QProjector<dim>::DataSetDescriptor::subface(this->reference_cell(),
                                                 face_no,
                                                 sub_no,
                                                 cell->face_orientation(face_no),

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -666,10 +666,10 @@ FE_Q_Base<dim, spacedim>::get_subface_interpolation_matrix(
       // be done for the face orientation flag in 3D.
       const Quadrature<dim> subface_quadrature =
         subface == numbers::invalid_unsigned_int ?
-          QProjector<dim>::project_to_face(this->reference_cell_type(),
+          QProjector<dim>::project_to_face(this->reference_cell(),
                                            quad_face_support,
                                            0) :
-          QProjector<dim>::project_to_subface(this->reference_cell_type(),
+          QProjector<dim>::project_to_subface(this->reference_cell(),
                                               quad_face_support,
                                               0,
                                               subface);

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -201,21 +201,17 @@ FE_RaviartThomas<dim>::initialize_support_points(const unsigned int deg)
         }
 
       Quadrature<dim> faces =
-        QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+        QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                               face_points);
       for (; current < GeometryInfo<dim>::faces_per_cell * n_face_points;
            ++current)
         {
           // Enter the support point
           // into the vector
-          this->generalized_support_points[current] =
-            faces.point(current + QProjector<dim>::DataSetDescriptor::face(
-                                    this->reference_cell_type(),
-                                    0,
-                                    true,
-                                    false,
-                                    false,
-                                    n_face_points));
+          this->generalized_support_points[current] = faces.point(
+            current +
+            QProjector<dim>::DataSetDescriptor::face(
+              this->reference_cell(), 0, true, false, false, n_face_points));
         }
     }
 
@@ -293,9 +289,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
       // in the quadrature points
       // of a full face.
       Quadrature<dim> q_face =
-        QProjector<dim>::project_to_face(this->reference_cell_type(),
-                                         q_base,
-                                         face);
+        QProjector<dim>::project_to_face(this->reference_cell(), q_base, face);
       // Store shape values, since the
       // evaluation suffers if not
       // ordered by point
@@ -314,7 +308,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
           // evaluated on the subface
           // only.
           Quadrature<dim> q_sub = QProjector<dim>::project_to_subface(
-            this->reference_cell_type(), q_base, face, sub);
+            this->reference_cell(), q_base, face, sub);
           const unsigned int child = GeometryInfo<dim>::child_cell_on_face(
             RefinementCase<dim>::isotropic_refinement, face, sub);
 
@@ -397,7 +391,7 @@ FE_RaviartThomas<dim>::initialize_restriction()
        ++child)
     {
       Quadrature<dim> q_sub =
-        QProjector<dim>::project_to_child(this->reference_cell_type(),
+        QProjector<dim>::project_to_child(this->reference_cell(),
                                           q_cell,
                                           child);
 

--- a/source/fe/fe_raviart_thomas_nodal.cc
+++ b/source/fe/fe_raviart_thomas_nodal.cc
@@ -182,19 +182,19 @@ FE_RaviartThomasNodal<dim>::initialize_support_points(const unsigned int deg)
         this->generalized_face_support_points[face_no][k] =
           face_points.point(k);
       Quadrature<dim> faces =
-        QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+        QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                               face_points);
       for (unsigned int k = 0; k < this->n_dofs_per_face(face_no) *
                                      GeometryInfo<dim>::faces_per_cell;
            ++k)
-        this->generalized_support_points[k] =
-          faces.point(k + QProjector<dim>::DataSetDescriptor::face(
-                            this->reference_cell_type(),
-                            0,
-                            true,
-                            false,
-                            false,
-                            this->n_dofs_per_face(face_no)));
+        this->generalized_support_points[k] = faces.point(
+          k + QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
+                                                       0,
+                                                       true,
+                                                       false,
+                                                       false,
+                                                       this->n_dofs_per_face(
+                                                         face_no)));
 
       current =
         this->n_dofs_per_face(face_no) * GeometryInfo<dim>::faces_per_cell;
@@ -650,7 +650,7 @@ FE_RaviartThomasNodal<dim>::get_face_interpolation_matrix(
   // matrix by simply taking the
   // value at the support points.
   const Quadrature<dim> face_projection =
-    QProjector<dim>::project_to_face(this->reference_cell_type(),
+    QProjector<dim>::project_to_face(this->reference_cell(),
                                      quad_face_support,
                                      0);
 
@@ -759,7 +759,7 @@ FE_RaviartThomasNodal<dim>::get_subface_interpolation_matrix(
   // value at the support points.
 
   const Quadrature<dim> subface_projection =
-    QProjector<dim>::project_to_subface(this->reference_cell_type(),
+    QProjector<dim>::project_to_subface(this->reference_cell(),
                                         quad_face_support,
                                         0,
                                         subface);

--- a/source/fe/fe_rt_bubbles.cc
+++ b/source/fe/fe_rt_bubbles.cc
@@ -163,19 +163,19 @@ FE_RT_Bubbles<dim>::initialize_support_points(const unsigned int deg)
         this->generalized_face_support_points[face_no][k] =
           face_points.point(k);
       Quadrature<dim> faces =
-        QProjector<dim>::project_to_all_faces(this->reference_cell_type(),
+        QProjector<dim>::project_to_all_faces(this->reference_cell(),
                                               face_points);
       for (unsigned int k = 0; k < this->n_dofs_per_face(face_no) *
                                      GeometryInfo<dim>::faces_per_cell;
            ++k)
-        this->generalized_support_points[k] =
-          faces.point(k + QProjector<dim>::DataSetDescriptor::face(
-                            this->reference_cell_type(),
-                            0,
-                            true,
-                            false,
-                            false,
-                            this->n_dofs_per_face(face_no)));
+        this->generalized_support_points[k] = faces.point(
+          k + QProjector<dim>::DataSetDescriptor::face(this->reference_cell(),
+                                                       0,
+                                                       true,
+                                                       false,
+                                                       false,
+                                                       this->n_dofs_per_face(
+                                                         face_no)));
 
       current =
         this->n_dofs_per_face(face_no) * GeometryInfo<dim>::faces_per_cell;

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4390,8 +4390,7 @@ FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
       q.size(),
       fe.n_dofs_per_cell(),
       update_default,
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe)
   , quadrature(q)
 {
@@ -4502,10 +4501,10 @@ FEValues<dim, spacedim>::reinit(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell)
 {
   // Check that mapping and reference cell type are compatible:
-  Assert(this->get_mapping().is_compatible_with(cell->reference_cell_type()),
+  Assert(this->get_mapping().is_compatible_with(cell->reference_cell()),
          ExcMessage(
            "You are trying to call FEValues::reinit() with a cell of type " +
-           cell->reference_cell_type().to_string() +
+           cell->reference_cell().to_string() +
            " with a Mapping that is not compatible with it."));
 
   // no FE in this cell, so no assertion
@@ -4538,10 +4537,10 @@ FEValues<dim, spacedim>::reinit(
          (typename FEValuesBase<dim, spacedim>::ExcFEDontMatch()));
 
   // Check that mapping and reference cell type are compatible:
-  Assert(this->get_mapping().is_compatible_with(cell->reference_cell_type()),
+  Assert(this->get_mapping().is_compatible_with(cell->reference_cell()),
          ExcMessage(
            "You are trying to call FEValues::reinit() with a cell of type " +
-           cell->reference_cell_type().to_string() +
+           cell->reference_cell().to_string() +
            " with a Mapping that is not compatible with it."));
 
   this->maybe_invalidate_previous_present_cell(cell);
@@ -4639,7 +4638,7 @@ FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
 {
   Assert(quadrature.size() == 1 ||
            quadrature.size() ==
-             internal::Info::get_cell(fe.reference_cell_type()).n_faces(),
+             internal::Info::get_cell(fe.reference_cell()).n_faces(),
          ExcInternalError());
 }
 
@@ -4729,8 +4728,7 @@ FEFaceValues<dim, spacedim>::FEFaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature)
 {
@@ -4961,8 +4959,7 @@ FESubfaceValues<dim, spacedim>::FESubfaceValues(
   : FEFaceValuesBase<dim, spacedim>(
       fe.n_dofs_per_cell(),
       update_flags,
-      fe.reference_cell_type()
-        .template get_default_linear_mapping<dim, spacedim>(),
+      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
       fe,
       quadrature)
 {

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -208,7 +208,7 @@ MappingFEField<dim, spacedim, VectorType, void>::MappingFEField(
   , fe_to_real(fe_mask.size(), numbers::invalid_unsigned_int)
   , fe_values(this->euler_dof_handler->get_fe(),
               this->euler_dof_handler->get_fe()
-                .reference_cell_type()
+                .reference_cell()
                 .template get_nodal_type_quadrature<dim>(),
               update_values)
 {
@@ -238,7 +238,7 @@ MappingFEField<dim, spacedim, VectorType, void>::MappingFEField(
   , fe_to_real(fe_mask.size(), numbers::invalid_unsigned_int)
   , fe_values(this->euler_dof_handler->get_fe(),
               this->euler_dof_handler->get_fe()
-                .reference_cell_type()
+                .reference_cell()
                 .template get_nodal_type_quadrature<dim>(),
               update_values)
 {
@@ -279,7 +279,7 @@ MappingFEField<dim, spacedim, VectorType, void>::MappingFEField(
   , fe_to_real(fe_mask.size(), numbers::invalid_unsigned_int)
   , fe_values(this->euler_dof_handler->get_fe(),
               this->euler_dof_handler->get_fe()
-                .reference_cell_type()
+                .reference_cell()
                 .template get_nodal_type_quadrature<dim>(),
               update_values)
 {
@@ -317,7 +317,7 @@ MappingFEField<dim, spacedim, VectorType, void>::MappingFEField(
   , fe_to_real(mapping.fe_to_real)
   , fe_values(mapping.euler_dof_handler->get_fe(),
               this->euler_dof_handler->get_fe()
-                .reference_cell_type()
+                .reference_cell()
                 .template get_nodal_type_quadrature<dim>(),
               update_values)
 {}
@@ -358,7 +358,7 @@ MappingFEField<dim, spacedim, VectorType, void>::is_compatible_with(
                     Utilities::to_string(cell_type.get_dimension()) +
                     " ) do not agree."));
 
-  return euler_dof_handler->get_fe().reference_cell_type() == cell_type;
+  return euler_dof_handler->get_fe().reference_cell() == cell_type;
 }
 
 
@@ -589,27 +589,27 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
 
 
           // TODO: only a single reference cell type possible...
-          const auto reference_cell_type =
-            this->euler_dof_handler->get_fe().reference_cell_type();
+          const auto reference_cell =
+            this->euler_dof_handler->get_fe().reference_cell();
           const auto n_faces =
-            internal::Info::get_cell(reference_cell_type).n_faces();
+            internal::Info::get_cell(reference_cell).n_faces();
 
           // Compute tangentials to the unit cell.
           for (unsigned int i = 0; i < n_faces; ++i)
             {
               data.unit_tangentials[i].resize(n_original_q_points);
-              std::fill(data.unit_tangentials[i].begin(),
-                        data.unit_tangentials[i].end(),
-                        reference_cell_type
-                          .template unit_tangential_vectors<dim>(i, 0));
+              std::fill(
+                data.unit_tangentials[i].begin(),
+                data.unit_tangentials[i].end(),
+                reference_cell.template unit_tangential_vectors<dim>(i, 0));
               if (dim > 2)
                 {
                   data.unit_tangentials[n_faces + i].resize(
                     n_original_q_points);
-                  std::fill(data.unit_tangentials[n_faces + i].begin(),
-                            data.unit_tangentials[n_faces + i].end(),
-                            reference_cell_type
-                              .template unit_tangential_vectors<dim>(i, 1));
+                  std::fill(
+                    data.unit_tangentials[n_faces + i].begin(),
+                    data.unit_tangentials[n_faces + i].end(),
+                    reference_cell.template unit_tangential_vectors<dim>(i, 1));
                 }
             }
         }

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -1559,7 +1559,7 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
   std::size_t element_id = 1;
 
   const auto add_element = [&](const auto &element, const int &entity_tag) {
-    const auto type = element->reference_cell_type();
+    const auto type = element->reference_cell();
 
     Assert(entity_tag > 0, ExcInternalError());
     // Add all vertex ids. Make sure we renumber to gmsh, and we add 1 to the
@@ -3175,8 +3175,8 @@ namespace
     for (; cell != end; ++cell)
       {
         DataOutBase::Patch<dim, spacedim> patch;
-        patch.reference_cell_type = cell->reference_cell_type();
-        patch.n_subdivisions      = 1;
+        patch.reference_cell = cell->reference_cell();
+        patch.n_subdivisions = 1;
         patch.data.reinit(5, cell->n_vertices());
 
         for (const unsigned int v : cell->vertex_indices())
@@ -3439,18 +3439,18 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
         for (const unsigned int i : cell->vertex_indices())
           {
             out << ' ';
-            const auto reference_cell_type = cell->reference_cell_type();
+            const auto reference_cell = cell->reference_cell();
 
-            if ((reference_cell_type == ReferenceCell::Vertex) ||
-                (reference_cell_type == ReferenceCell::Line) ||
-                (reference_cell_type == ReferenceCell::Quad) ||
-                (reference_cell_type == ReferenceCell::Hex))
+            if ((reference_cell == ReferenceCell::Vertex) ||
+                (reference_cell == ReferenceCell::Line) ||
+                (reference_cell == ReferenceCell::Quad) ||
+                (reference_cell == ReferenceCell::Hex))
               out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[i]);
-            else if ((reference_cell_type == ReferenceCell::Tri) ||
-                     (reference_cell_type == ReferenceCell::Tet) ||
-                     (reference_cell_type == ReferenceCell::Wedge))
+            else if ((reference_cell == ReferenceCell::Tri) ||
+                     (reference_cell == ReferenceCell::Tet) ||
+                     (reference_cell == ReferenceCell::Wedge))
               out << cell->vertex_index(i);
-            else if (reference_cell_type == ReferenceCell::Pyramid)
+            else if (reference_cell == ReferenceCell::Pyramid)
               {
                 static const std::array<unsigned int, 5> permutation_table{
                   {0, 1, 3, 2, 4}};
@@ -3490,19 +3490,19 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
   if (vtk_flags.output_cells)
     {
       for (const auto &cell : tria.active_cell_iterators())
-        out << table[static_cast<int>(cell->reference_cell_type())] << ' ';
+        out << table[static_cast<int>(cell->reference_cell())] << ' ';
       out << '\n';
     }
   if (vtk_flags.output_faces)
     {
       for (const auto &face : faces)
-        out << table[static_cast<int>(face->reference_cell_type())] << ' ';
+        out << table[static_cast<int>(face->reference_cell())] << ' ';
       out << '\n';
     }
   if (vtk_flags.output_edges)
     {
       for (const auto &edge : edges)
-        out << table[static_cast<int>(edge->reference_cell_type())] << ' ';
+        out << table[static_cast<int>(edge->reference_cell())] << ' ';
     }
   out << "\n\nCELL_DATA " << n_cells << '\n'
       << "SCALARS MaterialID int 1\n"

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -1542,7 +1542,7 @@ namespace GridTools
               // then we need to also add this neighbor
               if (dim >= 2)
                 for (const auto face :
-                     cell->reference_cell_type().faces_for_given_vertex(v))
+                     cell->reference_cell().faces_for_given_vertex(v))
                   if (!cell->at_boundary(face) &&
                       cell->neighbor(face)->is_active())
                     {

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -267,7 +267,7 @@ namespace GridTools
               // then we need to also add this neighbor
               if (dim >= 2)
                 for (const auto face :
-                     cell->reference_cell_type().faces_for_given_vertex(v))
+                     cell->reference_cell().faces_for_given_vertex(v))
                   if (!cell->at_boundary(face) &&
                       cell->neighbor(face)->is_active())
                     {

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -895,9 +895,9 @@ FlatManifold<dim, spacedim>::normal_vector(
 
   Point<facedim> xi;
 
-  const auto face_reference_cell_type = face->reference_cell_type();
+  const auto face_reference_cell = face->reference_cell();
 
-  if (face_reference_cell_type == ReferenceCell::get_hypercube<facedim>())
+  if (face_reference_cell == ReferenceCell::get_hypercube<facedim>())
     {
       for (unsigned int i = 0; i < facedim; ++i)
         xi[i] = 1. / 2;
@@ -915,8 +915,8 @@ FlatManifold<dim, spacedim>::normal_vector(
     {
       Point<spacedim> F;
       for (const unsigned int v : face->vertex_indices())
-        F += face->vertex(v) *
-             face_reference_cell_type.d_linear_shape_function(xi, v);
+        F +=
+          face->vertex(v) * face_reference_cell.d_linear_shape_function(xi, v);
 
       for (unsigned int i = 0; i < facedim; ++i)
         {
@@ -924,8 +924,7 @@ FlatManifold<dim, spacedim>::normal_vector(
           for (const unsigned int v : face->vertex_indices())
             grad_F[i] +=
               face->vertex(v) *
-              face_reference_cell_type.d_linear_shape_function_gradient(xi,
-                                                                        v)[i];
+              face_reference_cell.d_linear_shape_function_gradient(xi, v)[i];
         }
 
       Tensor<1, facedim> J;

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -171,8 +171,8 @@ template <int dim, int spacedim>
 const Mapping<dim, spacedim> &
 get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
 {
-  const auto &reference_cell_types = triangulation.get_reference_cell_types();
-  Assert(reference_cell_types.size() == 1,
+  const auto &reference_cells = triangulation.get_reference_cells();
+  Assert(reference_cells.size() == 1,
          ExcMessage(
            "This function can only work for triangulations that "
            "use only a single cell type -- for example, only triangles "
@@ -181,7 +181,7 @@ get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
            "cells of the triangulation. The triangulation you are "
            "passing to this function uses multiple cell types."));
 
-  return reference_cell_types.front()
+  return reference_cells.front()
     .template get_default_linear_mapping<dim, spacedim>();
 }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1178,10 +1178,10 @@ namespace internal
               tria_faces.quads_line_orientations.size(),
             true);
 
-          tria_faces.quad_reference_cell_type.reserve(new_size);
-          tria_faces.quad_reference_cell_type.insert(
-            tria_faces.quad_reference_cell_type.end(),
-            new_size - tria_faces.quad_reference_cell_type.size(),
+          tria_faces.quad_reference_cell.reserve(new_size);
+          tria_faces.quad_reference_cell.insert(
+            tria_faces.quad_reference_cell.end(),
+            new_size - tria_faces.quad_reference_cell.size(),
             dealii::ReferenceCell::Quad);
         }
     }
@@ -1304,10 +1304,10 @@ namespace internal
 
           if (tria_level.dim == 2 || tria_level.dim == 3)
             {
-              tria_level.reference_cell_type.reserve(total_cells);
-              tria_level.reference_cell_type.insert(
-                tria_level.reference_cell_type.end(),
-                total_cells - tria_level.reference_cell_type.size(),
+              tria_level.reference_cell.reserve(total_cells);
+              tria_level.reference_cell.insert(
+                tria_level.reference_cell.end(),
+                total_cells - tria_level.reference_cell.size(),
                 tria_level.dim == 2 ? dealii::ReferenceCell::Quad :
                                       dealii::ReferenceCell::Hex);
             }
@@ -2414,8 +2414,7 @@ namespace internal
             for (unsigned int q = 0, k = 0; q < n_quads; ++q)
               {
                 // set entity type of quads
-                faces.quad_reference_cell_type[q] =
-                  connectivity.entity_types(2)[q];
+                faces.quad_reference_cell[q] = connectivity.entity_types(2)[q];
 
                 // loop over all its lines
                 for (unsigned int i = crs.ptr[q], j = 0; i < crs.ptr[q + 1];
@@ -2466,8 +2465,7 @@ namespace internal
               cells_0.manifold_id[cell] = cells[cell].manifold_id;
 
               // set entity types
-              level.reference_cell_type[cell] =
-                connectivity.entity_types(dim)[cell];
+              level.reference_cell[cell] = connectivity.entity_types(dim)[cell];
 
               // loop over faces
               for (unsigned int i = crs.ptr[cell], j = 0; i < crs.ptr[cell + 1];
@@ -2668,8 +2666,8 @@ namespace internal
         if (dim == 3 && structdim == 2)
           {
             // quad entity types
-            faces.quad_reference_cell_type.assign(
-              size, dealii::ReferenceCell::Invalid);
+            faces.quad_reference_cell.assign(size,
+                                             dealii::ReferenceCell::Invalid);
 
             // quad line orientations
             faces.quads_line_orientations.assign(size * faces_per_cell, -1);
@@ -2705,7 +2703,7 @@ namespace internal
 
         level.neighbors.assign(size * faces_per_cell, {-1, -1});
 
-        level.reference_cell_type.assign(size, dealii::ReferenceCell::Invalid);
+        level.reference_cell.assign(size, dealii::ReferenceCell::Invalid);
 
         if (orientation_needed)
           level.face_orientations.assign(size * faces_per_cell, -1);
@@ -4110,13 +4108,13 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
-                  if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
+                  if (cell->reference_cell() == dealii::ReferenceCell::Tri)
                     {
                       needed_cells += 4;
                       needed_vertices += 0;
                       n_single_lines += 3;
                     }
-                  else if (cell->reference_cell_type() ==
+                  else if (cell->reference_cell() ==
                            dealii::ReferenceCell::Quad)
                     {
                       needed_cells += 4;
@@ -4270,9 +4268,9 @@ namespace internal
 
           unsigned int n_new_vertices = 0;
 
-          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
             n_new_vertices = 6;
-          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
             n_new_vertices = 9;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4286,7 +4284,7 @@ namespace internal
               new_vertices[cell->n_vertices() + line_no] =
                 cell->line(line_no)->child(0)->vertex_index(1);
 
-          if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
+          if (cell->reference_cell() == dealii::ReferenceCell::Quad)
             {
               while (triangulation.vertices_used[next_unused_vertex] == true)
                 ++next_unused_vertex;
@@ -4325,12 +4323,12 @@ namespace internal
           unsigned int lmin = 0;
           unsigned int lmax = 0;
 
-          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
             {
               lmin = 6;
               lmax = 9;
             }
-          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
             {
               lmin = 8;
               lmax = 12;
@@ -4355,7 +4353,7 @@ namespace internal
 
           if (true)
             {
-              if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
+              if (cell->reference_cell() == dealii::ReferenceCell::Tri)
                 {
                   // add lines in the right order [TODO: clean up]
                   const auto ref = [&](const unsigned int face_no,
@@ -4390,8 +4388,7 @@ namespace internal
                   new_lines[8]->set_bounding_object_indices(
                     {new_vertices[5], new_vertices[3]});
                 }
-              else if (cell->reference_cell_type() ==
-                       dealii::ReferenceCell::Quad)
+              else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
                 {
                   unsigned int l = 0;
                   for (const unsigned int face_no : cell->face_indices())
@@ -4433,9 +4430,9 @@ namespace internal
 
           unsigned int n_children = 0;
 
-          if (cell->reference_cell_type() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
             n_children = 4;
-          else if (cell->reference_cell_type() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
             n_children = 4;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4454,7 +4451,7 @@ namespace internal
             }
 
           if ((dim == 2) &&
-              (cell->reference_cell_type() == dealii::ReferenceCell::Tri))
+              (cell->reference_cell() == dealii::ReferenceCell::Tri))
             {
               subcells[0]->set_bounding_object_indices({new_lines[0]->index(),
                                                         new_lines[8]->index(),
@@ -4505,7 +4502,7 @@ namespace internal
               // * GeometryInfo<2>::faces_per_cell + 0] = 0;
             }
           else if ((dim == 2) &&
-                   (cell->reference_cell_type() == dealii::ReferenceCell::Quad))
+                   (cell->reference_cell() == dealii::ReferenceCell::Quad))
             {
               subcells[0]->set_bounding_object_indices(
                 {new_lines[0]->index(),
@@ -4549,8 +4546,7 @@ namespace internal
               // TODO: here we assume that all children have the same reference
               // cell type as the parent! This is justified for 2D.
               triangulation.levels[subcells[i]->level()]
-                ->reference_cell_type[subcells[i]->index()] =
-                cell->reference_cell_type();
+                ->reference_cell[subcells[i]->index()] = cell->reference_cell();
 
               if (i % 2 == 0)
                 subcells[i]->set_parent(cell->index());
@@ -4586,8 +4582,7 @@ namespace internal
                                   next_unused_cell,
                                   cell);
 
-                  if (cell->reference_cell_type() ==
-                        dealii::ReferenceCell::Quad &&
+                  if (cell->reference_cell() == dealii::ReferenceCell::Quad &&
                       check_for_distorted_cells &&
                       has_distorted_children<dim, spacedim>(cell))
                     cells_with_distorted_children.distorted_cells.push_back(
@@ -9612,7 +9607,7 @@ namespace internal
                         // to check it, transform to the unit cell
                         // with a linear mapping
                         const Point<dim> new_unit =
-                          cell->reference_cell_type()
+                          cell->reference_cell()
                             .template get_default_linear_mapping<dim,
                                                                  spacedim>()
                             .transform_real_to_unit_cell(cell, new_bound);
@@ -10100,7 +10095,7 @@ Triangulation<dim, spacedim>::Triangulation(
   Triangulation<dim, spacedim> &&tria) noexcept
   : Subscriptor(std::move(tria))
   , smooth_grid(tria.smooth_grid)
-  , reference_cell_types(std::move(tria.reference_cell_types))
+  , reference_cells(std::move(tria.reference_cells))
   , periodic_face_pairs_level_0(std::move(tria.periodic_face_pairs_level_0))
   , periodic_face_map(std::move(tria.periodic_face_map))
   , levels(std::move(tria.levels))
@@ -10126,7 +10121,7 @@ operator=(Triangulation<dim, spacedim> &&tria) noexcept
   Subscriptor::operator=(std::move(tria));
 
   smooth_grid                  = tria.smooth_grid;
-  reference_cell_types         = std::move(tria.reference_cell_types);
+  reference_cells              = std::move(tria.reference_cells);
   periodic_face_pairs_level_0  = std::move(tria.periodic_face_pairs_level_0);
   periodic_face_map            = std::move(tria.periodic_face_map);
   levels                       = std::move(tria.levels);
@@ -10185,7 +10180,7 @@ Triangulation<dim, spacedim>::clear()
   clear_despite_subscriptions();
   periodic_face_pairs_level_0.clear();
   periodic_face_map.clear();
-  reference_cell_types.clear();
+  reference_cells.clear();
 }
 
 
@@ -10414,7 +10409,7 @@ Triangulation<dim, spacedim>::copy_triangulation(
   vertices_used          = other_tria.vertices_used;
   anisotropic_refinement = other_tria.anisotropic_refinement;
   smooth_grid            = other_tria.smooth_grid;
-  reference_cell_types   = other_tria.reference_cell_types;
+  reference_cells        = other_tria.reference_cells;
 
   if (dim > 1)
     faces = std::make_unique<internal::TriangulationImplementation::TriaFaces>(
@@ -10500,7 +10495,7 @@ Triangulation<dim, spacedim>::create_triangulation(
       internal::TriangulationImplementation::Implementation::
         create_triangulation(v, cells, subcelldata, *this);
 
-      this->update_reference_cell_types();
+      this->update_reference_cells();
     }
   catch (...)
     {
@@ -10508,7 +10503,7 @@ Triangulation<dim, spacedim>::create_triangulation(
       throw;
     }
 
-  if (this->all_reference_cell_types_are_hyper_cube())
+  if (this->all_reference_cells_are_hyper_cube())
     {
       this->policy =
         std::make_unique<internal::TriangulationImplementation::PolicyWrapper<
@@ -13505,37 +13500,37 @@ Triangulation<dim, spacedim>::update_periodic_face_map()
 
 template <int dim, int spacedim>
 void
-Triangulation<dim, spacedim>::update_reference_cell_types()
+Triangulation<dim, spacedim>::update_reference_cells()
 {
-  std::set<ReferenceCell> reference_cell_types_set;
+  std::set<ReferenceCell> reference_cells_set;
   for (auto cell : active_cell_iterators())
     if (cell->is_locally_owned())
-      reference_cell_types_set.insert(cell->reference_cell_type());
+      reference_cells_set.insert(cell->reference_cell());
 
-  std::vector<ReferenceCell> reference_cell_types(
-    reference_cell_types_set.begin(), reference_cell_types_set.end());
+  std::vector<ReferenceCell> reference_cells(reference_cells_set.begin(),
+                                             reference_cells_set.end());
 
-  this->reference_cell_types = reference_cell_types;
+  this->reference_cells = reference_cells;
 }
 
 
 
 template <int dim, int spacedim>
 const std::vector<ReferenceCell> &
-Triangulation<dim, spacedim>::get_reference_cell_types() const
+Triangulation<dim, spacedim>::get_reference_cells() const
 {
-  return this->reference_cell_types;
+  return this->reference_cells;
 }
 
 
 
 template <int dim, int spacedim>
 bool
-Triangulation<dim, spacedim>::all_reference_cell_types_are_hyper_cube() const
+Triangulation<dim, spacedim>::all_reference_cells_are_hyper_cube() const
 {
-  return (this->reference_cell_types.size() == 0) ||
-         (this->reference_cell_types.size() == 1 &&
-          this->reference_cell_types[0] == ReferenceCell::get_hypercube<dim>());
+  return (this->reference_cells.size() == 0) ||
+         (this->reference_cells.size() == 1 &&
+          this->reference_cells[0] == ReferenceCell::get_hypercube<dim>());
 }
 
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1857,7 +1857,7 @@ CellAccessor<3>::point_inside(const Point<3> &p) const
     {
       const TriaRawIterator<CellAccessor<dim, spacedim>> cell_iterator(*this);
       return (GeometryInfo<dim>::is_inside_unit_cell(
-        reference_cell_type()
+        reference_cell()
           .template get_default_linear_mapping<dim, spacedim>()
           .transform_real_to_unit_cell(cell_iterator, p)));
     }
@@ -2845,7 +2845,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
     {
       case 2:
         {
-          if (this->reference_cell_type() == ReferenceCell::Tri)
+          if (this->reference_cell() == ReferenceCell::Tri)
             {
               const auto neighbor_cell = this->neighbor(face);
 
@@ -2882,7 +2882,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
               return sub_neighbor;
             }
-          else if (this->reference_cell_type() == ReferenceCell::Quad)
+          else if (this->reference_cell() == ReferenceCell::Quad)
             {
               const unsigned int neighbor_neighbor =
                 this->neighbor_of_neighbor(face);
@@ -2922,7 +2922,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
       case 3:
         {
-          if (this->reference_cell_type() == ReferenceCell::Hex)
+          if (this->reference_cell() == ReferenceCell::Hex)
             {
               // this function returns the neighbor's
               // child on a given face and

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -74,7 +74,7 @@ namespace MeshWorker
     const UpdateFlags &                 update_flags,
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags)
-    : ScratchData(fe.reference_cell_type()
+    : ScratchData(fe.reference_cell()
                     .template get_default_linear_mapping<dim, spacedim>(),
                   fe,
                   quadrature,
@@ -94,7 +94,7 @@ namespace MeshWorker
     const Quadrature<dim - 1> &         face_quadrature,
     const UpdateFlags &                 face_update_flags,
     const UpdateFlags &                 neighbor_face_update_flags)
-    : ScratchData(fe.reference_cell_type()
+    : ScratchData(fe.reference_cell()
                     .template get_default_linear_mapping<dim, spacedim>(),
                   fe,
                   quadrature,

--- a/source/multigrid/mg_tools.cc
+++ b/source/multigrid/mg_tools.cc
@@ -165,7 +165,7 @@ namespace MGTools
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
 
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
+        Assert(fe.reference_cell() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         unsigned int increment =
@@ -345,7 +345,7 @@ namespace MGTools
 
         // TODO: This assumes that the dofs per face on all faces coincide!
         const unsigned int face_no = 0;
-        Assert(fe.reference_cell_type() == ReferenceCell::get_hypercube<dim>(),
+        Assert(fe.reference_cell() == ReferenceCell::get_hypercube<dim>(),
                ExcNotImplemented());
 
         Assert(couplings.n_rows() == fe.n_components(),

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -97,8 +97,8 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
   ::dealii::DataOutBase::Patch<DoFHandlerType::dimension,
                                DoFHandlerType::space_dimension>
     patch;
-  patch.n_subdivisions      = n_subdivisions;
-  patch.reference_cell_type = cell_and_index->first->reference_cell_type();
+  patch.n_subdivisions = n_subdivisions;
+  patch.reference_cell = cell_and_index->first->reference_cell();
 
   // initialize FEValues
   scratch_data.reinit_all_fe_values(this->dof_data, cell_and_index->first);
@@ -147,7 +147,7 @@ DataOut<dim, DoFHandlerType>::build_one_patch(
       (curved_cell_region == curved_boundary &&
        (cell_and_index->first->at_boundary() ||
         (DoFHandlerType::dimension != DoFHandlerType::space_dimension))) ||
-      (cell_and_index->first->reference_cell_type() !=
+      (cell_and_index->first->reference_cell() !=
        ReferenceCell::get_hypercube<dim>()))
     {
       Assert(patch.space_dim == DoFHandlerType::space_dimension,

--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -1101,7 +1101,7 @@ namespace DerivativeApproximation
   {
     // just call the respective function with Q1 mapping
     approximate_derivative_tensor(
-      cell->reference_cell_type()
+      cell->reference_cell()
         .template get_default_linear_mapping<dim, spacedim>(),
       dof,
       solution,

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -471,7 +471,7 @@ namespace Simplex
 
         std::vector<Point<dim>> face_quadrature_points(
           quad_face_support.size());
-        QProjector<dim>::project_to_face(this->reference_cell_type(),
+        QProjector<dim>::project_to_face(this->reference_cell(),
                                          quad_face_support,
                                          face_no,
                                          face_quadrature_points);
@@ -541,7 +541,7 @@ namespace Simplex
 
         std::vector<Point<dim>> subface_quadrature_points(
           quad_face_support.size());
-        QProjector<dim>::project_to_subface(this->reference_cell_type(),
+        QProjector<dim>::project_to_subface(this->reference_cell(),
                                             quad_face_support,
                                             face_no,
                                             subface,

--- a/tests/grid/reference_cell_type_01.cc
+++ b/tests/grid/reference_cell_type_01.cc
@@ -14,7 +14,7 @@
 // ---------------------------------------------------------------------
 
 
-// Test TriaAccessor::reference_cell_type() on a 1D/2D/3D HEX mesh.
+// Test TriaAccessor::reference_cell() on a 1D/2D/3D HEX mesh.
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/tria.h>
@@ -31,17 +31,17 @@ test()
   GridGenerator::subdivided_hyper_cube(tria, 3);
 
   for (const auto &cell : tria.active_cell_iterators())
-    deallog << static_cast<int>(cell->reference_cell_type()) << " ";
+    deallog << static_cast<int>(cell->reference_cell()) << " ";
   deallog << std::endl;
 
   if (dim != 1)
     for (const auto &face : tria.active_face_iterators())
-      deallog << static_cast<int>(face->reference_cell_type()) << " ";
+      deallog << static_cast<int>(face->reference_cell()) << " ";
   deallog << std::endl;
 
   for (const auto &cell : tria.active_cell_iterators())
     for (const auto &face : cell->face_iterators())
-      deallog << static_cast<int>(face->reference_cell_type()) << " ";
+      deallog << static_cast<int>(face->reference_cell()) << " ";
   deallog << std::endl;
 }
 

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -43,13 +43,13 @@ process(const std::vector<Point<spacedim>> &vertices,
 
   std::shared_ptr<MappingFE<dim>> mapping;
 
-  const auto reference_cell_types = tria.get_reference_cell_types();
+  const auto reference_cells = tria.get_reference_cells();
 
-  AssertDimension(reference_cell_types.size(), 1);
+  AssertDimension(reference_cells.size(), 1);
 
-  if (reference_cell_types[0] == ReferenceCell::get_simplex<dim>())
+  if (reference_cells[0] == ReferenceCell::get_simplex<dim>())
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_P<dim>(1));
-  else if (reference_cell_types[0] == ReferenceCell::Wedge)
+  else if (reference_cells[0] == ReferenceCell::Wedge)
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_WedgeP<dim>(1));
   else
     AssertThrow(false, ExcNotImplemented());

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -84,9 +84,9 @@ test(const FiniteElement<dim, spacedim> &fe_0,
       if (cell->is_locally_owned() == false)
         continue;
 
-      if (cell->reference_cell_type() == ReferenceCell::Tri)
+      if (cell->reference_cell() == ReferenceCell::Tri)
         cell->set_active_fe_index(0);
-      else if (cell->reference_cell_type() == ReferenceCell::Quad)
+      else if (cell->reference_cell() == ReferenceCell::Quad)
         cell->set_active_fe_index(1);
       else
         Assert(false, ExcNotImplemented());

--- a/tests/simplex/fe_lib_01.cc
+++ b/tests/simplex/fe_lib_01.cc
@@ -29,8 +29,7 @@ test(const FiniteElement<dim, spacedim> &fe)
 {
   deallog << fe.get_name() << ": " << std::endl;
 
-  const auto &reference_cell =
-    internal::Info::get_cell(fe.reference_cell_type());
+  const auto &reference_cell = internal::Info::get_cell(fe.reference_cell());
 
   deallog << "  n_dofs_per_vertex(): " << fe.n_dofs_per_vertex() << std::endl;
   deallog << "  n_dofs_per_line():   " << fe.n_dofs_per_line() << std::endl;

--- a/tests/simplex/fe_p_bubbles_02.cc
+++ b/tests/simplex/fe_p_bubbles_02.cc
@@ -44,7 +44,7 @@ compute_nodal_quadrature(const FiniteElement<dim, spacedim> &fe)
   Assert(fe.n_blocks() == 1, ExcNotImplemented());
   Assert(fe.n_components() == 1, ExcNotImplemented());
 
-  const ReferenceCell type = fe.reference_cell_type();
+  const ReferenceCell type = fe.reference_cell();
 
   const Quadrature<dim> q_gauss =
     type.get_gauss_type_quadrature<dim>(fe.tensor_degree() + 1);
@@ -110,7 +110,7 @@ test_interpolate()
 
           Simplex::FE_P_Bubbles<dim, spacedim> fe(degree);
 
-          const ReferenceCell       type = fe.reference_cell_type();
+          const ReferenceCell       type = fe.reference_cell();
           DoFHandler<dim, spacedim> dh(tria);
           dh.distribute_dofs(fe);
           deallog << "number of dofs = " << dh.n_dofs() << std::endl;
@@ -175,7 +175,7 @@ test_lumped_project()
 
           Simplex::FE_P_Bubbles<dim, spacedim> fe(degree);
 
-          const ReferenceCell       type = fe.reference_cell_type();
+          const ReferenceCell       type = fe.reference_cell();
           DoFHandler<dim, spacedim> dh(tria);
           dh.distribute_dofs(fe);
           deallog << "number of dofs = " << dh.n_dofs() << std::endl;

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -157,8 +157,8 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell_type() == ReferenceCell::Tri ||
-        cell->reference_cell_type() == ReferenceCell::Tet)
+    if (cell->reference_cell() == ReferenceCell::Tri ||
+        cell->reference_cell() == ReferenceCell::Tet)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -260,8 +260,8 @@ test(const unsigned version, const unsigned int degree)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell_type() == ReferenceCell::Tri ||
-        cell->reference_cell_type() == ReferenceCell::Tet)
+    if (cell->reference_cell() == ReferenceCell::Tri ||
+        cell->reference_cell() == ReferenceCell::Tet)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);


### PR DESCRIPTION
Generally, *variables* should not have 'type' in their name unless they actually denote
*types*. These variables just reference what kind of reference cells we are dealing with.

Follow-up to #11544.

/rebuild