### PR TITLE
Replace passing by const std::unique_ptr<T>& by const T&

### DIFF
--- a/doc/news/changes/incompatibilities/20210222DanielArndt
+++ b/doc/news/changes/incompatibilities/20210222DanielArndt
@@ -1,0 +1,5 @@
+Changed: The various parse_arguments(), to_string(), and to_value() functions
+related to the Pattern namespace take their last argument by `const&` instead of
+`const std::unique_ptr<>&`.
+<br>
+(Daniel Arndt, 2021/02/22)

--- a/include/deal.II/base/mutable_bind.h
+++ b/include/deal.II/base/mutable_bind.h
@@ -145,9 +145,9 @@ namespace Utilities
      * the conversion
      */
     void
-    parse_arguments(const std::string &                           value_string,
-                    const std::unique_ptr<Patterns::PatternBase> &pattern =
-                      Patterns::Tools::Convert<TupleType>::to_pattern());
+    parse_arguments(const std::string &          value_string,
+                    const Patterns::PatternBase &pattern =
+                      *Patterns::Tools::Convert<TupleType>::to_pattern());
 
   private:
     /**
@@ -280,8 +280,8 @@ namespace Utilities
   template <typename ReturnType, class... FunctionArgs>
   void
   MutableBind<ReturnType, FunctionArgs...>::parse_arguments(
-    const std::string &                           value_string,
-    const std::unique_ptr<Patterns::PatternBase> &pattern)
+    const std::string &          value_string,
+    const Patterns::PatternBase &pattern)
   {
     arguments =
       Patterns::Tools::Convert<TupleType>::to_value(value_string, pattern);

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2345,7 +2345,7 @@ ParameterHandler::add_parameter(const std::string &          entry,
 
   auto action = [&, pattern_index](const std::string &val) {
     parameter = Patterns::Tools::Convert<ParameterType>::to_value(
-      val, patterns[pattern_index]);
+      val, *patterns[pattern_index]);
   };
   add_action(entry, action);
 }

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2334,7 +2334,7 @@ ParameterHandler::add_parameter(const std::string &          entry,
 
   declare_entry(entry,
                 Patterns::Tools::Convert<ParameterType>::to_string(
-                  parameter, pattern.clone()),
+                  parameter, *pattern.clone()),
                 pattern,
                 documentation,
                 has_to_be_set);
@@ -2345,7 +2345,7 @@ ParameterHandler::add_parameter(const std::string &          entry,
 
   auto action = [&, pattern_index](const std::string &val) {
     parameter = Patterns::Tools::Convert<ParameterType>::to_value(
-      val, patterns[pattern_index]->clone());
+      val, *patterns[pattern_index]->clone());
   };
   add_action(entry, action);
 }

--- a/include/deal.II/base/parameter_handler.h
+++ b/include/deal.II/base/parameter_handler.h
@@ -2333,8 +2333,8 @@ ParameterHandler::add_parameter(const std::string &          entry,
                 "that is const. Use a non-const type.");
 
   declare_entry(entry,
-                Patterns::Tools::Convert<ParameterType>::to_string(
-                  parameter, *pattern.clone()),
+                Patterns::Tools::Convert<ParameterType>::to_string(parameter,
+                                                                   pattern),
                 pattern,
                 documentation,
                 has_to_be_set);
@@ -2345,7 +2345,7 @@ ParameterHandler::add_parameter(const std::string &          entry,
 
   auto action = [&, pattern_index](const std::string &val) {
     parameter = Patterns::Tools::Convert<ParameterType>::to_value(
-      val, *patterns[pattern_index]->clone());
+      val, patterns[pattern_index]);
   };
   add_action(entry, action);
 }

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -2292,7 +2292,7 @@ namespace Patterns
       {
         std::array<std::string, std::tuple_size<T>::value> a = {
           {Convert<typename std::tuple_element<U, T>::type>::to_string(
-            std::get<U>(t), *pattern.get_pattern(U).clone())...}};
+            std::get<U>(t), pattern.get_pattern(U))...}};
         return a;
       }
 
@@ -2311,7 +2311,7 @@ namespace Patterns
       {
         return std::make_tuple(
           Convert<typename std::tuple_element<U, T>::type>::to_value(
-            s[U], *pattern.get_pattern(U).clone())...);
+            s[U], pattern.get_pattern(U))...);
       }
 
       static T

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1321,9 +1321,9 @@ namespace Patterns
        * class template for particular kinds of template arguments @p T.
        */
       static std::string
