### PR TITLE
doxygen: stop unintentional cross-referencing of 'Function'.

### DIFF
--- a/include/deal.II/base/job_identifier.h
+++ b/include/deal.II/base/job_identifier.h
@@ -67,7 +67,7 @@ public:
   operator()() const;
 
   /**
-   * Function to identify the presently running program.
+   * %Function to identify the presently running program.
    */
   static const JobIdentifier &
   get_dealjobid();

--- a/include/deal.II/base/parsed_convergence_table.h
+++ b/include/deal.II/base/parsed_convergence_table.h
@@ -345,7 +345,7 @@ public:
    *
    *
    * @param column_name Name of the column to add;
-   * @param custom_function Function that will be called to fill the given
+   * @param custom_function %Function that will be called to fill the given
    * entry. You need to make sure that the scope of this function is valid
    * up to the call to error_from_exact() or difference();
    * @param compute_rate If set to true, then this column will be included in

--- a/include/deal.II/base/parsed_function.h
+++ b/include/deal.II/base/parsed_function.h
@@ -128,7 +128,7 @@ namespace Functions
      *
      *  @endcode
      *
-     * Function constants is a collection of pairs in the form name=value,
+     * %Function constants is a collection of pairs in the form name=value,
      * separated by commas, for example:
      *
      *  @code

--- a/include/deal.II/distributed/cell_data_transfer.h
+++ b/include/deal.II/distributed/cell_data_transfer.h
@@ -214,10 +214,10 @@ namespace parallel
        *   container stores values that differ in size. A varying amount of data
        *   may be packed per cell, if for example the underlying ValueType of
        *   the VectorType container is a container itself.
