### PR TITLE
Accept unique_ptr in different MG-related classes

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -763,20 +763,42 @@ namespace Utilities
    */
   template <typename To, typename From>
   std::unique_ptr<To>
-  dynamic_unique_cast(std::unique_ptr<From> &&p)
-  {
-    // Let's see if we can cast from 'From' to 'To'. If so, do the cast,
-    // and then release the pointer from the old
-    // owner
-    if (To *cast = dynamic_cast<To *>(p.get()))
-      {
-        std::unique_ptr<To> result(cast);
-        p.release();
-        return result;
-      }
-    else
-      throw std::bad_cast();
-  }
+  dynamic_unique_cast(std::unique_ptr<From> &&p);
+
+  /**
+   * Return underlying value. Default: return input.
+   */
+  template <typename T>
+  T &
+  get_underlying_value(T &p);
+
+  /**
+   * Return underlying value. Specialization for std::shared_ptr<T>.
+   */
+  template <typename T>
+  T &
+  get_underlying_value(std::shared_ptr<T> &p);
+
+  /**
+   * Return underlying value. Specialization for const std::shared_ptr<T>.
+   */
+  template <typename T>
+  T &
+  get_underlying_value(const std::shared_ptr<T> &p);
+
+  /**
+   * Return underlying value. Specialization for std::unique_ptr<T>.
+   */
+  template <typename T>
+  T &
+  get_underlying_value(std::unique_ptr<T> &p);
+
+  /**
+   * Return underlying value. Specialization for const std::unique_ptr<T>.
+   */
+  template <typename T>
+  T &
+  get_underlying_value(const std::unique_ptr<T> &p);
 
   /**
    * A namespace for utility functions that probe system properties.
@@ -1372,6 +1394,70 @@ namespace Utilities
     // https://stackoverflow.com/questions/47981/how-do-you-set-clear-and-toggle-a-single-bit
     // "Changing the nth bit to x"
     number ^= (-static_cast<unsigned char>(x) ^ number) & (1U << n);
+  }
+
+
+
+  template <typename To, typename From>
+  inline std::unique_ptr<To>
+  dynamic_unique_cast(std::unique_ptr<From> &&p)
+  {
+    // Let's see if we can cast from 'From' to 'To'. If so, do the cast,
+    // and then release the pointer from the old
+    // owner
+    if (To *cast = dynamic_cast<To *>(p.get()))
+      {
+        std::unique_ptr<To> result(cast);
+        p.release();
+        return result;
+      }
+    else
+      throw std::bad_cast();
+  }
+
+
+
+  template <typename T>
+  inline T &
+  get_underlying_value(T &p)
+  {
+    return p;
+  }
+
+
+
+  template <typename T>
+  inline T &
+  get_underlying_value(std::shared_ptr<T> &p)
+  {
+    return *p;
+  }
+
+
+
+  template <typename T>
+  inline T &
+  get_underlying_value(const std::shared_ptr<T> &p)
+  {
+    return *p;
+  }
+
+
+
+  template <typename T>
+  inline T &
+  get_underlying_value(std::unique_ptr<T> &p)
+  {
+    return *p;
+  }
+
+
+
+  template <typename T>
+  inline T &
+  get_underlying_value(const std::unique_ptr<T> &p)
+  {
+    return *p;
   }
 
 

--- a/include/deal.II/multigrid/mg_matrix.h
+++ b/include/deal.II/multigrid/mg_matrix.h
@@ -208,7 +208,9 @@ namespace mg
         // rich enough interface to populate reinit_(domain|range)_vector.
         // Thus, apply an empty LinearOperator exemplar.
         matrices[level] =
-          linear_operator<VectorType>(LinearOperator<VectorType>(), p[level]);
+          linear_operator<VectorType>(LinearOperator<VectorType>(),
+                                      Utilities::get_underlying_value(
+                                        p[level]));
       }
   }
 

--- a/include/deal.II/multigrid/mg_smoother.h
+++ b/include/deal.II/multigrid/mg_smoother.h
@@ -1062,8 +1062,9 @@ MGSmootherPrecondition<MatrixType, PreconditionerType, VectorType>::initialize(
       // enough interface to populate reinit_(domain|range)_vector. Thus,
       // apply an empty LinearOperator exemplar.
       matrices[i] =
-        linear_operator<VectorType>(LinearOperator<VectorType>(), m[i]);
-      smoothers[i].initialize(m[i], data[i]);
+        linear_operator<VectorType>(LinearOperator<VectorType>(),
+                                    Utilities::get_underlying_value(m[i]));
+      smoothers[i].initialize(Utilities::get_underlying_value(m[i]), data[i]);
     }
 }
 


### PR DESCRIPTION
PR #11699 introduces a base class `MGSolverOperatorBase` that would be accepted by the new class `MGSolver`. Users would need to implement `MGSolverOperatorBase` with relevant functionalities as needed by the selected smoother/transfer operator as it is done in step-75 for the matrix-free hp case:

https://github.com/dealii/dealii/blob/aba3dd712467cba2ead2676b7d468f62684dca75/examples/step-75/step-75.cc#L318-L624

I am reluctant to template `MGSolver` with the the "OperatorType" but would like to pass reference (`std::unique_ptr`) to the base class. Since some MG-related classes (e.g., `MGLevelObjects`) cannot deal with virtual and pure virtual classes `T` directly, they need to be of type `std::unique_ptr<T>` (or something similar).

This PR was requested by https://github.com/dealii/dealii/pull/11254#pullrequestreview-583215678.