### PR TITLE
Rename namespace internal::Info to internal::ReferenceCell.

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -235,7 +235,8 @@ namespace FETools
       // one, taking into account multiplicities, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::Info::get_cell(fes.front()->reference_cell())
+           dealii::internal::ReferenceCell::get_cell(
+             fes.front()->reference_cell())
              .vertex_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -257,7 +258,8 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           dealii::internal::Info::get_cell(fes.front()->reference_cell())
+           dealii::internal::ReferenceCell::get_cell(
+             fes.front()->reference_cell())
              .line_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -279,12 +281,12 @@ namespace FETools
 
       // 3. Quads
       for (unsigned int quad_number = 0;
-           quad_number < (dim == 2 ?
-                            1 :
-                            (dim == 3 ? dealii::internal::Info::get_cell(
-                                          fes.front()->reference_cell())
-                                          .n_faces() :
-                                        0));
+           quad_number <
+           (dim == 2 ? 1 :
+                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
+                                     fes.front()->reference_cell())
+                                     .n_faces() :
+                                   0));
            ++quad_number)
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -426,7 +428,8 @@ namespace FETools
       // base elements, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::Info::get_cell(fes.front()->reference_cell())
+           dealii::internal::ReferenceCell::get_cell(
+             fes.front()->reference_cell())
              .vertex_indices())
         {
           unsigned int comp_start = 0;
@@ -460,7 +463,8 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           dealii::internal::Info::get_cell(fes.front()->reference_cell())
+           dealii::internal::ReferenceCell::get_cell(
+             fes.front()->reference_cell())
              .line_indices())
         {
           unsigned int comp_start = 0;
@@ -494,12 +498,12 @@ namespace FETools
 
       // 3. Quads
       for (unsigned int quad_number = 0;
-           quad_number < (dim == 2 ?
-                            1 :
-                            (dim == 3 ? dealii::internal::Info::get_cell(
-                                          fes.front()->reference_cell())
-                                          .n_faces() :
-                                        0));
+           quad_number <
+           (dim == 2 ? 1 :
+                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
+                                     fes.front()->reference_cell())
+                                     .n_faces() :
+                                   0));
            ++quad_number)
         {
           unsigned int comp_start = 0;
@@ -669,7 +673,7 @@ namespace FETools
       // vertex, etc
       total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::Info::get_cell(fe.reference_cell())
+           dealii::internal::ReferenceCell::get_cell(fe.reference_cell())
              .vertex_indices())
         {
           unsigned int comp_start = 0;
@@ -712,7 +716,8 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           dealii::internal::Info::get_cell(fe.reference_cell()).line_indices())
+           dealii::internal::ReferenceCell::get_cell(fe.reference_cell())
+             .line_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
@@ -756,11 +761,11 @@ namespace FETools
       // 3. Quads
       for (unsigned int quad_number = 0;
            quad_number <
-           (dim == 2 ?
-              1 :
-              (dim == 3 ? dealii::internal::Info::get_cell(fe.reference_cell())
-                            .n_faces() :
-                          0));
+           (dim == 2 ? 1 :
+                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
+                                     fe.reference_cell())
+                                     .n_faces() :
+                                   0));
            ++quad_number)
         {
           unsigned int comp_start = 0;
@@ -867,7 +872,8 @@ namespace FETools
       unsigned int total_index = 0;
       for (unsigned int vertex_number = 0;
            vertex_number <
-           dealii::internal::Info::get_face(fe.reference_cell(), face_no)
+           dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
+                                                     face_no)
              .n_vertices();
            ++vertex_number)
         {
@@ -926,7 +932,8 @@ namespace FETools
       // 2. Lines
       for (unsigned int line_number = 0;
            line_number <
-           dealii::internal::Info::get_face(fe.reference_cell(), face_no)
+           dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
+                                                     face_no)
              .n_lines();
            ++line_number)
         {
@@ -1988,7 +1995,8 @@ namespace FETools
     {
       unsigned int face_dof = 0;
       for (unsigned int i = 0;
-           i < dealii::internal::Info::get_face(fe.reference_cell(), face_no)
+           i < dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
+                                                         face_no)
                  .n_vertices();
            ++i)
         {
@@ -2007,7 +2015,8 @@ namespace FETools
         }
 
       for (unsigned int i = 1;
-           i <= dealii::internal::Info::get_face(fe.reference_cell(), face_no)
+           i <= dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
+                                                          face_no)
                   .n_lines();
            ++i)
         {

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -770,7 +770,7 @@ namespace internal
   /**
    * A namespace for geometric information on reference cells.
    */
-  namespace Info
+  namespace ReferenceCell
   {
     /**
      * Interface to be used in TriaAccessor/TriaCellAccessor to access
@@ -1885,18 +1885,18 @@ namespace internal
     /**
      * Return for a given reference-cell type the right Info.
      */
-    inline const internal::Info::Base &
+    inline const internal::ReferenceCell::Base &
     get_cell(const dealii::ReferenceCell &type)
     {
-      static const std::array<std::unique_ptr<internal::Info::Base>, 8> gei{
-        {std::make_unique<internal::Info::Vertex>(),
-         std::make_unique<internal::Info::Line>(),
-         std::make_unique<internal::Info::Tri>(),
-         std::make_unique<internal::Info::Quad>(),
-         std::make_unique<internal::Info::Tet>(),
-         std::make_unique<internal::Info::Pyramid>(),
-         std::make_unique<internal::Info::Wedge>(),
-         std::make_unique<internal::Info::Hex>()}};
+      static const std::array<std::unique_ptr<internal::ReferenceCell::Base>, 8>
+        gei{{std::make_unique<internal::ReferenceCell::Vertex>(),
+             std::make_unique<internal::ReferenceCell::Line>(),
+             std::make_unique<internal::ReferenceCell::Tri>(),
+             std::make_unique<internal::ReferenceCell::Quad>(),
+             std::make_unique<internal::ReferenceCell::Tet>(),
+             std::make_unique<internal::ReferenceCell::Pyramid>(),
+             std::make_unique<internal::ReferenceCell::Wedge>(),
+             std::make_unique<internal::ReferenceCell::Hex>()}};
       AssertIndexRange(static_cast<std::uint8_t>(type), 8);
       return *gei[static_cast<std::uint8_t>(type)];
     }
@@ -1905,13 +1905,13 @@ namespace internal
      * Return for a given reference-cell type @p and face number @p face_no the
      * right Info of the @p face_no-th face.
      */
-    inline const internal::Info::Base &
+    inline const internal::ReferenceCell::Base &
     get_face(const dealii::ReferenceCell &type, const unsigned int face_no)
     {
       return get_cell(get_cell(type).face_reference_cell(face_no));
     }
 
-  } // namespace Info
+  } // namespace ReferenceCell
 } // namespace internal
 
 
