### PR TITLE
Remove outdated comment of DoFCellAccessor::get_dof_indices()

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -1864,10 +1864,6 @@ public:
    * <code>fe.n_dofs_per_cell()</code>) but instead that the returned values are
    * the <i>global</i> indices of those degrees of freedom that are located
    * locally on the current cell.
-   *
-   * @deprecated Currently, this function can also be called for non-active
-   * cells, if all degrees of freedom of the FiniteElement are located in
-   * vertices. This functionality will vanish in a future release.
    */
   void
   get_dof_indices(std::vector<types::global_dof_index> &dof_indices) const;


### PR DESCRIPTION
Fixes #11886.

Actually, the assert was already in place:

https://github.com/dealii/dealii/blob/aa1397400d6f9165ef0da509d6646e8623faafff/include/deal.II/dofs/dof_accessor.templates.h#L2571-L2577

so that I only removed the note.