### PR TITLE
Adapt the order of factors in an integral.

### DIFF
--- a/examples/step-7/step-7.cc
+++ b/examples/step-7/step-7.cc
@@ -660,8 +660,8 @@ namespace Step7
 
                   for (unsigned int i = 0; i < dofs_per_cell; ++i)
                     cell_rhs(i) +=
-                      (neumann_value *                          // g(x_q)
-                       fe_face_values.shape_value(i, q_point) * // phi_i(x_q)
+                      (fe_face_values.shape_value(i, q_point) * // phi_i(x_q)
+                       neumann_value *                          // g(x_q)
                        fe_face_values.JxW(q_point));            // dx
                 }
             }


### PR DESCRIPTION
Multiply test function from the left, as we usually do. (Follow-up to #11799.)

/rebuild