### PR TITLE
Fix refinement flags in mpi/prepare_coarsening_and_refinement_03().

### DIFF
--- a/tests/mpi/prepare_coarsening_and_refinement_03.cc
+++ b/tests/mpi/prepare_coarsening_and_refinement_03.cc
@@ -80,10 +80,9 @@ test(parallel::TriangulationBase<dim> &tria,
   for (unsigned int i = 0; i < n_refinements; ++i)
     {
       for (const auto &cell : tria.active_cell_iterators())
-        if (cell->is_locally_owned())
-          for (unsigned int v = 0; v < cell->n_vertices(); ++v)
-            if (cell->vertex(v)[0] == 0.)
-              cell->set_refine_flag();
+        for (unsigned int v = 0; v < cell->n_vertices(); ++v)
+          if (cell->vertex(v)[0] == 0.)
+            cell->set_refine_flag();
 
       tria.execute_coarsening_and_refinement();
     }


### PR DESCRIPTION
Spotted in #11901.

While it is sufficient to only set refinement flags on locally owned cells for distributed Triangulation classes, it is mandatory to do that on all cells for shared Triangulations.

This PR together with #11901 will fix the current issues with `tests/mpi/prepare_coarsening_and_refinement_*`.