### PR TITLE
examples/step-69: use std::copy_n instead of std::copy

### DIFF
--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -1329,7 +1329,7 @@ namespace Step69
   ProblemDescription<dim>::momentum(const state_type &U)
   {
     Tensor<1, dim> result;
-    std::copy(&U[1], &U[1 + dim], &result[0]);
+    std::copy_n(&U[1], dim, &result[0]);
     return result;
   }
 


### PR DESCRIPTION
A std::copy_n is more more elegant than the std::copy variant that need
to take the address of an element past the momentum.

Thanks to @guermond and @ejtovar for pointing this out.