### PR TITLE
Move the special ReferenceCell objects into a namespace of their own.

### DIFF
--- a/include/deal.II/grid/connectivity.h
+++ b/include/deal.II/grid/connectivity.h
@@ -77,7 +77,7 @@ namespace internal
         (void)d;
         (void)e;
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       /**
@@ -156,11 +156,11 @@ namespace internal
         (void)e;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -210,14 +210,14 @@ namespace internal
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -267,14 +267,14 @@ namespace internal
         (void)e;
 
         if (d == 2)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -332,17 +332,17 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Tetrahedron;
+          return dealii::ReferenceCells::Tetrahedron;
 
         if (d == 2)
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -443,19 +443,19 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Pyramid;
+          return dealii::ReferenceCells::Pyramid;
 
         if (d == 2 && e == 0)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -569,19 +569,19 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Wedge;
+          return dealii::ReferenceCells::Wedge;
 
         if (d == 2 && e > 1)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
         else if (d == 2)
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -697,17 +697,17 @@ namespace internal
         (void)e;
 
         if (d == 3)
-          return dealii::ReferenceCell::Hexahedron;
+          return dealii::ReferenceCells::Hexahedron;
 
         if (d == 2)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
 
         if (d == 1)
-          return dealii::ReferenceCell::Line;
+          return dealii::ReferenceCells::Line;
 
         Assert(false, ExcNotImplemented());
 
-        return dealii::ReferenceCell::Vertex;
+        return dealii::ReferenceCells::Vertex;
       }
 
       unsigned int
@@ -1449,25 +1449,25 @@ namespace internal
       std::vector<std::shared_ptr<CellTypeBase>> cell_types_impl(8);
 
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Line)]
+                        dealii::ReferenceCells::Line)]
         .reset(new CellTypeLine());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Triangle)]
+                        dealii::ReferenceCells::Triangle)]
         .reset(new CellTypeTri());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Quadrilateral)]
+                        dealii::ReferenceCells::Quadrilateral)]
         .reset(new CellTypeQuad());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Tetrahedron)]
+                        dealii::ReferenceCells::Tetrahedron)]
         .reset(new CellTypeTet());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Pyramid)]
+                        dealii::ReferenceCells::Pyramid)]
         .reset(new CellTypePyramid());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Wedge)]
+                        dealii::ReferenceCells::Wedge)]
         .reset(new CellTypeWedge());
       cell_types_impl[static_cast<types::geometric_entity_type>(
-                        dealii::ReferenceCell::Hexahedron)]
+                        dealii::ReferenceCells::Hexahedron)]
         .reset(new CellTypeHex());
 
       // determine cell types and process vertices
@@ -1494,7 +1494,7 @@ namespace internal
             dealii::ReferenceCell::n_vertices_to_type(dim,
                                                       cell.vertices.size());
 
-          Assert(reference_cell != dealii::ReferenceCell::Invalid,
+          Assert(reference_cell != dealii::ReferenceCells::Invalid,
                  ExcNotImplemented());
           AssertIndexRange(static_cast<types::geometric_entity_type>(
                              reference_cell),

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -346,23 +346,23 @@ namespace internal
 
 namespace ReferenceCells
 {
-  constexpr ReferenceCell Vertex =
+  DEAL_II_CONSTEXPR const ReferenceCell Vertex =
     internal::ReferenceCell::make_reference_cell_from_int(0);
-  constexpr ReferenceCell Line =
+  DEAL_II_CONSTEXPR const ReferenceCell Line =
     internal::ReferenceCell::make_reference_cell_from_int(1);
-  constexpr ReferenceCell Triangle =
+  DEAL_II_CONSTEXPR const ReferenceCell Triangle =
     internal::ReferenceCell::make_reference_cell_from_int(2);
-  constexpr ReferenceCell Quadrilateral =
+  DEAL_II_CONSTEXPR const ReferenceCell Quadrilateral =
     internal::ReferenceCell::make_reference_cell_from_int(3);
-  constexpr ReferenceCell Tetrahedron =
+  DEAL_II_CONSTEXPR const ReferenceCell Tetrahedron =
     internal::ReferenceCell::make_reference_cell_from_int(4);
-  constexpr ReferenceCell Pyramid =
+  DEAL_II_CONSTEXPR const ReferenceCell Pyramid =
     internal::ReferenceCell::make_reference_cell_from_int(5);
-  constexpr ReferenceCell Wedge =
+  DEAL_II_CONSTEXPR const ReferenceCell Wedge =
     internal::ReferenceCell::make_reference_cell_from_int(6);
-  constexpr ReferenceCell Hexahedron =
+  DEAL_II_CONSTEXPR const ReferenceCell Hexahedron =
     internal::ReferenceCell::make_reference_cell_from_int(7);
-  constexpr ReferenceCell Invalid =
+  DEAL_II_CONSTEXPR const ReferenceCell Invalid =
     internal::ReferenceCell::make_reference_cell_from_int(
       static_cast<std::uint8_t>(-1));
 } // namespace ReferenceCells

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -67,6 +67,15 @@ namespace internal
  * This includes quadrilaterals and hexahedra (i.e., "hypercubes"),
  * triangles and tetrahedra (simplices), and the pyramids and wedges
  * necessary when using mixed 3d meshes.
+ *
+ * Objects of this type should not be created in user code, and as a
+ * consequence the class does not have a user-accessible constructor
+ * other than the default constructor (which creates an invalid object).
+ * Rather, there is a finite number of specific reference cell objects
+ * defined in the ReferenceCells namespace that completely enumerate
+ * all of the possible values. User codes should therefore rely
+ * exclusively on assigning ReferenceCell objects from these special
+ * objects, and comparing against those special objects.
  */
 class ReferenceCell
 {
@@ -344,6 +353,13 @@ namespace internal
 
 
 
+/**
+ * A namespace in which we define objects that correspond to specific
+ * reference cells. The objects defined here are a complete enumeration
+ * of all possible reference cells that can be used in deal.II.
+ *
+ * @relates ReferenceCell
+ */
 namespace ReferenceCells
 {
   DEAL_II_CONSTEXPR const ReferenceCell Vertex =

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -71,16 +71,6 @@ namespace internal
 class ReferenceCell
 {
 public:
-  static const ReferenceCell Vertex;
-  static const ReferenceCell Line;
-  static const ReferenceCell Triangle;
-  static const ReferenceCell Quadrilateral;
-  static const ReferenceCell Tetrahedron;
-  static const ReferenceCell Pyramid;
-  static const ReferenceCell Wedge;
-  static const ReferenceCell Hexahedron;
-  static const ReferenceCell Invalid;
-
   /**
    * Return the correct simplex reference cell type for the given dimension
    * `dim`. Depending on the template argument `dim`, this function returns a
@@ -354,6 +344,31 @@ namespace internal
 
 
 
+namespace ReferenceCells
+{
+  constexpr ReferenceCell Vertex =
+    internal::ReferenceCell::make_reference_cell_from_int(0);
+  constexpr ReferenceCell Line =
+    internal::ReferenceCell::make_reference_cell_from_int(1);
+  constexpr ReferenceCell Triangle =
+    internal::ReferenceCell::make_reference_cell_from_int(2);
+  constexpr ReferenceCell Quadrilateral =
+    internal::ReferenceCell::make_reference_cell_from_int(3);
+  constexpr ReferenceCell Tetrahedron =
+    internal::ReferenceCell::make_reference_cell_from_int(4);
+  constexpr ReferenceCell Pyramid =
+    internal::ReferenceCell::make_reference_cell_from_int(5);
+  constexpr ReferenceCell Wedge =
+    internal::ReferenceCell::make_reference_cell_from_int(6);
+  constexpr ReferenceCell Hexahedron =
+    internal::ReferenceCell::make_reference_cell_from_int(7);
+  constexpr ReferenceCell Invalid =
+    internal::ReferenceCell::make_reference_cell_from_int(
+      static_cast<std::uint8_t>(-1));
+} // namespace ReferenceCells
+
+
+
 template <class Archive>
 inline void
 ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)
@@ -366,22 +381,22 @@ ReferenceCell::serialize(Archive &archive, const unsigned int /*version*/)
 inline ArrayView<const unsigned int>
 ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 {
-  if (*this == ReferenceCell::Line)
+  if (*this == ReferenceCells::Line)
     {
       AssertIndexRange(vertex, GeometryInfo<1>::vertices_per_cell);
       return {&GeometryInfo<2>::vertex_to_face[vertex][0], 1};
     }
-  else if (*this == ReferenceCell::Quadrilateral)
+  else if (*this == ReferenceCells::Quadrilateral)
     {
       AssertIndexRange(vertex, GeometryInfo<2>::vertices_per_cell);
       return {&GeometryInfo<2>::vertex_to_face[vertex][0], 2};
     }
-  else if (*this == ReferenceCell::Hexahedron)
+  else if (*this == ReferenceCells::Hexahedron)
     {
       AssertIndexRange(vertex, GeometryInfo<3>::vertices_per_cell);
       return {&GeometryInfo<3>::vertex_to_face[vertex][0], 3};
     }
-  else if (*this == ReferenceCell::Triangle)
+  else if (*this == ReferenceCells::Triangle)
     {
       AssertIndexRange(vertex, 3);
       static const std::array<std::array<unsigned int, 2>, 3> table = {
@@ -389,7 +404,7 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 
       return table[vertex];
     }
-  else if (*this == ReferenceCell::Tetrahedron)
+  else if (*this == ReferenceCells::Tetrahedron)
     {
       AssertIndexRange(vertex, 4);
       static const std::array<std::array<unsigned int, 3>, 4> table = {
@@ -397,7 +412,7 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 
       return table[vertex];
     }
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     {
       AssertIndexRange(vertex, 6);
       static const std::array<std::array<unsigned int, 3>, 6> table = {
@@ -410,7 +425,7 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 
       return table[vertex];
     }
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     {
       AssertIndexRange(vertex, 5);
       static const unsigned int X = numbers::invalid_unsigned_int;
@@ -434,8 +449,9 @@ ReferenceCell::faces_for_given_vertex(const unsigned int vertex) const
 inline bool
 ReferenceCell::is_hyper_cube() const
 {
-  return (*this == Vertex || *this == Line || *this == Quadrilateral ||
-          *this == Hexahedron);
+  return (*this == ReferenceCells::Vertex || *this == ReferenceCells::Line ||
+          *this == ReferenceCells::Quadrilateral ||
+          *this == ReferenceCells::Hexahedron);
 }
 
 
@@ -443,8 +459,9 @@ ReferenceCell::is_hyper_cube() const
 inline bool
 ReferenceCell::is_simplex() const
 {
-  return (*this == Vertex || *this == Line || *this == Triangle ||
-          *this == Tetrahedron);
+  return (*this == ReferenceCells::Vertex || *this == ReferenceCells::Line ||
+          *this == ReferenceCells::Triangle ||
+          *this == ReferenceCells::Tetrahedron);
 }
 
 
@@ -452,14 +469,17 @@ ReferenceCell::is_simplex() const
 inline unsigned int
 ReferenceCell::get_dimension() const
 {
-  if (*this == Vertex)
+  if (*this == ReferenceCells::Vertex)
     return 0;
-  else if (*this == Line)
+  else if (*this == ReferenceCells::Line)
     return 1;
-  else if ((*this == Triangle) || (*this == Quadrilateral))
+  else if ((*this == ReferenceCells::Triangle) ||
+           (*this == ReferenceCells::Quadrilateral))
     return 2;
-  else if ((*this == Tetrahedron) || (*this == Pyramid) || (*this == Wedge) ||
-           (*this == Hexahedron))
+  else if ((*this == ReferenceCells::Tetrahedron) ||
+           (*this == ReferenceCells::Pyramid) ||
+           (*this == ReferenceCells::Wedge) ||
+           (*this == ReferenceCells::Hexahedron))
     return 3;
 
   Assert(false, ExcNotImplemented());
@@ -475,16 +495,16 @@ ReferenceCell::get_simplex()
   switch (dim)
     {
       case 0:
-        return ReferenceCell::Vertex;
+        return ReferenceCells::Vertex;
       case 1:
-        return ReferenceCell::Line;
+        return ReferenceCells::Line;
       case 2:
-        return ReferenceCell::Triangle;
+        return ReferenceCells::Triangle;
       case 3:
-        return ReferenceCell::Tetrahedron;
+        return ReferenceCells::Tetrahedron;
       default:
         Assert(false, ExcNotImplemented());
-        return ReferenceCell::Invalid;
+        return ReferenceCells::Invalid;
     }
 }
 
@@ -497,16 +517,16 @@ ReferenceCell::get_hypercube()
   switch (dim)
     {
       case 0:
-        return ReferenceCell::Vertex;
+        return ReferenceCells::Vertex;
       case 1:
-        return ReferenceCell::Line;
+        return ReferenceCells::Line;
       case 2:
-        return ReferenceCell::Quadrilateral;
+        return ReferenceCells::Quadrilateral;
       case 3:
-        return ReferenceCell::Hexahedron;
+        return ReferenceCells::Hexahedron;
       default:
         Assert(false, ExcNotImplemented());
-        return ReferenceCell::Invalid;
+        return ReferenceCells::Invalid;
     }
 }
 
@@ -518,19 +538,19 @@ ReferenceCell::n_vertices_to_type(const int dim, const unsigned int n_vertices)
   AssertIndexRange(dim, 4);
   AssertIndexRange(n_vertices, 9);
 
-  const auto X = ReferenceCell::Invalid;
+  const auto X = ReferenceCells::Invalid;
   static const std::array<std::array<ReferenceCell, 9>,
                           4>
     table = {{// dim 0
-              {{X, ReferenceCell::Vertex, X, X, X, X, X, X, X}},
+              {{X, ReferenceCells::Vertex, X, X, X, X, X, X, X}},
               // dim 1
-              {{X, X, ReferenceCell::Line, X, X, X, X, X, X}},
+              {{X, X, ReferenceCells::Line, X, X, X, X, X, X}},
               // dim 2
               {{X,
                 X,
                 X,
-                ReferenceCell::Triangle,
-                ReferenceCell::Quadrilateral,
+                ReferenceCells::Triangle,
+                ReferenceCells::Quadrilateral,
                 X,
                 X,
                 X,
@@ -540,12 +560,12 @@ ReferenceCell::n_vertices_to_type(const int dim, const unsigned int n_vertices)
                 X,
                 X,
                 X,
-                ReferenceCell::Tetrahedron,
-                ReferenceCell::Pyramid,
-                ReferenceCell::Wedge,
+                ReferenceCells::Tetrahedron,
+                ReferenceCells::Pyramid,
+                ReferenceCells::Wedge,
                 X,
-                ReferenceCell::Hexahedron}}}};
-  Assert(table[dim][n_vertices] != ReferenceCell::Invalid,
+                ReferenceCells::Hexahedron}}}};
+  Assert(table[dim][n_vertices] != ReferenceCells::Invalid,
          ExcMessage("The combination of dim = " + std::to_string(dim) +
                     " and n_vertices = " + std::to_string(n_vertices) +
                     " does not correspond to a known reference cell type."));
@@ -564,8 +584,8 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
     return GeometryInfo<dim>::d_linear_shape_function(xi, i);
 
   if (*this ==
-      ReferenceCell::Triangle) // see also
-                               // Simplex::ScalarPolynomial::compute_value
+      ReferenceCells::Triangle) // see also
+                                // Simplex::ScalarPolynomial::compute_value
     {
       switch (i)
         {
@@ -579,8 +599,8 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
     }
 
   if (*this ==
-      ReferenceCell::Tetrahedron) // see also
-                                  // Simplex::ScalarPolynomial::compute_value
+      ReferenceCells::Tetrahedron) // see also
+                                   // Simplex::ScalarPolynomial::compute_value
     {
       switch (i)
         {
@@ -597,21 +617,21 @@ ReferenceCell::d_linear_shape_function(const Point<dim> & xi,
     }
 
   if (*this ==
-      ReferenceCell::Wedge) // see also
-                            // Simplex::ScalarWedgePolynomial::compute_value
+      ReferenceCells::Wedge) // see also
+                             // Simplex::ScalarWedgePolynomial::compute_value
     {
-      return ReferenceCell(ReferenceCell::Triangle)
+      return ReferenceCell(ReferenceCells::Triangle)
                .d_linear_shape_function<2>(Point<2>(xi[std::min(0, dim - 1)],
                                                     xi[std::min(1, dim - 1)]),
                                            i % 3) *
-             ReferenceCell(ReferenceCell::Line)
+             ReferenceCell(ReferenceCells::Line)
                .d_linear_shape_function<1>(Point<1>(xi[std::min(2, dim - 1)]),
                                            i / 3);
     }
 
-  if (*this ==
-      ReferenceCell::Pyramid) // see also
-                              // Simplex::ScalarPyramidPolynomial::compute_value
+  if (*this == ReferenceCells::
+                 Pyramid) // see also
+                          // Simplex::ScalarPyramidPolynomial::compute_value
     {
       const double Q14 = 0.25;
       double       ration;
@@ -658,8 +678,8 @@ ReferenceCell::d_linear_shape_function_gradient(const Point<dim> & xi,
     return GeometryInfo<dim>::d_linear_shape_function_gradient(xi, i);
 
   if (*this ==
-      ReferenceCell::Triangle) // see also
-                               // Simplex::ScalarPolynomial::compute_grad
+      ReferenceCells::Triangle) // see also
+                                // Simplex::ScalarPolynomial::compute_grad
     {
       switch (i)
         {
@@ -691,7 +711,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
       AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
       return GeometryInfo<dim>::unit_tangential_vectors[face_no][i];
     }
-  else if (*this == ReferenceCell::Triangle)
+  else if (*this == ReferenceCells::Triangle)
     {
       AssertIndexRange(face_no, 3);
       static const std::array<Tensor<1, dim>, 3> table = {
@@ -701,7 +721,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
 
       return table[face_no];
     }
-  else if (*this == ReferenceCell::Tetrahedron)
+  else if (*this == ReferenceCells::Tetrahedron)
     {
       AssertIndexRange(face_no, 4);
       static const std::array<std::array<Tensor<1, dim>, 2>, 4> table = {
@@ -717,7 +737,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
 
       return table[face_no][i];
     }
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     {
       AssertIndexRange(face_no, 5);
       static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
@@ -730,7 +750,7 @@ ReferenceCell::unit_tangential_vectors(const unsigned int face_no,
 
       return table[face_no][i];
     }
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     {
       AssertIndexRange(face_no, 5);
       static const std::array<std::array<Tensor<1, dim>, 2>, 5> table = {
@@ -767,7 +787,7 @@ ReferenceCell::unit_normal_vectors(const unsigned int face_no) const
     }
   else if (dim == 2)
     {
-      Assert(*this == Triangle, ExcInternalError());
+      Assert(*this == ReferenceCells::Triangle, ExcInternalError());
 
       // Return the rotated vector
       return cross_product_2d(unit_tangential_vectors<dim>(face_no, 0));
@@ -952,7 +972,7 @@ namespace internal
         Assert(false, ExcNotImplemented());
         (void)face_no;
 
-        return dealii::ReferenceCell::Invalid;
+        return ReferenceCells::Invalid;
       }
 
       /**
@@ -1090,7 +1110,7 @@ namespace internal
       face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
-        return dealii::ReferenceCell::Invalid;
+        return ReferenceCells::Invalid;
       }
 
       virtual unsigned int
@@ -1114,7 +1134,7 @@ namespace internal
       face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
-        return dealii::ReferenceCell::Vertex;
+        return ReferenceCells::Vertex;
       }
 
       virtual unsigned int
@@ -1190,7 +1210,7 @@ namespace internal
 
         AssertIndexRange(face_no, n_faces());
 
-        return dealii::ReferenceCell::Line;
+        return dealii::ReferenceCells::Line;
       }
 
       unsigned int
@@ -1273,7 +1293,7 @@ namespace internal
       face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
-        return dealii::ReferenceCell::Line;
+        return dealii::ReferenceCells::Line;
       }
 
       virtual unsigned int
@@ -1400,7 +1420,7 @@ namespace internal
 
         AssertIndexRange(face_no, n_faces());
 
-        return dealii::ReferenceCell::Triangle;
+        return dealii::ReferenceCells::Triangle;
       }
 
       unsigned int
@@ -1570,9 +1590,9 @@ namespace internal
         AssertIndexRange(face_no, n_faces());
 
         if (face_no == 0)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
         else
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
       }
 
       unsigned int
@@ -1744,9 +1764,9 @@ namespace internal
         AssertIndexRange(face_no, n_faces());
 
         if (face_no > 1)
-          return dealii::ReferenceCell::Quadrilateral;
+          return dealii::ReferenceCells::Quadrilateral;
         else
-          return dealii::ReferenceCell::Triangle;
+          return dealii::ReferenceCells::Triangle;
       }
 
       unsigned int
@@ -1879,7 +1899,7 @@ namespace internal
       face_reference_cell(const unsigned int face_no) const override
       {
         (void)face_no;
-        return dealii::ReferenceCell::Quadrilateral;
+        return dealii::ReferenceCells::Quadrilateral;
       }
 
       virtual unsigned int
@@ -2013,7 +2033,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
 {
   AssertIndexRange(internal::ReferenceCell::get_cell(*this).n_vertices(),
                    N + 1);
-  if (*this == ReferenceCell::Line)
+  if (*this == ReferenceCells::Line)
     {
       const std::array<T, 2> i{{vertices_0[0], vertices_0[1]}};
       const std::array<T, 2> j{{vertices_1[0], vertices_1[1]}};
@@ -2026,7 +2046,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
       if (i == std::array<T, 2>{{j[1], j[0]}})
         return 0;
     }
-  else if (*this == ReferenceCell::Triangle)
+  else if (*this == ReferenceCells::Triangle)
     {
       const std::array<T, 3> i{{vertices_0[0], vertices_0[1], vertices_0[2]}};
       const std::array<T, 3> j{{vertices_1[0], vertices_1[1], vertices_1[2]}};
@@ -2055,7 +2075,7 @@ ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
       if (i == std::array<T, 3>{{j[1], j[0], j[2]}})
         return 4;
     }
-  else if (*this == ReferenceCell::Quadrilateral)
+  else if (*this == ReferenceCells::Quadrilateral)
     {
       const std::array<T, 4> i{
         {vertices_0[0], vertices_0[1], vertices_0[2], vertices_0[3]}};
@@ -2110,7 +2130,7 @@ ReferenceCell::permute_according_orientation(
 {
   std::array<T, 4> temp;
 
-  if (*this == ReferenceCell::Line)
+  if (*this == ReferenceCells::Line)
     {
       switch (orientation)
         {
@@ -2124,7 +2144,7 @@ ReferenceCell::permute_according_orientation(
             Assert(false, ExcNotImplemented());
         }
     }
-  else if (*this == ReferenceCell::Triangle)
+  else if (*this == ReferenceCells::Triangle)
     {
       switch (orientation)
         {
@@ -2150,7 +2170,7 @@ ReferenceCell::permute_according_orientation(
             Assert(false, ExcNotImplemented());
         }
     }
-  else if (*this == ReferenceCell::Quadrilateral)
+  else if (*this == ReferenceCells::Quadrilateral)
     {
       switch (orientation)
         {

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -57,19 +57,19 @@ namespace internal
       const dealii::ReferenceCell reference_cell =
         dealii::ReferenceCell::n_vertices_to_type(dim, vertices.size());
 
-      if (reference_cell == dealii::ReferenceCell::Line)
+      if (reference_cell == dealii::ReferenceCells::Line)
         // Return the distance between the two vertices
         return (vertices[1] - vertices[0]).norm();
-      else if (reference_cell == dealii::ReferenceCell::Triangle)
+      else if (reference_cell == dealii::ReferenceCells::Triangle)
         // Return the longest of the three edges
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm(),
                          (vertices[2] - vertices[0]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Quadrilateral)
+      else if (reference_cell == dealii::ReferenceCells::Quadrilateral)
         // Return the longer one of the two diagonals of the quadrilateral
         return std::max({(vertices[3] - vertices[0]).norm(),
                          (vertices[2] - vertices[1]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Tetrahedron)
+      else if (reference_cell == dealii::ReferenceCells::Tetrahedron)
         // Return the longest of the six edges of the tetrahedron
         return std::max({(vertices[1] - vertices[0]).norm(),
                          (vertices[2] - vertices[0]).norm(),
@@ -77,7 +77,7 @@ namespace internal
                          (vertices[3] - vertices[0]).norm(),
                          (vertices[3] - vertices[1]).norm(),
                          (vertices[3] - vertices[2]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Pyramid)
+      else if (reference_cell == dealii::ReferenceCells::Pyramid)
         // Return ...
         return std::max({// the longest diagonal of the quadrilateral base
                          // of the pyramid or ...
@@ -89,7 +89,7 @@ namespace internal
                          (vertices[4] - vertices[1]).norm(),
                          (vertices[4] - vertices[2]).norm(),
                          (vertices[4] - vertices[3]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Wedge)
+      else if (reference_cell == dealii::ReferenceCells::Wedge)
         // Return ...
         return std::max({// the longest of the 2*3=6 diagonals of the three
                          // quadrilateral sides of the wedge or ...
@@ -107,7 +107,7 @@ namespace internal
                          (vertices[4] - vertices[3]).norm(),
                          (vertices[5] - vertices[4]).norm(),
                          (vertices[5] - vertices[3]).norm()});
-      else if (reference_cell == dealii::ReferenceCell::Hexahedron)
+      else if (reference_cell == dealii::ReferenceCells::Hexahedron)
         // Return the longest of the four diagonals of the hexahedron
         return std::max({(vertices[7] - vertices[0]).norm(),
                          (vertices[6] - vertices[1]).norm(),
@@ -1090,9 +1090,9 @@ inline ReferenceCell
 TriaAccessor<structdim, dim, spacedim>::reference_cell() const
 {
   if (structdim == 0)
-    return ReferenceCell::Vertex;
+    return ReferenceCells::Vertex;
   else if (structdim == 1)
-    return ReferenceCell::Line;
+    return ReferenceCells::Line;
   else if (structdim == dim)
     return this->tria->levels[this->present_level]
       ->reference_cell[this->present_index];
@@ -2252,9 +2252,9 @@ inline const internal::ReferenceCell::Base &
 TriaAccessor<structdim, dim, spacedim>::reference_cell_info() const
 {
   if (structdim == 0)
-    return internal::ReferenceCell::get_cell(ReferenceCell::Vertex);
+    return internal::ReferenceCell::get_cell(ReferenceCells::Vertex);
   else if (structdim == 1)
-    return internal::ReferenceCell::get_cell(ReferenceCell::Line);
+    return internal::ReferenceCell::get_cell(ReferenceCells::Line);
   else
     return internal::ReferenceCell::get_cell(this->reference_cell());
 }
@@ -3113,7 +3113,7 @@ template <int spacedim>
 inline ReferenceCell
 TriaAccessor<0, 1, spacedim>::reference_cell() const
 {
-  return ReferenceCell::Vertex;
+  return ReferenceCells::Vertex;
 }
 
 

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1751,11 +1751,11 @@ namespace internal
         const unsigned int          face_no,
         const unsigned int          index,
         const dealii::ReferenceCell reference_cell =
-          dealii::ReferenceCell::Invalid)
+          dealii::ReferenceCells::Invalid)
       {
         Assert(index < dim, ExcInternalError());
 
-        if ((reference_cell == dealii::ReferenceCell::Invalid ||
+        if ((reference_cell == dealii::ReferenceCells::Invalid ||
              reference_cell == dealii::ReferenceCell::get_hypercube<dim>()) ==
             false)
           {

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -232,17 +232,18 @@ namespace internal
               {
                 const auto reference_cell = (*fe)[i].reference_cell();
 
-                if ((reference_cell == dealii::ReferenceCell::Vertex) ||
-                    (reference_cell == dealii::ReferenceCell::Line) ||
-                    (reference_cell == dealii::ReferenceCell::Quadrilateral) ||
-                    (reference_cell == dealii::ReferenceCell::Hexahedron))
+                if ((reference_cell == dealii::ReferenceCells::Vertex) ||
+                    (reference_cell == dealii::ReferenceCells::Line) ||
+                    (reference_cell == dealii::ReferenceCells::Quadrilateral) ||
+                    (reference_cell == dealii::ReferenceCells::Hexahedron))
                   needs_hypercube_setup |= true;
-                else if ((reference_cell == dealii::ReferenceCell::Triangle) ||
-                         (reference_cell == dealii::ReferenceCell::Tetrahedron))
+                else if ((reference_cell == dealii::ReferenceCells::Triangle) ||
+                         (reference_cell ==
+                          dealii::ReferenceCells::Tetrahedron))
                   needs_simplex_setup |= true;
-                else if (reference_cell == dealii::ReferenceCell::Wedge)
+                else if (reference_cell == dealii::ReferenceCells::Wedge)
                   needs_wedge_setup |= true;
-                else if (reference_cell == dealii::ReferenceCell::Pyramid)
+                else if (reference_cell == dealii::ReferenceCells::Pyramid)
                   needs_pyramid_setup |= true;
                 else
                   Assert(false, ExcNotImplemented());
@@ -321,20 +322,22 @@ namespace internal
                       const auto reference_cell =
                         (*finite_elements[i])[j].reference_cell();
 
-                      if ((reference_cell == dealii::ReferenceCell::Vertex) ||
-                          (reference_cell == dealii::ReferenceCell::Line) ||
+                      if ((reference_cell == dealii::ReferenceCells::Vertex) ||
+                          (reference_cell == dealii::ReferenceCells::Line) ||
                           (reference_cell ==
-                           dealii::ReferenceCell::Quadrilateral) ||
-                          (reference_cell == dealii::ReferenceCell::Hexahedron))
+                           dealii::ReferenceCells::Quadrilateral) ||
+                          (reference_cell ==
+                           dealii::ReferenceCells::Hexahedron))
                         quadrature.push_back(*quadrature_hypercube);
                       else if ((reference_cell ==
-                                dealii::ReferenceCell::Triangle) ||
+                                dealii::ReferenceCells::Triangle) ||
                                (reference_cell ==
-                                dealii::ReferenceCell::Tetrahedron))
+                                dealii::ReferenceCells::Tetrahedron))
                         quadrature.push_back(*quadrature_simplex);
-                      else if (reference_cell == dealii::ReferenceCell::Wedge)
+                      else if (reference_cell == dealii::ReferenceCells::Wedge)
                         quadrature.push_back(*quadrature_wedge);
-                      else if (reference_cell == dealii::ReferenceCell::Pyramid)
+                      else if (reference_cell ==
+                               dealii::ReferenceCells::Pyramid)
                         quadrature.push_back(*quadrature_pyramid);
                       else
                         Assert(false, ExcNotImplemented());

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -625,7 +625,7 @@ namespace
             vtk_cell_id[0] = cell_type_by_dim[dim];
             vtk_cell_id[1] = 1;
           }
-        else if (patch.reference_cell == ReferenceCell::Triangle)
+        else if (patch.reference_cell == ReferenceCells::Triangle)
           {
             vtk_cell_id[0] = VTK_LAGRANGE_TRIANGLE;
             vtk_cell_id[1] = 1;
@@ -635,37 +635,37 @@ namespace
             Assert(false, ExcNotImplemented());
           }
       }
-    else if (patch.reference_cell == ReferenceCell::Triangle &&
+    else if (patch.reference_cell == ReferenceCells::Triangle &&
              patch.data.n_cols() == 3)
       {
         vtk_cell_id[0] = VTK_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Triangle &&
+    else if (patch.reference_cell == ReferenceCells::Triangle &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TRIANGLE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Tetrahedron &&
+    else if (patch.reference_cell == ReferenceCells::Tetrahedron &&
              patch.data.n_cols() == 4)
       {
         vtk_cell_id[0] = VTK_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Tetrahedron &&
+    else if (patch.reference_cell == ReferenceCells::Tetrahedron &&
              patch.data.n_cols() == 10)
       {
         vtk_cell_id[0] = VTK_QUADRATIC_TETRA;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Wedge &&
+    else if (patch.reference_cell == ReferenceCells::Wedge &&
              patch.data.n_cols() == 6)
       {
         vtk_cell_id[0] = VTK_WEDGE;
         vtk_cell_id[1] = 1;
       }
-    else if (patch.reference_cell == ReferenceCell::Pyramid &&
+    else if (patch.reference_cell == ReferenceCells::Pyramid &&
              patch.data.n_cols() == 5)
       {
         vtk_cell_id[0] = VTK_PYRAMID;
@@ -8721,19 +8721,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
            << "\" NodesPerElement=\"2\">\n";
       else if (dimension == 2)
         {
-          Assert(reference_cell == ReferenceCell::Quadrilateral ||
-                   reference_cell == ReferenceCell::Triangle,
+          Assert(reference_cell == ReferenceCells::Quadrilateral ||
+                   reference_cell == ReferenceCells::Triangle,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell == ReferenceCell::Quadrilateral)
+          if (reference_cell == ReferenceCells::Quadrilateral)
             {
               ss << "Quadrilateral"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell == ReferenceCell::Triangle)
+          else // if (reference_cell == ReferenceCells::Triangle)
             {
               ss << "Triangle"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
@@ -8743,19 +8743,19 @@ XDMFEntry::get_xdmf_content(const unsigned int   indent_level,
         }
       else if (dimension == 3)
         {
-          Assert(reference_cell == ReferenceCell::Hexahedron ||
-                   reference_cell == ReferenceCell::Tetrahedron,
+          Assert(reference_cell == ReferenceCells::Hexahedron ||
+                   reference_cell == ReferenceCells::Tetrahedron,
                  ExcNotImplemented());
 
           ss << indent(indent_level + 1) << "<Topology TopologyType=\"";
-          if (reference_cell == ReferenceCell::Hexahedron)
+          if (reference_cell == ReferenceCells::Hexahedron)
             {
               ss << "Hexahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"
                  << indent(indent_level + 2) << "<DataItem Dimensions=\""
                  << num_cells << " " << (1 << dimension);
             }
-          else // if (reference_cell == ReferenceCell::Tetrahedron)
+          else // if (reference_cell == ReferenceCells::Tetrahedron)
             {
               ss << "Tetrahedron"
                  << "\" NumberOfElements=\"" << num_cells << "\">\n"

--- a/source/base/qprojector.cc
+++ b/source/base/qprojector.cc
@@ -86,7 +86,7 @@ QProjector<1>::project_to_face(const Quadrature<0> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<1>> &q_points)
 {
-  project_to_face(ReferenceCell::Line, quadrature, face_no, q_points);
+  project_to_face(ReferenceCells::Line, quadrature, face_no, q_points);
 }
 
 
@@ -98,7 +98,7 @@ QProjector<1>::project_to_face(const ReferenceCell reference_cell,
                                const unsigned int     face_no,
                                std::vector<Point<1>> &q_points)
 {
-  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Line, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 1;
@@ -116,7 +116,7 @@ QProjector<2>::project_to_face(const Quadrature<1> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<2>> &q_points)
 {
-  project_to_face(ReferenceCell::Quadrilateral, quadrature, face_no, q_points);
+  project_to_face(ReferenceCells::Quadrilateral, quadrature, face_no, q_points);
 }
 
 
@@ -133,7 +133,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell == ReferenceCell::Triangle)
+  if (reference_cell == ReferenceCells::Triangle)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -154,7 +154,7 @@ QProjector<2>::project_to_face(const ReferenceCell    reference_cell,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell == ReferenceCell::Quadrilateral)
+  else if (reference_cell == ReferenceCells::Quadrilateral)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -189,7 +189,7 @@ QProjector<3>::project_to_face(const Quadrature<2> &  quadrature,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  project_to_face(ReferenceCell::Hexahedron, quadrature, face_no, q_points);
+  project_to_face(ReferenceCells::Hexahedron, quadrature, face_no, q_points);
 }
 
 
@@ -201,7 +201,7 @@ QProjector<3>::project_to_face(const ReferenceCell    reference_cell,
                                const unsigned int     face_no,
                                std::vector<Point<3>> &q_points)
 {
-  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 3;
@@ -253,7 +253,7 @@ QProjector<1>::project_to_subface(const Quadrature<0> &    quadrature,
                                   const RefinementCase<0> &ref_case)
 {
   project_to_subface(
-    ReferenceCell::Line, quadrature, face_no, subface_no, q_points, ref_case);
+    ReferenceCells::Line, quadrature, face_no, subface_no, q_points, ref_case);
 }
 
 
@@ -267,7 +267,7 @@ QProjector<1>::project_to_subface(const ReferenceCell reference_cell,
                                   std::vector<Point<1>> &q_points,
                                   const RefinementCase<0> &)
 {
-  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Line, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 1;
@@ -287,7 +287,7 @@ QProjector<2>::project_to_subface(const Quadrature<1> &    quadrature,
                                   std::vector<Point<2>> &  q_points,
                                   const RefinementCase<1> &ref_case)
 {
-  project_to_subface(ReferenceCell::Quadrilateral,
+  project_to_subface(ReferenceCells::Quadrilateral,
                      quadrature,
                      face_no,
                      subface_no,
@@ -313,7 +313,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
   Assert(q_points.size() == quadrature.size(),
          ExcDimensionMismatch(q_points.size(), quadrature.size()));
 
-  if (reference_cell == ReferenceCell::Triangle)
+  if (reference_cell == ReferenceCells::Triangle)
     {
       // use linear polynomial to map the reference quadrature points correctly
       // on faces, i.e., Simplex::ScalarPolynomial<1>(1)
@@ -367,7 +367,7 @@ QProjector<2>::project_to_subface(const ReferenceCell    reference_cell,
               Assert(false, ExcInternalError());
           }
     }
-  else if (reference_cell == ReferenceCell::Quadrilateral)
+  else if (reference_cell == ReferenceCells::Quadrilateral)
     {
       for (unsigned int p = 0; p < quadrature.size(); ++p)
         switch (face_no)
@@ -449,7 +449,7 @@ QProjector<3>::project_to_subface(const Quadrature<2> &    quadrature,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  project_to_subface(ReferenceCell::Hexahedron,
+  project_to_subface(ReferenceCells::Hexahedron,
                      quadrature,
                      face_no,
                      subface_no,
@@ -468,7 +468,7 @@ QProjector<3>::project_to_subface(const ReferenceCell      reference_cell,
                                   std::vector<Point<3>> &  q_points,
                                   const RefinementCase<2> &ref_case)
 {
-  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 3;
@@ -555,7 +555,7 @@ QProjector<1>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<0> &quadrature)
 {
   AssertDimension(quadrature.size(), 1);
-  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Line, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 1;
@@ -600,15 +600,15 @@ Quadrature<2>
 QProjector<2>::project_to_all_faces(const ReferenceCell       reference_cell,
                                     const hp::QCollection<1> &quadrature)
 {
-  if (reference_cell == ReferenceCell::Triangle)
+  if (reference_cell == ReferenceCells::Triangle)
     {
       const auto support_points_line =
         [](const auto &face, const auto &orientation) -> std::vector<Point<2>> {
         std::array<Point<2>, 2> vertices;
         std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
         const auto temp =
-          ReferenceCell::Line.permute_according_orientation(vertices,
-                                                            orientation);
+          ReferenceCells::Line.permute_according_orientation(vertices,
+                                                             orientation);
         return std::vector<Point<2>>(temp.begin(),
                                      temp.begin() + face.first.size());
       };
@@ -667,7 +667,7 @@ QProjector<2>::project_to_all_faces(const ReferenceCell       reference_cell,
       return {points, weights};
     }
 
-  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Quadrilateral, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -728,8 +728,8 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     std::array<Point<3>, 3> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Triangle.permute_according_orientation(vertices,
-                                                            orientation);
+      ReferenceCells::Triangle.permute_according_orientation(vertices,
+                                                             orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -739,8 +739,8 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     std::array<Point<3>, 4> vertices;
     std::copy_n(face.first.begin(), face.first.size(), vertices.begin());
     const auto temp =
-      ReferenceCell::Quadrilateral.permute_according_orientation(vertices,
-                                                                 orientation);
+      ReferenceCells::Quadrilateral.permute_according_orientation(vertices,
+                                                                  orientation);
     return std::vector<Point<3>>(temp.begin(),
                                  temp.begin() + face.first.size());
   };
@@ -850,7 +850,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     return Quadrature<3>(points, weights);
   };
 
-  if (reference_cell == ReferenceCell::Tetrahedron)
+  if (reference_cell == ReferenceCells::Tetrahedron)
     {
       // reference faces (defined by its support points and its area)
       // note: the area is later not used as a scaling factor but recomputed
@@ -874,7 +874,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
 
       return process(faces);
     }
-  else if (reference_cell == ReferenceCell::Wedge)
+  else if (reference_cell == ReferenceCells::Wedge)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(1.0, 0.0, 0.0),
@@ -903,7 +903,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
 
       return process(faces);
     }
-  else if (reference_cell == ReferenceCell::Pyramid)
+  else if (reference_cell == ReferenceCells::Pyramid)
     {
       const std::vector<std::pair<std::vector<Point<3>>, double>> faces = {
         {{{{Point<3>(-1.0, -1.0, 0.0),
@@ -932,7 +932,7 @@ QProjector<3>::project_to_all_faces(const ReferenceCell       reference_cell,
     }
 
 
-  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Hexahedron, ExcNotImplemented());
 
   const unsigned int dim = 3;
 
@@ -1029,7 +1029,7 @@ template <>
 Quadrature<1>
 QProjector<1>::project_to_all_subfaces(const Quadrature<0> &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Line, quadrature);
+  return project_to_all_subfaces(ReferenceCells::Line, quadrature);
 }
 
 
@@ -1039,7 +1039,7 @@ Quadrature<1>
 QProjector<1>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const Quadrature<0> &quadrature)
 {
-  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Line, ExcNotImplemented());
   (void)reference_cell;
 
   const unsigned int dim = 1;
@@ -1086,11 +1086,11 @@ Quadrature<2>
 QProjector<2>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell == ReferenceCell::Triangle ||
-      reference_cell == ReferenceCell::Tetrahedron)
+  if (reference_cell == ReferenceCells::Triangle ||
+      reference_cell == ReferenceCells::Tetrahedron)
     return Quadrature<2>(); // nothing to do
 
-  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Quadrilateral, ExcNotImplemented());
 
   const unsigned int dim = 2;
 
@@ -1136,7 +1136,7 @@ template <>
 Quadrature<2>
 QProjector<2>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Quadrilateral, quadrature);
+  return project_to_all_subfaces(ReferenceCells::Quadrilateral, quadrature);
 }
 
 
@@ -1146,11 +1146,11 @@ Quadrature<3>
 QProjector<3>::project_to_all_subfaces(const ReferenceCell  reference_cell,
                                        const SubQuadrature &quadrature)
 {
-  if (reference_cell == ReferenceCell::Triangle ||
-      reference_cell == ReferenceCell::Tetrahedron)
+  if (reference_cell == ReferenceCells::Triangle ||
+      reference_cell == ReferenceCells::Tetrahedron)
     return Quadrature<3>(); // nothing to do
 
-  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Hexahedron, ExcNotImplemented());
 
   const unsigned int dim         = 3;
   SubQuadrature      q_reflected = internal::QProjector::reflect(quadrature);
@@ -1228,7 +1228,7 @@ template <>
 Quadrature<3>
 QProjector<3>::project_to_all_subfaces(const SubQuadrature &quadrature)
 {
-  return project_to_all_subfaces(ReferenceCell::Hexahedron, quadrature);
+  return project_to_all_subfaces(ReferenceCells::Hexahedron, quadrature);
 }
 
 
@@ -1388,8 +1388,8 @@ QProjector<dim>::DataSetDescriptor::face(const ReferenceCell reference_cell,
                                          const bool          face_rotation,
                                          const unsigned int n_quadrature_points)
 {
-  if (reference_cell == ReferenceCell::Triangle ||
-      reference_cell == ReferenceCell::Tetrahedron)
+  if (reference_cell == ReferenceCells::Triangle ||
+      reference_cell == ReferenceCells::Tetrahedron)
     {
       if (dim == 2)
         return {(2 * face_no + face_orientation) * n_quadrature_points};
@@ -1476,10 +1476,10 @@ QProjector<dim>::DataSetDescriptor::face(
   const bool                      face_rotation,
   const hp::QCollection<dim - 1> &quadrature)
 {
-  if (reference_cell == ReferenceCell::Triangle ||
-      reference_cell == ReferenceCell::Tetrahedron ||
-      reference_cell == ReferenceCell::Wedge ||
-      reference_cell == ReferenceCell::Pyramid)
+  if (reference_cell == ReferenceCells::Triangle ||
+      reference_cell == ReferenceCells::Tetrahedron ||
+      reference_cell == ReferenceCells::Wedge ||
+      reference_cell == ReferenceCells::Pyramid)
     {
       unsigned int offset = 0;
 
@@ -1491,12 +1491,12 @@ QProjector<dim>::DataSetDescriptor::face(
         {8, 6, 6, 6, 6}};
 
       const auto &scale =
-        (reference_cell == ReferenceCell::Triangle) ?
+        (reference_cell == ReferenceCells::Triangle) ?
           scale_tri :
-          ((reference_cell == ReferenceCell::Tetrahedron) ?
+          ((reference_cell == ReferenceCells::Tetrahedron) ?
              scale_tet :
-             ((reference_cell == ReferenceCell::Wedge) ? scale_wedge :
-                                                         scale_pyramid));
+             ((reference_cell == ReferenceCells::Wedge) ? scale_wedge :
+                                                          scale_pyramid));
 
       if (quadrature.size() == 1)
         offset = scale[0] * quadrature[0].size() * face_no;
@@ -1614,7 +1614,7 @@ QProjector<1>::DataSetDescriptor::subface(
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<1>)
 {
-  Assert(reference_cell == ReferenceCell::Line, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Line, ExcNotImplemented());
   (void)reference_cell;
 
   Assert(face_no < GeometryInfo<1>::faces_per_cell, ExcInternalError());
@@ -1638,7 +1638,7 @@ QProjector<1>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<1> ref_case)
 {
-  return subface(ReferenceCell::Line,
+  return subface(ReferenceCells::Line,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1662,7 +1662,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int n_quadrature_points,
   const internal::SubfaceCase<2>)
 {
-  Assert(reference_cell == ReferenceCell::Quadrilateral, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Quadrilateral, ExcNotImplemented());
   (void)reference_cell;
 
   Assert(face_no < GeometryInfo<2>::faces_per_cell, ExcInternalError());
@@ -1686,7 +1686,7 @@ QProjector<2>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<2> ref_case)
 {
-  return subface(ReferenceCell::Quadrilateral,
+  return subface(ReferenceCells::Quadrilateral,
                  face_no,
                  subface_no,
                  face_orientation,
@@ -1711,7 +1711,7 @@ QProjector<3>::DataSetDescriptor::subface(
 {
   const unsigned int dim = 3;
 
-  Assert(reference_cell == ReferenceCell::Hexahedron, ExcNotImplemented());
+  Assert(reference_cell == ReferenceCells::Hexahedron, ExcNotImplemented());
   (void)reference_cell;
 
   Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
@@ -1965,7 +1965,7 @@ QProjector<3>::DataSetDescriptor::subface(
   const unsigned int             n_quadrature_points,
   const internal::SubfaceCase<3> ref_case)
 {
-  return subface(ReferenceCell::Hexahedron,
+  return subface(ReferenceCells::Hexahedron,
                  face_no,
                  subface_no,
                  face_orientation,

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -838,7 +838,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCell::Quadrilateral],
+                                   dealii::ReferenceCells::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)
@@ -1595,7 +1595,7 @@ namespace internal
                                 quad_dof_identities
                                   [most_dominating_fe_index][other_fe_index]
                                   [cell->quad(q)->reference_cell() ==
-                                   dealii::ReferenceCell::Quadrilateral],
+                                   dealii::ReferenceCells::Quadrilateral],
                                 most_dominating_fe_index_face_no);
 
                             for (const auto &identity : identities)

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -159,7 +159,7 @@ FiniteElement<dim, spacedim>::FiniteElement(
           adjust_quad_dof_index_for_face_orientation_table[f] = Table<2, int>(
             this->n_dofs_per_quad(f),
             internal::ReferenceCell::get_cell(this->reference_cell())
-                  .face_reference_cell(f) == ReferenceCell::Quadrilateral ?
+                  .face_reference_cell(f) == ReferenceCells::Quadrilateral ?
               8 :
               6);
           adjust_quad_dof_index_for_face_orientation_table[f].fill(0);
@@ -686,7 +686,7 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
              [this->n_unique_quads() == 1 ? 0 : face]
                .n_elements() ==
            (internal::ReferenceCell::get_cell(this->reference_cell())
-                  .face_reference_cell(face) == ReferenceCell::Quadrilateral ?
+                  .face_reference_cell(face) == ReferenceCells::Quadrilateral ?
               8 :
               6) *
              this->n_dofs_per_quad(face),

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -122,10 +122,10 @@ FiniteElementData<dim>::FiniteElementData(
   const BlockIndices &             block_indices)
   : FiniteElementData(dofs_per_object,
                       dim == 0 ?
-                        ReferenceCell::Vertex :
-                        (dim == 1 ? ReferenceCell::Line :
-                                    (dim == 2 ? ReferenceCell::Quadrilateral :
-                                                ReferenceCell::Hexahedron)),
+                        ReferenceCells::Vertex :
+                        (dim == 1 ? ReferenceCells::Line :
+                                    (dim == 2 ? ReferenceCells::Quadrilateral :
+                                                ReferenceCells::Hexahedron)),
                       n_components,
                       degree,
                       conformity,

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1726,7 +1726,7 @@ namespace GridGenerator
       {
         GridGenerator::hyper_cube(tria, 0, 1);
       }
-    else if ((dim == 2) && (reference_cell == ReferenceCell::Triangle))
+    else if ((dim == 2) && (reference_cell == ReferenceCells::Triangle))
       {
         const std::vector<Point<spacedim>> vertices = {
           Point<spacedim>(),               // the origin
@@ -1739,7 +1739,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Tetrahedron))
+    else if ((dim == 3) && (reference_cell == ReferenceCells::Tetrahedron))
       {
         AssertDimension(spacedim, 3);
 
@@ -1751,7 +1751,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Pyramid))
+    else if ((dim == 3) && (reference_cell == ReferenceCells::Pyramid))
       {
         AssertDimension(spacedim, 3);
 
@@ -1767,7 +1767,7 @@ namespace GridGenerator
 
         tria.create_triangulation(vertices, cells, {});
       }
-    else if ((dim == 3) && (reference_cell == ReferenceCell::Wedge))
+    else if ((dim == 3) && (reference_cell == ReferenceCells::Wedge))
       {
         AssertDimension(spacedim, 3);
 

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3063,28 +3063,28 @@ namespace
                       type_name_2.end());
 
     if (type_name_2 == "TRI" || type_name_2 == "TRIANGLE")
-      return ReferenceCell::Triangle;
+      return ReferenceCells::Triangle;
     else if (type_name_2 == "QUAD" || type_name_2 == "QUADRILATERAL")
-      return ReferenceCell::Quadrilateral;
+      return ReferenceCells::Quadrilateral;
     else if (type_name_2 == "SHELL")
       {
         if (n_nodes_per_element == 3)
-          return ReferenceCell::Triangle;
+          return ReferenceCells::Triangle;
         else
-          return ReferenceCell::Quadrilateral;
+          return ReferenceCells::Quadrilateral;
       }
     else if (type_name_2 == "TET" || type_name_2 == "TETRA" ||
              type_name_2 == "TETRAHEDRON")
-      return ReferenceCell::Tetrahedron;
+      return ReferenceCells::Tetrahedron;
     else if (type_name_2 == "PYRA" || type_name_2 == "PYRAMID")
-      return ReferenceCell::Pyramid;
+      return ReferenceCells::Pyramid;
     else if (type_name_2 == "WEDGE")
-      return ReferenceCell::Wedge;
+      return ReferenceCells::Wedge;
     else if (type_name_2 == "HEX" || type_name_2 == "HEXAHEDRON")
-      return ReferenceCell::Hexahedron;
+      return ReferenceCells::Hexahedron;
 
     Assert(false, ExcNotImplemented());
-    return ReferenceCell::Invalid;
+    return ReferenceCells::Invalid;
   }
 
   // Associate deal.II boundary ids with sidesets (a face can be in multiple

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -3441,16 +3441,16 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
             out << ' ';
             const auto reference_cell = cell->reference_cell();
 
-            if ((reference_cell == ReferenceCell::Vertex) ||
-                (reference_cell == ReferenceCell::Line) ||
-                (reference_cell == ReferenceCell::Quadrilateral) ||
-                (reference_cell == ReferenceCell::Hexahedron))
+            if ((reference_cell == ReferenceCells::Vertex) ||
+                (reference_cell == ReferenceCells::Line) ||
+                (reference_cell == ReferenceCells::Quadrilateral) ||
+                (reference_cell == ReferenceCells::Hexahedron))
               out << cell->vertex_index(GeometryInfo<dim>::ucd_to_deal[i]);
-            else if ((reference_cell == ReferenceCell::Triangle) ||
-                     (reference_cell == ReferenceCell::Tetrahedron) ||
-                     (reference_cell == ReferenceCell::Wedge))
+            else if ((reference_cell == ReferenceCells::Triangle) ||
+                     (reference_cell == ReferenceCells::Tetrahedron) ||
+                     (reference_cell == ReferenceCells::Wedge))
               out << cell->vertex_index(i);
-            else if (reference_cell == ReferenceCell::Pyramid)
+            else if (reference_cell == ReferenceCells::Pyramid)
               {
                 static const std::array<unsigned int, 5> permutation_table{
                   {0, 1, 3, 2, 4}};
@@ -4274,7 +4274,7 @@ namespace internal
           Quadrature<dim - 1> quadrature(boundary_points, dummy_weights);
 
           q_projector = QProjector<dim>::project_to_all_faces(
-            dealii::ReferenceCell::Quadrilateral, quadrature);
+            dealii::ReferenceCells::Quadrilateral, quadrature);
         }
 
       for (const auto &cell : tria.active_cell_iterators())

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -34,49 +34,26 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-
-const ReferenceCell ReferenceCell::Vertex =
-  internal::ReferenceCell::make_reference_cell_from_int(0);
-const ReferenceCell ReferenceCell::Line =
-  internal::ReferenceCell::make_reference_cell_from_int(1);
-const ReferenceCell ReferenceCell::Triangle =
-  internal::ReferenceCell::make_reference_cell_from_int(2);
-const ReferenceCell ReferenceCell::Quadrilateral =
-  internal::ReferenceCell::make_reference_cell_from_int(3);
-const ReferenceCell ReferenceCell::Tetrahedron =
-  internal::ReferenceCell::make_reference_cell_from_int(4);
-const ReferenceCell ReferenceCell::Pyramid =
-  internal::ReferenceCell::make_reference_cell_from_int(5);
-const ReferenceCell ReferenceCell::Wedge =
-  internal::ReferenceCell::make_reference_cell_from_int(6);
-const ReferenceCell ReferenceCell::Hexahedron =
-  internal::ReferenceCell::make_reference_cell_from_int(7);
-const ReferenceCell ReferenceCell::Invalid =
-  internal::ReferenceCell::make_reference_cell_from_int(
-    static_cast<std::uint8_t>(-1));
-
-
-
 std::string
 ReferenceCell::to_string() const
 {
-  if (*this == Vertex)
+  if (*this == ReferenceCells::Vertex)
     return "Vertex";
-  else if (*this == Line)
+  else if (*this == ReferenceCells::Line)
     return "Line";
-  else if (*this == Triangle)
+  else if (*this == ReferenceCells::Triangle)
     return "Tri";
-  else if (*this == Quadrilateral)
+  else if (*this == ReferenceCells::Quadrilateral)
     return "Quad";
-  else if (*this == Tetrahedron)
+  else if (*this == ReferenceCells::Tetrahedron)
     return "Tet";
-  else if (*this == Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     return "Pyramid";
-  else if (*this == Wedge)
+  else if (*this == ReferenceCells::Wedge)
     return "Wedge";
-  else if (*this == Hexahedron)
+  else if (*this == ReferenceCells::Hexahedron)
     return "Hex";
-  else if (*this == Invalid)
+  else if (*this == ReferenceCells::Invalid)
     return "Invalid";
 
   Assert(false, ExcNotImplemented());
@@ -97,10 +74,10 @@ ReferenceCell::get_default_mapping(const unsigned int degree) const
   else if (is_simplex())
     return std::make_unique<MappingFE<dim, spacedim>>(
       Simplex::FE_P<dim, spacedim>(degree));
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     return std::make_unique<MappingFE<dim, spacedim>>(
       Simplex::FE_PyramidP<dim, spacedim>(degree));
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     return std::make_unique<MappingFE<dim, spacedim>>(
       Simplex::FE_WedgeP<dim, spacedim>(degree));
   else
@@ -129,13 +106,13 @@ ReferenceCell::get_default_linear_mapping() const
         Simplex::FE_P<dim, spacedim>(1));
       return mapping;
     }
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     {
       static const MappingFE<dim, spacedim> mapping(
         Simplex::FE_PyramidP<dim, spacedim>(1));
       return mapping;
     }
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     {
       static const MappingFE<dim, spacedim> mapping(
         Simplex::FE_WedgeP<dim, spacedim>(1));
@@ -161,9 +138,9 @@ ReferenceCell::get_gauss_type_quadrature(const unsigned n_points_1D) const
     return QGauss<dim>(n_points_1D);
   else if (is_simplex())
     return Simplex::QGauss<dim>(n_points_1D);
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     return Simplex::QGaussPyramid<dim>(n_points_1D);
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     return Simplex::QGaussWedge<dim>(n_points_1D);
   else
     Assert(false, ExcNotImplemented());
@@ -199,12 +176,12 @@ ReferenceCell::get_nodal_type_quadrature() const
       static const Quadrature<dim> quadrature = create_quadrature(*this);
       return quadrature;
     }
-  else if (*this == ReferenceCell::Pyramid)
+  else if (*this == ReferenceCells::Pyramid)
     {
       static const Quadrature<dim> quadrature = create_quadrature(*this);
       return quadrature;
     }
-  else if (*this == ReferenceCell::Wedge)
+  else if (*this == ReferenceCells::Wedge)
     {
       static const Quadrature<dim> quadrature = create_quadrature(*this);
       return quadrature;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1182,7 +1182,7 @@ namespace internal
           tria_faces.quad_reference_cell.insert(
             tria_faces.quad_reference_cell.end(),
             new_size - tria_faces.quad_reference_cell.size(),
-            dealii::ReferenceCell::Quadrilateral);
+            dealii::ReferenceCells::Quadrilateral);
         }
     }
 
@@ -1308,8 +1308,8 @@ namespace internal
               tria_level.reference_cell.insert(
                 tria_level.reference_cell.end(),
                 total_cells - tria_level.reference_cell.size(),
-                tria_level.dim == 2 ? dealii::ReferenceCell::Quadrilateral :
-                                      dealii::ReferenceCell::Hexahedron);
+                tria_level.dim == 2 ? dealii::ReferenceCells::Quadrilateral :
+                                      dealii::ReferenceCells::Hexahedron);
             }
         }
     }
@@ -2667,7 +2667,7 @@ namespace internal
           {
             // quad entity types
             faces.quad_reference_cell.assign(size,
-                                             dealii::ReferenceCell::Invalid);
+                                             dealii::ReferenceCells::Invalid);
 
             // quad line orientations
             faces.quads_line_orientations.assign(size * faces_per_cell, -1);
@@ -2703,7 +2703,7 @@ namespace internal
 
         level.neighbors.assign(size * faces_per_cell, {-1, -1});
 
-        level.reference_cell.assign(size, dealii::ReferenceCell::Invalid);
+        level.reference_cell.assign(size, dealii::ReferenceCells::Invalid);
 
         if (orientation_needed)
           level.face_orientations.assign(size * faces_per_cell, -1);
@@ -4108,14 +4108,15 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
-                  if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
+                  if (cell->reference_cell() ==
+                      dealii::ReferenceCells::Triangle)
                     {
                       needed_cells += 4;
                       needed_vertices += 0;
                       n_single_lines += 3;
                     }
                   else if (cell->reference_cell() ==
-                           dealii::ReferenceCell::Quadrilateral)
+                           dealii::ReferenceCells::Quadrilateral)
                     {
                       needed_cells += 4;
                       needed_vertices += 1;
@@ -4268,10 +4269,10 @@ namespace internal
 
           unsigned int n_new_vertices = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
+          if (cell->reference_cell() == dealii::ReferenceCells::Triangle)
             n_new_vertices = 6;
           else if (cell->reference_cell() ==
-                   dealii::ReferenceCell::Quadrilateral)
+                   dealii::ReferenceCells::Quadrilateral)
             n_new_vertices = 9;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4285,7 +4286,7 @@ namespace internal
               new_vertices[cell->n_vertices() + line_no] =
                 cell->line(line_no)->child(0)->vertex_index(1);
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Quadrilateral)
+          if (cell->reference_cell() == dealii::ReferenceCells::Quadrilateral)
             {
               while (triangulation.vertices_used[next_unused_vertex] == true)
                 ++next_unused_vertex;
@@ -4324,13 +4325,13 @@ namespace internal
           unsigned int lmin = 0;
           unsigned int lmax = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
+          if (cell->reference_cell() == dealii::ReferenceCells::Triangle)
             {
               lmin = 6;
               lmax = 9;
             }
           else if (cell->reference_cell() ==
-                   dealii::ReferenceCell::Quadrilateral)
+                   dealii::ReferenceCells::Quadrilateral)
             {
               lmin = 8;
               lmax = 12;
@@ -4355,7 +4356,7 @@ namespace internal
 
           if (true)
             {
-              if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
+              if (cell->reference_cell() == dealii::ReferenceCells::Triangle)
                 {
                   // add lines in the right order [TODO: clean up]
                   const auto ref = [&](const unsigned int face_no,
@@ -4391,7 +4392,7 @@ namespace internal
                     {new_vertices[5], new_vertices[3]});
                 }
               else if (cell->reference_cell() ==
-                       dealii::ReferenceCell::Quadrilateral)
+                       dealii::ReferenceCells::Quadrilateral)
                 {
                   unsigned int l = 0;
                   for (const unsigned int face_no : cell->face_indices())
@@ -4433,10 +4434,10 @@ namespace internal
 
           unsigned int n_children = 0;
 
-          if (cell->reference_cell() == dealii::ReferenceCell::Triangle)
+          if (cell->reference_cell() == dealii::ReferenceCells::Triangle)
             n_children = 4;
           else if (cell->reference_cell() ==
-                   dealii::ReferenceCell::Quadrilateral)
+                   dealii::ReferenceCells::Quadrilateral)
             n_children = 4;
           else
             AssertThrow(false, ExcNotImplemented());
@@ -4455,7 +4456,7 @@ namespace internal
             }
 
           if ((dim == 2) &&
-              (cell->reference_cell() == dealii::ReferenceCell::Triangle))
+              (cell->reference_cell() == dealii::ReferenceCells::Triangle))
             {
               subcells[0]->set_bounding_object_indices({new_lines[0]->index(),
                                                         new_lines[8]->index(),
@@ -4506,7 +4507,7 @@ namespace internal
               // * GeometryInfo<2>::faces_per_cell + 0] = 0;
             }
           else if ((dim == 2) && (cell->reference_cell() ==
-                                  dealii::ReferenceCell::Quadrilateral))
+                                  dealii::ReferenceCells::Quadrilateral))
             {
               subcells[0]->set_bounding_object_indices(
                 {new_lines[0]->index(),
@@ -4587,7 +4588,7 @@ namespace internal
                                   cell);
 
                   if (cell->reference_cell() ==
-                        dealii::ReferenceCell::Quadrilateral &&
+                        dealii::ReferenceCells::Quadrilateral &&
                       check_for_distorted_cells &&
                       has_distorted_children<dim, spacedim>(cell))
                     cells_with_distorted_children.distorted_cells.push_back(

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2845,7 +2845,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
     {
       case 2:
         {
-          if (this->reference_cell() == ReferenceCell::Triangle)
+          if (this->reference_cell() == ReferenceCells::Triangle)
             {
               const auto neighbor_cell = this->neighbor(face);
 
@@ -2869,7 +2869,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
                   subface;
 
               const auto &info =
-                internal::ReferenceCell::get_cell(ReferenceCell::Triangle);
+                internal::ReferenceCell::get_cell(ReferenceCells::Triangle);
               const unsigned int neighbor_child_index =
                 info.child_cell_on_face(neighbor_face, neighbor_subface);
               TriaIterator<CellAccessor<dim, spacedim>> sub_neighbor =
@@ -2883,7 +2883,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
               return sub_neighbor;
             }
-          else if (this->reference_cell() == ReferenceCell::Quadrilateral)
+          else if (this->reference_cell() == ReferenceCells::Quadrilateral)
             {
               const unsigned int neighbor_neighbor =
                 this->neighbor_of_neighbor(face);
@@ -2923,7 +2923,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
 
       case 3:
         {
-          if (this->reference_cell() == ReferenceCell::Hexahedron)
+          if (this->reference_cell() == ReferenceCells::Hexahedron)
             {
               // this function returns the neighbor's
               // child on a given face and

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -155,7 +155,7 @@ namespace Simplex
         return {};
 
       const auto &info = internal::ReferenceCell::get_cell(
-        dim == 2 ? ReferenceCell::Triangle : ReferenceCell::Tetrahedron);
+        dim == 2 ? ReferenceCells::Triangle : ReferenceCells::Tetrahedron);
       std::vector<std::vector<Point<dim - 1>>> unit_face_points;
 
       // all faces have the same support points
@@ -310,7 +310,7 @@ namespace Simplex
       else
         Assert(false, ExcNotImplemented());
 
-      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCell::Wedge);
+      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCells::Wedge);
     }
 
     /**
@@ -351,7 +351,7 @@ namespace Simplex
       else
         Assert(false, ExcNotImplemented());
 
-      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCell::Pyramid);
+      return internal::expand(3, {{0, 0, 0, n_dofs}}, ReferenceCells::Pyramid);
     }
   } // namespace
 
@@ -365,23 +365,23 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         BarycentricPolynomials<dim>::get_fe_p_basis(degree),
         FiniteElementData<dim>(dpo_vector,
-                               dim == 2 ? ReferenceCell::Triangle :
-                                          ReferenceCell::Tetrahedron,
+                               dim == 2 ? ReferenceCells::Triangle :
+                                          ReferenceCells::Tetrahedron,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(FiniteElementData<dim>(dpo_vector,
                                                  dim == 2 ?
-                                                   ReferenceCell::Triangle :
-                                                   ReferenceCell::Tetrahedron,
+                                                   ReferenceCells::Triangle :
+                                                   ReferenceCells::Tetrahedron,
                                                  1,
                                                  degree)
                             .dofs_per_cell,
                           true),
         std::vector<ComponentMask>(
           FiniteElementData<dim>(dpo_vector,
-                                 dim == 2 ? ReferenceCell::Triangle :
-                                            ReferenceCell::Tetrahedron,
+                                 dim == 2 ? ReferenceCells::Triangle :
+                                            ReferenceCells::Tetrahedron,
                                  1,
                                  degree)
             .dofs_per_cell,
@@ -958,16 +958,16 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         Simplex::ScalarWedgePolynomial<dim>(degree),
         FiniteElementData<dim>(dpos,
-                               ReferenceCell::Wedge,
+                               ReferenceCells::Wedge,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Wedge, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCells::Wedge, 1, degree)
             .dofs_per_cell,
           true),
         std::vector<ComponentMask>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Wedge, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCells::Wedge, 1, degree)
             .dofs_per_cell,
           std::vector<bool>(1, true)))
   {
@@ -1192,16 +1192,16 @@ namespace Simplex
     : dealii::FE_Poly<dim, spacedim>(
         Simplex::ScalarPyramidPolynomial<dim>(degree),
         FiniteElementData<dim>(dpos,
-                               ReferenceCell::Pyramid,
+                               ReferenceCells::Pyramid,
                                1,
                                degree,
                                conformity),
         std::vector<bool>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Pyramid, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCells::Pyramid, 1, degree)
             .dofs_per_cell,
           true),
         std::vector<ComponentMask>(
-          FiniteElementData<dim>(dpos, ReferenceCell::Pyramid, 1, degree)
+          FiniteElementData<dim>(dpos, ReferenceCells::Pyramid, 1, degree)
             .dofs_per_cell,
           std::vector<bool>(1, true)))
   {

--- a/tests/hp/fe_nothing_22.cc
+++ b/tests/hp/fe_nothing_22.cc
@@ -39,25 +39,25 @@ test()
           << std::endl;
   if (dim == 2)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Quadrilateral, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCells::Quadrilateral, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Triangle, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCells::Triangle, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
     }
   if (dim == 3)
     {
-      deallog << (FE_Nothing<dim>(ReferenceCell::Hexahedron, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCells::Hexahedron, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Tetrahedron, 2, true) ==
+      deallog << (FE_Nothing<dim>(ReferenceCells::Tetrahedron, 2, true) ==
                   FE_Nothing<dim>(2, true))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Wedge, 1, false) ==
-                  FE_Nothing<dim>(ReferenceCell::Pyramid, 1, false))
+      deallog << (FE_Nothing<dim>(ReferenceCells::Wedge, 1, false) ==
+                  FE_Nothing<dim>(ReferenceCells::Pyramid, 1, false))
               << std::endl;
-      deallog << (FE_Nothing<dim>(ReferenceCell::Wedge, 3) ==
+      deallog << (FE_Nothing<dim>(ReferenceCells::Wedge, 3) ==
                   FE_Nothing<dim>(3))
               << std::endl;
     }

--- a/tests/simplex/cell_measure_01.cc
+++ b/tests/simplex/cell_measure_01.cc
@@ -49,7 +49,7 @@ process(const std::vector<Point<spacedim>> &vertices,
 
   if (reference_cells[0] == ReferenceCell::get_simplex<dim>())
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_P<dim>(1));
-  else if (reference_cells[0] == ReferenceCell::Wedge)
+  else if (reference_cells[0] == ReferenceCells::Wedge)
     mapping = std::make_shared<MappingFE<dim>>(Simplex::FE_WedgeP<dim>(1));
   else
     AssertThrow(false, ExcNotImplemented());

--- a/tests/simplex/data_out_write_vtk_02.cc
+++ b/tests/simplex/data_out_write_vtk_02.cc
@@ -84,9 +84,9 @@ test(const FiniteElement<dim, spacedim> &fe_0,
       if (cell->is_locally_owned() == false)
         continue;
 
-      if (cell->reference_cell() == ReferenceCell::Triangle)
+      if (cell->reference_cell() == ReferenceCells::Triangle)
         cell->set_active_fe_index(0);
-      else if (cell->reference_cell() == ReferenceCell::Quadrilateral)
+      else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
         cell->set_active_fe_index(1);
       else
         Assert(false, ExcNotImplemented());

--- a/tests/simplex/matrix_free_02.cc
+++ b/tests/simplex/matrix_free_02.cc
@@ -157,8 +157,8 @@ test(const unsigned version, const unsigned int degree, const bool do_helmholtz)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell() == ReferenceCell::Triangle ||
-        cell->reference_cell() == ReferenceCell::Tetrahedron)
+    if (cell->reference_cell() == ReferenceCells::Triangle ||
+        cell->reference_cell() == ReferenceCells::Tetrahedron)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/matrix_free_04.cc
+++ b/tests/simplex/matrix_free_04.cc
@@ -260,8 +260,8 @@ test(const unsigned version, const unsigned int degree)
   DoFHandler<dim> dof_handler(tria);
 
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->reference_cell() == ReferenceCell::Triangle ||
-        cell->reference_cell() == ReferenceCell::Tetrahedron)
+    if (cell->reference_cell() == ReferenceCells::Triangle ||
+        cell->reference_cell() == ReferenceCells::Tetrahedron)
       cell->set_active_fe_index(0);
     else
       cell->set_active_fe_index(1);

--- a/tests/simplex/orientation_01.cc
+++ b/tests/simplex/orientation_01.cc
@@ -46,9 +46,9 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Line, 2);
-  test<3>(ReferenceCell::Triangle, 3);
-  test<4>(ReferenceCell::Quadrilateral, 4);
+  test<2>(ReferenceCells::Line, 2);
+  test<3>(ReferenceCells::Triangle, 3);
+  test<4>(ReferenceCells::Quadrilateral, 4);
 
   deallog << "OK!" << std::endl;
 }

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -30,7 +30,7 @@ test(const unsigned int orientation)
 
 
   Triangulation<3> dummy, tria;
-  GridGenerator::reference_cell(ReferenceCell::Tetrahedron, dummy);
+  GridGenerator::reference_cell(ReferenceCells::Tetrahedron, dummy);
 
   auto vertices = dummy.get_vertices();
 
@@ -46,7 +46,7 @@ test(const unsigned int orientation)
   {
     const auto &face = dummy.begin()->face(face_no);
     const auto  permuted =
-      ReferenceCell(ReferenceCell::Triangle)
+      ReferenceCell(ReferenceCells::Triangle)
         .permute_according_orientation(
           std::array<unsigned int, 3>{{face->vertex_index(0),
                                        face->vertex_index(1),

--- a/tests/simplex/q_projection_01.cc
+++ b/tests/simplex/q_projection_01.cc
@@ -41,7 +41,7 @@ test<2>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Triangle, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCells::Triangle, quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation) {
@@ -50,12 +50,13 @@ test<2>(const unsigned int n_points)
             << ":" << std::endl;
     for (unsigned int
            q = 0,
-           i = QProjector<dim>::DataSetDescriptor::face(ReferenceCell::Triangle,
-                                                        face_no,
-                                                        face_orientation,
-                                                        false,
-                                                        false,
-                                                        quad_ref.size());
+           i =
+             QProjector<dim>::DataSetDescriptor::face(ReferenceCells::Triangle,
+                                                      face_no,
+                                                      face_orientation,
+                                                      false,
+                                                      false,
+                                                      quad_ref.size());
          q < quad_ref.size();
          ++q, ++i)
       {
@@ -82,7 +83,8 @@ test<3>(const unsigned int n_points)
   Simplex::QGauss<dim - 1> quad_ref(n_points);
 
   const auto quad =
-    QProjector<dim>::project_to_all_faces(ReferenceCell::Tetrahedron, quad_ref);
+    QProjector<dim>::project_to_all_faces(ReferenceCells::Tetrahedron,
+                                          quad_ref);
 
   const auto print = [&](const unsigned int face_no,
                          const bool         face_orientation,
@@ -95,7 +97,7 @@ test<3>(const unsigned int n_points)
             << std::endl;
     for (unsigned int q = 0,
                       i = QProjector<dim>::DataSetDescriptor::face(
-                        ReferenceCell::Tetrahedron,
+                        ReferenceCells::Tetrahedron,
                         face_no,
                         face_orientation,
                         face_flip,

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -49,11 +49,11 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Line);
-  test<2>(ReferenceCell::Triangle);
-  test<2>(ReferenceCell::Quadrilateral);
-  test<3>(ReferenceCell::Tetrahedron);
-  test<3>(ReferenceCell::Pyramid);
-  test<3>(ReferenceCell::Wedge);
-  test<3>(ReferenceCell::Hexahedron);
+  test<2>(ReferenceCells::Line);
+  test<2>(ReferenceCells::Triangle);
+  test<2>(ReferenceCells::Quadrilateral);
+  test<3>(ReferenceCells::Tetrahedron);
+  test<3>(ReferenceCells::Pyramid);
+  test<3>(ReferenceCells::Wedge);
+  test<3>(ReferenceCells::Hexahedron);
 }

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -51,10 +51,10 @@ main()
 {
   initlog();
 
-  test<2>(ReferenceCell::Triangle);
-  test<2>(ReferenceCell::Quadrilateral);
-  test<3>(ReferenceCell::Tetrahedron);
-  test<3>(ReferenceCell::Pyramid);
-  test<3>(ReferenceCell::Wedge);
-  test<3>(ReferenceCell::Hexahedron);
+  test<2>(ReferenceCells::Triangle);
+  test<2>(ReferenceCells::Quadrilateral);
+  test<3>(ReferenceCells::Tetrahedron);
+  test<3>(ReferenceCells::Pyramid);
+  test<3>(ReferenceCells::Wedge);
+  test<3>(ReferenceCells::Hexahedron);
 }

--- a/tests/simplex/variable_face_quadratures_01.cc
+++ b/tests/simplex/variable_face_quadratures_01.cc
@@ -75,14 +75,14 @@ test<2>()
                                             QGauss<dim - 1>(4));
 
     const auto quad =
-      QProjector<dim>::project_to_all_faces(ReferenceCell::Quadrilateral,
+      QProjector<dim>::project_to_all_faces(ReferenceCells::Quadrilateral,
                                             quad_ref);
 
     const auto print = [&](const unsigned int face_no) {
       deallog << "face_no=" << face_no << ":" << std::endl;
       for (unsigned int q = 0,
                         i = QProjector<dim>::DataSetDescriptor::face(
-                          ReferenceCell::Quadrilateral,
+                          ReferenceCells::Quadrilateral,
                           face_no,
                           false,
                           false,


### PR DESCRIPTION
This also allows to mark them as 'constexpr', since they are now declared and initialized *after* the class type is complete. I have a feeling that this isn't going to work with GCC 5.4 given the back-and-forth in #11695 but we'll just have to see.

Keep going following #11544.

/rebuild