### PR TITLE
Improve assert in FEFaceEvaluation

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -8493,7 +8493,10 @@ FEFaceEvaluation<dim,
       face_index <
         this->matrix_info->get_task_info().boundary_partition_data.back())
     Assert(this->is_interior_face,
-           ExcMessage("Boundary faces do not have a neighbor"));
+           ExcMessage(
+             "Boundary faces do not have a neighbor. When looping over "
+             "boundary faces use FEFaceEvaluation with the parameter "
+             "is_interior_face set to true. "));
 
   this->face_no =
     (this->is_interior_face ? faces.interior_face_no : faces.exterior_face_no);


### PR DESCRIPTION
This PR makes the assert message, when `FEFaceEvaluation` is configured with `is_interior_face=false` and a boundary face is requested, more verbose. This assert could happen if one is used to `FEEvaluation` and uses `FEFaceEvaluation<dim>` in the same spirit, with the second argument being the `dof_idx`, which will be in case of `dof_idx=0` implicitly converted to `bool is_interior_face=false`. More details on this issue are pointed out in #11845.