### PR TITLE
Treat cells to be h-coarsened as their parent in DoFHandler::prepare_coarsening_and_refinement().

### DIFF
--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -2952,6 +2952,11 @@ DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
         ExcMessage(
           "You ask for information on children of this cell which is only "
           "available for active cells. One of its children is not active."));
+      Assert(child->is_locally_owned(),
+             ExcMessage(
+               "You ask for information on children of this cell which is only "
+               "available for locally owned cells. One of its children is not "
+               "locally owned."));
       future_fe_indices_children.insert(child->future_fe_index());
     }
   Assert(!future_fe_indices_children.empty(), ExcInternalError());

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -724,6 +724,13 @@ public:
    * call this function, nor will it be automatically invoked in any part of the
    * library (contrary to its Triangulation counterpart).
    *
+   * On cells that will be h-coarsened, we enforce the difference criterion as
+   * if it's already a parent cell. That means, we set the level of all siblings
+   * to the highest one among them. In that case, all sibling cells need to have
+   * the h-coarsenening flags set terminally via
+   * Triangulation::prepare_coarsening_and_refinement() beforehand. Otherwise
+   * an assertion will be triggered.
+   *
    * Returns whether any future FE indices have been changed by this function.
    */
   bool

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2762,8 +2762,8 @@ DoFHandler<dim, spacedim>::prepare_coarsening_and_refinement(
                    (typename dealii::Triangulation<dim, spacedim>::
                       ExcInconsistentCoarseningFlags()));
 
