### PR TITLE
::SolutionTransfer with p::s::Triangulation and artificial cells.

### DIFF
--- a/source/numerics/solution_transfer.cc
+++ b/source/numerics/solution_transfer.cc
@@ -100,12 +100,9 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::prepare_for_pure_refinement()
   std::vector<std::vector<types::global_dof_index>>(n_active_cells)
     .swap(indices_on_cell);
 
-  typename DoFHandlerType::active_cell_iterator cell =
-                                                  dof_handler->begin_active(),
-                                                endc = dof_handler->end();
-
-  for (unsigned int i = 0; cell != endc; ++cell, ++i)
+  for (const auto &cell : dof_handler->active_cell_iterators())
     {
+      const unsigned int i = cell->active_cell_index();
       indices_on_cell[i].resize(cell->get_fe().n_dofs_per_cell());
       // on each cell store the indices of the
       // dofs. after refining we get the values
@@ -138,14 +135,11 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::refine_interpolate(
 
   Vector<typename VectorType::value_type> local_values(0);
 
-  typename DoFHandlerType::cell_iterator cell = dof_handler->begin(),
-                                         endc = dof_handler->end();
-
   typename std::map<std::pair<unsigned int, unsigned int>,
                     Pointerstruct>::const_iterator pointerstruct,
     cell_map_end = cell_map.end();
 
-  for (; cell != endc; ++cell)
+  for (const auto &cell : dof_handler->cell_iterators())
     {
       pointerstruct =
         cell_map.find(std::make_pair(cell->level(), cell->index()));
@@ -265,23 +259,20 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
   Assert(prepared_for != coarsening_and_refinement,
          ExcAlreadyPrepForCoarseAndRef());
 
+  clear();
+  n_dofs_old                 = dof_handler->n_dofs();
   const unsigned int in_size = all_in.size();
+
+#ifdef DEBUG
   Assert(in_size != 0,
          ExcMessage("The array of input vectors you pass to this "
                     "function has no elements. This is not useful."));
-
-  clear();
-
-  const unsigned int n_active_cells =
-    dof_handler->get_triangulation().n_active_cells();
-  (void)n_active_cells;
-  n_dofs_old = dof_handler->n_dofs();
-
   for (unsigned int i = 0; i < in_size; ++i)
     {
       Assert(all_in[i].size() == n_dofs_old,
              ExcDimensionMismatch(all_in[i].size(), n_dofs_old));
     }
+#endif
 
   // first count the number
   // of cells that will be coarsened
@@ -295,13 +286,12 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
       else
         ++n_cells_to_stay_or_refine;
     }
-  Assert((n_cells_to_coarsen + n_cells_to_stay_or_refine) == n_active_cells,
+  Assert((n_cells_to_coarsen + n_cells_to_stay_or_refine) ==
+           dof_handler->get_triangulation().n_active_cells(),
          ExcInternalError());
 
   unsigned int n_coarsen_fathers = 0;
-  for (typename DoFHandlerType::cell_iterator cell = dof_handler->begin();
-       cell != dof_handler->end();
-       ++cell)
+  for (const auto &cell : dof_handler->cell_iterators())
     if (!cell->is_active() && cell->child(0)->coarsen_flag_set())
       ++n_coarsen_fathers;
   Assert(n_cells_to_coarsen >= 2 * n_coarsen_fathers, ExcInternalError());
@@ -328,9 +318,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::
   // the 'to_stay_or_refine' cells 'n_sr' and
   // the 'coarsen_fathers' cells 'n_cf',
   unsigned int n_sr = 0, n_cf = 0;
-  for (typename DoFHandlerType::cell_iterator cell = dof_handler->begin();
-       cell != dof_handler->end();
-       ++cell)
+  for (const auto &cell : dof_handler->cell_iterators())
     {
       // CASE 1: active cell that remains as it is
       if (cell->is_active() && !cell->coarsen_flag_set())
@@ -424,8 +412,9 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::interpolate(
   const std::vector<VectorType> &all_in,
   std::vector<VectorType> &      all_out) const
 {
-  Assert(prepared_for == coarsening_and_refinement, ExcNotPrepared());
   const unsigned int size = all_in.size();
+#ifdef DEBUG
+  Assert(prepared_for == coarsening_and_refinement, ExcNotPrepared());
   Assert(all_out.size() == size, ExcDimensionMismatch(all_out.size(), size));
   for (unsigned int i = 0; i < size; ++i)
     Assert(all_in[i].size() == n_dofs_old,
@@ -438,6 +427,7 @@ SolutionTransfer<dim, VectorType, DoFHandlerType>::interpolate(
       Assert(&all_in[i] != &all_out[j],
              ExcMessage("Vectors cannot be used as input and output"
                         " at the same time!"));
+#endif
 
   Vector<typename VectorType::value_type> local_values;
   std::vector<types::global_dof_index>    dofs;

--- a/tests/mpi/solution_transfer_07.cc
+++ b/tests/mpi/solution_transfer_07.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Verify that SolutionTransfer works on parallel shared Triangulation
+// objects with or without artificial cells.
+//
+// Test 'coarsening_and_refinement'.
+
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test(const bool allow_artificial_cells)
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            allow_artificial_cells);
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  tria.begin_active()->set_refine_flag();
+  tria.prepare_coarsening_and_refinement();
+
+  Vector<double> sol_old(dh.n_dofs());
+  sol_old = 1.;
+
+  SolutionTransfer<dim> soltrans(dh);
+  soltrans.prepare_for_coarsening_and_refinement(sol_old);
+
+  tria.execute_coarsening_and_refinement();
+  dh.distribute_dofs(fe);
+
+  Vector<double> sol_new(dh.n_dofs());
+  soltrans.interpolate(sol_old, sol_new);
+  for (unsigned int i = 0; i < sol_new.size(); ++i)
+    AssertThrow(sol_new[i] == 1., ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("1d");
+  test<1>(false);
+  test<1>(true);
+  deallog.pop();
+  deallog.push("2d");
+  test<2>(false);
+  test<2>(true);
+  deallog.pop();
+  deallog.push("3d");
+  test<3>(false);
+  test<3>(true);
+  deallog.pop();
+}

--- a/tests/mpi/solution_transfer_07.with_mpi=true.mpirun=2.output
+++ b/tests/mpi/solution_transfer_07.with_mpi=true.mpirun=2.output
@@ -1,0 +1,15 @@
+
+DEAL:0:1d::OK
+DEAL:0:1d::OK
+DEAL:0:2d::OK
+DEAL:0:2d::OK
+DEAL:0:3d::OK
+DEAL:0:3d::OK
+
+DEAL:1:1d::OK
+DEAL:1:1d::OK
+DEAL:1:2d::OK
+DEAL:1:2d::OK
+DEAL:1:3d::OK
+DEAL:1:3d::OK
+

--- a/tests/mpi/solution_transfer_08.cc
+++ b/tests/mpi/solution_transfer_08.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Verify that SolutionTransfer works on parallel shared Triangulation
+// objects with or without artificial cells.
+//
+// Test 'pure_refinement'.
+
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test(const bool allow_artificial_cells)
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            allow_artificial_cells);
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  tria.begin_active()->set_refine_flag();
+  tria.prepare_coarsening_and_refinement();
+
+  Vector<double> sol_old(dh.n_dofs());
+  sol_old = 1.;
+
+  SolutionTransfer<dim> soltrans(dh);
+  soltrans.prepare_for_pure_refinement();
+
+  tria.execute_coarsening_and_refinement();
+  dh.distribute_dofs(fe);
+
+  Vector<double> sol_new(dh.n_dofs());
+  soltrans.refine_interpolate(sol_old, sol_new);
+  for (unsigned int i = 0; i < sol_new.size(); ++i)
+    AssertThrow(sol_new[i] == 1., ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("1d");
+  test<1>(false);
+  test<1>(true);
+  deallog.pop();
+  deallog.push("2d");
+  test<2>(false);
+  test<2>(true);
+  deallog.pop();
+  deallog.push("3d");
+  test<3>(false);
+  test<3>(true);
+  deallog.pop();
+}

--- a/tests/mpi/solution_transfer_08.with_mpi=true.mpirun=2.output
+++ b/tests/mpi/solution_transfer_08.with_mpi=true.mpirun=2.output
@@ -1,0 +1,15 @@
+
+DEAL:0:1d::OK
+DEAL:0:1d::OK
+DEAL:0:2d::OK
+DEAL:0:2d::OK
+DEAL:0:3d::OK
+DEAL:0:3d::OK
+
+DEAL:1:1d::OK
+DEAL:1:1d::OK
+DEAL:1:2d::OK
+DEAL:1:2d::OK
+DEAL:1:3d::OK
+DEAL:1:3d::OK
+

--- a/tests/mpi/solution_transfer_09.cc
+++ b/tests/mpi/solution_transfer_09.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Verify that SolutionTransfer yields the same result on parallel
+// shared Triangulation objects with and without artificial cells.
+//
+// Test 'coarsening_and_refinement'.
+
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+Vector<double>
+refine_and_transfer(const Function<dim> &function, Triangulation<dim> &tria)
+{
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  tria.begin_active()->set_refine_flag();
+  tria.prepare_coarsening_and_refinement();
+
+  Vector<double> sol_old(dh.n_dofs());
+  VectorTools::interpolate(MappingQGeneric<dim>(1), dh, function, sol_old);
+
+  SolutionTransfer<dim> soltrans(dh);
+  soltrans.prepare_for_coarsening_and_refinement(sol_old);
+
+  tria.execute_coarsening_and_refinement();
+  dh.distribute_dofs(fe);
+
+  Vector<double> sol_new(dh.n_dofs());
+  soltrans.interpolate(sol_old, sol_new);
+
+  return sol_new;
+}
+
+
+template <int dim>
+void
+test(const Function<dim> &function)
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            false);
+  parallel::shared::Triangulation<dim> tria_artificial(MPI_COMM_WORLD,
+                                                       Triangulation<dim>::none,
+                                                       true);
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  GridGenerator::subdivided_hyper_cube(tria_artificial, 2);
+
+  Vector<double> sol = refine_and_transfer(function, tria);
+  Vector<double> sol_artificial =
+    refine_and_transfer(function, tria_artificial);
+
+  AssertDimension(sol.size(), sol_artificial.size());
+  AssertThrow(sol == sol_artificial, ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("1d");
+  test<1>(Functions::CosineFunction<1>());
+  deallog.pop();
+  deallog.push("2d");
+  test<2>(Functions::CosineFunction<2>());
+  deallog.pop();
+  deallog.push("3d");
+  test<3>(Functions::CosineFunction<3>());
+  deallog.pop();
+}

--- a/tests/mpi/solution_transfer_09.with_mpi=true.mpirun=2.output
+++ b/tests/mpi/solution_transfer_09.with_mpi=true.mpirun=2.output
@@ -1,0 +1,9 @@
+
+DEAL:0:1d::OK
+DEAL:0:2d::OK
+DEAL:0:3d::OK
+
+DEAL:1:1d::OK
+DEAL:1:2d::OK
+DEAL:1:3d::OK
+

--- a/tests/mpi/solution_transfer_10.cc
+++ b/tests/mpi/solution_transfer_10.cc
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Verify that SolutionTransfer yields the same result on parallel
+// shared Triangulation objects with and without artificial cells.
+//
+// Test 'pure_refinement'.
+
+
+#include <deal.II/base/function.h>
+#include <deal.II/base/function_lib.h>
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/solution_transfer.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+Vector<double>
+refine_and_transfer(const Function<dim> &function, Triangulation<dim> &tria)
+{
+  FE_Q<dim>       fe(1);
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(fe);
+
+  tria.begin_active()->set_refine_flag();
+  tria.prepare_coarsening_and_refinement();
+
+  Vector<double> sol_old(dh.n_dofs());
+  VectorTools::interpolate(MappingQGeneric<dim>(1), dh, function, sol_old);
+
+  SolutionTransfer<dim> soltrans(dh);
+  soltrans.prepare_for_pure_refinement();
+
+  tria.execute_coarsening_and_refinement();
+  dh.distribute_dofs(fe);
+
+  Vector<double> sol_new(dh.n_dofs());
+  soltrans.refine_interpolate(sol_old, sol_new);
+
+  return sol_new;
+}
+
+
+template <int dim>
+void
+test(const Function<dim> &function)
+{
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            false);
+  parallel::shared::Triangulation<dim> tria_artificial(MPI_COMM_WORLD,
+                                                       Triangulation<dim>::none,
+                                                       true);
+  GridGenerator::subdivided_hyper_cube(tria, 2);
+  GridGenerator::subdivided_hyper_cube(tria_artificial, 2);
+
+  Vector<double> sol = refine_and_transfer(function, tria);
+  Vector<double> sol_artificial =
+    refine_and_transfer(function, tria_artificial);
+
+  AssertDimension(sol.size(), sol_artificial.size());
+  AssertThrow(sol == sol_artificial, ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog.push("1d");
+  test<1>(Functions::CosineFunction<1>());
+  deallog.pop();
+  deallog.push("2d");
+  test<2>(Functions::CosineFunction<2>());
+  deallog.pop();
+  deallog.push("3d");
+  test<3>(Functions::CosineFunction<3>());
+  deallog.pop();
+}

--- a/tests/mpi/solution_transfer_10.with_mpi=true.mpirun=2.output
+++ b/tests/mpi/solution_transfer_10.with_mpi=true.mpirun=2.output
@@ -1,0 +1,9 @@
+
+DEAL:0:1d::OK
+DEAL:0:2d::OK
+DEAL:0:3d::OK
+
+DEAL:1:1d::OK
+DEAL:1:2d::OK
+DEAL:1:3d::OK
+


### PR DESCRIPTION
Closes #11668.

The provided `Vector` needs to contain valid data on all cells (not only the locally relevant ones).

Further, we use the same kind of code to set and recover the true subdomain ids of `p::s::Triangulations` in multiple locations in the library. We might consider to move it to a separate function.

@adamqc Would you verify that this patch will solve the issue in your use case? I would like to have your okay before merging.