### PR TITLE
Move some functions from internal::ReferenceCell::Base to ReferenceCell

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -282,11 +282,9 @@ namespace FETools
       // 3. Quads
       for (unsigned int quad_number = 0;
            quad_number <
-           (dim == 2 ? 1 :
-                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
-                                     fes.front()->reference_cell())
-                                     .n_faces() :
-                                   0));
+           (dim == 2 ?
+              1 :
+              (dim == 3 ? fes.front()->reference_cell().n_faces() : 0));
            ++quad_number)
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -499,11 +497,9 @@ namespace FETools
       // 3. Quads
       for (unsigned int quad_number = 0;
            quad_number <
-           (dim == 2 ? 1 :
-                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
-                                     fes.front()->reference_cell())
-                                     .n_faces() :
-                                   0));
+           (dim == 2 ?
+              1 :
+              (dim == 3 ? fes.front()->reference_cell().n_faces() : 0));
            ++quad_number)
         {
           unsigned int comp_start = 0;
@@ -761,11 +757,7 @@ namespace FETools
       // 3. Quads
       for (unsigned int quad_number = 0;
            quad_number <
-           (dim == 2 ? 1 :
-                       (dim == 3 ? dealii::internal::ReferenceCell::get_cell(
-                                     fe.reference_cell())
-                                     .n_faces() :
-                                   0));
+           (dim == 2 ? 1 : (dim == 3 ? fe.reference_cell().n_faces() : 0));
            ++quad_number)
         {
           unsigned int comp_start = 0;
@@ -872,9 +864,7 @@ namespace FETools
       unsigned int total_index = 0;
       for (unsigned int vertex_number = 0;
            vertex_number <
-           dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
-                                                     face_no)
-             .n_vertices();
+           fe.reference_cell().face_reference_cell(face_no).n_vertices();
            ++vertex_number)
         {
           unsigned int comp_start = 0;
@@ -932,9 +922,7 @@ namespace FETools
       // 2. Lines
       for (unsigned int line_number = 0;
            line_number <
-           dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
-                                                     face_no)
-             .n_lines();
+           fe.reference_cell().face_reference_cell(face_no).n_lines();
            ++line_number)
         {
           unsigned int comp_start = 0;
@@ -1995,9 +1983,7 @@ namespace FETools
     {
       unsigned int face_dof = 0;
       for (unsigned int i = 0;
-           i < dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
-                                                         face_no)
-                 .n_vertices();
+           i < fe.reference_cell().face_reference_cell(face_no).n_vertices();
            ++i)
         {
           const unsigned int offset_c =
@@ -2015,9 +2001,7 @@ namespace FETools
         }
 
       for (unsigned int i = 1;
-           i <= dealii::internal::ReferenceCell::get_face(fe.reference_cell(),
-                                                          face_no)
-                  .n_lines();
+           i <= fe.reference_cell().face_reference_cell(face_no).n_lines();
            ++i)
         {
           const unsigned int offset_c =

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -235,9 +235,7 @@ namespace FETools
       // one, taking into account multiplicities, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::ReferenceCell::get_cell(
-             fes.front()->reference_cell())
-             .vertex_indices())
+           fes.front()->reference_cell().vertex_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
@@ -258,9 +256,7 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           dealii::internal::ReferenceCell::get_cell(
-             fes.front()->reference_cell())
-             .line_indices())
+           fes.front()->reference_cell().line_indices())
         {
           for (unsigned int base = 0; base < fes.size(); ++base)
             for (unsigned int m = 0; m < multiplicities[base]; ++m)
@@ -426,9 +422,7 @@ namespace FETools
       // base elements, and other complications
       unsigned int total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::ReferenceCell::get_cell(
-             fes.front()->reference_cell())
-             .vertex_indices())
+           fes.front()->reference_cell().vertex_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -461,9 +455,7 @@ namespace FETools
 
       // 2. Lines
       for (const unsigned int line_number :
-           dealii::internal::ReferenceCell::get_cell(
-             fes.front()->reference_cell())
-             .line_indices())
+           fes.front()->reference_cell().line_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fes.size(); ++base)
@@ -669,8 +661,7 @@ namespace FETools
       // vertex, etc
       total_index = 0;
       for (const unsigned int vertex_number :
-           dealii::internal::ReferenceCell::get_cell(fe.reference_cell())
-             .vertex_indices())
+           fe.reference_cell().vertex_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fe.n_base_elements(); ++base)
@@ -711,9 +702,7 @@ namespace FETools
         }
 
       // 2. Lines