-       * @param[in] refinement_strategy Function deciding how data will be
-       * stored on refined cells from its parent cell.
-       * @param[in] coarsening_strategy Function deciding which data to store on
-       *   a cell whose children will get coarsened into.
+       * @param[in] refinement_strategy %Function deciding how data will be
+       *   stored on refined cells from its parent cell.
+       * @param[in] coarsening_strategy %Function deciding which data to store
+       *   on a cell whose children will get coarsened into.
        */
       CellDataTransfer(
         const parallel::distributed::Triangulation<dim, spacedim>
@@ -246,8 +246,8 @@ namespace parallel
        *   container stores values that differ in size. A varying amount of data
        *   may be packed per cell, if for example the underlying ValueType of
        *   the VectorType container is a container itself.
-       * @param[in] coarsening_strategy Function deciding which data to store on
-       *   a cell whose children will get coarsened into.
+       * @param[in] coarsening_strategy %Function deciding which data to store
+       *   on a cell whose children will get coarsened into.
        *
        * @deprecated Use the above constructor instead.
        */
@@ -341,7 +341,7 @@ namespace parallel
       const bool transfer_variable_size_data;
 
       /**
-       * Function deciding how data will be stored on refined cells from its
+       * %Function deciding how data will be stored on refined cells from its
        * parent cell.
        */
       const std::function<std::vector<value_type>(
@@ -350,7 +350,7 @@ namespace parallel
         refinement_strategy;
 
       /**
-       * Function deciding on how to process data from children to be stored on
+       * %Function deciding on how to process data from children to be stored on
        * the parent cell.
        */
       const std::function<value_type(

--- a/include/deal.II/hp/fe_collection.h
+++ b/include/deal.II/hp/fe_collection.h
@@ -528,7 +528,7 @@ namespace hp
     get_hierarchy_sequence(const unsigned int fe_index = 0) const;
 
     /**
-     * Function returning the index of the finite element following the given
+     * %Function returning the index of the finite element following the given
      * @p fe_index in hierarchy.
      *
      * By default, the index succeeding @p fe_index will be returned. If @p fe_index
@@ -540,7 +540,7 @@ namespace hp
     next_in_hierarchy(const unsigned int fe_index) const;
 
     /**
-     * Function returning the index of the finite element preceding the given
+     * %Function returning the index of the finite element preceding the given
      * @p fe_index in hierarchy.
      *
      * By default, the index preceding @p fe_index will be returned. If @p fe_index
@@ -768,7 +768,7 @@ namespace hp
       finite_elements;
 
     /**
-     * Function returning the index of the finite element following the given
+     * %Function returning the index of the finite element following the given
      * one in hierarchy.
      */
     std::function<unsigned int(const typename hp::FECollection<dim, spacedim> &,
@@ -776,7 +776,7 @@ namespace hp
       hierarchy_next;
 
     /**
-     * Function returning the index of the finite element preceding the given
+     * %Function returning the index of the finite element preceding the given
      * one in hierarchy.
      */
     std::function<unsigned int(const typename hp::FECollection<dim, spacedim> &,

--- a/include/deal.II/lac/lapack_support.h
+++ b/include/deal.II/lac/lapack_support.h
@@ -73,7 +73,7 @@ namespace LAPACKSupport
   };
 
   /**
-   * Function printing the name of a State.
+   * %Function printing the name of a State.
    */
   inline const char *
   state_name(State s)
@@ -122,7 +122,7 @@ namespace LAPACKSupport
   };
 
   /**
-   * Function printing the name of a Property.
+   * %Function printing the name of a Property.
    */
   inline const char *
   property_name(const Property s)

--- a/include/deal.II/lac/matrix_out.h
+++ b/include/deal.II/lac/matrix_out.h
@@ -161,7 +161,7 @@ private:
   std::string name;
 
   /**
-   * Function by which the base class's functions get to know what patches
+   * %Function by which the base class's functions get to know what patches
    * they shall write to a file.
    */
   virtual const std::vector<Patch> &

--- a/include/deal.II/lac/petsc_solver.h
+++ b/include/deal.II/lac/petsc_solver.h
@@ -186,7 +186,7 @@ namespace PETScWrappers
     const MPI_Comm mpi_communicator;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is requested by the derived class.
      */
     virtual void
@@ -311,7 +311,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -362,7 +362,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -412,7 +412,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -462,7 +462,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -529,7 +529,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -580,7 +580,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -629,7 +629,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -679,7 +679,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -734,7 +734,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -784,7 +784,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -835,7 +835,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void
@@ -890,7 +890,7 @@ namespace PETScWrappers
     const AdditionalData additional_data;
 
     /**
-     * Function that takes a Krylov Subspace Solver context object, and sets
+     * %Function that takes a Krylov Subspace Solver context object, and sets
      * the type of solver that is appropriate for this class.
      */
     virtual void

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -475,7 +475,7 @@ namespace MatrixFreeOperators
     bool have_interface_matrices;
 
     /**
-     * Function which implements vmult_add (@p transpose = false) and
+     * %Function which implements vmult_add (@p transpose = false) and
      * Tvmult_add (@p transpose = true).
      */
     void

--- a/include/deal.II/matrix_free/task_info.h
+++ b/include/deal.II/matrix_free/task_info.h
@@ -336,7 +336,7 @@ namespace internal
         DynamicSparsityPattern &          connectivity_blocks) const;
 
       /**
-       * Function to create coloring on the second layer within each
+       * %Function to create coloring on the second layer within each
        * partition.
        */
       void
@@ -349,7 +349,7 @@ namespace internal
         std::vector<unsigned int> &      partition_color_list);
 
       /**
-       * Function to create partitioning on the second layer within each
+       * %Function to create partitioning on the second layer within each
        * partition.
        */
       void

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -373,7 +373,7 @@ private:
   const MGLevelObject<MGTwoLevelTransfer<dim, VectorType>> &transfer;
 
   /**
-   * Function to initialize internal level vectors.
+   * %Function to initialize internal level vectors.
    */
   const std::function<void(const unsigned int, VectorType &)>
     initialize_dof_vector;

--- a/include/deal.II/numerics/cell_data_transfer.h
+++ b/include/deal.II/numerics/cell_data_transfer.h
@@ -119,9 +119,9 @@ public:
    * @param[in] triangulation The triangulation on which all operations will
    *   happen. At the time when this constructor is called, the refinement
    *   in question has not happened yet.
-   * @param[in] refinement_strategy Function deciding how data will be stored on
-   *   refined cells from its parent cell.
-   * @param[in] coarsening_strategy Function deciding which data to store on
+   * @param[in] refinement_strategy %Function deciding how data will be stored
+   *   on refined cells from its parent cell.
+   * @param[in] coarsening_strategy %Function deciding which data to store on
    *   a cell whose children will get coarsened into.
    */
   CellDataTransfer(
@@ -165,7 +165,7 @@ private:
     triangulation;
 
   /**
-   * Function deciding how data will be stored on refined cells from its parent
+   * %Function deciding how data will be stored on refined cells from its parent
    * cell.
    */
   const std::function<std::vector<value_type>(
@@ -174,7 +174,7 @@ private:
     refinement_strategy;
 
   /**
-   * Function deciding on how to process data from children to be stored on the
+   * %Function deciding on how to process data from children to be stored on the
    * parent cell.
    */
   const std::function<value_type(

--- a/include/deal.II/numerics/data_out_dof_data.h
+++ b/include/deal.II/numerics/data_out_dof_data.h
@@ -1000,7 +1000,7 @@ protected:
   std::vector<Patch> patches;
 
   /**
-   * Function by which the base class's functions get to know what patches
+   * %Function by which the base class's functions get to know what patches
    * they shall write to a file.
    */
   virtual const std::vector<Patch> &

--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -241,7 +241,7 @@ namespace SUNDIALS
        * @param strategy Solution strategy
        * @param maximum_non_linear_iterations Maximum number of nonlinear
        * iterations
-       * @param function_tolerance Function norm stopping tolerance
+       * @param function_tolerance %Function norm stopping tolerance
        * @param step_tolerance Scaled step stopping tolerance
        *
        * Newton parameters:

--- a/include/deal.II/sundials/sunlinsol_wrapper.h
+++ b/include/deal.II/sundials/sunlinsol_wrapper.h
@@ -66,7 +66,7 @@ namespace SUNDIALS
     void *A_data;
 
     /**
-     * Function pointer declared by SUNDIALS to evaluate the matrix vector
+     * %Function pointer declared by SUNDIALS to evaluate the matrix vector
      * product.
      */
     ATimesFn a_times_fn;
@@ -109,7 +109,7 @@ namespace SUNDIALS
     void *P_data;
 
     /**
-     * Function pointer to a function that computes the preconditioner
+     * %Function pointer to a function that computes the preconditioner
      * application.
      */
     PSolveFn p_solve_fn;


### PR DESCRIPTION
I've spotted that `doxygen` cross-references many occurrences of `Function` in the documentation unintentionally to the actual `dealii::Function` class. With the `%` flag, this can be disabled. See [doxygen documentation](https://www.doxygen.nl/manual/autolink.html#linkclass).

---

Old:
![Screenshot from 2021-03-02 01-36-45](https://user-images.githubusercontent.com/18285973/109621013-d530d900-7b3a-11eb-8cff-5c6379f6caf6.png)

New:
![Screenshot from 2021-03-02 01-25-42](https://user-images.githubusercontent.com/18285973/109620900-af0b3900-7b3a-11eb-85e6-b458590d6800.png)
