### PR TITLE
Spell out Tri->Triangle, Quad->Quadrilateral, etc.

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -210,7 +210,7 @@ namespace internal
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -267,7 +267,7 @@ namespace internal
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -332,10 +332,10 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Tet;
+          return dealii::ReferenceCell::Tetrahedron;
 
         if (d == 2)
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -446,9 +446,9 @@ namespace internal
           return dealii::ReferenceCell::Pyramid;
 
         if (d == 2 && e == 0)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -572,9 +572,9 @@ namespace internal
           return dealii::ReferenceCell::Wedge;
 
         if (d == 2 && e > 1)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -697,10 +697,10 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Hex;
+          return dealii::ReferenceCell::Hexahedron;
 
         if (d == 2)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
 
         if (d == 1)
           return dealii::ReferenceCell::Line;
@@ -1452,13 +1452,13 @@ namespace internal
                         dealii::ReferenceCell::Line)]
         .reset(new CellTypeLine());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Tri)]
+                        dealii::ReferenceCell::Triangle)]
         .reset(new CellTypeTri());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Quad)]
+                        dealii::ReferenceCell::Quadrilateral)]
         .reset(new CellTypeQuad());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Tet)]
+                        dealii::ReferenceCell::Tetrahedron)]
         .reset(new CellTypeTet());
       cell_types_impl[static_cast<types::geometric_entity_type>(
                         dealii::ReferenceCell::Pyramid)]
@@ -1467,7 +1467,7 @@ namespace internal
                         dealii::ReferenceCell::Wedge)]
         .reset(new CellTypeWedge());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Hex)]
+                        dealii::ReferenceCell::Hexahedron)]
         .reset(new CellTypeHex());
 
       // determine cell types and process vertices

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -74,18 +74,18 @@ class ReferenceCell
 public:
   static const ReferenceCell Vertex;
   static const ReferenceCell Line;
-  static const ReferenceCell Tri;
-  static const ReferenceCell Quad;
-  static const ReferenceCell Tet;
+  static const ReferenceCell Triangle;
+  static const ReferenceCell Quadrilateral;
+  static const ReferenceCell Tetrahedron;
   static const ReferenceCell Pyramid;
   static const ReferenceCell Wedge;
-  static const ReferenceCell Hex;
+  static const ReferenceCell Hexahedron;
   static const ReferenceCell Invalid;
 
   /**
    * Return the correct simplex reference cell type for the given dimension
    * `dim`. Depending on the template argument `dim`, this function returns a
-   * reference to either Vertex, Tri, or Tet.
+   * reference to either Vertex, Triangle, or Tetrahedron.
    */
   template <int dim>
   static constexpr const ReferenceCell &
@@ -94,7 +94,7 @@ public:
   /**
    * Return the correct hypercube reference cell type for the given dimension
    * `dim`. Depending on the template argument `dim`, this function returns a
-   * reference to either Vertex, Quad, or Hex.
+   * reference to either Vertex, Quadrilateral, or Hexahedron.
    */
   template <int dim>
   static constexpr const ReferenceCell &
@@ -103,8 +103,8 @@ public:
   /**
    * Return the correct ReferenceCell for a given structural
    * dimension and number of vertices. For example, if `dim==2` and
-   * `n_vertices==4`, this function will return `Quad`. But if `dim==3` and
-   * `n_vertices==4`, it will return `Tri`.
+   * `n_vertices==4`, this function will return `Quadrilateral`. But if `dim==3`
+   * and `n_vertices==4`, it will return `Tetrahedron`.
    */
   static ReferenceCell
   n_vertices_to_type(const int dim, const unsigned int n_vertices);
@@ -115,13 +115,13 @@ public:
   constexpr ReferenceCell();
 
   /**
-   * Return true if the object is a Vertex, Line, Quad, or Hex.
+   * Return true if the object is a Vertex, Line, Quadrilateral, or Hexahedron.
    */
   bool
   is_hyper_cube() const;
 
   /**
-   * Return true if the object is a Vertex, Line, Tri, or Tet.
+   * Return true if the object is a Vertex, Line, Triangle, or Tetrahedron.
    */
   bool
   is_simplex() const;
@@ -372,17 +372,17 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
       AssertIndexRange(vertex, GeometryInfo<1>::vertices_per_cell);
       return {&GeometryInfo<2>::vertex_to_face[vertex][0], 1};
     }
-  else if (*this == ReferenceCell::Quad)
+  else if (*this == ReferenceCell::Quadrilateral)
     {
       AssertIndexRange(vertex, GeometryInfo<2>::vertices_per_cell);
       return {&GeometryInfo<2>::vertex_to_face[vertex][0], 2};
     }
-  else if (*this == ReferenceCell::Hex)
+  else if (*this == ReferenceCell::Hexahedron)
     {
       AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_cell);
       return {&GeometryInfo<3>::vertex_to_face[vertex][0], 3};
     }
