### PR TITLE
New class TemporarilyRestoreSubdomainIds.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -387,7 +387,7 @@ namespace internal
    * @relatesalso AlignedVector
    */
   template <typename T>
-  class AlignedVectorCopy : private parallel::ParallelForInteger
+  class AlignedVectorCopy : private dealii::parallel::ParallelForInteger
   {
     static const std::size_t minimum_parallel_grain_size =
       160000 / sizeof(T) + 1;
@@ -454,7 +454,7 @@ namespace internal
    * @relatesalso AlignedVector
    */
   template <typename T>
-  class AlignedVectorMove : private parallel::ParallelForInteger
+  class AlignedVectorMove : private dealii::parallel::ParallelForInteger
   {
     static const std::size_t minimum_parallel_grain_size =
       160000 / sizeof(T) + 1;
@@ -532,7 +532,7 @@ namespace internal
    * @relatesalso AlignedVector
    */
   template <typename T, bool initialize_memory>
-  class AlignedVectorSet : private parallel::ParallelForInteger
+  class AlignedVectorSet : private dealii::parallel::ParallelForInteger
   {
     static const std::size_t minimum_parallel_grain_size =
       160000 / sizeof(T) + 1;
@@ -634,7 +634,8 @@ namespace internal
    * @relatesalso AlignedVector
    */
   template <typename T, bool initialize_memory>
-  class AlignedVectorDefaultInitialize : private parallel::ParallelForInteger
+  class AlignedVectorDefaultInitialize
+    : private dealii::parallel::ParallelForInteger
   {
     static const std::size_t minimum_parallel_grain_size =
       160000 / sizeof(T) + 1;

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -460,6 +460,73 @@ namespace parallel
 #endif
 } // namespace parallel
 
+
+namespace internal
+{
+  namespace parallel
+  {
+    namespace shared
+    {
+      /**
+       * This class temporarily modifies the subdomain ID of all active cells to
+       * their respective "true" owner.
+       *
+       * The modification only happens on parallel::shared::Triangulation
+       * objects with artificial cells, and persists for the lifetime of an
+       * instantiation of this class.
+       *
+       * The TemporarilyRestoreSubdomainIds class should only be used for
+       * temporary read-only purposes. For example, whenever your implementation
+       * requires to treat artificial cells temporarily as locally relevant to
+       * access their dof indices.
+       *
+       * This class has effect only if artificial cells are allowed. Without
+       * artificial cells, the current subdomain IDs already correspond to the
+       * true subdomain IDs. See the @ref GlossArtificialCell "glossary"
+       * for more information about artificial cells.
+       */
+      template <int dim, int spacedim>
+      class TemporarilyRestoreSubdomainIds : public Subscriptor
+      {
+      public:
+        /**
+         * Constructor.
+         *
+         * Stores the subdomain ID of all active cells if the provided
+         * Triangulation is of type parallel::shared::Triangulation.
+         *
+         * Replaces them by their true subdomain ID equivalent.
+         */
+        TemporarilyRestoreSubdomainIds(
+          const Triangulation<dim, spacedim> &tria);
+
+        /**
+         * Destructor.
+         *
+         * Returns the subdomain ID of all active cells on the
+         * parallel::shared::Triangulation into their previous state.
+         */
+        ~TemporarilyRestoreSubdomainIds();
+
+      private:
+        /**
+         * The modified parallel::shared::Triangulation.
+         */
+        SmartPointer<
+          const dealii::parallel::shared::Triangulation<dim, spacedim>>
+          shared_tria;
+
+        /**
+         * A vector that temporarily stores the subdomain IDs on all active
+         * cells before they have been modified on the
+         * parallel::shared::Triangulation.
+         */
+        std::vector<unsigned int> saved_subdomain_ids;
+      };
+    } // namespace shared
+  }   // namespace parallel
+} // namespace internal
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/source/distributed/shared_tria.inst.in
+++ b/source/distributed/shared_tria.inst.in
@@ -15,19 +15,31 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
     namespace parallel
     \{
       namespace shared
       \{
-        template class Triangulation<deal_II_dimension>;
-#if deal_II_dimension < 3
-        template class Triangulation<deal_II_dimension, deal_II_dimension + 1>;
+#if deal_II_dimension <= deal_II_space_dimension
+        template class Triangulation<deal_II_dimension,
+                                     deal_II_space_dimension>;
 #endif
-#if deal_II_dimension < 2
-        template class Triangulation<deal_II_dimension, deal_II_dimension + 2>;
+      \}
+    \}
+
+    namespace internal
+    \{
+      namespace parallel
+      \{
+        namespace shared
+        \{
+#if deal_II_dimension <= deal_II_space_dimension
+          template class TemporarilyRestoreSubdomainIds<
+            deal_II_dimension,
+            deal_II_space_dimension>;
 #endif
+        \}
       \}
     \}
   }


### PR DESCRIPTION
~Blocked by #11733.~ (Edit: Has been merged.)

We are using true subdomain ids for `p::s::T` in multiple locations of the library. Instead of copying the same code snippet for future uses, this is an attempt to provide a general interface to set true subdomain ids and recover the default ones.

@peterrum @bangerth -- I'm open for naming suggestions.