### PR TITLE
Make active_cell_index_partitioner to std::shared_ptr

### DIFF
--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -206,14 +206,14 @@ namespace parallel
      * Return partitioner for the global indices of the cells on the active
      * level of the triangulation.
      */
-    const Utilities::MPI::Partitioner &
+    const std::weak_ptr<const Utilities::MPI::Partitioner>
     global_active_cell_index_partitioner() const;
 
     /**
      * Return partitioner for the global indices of the cells on the given @p
      * level of the triangulation.
      */
-    const Utilities::MPI::Partitioner &
+    const std::weak_ptr<const Utilities::MPI::Partitioner>
     global_level_cell_index_partitioner(const unsigned int level) const;
 
     /**
@@ -356,12 +356,14 @@ namespace parallel
       /**
        * Partitioner for the global active cell indices.
        */
-      Utilities::MPI::Partitioner active_cell_index_partitioner;
+      std::shared_ptr<const Utilities::MPI::Partitioner>
+        active_cell_index_partitioner;
 
       /**
        * Partitioner for the global level cell indices for each level.
        */
-      std::vector<Utilities::MPI::Partitioner> level_cell_index_partitioners;
+      std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
+        level_cell_index_partitioners;
 
       NumberCache();
     };

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -443,7 +443,8 @@ namespace parallel
     is_ghost.add_indices(is_ghost_vector.begin(), is_ghost_vector.end());
 
     number_cache.active_cell_index_partitioner =
-      Utilities::MPI::Partitioner(is_local, is_ghost, this->mpi_communicator);
+      std::make_shared<const Utilities::MPI::Partitioner>(
+        is_local, is_ghost, this->mpi_communicator);
 
     // 6) proceed with multigrid levels if requested
     if (this->is_multilevel_hierarchy_constructed() == true)
@@ -536,9 +537,8 @@ namespace parallel
                                  is_ghost_vector.end());
 
             number_cache.level_cell_index_partitioners[l] =
-              Utilities::MPI::Partitioner(is_local,
-                                          is_ghost,
-                                          this->mpi_communicator);
+              std::make_shared<const Utilities::MPI::Partitioner>(
+                is_local, is_ghost, this->mpi_communicator);
           }
       }
 
@@ -598,14 +598,14 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  const Utilities::MPI::Partitioner &
+  const std::weak_ptr<const Utilities::MPI::Partitioner>
   TriangulationBase<dim, spacedim>::global_active_cell_index_partitioner() const
   {
     return number_cache.active_cell_index_partitioner;
   }
 
   template <int dim, int spacedim>
-  const Utilities::MPI::Partitioner &
+  const std::weak_ptr<const Utilities::MPI::Partitioner>
   TriangulationBase<dim, spacedim>::global_level_cell_index_partitioner(
     const unsigned int level) const
   {

--- a/tests/grid/global_ids_01.cc
+++ b/tests/grid/global_ids_01.cc
@@ -45,7 +45,8 @@ test(int n_refinements, MPI_Comm comm)
       deallog << cell->id() << " -> " << cell->subdomain_id() << " "
               << cell->global_active_cell_index() << std::endl;
 
-  const auto &part = tria.global_active_cell_index_partitioner();
+  const Utilities::MPI::Partitioner &part =
+    *tria.global_active_cell_index_partitioner().lock();
 
   part.locally_owned_range().print(deallog);
   part.ghost_indices().print(deallog);

--- a/tests/grid/global_ids_03.cc
+++ b/tests/grid/global_ids_03.cc
@@ -52,7 +52,8 @@ test(int n_refinements, MPI_Comm comm)
           deallog << cell->id() << " -> " << cell->level_subdomain_id() << " "
                   << cell->global_level_cell_index() << std::endl;
 
-      const auto &part = tria.global_level_cell_index_partitioner(l);
+      const Utilities::MPI::Partitioner &part =
+        *tria.global_level_cell_index_partitioner(l).lock();
 
       part.locally_owned_range().print(deallog);
       part.ghost_indices().print(deallog);


### PR DESCRIPTION
While reviewing #11857, I noticed that it would be better to make `active_cell_index_partitioner` and `level_cell_index_partitioners` to `std::shared_ptr`, since this is the way it is needed to set up global vectors (in my opinion the main purpose of the partitioner).