### PR TITLE
Enable Utilities::MPI::compute_point_to_point_communication_pattern for self communication

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -368,9 +368,6 @@ namespace Utilities
         {
           (void)destination;
           AssertIndexRange(destination, n_procs);
-          Assert(destination != myid,
-                 ExcMessage(
-                   "There is no point in communicating with ourselves."));
         }
 
 #  if DEAL_II_MPI_VERSION_GTE(3, 0)


### PR DESCRIPTION
In many cases, it allows to writer simpler code if one assume that a process can also communicate with itself, since no extra specialization has to be explicitly written. This might be a bit slower since data has be written and read to/from buffers but the code is simpler.