### PR TITLE
Hide a forward declaration from doxygen.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -33,10 +33,10 @@ class Mapping;
 
 template <int dim>
 class Quadrature;
-#endif
-
 
 class ReferenceCell;
+#endif
+
 
 namespace internal
 {


### PR DESCRIPTION
Promised in an earlier patch.

/rebuild