### PR TITLE
Mark some classes as 'extern template'.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -2272,6 +2272,15 @@ DoFHandler<dim, spacedim>::MGVertexDoFs::set_index(
 }
 
 
+
+extern template class DoFHandler<1, 1>;
+extern template class DoFHandler<1, 2>;
+extern template class DoFHandler<1, 3>;
+extern template class DoFHandler<2, 2>;
+extern template class DoFHandler<2, 3>;
+extern template class DoFHandler<3, 3>;
+
+
 #endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -4399,6 +4399,13 @@ bool
 Triangulation<1, 3>::prepare_coarsening_and_refinement();
 
 
+extern template class Triangulation<1, 1>;
+extern template class Triangulation<1, 2>;
+extern template class Triangulation<1, 3>;
+extern template class Triangulation<2, 2>;
+extern template class Triangulation<2, 3>;
+extern template class Triangulation<3, 3>;
+
 #endif // DOXYGEN
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
This is an experiment that uncovered what I fixed in #11856. C++11 allows us to mark templates as `extern` if we have explicit instantiations elsewhere. This tries this out for `Triangulation` and `DoFHandler` to see whether we save something.

This saves a small amount of space and, possibly, compile time. Here is a comparison of the cumulative size of all object files for the debug and release configurations without and with the patch:

without patch:
debug   2,414,548,192
release   459,866,272

with patch:
debug    2,404,864,416
release    459,686,888

One can also compare the sizes of the .so files. I did this only for the release library:

without patch: 459,866,272
with patch:    459,686,888

So it's a rather minor improvement. One could do this to a lot more classes than just the two in this patch, though, if we wanted to go that route. Whether that's worth it is a different question. 

Discussion encouraged!

/rebuild