### PR TITLE
Fix TriangulationBase::reset_global_cell_indices()

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -400,14 +400,17 @@ namespace parallel
           for (unsigned int i = 0; i < n_subdomains; ++i)
             cell_counter[i + 1] += cell_counter[i];
 
+          AssertDimension(cell_counter.back(), this->n_active_cells());
+
           // create partitioners
-          IndexSet is_local(cell_counter.back());
+          IndexSet is_local(this->n_active_cells());
           is_local.add_range(cell_counter[my_subdomain],
                              cell_counter[my_subdomain + 1]);
-          IndexSet is_ghost(cell_counter.back());
           number_cache.active_cell_index_partitioner =
             std::make_shared<const Utilities::MPI::Partitioner>(
-              is_local, is_ghost, this->mpi_communicator);
+              is_local,
+              complete_index_set(this->n_active_cells()),
+              this->mpi_communicator);
 
           // set global active cell indices and increment process-local counters
           for (const auto &cell : this->active_cell_iterators())

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2711,11 +2711,8 @@ DoFHandler<dim, spacedim>::prepare_coarsening_and_refinement(
         dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
           &(*tria)))
     {
-      const auto &partitioner =
-        *parallel_tria->global_active_cell_index_partitioner().lock();
-      future_levels.reinit(partitioner.locally_owned_range(),
-                           partitioner.ghost_indices(),
-                           partitioner.get_mpi_communicator());
+      future_levels.reinit(
+        parallel_tria->global_active_cell_index_partitioner().lock());
     }
   else
     {


### PR DESCRIPTION
Fixes the failing tests:
```
	4237 - mpi/prepare_coarsening_and_refinement_01.mpirun=4.debug (Failed)
	4239 - mpi/prepare_coarsening_and_refinement_02.mpirun=4.debug (Failed)
```

The following test is still failing:
```
	4241 - mpi/prepare_coarsening_and_refinement_03.mpirun=4.debug (Failed)
```
with:
```
4210: An error occurred in line <90> of file </home/munch/sw-index/dealii2/source/distributed/shared_tria.cc> in function
4210:     void dealii::parallel::shared::Triangulation<dim, spacedim>::partition() [with int dim = 2; int spacedim = 2]
4210: The violated condition was: 
4210:     max_active_cells == this->n_active_cells()
4210: Additional information: 
4210:     A parallel::shared::Triangulation needs to be refined in the same way
4210:     on all processors, but the participating processors don't agree on the
4210:     number of active cells.

```

FYI @marcfehling 
