### PR TITLE
Use std::pair for local_cell_relations

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -266,7 +266,7 @@ namespace parallel
 
       /**
        * Go through all locally owned cells and store the relations between
-       * cells and their status in the private member local_cell_relations.
+       * cells and their CellStatus in the private member local_cell_relations.
        *
        * The stored vector will be ordered by the occurrence of cells.
        */

--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -30,7 +30,6 @@
 #include <functional>
 #include <list>
 #include <set>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -33,7 +33,6 @@
 #include <functional>
 #include <list>
 #include <set>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -695,8 +694,8 @@ namespace parallel
       typename dealii::internal::p4est::types<dim>::ghost *parallel_ghost;
 
       /**
-       * Go through all p4est trees and store the relations between the status
-       * of locally owned quadrants and cells in the private member
+       * Go through all p4est trees and store the relations between a deal.II
+       * cell and its current CellStatus in the private member
        * local_cell_relations.
        *
        * The stored vector will be ordered by the occurrence of quadrants in

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -30,7 +30,6 @@
 #include <functional>
 #include <list>
 #include <set>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -689,9 +688,10 @@ namespace parallel
                        const unsigned int n_attached_deserialize_variable);
 
     /**
-     * Go through all cells and store the relations between locally
-     * owned quadrants and cells in the private member
-     * local_cell_relations.
+     * Go through all cells and store the relations between a deal.II cell and
+     * its current CellStatus in the private member local_cell_relations.
+     * For an extensive description of CellStatus, see the documentation
+     * for the member function register_data_attach().
      *
      * The stored vector will be ordered by the occurrence of quadrants.
      */
@@ -704,12 +704,12 @@ namespace parallel
      * description of the latter, see the documentation for the member
      * function register_data_attach().
      */
-    using cell_relation_t = typename std::tuple<CellStatus, cell_iterator>;
+    using cell_relation_t = typename std::pair<cell_iterator, CellStatus>;
 
     /**
-     * Vector of tuples, which each contain a deal.II cell
+     * Vector of pair, each containing a deal.II cell iterator
      * and their relation after refinement. To update its contents, use the
-     * compute_cell_relations member function.
+     * update_cell_relations() member function.
      *
      * The size of this vector is assumed to be equal to the number of locally
      * owned quadrants in the parallel_forest object.

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -419,7 +419,7 @@ namespace parallel
             continue;
 
           this->local_cell_relations[cell_id] =
-            std::make_tuple(Triangulation<dim, spacedim>::CELL_PERSIST, cell);
+            std::make_pair(cell, Triangulation<dim, spacedim>::CELL_PERSIST);
           ++cell_id;
         }
     }

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -745,7 +745,7 @@ namespace parallel
           {
             (void)cell_rel;
             Assert(
-              (std::get<0>(cell_rel) == // cell_status
+              (cell_rel.second == // cell_status
                parallel::DistributedTriangulationBase<dim,
                                                       spacedim>::CELL_PERSIST),
               ExcInternalError());
@@ -819,7 +819,7 @@ namespace parallel
       {
         // reset all cell_status entries after coarsening/refinement
         for (auto &cell_rel : local_cell_relations)
-          std::get<0>(cell_rel) =
+          cell_rel.second =
             parallel::DistributedTriangulationBase<dim, spacedim>::CELL_PERSIST;
       }
   }
@@ -893,8 +893,8 @@ namespace parallel
       auto data_cell_variable_it = packed_variable_size_data.begin();
       for (; cell_rel_it != cell_relations.cend(); ++cell_rel_it)
         {
-          const auto &cell_status = std::get<0>(*cell_rel_it);
-          const auto &dealii_cell = std::get<1>(*cell_rel_it);
+          const auto &dealii_cell = cell_rel_it->first;
+          const auto &cell_status = cell_rel_it->second;
 
           // Assertions about the tree structure.
           switch (cell_status)
@@ -1197,7 +1197,7 @@ namespace parallel
     for (; cell_rel_it != cell_relations.end();
          ++cell_rel_it, dest_fixed_it += sizes_fixed_cumulative.back())
       {
-        std::get<0>(*cell_rel_it) = // cell_status
+        cell_rel_it->second = // cell_status
           Utilities::unpack<typename parallel::DistributedTriangulationBase<
             dim,
             spacedim>::CellStatus>(dest_fixed_it,
@@ -1298,8 +1298,8 @@ namespace parallel
     auto dest_sizes_it = dest_sizes_variable.cbegin();
     for (; cell_rel_it != cell_relations.end(); ++cell_rel_it)
       {
-        const auto &cell_status = std::get<0>(*cell_rel_it);
-        const auto &dealii_cell = std::get<1>(*cell_rel_it);
+        const auto &dealii_cell = cell_rel_it->first;
+        const auto &cell_status = cell_rel_it->second;
 
         if (callback_variable_transfer)
           {


### PR DESCRIPTION
This PR proposes to store the `p::DistributedTriangulationBase::local_cell_relations` member as a `std::vector<std::pair<cell_iterator, CellStatus>>`, rather than a `std::vector<std::tuple<CellStatus, cell_iterator>>`.

The `std::tuple` was a leftover from #11515, whereas the swapped sorting `cell_iterator <-> CellStatus` is just for consistency with the `p::d::SolutionTransfer` callback methods (_e.g._ [this one](https://github.com/dealii/dealii/blob/master/include/deal.II/distributed/solution_transfer.h#L345)).

Related to #11589.
