### PR TITLE
Fix missing header in sundials/n_vector.h

### DIFF
--- a/include/deal.II/sundials/n_vector.h
+++ b/include/deal.II/sundials/n_vector.h
@@ -21,6 +21,7 @@
 #ifdef DEAL_II_WITH_SUNDIALS
 #  include <sundials/sundials_nvector.h>
 
+#  include <functional>
 #  include <memory>
 
 DEAL_II_NAMESPACE_OPEN


### PR DESCRIPTION
Should fix https://cdash.43-1.org/viewBuildError.php?buildid=16339.