### PR TITLE
Conversion from a linear solver to a SUNLinSolver

### DIFF
--- a/include/deal.II/sundials/arkode.h
+++ b/include/deal.II/sundials/arkode.h
@@ -975,6 +975,27 @@ namespace SUNDIALS
      */
     LinearSolveFunction<VectorType> solve_linearized_system;
 
+
+    /**
+     * Set the given @p solver for the solution of the linearized system.
+     *
+     * @note Alternative to setting solve_linearized_system directly.
+     */
+    template <typename SolverType>
+    void
+    set_linear_solver(SolverType &solver);
+
+    /**
+     * Set the given @p solver with SolverControl @p control for the solution of
+     * the linearized system. The @p control will receive tolerances directly
+     * from SUNDIALS.
+     *
+     * @note Alternative to setting solve_linearized_system directly.
+     */
+    template <typename SolverType>
+    void
+    set_linear_solver(SolverType &solver, SolverControl &control);
+
     /**
      * A LinearSolveFunction object that users may supply and that is intended
      * to solve the mass system $Mx=b$. The matrix-vector product $Mx$ is
@@ -1314,6 +1335,33 @@ namespace SUNDIALS
                  << ". Please consult SUNDIALS manual.");
 
 } // namespace SUNDIALS
+
+/*-------------------------------- Inline functions ------------------------*/
+
+#  ifndef DOXYGEN
+
+template <typename VectorType>
+template <typename SolverType>
+void
+SUNDIALS::ARKode<VectorType>::set_linear_solver(SolverType &solver)
+{
+  linear_solver =
+    std::make_unique<internal::LinearSolverWrapper<VectorType>>(solver);
+}
+
+
+
+template <typename VectorType>
+template <typename SolverType>
+void
+SUNDIALS::ARKode<VectorType>::set_linear_solver(SolverType &   solver,
+                                                SolverControl &control)
+{
+  linear_solver =
+    std::make_unique<internal::LinearSolverWrapper<VectorType>>(solver,
+                                                                control);
+}
+#  endif
 
 DEAL_II_NAMESPACE_CLOSE
 #endif

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -653,6 +653,11 @@ namespace SUNDIALS
                 solve_linearized_system);
             sun_linear_solver = *linear_solver;
           }
+        else if (linear_solver)
+          {
+            // user called set_linear_solver() which already created the wrapper
+            sun_linear_solver = *linear_solver;
+          }
         else
           {
             // use default solver from SUNDIALS

--- a/tests/sundials/arkode_07.cc
+++ b/tests/sundials/arkode_07.cc
@@ -118,17 +118,9 @@ main(int argc, char **argv)
     return 0;
   };
 
-  ode.solve_linearized_system =
-    [&](SUNDIALS::SundialsOperator<VectorType> &      op,
-        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
-        VectorType &                                  x,
-        const VectorType &                            b,
-        double                                        tol) -> int {
-    ReductionControl     control;
-    SolverCG<VectorType> solver_cg(control);
-    solver_cg.solve(op, x, b, prec);
-    return 0;
-  };
+  ReductionControl     control;
+  SolverCG<VectorType> solver_cg(control);
+  ode.set_linear_solver(solver_cg, control);
 
   ode.jacobian_preconditioner_setup = [&](double            t,
                                           const VectorType &y,


### PR DESCRIPTION
I want to use this PR to discuss the interface of linear solvers with SUNDIALS. #11278 introduced a std::function that carries out the linear solve. For that functions, I assume that most users would write something like (copied from a test)

```cpp
  const auto solve_function =
    [&](SUNDIALS::SundialsOperator<VectorType> &      op,
        SUNDIALS::SundialsPreconditioner<VectorType> &prec,
        VectorType &                                  x,
        const VectorType &                            b,
        double                                        tol) -> int {
    ReductionControl     control;
    SolverCG<VectorType> solver_cg(control);
    solver_cg.solve(op, x, b, prec);
    return 0;
  };
```
which is quite verbose for a simple solve call. Most of the code is boilerplate and the SUNDIALS operators are irritating. Instead, it seems more natural to just pass a solver (and the control, more on that below) to ARKode, KINSOL ...

This PR adds such a function to ARKode's interface, currently redundant to the old way.

@bangerth might be interesting for you in context of #11829 

fyi @luca-heltai 