### PR TITLE
Fix compilation with ExodusII.

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3194,12 +3194,12 @@ namespace
             const CellData<dim> &cell = cells[face_id / max_faces_per_cell];
             const ReferenceCell  cell_type =
               ReferenceCell::n_vertices_to_type(dim, cell.vertices.size());
-            const ReferenceCell::internal::Info::Base &info =
+            const internal::Info::Base &info =
               internal::Info::get_cell(cell_type);
             const unsigned int deal_face_n =
               info.exodusii_face_to_deal_face(local_face_n);
-            const ReferenceCell::internal::Info::Base &face_info =
-              ReferenceCell::internal::Info::get_face(cell_type, deal_face_n);
+            const internal::Info::Base &face_info =
+              internal::Info::get_face(cell_type, deal_face_n);
 
             // The orientation we pick doesn't matter here since when we create
             // the Triangulation we will sort the vertices for each CellData
@@ -3346,8 +3346,7 @@ GridIn<dim, spacedim>::read_exodusii(
       AssertThrowExodusII(ierr);
       const ReferenceCell type =
         exodusii_name_to_type(string_temp.data(), n_nodes_per_element);
-      const ReferenceCell::internal::Info::Base &info =
-        internal::Info::get_cell(type);
+      const internal::Info::Base &info = internal::Info::get_cell(type);
       // The number of nodes per element may be larger than what we want to
       // read - for example, if the Exodus file contains a QUAD9 element, we
       // only want to read the first four values and ignore the rest.


### PR DESCRIPTION
Our CI doesn't have an ExodusII configuration with simplices, so this wasn't renamed when we moved stuff out of that namespace.