### PR TITLE
Fix python wrapper.

### DIFF
--- a/contrib/python-bindings/source/wrappers.cc
+++ b/contrib/python-bindings/source/wrappers.cc
@@ -37,8 +37,6 @@ namespace python
   export_manifold();
   void
   export_quadrature();
-  void
-  export_reference_cell();
 } // namespace python
 
 DEAL_II_NAMESPACE_CLOSE
@@ -67,7 +65,6 @@ BOOST_PYTHON_MODULE(Debug)
   // message is printed.
   dealii::deal_II_exceptions::disable_abort_on_exception();
 
-  dealii::python::export_reference_cell();
   dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();
@@ -88,7 +85,6 @@ BOOST_PYTHON_MODULE(Release)
   doc_options.enable_py_signatures();
   doc_options.disable_cpp_signatures();
 
-  dealii::python::export_reference_cell();
   dealii::python::export_tria_accessor();
   dealii::python::export_cell_accessor();
   dealii::python::export_point();


### PR DESCRIPTION
In #11632, the wrapping for reference cell was removed, but it still has some legacies. This breaks the python wrapper. 