-      to_string(const T &                                     s,
-                const std::unique_ptr<Patterns::PatternBase> &p =
-                  Convert<T>::to_pattern()) = delete;
+      to_string(const T &                    s,
+                const Patterns::PatternBase &p = *Convert<T>::to_pattern()) =
+        delete;
 
       /**
        * Convert a string to a value, using the given pattern. Use the pattern
@@ -1335,9 +1335,9 @@ namespace Patterns
        * class template for particular kinds of template arguments @p T.
        */
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &p =
-                 Convert<T>::to_pattern()) = delete;
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &p = *Convert<T>::to_pattern()) =
+        delete;
     };
 
     /**
@@ -1520,9 +1520,8 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     value,
-                const std::unique_ptr<Patterns::PatternBase> &p =
-                  Convert<T>::to_pattern())
+      to_string(const T &                    value,
+                const Patterns::PatternBase &p = *Convert<T>::to_pattern())
       {
         std::stringstream str;
         if (std::is_same<T, unsigned char>::value ||
@@ -1532,17 +1531,15 @@ namespace Patterns
           str << (static_cast<bool>(value) ? "true" : "false");
         else
           str << value;
-        AssertThrow(p->match(str.str()),
-                    ExcNoMatch(str.str(), p->description()));
+        AssertThrow(p.match(str.str()), ExcNoMatch(str.str(), p.description()));
         return str.str();
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &p =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &p = *Convert<T>::to_pattern())
       {
-        AssertThrow(p->match(s), ExcNoMatch(s, p->description()));
+        AssertThrow(p.match(s), ExcNoMatch(s, p.description()));
         T value;
         if (std::is_same<T, bool>::value)
           value = (s == "true");
@@ -1781,11 +1778,11 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a "
                                "string to a List type."));
@@ -1794,7 +1791,7 @@ namespace Patterns
 
         std::transform(
           t.cbegin(), t.cend(), vec.begin(), [&base_p](const auto &entry) {
-            return Convert<typename T::value_type>::to_string(entry, base_p);
+            return Convert<typename T::value_type>::to_string(entry, *base_p);
           });
 
         std::string s;
@@ -1803,18 +1800,17 @@ namespace Patterns
         for (unsigned int i = 1; i < vec.size(); ++i)
           s += p->get_separator() + " " + vec[i];
 
-        AssertThrow(pattern->match(s), ExcNoMatch(s, p->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, p->description()));
         return s;
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List type."));
@@ -1825,7 +1821,7 @@ namespace Patterns
         auto v = Utilities::split_string_list(s, p->get_separator());
         for (const auto &str : v)
           t.insert(t.end(),
-                   Convert<typename T::value_type>::to_value(str, base_p));
+                   Convert<typename T::value_type>::to_value(str, *base_p));
 
         return t;
       }
@@ -1854,11 +1850,11 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::Map *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::Map *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a Map pattern to convert a string to "
                                "a Map compatible type."));
@@ -1869,9 +1865,9 @@ namespace Patterns
         unsigned int i = 0;
         for (const auto &ti : t)
           vec[i++] =
-            Convert<typename T::key_type>::to_string(ti.first, key_p) +
+            Convert<typename T::key_type>::to_string(ti.first, *key_p) +
             p->get_key_value_separator() +
-            Convert<typename T::mapped_type>::to_string(ti.second, val_p);
+            Convert<typename T::mapped_type>::to_string(ti.second, *val_p);
 
         std::string s;
         if (vec.size() > 0)
@@ -1884,13 +1880,12 @@ namespace Patterns
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::Map *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::Map *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a Map pattern to convert a "
                                "string to a Map compatible type."));
@@ -1906,7 +1901,7 @@ namespace Patterns
               Utilities::split_string_list(str, p->get_key_value_separator());
             AssertDimension(key_val.size(), 2);
             t.insert(std::make_pair(
-              Convert<typename T::key_type>::to_value(key_val[0], key_p),
+              Convert<typename T::key_type>::to_value(key_val[0], *key_p),
               Convert<typename T::mapped_type>::to_value(key_val[1])));
           }
 
@@ -1933,11 +1928,11 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
@@ -1945,7 +1940,7 @@ namespace Patterns
         std::vector<std::string> vec(dim);
 
         for (unsigned int i = 0; i < dim; ++i)
-          vec[i] = Convert<typename T::value_type>::to_string(t[i], base_p);
+          vec[i] = Convert<typename T::value_type>::to_string(t[i], *base_p);
 
         std::string s;
         if (vec.size() > 0)
@@ -1958,13 +1953,12 @@ namespace Patterns
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
@@ -1975,7 +1969,7 @@ namespace Patterns
         auto         v = Utilities::split_string_list(s, p->get_separator());
         unsigned int i = 0;
         for (const auto &str : v)
-          t[i++] = Convert<typename T::value_type>::to_value(str, base_p);
+          t[i++] = Convert<typename T::value_type>::to_value(str, *base_p);
 
         return t;
       }
@@ -1994,18 +1988,17 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         return Convert<Tensor<1, dim, Number>>::to_string(
           Tensor<1, dim, Number>(t), pattern);
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         return T(Convert<Tensor<1, dim, Number>>::to_value(s, pattern));
       }
@@ -2032,11 +2025,11 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
@@ -2049,18 +2042,17 @@ namespace Patterns
         for (unsigned int i = 1; i < expressions.size(); ++i)
           s = s + p->get_separator() + expressions[i];
 
-        AssertThrow(pattern->match(s), ExcNoMatch(s, p->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, p->description()));
         return s;
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
@@ -2090,9 +2082,9 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         std::vector<bool> mask(t.size());
         for (unsigned int i = 0; i < t.size(); ++i)
@@ -2102,9 +2094,8 @@ namespace Patterns
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         const auto mask = Convert<std::vector<bool>>::to_value(s, pattern);
         return ComponentMask(mask);
@@ -2131,22 +2122,22 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
 
         auto        base_p = p->get_base_pattern().clone();
         std::string s =
-          Convert<typename T::value_type>::to_string(t.real(), base_p) +
+          Convert<typename T::value_type>::to_string(t.real(), *base_p) +
           p->get_separator() + " " +
-          Convert<typename T::value_type>::to_string(t.imag(), base_p);
+          Convert<typename T::value_type>::to_string(t.imag(), *base_p);
 
-        AssertThrow(pattern->match(s), ExcNoMatch(s, p->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, p->description()));
         return s;
       }
 
@@ -2154,13 +2145,12 @@ namespace Patterns
        * Convert a string to a value, using the given pattern, or a default one.
        */
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::List *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::List *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a List pattern to convert a string "
                                "to a List compatible type."));
