### PR TITLE
Use the correct file extension.

### DIFF
--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -660,7 +660,7 @@ namespace Step15
         data_out.build_patches();
 
         const std::string filename =
-          "solution-" + Utilities::int_to_string(refinement_cycle, 2) + ".vtk";
+          "solution-" + Utilities::int_to_string(refinement_cycle, 2) + ".vtu";
         std::ofstream output(filename);
         data_out.write_vtu(output);
 


### PR DESCRIPTION
I don't know when this was changed, but step-15 writes VTU file format into files that have `.vtk` extension. My visit version doesn't want to read this. Easy to fix.

/rebuild