### PR TITLE
Move get_default_linear_mapping() to mapping.h/cc.

### DIFF
--- a/include/deal.II/fe/mapping.h
+++ b/include/deal.II/fe/mapping.h
@@ -1285,6 +1285,18 @@ public:
 };
 
 
+/**
+ * Return a default linear mapping that works for the given triangulation.
+ * Internally, this function calls the function above for the reference
+ * cell used by the given triangulation, assuming that the triangulation
+ * uses only a single cell type. If the triangulation uses mixed cell
+ * types, then this function will trigger an exception.
+ */
+template <int dim, int spacedim>
+const Mapping<dim, spacedim> &
+get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation);
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -29,9 +29,8 @@ DEAL_II_NAMESPACE_OPEN
 // Forward declarations
 #ifndef DOXYGEN
 template <int dim, int spacedim>
-class Triangulation;
-template <int dim, int spacedim>
 class Mapping;
+
 template <int dim>
 class Quadrature;
 #endif
@@ -750,16 +749,6 @@ ReferenceCell::unit_normal_vectors(const unsigned int face_no) const
   return {};
 }
 
-/**
- * Return a default linear mapping that works for the given triangulation.
- * Internally, this function calls the function above for the reference
- * cell used by the given triangulation, assuming that the triangulation
- * uses only a single cell type. If the triangulation uses mixed cell
- * types, then this function will trigger an exception.
- */
-template <int dim, int spacedim>
-const Mapping<dim, spacedim> &
-get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation);
 
 namespace internal
 {

--- a/source/fe/mapping.cc
+++ b/source/fe/mapping.cc
@@ -233,7 +233,25 @@ Mapping<dim, spacedim>::InternalDataBase::memory_consumption() const
 }
 
 
-/*------------------------------ InternalData ------------------------------*/
+/* ------------------------------ Global functions ------------------------- */
+
+template <int dim, int spacedim>
+const Mapping<dim, spacedim> &
+get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
+{
+  const auto &reference_cells = triangulation.get_reference_cells();
+  Assert(reference_cells.size() == 1,
+         ExcMessage(
+           "This function can only work for triangulations that "
+           "use only a single cell type -- for example, only triangles "
+           "or only quadrilaterals. For mixed meshes, there is no "
+           "single linear mapping object that can be used for all "
+           "cells of the triangulation. The triangulation you are "
+           "passing to this function uses multiple cell types."));
+
+  return reference_cells.front()
+    .template get_default_linear_mapping<dim, spacedim>();
+}
 
 
 

--- a/source/fe/mapping.inst.in
+++ b/source/fe/mapping.inst.in
@@ -19,5 +19,10 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
 #if deal_II_dimension <= deal_II_space_dimension
     template class Mapping<deal_II_dimension, deal_II_space_dimension>;
+
+    template const Mapping<deal_II_dimension, deal_II_space_dimension>
+      &get_default_linear_mapping(
+        const Triangulation<deal_II_dimension, deal_II_space_dimension>
+          &triangulation);
 #endif
   }

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -167,26 +167,6 @@ ReferenceCell::get_default_linear_mapping() const
 
 
 
-template <int dim, int spacedim>
-const Mapping<dim, spacedim> &
-get_default_linear_mapping(const Triangulation<dim, spacedim> &triangulation)
-{
-  const auto &reference_cells = triangulation.get_reference_cells();
-  Assert(reference_cells.size() == 1,
-         ExcMessage(
-           "This function can only work for triangulations that "
-           "use only a single cell type -- for example, only triangles "
-           "or only quadrilaterals. For mixed meshes, there is no "
-           "single linear mapping object that can be used for all "
-           "cells of the triangulation. The triangulation you are "
-           "passing to this function uses multiple cell types."));
-
-  return reference_cells.front()
-    .template get_default_linear_mapping<dim, spacedim>();
-}
-
-
-
 template <int dim>
 Quadrature<dim>
 ReferenceCell::get_gauss_type_quadrature(const unsigned n_points_1D) const

--- a/source/grid/reference_cell.inst.in
+++ b/source/grid/reference_cell.inst.in
@@ -22,11 +22,6 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 
     template const Mapping<deal_II_dimension, deal_II_space_dimension>
       &ReferenceCell::get_default_linear_mapping() const;
-
-    template const Mapping<deal_II_dimension, deal_II_space_dimension>
-      &get_default_linear_mapping(
-        const Triangulation<deal_II_dimension, deal_II_space_dimension>
-          &triangulation);
 #endif
   }
 


### PR DESCRIPTION
Follow-up to #11544. Moving this function was mentioned in some of the other PRs since the function is not actually related to `ReferenceCell`.

/rebuild