@@ -2169,8 +2159,8 @@ namespace Patterns
 
         auto v = Utilities::split_string_list(s, p->get_separator());
         AssertDimension(v.size(), 2);
-        T t(Convert<typename T::value_type>::to_value(v[0], base_p),
-            Convert<typename T::value_type>::to_value(v[1], base_p));
+        T t(Convert<typename T::value_type>::to_value(v[0], *base_p),
+            Convert<typename T::value_type>::to_value(v[1], *base_p));
         return t;
       }
     };
@@ -2188,20 +2178,19 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(t), ExcNoMatch(t, pattern->description()));
+        AssertThrow(pattern.match(t), ExcNoMatch(t, pattern.description()));
         return t;
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
         return s;
       }
     };
@@ -2224,20 +2213,19 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         std::tuple<Key, Value> m(t);
         std::string            s = Convert<decltype(m)>::to_string(m, pattern);
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
         return s;
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
         std::tuple<Key, Value> m;
         m = Convert<decltype(m)>::to_value(s, pattern);
@@ -2262,11 +2250,11 @@ namespace Patterns
       }
 
       static std::string
-      to_string(const T &                                     t,
-                const std::unique_ptr<Patterns::PatternBase> &pattern =
-                  Convert<T>::to_pattern())
+      to_string(
+        const T &                    t,
+        const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        auto p = dynamic_cast<const Patterns::Tuple *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::Tuple *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a Tuple pattern to convert a tuple "
                                "to a string."));
@@ -2280,13 +2268,12 @@ namespace Patterns
       }
 
       static T
