### PR TITLE
Move LinearAlgebra::CommunicationBase -> Utilities::MPI::CommunicationBase.

### DIFF
--- a/doc/news/changes/minor/20210215DavidWells
+++ b/doc/news/changes/minor/20210215DavidWells
@@ -1,0 +1,4 @@
+Moved: The CommunicationPatternBase class has been moved from the LinearAlgebra
+namespace into the more general Utilities::MPI namespace.
+<br>
+(David Wells, 2021/02/15)

--- a/include/deal.II/base/communication_pattern_base.h
+++ b/include/deal.II/base/communication_pattern_base.h
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_base_communication_pattern_base_h
+#define dealii_base_communication_pattern_base_h
+
+#include <deal.II/base/config.h>
+
+#include <deal.II/base/mpi.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+// Forward declaration
+#ifndef DOXYGEN
+class IndexSet;
+#endif
+
+namespace Utilities
+{
+  namespace MPI
+  {
+    /**
+     * CommunicationPattern is an abstract class that is used to define a
+     * communication plan that can be called repeatedly to efficiently obtain
+     * off-processor elements. The idea is to decouple the communication pattern
+     * from the data that needs to be communicated. The goal is to reuse the
+     * same communication pattern for different containers. This is similar to
+     * the way SparseMatrix and SparsityPattern works.
+     */
+    class CommunicationPatternBase
+    {
+    public:
+      /**
+       * Destructor.
+       */
+      virtual ~CommunicationPatternBase() = default;
+
+      /**
+       * Reinitialize the communication pattern. The first argument
+       * `vector_space_vector_index_set` is the index set associated to a
+       * VectorSpaceVector object. The second argument
+       * `read_write_vector_index_set` is the index set associated to a
+       * ReadWriteVector object.
+       */
+      virtual void
+      reinit(const IndexSet &vector_space_vector_index_set,
+             const IndexSet &read_write_vector_index_set,
+             const MPI_Comm &communicator) = 0;
+
+      /**
+       * Return a constant reference to the underlying MPI communicator.
+       */
+      virtual const MPI_Comm &
+      get_mpi_communicator() const = 0;
+    };
+
+  } // namespace MPI
+
+} // namespace Utilities
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.h
@@ -18,11 +18,11 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
 #include <deal.II/base/mpi_tags.h>
 
-#include <deal.II/lac/communication_pattern_base.h>
 #include <deal.II/lac/vector_space_vector.h>
 
 
@@ -37,7 +37,7 @@ namespace Utilities
      * regarding the order of the underlying index sets.
      */
     class NoncontiguousPartitioner
-      : public dealii::LinearAlgebra::CommunicationPatternBase
+      : public Utilities::MPI::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
@@ -23,7 +23,6 @@
 #include <deal.II/base/mpi_compute_index_owner_internal.h>
 #include <deal.II/base/mpi_noncontiguous_partitioner.h>
 
-#include <deal.II/lac/communication_pattern_base.h>
 #include <deal.II/lac/vector_space_vector.h>
 
 

--- a/include/deal.II/base/partitioner.h
+++ b/include/deal.II/base/partitioner.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/memory_space.h>
@@ -26,7 +27,6 @@
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>
 
-#include <deal.II/lac/communication_pattern_base.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/lac/vector_operation.h>
 
@@ -190,7 +190,7 @@ namespace Utilities
      * detect this case and only send the selected indices, taken from the
      * full array of ghost entries.
      */
-    class Partitioner : public ::dealii::LinearAlgebra::CommunicationPatternBase
+    class Partitioner : public Utilities::MPI::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/lac/communication_pattern_base.h
+++ b/include/deal.II/lac/communication_pattern_base.h
@@ -13,57 +13,25 @@
 //
 // ---------------------------------------------------------------------
 
-#ifndef dealii_communication_pattern_base_h
-#define dealii_communication_pattern_base_h
+#ifndef dealii_lac_communication_pattern_base_h
+#define dealii_lac_communication_pattern_base_h
 
-#include <deal.II/base/config.h>
-
-#include <deal.II/base/mpi.h>
+#include <deal.II/base/communication_pattern_base.h>
 
 DEAL_II_NAMESPACE_OPEN
 
