### PR TITLE
Add recv and send data to particle cache

### DIFF
--- a/include/deal.II/particles/partitioner.h
+++ b/include/deal.II/particles/partitioner.h
@@ -99,14 +99,18 @@ namespace Particles
         ghost_particles_iterators;
 
       /**
-       * Vector of char that is used to organize the particle information to be
-       * sent to other processors
+       * Temporary storage that holds the data of the particles to be sent
+       * to other processors to update the ghost particles information
+       * in update_ghost_particles()
+       * send_recv_particles_properties_and_location()
        */
       std::vector<char> send_data;
 
       /**
-       * Vector of char that is used to organize the particle information to
-       * received from other processors
+       * Temporary storage that holds the data of the particles to receive
+       * the ghost particles information from other processors in
+       * in update_ghost_particles()
+       * send_recv_particles_properties_and_location()
        */
       std::vector<char> recv_data;
     };

--- a/include/deal.II/particles/partitioner.h
+++ b/include/deal.II/particles/partitioner.h
@@ -97,6 +97,18 @@ namespace Particles
       std::vector<typename std::multimap<internal::LevelInd,
                                          Particle<dim, spacedim>>::iterator>
         ghost_particles_iterators;
+
+      /**
+       * Vector of char that is used to organize the particle information to be
+       * sent to other processors
+       */
+      std::vector<char> send_data;
+
+      /**
+       * Vector of char that is used to organize the particle information to
+       * received from other processors
+       */
+      std::vector<char> recv_data;
     };
   } // namespace internal
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1521,6 +1521,11 @@ namespace Particles
             n_recv_data[i] * individual_particle_data_size;
 
         ghost_particles_cache.neighbors = neighbors;
+
+        ghost_particles_cache.send_data.resize(
+          ghost_particles_cache.send_pointers.back());
+        ghost_particles_cache.recv_data.resize(
+          ghost_particles_cache.recv_pointers.back());
       }
 
     while (reinterpret_cast<std::size_t>(recv_data_it) -
@@ -1580,13 +1585,11 @@ namespace Particles
       ExcMessage(
         "This function is only implemented for parallel::TriangulationBase objects."));
 
-    std::vector<char> send_data;
+    std::vector<char> &send_data = ghost_particles_cache.send_data;
 
     // Fill data to send
     if (send_pointers.back() > 0)
       {
-        // Allocate space for sending particle data
-        send_data.resize(send_pointers.back());
         void *data = static_cast<void *>(&send_data.front());
 
         // Serialize the data sorted by receiving process
@@ -1599,8 +1602,7 @@ namespace Particles
             }
       }
 
-    // Set up the space for the received particle data
-    std::vector<char> recv_data(recv_pointers.back());
+    std::vector<char> &recv_data = ghost_particles_cache.recv_data;
 
     // Exchange the particle data between domains
     {


### PR DESCRIPTION
This adds the recv and send data to the particle cache in order
to prevent dynamic reallocation of this vector, whose size is not
changing anyway. This can significantly (10%) increase performance
in some of our applications