-            const level_type child_level =
-              future_levels[child->global_active_cell_index()];
+            const level_type child_level = static_cast<level_type>(
+              future_levels[child->global_active_cell_index()]);
             Assert(child_level != invalid_level,
                    ExcMessage("The FiniteElement on one of the siblings of "
                               "a cell you are trying to coarsen is not part "

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -1957,8 +1957,8 @@ namespace internal
         static unsigned int
         determine_fe_from_children(
           const typename Triangulation<dim, spacedim>::cell_iterator &,
-          const std::vector<unsigned int> &        children_fe_indices,
-          dealii::hp::FECollection<dim, spacedim> &fe_collection)
+          const std::vector<unsigned int> &              children_fe_indices,
+          const dealii::hp::FECollection<dim, spacedim> &fe_collection)
         {
           Assert(!children_fe_indices.empty(), ExcInternalError());
 

--- a/tests/hp/prepare_coarsening_and_refinement_04.cc
+++ b/tests/hp/prepare_coarsening_and_refinement_04.cc
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// verify restrictions on level differences imposed by
+// DoFHandler::prepare_coarsening_and_refinement()
+// on h-coarsened grids
+
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/tria.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+#include "../test_grids.h"
+
+
+template <int dim>
+void
+test(const unsigned int max_difference)
+{
+  Assert(max_difference > 0, ExcInternalError());
+
+  // setup FE collection
+  const unsigned int fes_size = 2 * max_difference + 2;
+
+  hp::FECollection<dim> fes;
+  while (fes.size() < fes_size)
+    fes.push_back(FE_Q<dim>(1));
+
+  const unsigned int contains_fe_index = 0;
+  const auto         sequence = fes.get_hierarchy_sequence(contains_fe_index);
+
+  // set up line grid
+  // - refine central cell and flag them for coarsening
+  // - assign highest p-level to leftmost cell
+  //
+  // +-------+---+---+-------+
+  // |       | c | c |       |
+  // |       +---+---+       |
+  // |       | c | c |       |
+  // +-------+---+---+-------+
+  //
+  // after prepare_coarsening_and_refinement(), the p-levels should propagate
+  // through the central cells as if they were already coarsened
+
+  Triangulation<dim> tria;
+  TestGrids::hyper_line(tria, 3);
+
+  // refine the central cell
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  // now flag these cells for coarsening
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_coarsen_flag();
+
+  DoFHandler<dim> dofh(tria);
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->center()[0] < 1.)
+      cell->set_active_fe_index(sequence.back());
+  dofh.distribute_dofs(fes);
+
+  const bool fe_indices_changed =
+    dofh.prepare_coarsening_and_refinement(max_difference, contains_fe_index);
+  (void)fe_indices_changed;
+  Assert(fe_indices_changed, ExcInternalError());
+
+  deallog << "future FE indices before adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    deallog << " " << cell->id().to_string() << " " << cell->future_fe_index()
+            << std::endl;
+
+  tria.execute_coarsening_and_refinement();
+
+  deallog << "active FE indices after adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    deallog << " " << cell->id().to_string() << " " << cell->active_fe_index()
+            << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test<2>(1);
+  test<2>(2);
+  test<2>(3);
+}

--- a/tests/hp/prepare_coarsening_and_refinement_04.output
+++ b/tests/hp/prepare_coarsening_and_refinement_04.output
@@ -1,0 +1,37 @@
+
+DEAL::future FE indices before adaptation:
+DEAL:: 0_0: 3
+DEAL:: 2_0: 1
+DEAL:: 1_1:0 2
+DEAL:: 1_1:1 2
+DEAL:: 1_1:2 2
+DEAL:: 1_1:3 2
+DEAL::active FE indices after adaptation:
+DEAL:: 0_0: 3
+DEAL:: 1_0: 2
+DEAL:: 2_0: 1
+DEAL::OK
+DEAL::future FE indices before adaptation:
+DEAL:: 0_0: 5
+DEAL:: 2_0: 1
+DEAL:: 1_1:0 3
+DEAL:: 1_1:1 3
+DEAL:: 1_1:2 3
+DEAL:: 1_1:3 3
+DEAL::active FE indices after adaptation:
+DEAL:: 0_0: 5
+DEAL:: 1_0: 3
+DEAL:: 2_0: 1
+DEAL::OK
+DEAL::future FE indices before adaptation:
+DEAL:: 0_0: 7
+DEAL:: 2_0: 1
+DEAL:: 1_1:0 4
+DEAL:: 1_1:1 4
+DEAL:: 1_1:2 4
+DEAL:: 1_1:3 4
+DEAL::active FE indices after adaptation:
+DEAL:: 0_0: 7
+DEAL:: 1_0: 4
+DEAL:: 2_0: 1
+DEAL::OK

--- a/tests/mpi/prepare_coarsening_and_refinement_04.cc
+++ b/tests/mpi/prepare_coarsening_and_refinement_04.cc
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// verify restrictions on level differences imposed by
+// DoFHandler::prepare_coarsening_and_refinement()
+// on h-coarsened grids
+
+
+#include <deal.II/distributed/shared_tria.h>
+#include <deal.II/distributed/tria.h>
+#include <deal.II/distributed/tria_base.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/hp/fe_collection.h>
+
+#include "../tests.h"
+
+#include "../test_grids.h"
+
+
+template <int dim>
+void
+test(parallel::TriangulationBase<dim> &tria, const unsigned int max_difference)
+{
+  Assert(tria.n_levels() == 0, ExcInternalError());
+  Assert(max_difference > 0, ExcInternalError());
+
+  // setup FE collection
+  const unsigned int fes_size = 2 * max_difference + 2;
+
+  hp::FECollection<dim> fes;
+  while (fes.size() < fes_size)
+    fes.push_back(FE_Q<dim>(1));
+
+  const unsigned int contains_fe_index = 0;
+  const auto         sequence = fes.get_hierarchy_sequence(contains_fe_index);
+
+  // set up line grid
+  // - refine central cell and flag them for coarsening
+  // - assign highest p-level to leftmost cell
+  //
+  // +-------+---+---+-------+
+  // |       | c | c |       |
+  // |       +---+---+       |
+  // |       | c | c |       |
+  // +-------+---+---+-------+
+  //
+  // after prepare_coarsening_and_refinement(), the p-levels should propagate
+  // through the central cells as if they were already coarsened
+
+  TestGrids::hyper_line(tria, 3);
+
+  // refine the central cell
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  // now flag these cells for coarsening
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_coarsen_flag();
+
+  DoFHandler<dim> dofh(tria);
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned() && cell->center()[0] < 1.)
+      cell->set_active_fe_index(sequence.back());
+  dofh.distribute_dofs(fes);
+
+  const bool fe_indices_changed =
+    dofh.prepare_coarsening_and_refinement(max_difference, contains_fe_index);
+  (void)fe_indices_changed;
+  Assert(fe_indices_changed, ExcInternalError());
+
+  deallog << "future FE indices before adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      deallog << " " << cell->id().to_string() << " " << cell->future_fe_index()
+              << std::endl;
+
+  tria.execute_coarsening_and_refinement();
+
+  deallog << "active FE indices after adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      deallog << " " << cell->id().to_string() << " " << cell->active_fe_index()
+              << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  constexpr const unsigned int dim = 2;
+
+  // Known bug:
+  //   Collecting FE indices for parent cells on children fails for p::s::T
+  //   at the moment whenever siblings belong to the different processors.
+  //
+  //  deallog << "parallel::shared::Triangulation" << std::endl;
+  //  {
+  //    parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD);
+  //
+  //    test<dim>(tria, 1);
+  //    tria.clear();
+  //    test<dim>(tria, 2);
+  //    tria.clear();
+  //    test<dim>(tria, 3);
+  //  }
+  //
+  //  deallog << "parallel::shared::Triangulation with artificial cells"
+  //          << std::endl;
+  //  {
+  //    parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+  //                                              Triangulation<dim>::none,
+  //                                              /*allow_artificial_cells=*/true);
+  //
+  //    test<dim>(tria, 1);
+  //    tria.clear();
+  //    test<dim>(tria, 2);
+  //    tria.clear();
+  //    test<dim>(tria, 3);
+  //  }
+
+  deallog << "parallel::distributed::Triangulation" << std::endl;
+  {
+    parallel::distributed::Triangulation<dim> tria(MPI_COMM_WORLD);
+
+    test<dim>(tria, 1);
+    tria.clear();
+    test<dim>(tria, 2);
+    tria.clear();
+    test<dim>(tria, 3);
+  }
+}

