### PR TITLE
Sundials: Mark function as inline

### DIFF
--- a/include/deal.II/sundials/sunlinsol_newempty.h
+++ b/include/deal.II/sundials/sunlinsol_newempty.h
@@ -41,7 +41,7 @@ namespace SUNDIALS
      * Create a new SUNLinearSolver structure without any content and
      * operations set to `nullptr`.
      */
-    SUNLinearSolver
+    inline SUNLinearSolver
     SUNLinSolNewEmpty()
     {
       /* create linear solver object */
@@ -80,7 +80,7 @@ namespace SUNDIALS
      *
      * @param solver The solver memory to free
      */
-    void
+    inline void
     SUNLinSolFreeEmpty(SUNLinearSolver solver)
     {
       if (solver == nullptr)


### PR DESCRIPTION
These two functions have a complete definition in a header file that
gets including in multiple compilation units. In this case we have to
mark these functions as "inline" so that the compiler emits a so-called
"weak symbol". Otherwise linkage will fail due to multiply defined
symbols.

See: https://cdash.43-1.org/buildSummary.php?buildid=16810