### PR TITLE
Fix clear particle locations in property pool

### DIFF
--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -124,10 +124,12 @@ namespace Particles
     // If this was the last handle, resize containers to 0.
     // This guarantees that all future properties
     // are allocated in a sorted way without requiring reallocation.
-    if (currently_available_handles.size() * n_properties == properties.size())
+    if (currently_available_handles.size() == locations.size())
       {
         currently_available_handles.clear();
         properties.clear();
+        locations.clear();
+        reference_locations.clear();
       }
   }
 

--- a/tests/particles/step-68.cc
+++ b/tests/particles/step-68.cc
@@ -704,6 +704,9 @@ namespace Step68
   {
     if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
       deallog << "Particles location" << std::endl;
+
+    MPI_Barrier(mpi_communicator);
+
     for (unsigned int proc = 0;
          proc < Utilities::MPI::n_mpi_processes(mpi_communicator);
          ++proc)
@@ -737,7 +740,7 @@ main(int argc, char *argv[])
   using namespace dealii;
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  initlog();
+  MPILogInitAll all;
   deallog.depth_console(1);
 
   try

--- a/tests/particles/step-68.with_p4est=true.mpirun=1.output
+++ b/tests/particles/step-68.with_p4est=true.mpirun=1.output
@@ -1,64 +1,64 @@
 
-DEAL::Number of particles inserted: 24
-DEAL::Repartitioning triangulation after particle generation
-DEAL::Writing particle output file: analytical-particles-0
-DEAL::Writing particle output file: analytical-particles-1000
-DEAL::Writing particle output file: analytical-particles-2000
-DEAL::Particles location
-DEAL::0.406412 0.734191
-DEAL::0.431983 0.684517
-DEAL::0.475595 0.747746
-DEAL::0.479874 0.652444
-DEAL::0.486369 0.728375
-DEAL::0.406474 0.787612
-DEAL::0.433208 0.833310
-DEAL::0.480928 0.859777
-DEAL::0.475771 0.769133
-DEAL::0.486655 0.787079
-DEAL::0.505864 0.716196
-DEAL::0.529232 0.714603
-DEAL::0.549978 0.724169
-DEAL::0.540635 0.648620
-DEAL::0.561942 0.742488
-DEAL::0.595944 0.672859
-DEAL::0.627051 0.720283
-DEAL::0.505916 0.796997
-DEAL::0.538993 0.858949
-DEAL::0.528847 0.796079
-DEAL::0.549447 0.784270
-DEAL::0.561753 0.764590
-DEAL::0.592056 0.829624
-DEAL::0.624984 0.778592
-DEAL::Number of particles inserted: 24
-DEAL::Repartitioning triangulation after particle generation
-DEAL::Writing particle output file: interpolated-particles-0
-DEAL::Writing background field file: background-0
-DEAL::Writing particle output file: interpolated-particles-1000
-DEAL::Writing background field file: background-1000
-DEAL::Writing particle output file: interpolated-particles-2000
-DEAL::Writing background field file: background-2000
-DEAL::Particles location
-DEAL::0.400130 0.731196
-DEAL::0.429540 0.682369
-DEAL::0.469064 0.746158
-DEAL::0.481181 0.651665
-DEAL::0.480772 0.726826
-DEAL::0.405024 0.786934
-DEAL::0.430296 0.832760
-DEAL::0.478813 0.859498
-DEAL::0.474379 0.768388
-DEAL::0.484713 0.786526
-DEAL::0.501301 0.714975
-DEAL::0.524473 0.713858
-DEAL::0.544304 0.724010
-DEAL::0.555643 0.742845
-DEAL::0.541116 0.647681
-DEAL::0.592865 0.672731
-DEAL::0.621474 0.721859
-DEAL::0.503905 0.796598
-DEAL::0.536869 0.858844
-DEAL::0.526482 0.795790
-DEAL::0.547001 0.784040
-DEAL::0.559416 0.764401
-DEAL::0.589307 0.829611
-DEAL::0.622637 0.778386
+DEAL:0::Number of particles inserted: 24
+DEAL:0::Repartitioning triangulation after particle generation
+DEAL:0::Writing particle output file: analytical-particles-0
+DEAL:0::Writing particle output file: analytical-particles-1000
+DEAL:0::Writing particle output file: analytical-particles-2000
+DEAL:0::Particles location
+DEAL:0::0.406412 0.734191
+DEAL:0::0.431983 0.684517
+DEAL:0::0.475595 0.747746
+DEAL:0::0.479874 0.652444
+DEAL:0::0.486369 0.728375
+DEAL:0::0.406474 0.787612
+DEAL:0::0.433208 0.833310
+DEAL:0::0.480928 0.859777
+DEAL:0::0.475771 0.769133
+DEAL:0::0.486655 0.787079
+DEAL:0::0.505864 0.716196
+DEAL:0::0.529232 0.714603
+DEAL:0::0.549978 0.724169
+DEAL:0::0.540635 0.648620
+DEAL:0::0.561942 0.742488
+DEAL:0::0.595944 0.672859
+DEAL:0::0.627051 0.720283
+DEAL:0::0.505916 0.796997
+DEAL:0::0.538993 0.858949
+DEAL:0::0.528847 0.796079
+DEAL:0::0.549447 0.784270
+DEAL:0::0.561753 0.764590
+DEAL:0::0.592056 0.829624
+DEAL:0::0.624984 0.778592
+DEAL:0::Number of particles inserted: 24
+DEAL:0::Repartitioning triangulation after particle generation
+DEAL:0::Writing particle output file: interpolated-particles-0
+DEAL:0::Writing background field file: background-0
+DEAL:0::Writing particle output file: interpolated-particles-1000
+DEAL:0::Writing background field file: background-1000
+DEAL:0::Writing particle output file: interpolated-particles-2000
+DEAL:0::Writing background field file: background-2000
+DEAL:0::Particles location
+DEAL:0::0.400130 0.731196
+DEAL:0::0.429540 0.682369
+DEAL:0::0.469064 0.746158
+DEAL:0::0.481181 0.651665
+DEAL:0::0.480772 0.726826
+DEAL:0::0.405024 0.786934
+DEAL:0::0.430296 0.832760
+DEAL:0::0.478813 0.859498
+DEAL:0::0.474379 0.768388
+DEAL:0::0.484713 0.786526
+DEAL:0::0.501301 0.714975
+DEAL:0::0.524473 0.713858
+DEAL:0::0.544304 0.724010
+DEAL:0::0.555643 0.742845
+DEAL:0::0.541116 0.647681
+DEAL:0::0.592865 0.672731
+DEAL:0::0.621474 0.721859
+DEAL:0::0.503905 0.796598
+DEAL:0::0.536869 0.858844
+DEAL:0::0.526482 0.795790
+DEAL:0::0.547001 0.784040
+DEAL:0::0.559416 0.764401
+DEAL:0::0.589307 0.829611
+DEAL:0::0.622637 0.778386

--- a/tests/particles/step-68.with_p4est=true.mpirun=2.output
+++ b/tests/particles/step-68.with_p4est=true.mpirun=2.output
@@ -1,64 +1,66 @@
 
-DEAL::Number of particles inserted: 24
-DEAL::Repartitioning triangulation after particle generation
-DEAL::Writing particle output file: analytical-particles-0
-DEAL::Writing particle output file: analytical-particles-1000
-DEAL::Writing particle output file: analytical-particles-2000
-DEAL::Particles location
-DEAL::0.406412 0.734191
-DEAL::0.431983 0.684517
-DEAL::0.475595 0.747746
-DEAL::0.479874 0.652444
-DEAL::0.486369 0.728375
-DEAL::0.406474 0.787612
-DEAL::0.433208 0.833310
-DEAL::0.480928 0.859777
-DEAL::0.475771 0.769133
-DEAL::0.486655 0.787079
-DEAL::0.505864 0.716196
-DEAL::0.529232 0.714603
-DEAL::0.549978 0.724169
-DEAL::0.540635 0.648620
-DEAL::0.561942 0.742488
-DEAL::0.595944 0.672859
-DEAL::0.627051 0.720283
-DEAL::0.505916 0.796997
-DEAL::0.538993 0.858949
-DEAL::0.528847 0.796079
-DEAL::0.549447 0.784270
-DEAL::0.561753 0.764590
-DEAL::0.592056 0.829624
-DEAL::0.624984 0.778592
-DEAL::Number of particles inserted: 24
-DEAL::Repartitioning triangulation after particle generation
-DEAL::Writing particle output file: interpolated-particles-0
-DEAL::Writing background field file: background-0
-DEAL::Writing particle output file: interpolated-particles-1000
-DEAL::Writing background field file: background-1000
-DEAL::Writing particle output file: interpolated-particles-2000
-DEAL::Writing background field file: background-2000
-DEAL::Particles location
-DEAL::0.400130 0.731196
-DEAL::0.429540 0.682369
-DEAL::0.469064 0.746158
-DEAL::0.481181 0.651665
-DEAL::0.480772 0.726826
-DEAL::0.405024 0.786934
-DEAL::0.430296 0.832760
-DEAL::0.478813 0.859498
-DEAL::0.474379 0.768388
-DEAL::0.484713 0.786526
-DEAL::0.501301 0.714975
-DEAL::0.524473 0.713858
-DEAL::0.544304 0.724010
-DEAL::0.555643 0.742845
-DEAL::0.541116 0.647681
-DEAL::0.592865 0.672731
-DEAL::0.621474 0.721859
-DEAL::0.503905 0.796598
-DEAL::0.536869 0.858844
-DEAL::0.526482 0.795790
-DEAL::0.547001 0.784040
-DEAL::0.559416 0.764401
-DEAL::0.589307 0.829611
-DEAL::0.622637 0.778386
+DEAL:0::Number of particles inserted: 24
+DEAL:0::Repartitioning triangulation after particle generation
+DEAL:0::Writing particle output file: analytical-particles-0
+DEAL:0::Writing particle output file: analytical-particles-1000
+DEAL:0::Writing particle output file: analytical-particles-2000
+DEAL:0::Particles location
+DEAL:0::0.406412 0.734191
+DEAL:0::0.431983 0.684517
+DEAL:0::0.475595 0.747746
+DEAL:0::0.479874 0.652444
+DEAL:0::0.486369 0.728375
+DEAL:0::0.505864 0.716196
+DEAL:0::0.529232 0.714603
+DEAL:0::0.549978 0.724169
+DEAL:0::0.540635 0.648620
+DEAL:0::0.561942 0.742488
+DEAL:0::0.595944 0.672859
+DEAL:0::0.627051 0.720283
+DEAL:0::0.406474 0.787612
+DEAL:0::0.433208 0.833310
+DEAL:0::0.480928 0.859777
+DEAL:0::0.475771 0.769133
+DEAL:0::0.486655 0.787079
+DEAL:0::Number of particles inserted: 24
+DEAL:0::Repartitioning triangulation after particle generation
+DEAL:0::Writing particle output file: interpolated-particles-0
+DEAL:0::Writing background field file: background-0
+DEAL:0::Writing particle output file: interpolated-particles-1000
+DEAL:0::Writing background field file: background-1000
+DEAL:0::Writing particle output file: interpolated-particles-2000
+DEAL:0::Writing background field file: background-2000
+DEAL:0::Particles location
+DEAL:0::0.400130 0.731196
+DEAL:0::0.429540 0.682369
+DEAL:0::0.469064 0.746158
+DEAL:0::0.481181 0.651665
+DEAL:0::0.480772 0.726826
+DEAL:0::0.501301 0.714975
+DEAL:0::0.524473 0.713858
+DEAL:0::0.544304 0.724010
+DEAL:0::0.555643 0.742845
+DEAL:0::0.541116 0.647681
+DEAL:0::0.592865 0.672731
+DEAL:0::0.621474 0.721859
+DEAL:0::0.405024 0.786934
+DEAL:0::0.430296 0.832760
+DEAL:0::0.478813 0.859498
+DEAL:0::0.474379 0.768388
+DEAL:0::0.484713 0.786526
+
+DEAL:1::0.505916 0.796997
+DEAL:1::0.538993 0.858949
+DEAL:1::0.528847 0.796079
+DEAL:1::0.549447 0.784270
+DEAL:1::0.561753 0.764590
+DEAL:1::0.592056 0.829624
+DEAL:1::0.624984 0.778592
+DEAL:1::0.503905 0.796598
+DEAL:1::0.536869 0.858844
+DEAL:1::0.526482 0.795790
+DEAL:1::0.547001 0.784040
+DEAL:1::0.559416 0.764401
+DEAL:1::0.589307 0.829611
+DEAL:1::0.622637 0.778386
+


### PR DESCRIPTION
This fixes #11591. In #11443 we forgot to clear particle locations and reference locations when the property pool deregisters the last particle (in order to start over with an order storage). Because handles are created based on the size of locations that caused it to create invalid handles later.

The test particles/step-68.cc already tests for this and fails for mpi=2 for me, I am not sure why the test suite did not capture that. Can someone explain how I activate this test for mpi=2? It already has an output file for this case.

@blaisb: This should fix your problem, sorry it took so long to take a look.