--- a/tests/mpi/prepare_coarsening_and_refinement_04.with_p4est=true.mpirun=1.output
+++ b/tests/mpi/prepare_coarsening_and_refinement_04.with_p4est=true.mpirun=1.output
@@ -1,0 +1,38 @@
+
+DEAL:0::parallel::distributed::Triangulation
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 2
+DEAL:0:: 1_1:1 2
+DEAL:0:: 1_1:2 2
+DEAL:0:: 1_1:3 2
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 1_0: 2
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 3
+DEAL:0:: 1_1:1 3
+DEAL:0:: 1_1:2 3
+DEAL:0:: 1_1:3 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 1_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 4
+DEAL:0:: 1_1:1 4
+DEAL:0:: 1_1:2 4
+DEAL:0:: 1_1:3 4
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 1_0: 4
+DEAL:0:: 2_0: 1
+DEAL:0::OK

--- a/tests/mpi/prepare_coarsening_and_refinement_04.with_p4est=true.mpirun=4.output
+++ b/tests/mpi/prepare_coarsening_and_refinement_04.with_p4est=true.mpirun=4.output
@@ -1,0 +1,74 @@
+
+DEAL:0::parallel::distributed::Triangulation
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+
+DEAL:1::parallel::distributed::Triangulation
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 1_1:0 2
+DEAL:1:: 1_1:1 2
+DEAL:1:: 1_1:2 2
+DEAL:1:: 1_1:3 2
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 0_0: 3
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 1_1:0 3
+DEAL:1:: 1_1:1 3
+DEAL:1:: 1_1:2 3
+DEAL:1:: 1_1:3 3
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 0_0: 5
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 1_1:0 4
+DEAL:1:: 1_1:1 4
+DEAL:1:: 1_1:2 4
+DEAL:1:: 1_1:3 4
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 0_0: 7
+DEAL:1::OK
+
+
+DEAL:2::parallel::distributed::Triangulation
+DEAL:2::future FE indices before adaptation:
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 1_0: 2
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 1_0: 3
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 1_0: 4
+DEAL:2::OK
+
+
+DEAL:3::parallel::distributed::Triangulation
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 2_0: 1
+DEAL:3::OK
+


### PR DESCRIPTION
We need to set future FE indices similarly on all siblings of a cell that will be h-coarsened during `DoFHandler::prepare_coarsening_and_refinement()`. Otherwise, the `max_difference` criterion will not be met on the updated mesh for former parent cells.

---

This functionality does not work entirely for `p:s:T`. It relies on the following features:
- #11860 global_active_cell_index for `p:s:T` without artificial cells
- future FE indices need to be accessed on ghost cells.
We currently require that all siblings of a cell need to belong to the same processor.

However, this feature already works with `p:d:T`, so I didn't want to hold it back until it also works for the shared one.