-// Forward declaration
-#ifndef DOXYGEN
-class IndexSet;
-#endif
+DEAL_II_WARNING(
+  "This file is deprecated. Use deal.II/base/communication_pattern_base.h instead!")
 
 namespace LinearAlgebra
 {
   /**
-   * CommunicationPattern is an abstract class that is used to define a
-   * communication plan that can be called repeatedly to efficiently obtain
-   * off-processor elements. The idea is to decouple the communication pattern
-   * from the data that needs to be communicated. The goal is to reuse the same
-   * communication pattern for different containers.
-   * This is similar to the way SparseMatrix and SparsityPattern works.
+   * Alias for Utilities::MPI::CommunicationPatternBase. This class was
+   * originally defined in the LinearAlgebra namespace but is now used for more
+   * general purposes.
    */
-  class CommunicationPatternBase
-  {
-  public:
-    /**
-     * Destructor.
-     */
-    virtual ~CommunicationPatternBase() = default;
-
-    /**
-     * Reinitialize the communication pattern. The first argument
-     * `vector_space_vector_index_set` is the index set associated to a
-     * VectorSpaceVector object. The second argument
-     * `read_write_vector_index_set` is the index set associated to a
-     * ReadWriteVector object.
-     */
-    virtual void
-    reinit(const IndexSet &vector_space_vector_index_set,
-           const IndexSet &read_write_vector_index_set,
-           const MPI_Comm &communicator) = 0;
-
-    /**
-     * Return a constant reference to the underlying MPI communicator.
-     */
-    virtual const MPI_Comm &
-    get_mpi_communicator() const = 0;
-  };
-
+  using CommunicationPatternBase DEAL_II_DEPRECATED_EARLY =
+    Utilities::MPI::CommunicationPatternBase;
 } // end of namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/lac/cuda_vector.h
+++ b/include/deal.II/lac/cuda_vector.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/index_set.h>
 
@@ -30,7 +31,6 @@ DEAL_II_NAMESPACE_OPEN
 
 // Forward declarations
 #  ifndef DOXYGEN
-class CommunicationPatternBase;
 template <typename Number>
 class ReadWriteVector;
 #  endif
@@ -141,11 +141,10 @@ namespace LinearAlgebra
        * copy a vector to the GPU.
        */
       virtual void
-      import(
-        const ReadWriteVector<Number> &                 V,
-        VectorOperation::values                         operation,
-        std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-          std::shared_ptr<const CommunicationPatternBase>()) override;
+      import(const ReadWriteVector<Number> &V,
+             VectorOperation::values        operation,
+             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+               communication_pattern = {}) override;
 
       /**
        * Sets all elements of the vector to the scalar @p s. This operation is

--- a/include/deal.II/lac/la_parallel_block_vector.h
+++ b/include/deal.II/lac/la_parallel_block_vector.h
@@ -476,11 +476,10 @@ namespace LinearAlgebra
        * improve performance.
        */
       virtual void
-      import(
-        const LinearAlgebra::ReadWriteVector<Number> &  V,
-        VectorOperation::values                         operation,
-        std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-          std::shared_ptr<const CommunicationPatternBase>()) override;
+      import(const LinearAlgebra::ReadWriteVector<Number> &V,
+             VectorOperation::values                       operation,
+             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+               communication_pattern = {}) override;
 
       /**
        * Return the scalar product of two vectors.

--- a/include/deal.II/lac/la_parallel_block_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_block_vector.templates.h
@@ -836,9 +836,10 @@ namespace LinearAlgebra
 
     template <typename Number>
     inline void
-    BlockVector<Number>::import(const LinearAlgebra::ReadWriteVector<Number> &,
-                                VectorOperation::values,
-                                std::shared_ptr<const CommunicationPatternBase>)
+    BlockVector<Number>::import(
+      const LinearAlgebra::ReadWriteVector<Number> &,
+      VectorOperation::values,
+      std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>)
     {
       AssertThrow(false, ExcNotImplemented());
     }

--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/memory_space_data.h>
 #include <deal.II/base/mpi.h>
@@ -720,11 +721,10 @@ namespace LinearAlgebra
        * be moved to the device.
        */
       virtual void
-      import(
-        const LinearAlgebra::ReadWriteVector<Number> &  V,
-        VectorOperation::values                         operation,
-        std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-          std::shared_ptr<const CommunicationPatternBase>()) override;
+      import(const LinearAlgebra::ReadWriteVector<Number> &V,
+             VectorOperation::values                       operation,
+             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+               communication_pattern = {}) override;
 
       /**
        * Return the scalar product of two vectors.

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -1282,9 +1282,10 @@ namespace LinearAlgebra
     template <typename Number, typename MemorySpaceType>
     void
     Vector<Number, MemorySpaceType>::import(
-      const ReadWriteVector<Number> &                 V,
-      VectorOperation::values                         operation,
-      std::shared_ptr<const CommunicationPatternBase> communication_pattern)
+      const ReadWriteVector<Number> &V,
+      VectorOperation::values        operation,
+      std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+        communication_pattern)
     {
       // If no communication pattern is given, create one. Otherwise, use the
       // given one.

--- a/include/deal.II/lac/la_vector.h
+++ b/include/deal.II/lac/la_vector.h
@@ -220,11 +220,10 @@ namespace LinearAlgebra
      * This function is not implemented and will throw an exception.
      */
     virtual void
