### PR TITLE
N_Vector: get_communicator return nullptr in serial

### DIFF
--- a/tests/sundials/n_vector.cc
+++ b/tests/sundials/n_vector.cc
@@ -314,6 +314,7 @@ test_get_communicator()
 {
   auto vector   = create_test_vector<VectorType>();
   auto n_vector = make_nvector_view(vector);
+  // required by SUNDIALS: MPI-unaware vectors should return the nullptr
   Assert(N_VGetCommunicator(n_vector) == nullptr, NVectorTestError());
 
   deallog << "test_get_communicator OK" << std::endl;


### PR DESCRIPTION
Fixes: N_Vector must return a nullptr for MPI-unaware vectors or in serial.

See https://github.com/dealii/dealii/pull/11701#discussion_r575297184

@masterleinad @bangerth 