@@ -1947,7 +1947,7 @@ namespace internal
       out << "[";
 
       const unsigned int n_vertices =
-        internal::Info::get_cell(entity_type).n_vertices();
+        internal::ReferenceCell::get_cell(entity_type).n_vertices();
 
       for (unsigned int i = 0; i < n_vertices; ++i)
         {
@@ -1992,7 +1992,8 @@ inline unsigned char
 ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
                                    const std::array<T, N> &vertices_1) const
 {
-  AssertIndexRange(internal::Info::get_cell(*this).n_vertices(), N + 1);
+  AssertIndexRange(internal::ReferenceCell::get_cell(*this).n_vertices(),
+                   N + 1);
   if (*this == ReferenceCell::Line)
     {
       const std::array<T, 2> i{{vertices_0[0], vertices_0[1]}};

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -1693,7 +1693,7 @@ protected:
    * Return additional information related to the current geometric entity
    * type.
    */
-  inline const internal::Info::Base &
+  inline const internal::ReferenceCell::Base &
   reference_cell_info() const;
 
 private:

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2248,15 +2248,15 @@ TriaAccessor<structdim, dim, spacedim>::face_indices() const
 
 
 template <int structdim, int dim, int spacedim>
-inline const internal::Info::Base &
+inline const internal::ReferenceCell::Base &
 TriaAccessor<structdim, dim, spacedim>::reference_cell_info() const
 {
   if (structdim == 0)
-    return internal::Info::get_cell(ReferenceCell::Vertex);
+    return internal::ReferenceCell::get_cell(ReferenceCell::Vertex);
   else if (structdim == 1)
-    return internal::Info::get_cell(ReferenceCell::Line);
+    return internal::ReferenceCell::get_cell(ReferenceCell::Line);
   else
-    return internal::Info::get_cell(this->reference_cell());
+    return internal::ReferenceCell::get_cell(this->reference_cell());
 }
 
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -324,7 +324,8 @@ namespace internal
 
               const unsigned int n_face_orientations = dim == 2 ? 2 : 6;
               const unsigned int n_faces =
-                dealii::internal::Info::get_cell(reference_cell).n_faces();
+                dealii::internal::ReferenceCell::get_cell(reference_cell)
+                  .n_faces();
 
               const auto projected_quad_face =
                 QProjector<dim>::project_to_all_faces(reference_cell,

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -927,7 +927,8 @@ namespace
         else
           {
             Assert(patch.n_subdivisions == 1, ExcNotImplemented());
-            const auto &info = internal::Info::get_cell(patch.reference_cell);
+            const auto &info =
+              internal::ReferenceCell::get_cell(patch.reference_cell);
             n_nodes += info.n_vertices();
             n_cells += 1;
           }
@@ -7738,7 +7739,8 @@ DataOutBase::write_hdf5_parallel(
   // patches
   Assert(patches.size() > 0, ExcNoPatches());
 
-  const auto &cell_info = internal::Info::get_cell(patches[0].reference_cell);
+  const auto &cell_info =
+    internal::ReferenceCell::get_cell(patches[0].reference_cell);
 
   hid_t h5_mesh_file_id = -1, h5_solution_file_id, file_plist_id, plist_id;
   hid_t node_dataspace, node_dataset, node_file_dataspace,

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -690,9 +690,10 @@ namespace DoFTools
                 const auto reference_cell = cell->reference_cell();
 
                 const auto &cell_rc =
-                  dealii::internal::Info::get_cell(reference_cell);
+                  dealii::internal::ReferenceCell::get_cell(reference_cell);
                 const auto &face_rc =
-                  dealii::internal::Info::get_face(reference_cell, face);
+                  dealii::internal::ReferenceCell::get_face(reference_cell,
+                                                            face);
 
                 const unsigned int n_vertices_per_cell = cell_rc.n_vertices();
                 const unsigned int n_lines_per_cell    = cell_rc.n_lines();

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -158,7 +158,8 @@ FiniteElement<dim, spacedim>::FiniteElement(
         {
           adjust_quad_dof_index_for_face_orientation_table[f] =
             Table<2, int>(this->n_dofs_per_quad(f),
-                          internal::Info::get_cell(this->reference_cell())
+                          internal::ReferenceCell::get_cell(
+                            this->reference_cell())
                                 .face_reference_cell(f) == ReferenceCell::Quad ?
                             8 :
                             6);
@@ -571,7 +572,8 @@ FiniteElement<dim, spacedim>::face_to_cell_index(const unsigned int face_index,
                                                  const bool face_flip,
                                                  const bool face_rotation) const
 {
-  const auto &refence_cell = internal::Info::get_cell(this->reference_cell());
+  const auto &refence_cell =
+    internal::ReferenceCell::get_cell(this->reference_cell());
 
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
   AssertIndexRange(face, refence_cell.n_faces());
@@ -684,7 +686,7 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   Assert(adjust_quad_dof_index_for_face_orientation_table
              [this->n_unique_quads() == 1 ? 0 : face]
                .n_elements() ==
-           (internal::Info::get_cell(this->reference_cell())
+           (internal::ReferenceCell::get_cell(this->reference_cell())
                   .face_reference_cell(face) == ReferenceCell::Quad ?
               8 :
               6) *

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -54,13 +54,14 @@ namespace internal
 
     // first_line_index
     const unsigned int first_line_index =
-      (internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex);
+      (internal::ReferenceCell::get_cell(cell_type).n_vertices() *
+       dofs_per_vertex);
     result.object_index[1][0] = first_line_index;
 
     // first_quad_index
     const unsigned int first_quad_index =
       (first_line_index +
-       internal::Info::get_cell(cell_type).n_lines() * dofs_per_line);
+       internal::ReferenceCell::get_cell(cell_type).n_lines() * dofs_per_line);
     result.object_index[2][0] = first_quad_index;
 
     // first_hex_index
@@ -68,37 +69,43 @@ namespace internal
       (first_quad_index +
        (dim == 2 ?
           1 :
-          (dim == 3 ? internal::Info::get_cell(cell_type).n_faces() : 0)) *
+          (dim == 3 ? internal::ReferenceCell::get_cell(cell_type).n_faces() :
+                      0)) *
          dofs_per_quad);
 
     // first_face_line_index
     result.first_object_index_on_face[1][0] =
-      (internal::Info::get_face(cell_type, face_no).n_vertices() *
+      (internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
        dofs_per_vertex);
 
     // first_face_quad_index
     result.first_object_index_on_face[2][0] =
       ((dim == 3 ?
-          internal::Info::get_face(cell_type, face_no).n_vertices() *
+          internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
             dofs_per_vertex :
-          internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex) +
-       internal::Info::get_face(cell_type, face_no).n_lines() * dofs_per_line);
+          internal::ReferenceCell::get_cell(cell_type).n_vertices() *
+            dofs_per_vertex) +
+       internal::ReferenceCell::get_face(cell_type, face_no).n_lines() *
+         dofs_per_line);
 
     // dofs_per_face
     result.dofs_per_object_inclusive[dim - 1][0] =
-      (internal::Info::get_face(cell_type, face_no).n_vertices() *
+      (internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
          dofs_per_vertex +
-       internal::Info::get_face(cell_type, face_no).n_lines() * dofs_per_line +
+       internal::ReferenceCell::get_face(cell_type, face_no).n_lines() *
+         dofs_per_line +
        (dim == 3 ? 1 : 0) * dofs_per_quad);
 
 
     // dofs_per_cell
     result.dofs_per_object_inclusive[dim][0] =
-      (internal::Info::get_cell(cell_type).n_vertices() * dofs_per_vertex +
-       internal::Info::get_cell(cell_type).n_lines() * dofs_per_line +
+      (internal::ReferenceCell::get_cell(cell_type).n_vertices() *
+         dofs_per_vertex +
+       internal::ReferenceCell::get_cell(cell_type).n_lines() * dofs_per_line +
        (dim == 2 ?
           1 :
-          (dim == 3 ? internal::Info::get_cell(cell_type).n_faces() : 0)) *
+          (dim == 3 ? internal::ReferenceCell::get_cell(cell_type).n_faces() :
+                      0)) *
          dofs_per_quad +
        (dim == 3 ? 1 : 0) * dofs_per_hex);
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4638,7 +4638,7 @@ FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
 {
   Assert(quadrature.size() == 1 ||
            quadrature.size() ==
-             internal::Info::get_cell(fe.reference_cell()).n_faces(),
+             internal::ReferenceCell::get_cell(fe.reference_cell()).n_faces(),
          ExcInternalError());
 }
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -154,7 +154,8 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 
       // Compute tangentials to the unit cell.
       const auto reference_cell = this->fe.reference_cell();
-      const auto n_faces = internal::Info::get_cell(reference_cell).n_faces();
+      const auto n_faces =
+        internal::ReferenceCell::get_cell(reference_cell).n_faces();
 
       for (unsigned int i = 0; i < n_faces; ++i)
         {
@@ -863,7 +864,7 @@ MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe)
 
   const unsigned int n_points = mapping_support_points.size();
   const unsigned int n_shape_functions =
-    internal::Info::get_cell(reference_cell).n_vertices();
+    internal::ReferenceCell::get_cell(reference_cell).n_vertices();
 
   this->mapping_support_point_weights =
     Table<2, double>(n_points, n_shape_functions);

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -592,7 +592,7 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
           const auto reference_cell =
             this->euler_dof_handler->get_fe().reference_cell();
           const auto n_faces =
-            internal::Info::get_cell(reference_cell).n_faces();
+            internal::ReferenceCell::get_cell(reference_cell).n_faces();
 
           // Compute tangentials to the unit cell.
           for (unsigned int i = 0; i < n_faces; ++i)

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3194,12 +3194,12 @@ namespace
             const CellData<dim> &cell = cells[face_id / max_faces_per_cell];
             const ReferenceCell  cell_type =
               ReferenceCell::n_vertices_to_type(dim, cell.vertices.size());
-            const internal::Info::Base &info =
-              internal::Info::get_cell(cell_type);
+            const internal::ReferenceCell::Base &info =
+              internal::ReferenceCell::get_cell(cell_type);
             const unsigned int deal_face_n =
               info.exodusii_face_to_deal_face(local_face_n);
-            const internal::Info::Base &face_info =
-              internal::Info::get_face(cell_type, deal_face_n);
+            const internal::ReferenceCell::Base &face_info =
+              internal::ReferenceCell::get_face(cell_type, deal_face_n);
 
             // The orientation we pick doesn't matter here since when we create
             // the Triangulation we will sort the vertices for each CellData
@@ -3346,7 +3346,9 @@ GridIn<dim, spacedim>::read_exodusii(
       AssertThrowExodusII(ierr);
       const ReferenceCell type =
         exodusii_name_to_type(string_temp.data(), n_nodes_per_element);
-      const internal::Info::Base &info = internal::Info::get_cell(type);
+      const internal::ReferenceCell::Base &info =
+        internal::ReferenceCell::get_cell(type);
+
       // The number of nodes per element may be larger than what we want to
       // read - for example, if the Exodus file contains a QUAD9 element, we
       // only want to read the first four values and ignore the rest.

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2868,7 +2868,8 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
                   (1 - subface) :
                   subface;
 
-              const auto &info = internal::Info::get_cell(ReferenceCell::Tri);
+              const auto &info =
+                internal::ReferenceCell::get_cell(ReferenceCell::Tri);
               const unsigned int neighbor_child_index =
                 info.child_cell_on_face(neighbor_face, neighbor_subface);
               TriaIterator<CellAccessor<dim, spacedim>> sub_neighbor =

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -154,7 +154,7 @@ namespace Simplex
       if (dim == 1)
         return {};
 
-      const auto &info = internal::Info::get_cell(
+      const auto &info = internal::ReferenceCell::get_cell(
         dim == 2 ? ReferenceCell::Tri : ReferenceCell::Tet);
       std::vector<std::vector<Point<dim - 1>>> unit_face_points;
 

--- a/tests/simplex/fe_lib_01.cc
+++ b/tests/simplex/fe_lib_01.cc
@@ -29,7 +29,8 @@ test(const FiniteElement<dim, spacedim> &fe)
 {
   deallog << fe.get_name() << ": " << std::endl;
 
-  const auto &reference_cell = internal::Info::get_cell(fe.reference_cell());
+  const auto &reference_cell =
+    internal::ReferenceCell::get_cell(fe.reference_cell());
 
   deallog << "  n_dofs_per_vertex(): " << fe.n_dofs_per_vertex() << std::endl;
   deallog << "  n_dofs_per_line():   " << fe.n_dofs_per_line() << std::endl;

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -97,9 +97,9 @@ test(const unsigned int orientation)
   for (const auto l : face->line_indices())
     {
       const unsigned int l_ =
-        internal::Info::Tet().standard_to_real_face_line(l,
-                                                         face_no,
-                                                         orientation);
+        internal::ReferenceCell::Tet().standard_to_real_face_line(l,
+                                                                  face_no,
+                                                                  orientation);
 
       std::array<unsigned int, 2> a = {
         {face->line(l_)->vertex_index(0), face->line(l_)->vertex_index(1)}};

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -30,7 +30,7 @@ void
 test(const ReferenceCell &reference_cell)
 {
   const auto  kind = ReferenceCell(reference_cell);
-  const auto &info = internal::Info::get_cell(reference_cell);
+  const auto &info = internal::ReferenceCell::get_cell(reference_cell);
 
   for (const auto v : info.vertex_indices())
     {

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -31,7 +31,7 @@ void
 test(const ReferenceCell &reference_cell)
 {
   for (const auto face_no :
-       internal::Info::get_cell(reference_cell).face_indices())
+       internal::ReferenceCell::get_cell(reference_cell).face_indices())
     {
       deallog << reference_cell.template unit_normal_vectors<dim>(face_no)
               << std::endl;


### PR DESCRIPTION
As previously mentioned in a comment to one of the other PRs, the namespace is too generically named -- but easy enough to give a better name.

Follow-up to #11544.

/rebuild