-  else if (*this == ReferenceCell::Tri)
+  else if (*this == ReferenceCell::Triangle)
     {
       AssertIndexRange(vertex, 3);
       static const std::array<std::array<unsigned int, 2>, 3> table = {
@@ -390,7 +390,7 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 
       return table[vertex];
     }
-  else if (*this == ReferenceCell::Tet)
+  else if (*this == ReferenceCell::Tetrahedron)
     {
       AssertIndexRange(vertex, 4);
       static const std::array<std::array<unsigned int, 3>, 4> table = {
@@ -435,7 +435,8 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 inline bool
 ReferenceCell::is_hyper_cube() const
 {
-  return (*this == Vertex || *this == Line || *this == Quad || *this == Hex);
+  return (*this == Vertex || *this == Line || *this == Quadrilateral ||
+          *this == Hexahedron);
 }
 
 
@@ -443,7 +444,8 @@ ReferenceCell::is_hyper_cube() const
 inline bool
 ReferenceCell::is_simplex() const
 {
-  return (*this == Vertex || *this == Line || *this == Tri || *this == Tet);
+  return (*this == Vertex || *this == Line || *this == Triangle ||
+          *this == Tetrahedron);
 }
 
 
@@ -455,10 +457,10 @@ ReferenceCell::get_dimension() const
     return 0;
   else if (*this == Line)
     return 1;
-  else if ((*this == Tri) || (*this == Quad))
+  else if ((*this == Triangle) || (*this == Quadrilateral))
     return 2;
-  else if ((*this == Tet) || (*this == Pyramid) || (*this == Wedge) ||
-           (*this == Hex))
+  else if ((*this == Tetrahedron) || (*this == Pyramid) || (*this == Wedge) ||
+           (*this == Hexahedron))
     return 3;
 
   Assert(false, ExcNotImplemented());
@@ -478,9 +480,9 @@ ReferenceCell::get_simplex()
       case 1:
         return ReferenceCell::Line;
       case 2:
-        return ReferenceCell::Tri;
+        return ReferenceCell::Triangle;
       case 3:
-        return ReferenceCell::Tet;
+        return ReferenceCell::Tetrahedron;
       default:
         Assert(false, ExcNotImplemented());
         return ReferenceCell::Invalid;
@@ -500,9 +502,9 @@ ReferenceCell::get_hypercube()
       case 1:
         return ReferenceCell::Line;
       case 2:
-        return ReferenceCell::Quad;
+        return ReferenceCell::Quadrilateral;
       case 3:
-        return ReferenceCell::Hex;
+        return ReferenceCell::Hexahedron;
       default:
         Assert(false, ExcNotImplemented());
         return ReferenceCell::Invalid;
@@ -525,17 +527,25 @@ ReferenceCell::n_vertices_to_type(const int dim, const unsigned int n_vertices)
               // dim 1
               {{X, X, ReferenceCell::Line, X, X, X, X, X, X}},
               // dim 2
-              {{X, X, X, ReferenceCell::Tri, ReferenceCell::Quad, X, X, X, X}},
+              {{X,
+                X,
+                X,
+                ReferenceCell::Triangle,
+                ReferenceCell::Quadrilateral,
+                X,
+                X,
+                X,
+                X}},
               // dim 3
               {{X,
                 X,
                 X,
                 X,
-                ReferenceCell::Tet,
+                ReferenceCell::Tetrahedron,
                 ReferenceCell::Pyramid,
                 ReferenceCell::Wedge,
                 X,
-                ReferenceCell::Hex}}}};
+                ReferenceCell::Hexahedron}}}};
   Assert(table[dim][n_vertices] != ReferenceCell::Invalid,
          ExcMessage("The combination of dim = " + std::to_string(dim) +
                     " and n_vertices = " + std::to_string(n_vertices) +
@@ -555,7 +565,8 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
     return GeometryInfo<dim>::d_linear_shape_function(xi, i);
 
   if (*this ==
-      ReferenceCell::Tri) // see also Simplex::ScalarPolynomial::compute_value
+      ReferenceCell::Triangle) // see also
+                               // Simplex::ScalarPolynomial::compute_value
     {
       switch (i)
         {
@@ -569,7 +580,8 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
     }
 
   if (*this ==
-      ReferenceCell::Tet) // see also Simplex::ScalarPolynomial::compute_value
+      ReferenceCell::Tetrahedron) // see also
+                                  // Simplex::ScalarPolynomial::compute_value
     {
       switch (i)
         {
@@ -589,7 +601,7 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
       ReferenceCell::Wedge) // see also
                             // Simplex::ScalarWedgePolynomial::compute_value
     {
-      return ReferenceCell(ReferenceCell::Tri)
+      return ReferenceCell(ReferenceCell::Triangle)
                .d_linear_shape_function<2>(Point<2>(xi[std::min(0, dim - 1)],
                                                     xi[std::min(1, dim - 1)]),
                                            i % 3) *
@@ -647,7 +659,8 @@ ReferenceCell::d_linear_shape_function_gradient(const Point<dim> & xi,
     return GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i);
 
   if (*this ==
-      ReferenceCell::Tri) // see also Simplex::ScalarPolynomial::compute_grad
+      ReferenceCell::Triangle) // see also
+                               // Simplex::ScalarPolynomial::compute_grad
     {
       switch (i)
         {
@@ -679,7 +692,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
       AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
       return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
     }
-  else if (*this == ReferenceCell::Tri)
+  else if (*this == ReferenceCell::Triangle)
     {
       AssertIndexRange(face_no, 3);
       static const std::array<Tensor<1, dim>, 3> table = {
@@ -689,7 +702,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
 
       return table[face_no];
     }
-  else if (*this == ReferenceCell::Tet)
+  else if (*this == ReferenceCell::Tetrahedron)
     {
       AssertIndexRange(face_no, 4);
       static const std::array<std::array<Tensor<1, dim>, 2>, 4> table = {
@@ -755,7 +768,7 @@ ReferenceCell::unit_normal_vectors(const unsigned int face_no) const
     }
   else if (dim == 2)
     {
-      Assert(*this == Tri, ExcInternalError());
+      Assert(*this == Triangle, ExcInternalError());
 
       // Return the rotated vector
       return cross_product_2d(unit_tangential_vectors<dim>(face_no, 0));
@@ -1135,7 +1148,7 @@ namespace internal
     /**
      * Triangle.
      */
-    struct Tri : public Base
+    struct Triangle : public Base
     {
       unsigned int
       n_vertices() const override
@@ -1243,9 +1256,9 @@ namespace internal
 
 
     /**
-     * Quad.
+     * Quadrilateral
      */
-    struct Quad : public TensorProductBase<2>
+    struct Quadrilateral : public TensorProductBase<2>
     {
       std::array<unsigned int, 2>
       standard_vertex_to_face_and_vertex_index(
@@ -1294,9 +1307,9 @@ namespace internal
 
 
     /**
-     * Tet.
+     * Tetrahedron
      */
-    struct Tet : public Base
+    struct Tetrahedron : public Base
     {
       unsigned int
       n_vertices() const override
@@ -1398,7 +1411,7 @@ namespace internal
 
         AssertIndexRange(face_no, n_faces());
 
-        return dealii::ReferenceCell::Tri;
+        return dealii::ReferenceCell::Triangle;
       }
 
       unsigned int
@@ -1568,9 +1581,9 @@ namespace internal
         AssertIndexRange(face_no, n_faces());
 
         if (face_no == 0)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
         else
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
       }
 
       unsigned int
@@ -1742,9 +1755,9 @@ namespace internal
         AssertIndexRange(face_no, n_faces());
 
         if (face_no > 1)
-          return dealii::ReferenceCell::Quad;
+          return dealii::ReferenceCell::Quadrilateral;
         else
-          return dealii::ReferenceCell::Tri;
+          return dealii::ReferenceCell::Triangle;
       }
 
       unsigned int
@@ -1796,7 +1809,7 @@ namespace internal
     /**
      * Hex.
      */
-    struct Hex : public TensorProductBase<3>
+    struct Hexahedron : public TensorProductBase<3>
     {
       std::array<unsigned int, 2>
       standard_line_to_face_and_line_index(
@@ -1877,7 +1890,7 @@ namespace internal
       face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
-        return dealii::ReferenceCell::Quad;
+        return dealii::ReferenceCell::Quadrilateral;
       }
 
       virtual unsigned int
@@ -1908,12 +1921,12 @@ namespace internal
       static const std::array<std::unique_ptr<internal::ReferenceCell::Base>, 8>
         gei{{std::make_unique<internal::ReferenceCell::Vertex>(),
              std::make_unique<internal::ReferenceCell::Line>(),
-             std::make_unique<internal::ReferenceCell::Tri>(),
-             std::make_unique<internal::ReferenceCell::Quad>(),
-             std::make_unique<internal::ReferenceCell::Tet>(),
+             std::make_unique<internal::ReferenceCell::Triangle>(),
+             std::make_unique<internal::ReferenceCell::Quadrilateral>(),
+             std::make_unique<internal::ReferenceCell::Tetrahedron>(),
              std::make_unique<internal::ReferenceCell::Pyramid>(),
              std::make_unique<internal::ReferenceCell::Wedge>(),
-             std::make_unique<internal::ReferenceCell::Hex>()}};
+             std::make_unique<internal::ReferenceCell::Hexahedron>()}};
       AssertIndexRange(static_cast<std::uint8_t>(type), 8);
       return *gei[static_cast<std::uint8_t>(type)];
     }
@@ -2024,7 +2037,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
       if (i == std::array<T, 2>{{j[1], j[0]}})
         return 0;
     }
-  else if (*this == ReferenceCell::Tri)
+  else if (*this == ReferenceCell::Triangle)
     {
       const std::array<T, 3> i{{vertices_0[0], vertices_0[1], vertices_0[2]}};
       const std::array<T, 3> j{{vertices_1[0], vertices_1[1], vertices_1[2]}};
@@ -2053,7 +2066,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
       if (i == std::array<T, 3>{{j[1], j[0], j[2]}})
         return 4;
     }
-  else if (*this == ReferenceCell::Quad)
+  else if (*this == ReferenceCell::Quadrilateral)
     {
       const std::array<T, 4> i{
         {vertices_0[0], vertices_0[1], vertices_0[2], vertices_0[3]}};
@@ -2122,7 +2135,7 @@ ReferenceCell::permute_according_orientation(
             Assert(false, ExcNotImplemented());
         }
     }
-  else if (*this == ReferenceCell::Tri)
+  else if (*this == ReferenceCell::Triangle)
     {
       switch (orientation)
         {
@@ -2148,7 +2161,7 @@ ReferenceCell::permute_according_orientation(
             Assert(false, ExcNotImplemented());
         }
     }
-  else if (*this == ReferenceCell::Quad)
+  else if (*this == ReferenceCell::Quadrilateral)
     {
       switch (orientation)
         {

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -60,16 +60,16 @@ namespace internal
       if (reference_cell == dealii::ReferenceCell::Line)
         // Return the distance between the two vertices
         return (vertices[1] - vertices[0]).norm();
-      else if (reference_cell == dealii::ReferenceCell::Tri)
+      else if (reference_cell == dealii::ReferenceCell::Triangle)
         // Return the longest of the three edges
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm(),
                          (vertices[2] - vertices[0]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Quad)
+      else if (reference_cell == dealii::ReferenceCell::Quadrilateral)
         // Return the longer one of the two diagonals of the quadrilateral
         return std::max({(vertices[3] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Tet)
+      else if (reference_cell == dealii::ReferenceCell::Tetrahedron)
         // Return the longest of the six edges of the tetrahedron
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[0]).norm(),
@@ -107,7 +107,7 @@ namespace internal
                          (vertices[4] - vertices[3]).norm(),
                          (vertices[5] - vertices[4]).norm(),
                          (vertices[5] - vertices[3]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Hex)
+      else if (reference_cell == dealii::ReferenceCell::Hexahedron)
         // Return the longest of the four diagonals of the hexahedron
         return std::max({(vertices[7] - vertices[0]).norm(),
                          (vertices[6] - vertices[1]).norm(),

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -234,11 +234,11 @@ namespace internal
 
                 if ((reference_cell == dealii::ReferenceCell::Vertex) ||
                     (reference_cell == dealii::ReferenceCell::Line) ||
-                    (reference_cell == dealii::ReferenceCell::Quad) ||
-                    (reference_cell == dealii::ReferenceCell::Hex))
+                    (reference_cell == dealii::ReferenceCell::Quadrilateral) ||
+                    (reference_cell == dealii::ReferenceCell::Hexahedron))
                   needs_hypercube_setup |= true;
-                else if ((reference_cell == dealii::ReferenceCell::Tri) ||
-                         (reference_cell == dealii::ReferenceCell::Tet))
+                else if ((reference_cell == dealii::ReferenceCell::Triangle) ||
+                         (reference_cell == dealii::ReferenceCell::Tetrahedron))
                   needs_simplex_setup |= true;
                 else if (reference_cell == dealii::ReferenceCell::Wedge)
                   needs_wedge_setup |= true;
@@ -323,11 +323,14 @@ namespace internal
 
                       if ((reference_cell == dealii::ReferenceCell::Vertex) ||
                           (reference_cell == dealii::ReferenceCell::Line) ||
-                          (reference_cell == dealii::ReferenceCell::Quad) ||
-                          (reference_cell == dealii::ReferenceCell::Hex))
+                          (reference_cell ==
+                           dealii::ReferenceCell::Quadrilateral) ||
+                          (reference_cell == dealii::ReferenceCell::Hexahedron))
                         quadrature.push_back(*quadrature_hypercube);
-                      else if ((reference_cell == dealii::ReferenceCell::Tri) ||
-                               (reference_cell == dealii::ReferenceCell::Tet))
+                      else if ((reference_cell ==
+                                dealii::ReferenceCell::Triangle) ||
+                               (reference_cell ==
+                                dealii::ReferenceCell::Tetrahedron))
                         quadrature.push_back(*quadrature_simplex);
                       else if (reference_cell == dealii::ReferenceCell::Wedge)
                         quadrature.push_back(*quadrature_wedge);

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -625,7 +625,7 @@ namespace
             vtk_cell_id[0] = cell_type_by_dim[dim];
             vtk_cell_id[1] = 1;
           }
-        else if (patch.reference_cell == ReferenceCell::Tri)
+        else if (patch.reference_cell == ReferenceCell::Triangle)
           {
             vtk_cell_id[0] = VTK_LAGRANGE_TRIANGLE;
             vtk_cell_id[1] = 1;
@@ -635,25 +635,25 @@ namespace
             Assert(false, ExcNotImplemented());
           }
       }
-    else if (patch.reference_cell == ReferenceCell::Tri &&
+    else if (patch.reference_cell == ReferenceCell::Triangle &&
              patch.data.n_cols() == 3)
       {
         vtk_cell_id[0] = VTK_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Tri &&
+    else if (patch.reference_cell == ReferenceCell::Triangle &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Tet &&
+    else if (patch.reference_cell == ReferenceCell::Tetrahedron &&
              patch.data.n_cols() == 4)
       {
         vtk_cell_id[0] = VTK_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Tet &&
+    else if (patch.reference_cell == ReferenceCell::Tetrahedron &&
              patch.data.n_cols() == 10)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TETRA;
@@ -8721,19 +8721,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
            << "\" NodesPerElement=\"2\">\n";
       else if (dimension == 2)
         {
-          Assert(reference_cell == ReferenceCell::Quad ||
-                   reference_cell == ReferenceCell::Tri,
+          Assert(reference_cell == ReferenceCell::Quadrilateral ||
+                   reference_cell == ReferenceCell::Triangle,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell == ReferenceCell::Quad)
+          if (reference_cell == ReferenceCell::Quadrilateral)
             {
               ss << "Quadrilateral"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell == ReferenceCell::Tri)
+          else // if (reference_cell == ReferenceCell::Triangle)
             {
               ss << "Triangle"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
@@ -8743,19 +8743,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
         }
       else if (dimension == 3)
         {
-          Assert(reference_cell == ReferenceCell::Hex ||
-                   reference_cell == ReferenceCell::Tet,
+          Assert(reference_cell == ReferenceCell::Hexahedron ||
+                   reference_cell == ReferenceCell::Tetrahedron,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell == ReferenceCell::Hex)
+          if (reference_cell == ReferenceCell::Hexahedron)
             {
               ss << "Hexahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell == ReferenceCell::Tet)
+          else // if (reference_cell == ReferenceCell::Tetrahedron)
             {
               ss << "Tetrahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -116,7 +116,7 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<2>> &q_points)
 {
-  project_to_face(ReferenceCell::Quad, quadrature, face_no, q_points);
+  project_to_face(ReferenceCell::Quadrilateral, quadrature, face_no, q_points);
 }
 
 
@@ -133,7 +133,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Triangle)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -154,7 +154,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell == ReferenceCell::Quad)
+  else if (reference_cell == ReferenceCell::Quadrilateral)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -189,7 +189,7 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  project_to_face(ReferenceCell::Hex, quadrature, face_no, q_points);
+  project_to_face(ReferenceCell::Hexahedron, quadrature, face_no, q_points);
 }
 
 
@@ -201,7 +201,7 @@ QProjector<3>::project_to_face(const ReferenceCell    reference_cell,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 3;
@@ -287,8 +287,12 @@ QProjector<2>::project_to_subface(const Quadrature<1> &    quadrature,
                                   std::vector<Point<2>> &  q_points,
                                   const RefinementCase<1> &ref_case)
 {
-  project_to_subface(
-    ReferenceCell::Quad, quadrature, face_no, subface_no, q_points, ref_case);
+  project_to_subface(ReferenceCell::Quadrilateral,
+                     quadrature,
+                     face_no,
+                     subface_no,
+                     q_points,
+                     ref_case);
 }
 
 
@@ -309,7 +313,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Triangle)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -363,7 +367,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell == ReferenceCell::Quad)
+  else if (reference_cell == ReferenceCell::Quadrilateral)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -445,8 +449,12 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  project_to_subface(
-    ReferenceCell::Hex, quadrature, face_no, subface_no, q_points, ref_case);
+  project_to_subface(ReferenceCell::Hexahedron,
+                     quadrature,
+                     face_no,
+                     subface_no,
+                     q_points,
+                     ref_case);
 }
 
 
@@ -460,7 +468,7 @@ QProjector<3>::project_to_subface(const ReferenceCell      reference_cell,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 3;
@@ -592,7 +600,7 @@ Quadrature<2>
 QProjector<2>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<1> &quadrature)
 {
-  if (reference_cell == ReferenceCell::Tri)
+  if (reference_cell == ReferenceCell::Triangle)
     {
       const auto support_points_line =
         [](const auto &face, const auto &orientation) -> std::vector<Point<2>> {
@@ -659,7 +667,7 @@ QProjector<2>::project_to_all_faces(const ReferenceCell       reference_cell,
       return {points, weights};
     }
 
-  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -720,7 +728,8 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     std::array<Point<3>, 3> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Tri.permute_according_orientation(vertices, orientation);
+      ReferenceCell::Triangle.permute_according_orientation(vertices,
+                                                            orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -730,7 +739,8 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     std::array<Point<3>, 4> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Quad.permute_according_orientation(vertices, orientation);
+      ReferenceCell::Quadrilateral.permute_according_orientation(vertices,
+                                                                 orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -840,7 +850,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     return Quadrature<3>(points, weights);
   };
 
-  if (reference_cell == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Tetrahedron)
     {
       // reference faces (defined by its support points and its area)
       // note: the area is later not used as a scaling factor but recomputed
@@ -922,7 +932,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     }
 
 
-  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
 
   const unsigned int dim = 3;
 
@@ -1076,11 +1086,11 @@ Quadrature<2>
 QProjector<2>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell == ReferenceCell::Tri ||
-      reference_cell == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Triangle ||
+      reference_cell == ReferenceCell::Tetrahedron)
     return Quadrature<2>(); // nothing to do
 
-  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -1126,7 +1136,7 @@ template <>
 Quadrature<2>
 QProjector<2>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Quad, quadrature);
+  return project_to_all_subfaces(ReferenceCell::Quadrilateral, quadrature);
 }
 
 
@@ -1136,11 +1146,11 @@ Quadrature<3>
 QProjector<3>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell == ReferenceCell::Tri ||
-      reference_cell == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Triangle ||
+      reference_cell == ReferenceCell::Tetrahedron)
     return Quadrature<3>(); // nothing to do
 
-  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
 
   const unsigned int dim         = 3;
   SubQuadrature      q_reflected = internal::QProjector::reflect(quadrature);
@@ -1218,7 +1228,7 @@ template <>
 Quadrature<3>
 QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Hex, quadrature);
+  return project_to_all_subfaces(ReferenceCell::Hexahedron, quadrature);
 }
 
 
@@ -1378,8 +1388,8 @@ QProjector<dim>::DataSetDescriptor::face(const ReferenceCell reference_cell,
                                          const bool          face_rotation,
                                          const unsigned int n_quadrature_points)
 {
-  if (reference_cell == ReferenceCell::Tri ||
-      reference_cell == ReferenceCell::Tet)
+  if (reference_cell == ReferenceCell::Triangle ||
+      reference_cell == ReferenceCell::Tetrahedron)
     {
       if (dim == 2)
         return {(2 * face_no + face_orientation) * n_quadrature_points};
@@ -1466,8 +1476,8 @@ QProjector<dim>::DataSetDescriptor::face(
   const bool                      face_rotation,
   const hp::QCollection<dim - 1> &quadrature)
 {
-  if (reference_cell == ReferenceCell::Tri ||
-      reference_cell == ReferenceCell::Tet ||
+  if (reference_cell == ReferenceCell::Triangle ||
+      reference_cell == ReferenceCell::Tetrahedron ||
       reference_cell == ReferenceCell::Wedge ||
       reference_cell == ReferenceCell::Pyramid)
     {
@@ -1481,9 +1491,9 @@ QProjector<dim>::DataSetDescriptor::face(
         {8, 6, 6, 6, 6}};
 
       const auto &scale =
-        (reference_cell == ReferenceCell::Tri) ?
+        (reference_cell == ReferenceCell::Triangle) ?
           scale_tri :
-          ((reference_cell == ReferenceCell::Tet) ?
+          ((reference_cell == ReferenceCell::Tetrahedron) ?
              scale_tet :
              ((reference_cell == ReferenceCell::Wedge) ? scale_wedge :
                                                          scale_pyramid));
@@ -1652,7 +1662,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<2>)
 {
-  Assert(reference_cell == ReferenceCell::Quad, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
   (void)reference_cell;
 
   Assert(face_no < GeometryInfo<2>::faces_per_cell, ExcInternalError());
@@ -1676,7 +1686,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<2> ref_case)
 {
-  return subface(ReferenceCell::Quad,
+  return subface(ReferenceCell::Quadrilateral,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1701,7 +1711,7 @@ QProjector<3>::DataSetDescriptor::subface(
 {
   const unsigned int dim = 3;
 
-  Assert(reference_cell == ReferenceCell::Hex, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1955,7 +1965,7 @@ QProjector<3>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<3> ref_case)
 {
-  return subface(ReferenceCell::Hex,
+  return subface(ReferenceCell::Hexahedron,
                  face_no,
                  subface_no,
                  face_orientation,

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -838,7 +838,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCell::Quad],
+                                   dealii::ReferenceCell::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)
@@ -1595,7 +1595,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCell::Quad],
+                                   dealii::ReferenceCell::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -156,13 +156,12 @@ FiniteElement<dim, spacedim>::FiniteElement(
 
       for (unsigned int f = 0; f < this->n_unique_quads(); ++f)
         {
-          adjust_quad_dof_index_for_face_orientation_table[f] =
-            Table<2, int>(this->n_dofs_per_quad(f),
-                          internal::ReferenceCell::get_cell(
-                            this->reference_cell())
-                                .face_reference_cell(f) == ReferenceCell::Quad ?
-                            8 :
-                            6);
+          adjust_quad_dof_index_for_face_orientation_table[f] = Table<2, int>(
+            this->n_dofs_per_quad(f),
+            internal::ReferenceCell::get_cell(this->reference_cell())
+                  .face_reference_cell(f) == ReferenceCell::Quadrilateral ?
+              8 :
+              6);
           adjust_quad_dof_index_for_face_orientation_table[f].fill(0);
         }
     }
@@ -687,7 +686,7 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
              [this->n_unique_quads() == 1 ? 0 : face]
                .n_elements() ==
            (internal::ReferenceCell::get_cell(this->reference_cell())
-                  .face_reference_cell(face) == ReferenceCell::Quad ?
+                  .face_reference_cell(face) == ReferenceCell::Quadrilateral ?
               8 :
               6) *
              this->n_dofs_per_quad(face),

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -121,10 +121,11 @@ FiniteElementData<dim>::FiniteElementData(
   const Conformity                 conformity,
   const BlockIndices &             block_indices)
   : FiniteElementData(dofs_per_object,
-                      dim == 0 ? ReferenceCell::Vertex :
-                                 (dim == 1 ? ReferenceCell::Line :
-                                             (dim == 2 ? ReferenceCell::Quad :
-                                                         ReferenceCell::Hex)),
+                      dim == 0 ?
+                        ReferenceCell::Vertex :
+                        (dim == 1 ? ReferenceCell::Line :
+                                    (dim == 2 ? ReferenceCell::Quadrilateral :
+                                                ReferenceCell::Hexahedron)),
                       n_components,
                       degree,
                       conformity,

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1726,7 +1726,7 @@ namespace GridGenerator
       {
         GridGenerator::hyper_cube(tria, 0, 1);
       }
-    else if ((dim == 2) && (reference_cell == ReferenceCell::Tri))
+    else if ((dim == 2) && (reference_cell == ReferenceCell::Triangle))
       {
         const std::vector<Point<spacedim>> vertices = {
           Point<spacedim>(),               // the origin
@@ -1739,7 +1739,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Tet))
+    else if ((dim == 3) && (reference_cell == ReferenceCell::Tetrahedron))
       {
         AssertDimension(spacedim, 3);
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3063,25 +3063,25 @@ namespace
                       type_name_2.end());
 
     if (type_name_2 == "TRI" || type_name_2 == "TRIANGLE")
-      return ReferenceCell::Tri;
+      return ReferenceCell::Triangle;
     else if (type_name_2 == "QUAD" || type_name_2 == "QUADRILATERAL")
-      return ReferenceCell::Quad;
+      return ReferenceCell::Quadrilateral;
     else if (type_name_2 == "SHELL")
       {
         if (n_nodes_per_element == 3)
-          return ReferenceCell::Tri;
+          return ReferenceCell::Triangle;
         else
-          return ReferenceCell::Quad;
+          return ReferenceCell::Quadrilateral;
       }
     else if (type_name_2 == "TET" || type_name_2 == "TETRA" ||
              type_name_2 == "TETRAHEDRON")
-      return ReferenceCell::Tet;
+      return ReferenceCell::Tetrahedron;
     else if (type_name_2 == "PYRA" || type_name_2 == "PYRAMID")
       return ReferenceCell::Pyramid;
     else if (type_name_2 == "WEDGE")
       return ReferenceCell::Wedge;
     else if (type_name_2 == "HEX" || type_name_2 == "HEXAHEDRON")
-      return ReferenceCell::Hex;
+      return ReferenceCell::Hexahedron;
 
     Assert(false, ExcNotImplemented());
     return ReferenceCell::Invalid;

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3443,11 +3443,11 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
 
             if ((reference_cell == ReferenceCell::Vertex) ||
                 (reference_cell == ReferenceCell::Line) ||
-                (reference_cell == ReferenceCell::Quad) ||
-                (reference_cell == ReferenceCell::Hex))
+                (reference_cell == ReferenceCell::Quadrilateral) ||
+                (reference_cell == ReferenceCell::Hexahedron))
               out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[i]);
-            else if ((reference_cell == ReferenceCell::Tri) ||
-                     (reference_cell == ReferenceCell::Tet) ||
+            else if ((reference_cell == ReferenceCell::Triangle) ||
+                     (reference_cell == ReferenceCell::Tetrahedron) ||
                      (reference_cell == ReferenceCell::Wedge))
               out << cell->vertex_index(i);
             else if (reference_cell == ReferenceCell::Pyramid)
@@ -4273,9 +4273,8 @@ namespace internal
           std::vector<double> dummy_weights(n_points, 1. / n_points);
           Quadrature<dim - 1> quadrature(boundary_points, dummy_weights);
 
-          q_projector =
-            QProjector<dim>::project_to_all_faces(dealii::ReferenceCell::Quad,
-                                                  quadrature);
+          q_projector = QProjector<dim>::project_to_all_faces(
+            dealii::ReferenceCell::Quadrilateral, quadrature);
         }
 
       for (const auto &cell : tria.active_cell_iterators())

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -19,6 +19,7 @@
 
 #include <deal.II/fe/mapping_fe.h>
 #include <deal.II/fe/mapping_q1.h>
+#include <deal.II/fe/mapping_q_generic.h>
 
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/reference_cell.h>
@@ -28,6 +29,8 @@
 #include <deal.II/simplex/polynomials.h>
 #include <deal.II/simplex/quadrature_lib.h>
 
+#include <memory>
+
 DEAL_II_NAMESPACE_OPEN
 
 
@@ -36,17 +39,17 @@ const ReferenceCell ReferenceCell::Vertex =
   internal::ReferenceCell::make_reference_cell_from_int(0);
 const ReferenceCell ReferenceCell::Line =
   internal::ReferenceCell::make_reference_cell_from_int(1);
-const ReferenceCell ReferenceCell::Tri =
+const ReferenceCell ReferenceCell::Triangle =
   internal::ReferenceCell::make_reference_cell_from_int(2);
-const ReferenceCell ReferenceCell::Quad =
+const ReferenceCell ReferenceCell::Quadrilateral =
   internal::ReferenceCell::make_reference_cell_from_int(3);
-const ReferenceCell ReferenceCell::Tet =
+const ReferenceCell ReferenceCell::Tetrahedron =
   internal::ReferenceCell::make_reference_cell_from_int(4);
 const ReferenceCell ReferenceCell::Pyramid =
   internal::ReferenceCell::make_reference_cell_from_int(5);
 const ReferenceCell ReferenceCell::Wedge =
   internal::ReferenceCell::make_reference_cell_from_int(6);
-const ReferenceCell ReferenceCell::Hex =
+const ReferenceCell ReferenceCell::Hexahedron =
   internal::ReferenceCell::make_reference_cell_from_int(7);
 const ReferenceCell ReferenceCell::Invalid =
   internal::ReferenceCell::make_reference_cell_from_int(
@@ -61,17 +64,17 @@ ReferenceCell::to_string() const
     return "Vertex";
   else if (*this == Line)
     return "Line";
-  else if (*this == Tri)
+  else if (*this == Triangle)
     return "Tri";
-  else if (*this == Quad)
+  else if (*this == Quadrilateral)
     return "Quad";
-  else if (*this == Tet)
+  else if (*this == Tetrahedron)
     return "Tet";
   else if (*this == Pyramid)
     return "Pyramid";
   else if (*this == Wedge)
     return "Wedge";
-  else if (*this == Hex)
+  else if (*this == Hexahedron)
     return "Hex";
   else if (*this == Invalid)
     return "Invalid";

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1182,7 +1182,7 @@ namespace internal
           tria_faces.quad_reference_cell.insert(
             tria_faces.quad_reference_cell.end(),
             new_size - tria_faces.quad_reference_cell.size(),
-            dealii::ReferenceCell::Quad);
+            dealii::ReferenceCell::Quadrilateral);
         }
     }
 
@@ -1308,8 +1308,8 @@ namespace internal
               tria_level.reference_cell.insert(
                 tria_level.reference_cell.end(),
                 total_cells - tria_level.reference_cell.size(),
-                tria_level.dim == 2 ? dealii::ReferenceCell::Quad :
-                                      dealii::ReferenceCell::Hex);
+                tria_level.dim == 2 ? dealii::ReferenceCell::Quadrilateral :
+                                      dealii::ReferenceCell::Hexahedron);
             }
         }
     }
@@ -4108,14 +4108,14 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
-                  if (cell->reference_cell() == dealii::ReferenceCell::Tri)
+                  if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
                     {
                       needed_cells += 4;
                       needed_vertices += 0;
                       n_single_lines += 3;
                     }
                   else if (cell->reference_cell() ==
-                           dealii::ReferenceCell::Quad)
+                           dealii::ReferenceCell::Quadrilateral)
                     {
                       needed_cells += 4;
                       needed_vertices += 1;
@@ -4268,9 +4268,10 @@ namespace internal
 
           unsigned int n_new_vertices = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
             n_new_vertices = 6;
-          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() ==
+                   dealii::ReferenceCell::Quadrilateral)
             n_new_vertices = 9;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4284,7 +4285,7 @@ namespace internal
               new_vertices[cell->n_vertices() + line_no] =
                 cell->line(line_no)->child(0)->vertex_index(1);
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Quad)
+          if (cell->reference_cell() == dealii::ReferenceCell::Quadrilateral)
             {
               while (triangulation.vertices_used[next_unused_vertex] == true)
                 ++next_unused_vertex;
@@ -4323,12 +4324,13 @@ namespace internal
           unsigned int lmin = 0;
           unsigned int lmax = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
             {
               lmin = 6;
               lmax = 9;
             }
-          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() ==
+                   dealii::ReferenceCell::Quadrilateral)
             {
               lmin = 8;
               lmax = 12;
@@ -4353,7 +4355,7 @@ namespace internal
 
           if (true)
             {
-              if (cell->reference_cell() == dealii::ReferenceCell::Tri)
+              if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
                 {
                   // add lines in the right order [TODO: clean up]
                   const auto ref = [&](const unsigned int face_no,
@@ -4388,7 +4390,8 @@ namespace internal
                   new_lines[8]->set_bounding_object_indices(
                     {new_vertices[5], new_vertices[3]});
                 }
-              else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
+              else if (cell->reference_cell() ==
+                       dealii::ReferenceCell::Quadrilateral)
                 {
                   unsigned int l = 0;
                   for (const unsigned int face_no : cell->face_indices())
@@ -4430,9 +4433,10 @@ namespace internal
 
           unsigned int n_children = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Tri)
+          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
             n_children = 4;
-          else if (cell->reference_cell() == dealii::ReferenceCell::Quad)
+          else if (cell->reference_cell() ==
+                   dealii::ReferenceCell::Quadrilateral)
             n_children = 4;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4451,7 +4455,7 @@ namespace internal
             }
 
           if ((dim == 2) &&
-              (cell->reference_cell() == dealii::ReferenceCell::Tri))
+              (cell->reference_cell() == dealii::ReferenceCell::Triangle))
             {
               subcells[0]->set_bounding_object_indices({new_lines[0]->index(),
                                                         new_lines[8]->index(),
@@ -4501,8 +4505,8 @@ namespace internal
               // triangulation.levels[subcells[2]->level()]->face_orientations[subcells[2]->index()
               // * GeometryInfo<2>::faces_per_cell + 0] = 0;
             }
-          else if ((dim == 2) &&
-                   (cell->reference_cell() == dealii::ReferenceCell::Quad))
+          else if ((dim == 2) && (cell->reference_cell() ==
+                                  dealii::ReferenceCell::Quadrilateral))
             {
               subcells[0]->set_bounding_object_indices(
                 {new_lines[0]->index(),
@@ -4582,7 +4586,8 @@ namespace internal
                                   next_unused_cell,
                                   cell);
 
-                  if (cell->reference_cell() == dealii::ReferenceCell::Quad &&
+                  if (cell->reference_cell() ==
+                        dealii::ReferenceCell::Quadrilateral &&
                       check_for_distorted_cells &&
                       has_distorted_children<dim, spacedim>(cell))
                     cells_with_distorted_children.distorted_cells.push_back(

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2845,7 +2845,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
     {
       case 2:
         {
-          if (this->reference_cell() == ReferenceCell::Tri)
+          if (this->reference_cell() == ReferenceCell::Triangle)
             {
               const auto neighbor_cell = this->neighbor(face);
 
@@ -2869,7 +2869,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
                   subface;
 
               const auto &info =
-                internal::ReferenceCell::get_cell(ReferenceCell::Tri);
+                internal::ReferenceCell::get_cell(ReferenceCell::Triangle);
               const unsigned int neighbor_child_index =
                 info.child_cell_on_face(neighbor_face, neighbor_subface);
               TriaIterator<CellAccessor<dim, spacedim>> sub_neighbor =
@@ -2883,7 +2883,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
               return sub_neighbor;
             }
-          else if (this->reference_cell() == ReferenceCell::Quad)
+          else if (this->reference_cell() == ReferenceCell::Quadrilateral)
             {
               const unsigned int neighbor_neighbor =
                 this->neighbor_of_neighbor(face);
@@ -2923,7 +2923,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
       case 3:
         {
-          if (this->reference_cell() == ReferenceCell::Hex)
+          if (this->reference_cell() == ReferenceCell::Hexahedron)
             {
               // this function returns the neighbor's
               // child on a given face and

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -155,7 +155,7 @@ namespace Simplex
         return {};
 
       const auto &info = internal::ReferenceCell::get_cell(
-        dim == 2 ? ReferenceCell::Tri : ReferenceCell::Tet);
+        dim == 2 ? ReferenceCell::Triangle : ReferenceCell::Tetrahedron);
       std::vector<std::vector<Point<dim - 1>>> unit_face_points;
 
       // all faces have the same support points
@@ -365,26 +365,27 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         BarycentricPolynomials<dim>::get_fe_p_basis(degree),
         FiniteElementData<dim>(dpo_vector,
-                               dim == 2 ? ReferenceCell::Tri :
-                                          ReferenceCell::Tet,
+                               dim == 2 ? ReferenceCell::Triangle :
+                                          ReferenceCell::Tetrahedron,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(FiniteElementData<dim>(dpo_vector,
-                                                 dim == 2 ? ReferenceCell::Tri :
-                                                            ReferenceCell::Tet,
+                                                 dim == 2 ?
+                                                   ReferenceCell::Triangle :
+                                                   ReferenceCell::Tetrahedron,
                                                  1,
                                                  degree)
                             .dofs_per_cell,
                           true),
-        std::vector<ComponentMask>(FiniteElementData<dim>(dpo_vector,
-                                                          dim == 2 ?
-                                                            ReferenceCell::Tri :
-                                                            ReferenceCell::Tet,
-                                                          1,
-                                                          degree)
-                                     .dofs_per_cell,
-                                   std::vector<bool>(1, true)))
+        std::vector<ComponentMask>(
+          FiniteElementData<dim>(dpo_vector,
+                                 dim == 2 ? ReferenceCell::Triangle :
+                                            ReferenceCell::Tetrahedron,
+                                 1,
+                                 degree)
+            .dofs_per_cell,
+          std::vector<bool>(1, true)))
   {
     this->unit_support_points = unit_support_points_fe_poly<dim>(degree);
     // Discontinuous elements don't have face support points

--- a/tests/hp/fe_nothing_22.cc
+++ b/tests/hp/fe_nothing_22.cc
@@ -39,19 +39,19 @@ test()
           << std::endl;
   if (dim == 2)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Quad, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Quadrilateral, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Tri, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Triangle, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
     }
   if (dim == 3)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Hex, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Hexahedron, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Tet, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCell::Tetrahedron, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
       deallog << (FE_Nothing<dim>(ReferenceCell::Wedge, 1, false) ==

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -84,9 +84,9 @@ test(const FiniteElement<dim, spacedim> &fe_0,
       if (cell->is_locally_owned() == false)
         continue;
 
-      if (cell->reference_cell() == ReferenceCell::Tri)
+      if (cell->reference_cell() == ReferenceCell::Triangle)
         cell->set_active_fe_index(0);
-      else if (cell->reference_cell() == ReferenceCell::Quad)
+      else if (cell->reference_cell() == ReferenceCell::Quadrilateral)
         cell->set_active_fe_index(1);
       else
         Assert(false, ExcNotImplemented());

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -157,8 +157,8 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell() == ReferenceCell::Tri ||
-        cell->reference_cell() == ReferenceCell::Tet)
+    if (cell->reference_cell() == ReferenceCell::Triangle ||
+        cell->reference_cell() == ReferenceCell::Tetrahedron)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -260,8 +260,8 @@ test(const unsigned version, const unsigned int degree)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell() == ReferenceCell::Tri ||
-        cell->reference_cell() == ReferenceCell::Tet)
+    if (cell->reference_cell() == ReferenceCell::Triangle ||
+        cell->reference_cell() == ReferenceCell::Tetrahedron)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/orientation_01.cc
+++ b/tests/simplex/orientation_01.cc
@@ -47,8 +47,8 @@ main()
   initlog();
 
   test<2>(ReferenceCell::Line, 2);
-  test<3>(ReferenceCell::Tri, 3);
-  test<4>(ReferenceCell::Quad, 4);
+  test<3>(ReferenceCell::Triangle, 3);
+  test<4>(ReferenceCell::Quadrilateral, 4);
 
   deallog << "OK!" << std::endl;
 }

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -30,7 +30,7 @@ test(const unsigned int orientation)
 
 
   Triangulation<3> dummy, tria;
-  GridGenerator::reference_cell(ReferenceCell::Tet, dummy);
+  GridGenerator::reference_cell(ReferenceCell::Tetrahedron, dummy);
 
   auto vertices = dummy.get_vertices();
 
@@ -46,7 +46,7 @@ test(const unsigned int orientation)
   {
     const auto &face = dummy.begin()->face(face_no);
     const auto  permuted =
-      ReferenceCell(ReferenceCell::Tri)
+      ReferenceCell(ReferenceCell::Triangle)
         .permute_according_orientation(
           std::array<unsigned int, 3>{{face->vertex_index(0),
                                        face->vertex_index(1),
@@ -97,9 +97,8 @@ test(const unsigned int orientation)
   for (const auto l : face->line_indices())
     {
       const unsigned int l_ =
-        internal::ReferenceCell::Tet().standard_to_real_face_line(l,
-                                                                  face_no,
-                                                                  orientation);
+        internal::ReferenceCell::Tetrahedron().standard_to_real_face_line(
+          l, face_no, orientation);
 
       std::array<unsigned int, 2> a = {
         {face->line(l_)->vertex_index(0), face->line(l_)->vertex_index(1)}};

--- a/tests/simplex/q_projection_01.cc
+++ b/tests/simplex/q_projection_01.cc
@@ -41,7 +41,7 @@ test<2>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Tri, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCell::Triangle, quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation) {
@@ -50,7 +50,7 @@ test<2>(const unsigned int n_points)
             << ":" << std::endl;
     for (unsigned int
            q = 0,
-           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Tri,
+           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Triangle,
                                                         face_no,
                                                         face_orientation,
                                                         false,
@@ -82,7 +82,7 @@ test<3>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Tet, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCell::Tetrahedron, quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation,
@@ -93,14 +93,14 @@ test<3>(const unsigned int n_points)
             << " face_flip=" << (face_flip ? "true" : "false")
             << " face_rotation=" << (face_rotation ? "true" : "false") << ":"
             << std::endl;
-    for (unsigned int
-           q = 0,
-           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Tet,
-                                                        face_no,
-                                                        face_orientation,
-                                                        face_flip,
-                                                        face_rotation,
-                                                        quad_ref.size());
+    for (unsigned int q = 0,
+                      i = QProjector<dim>::DataSetDescriptor::face(
+                        ReferenceCell::Tetrahedron,
+                        face_no,
+                        face_orientation,
+                        face_flip,
+                        face_rotation,
+                        quad_ref.size());
          q < quad_ref.size();
          ++q, ++i)
       {

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -50,10 +50,10 @@ main()
   initlog();
 
   test<2>(ReferenceCell::Line);
-  test<2>(ReferenceCell::Tri);
-  test<2>(ReferenceCell::Quad);
-  test<3>(ReferenceCell::Tet);
+  test<2>(ReferenceCell::Triangle);
+  test<2>(ReferenceCell::Quadrilateral);
+  test<3>(ReferenceCell::Tetrahedron);
   test<3>(ReferenceCell::Pyramid);
   test<3>(ReferenceCell::Wedge);
-  test<3>(ReferenceCell::Hex);
+  test<3>(ReferenceCell::Hexahedron);
 }

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -51,10 +51,10 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Tri);
-  test<2>(ReferenceCell::Quad);
-  test<3>(ReferenceCell::Tet);
+  test<2>(ReferenceCell::Triangle);
+  test<2>(ReferenceCell::Quadrilateral);
+  test<3>(ReferenceCell::Tetrahedron);
   test<3>(ReferenceCell::Pyramid);
   test<3>(ReferenceCell::Wedge);
-  test<3>(ReferenceCell::Hex);
+  test<3>(ReferenceCell::Hexahedron);
 }

--- a/tests/simplex/variable_face_quadratures_01.cc
+++ b/tests/simplex/variable_face_quadratures_01.cc
@@ -75,14 +75,19 @@ test<2>()
                                             QGauss<dim - 1>(4));
 
     const auto quad =
-      QProjector<dim>::project_to_all_faces(ReferenceCell::Quad, quad_ref);
+      QProjector<dim>::project_to_all_faces(ReferenceCell::Quadrilateral,
+                                            quad_ref);
 
     const auto print = [&](const unsigned int face_no) {
       deallog << "face_no=" << face_no << ":" << std::endl;
-      for (unsigned int
-             q = 0,
-             i = QProjector<dim>::DataSetDescriptor::face(
-               ReferenceCell::Quad, face_no, false, false, false, quad_ref);
+      for (unsigned int q = 0,
+                        i = QProjector<dim>::DataSetDescriptor::face(
+                          ReferenceCell::Quadrilateral,
+                          face_no,
+                          false,
+                          false,
+                          false,
+                          quad_ref);
            q < quad_ref[face_no].size();
            ++q, ++i)
         {


### PR DESCRIPTION
We're generally quite good at not using abbreviated words in deal.II function names,
with few exceptions that are mostly historic. Let's try to keep it that way.

Related to #11544.

/rebuild