### PR TITLE
Use correct invalid unsigned value for 64 bit integers (2)

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -2709,9 +2709,9 @@ namespace internal
           level.face_orientations.assign(size * faces_per_cell, -1);
 
         level.global_active_cell_indices.assign(size,
-                                                numbers::invalid_unsigned_int);
+                                                numbers::invalid_dof_index);
         level.global_level_cell_indices.assign(size,
-                                               numbers::invalid_unsigned_int);
+                                               numbers::invalid_dof_index);
       }
 
 


### PR DESCRIPTION
Follow-up to #11915.