### PR TITLE
Remove a deprecated doxygen feature option.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -106,7 +106,6 @@ VERBATIM_HEADERS       = NO
 #---------------------------------------------------------------------------
 
 ALPHABETICAL_INDEX     = YES
-COLS_IN_ALPHA_INDEX    = 3
 
 #---------------------------------------------------------------------------
 # configuration options related to the HTML output


### PR DESCRIPTION
`COLS_IN_ALPHA_INDEX` is deprecated in doxygen 1.9.1 and now I get a warning for it.

The layout generated at

https://www.dealii.org/current/doxygen/deal.II/classes.html

will always now have a single column (with or without the now-deprecated option), which is much more legible anyway.