### PR TITLE
Fix storage of boundary_id in MatrixFree

### DIFF
--- a/doc/news/changes/minor/20210316MartinKronbichler
+++ b/doc/news/changes/minor/20210316MartinKronbichler
@@ -1,0 +1,5 @@
+Fixed: MatrixFree::get_boundary_id() would previously only support boundary ids
+between 0 and 255 via an `unsigned char` type. This has now been changed to
+the correct types::boundary_id type, supporting also larger boundary ids.
+<br>
+(Martin Kronbichler, 2021/03/16)

--- a/include/deal.II/matrix_free/face_info.h
+++ b/include/deal.II/matrix_free/face_info.h
@@ -77,17 +77,17 @@ namespace internal
 
       /**
        * Index of the face between 0 and GeometryInfo::faces_per_cell within
-       * the cells on the "interior" side of the faces.
-       */
-      unsigned char interior_face_no;
-
-      /**
-       * Index of the face between 0 and GeometryInfo::faces_per_cell within
        * the cells on the "exterior" side of the faces.
        *
        * For a boundary face, this data field stores the boundary id.
        */
-      unsigned char exterior_face_no;
+      types::boundary_id exterior_face_no;
+
+      /**
+       * Index of the face between 0 and GeometryInfo::faces_per_cell within
+       * the cells on the "interior" side of the faces.
+       */
+      unsigned char interior_face_no;
 
       /**
        * For adaptively refined meshes, the cell on the exterior side of the

--- a/tests/matrix_free/boundary_id.cc
+++ b/tests/matrix_free/boundary_id.cc
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check MatrixFree::boundary_id() for some large boundary id numbers
+// (exceeding a very old case of 8 bit integers)
+
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include "../tests.h"
+
+
+template <int dim>
+void
+test()
+{
+  Triangulation<dim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1);
+  unsigned int count = 0;
+  for (unsigned int face = 0; face < 2 * dim; ++face)
+    {
+      tria.begin()->face(face)->set_boundary_id(count);
+      count += 100000;
+    }
+
+  MappingQGeneric<dim> mapping(1);
+  FE_Q<dim>            fe(1);
+  DoFHandler<dim>      dof(tria);
+  dof.distribute_dofs(fe);
+  AffineConstraints<double> constraints;
+  constraints.close();
+
+  MatrixFree<dim>                          mf_data;
+  typename MatrixFree<dim>::AdditionalData data;
+  data.tasks_parallel_scheme = MatrixFree<dim>::AdditionalData::none;
+  data.mapping_update_flags_inner_faces =
+    (update_gradients | update_JxW_values);
+  data.mapping_update_flags_boundary_faces =
+    (update_gradients | update_JxW_values);
+
+  mf_data.reinit(mapping, dof, constraints, QGauss<1>(2), data);
+  for (unsigned int i = 0; i < mf_data.n_boundary_face_batches(); ++i)
+    deallog << "Face "
+            << static_cast<unsigned int>(
+                 mf_data.get_face_info(i).interior_face_no)
+            << " boundary id " << mf_data.get_boundary_id(i) << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test<2>();
+  test<3>();
+}

--- a/tests/matrix_free/boundary_id.output
+++ b/tests/matrix_free/boundary_id.output
@@ -1,0 +1,11 @@
+
+DEAL::Face 0 boundary id 0
+DEAL::Face 1 boundary id 100000
+DEAL::Face 2 boundary id 200000
+DEAL::Face 3 boundary id 300000
+DEAL::Face 0 boundary id 0
+DEAL::Face 1 boundary id 100000
+DEAL::Face 2 boundary id 200000
+DEAL::Face 3 boundary id 300000
+DEAL::Face 4 boundary id 400000
+DEAL::Face 5 boundary id 500000


### PR DESCRIPTION
FYI @bergbauer @nfehn 

The old code would only use 8 bit integers for the boundary id (I think we did that very long back in the past also for the cell iterators). The correct thing to do is to use `types::boundary_id`. To nicely place this into the `FaceInfo`, which is sensitive on performance, I moved the field that stores the boundary id before all `unsigned char` types, making sure that there are no gaps in memory.