-      for (const unsigned int line_number :
-           dealii::internal::ReferenceCell::get_cell(fe.reference_cell())
-             .line_indices())
+      for (const unsigned int line_number : fe.reference_cell().line_indices())
         {
           unsigned int comp_start = 0;
           for (unsigned int base = 0; base < fe.n_base_elements(); ++base)

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -208,6 +208,54 @@ public:
    */
 
   /**
+   * @name Querying the number of building blocks of a reference cell
+   * @{
+   */
+
+  /**
+   * Return the number of vertices that make up the reference
+   * cell in question. A vertex is a "corner" (a zero-dimensional
+   * object) of the reference cell.
+   */
+  unsigned int
+  n_vertices() const;
+
+  /**
+   * Return the number of lines that make up the reference
+   * cell in question. A line is an "edge" (a one-dimensional
+   * object) of the reference cell.
+   */
+  unsigned int
+  n_lines() const;
+
+  /**
+   * Return the number of faces that make up the reference
+   * cell in question. A face is a `(dim-1)`-dimensional
+   * object bounding the reference cell.
+   */
+  unsigned int
+  n_faces() const;
+
+  /**
+   * Return the reference-cell type of face @p face_no of the current
+   * object. For example, if the current object is
+   * ReferenceCells::Tetrahedron, then `face_no` must be between
+   * in the interval $[0,4)$ and the function will always return
+   * ReferenceCells::Triangle. If the current object is
+   * ReferenceCells::Hexahedron, then `face_no` must be between
+   * in the interval $[0,6)$ and the function will always return
+   * ReferenceCells::Quadrilateral. For wedges and pyramids, the
+   * returned object may be either ReferenceCells::Triangle or
+   * ReferenceCells::Quadrilateral, depending on the given index.
+   */
+  ReferenceCell
+  face_reference_cell(const unsigned int face_no) const;
+
+  /**
+   * @}
+   */
+
+  /**
    * @name Geometric properties of reference cells
    * @{
    */
@@ -550,6 +598,122 @@ ReferenceCell::get_dimension() const
 
 
 
+inline unsigned int
+ReferenceCell::n_vertices() const
+{
+  if (*this == ReferenceCells::Vertex)
+    return 1;
+  else if (*this == ReferenceCells::Line)
+    return 2;
+  else if (*this == ReferenceCells::Triangle)
+    return 3;
+  else if (*this == ReferenceCells::Quadrilateral)
+    return 4;
+  else if (*this == ReferenceCells::Tetrahedron)
+    return 4;
+  else if (*this == ReferenceCells::Pyramid)
+    return 5;
+  else if (*this == ReferenceCells::Wedge)
+    return 6;
+  else if (*this == ReferenceCells::Hexahedron)
+    return 8;
+
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+inline unsigned int
+ReferenceCell::n_lines() const
+{
+  if (*this == ReferenceCells::Vertex)
+    return 0;
+  else if (*this == ReferenceCells::Line)
+    return 1;
+  else if (*this == ReferenceCells::Triangle)
+    return 3;
+  else if (*this == ReferenceCells::Quadrilateral)
+    return 4;
+  else if (*this == ReferenceCells::Tetrahedron)
+    return 6;
+  else if (*this == ReferenceCells::Pyramid)
+    return 7;
+  else if (*this == ReferenceCells::Wedge)
+    return 9;
+  else if (*this == ReferenceCells::Hexahedron)
+    return 12;
+
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+inline unsigned int
+ReferenceCell::n_faces() const
+{
+  if (*this == ReferenceCells::Vertex)
+    return 0;
+  else if (*this == ReferenceCells::Line)
+    return 2;
+  else if (*this == ReferenceCells::Triangle)
+    return 3;
+  else if (*this == ReferenceCells::Quadrilateral)
+    return 4;
+  else if (*this == ReferenceCells::Tetrahedron)
+    return 4;
+  else if (*this == ReferenceCells::Pyramid)
+    return 5;
+  else if (*this == ReferenceCells::Wedge)
+    return 5;
+  else if (*this == ReferenceCells::Hexahedron)
+    return 6;
+
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+inline ReferenceCell
+ReferenceCell::face_reference_cell(const unsigned int face_no) const
+{
+  AssertIndexRange(face_no, n_faces());
+
+  if (*this == ReferenceCells::Vertex)
+    return ReferenceCells::Invalid;
+  else if (*this == ReferenceCells::Line)
+    return ReferenceCells::Vertex;
+  else if (*this == ReferenceCells::Triangle)
+    return ReferenceCells::Line;
+  else if (*this == ReferenceCells::Quadrilateral)
+    return ReferenceCells::Line;
+  else if (*this == ReferenceCells::Tetrahedron)
+    return ReferenceCells::Triangle;
+  else if (*this == ReferenceCells::Pyramid)
+    {
+      if (face_no == 0)
+        return ReferenceCells::Quadrilateral;
+      else
+        return ReferenceCells::Triangle;
+    }
+  else if (*this == ReferenceCells::Wedge)
+    {
+      if (face_no > 1)
+        return ReferenceCells::Quadrilateral;
+      else
+        return ReferenceCells::Triangle;
+    }
+  else if (*this == ReferenceCells::Hexahedron)
+    return ReferenceCells::Quadrilateral;
+
+  Assert(false, ExcNotImplemented());
+  return ReferenceCells::Invalid;
+}
+
+
+
 namespace ReferenceCells
 {
   template <int dim>
@@ -887,6 +1051,7 @@ namespace internal
        */
       virtual ~Base() = default;
 
+    private:
       /**
        * Number of vertices.
        */
@@ -918,6 +1083,7 @@ namespace internal
         return 0;
       }
 
+    public:
       /**
        * Return an object that can be thought of as an array containing all
        * indices from zero to n_vertices().
@@ -1027,6 +1193,7 @@ namespace internal
         return true;
       }
 
+    private:
       /**
        * Return reference-cell type of face @p face_no.
        */
@@ -1039,6 +1206,7 @@ namespace internal
         return ReferenceCells::Invalid;
       }
 
+    public:
       /**
        * Map face line number to cell line number.
        */
@@ -2011,7 +2179,7 @@ namespace internal
     inline const internal::ReferenceCell::Base &
     get_face(const dealii::ReferenceCell &type, const unsigned int face_no)
     {
-      return get_cell(get_cell(type).face_reference_cell(face_no));
+      return get_cell(type.face_reference_cell(face_no));
     }
 
   } // namespace ReferenceCell
@@ -2049,8 +2217,7 @@ namespace internal
     {
       out << "[";
 
-      const unsigned int n_vertices =
-        internal::ReferenceCell::get_cell(entity_type).n_vertices();
+      const unsigned int n_vertices = entity_type.n_vertices();
 
       for (unsigned int i = 0; i < n_vertices; ++i)
         {
@@ -2095,8 +2262,7 @@ inline unsigned char
 ReferenceCell::compute_orientation(const std::array<T, N> &vertices_0,
                                    const std::array<T, N> &vertices_1) const
 {
-  AssertIndexRange(internal::ReferenceCell::get_cell(*this).n_vertices(),
-                   N + 1);
+  AssertIndexRange(n_vertices(), N + 1);
   if (*this == ReferenceCells::Line)
     {
       const std::array<T, 2> i{{vertices_0[0], vertices_0[1]}};

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -221,6 +221,13 @@ public:
   n_vertices() const;
 
   /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to n_vertices().
+   */
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  vertex_indices() const;
+
+  /**
    * Return the number of lines that make up the reference
    * cell in question. A line is an "edge" (a one-dimensional
    * object) of the reference cell.
@@ -229,12 +236,26 @@ public:
   n_lines() const;
 
   /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to n_lines().
+   */
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  line_indices() const;
+
+  /**
    * Return the number of faces that make up the reference
    * cell in question. A face is a `(dim-1)`-dimensional
    * object bounding the reference cell.
    */
   unsigned int
   n_faces() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to n_faces().
+   */
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  face_indices() const;
 
   /**
    * Return the reference-cell type of face @p face_no of the current
@@ -676,6 +697,30 @@ ReferenceCell::n_faces() const
 
 
 
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+ReferenceCell::vertex_indices() const
+{
+  return {0U, n_vertices()};
+}
+
+
+
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+ReferenceCell::line_indices() const
+{
+  return {0U, n_lines()};
+}
+
+
+
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+ReferenceCell::face_indices() const
+{
+  return {0U, n_faces()};
+}
+
+
+
 inline ReferenceCell
 ReferenceCell::face_reference_cell(const unsigned int face_no) const
 {
@@ -1083,7 +1128,6 @@ namespace internal
         return 0;
       }
 
-    public:
       /**
        * Return an object that can be thought of as an array containing all
        * indices from zero to n_vertices().
@@ -1114,6 +1158,7 @@ namespace internal
         return {0U, n_faces()};
       }
 
+    public:
       /**
        * Standard decomposition of vertex index into face and face-vertex
        * index.

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -277,7 +277,41 @@ public:
    */
 
   /**
+   * @name Relationships between objects in the cell and on faces
+   * @{
+   */
+
+  /**
+   * For a given vertex in a cell, return a pair of a face index and a
+   * vertex index within this face.
+   *
+   * @note In practice, a vertex is of course generally part of more than one
+   *   face, and one could return different faces and the corresponding
+   *   index within. Which face this function chooses is often not of
+   *   importance (and not exposed by this function on purpose).
+   */
+  std::array<unsigned int, 2>
+  standard_vertex_to_face_and_vertex_index(const unsigned int vertex) const;
+
+  /**
+   * For a given line in a cell, return a pair of a face index and a
+   * line index within this face.
+   *
+   * @note In practice, a line is of course generally part of more than one
+   *   face, and one could return different faces and the corresponding
+   *   index within. Which face this function chooses is often not of
+   *   importance (and not exposed by this function on purpose).
+   */
+  std::array<unsigned int, 2>
+  standard_line_to_face_and_line_index(const unsigned int line) const;
+
+  /**
+   * @}
+   */
+
+  /**
    * @name Geometric properties of reference cells
+   * @name Querying the number of building blocks of a reference cell
    * @{
    */
 
@@ -759,6 +793,132 @@ ReferenceCell::face_reference_cell(const unsigned int face_no) const
 
 
 
+inline std::array<unsigned int, 2>
+ReferenceCell::standard_vertex_to_face_and_vertex_index(
+  const unsigned int vertex) const
+{
+  AssertIndexRange(vertex, n_vertices());
+
+  if (*this == ReferenceCells::Vertex)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Line)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Triangle)
+    {
+      static const std::array<std::array<unsigned int, 2>, 3> table = {
+        {{{0, 0}}, {{0, 1}}, {{1, 1}}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCells::Quadrilateral)
+    {
+      return GeometryInfo<2>::standard_quad_vertex_to_line_vertex_index(vertex);
+    }
+  else if (*this == ReferenceCells::Tetrahedron)
+    {
+      static const std::array<unsigned int, 2> table[4] = {{{0, 0}},
+                                                           {{0, 1}},
+                                                           {{0, 2}},
+                                                           {{1, 2}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCells::Pyramid)
+    {
+      static const std::array<unsigned int, 2> table[5] = {
+        {{0, 0}}, {{0, 1}}, {{0, 2}}, {{0, 3}}, {{1, 2}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCells::Wedge)
+    {
+      static const std::array<std::array<unsigned int, 2>, 6> table = {
+        {{{0, 1}}, {{0, 0}}, {{0, 2}}, {{1, 0}}, {{1, 1}}, {{1, 2}}}};
+
+      return table[vertex];
+    }
+  else if (*this == ReferenceCells::Hexahedron)
+    {
+      return GeometryInfo<3>::standard_hex_vertex_to_quad_vertex_index(vertex);
+    }
+
+  Assert(false, ExcNotImplemented());
+  return {};
+}
+
+
+
+inline std::array<unsigned int, 2>
+ReferenceCell::standard_line_to_face_and_line_index(
+  const unsigned int line) const
+{
+  AssertIndexRange(line, n_lines());
+
+  if (*this == ReferenceCells::Vertex)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Line)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Triangle)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Quadrilateral)
+    {
+      Assert(false, ExcNotImplemented());
+    }
+  else if (*this == ReferenceCells::Tetrahedron)
+    {
+      static const std::array<unsigned int, 2> table[6] = {
+        {{0, 0}}, {{0, 1}}, {{0, 2}}, {{1, 1}}, {{1, 2}}, {{2, 1}}};
+
+      return table[line];
+    }
+  else if (*this == ReferenceCells::Pyramid)
+    {
+      static const std::array<unsigned int, 2> table[8] = {{{0, 0}},
+                                                           {{0, 1}},
+                                                           {{0, 2}},
+                                                           {{0, 3}},
+                                                           {{1, 2}},
+                                                           {{2, 1}},
+                                                           {{1, 1}},
+                                                           {{2, 2}}};
+
+      return table[line];
+    }
+  else if (*this == ReferenceCells::Wedge)
+    {
+      static const std::array<unsigned int, 2> table[9] = {{{0, 0}},
+                                                           {{0, 2}},
+                                                           {{0, 1}},
+                                                           {{1, 0}},
+                                                           {{1, 1}},
+                                                           {{1, 2}},
+                                                           {{2, 0}},
+                                                           {{2, 1}},
+                                                           {{3, 1}}};
+
+      return table[line];
+    }
+  else if (*this == ReferenceCells::Hexahedron)
+    {
+      return GeometryInfo<3>::standard_hex_line_to_quad_line_index(line);
+    }
+
+  Assert(false, ExcNotImplemented());
+  return {};
+}
+
+
+
 namespace ReferenceCells
 {
   template <int dim>
@@ -1158,7 +1318,6 @@ namespace internal
         return {0U, n_faces()};
       }
 
-    public:
       /**
        * Standard decomposition of vertex index into face and face-vertex
        * index.
@@ -1186,6 +1345,7 @@ namespace internal
         return {{0, 0}};
       }
 
+    public:
       /**
        * Correct vertex index depending on face orientation.
        */

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -2195,7 +2195,7 @@ template <int structdim, int dim, int spacedim>
 unsigned int
 TriaAccessor<structdim, dim, spacedim>::n_vertices() const
 {
-  return this->reference_cell_info().n_vertices();
+  return this->reference_cell().n_vertices();
 }
 
 
@@ -2204,7 +2204,7 @@ template <int structdim, int dim, int spacedim>
 unsigned int
 TriaAccessor<structdim, dim, spacedim>::n_lines() const
 {
-  return this->reference_cell_info().n_lines();
+  return this->reference_cell().n_lines();
 }
 
 
@@ -2215,7 +2215,7 @@ TriaAccessor<structdim, dim, spacedim>::n_faces() const
 {
   AssertDimension(structdim, dim);
 
-  return this->reference_cell_info().n_faces();
+  return this->reference_cell().n_faces();
 }
 
 

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -621,8 +621,7 @@ namespace internal
       line_index(const TriaAccessor<3, 3, 3> &accessor, const unsigned int i)
       {
         const auto pair =
-          accessor.reference_cell_info().standard_line_to_face_and_line_index(
-            i);
+          accessor.reference_cell().standard_line_to_face_and_line_index(i);
         const auto quad_index = pair[0];
         const auto line_index =
           accessor.reference_cell_info().standard_to_real_face_line(
@@ -834,8 +833,7 @@ namespace internal
         AssertIndexRange(line, accessor.n_lines());
 
         const auto pair =
-          accessor.reference_cell_info().standard_line_to_face_and_line_index(
-            line);
+          accessor.reference_cell().standard_line_to_face_and_line_index(line);
         const auto quad_index = pair[0];
         const auto line_index =
           accessor.reference_cell_info().standard_to_real_face_line(
@@ -1019,8 +1017,9 @@ namespace internal
       vertex_index(const TriaAccessor<2, dim, spacedim> &accessor,
                    const unsigned int                    corner)
       {
-        const auto pair = accessor.reference_cell_info()
-                            .standard_vertex_to_face_and_vertex_index(corner);
+        const auto pair =
+          accessor.reference_cell().standard_vertex_to_face_and_vertex_index(
+            corner);
         const auto line_index = pair[0];
         const auto vertex_index =
           accessor.reference_cell_info().standard_to_real_face_vertex(
@@ -1035,8 +1034,9 @@ namespace internal
       vertex_index(const TriaAccessor<3, 3, 3> &accessor,
                    const unsigned int           corner)
       {
-        const auto pair = accessor.reference_cell_info()
-                            .standard_vertex_to_face_and_vertex_index(corner);
+        const auto pair =
+          accessor.reference_cell().standard_vertex_to_face_and_vertex_index(
+            corner);
         const auto face_index = pair[0];
         const auto vertex_index =
           accessor.reference_cell_info().standard_to_real_face_vertex(

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -344,10 +344,10 @@ namespace internal
 
                 for (unsigned int face_no = 0; face_no < quad_face.size();
                      ++face_no)
-                  n_max_vertices = std::max(n_max_vertices,
-                                            internal::ReferenceCell::get_face(
-                                              reference_cell_type, face_no)
-                                              .n_vertices());
+                  n_max_vertices =
+                    std::max(n_max_vertices,
+                             reference_cell_type.face_reference_cell(face_no)
+                               .n_vertices());
 
                 const auto projected_quad_face =
                   QProjector<dim>::project_to_all_faces(reference_cell_type,
@@ -369,8 +369,7 @@ namespace internal
                   {
                     const unsigned int n_face_orientations =
                       dim == 2 ? 2 :
-                                 (2 * internal::ReferenceCell::get_face(
-                                        reference_cell_type, f)
+                                 (2 * reference_cell_type.face_reference_cell(f)
                                         .n_vertices());
 
                     const unsigned int n_q_points_face = quad_face[f].size();

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -927,9 +927,7 @@ namespace
         else
           {
             Assert(patch.n_subdivisions == 1, ExcNotImplemented());
-            const auto &info =
-              internal::ReferenceCell::get_cell(patch.reference_cell);
-            n_nodes += info.n_vertices();
+            n_nodes += patch.reference_cell.n_vertices();
             n_cells += 1;
           }
       }
@@ -7739,9 +7737,6 @@ DataOutBase::write_hdf5_parallel(
   // patches
   Assert(patches.size() > 0, ExcNoPatches());
 
-  const auto &cell_info =
-    internal::ReferenceCell::get_cell(patches[0].reference_cell);
-
   hid_t h5_mesh_file_id = -1, h5_solution_file_id, file_plist_id, plist_id;
   hid_t node_dataspace, node_dataset, node_file_dataspace,
     node_memory_dataspace;
@@ -7835,7 +7830,7 @@ DataOutBase::write_hdf5_parallel(
       AssertThrow(node_dataspace >= 0, ExcIO());
 
       cell_ds_dim[0] = global_node_cell_count[1];
-      cell_ds_dim[1] = cell_info.n_vertices();
+      cell_ds_dim[1] = patches[0].reference_cell.n_vertices();
       cell_dataspace = H5Screate_simple(2, cell_ds_dim, nullptr);
       AssertThrow(cell_dataspace >= 0, ExcIO());
 
@@ -7896,7 +7891,7 @@ DataOutBase::write_hdf5_parallel(
 
       // And repeat for cells
       count[0] = local_node_cell_count[1];
-      count[1] = cell_info.n_vertices();
+      count[1] = patches[0].reference_cell.n_vertices();
       offset[0] = global_node_cell_offsets[1];
       offset[1] = 0;
       cell_memory_dataspace = H5Screate_simple(2, count, nullptr);

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -689,16 +689,13 @@ namespace DoFTools
 
                 const auto reference_cell = cell->reference_cell();
 
-                const auto &cell_rc =
-                  dealii::internal::ReferenceCell::get_cell(reference_cell);
-                const auto &face_rc =
-                  dealii::internal::ReferenceCell::get_face(reference_cell,
-                                                            face);
-
-                const unsigned int n_vertices_per_cell = cell_rc.n_vertices();
-                const unsigned int n_lines_per_cell    = cell_rc.n_lines();
-                const unsigned int n_vertices_per_face = face_rc.n_vertices();
-                const unsigned int n_lines_per_face    = face_rc.n_lines();
+                const unsigned int n_vertices_per_cell =
+                  reference_cell.n_vertices();
+                const unsigned int n_lines_per_cell = reference_cell.n_lines();
+                const unsigned int n_vertices_per_face =
+                  reference_cell.face_reference_cell(face).n_vertices();
+                const unsigned int n_lines_per_face =
+                  reference_cell.face_reference_cell(face).n_lines();
 
                 const unsigned int dofs_per_face = fe.n_dofs_per_face(face);
                 face_dof_indices.resize(dofs_per_face);

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -156,12 +156,12 @@ FiniteElement<dim, spacedim>::FiniteElement(
 
       for (unsigned int f = 0; f < this->n_unique_quads(); ++f)
         {
-          adjust_quad_dof_index_for_face_orientation_table[f] = Table<2, int>(
-            this->n_dofs_per_quad(f),
-            internal::ReferenceCell::get_cell(this->reference_cell())
-                  .face_reference_cell(f) == ReferenceCells::Quadrilateral ?
-              8 :
-              6);
+          adjust_quad_dof_index_for_face_orientation_table[f] =
+            Table<2, int>(this->n_dofs_per_quad(f),
+                          this->reference_cell().face_reference_cell(f) ==
+                              ReferenceCells::Quadrilateral ?
+                            8 :
+                            6);
           adjust_quad_dof_index_for_face_orientation_table[f].fill(0);
         }
     }
@@ -575,7 +575,7 @@ FiniteElement<dim, spacedim>::face_to_cell_index(const unsigned int face_index,
     internal::ReferenceCell::get_cell(this->reference_cell());
 
   AssertIndexRange(face_index, this->n_dofs_per_face(face));
-  AssertIndexRange(face, refence_cell.n_faces());
+  AssertIndexRange(face, this->reference_cell().n_faces());
 
   // TODO: we could presumably solve the 3d case below using the
   // adjust_quad_dof_index_for_face_orientation_table field. for the
@@ -684,12 +684,11 @@ FiniteElement<dim, spacedim>::adjust_quad_dof_index_for_face_orientation(
   AssertIndexRange(index, this->n_dofs_per_quad(face));
   Assert(adjust_quad_dof_index_for_face_orientation_table
              [this->n_unique_quads() == 1 ? 0 : face]
-               .n_elements() ==
-           (internal::ReferenceCell::get_cell(this->reference_cell())
-                  .face_reference_cell(face) == ReferenceCells::Quadrilateral ?
-              8 :
-              6) *
-             this->n_dofs_per_quad(face),
+               .n_elements() == (this->reference_cell().face_reference_cell(
+                                   face) == ReferenceCells::Quadrilateral ?
+                                   8 :
+                                   6) *
+                                  this->n_dofs_per_quad(face),
          ExcInternalError());
   return index +
          adjust_quad_dof_index_for_face_orientation_table

--- a/source/fe/fe_data.cc
+++ b/source/fe/fe_data.cc
@@ -54,64 +54,49 @@ namespace internal
 
     // first_line_index
     const unsigned int first_line_index =
-      (internal::ReferenceCell::get_cell(cell_type).n_vertices() *
-       dofs_per_vertex);
+      (cell_type.n_vertices() * dofs_per_vertex);
     result.object_index[1][0] = first_line_index;
 
     // first_quad_index
     const unsigned int first_quad_index =
-      (first_line_index +
-       internal::ReferenceCell::get_cell(cell_type).n_lines() * dofs_per_line);
+      (first_line_index + cell_type.n_lines() * dofs_per_line);
     result.object_index[2][0] = first_quad_index;
 
     // first_hex_index
     result.object_index[3][0] =
       (first_quad_index +
-       (dim == 2 ?
-          1 :
-          (dim == 3 ? internal::ReferenceCell::get_cell(cell_type).n_faces() :
-                      0)) *
-         dofs_per_quad);
+       (dim == 2 ? 1 : (dim == 3 ? cell_type.n_faces() : 0)) * dofs_per_quad);
 
     // first_face_line_index
     result.first_object_index_on_face[1][0] =
-      (internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
-       dofs_per_vertex);
+      (cell_type.face_reference_cell(face_no).n_vertices() * dofs_per_vertex);
 
     // first_face_quad_index
     result.first_object_index_on_face[2][0] =
-      ((dim == 3 ?
-          internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
-            dofs_per_vertex :
-          internal::ReferenceCell::get_cell(cell_type).n_vertices() *
-            dofs_per_vertex) +
-       internal::ReferenceCell::get_face(cell_type, face_no).n_lines() *
-         dofs_per_line);
+      ((dim == 3 ? cell_type.face_reference_cell(face_no).n_vertices() *
+                     dofs_per_vertex :
+                   cell_type.n_vertices() * dofs_per_vertex) +
+       cell_type.face_reference_cell(face_no).n_lines() * dofs_per_line);
 
     // dofs_per_face
     result.dofs_per_object_inclusive[dim - 1][0] =
-      (internal::ReferenceCell::get_face(cell_type, face_no).n_vertices() *
-         dofs_per_vertex +
-       internal::ReferenceCell::get_face(cell_type, face_no).n_lines() *
-         dofs_per_line +
+      (cell_type.face_reference_cell(face_no).n_vertices() * dofs_per_vertex +
+       cell_type.face_reference_cell(face_no).n_lines() * dofs_per_line +
        (dim == 3 ? 1 : 0) * dofs_per_quad);
 
 
     // dofs_per_cell
     result.dofs_per_object_inclusive[dim][0] =
-      (internal::ReferenceCell::get_cell(cell_type).n_vertices() *
-         dofs_per_vertex +
-       internal::ReferenceCell::get_cell(cell_type).n_lines() * dofs_per_line +
-       (dim == 2 ?
-          1 :
-          (dim == 3 ? internal::ReferenceCell::get_cell(cell_type).n_faces() :
-                      0)) *
-         dofs_per_quad +
+      (cell_type.n_vertices() * dofs_per_vertex +
+       cell_type.n_lines() * dofs_per_line +
+       (dim == 2 ? 1 : (dim == 3 ? cell_type.n_faces() : 0)) * dofs_per_quad +
        (dim == 3 ? 1 : 0) * dofs_per_hex);
 
     return result;
   }
 } // namespace internal
+
+
 
 template <int dim>
 FiniteElementData<dim>::FiniteElementData(

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -4637,8 +4637,7 @@ FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
   , quadrature(quadrature)
 {
   Assert(quadrature.size() == 1 ||
-           quadrature.size() ==
-             internal::ReferenceCell::get_cell(fe.reference_cell()).n_faces(),
+           quadrature.size() == fe.reference_cell().n_faces(),
          ExcInternalError());
 }
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -154,8 +154,7 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 
       // Compute tangentials to the unit cell.
       const auto reference_cell = this->fe.reference_cell();
-      const auto n_faces =
-        internal::ReferenceCell::get_cell(reference_cell).n_faces();
+      const auto n_faces        = reference_cell.n_faces();
 
       for (unsigned int i = 0; i < n_faces; ++i)
         {
@@ -862,9 +861,8 @@ MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe)
 
   const auto reference_cell = fe.reference_cell();
 
-  const unsigned int n_points = mapping_support_points.size();
-  const unsigned int n_shape_functions =
-    internal::ReferenceCell::get_cell(reference_cell).n_vertices();
+  const unsigned int n_points          = mapping_support_points.size();
+  const unsigned int n_shape_functions = reference_cell.n_vertices();
 
   this->mapping_support_point_weights =
     Table<2, double>(n_points, n_shape_functions);

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -591,8 +591,7 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
           // TODO: only a single reference cell type possible...
           const auto reference_cell =
             this->euler_dof_handler->get_fe().reference_cell();
-          const auto n_faces =
-            internal::ReferenceCell::get_cell(reference_cell).n_faces();
+          const auto n_faces = reference_cell.n_faces();
 
           // Compute tangentials to the unit cell.
           for (unsigned int i = 0; i < n_faces; ++i)

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3346,13 +3346,11 @@ GridIn<dim, spacedim>::read_exodusii(
       AssertThrowExodusII(ierr);
       const ReferenceCell type =
         exodusii_name_to_type(string_temp.data(), n_nodes_per_element);
-      const internal::ReferenceCell::Base &info =
-        internal::ReferenceCell::get_cell(type);
 
       // The number of nodes per element may be larger than what we want to
       // read - for example, if the Exodus file contains a QUAD9 element, we
       // only want to read the first four values and ignore the rest.
-      Assert(int(info.n_vertices()) <= n_nodes_per_element, ExcInternalError());
+      Assert(int(type.n_vertices()) <= n_nodes_per_element, ExcInternalError());
 
       std::vector<int> connection(n_nodes_per_element * n_block_elements);
       ierr = ex_get_conn(ex_id,
@@ -3366,10 +3364,11 @@ GridIn<dim, spacedim>::read_exodusii(
       for (unsigned int elem_n = 0; elem_n < connection.size();
            elem_n += n_nodes_per_element)
         {
-          CellData<dim> cell(info.n_vertices());
-          for (unsigned int i : info.vertex_indices())
+          CellData<dim> cell(type.n_vertices());
+          for (unsigned int i : type.vertex_indices())
             {
-              cell.vertices[info.exodusii_vertex_to_deal_vertex(i)] =
+              cell.vertices[internal::ReferenceCell::get_cell(info)
+                              .exodusii_vertex_to_deal_vertex(i)] =
                 connection[elem_n + i] - 1;
             }
           cell.material_id = element_block_id;

--- a/source/simplex/fe_lib.cc
+++ b/source/simplex/fe_lib.cc
@@ -154,12 +154,12 @@ namespace Simplex
       if (dim == 1)
         return {};
 
-      const auto &info = internal::ReferenceCell::get_cell(
-        dim == 2 ? ReferenceCells::Triangle : ReferenceCells::Tetrahedron);
       std::vector<std::vector<Point<dim - 1>>> unit_face_points;
 
       // all faces have the same support points
-      for (auto face_n : info.face_indices())
+      for (auto face_n :
+           (dim == 2 ? ReferenceCells::Triangle : ReferenceCells::Tetrahedron)
+             .face_indices())
         {
           (void)face_n;
           unit_face_points.emplace_back(

--- a/tests/simplex/fe_lib_01.cc
+++ b/tests/simplex/fe_lib_01.cc
@@ -29,21 +29,19 @@ test(const FiniteElement<dim, spacedim> &fe)
 {
   deallog << fe.get_name() << ": " << std::endl;
 
-  const auto &reference_cell =
-    internal::ReferenceCell::get_cell(fe.reference_cell());
-
   deallog << "  n_dofs_per_vertex(): " << fe.n_dofs_per_vertex() << std::endl;
   deallog << "  n_dofs_per_line():   " << fe.n_dofs_per_line() << std::endl;
 
   deallog << "  n_dofs_per_quad():   ";
-  for (unsigned int i = 0; i < (dim == 2 ? 1 : reference_cell.n_faces()); ++i)
+  for (unsigned int i = 0; i < (dim == 2 ? 1 : fe.reference_cell().n_faces());
+       ++i)
     deallog << fe.n_dofs_per_quad(i) << " ";
   deallog << std::endl;
 
   deallog << "  n_dofs_per_hex():    " << fe.n_dofs_per_hex() << std::endl;
 
   deallog << "  n_dofs_per_face():   ";
-  for (unsigned int i = 0; i < reference_cell.n_faces(); ++i)
+  for (unsigned int i = 0; i < fe.reference_cell().n_faces(); ++i)
     deallog << fe.n_dofs_per_face(i) << " ";
   deallog << std::endl;
 

--- a/tests/simplex/reference_cell_kind_01.cc
+++ b/tests/simplex/reference_cell_kind_01.cc
@@ -29,10 +29,9 @@ template <int dim>
 void
 test(const ReferenceCell &reference_cell)
 {
-  const auto  kind = ReferenceCell(reference_cell);
-  const auto &info = internal::ReferenceCell::get_cell(reference_cell);
+  const auto kind = ReferenceCell(reference_cell);
 
-  for (const auto v : info.vertex_indices())
+  for (const auto v : reference_cell.vertex_indices())
     {
       deallog << v << ": ";
       for (const auto i : kind.faces_for_given_vertex(v))

--- a/tests/simplex/unit_tangential_vectors_01.cc
+++ b/tests/simplex/unit_tangential_vectors_01.cc
@@ -30,8 +30,7 @@ template <int dim>
 void
 test(const ReferenceCell &reference_cell)
 {
-  for (const auto face_no :
-       internal::ReferenceCell::get_cell(reference_cell).face_indices())
+  for (const auto face_no : reference_cell.face_indices())
     {
       deallog << reference_cell.template unit_normal_vectors<dim>(face_no)
               << std::endl;


### PR DESCRIPTION
The current set-up of `ReferenceCell` is a bit funny. Some of the functionality is implemented directly as member functions and largely consists of `if-else if-else if` chains covering all of the 8 different possible reference cells.

But then there is a parallel structure whereby there is a hierarchy of classes in `internal::ReferenceCell` that cover all of the 8 different cases; one accesses this hierarchy via the `internal::ReferenceCell::get_cell()` and `internal::ReferenceCell::get_face()` functions, and these then return a reference to one of 8 possible objects that one can query for other pieces of information such as the number of vertices per object. This avoids the longish chain of `if-else if` statements, but at the cost of a virtual function dispatch; also, getting the right reference of course *also* requires an `if-else if` chain.

I *suspect* that the intention was that one generates this kind of object reference only once and then the cost is simply the virtual function call. That works, except in most places I looked at, no caching is actually happening and we just do both of the steps every time, which is not more efficient. In practice, I would be very surprised if one could measure the cost of the `if-else if` statements -- but if it turns out that we can, we can always either reorder the different `if-else` branches, or switch to a table lookup. In any case, the split across two places also makes it quite hard to find from the documentation which information is where.

This patch does the first step in re-unifying the two classes. It moves the `n_vertices/lines/faces()` functions from `internal::ReferenceCell::Base` to `ReferenceCell` in the first commit. The second commit also moves the corresponding `vertex/line/face_indices()` functions. The last one does `standard_vertex_to_face_and_vertex_index()` and `standard_line_to_face_and_line_index()`. In all cases, I don't remove the original functions from their current location but just make these functions `private`, which allows me to find all of the places where we used them and convert these places. I will remove the functions in a final step, but some of the functions I haven't moved yet require the ones I'm touching here and so I will leave them `private` for now until I really can remove them.

/rebuild