### PR TITLE
Make a function 'constexpr'.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -60,7 +60,7 @@ namespace internal
      * but we have this one function in an internal namespace that is a friend
      * of the class and can be used to create the objects.
      */
-    dealii::ReferenceCell
+    constexpr dealii::ReferenceCell
     make_reference_cell_from_int(const std::uint8_t kind);
   } // namespace ReferenceCell
 } // namespace internal
@@ -297,7 +297,7 @@ private:
    * A kind of constructor -- not quite private because it can be
    * called by anyone, but at least hidden in an internal namespace.
    */
-  friend ReferenceCell
+  friend constexpr ReferenceCell
   internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
 };
 
@@ -338,6 +338,24 @@ ReferenceCell::operator!=(const ReferenceCell &type) const
 
 
 
+namespace internal
+{
+  namespace ReferenceCell
+  {
+    constexpr dealii::ReferenceCell
+    make_reference_cell_from_int(const std::uint8_t kind)
+    {
+      // Make sure these are the only indices from which objects can be
+      // created.
+      Assert((kind == static_cast<std::uint8_t>(-1)) || (kind < 8),
+             ExcInternalError());
+
+      // Call the private constructor, which we can from here because this
+      // function is a 'friend'.
+      return {kind};
+    }
+  } // namespace ReferenceCell
+} // namespace internal
 template <class Archive>
 inline void
 ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -342,8 +342,8 @@ namespace internal
 {
   namespace ReferenceCell
   {
-    DEAL_II_CONSTEXPR dealii::ReferenceCell
-                      make_reference_cell_from_int(const std::uint8_t kind)
+    inline DEAL_II_CONSTEXPR dealii::ReferenceCell
+                             make_reference_cell_from_int(const std::uint8_t kind)
     {
       // Make sure these are the only indices from which objects can be
       // created.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -60,8 +60,8 @@ namespace internal
      * but we have this one function in an internal namespace that is a friend
      * of the class and can be used to create the objects.
      */
-    constexpr dealii::ReferenceCell
-    make_reference_cell_from_int(const std::uint8_t kind);
+    DEAL_II_CONSTEXPR dealii::ReferenceCell
+                      make_reference_cell_from_int(const std::uint8_t kind);
   } // namespace ReferenceCell
 } // namespace internal
 
@@ -297,8 +297,8 @@ private:
    * A kind of constructor -- not quite private because it can be
    * called by anyone, but at least hidden in an internal namespace.
    */
-  friend constexpr ReferenceCell
-  internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
+  friend DEAL_II_CONSTEXPR ReferenceCell
+                           internal::ReferenceCell::make_reference_cell_from_int(const std::uint8_t);
 };
 
 
@@ -342,8 +342,8 @@ namespace internal
 {
   namespace ReferenceCell
   {
-    constexpr dealii::ReferenceCell
-    make_reference_cell_from_int(const std::uint8_t kind)
+    DEAL_II_CONSTEXPR dealii::ReferenceCell
+                      make_reference_cell_from_int(const std::uint8_t kind)
     {
       // Make sure these are the only indices from which objects can be
       // created.
@@ -356,6 +356,9 @@ namespace internal
     }
   } // namespace ReferenceCell
 } // namespace internal
+
+
+
 template <class Archive>
 inline void
 ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -31,25 +31,6 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-namespace internal
-{
-  namespace ReferenceCell
-  {
-    dealii::ReferenceCell
-    make_reference_cell_from_int(const std::uint8_t kind)
-    {
-      // Make sure these are the only indices from which objects can be
-      // created.
-      Assert((kind == static_cast<std::uint8_t>(-1)) || (kind < 8),
-             ExcInternalError());
-
-      // Call the private constructor, which we can from here because this
-      // function is a 'friend'.
-      return {kind};
-    }
-  } // namespace ReferenceCell
-} // namespace internal
-
 
 const ReferenceCell ReferenceCell::Vertex =
   internal::ReferenceCell::make_reference_cell_from_int(0);


### PR DESCRIPTION
Marking the function as `constexpr` means that it also needs to be defined in the `.h` file.

I will need this for a later patch where I make the special `ReferenceCell`
objects `constexpr` as well. This patch is simply meant to make that later
review marginally easier.

/rebuild