-    import(
-      const ReadWriteVector<Number> &                 V,
-      VectorOperation::values                         operation,
-      std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-        std::shared_ptr<const CommunicationPatternBase>()) override;
+    import(const ReadWriteVector<Number> &V,
+           VectorOperation::values        operation,
+           std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             communication_pattern = {}) override;
 
     /**
      * Add @p a to all components. Note that @p a is a scalar not a vector.

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -250,9 +250,10 @@ namespace LinearAlgebra
 
   template <typename Number>
   void
-  Vector<Number>::import(const ReadWriteVector<Number> &,
-                         VectorOperation::values,
-                         std::shared_ptr<const CommunicationPatternBase>)
+  Vector<Number>::import(
+    const ReadWriteVector<Number> &,
+    VectorOperation::values,
+    std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>)
   {
     AssertThrow(false, ExcMessage("This function is not implemented."));
   }

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
@@ -46,7 +47,6 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 namespace LinearAlgebra
 {
-  class CommunicationPatternBase;
   namespace distributed
   {
     template <typename, typename>
@@ -295,9 +295,8 @@ namespace LinearAlgebra
     void
     import(const distributed::Vector<Number, MemorySpace> &vec,
            VectorOperation::values                         operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 
 #ifdef DEAL_II_WITH_PETSC
     /**
@@ -311,9 +310,8 @@ namespace LinearAlgebra
     void
     import(const PETScWrappers::MPI::Vector &petsc_vec,
            VectorOperation::values           operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 #endif
 
 #ifdef DEAL_II_WITH_TRILINOS
@@ -330,9 +328,8 @@ namespace LinearAlgebra
     void
     import(const TrilinosWrappers::MPI::Vector &trilinos_vec,
            VectorOperation::values              operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 
 #  ifdef DEAL_II_WITH_MPI
 #    ifdef DEAL_II_TRILINOS_WITH_TPETRA
@@ -347,9 +344,8 @@ namespace LinearAlgebra
     void
     import(const TpetraWrappers::Vector<Number> &tpetra_vec,
            VectorOperation::values               operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 #    endif
 
     /**
@@ -363,9 +359,8 @@ namespace LinearAlgebra
     void
     import(const EpetraWrappers::Vector &epetra_vec,
            VectorOperation::values       operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 #  endif
 #endif
 
@@ -379,9 +374,8 @@ namespace LinearAlgebra
     void
     import(const CUDAWrappers::Vector<Number> &cuda_vec,
            VectorOperation::values             operation,
-           const std::shared_ptr<const CommunicationPatternBase>
-             &communication_pattern =
-               std::shared_ptr<const CommunicationPatternBase>());
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             &communication_pattern = {});
 #endif
 
     /**
@@ -623,7 +617,7 @@ namespace LinearAlgebra
       const IndexSet &        locally_owned_elements,
       VectorOperation::values operation,
       const MPI_Comm &        mpi_comm,
-      const std::shared_ptr<const CommunicationPatternBase>
+      const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
         &communication_pattern);
 #  endif
 
@@ -637,7 +631,7 @@ namespace LinearAlgebra
            const IndexSet &          locally_owned_elements,
            VectorOperation::values   operation,
            const MPI_Comm &          mpi_comm,
-           const std::shared_ptr<const CommunicationPatternBase>
+           const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
              &communication_pattern);
 #endif
 
@@ -693,7 +687,7 @@ namespace LinearAlgebra
      * CommunicationPattern for the communication between the
      * source_stored_elements IndexSet and the current vector.
      */
