### PR TITLE
Use correct invalid unsigned value for 64 bit integers

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -1249,13 +1249,13 @@ namespace internal
           tria_level.global_active_cell_indices.insert(
             tria_level.global_active_cell_indices.end(),
             total_cells - tria_level.global_active_cell_indices.size(),
-            numbers::invalid_unsigned_int);
+            numbers::invalid_dof_index);
 
           tria_level.global_level_cell_indices.reserve(total_cells);
           tria_level.global_level_cell_indices.insert(
             tria_level.global_level_cell_indices.end(),
             total_cells - tria_level.global_level_cell_indices.size(),
-            numbers::invalid_unsigned_int);
+            numbers::invalid_dof_index);
 
           if (dimension < space_dimension)
             {


### PR DESCRIPTION
While looking at something else, I observed that we do not use self-explaining initialization of unsigned integers, even though they should become 64 bit integers in case we have those enabled: https://github.com/dealii/dealii/blob/287024f7e8e158926c613e9007f1573ff27fde85/include/deal.II/grid/tria_levels.h#L108-L113