### PR TITLE
Document that adaptation flags need to be placed on all procs for p:s:Tria.

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -70,6 +70,11 @@ namespace parallel
      * about cells owned by other processors with the exception of a single
      * layer of ghost cells around their own part of the domain.
      *
+     * As a consequence of storing the entire mesh on each processor, active
+     * cells need to be flagged for refinement or coarsening consistently on
+     * all processors if you want to adapt them, regardless of being classified
+     * as locally owned, ghost or artificial.
+     *
      * The class is also useful in cases where compute time and memory
      * considerations dictate that the program needs to be run in parallel,
      * but where algorithmic concerns require that every processor knows


### PR DESCRIPTION
Follow-up to #11905.

@bangerth -- FYI