### PR TITLE
Adjust minimum grain size of dictionary for consensus algorithm

### DIFF
--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -157,9 +157,27 @@ namespace Utilities
         struct Dictionary
         {
           /**
-           * The minimum grain size for the ranges.
+           * The minimum grain size for the intervals.
+           *
+           * We choose to limit the smallest size an interval for the
+           * two-stage lookup can have with the following two conflicting
+           * goals in mind: On the one hand, we do not want intervals in the
+           * dictionary to become too short. For uneven distributions of
+           * unknowns (some ranks with several thousands of unknowns, others
+           * with none), the lookup DoFs -> dictionary then involves sending
+           * from one MPI rank to many other MPI ranks holding dictionary
+           * intervals, leading to an exceedingly high number of messages some
+           * ranks have to send. Also, fewer longer intervals are generally
+           * more efficient to look up. On the other hand, a range size too
+           * large leads to opposite effect of many messages that come into a
+           * particular dictionary owner in the lookup DoFs ->
+           * dictionary. With the current setting, we get at most 64 messages
+           * coming to a single MPI rank in case there is 1 dof per MPI rank,
+           * which is reasonably low. At the same time, uneven distributions
+           * up to factors of 4096 can be handled with at most 64 messages as
+           * well.
            */
-          static const unsigned int range_minimum_grain_size = 4096;
+          static const unsigned int range_minimum_grain_size = 64;
 
           /**
            * A vector with as many entries as there are dofs in the dictionary


### PR DESCRIPTION
Fixes #11746. ~~This could be the final fix needed to get the initialization of the triangulation work quickly again also on many MPI ranks, but my jobs to verify this are still in the queue.~~

Update: I verified that initialization times are now similar to the 9.2 release on 40k ranks.