### PR TITLE
Save output if simplex tests have failed

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -59,6 +59,8 @@ jobs:
         cmake --version
     - name: configure
       run: |
+        mkdir build
+        cd build
         cmake -D CMAKE_BUILD_TYPE=Debug \
               -D DEAL_II_CXX_FLAGS='-Werror' \
               -D DEAL_II_EARLY_DEPRECATIONS=ON \
@@ -72,19 +74,30 @@ jobs:
               -D HDF5_LIBRARY="/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5.so" \
               -D HDF5_HL_LIBRARY="/usr/lib/x86_64-linux-gnu/hdf5/openmpi/libhdf5_hl.so" \
               -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
-              .
+              ..
     - name: archive
       uses: actions/upload-artifact@v1
       with:
         name: linux-simplex-detailed.log
-        path: detailed.log
+        path: build/detailed.log
     - name: build
       run: |
+        cd build
         make -j 2
     - name: test
       run: |
+        cd build
         make -j 2 setup_tests_simplex
         ctest --output-on-failure -j 2
+    - name: failed test log
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-log
+        path: |
+          build/tests/**/*output*
+          build/tests/**/*stdout*
+
 
   linux-debug-cuda-10:
     # simple parallel debug build using cuda-10


### PR DESCRIPTION
Not optimal, since all output files in the simplex test folder are saved if any of the test fails. But for now it is OK, since the size of the whole output is less than one MB (once we have significantly more tests I would suggest to abandon the GitHub action and go to Jenkins). The output can be accessed zipped via the GitHub action.

Tried out for #11503.

FYI @bangerth @michelebucelli (sorry for taking this long)