### PR TITLE
Add some missing header files for sundials_wrapper.h

### DIFF
--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -23,6 +23,9 @@
 
 #    include <sundials/sundials_linearsolver.h>
 
+#    include <functional>
+#    include <memory>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace SUNDIALS


### PR DESCRIPTION
We use `std::funtion` and `std::unique_ptr` here.