-      to_value(const std::string &                           s,
-               const std::unique_ptr<Patterns::PatternBase> &pattern =
-                 Convert<T>::to_pattern())
+      to_value(const std::string &          s,
+               const Patterns::PatternBase &pattern = *Convert<T>::to_pattern())
       {
-        AssertThrow(pattern->match(s), ExcNoMatch(s, pattern->description()));
+        AssertThrow(pattern.match(s), ExcNoMatch(s, pattern.description()));
 
-        auto p = dynamic_cast<const Patterns::Tuple *>(pattern.get());
+        auto p = dynamic_cast<const Patterns::Tuple *>(&pattern);
         AssertThrow(p,
                     ExcMessage("I need a Tuple pattern to convert a string "
                                "to a tuple type."));
@@ -2305,7 +2292,7 @@ namespace Patterns
       {
         std::array<std::string, std::tuple_size<T>::value> a = {
           {Convert<typename std::tuple_element<U, T>::type>::to_string(
-            std::get<U>(t), pattern.get_pattern(U).clone())...}};
+            std::get<U>(t), *pattern.get_pattern(U).clone())...}};
         return a;
       }
 
@@ -2324,7 +2311,7 @@ namespace Patterns
       {
         return std::make_tuple(
           Convert<typename std::tuple_element<U, T>::type>::to_value(
-            s[U], pattern.get_pattern(U).clone())...);
+            s[U], *pattern.get_pattern(U).clone())...);
       }
 
       static T

--- a/include/deal.II/numerics/vector_tools_common.h
+++ b/include/deal.II/numerics/vector_tools_common.h
@@ -309,9 +309,9 @@ namespace Patterns
        * Convert a NormType to a string.
        */
       static std::string
-      to_string(const VectorTools::NormType &                 s,
-                const std::unique_ptr<Patterns::PatternBase> &p =
-                  Convert<VectorTools::NormType>::to_pattern())
+      to_string(const VectorTools::NormType &s,
+                const Patterns::PatternBase &p =
+                  *Convert<VectorTools::NormType>::to_pattern())
       {
         std::string str;
         if (s == VectorTools::mean)
@@ -342,7 +342,7 @@ namespace Patterns
           {
             AssertThrow(false, ExcMessage("Didn't recognize a norm type."));
           }
-        AssertThrow(p->match(str), ExcInternalError());
+        AssertThrow(p.match(str), ExcInternalError());
         return str;
       }
 
@@ -351,12 +351,12 @@ namespace Patterns
        * Convert a string to a NormType.
        */
       static VectorTools::NormType
-      to_value(const std::string &                           str,
-               const std::unique_ptr<Patterns::PatternBase> &p =
-                 Convert<VectorTools::NormType>::to_pattern())
+      to_value(const std::string &          str,
+               const Patterns::PatternBase &p =
+                 *Convert<VectorTools::NormType>::to_pattern())
       {
         VectorTools::NormType norm = VectorTools::mean;
-        AssertThrow(p->match(str),
+        AssertThrow(p.match(str),
                     ExcMessage(
                       "String " + str +
                       " cannot be converted to VectorTools::NormType"));

--- a/source/base/function_parser.cc
+++ b/source/base/function_parser.cc
@@ -64,12 +64,12 @@ FunctionParser<dim>::FunctionParser(const std::string &expression,
 {
   auto constants_map = Patterns::Tools::Convert<ConstMap>::to_value(
     constants,
-    std::make_unique<Patterns::Map>(Patterns::Anything(),
-                                    Patterns::Double(),
-                                    0,
-                                    Patterns::Map::max_int_value,
-                                    ",",
-                                    "="));
+    Patterns::Map(Patterns::Anything(),
+                  Patterns::Double(),
+                  0,
+                  Patterns::Map::max_int_value,
+                  ",",
+                  "="));
   initialize(variable_names,
              expression,
              constants_map,

--- a/source/base/tensor_function_parser.cc
+++ b/source/base/tensor_function_parser.cc
@@ -63,12 +63,12 @@ TensorFunctionParser<rank, dim, Number>::TensorFunctionParser(
 {
   auto constants_map = Patterns::Tools::Convert<ConstMap>::to_value(
     constants,
-    std::make_unique<Patterns::Map>(Patterns::Anything(),
-                                    Patterns::Double(),
-                                    0,
-                                    Patterns::Map::max_int_value,
-                                    ",",
-                                    "="));
+    Patterns::Map(Patterns::Anything(),
+                  Patterns::Double(),
+                  0,
+                  Patterns::Map::max_int_value,
+                  ",",
+                  "="));
   initialize(variable_names,
              expression,
              constants_map,


### PR DESCRIPTION
https://github.com/dealii/dealii/pull/11698#issuecomment-774854191:
> It is correct that in pattern.h, we could replace the std::unique_ptr arguments for the to_string() and to_value() functions to regular const references. I would accept a patch to this end.

This is what this pull request does. I am in favor of doing this but it's not backward-compatible. Let's see what people think.