### PR TITLE
Added Utilities::MPI::logical_or().

### DIFF
--- a/doc/news/changes/minor/20210304Fehling
+++ b/doc/news/changes/minor/20210304Fehling
@@ -1,0 +1,3 @@
+New: Utilities::MPI::logical_or() for collective <i>logical or</i> operations.
+<br>
+(Marc Fehling, 2021/03/04)

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1188,6 +1188,16 @@ namespace Utilities
     }
 
 
+    template bool
+    logical_or<bool>(const bool &, const MPI_Comm &);
+
+
+    template void
+    logical_or<bool>(const ArrayView<const bool> &,
+                     const MPI_Comm &,
+                     const ArrayView<bool> &);
+
+
     template std::vector<unsigned int>
     compute_set_union(const std::vector<unsigned int> &vec,
                       const MPI_Comm &                 comm);

--- a/tests/mpi/collective_logical_or.cc
+++ b/tests/mpi/collective_logical_or.cc
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::logical_or()
+
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  bool collective_false = Utilities::MPI::logical_or(false, MPI_COMM_WORLD);
+  bool collective_alternating =
+    Utilities::MPI::logical_or(((myid % 2) == 0) ? true : false,
+                               MPI_COMM_WORLD);
+
+  if (myid == 0)
+    deallog << std::boolalpha << collective_false << ' '
+            << collective_alternating << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+
+#endif
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test();
+      deallog.pop();
+    }
+  else
+    test();
+}

--- a/tests/mpi/collective_logical_or.mpirun=1.output
+++ b/tests/mpi/collective_logical_or.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or.mpirun=10.output
+++ b/tests/mpi/collective_logical_or.mpirun=10.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or.mpirun=4.output
+++ b/tests/mpi/collective_logical_or.mpirun=4.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array.cc
+++ b/tests/mpi/collective_logical_or_array.cc
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::logical_or() for arrays
+
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  bool values[2] = {false, (myid % 2) == 0};
+  bool results[2];
+  Utilities::MPI::logical_or(values, MPI_COMM_WORLD, results);
+  Assert(results[0] == false, ExcInternalError());
+  Assert(results[1] == true, ExcInternalError());
+
+  if (myid == 0)
+    deallog << std::boolalpha << results[0] << ' ' << results[1] << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+
+#endif
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test();
+      deallog.pop();
+    }
+  else
+    test();
+}

--- a/tests/mpi/collective_logical_or_array.mpirun=1.output
+++ b/tests/mpi/collective_logical_or_array.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array.mpirun=10.output
+++ b/tests/mpi/collective_logical_or_array.mpirun=10.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array.mpirun=4.output
+++ b/tests/mpi/collective_logical_or_array.mpirun=4.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array_in_place.cc
+++ b/tests/mpi/collective_logical_or_array_in_place.cc
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::logical_or() for arrays, but with input=output
+
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  bool results[2] = {false, (myid % 2) == 0};
+  Utilities::MPI::logical_or(results, MPI_COMM_WORLD, results);
+  Assert(results[0] == false, ExcInternalError());
+  Assert(results[1] == true, ExcInternalError());
+
+  if (myid == 0)
+    deallog << std::boolalpha << results[0] << ' ' << results[1] << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+
+#endif
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test();
+      deallog.pop();
+    }
+  else
+    test();
+}

--- a/tests/mpi/collective_logical_or_array_in_place.mpirun=1.output
+++ b/tests/mpi/collective_logical_or_array_in_place.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array_in_place.mpirun=10.output
+++ b/tests/mpi/collective_logical_or_array_in_place.mpirun=10.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_array_in_place.mpirun=4.output
+++ b/tests/mpi/collective_logical_or_array_in_place.mpirun=4.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector.cc
+++ b/tests/mpi/collective_logical_or_vector.cc
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::logical_or() for vectors
+//
+// std::vector<bool> does not necessarily store elements in contiguous array,
+// use std::vector<char> instead
+
+#include <deal.II/base/mpi.templates.h>
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  std::vector<char> values = {0, (myid % 2) == 0};
+  std::vector<char> results(2);
+  Utilities::MPI::logical_or(values, MPI_COMM_WORLD, results);
+  Assert(results[0] == false, ExcInternalError());
+  Assert(results[1] == true, ExcInternalError());
+
+  if (myid == 0)
+    deallog << std::boolalpha << static_cast<bool>(results[0]) << ' '
+            << static_cast<bool>(results[1]) << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+
+#endif
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test();
+      deallog.pop();
+    }
+  else
+    test();
+}

--- a/tests/mpi/collective_logical_or_vector.mpirun=1.output
+++ b/tests/mpi/collective_logical_or_vector.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector.mpirun=10.output
+++ b/tests/mpi/collective_logical_or_vector.mpirun=10.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector.mpirun=4.output
+++ b/tests/mpi/collective_logical_or_vector.mpirun=4.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector_in_place.cc
+++ b/tests/mpi/collective_logical_or_vector_in_place.cc
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check Utilities::MPI::logical_or for vectors, but with input=output
+//
+// std::vector<bool> does not necessarily store elements in contiguous array,
+// use std::vector<char> instead
+
+#include <deal.II/base/mpi.templates.h>
+#include <deal.II/base/utilities.h>
+
+#include "../tests.h"
+
+void
+test()
+{
+  const unsigned int myid = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  std::vector<char> results = {0, (myid % 2) == 0};
+  Utilities::MPI::logical_or(results, MPI_COMM_WORLD, results);
+  Assert(results[0] == false, ExcInternalError());
+  Assert(results[1] == true, ExcInternalError());
+
+  if (myid == 0)
+    deallog << std::boolalpha << static_cast<bool>(results[0]) << ' '
+            << static_cast<bool>(results[1]) << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+#ifdef DEAL_II_WITH_MPI
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(
+    argc, argv, testing_max_num_threads());
+#else
+  (void)argc;
+  (void)argv;
+  compile_time_error;
+
+#endif
+
+  if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    {
+      initlog();
+
+      deallog.push("mpi");
+      test();
+      deallog.pop();
+    }
+  else
+    test();
+}

--- a/tests/mpi/collective_logical_or_vector_in_place.mpirun=1.output
+++ b/tests/mpi/collective_logical_or_vector_in_place.mpirun=1.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector_in_place.mpirun=10.output
+++ b/tests/mpi/collective_logical_or_vector_in_place.mpirun=10.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true

--- a/tests/mpi/collective_logical_or_vector_in_place.mpirun=4.output
+++ b/tests/mpi/collective_logical_or_vector_in_place.mpirun=4.output
@@ -1,0 +1,2 @@
+
+DEAL:mpi::false true


### PR DESCRIPTION
New function for collective _logical or_ operations. Will be used in a follow-up PR.

Can not be used on `std::vector<bool>` since its specialization may not store its elements in a contiguous array.