### PR TITLE
Made Tensor::values a protected data member

### DIFF
--- a/doc/news/changes/minor/20210222AhmadShahba
+++ b/doc/news/changes/minor/20210222AhmadShahba
@@ -1,0 +1,3 @@
+Changed: Madde Tensor::values a protected data member
+<br>
+(Ahmad Shahba, 2021/02/22)

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -747,7 +747,6 @@ private:
   // Allow an arbitrary Tensor to access the underlying values.
   template <int, int, typename>
   friend class Tensor;
-
 };
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -717,7 +717,7 @@ public:
    */
   using tensor_type = Tensor<rank_, dim, Number>;
 
-private:
+protected:
   /**
    * Array of tensors holding the subelements.
    */
@@ -725,6 +725,7 @@ private:
   // ... avoid a compiler warning in case of dim == 0 and ensure that the
   // array always has positive size.
 
+private:
   /**
    * Internal helper function for unroll.
    */
@@ -747,9 +748,6 @@ private:
   template <int, int, typename>
   friend class Tensor;
 
-  // Point is allowed access to the coordinates. This is supposed to improve
-  // speed.
-  friend class Point<dim, Number>;
 };
 
 


### PR DESCRIPTION
`Tensor::values` is currently a private data member. Therefore, classes deriving from `dealii::Tensor` class in external projects would need to do `(*this)[ii] = new_value` (which is a bit ugly) to set and get tensor components. By making `Tensor::values` a protected data member, we can write a bit nicer code `this->values[ii] = new_value` in derived classes. Moreover, it means the `dealii::Point` class does not need to be declared as a friend of the Tensor class any longer