### PR TITLE
Bugfix: DoFHandler connects to Triangulation::Signals only in hp-mode.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1667,6 +1667,13 @@ private:
   std::vector<boost::signals2::connection> tria_listeners;
 
   /**
+   * A list of connections with which this object connects to the
+   * triangulation. They get triggered specifially when data needs to be
+   * transferred due to refinement or repartitioning. Only active in hp-mode.
+   */
+  std::vector<boost::signals2::connection> tria_listeners_for_transfer;
+
+  /**
    * Free all memory used for non-multigrid data structures.
    */
   void
@@ -1700,14 +1707,13 @@ private:
                 const types::global_dof_index global_index) const;
 
   /**
-   * Setup DoFHandler policy.
+   * Set up DoFHandler policy.
    */
   void
   setup_policy();
 
   /**
-   * Setup connections to refinement signals of the underlying triangulation.
-   * Necessary for the hp-mode.
+   * Set up connections to signals of the underlying triangulation.
    */
   void
   connect_to_triangulation_signals();

--- a/source/distributed/solution_transfer.cc
+++ b/source/distributed/solution_transfer.cc
@@ -137,6 +137,10 @@ namespace parallel
       prepare_for_coarsening_and_refinement(
         const std::vector<const VectorType *> &all_in)
     {
+      for (unsigned int i = 0; i < all_in.size(); ++i)
+        Assert(all_in[i]->size() == dof_handler->n_dofs(),
+               ExcDimensionMismatch(all_in[i]->size(), dof_handler->n_dofs()));
+
       input_vectors = all_in;
       register_data_attach();
     }
@@ -230,6 +234,9 @@ namespace parallel
     {
       Assert(input_vectors.size() == all_out.size(),
              ExcDimensionMismatch(input_vectors.size(), all_out.size()));
+      for (unsigned int i = 0; i < all_out.size(); ++i)
+        Assert(all_out[i]->size() == dof_handler->n_dofs(),
+               ExcDimensionMismatch(all_out[i]->size(), dof_handler->n_dofs()));
 
       // TODO: casting away constness is bad
       auto *tria = (dynamic_cast<parallel::DistributedTriangulationBase<

--- a/tests/dofs/clear_signal.cc
+++ b/tests/dofs/clear_signal.cc
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that DoFHandler::clear() will be called
+// whenever Triangulation::Signals::clear is triggered
+
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+void
+test_serial()
+{
+  constexpr const unsigned dim = 2;
+
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria);
+
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(FE_Q<dim>(1));
+
+  tria.clear();
+  deallog << "ndofs:" << dh.n_dofs() << std::endl;
+}
+
+
+void
+test_parallel_shared()
+{
+  constexpr const unsigned dim = 2;
+
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(FE_Q<dim>(1));
+
+  tria.clear();
+  deallog << "ndofs:" << dh.n_dofs() << std::endl;
+}
+
+
+void
+test_parallel_distributed()
+{
+  constexpr const unsigned dim = 2;
+
+  parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria);
+
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(FE_Q<dim>(1));
+
+  tria.clear();
+  deallog << "ndofs:" << dh.n_dofs() << std::endl;
+}
+
+
+void
+test_parallel_fullydistributed()
+{
+  constexpr const unsigned dim = 2;
+
+  parallel::distributed::Triangulation<dim> tria_base(MPI_COMM_WORLD);
+  GridGenerator::hyper_cube(tria_base);
+
+  const auto description =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria_base, MPI_COMM_WORLD);
+
+  parallel::fullydistributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+  tria.create_triangulation(description);
+
+  DoFHandler<dim> dh(tria);
+  dh.distribute_dofs(FE_Q<dim>(1));
+
+  tria.clear();
+  deallog << "ndofs:" << dh.n_dofs() << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  test_serial();
+  test_parallel_shared();
+  test_parallel_distributed();
+  test_parallel_fullydistributed();
+}

--- a/tests/dofs/clear_signal.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/dofs/clear_signal.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,0 +1,5 @@
+
+DEAL::ndofs:0
+DEAL::ndofs:0
+DEAL::ndofs:0
+DEAL::ndofs:0

--- a/tests/fullydistributed_grids/solution_transfer_01.cc
+++ b/tests/fullydistributed_grids/solution_transfer_01.cc
@@ -89,6 +89,7 @@ test(TriangulationType &triangulation)
 
   {
     triangulation.load(filename);
+    dof_handler.distribute_dofs(FE_Q<dim>(2));
 
     parallel::distributed::SolutionTransfer<dim, VectorType> solution_transfer(
       dof_handler);


### PR DESCRIPTION
Closes #11768.

Whenever a `Triangulation` will be cleared, the enumeration of dofs on associated `DoFHandlers` is no longer valid. This PR proposes to also clear the `DoFHandlers` as well.