### PR TITLE
Remove a commented-out part of code.

### DIFF
--- a/tests/sundials/kinsol_01.cc
+++ b/tests/sundials/kinsol_01.cc
@@ -43,13 +43,6 @@ main(int argc, char **argv)
   ParameterHandler                             prm;
   data.add_parameters(prm);
 
-  if (false)
-    {
-      std::ofstream ofile(SOURCE_DIR "/kinsol_01.prm");
-      prm.print_parameters(ofile, ParameterHandler::ShortText);
-      ofile.close();
-    }
-
   std::ifstream ifile(SOURCE_DIR "/kinsol_01.prm");
   prm.parse_input(ifile);
 


### PR DESCRIPTION
I suspect that the code was originally used to generate an input file, but if anyone commented it in by accident now, it would overwrite the current input file and lead to test errors.

/rebuild