-    std::shared_ptr<CommunicationPatternBase> comm_pattern;
+    std::shared_ptr<Utilities::MPI::CommunicationPatternBase> comm_pattern;
 
     /**
      * Pointer to the array of local elements of this vector.

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -413,7 +413,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const distributed::Vector<Number, MemorySpace> &vec,
     VectorOperation::values                         operation,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     // If no communication pattern is given, create one. Otherwise, use the
@@ -481,7 +481,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const PETScWrappers::MPI::Vector &petsc_vec,
     VectorOperation::values /*operation*/,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       & /*communication_pattern*/)
   {
     // TODO: this works only if no communication is needed.
@@ -514,7 +514,7 @@ namespace LinearAlgebra
     const IndexSet &                                            source_elements,
     VectorOperation::values                                     operation,
     const MPI_Comm &                                            mpi_comm,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     std::shared_ptr<const TpetraWrappers::CommunicationPattern>
@@ -631,7 +631,7 @@ namespace LinearAlgebra
     const IndexSet &          source_elements,
     VectorOperation::values   operation,
     const MPI_Comm &          mpi_comm,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     std::shared_ptr<const EpetraWrappers::CommunicationPattern>
@@ -770,7 +770,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const TrilinosWrappers::MPI::Vector &trilinos_vec,
     VectorOperation::values              operation,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     // While the import does work with Trilinos 12.8.x, it fails with 12.4.x. To
@@ -795,7 +795,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const LinearAlgebra::TpetraWrappers::Vector<Number> &trilinos_vec,
     VectorOperation::values                              operation,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     import(trilinos_vec.trilinos_vector(),
@@ -813,7 +813,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const LinearAlgebra::EpetraWrappers::Vector &trilinos_vec,
     VectorOperation::values                      operation,
-    const std::shared_ptr<const CommunicationPatternBase>
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
       &communication_pattern)
   {
     import(trilinos_vec.trilinos_vector(),
@@ -832,7 +832,7 @@ namespace LinearAlgebra
   ReadWriteVector<Number>::import(
     const LinearAlgebra::CUDAWrappers::Vector<Number> &cuda_vec,
     VectorOperation::values                            operation,
-    const std::shared_ptr<const CommunicationPatternBase> &)
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &)
   {
     const unsigned int n_elements = stored_elements.n_elements();
     if (operation == VectorOperation::insert)

--- a/include/deal.II/lac/trilinos_epetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_epetra_communication_pattern.h
@@ -23,7 +23,7 @@
 
 #  ifdef DEAL_II_WITH_MPI
 
-#    include <deal.II/lac/communication_pattern_base.h>
+#    include <deal.II/base/communication_pattern_base.h>
 
 #    include <Epetra_Import.h>
 
@@ -37,9 +37,10 @@ namespace LinearAlgebra
   {
     /**
      * This class implements a wrapper to a Trilinos Epetra_Import object,
-     * for use in places where a CommunicationPatternBase object is required.
+     * for use in places where a Utilities::MPI::CommunicationPatternBase object
+     * is required.
      */
-    class CommunicationPattern : public CommunicationPatternBase
+    class CommunicationPattern : public Utilities::MPI::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/lac/trilinos_epetra_vector.h
+++ b/include/deal.II/lac/trilinos_epetra_vector.h
@@ -127,11 +127,10 @@ namespace LinearAlgebra
        * improve performance.
        */
       virtual void
-      import(
-        const ReadWriteVector<double> &                 V,
-        VectorOperation::values                         operation,
-        std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-          std::shared_ptr<const CommunicationPatternBase>()) override;
+      import(const ReadWriteVector<double> &V,
+             VectorOperation::values        operation,
+             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+               communication_pattern = {}) override;
 
       /**
        * Multiply the entire vector by a fixed factor.

--- a/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
+++ b/include/deal.II/lac/trilinos_tpetra_communication_pattern.h
@@ -21,7 +21,7 @@
 
 #if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
 
-#  include <deal.II/lac/communication_pattern_base.h>
+#  include <deal.II/base/communication_pattern_base.h>
 
 #  include <Tpetra_Export.hpp>
 #  include <Tpetra_Import.hpp>
@@ -37,7 +37,7 @@ namespace LinearAlgebra
     /**
      * This class implements a wrapper to Tpetra::Import and Tpetra::Export.
      */
-    class CommunicationPattern : public CommunicationPatternBase
+    class CommunicationPattern : public Utilities::MPI::CommunicationPatternBase
     {
     public:
       /**

--- a/include/deal.II/lac/trilinos_tpetra_vector.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.h
@@ -150,11 +150,10 @@ namespace LinearAlgebra
        * improve performance.
        */
       virtual void
-      import(
-        const ReadWriteVector<Number> &                 V,
-        VectorOperation::values                         operation,
-        std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-          std::shared_ptr<const CommunicationPatternBase>()) override;
+      import(const ReadWriteVector<Number> &V,
+             VectorOperation::values        operation,
+             std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+               communication_pattern = {}) override;
 
       /**
        * Multiply the entire vector by a fixed factor.

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -165,9 +165,10 @@ namespace LinearAlgebra
     template <typename Number>
     void
     Vector<Number>::import(
-      const ReadWriteVector<Number> &                 V,
-      VectorOperation::values                         operation,
-      std::shared_ptr<const CommunicationPatternBase> communication_pattern)
+      const ReadWriteVector<Number> &V,
+      VectorOperation::values        operation,
+      std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+        communication_pattern)
     {
       // If no communication pattern is given, create one. Otherwise, use the
       // one given.

--- a/include/deal.II/lac/vector_space_vector.h
+++ b/include/deal.II/lac/vector_space_vector.h
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/base/communication_pattern_base.h>
 #include <deal.II/base/numbers.h>
 
 #include <deal.II/lac/vector_operation.h>
@@ -32,7 +33,6 @@ DEAL_II_NAMESPACE_OPEN
 class IndexSet;
 namespace LinearAlgebra
 {
-  class CommunicationPatternBase;
   template <typename Number>
   class ReadWriteVector;
 } // namespace LinearAlgebra
@@ -107,11 +107,10 @@ namespace LinearAlgebra
      * performance.
      */
     virtual void
-    import(
-      const ReadWriteVector<Number> &                 V,
-      VectorOperation::values                         operation,
-      std::shared_ptr<const CommunicationPatternBase> communication_pattern =
-        std::shared_ptr<const CommunicationPatternBase>()) = 0;
+    import(const ReadWriteVector<Number> &V,
+           VectorOperation::values        operation,
+           std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+             communication_pattern = {}) = 0;
 
     /**
      * Return the scalar product of two vectors.

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -126,9 +126,10 @@ namespace LinearAlgebra
 
     template <typename Number>
     void
-    Vector<Number>::import(const ReadWriteVector<Number> &V,
-                           VectorOperation::values        operation,
-                           std::shared_ptr<const CommunicationPatternBase>)
+    Vector<Number>::import(
+      const ReadWriteVector<Number> &V,
+      VectorOperation::values        operation,
+      std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>)
     {
       if (operation == VectorOperation::insert)
         {

--- a/source/lac/read_write_vector.cc
+++ b/source/lac/read_write_vector.cc
@@ -45,27 +45,27 @@ namespace LinearAlgebra
   ReadWriteVector<float>::import(
     const distributed::Vector<float, ::dealii::MemorySpace::Host> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 
   template void
   ReadWriteVector<double>::import(
     const distributed::Vector<double, ::dealii::MemorySpace::Host> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 #  ifdef DEAL_II_WITH_COMPLEX_VALUES
   template void
   ReadWriteVector<std::complex<float>>::import(
     const distributed::Vector<std::complex<float>, ::dealii::MemorySpace::Host>
       &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 
   template void
   ReadWriteVector<std::complex<double>>::import(
     const distributed::Vector<std::complex<double>, ::dealii::MemorySpace::Host>
       &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 #  endif
 #endif
 } // namespace LinearAlgebra

--- a/source/lac/read_write_vector.cu
+++ b/source/lac/read_write_vector.cu
@@ -25,23 +25,23 @@ namespace LinearAlgebra
   ReadWriteVector<float>::import(
     const CUDAWrappers::Vector<float> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
   template void
   ReadWriteVector<float>::import(
     const distributed::Vector<float, ::dealii::MemorySpace::CUDA> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 
   template void
   ReadWriteVector<double>::import(
     const CUDAWrappers::Vector<double> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
   template void
   ReadWriteVector<double>::import(
     const distributed::Vector<double, ::dealii::MemorySpace::CUDA> &,
     VectorOperation::values,
-    const std::shared_ptr<const CommunicationPatternBase> &);
+    const std::shared_ptr<const Utilities::MPI::CommunicationPatternBase> &);
 } // namespace LinearAlgebra
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -145,9 +145,10 @@ namespace LinearAlgebra
 
     void
     Vector::import(
-      const ReadWriteVector<double> &                 V,
-      VectorOperation::values                         operation,
-      std::shared_ptr<const CommunicationPatternBase> communication_pattern)
+      const ReadWriteVector<double> &V,
+      VectorOperation::values        operation,
+      std::shared_ptr<const Utilities::MPI::CommunicationPatternBase>
+        communication_pattern)
     {
       // If no communication pattern is given, create one. Otherwise, use the
       // one given.


### PR DESCRIPTION
Things use this outside of linear algebra classes now so we should move it out of LinearAlgebra.

Partly related to #11727.