### PR TITLE
a new class TimerTree for flexible and modular timer measurements

### DIFF
--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -450,8 +450,14 @@ private:
       other.print_id_and_data(pcout, offset, length, relative, ref_time);
   }
 
+  /**
+   * Identifier of this tree.
+   */
   std::string id;
 
+  /**
+   * Struct describing the data of a tree.
+   */
   struct Data
   {
     Data()
@@ -461,12 +467,25 @@ private:
     double wall_time;
   };
 
+  /**
+   * Data of this tree.
+   */
   std::shared_ptr<Data> data;
 
+  /**
+   * A vector of sub-trees.
+   */
   std::vector<std::shared_ptr<TimerTree>> sub_trees;
 
+  /**
+   * Offset per level for formatted output specified in number of characters.
+   */
   static constexpr unsigned int offset_per_level = 2;
-  static constexpr unsigned int precision        = 2;
+
+  /**
+   * Value passed to std::setprecision() in print functions.
+   */
+  static constexpr unsigned int precision = 2;
 };
 
 

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -24,7 +24,6 @@ DEAL_II_NAMESPACE_OPEN
 /**
  * A class for wall-time measurements enabling a modular coupling of modules in
  * a minimally invasive way.
- *
  */
 class TimerTree
 {
@@ -49,9 +48,9 @@ public:
   }
 
   /**
-   * Inserts a measured wall_time into the tree, by
+   * Inserts a measured @p wall_time into the tree, by
    * either creating a new entry in the tree if this function is called
-   * the first time with this ID, or by adding the wall_time to an
+   * the first time with the ID @p ids, or by adding the @p wall_time to an
    * entry already existing in the tree.
    */
   void
@@ -129,10 +128,10 @@ public:
 
   /**
    * Inserts a whole sub_tree into an existing tree, where
-   * the parameter names specifies the place at which to insert the sub_tree.
+   * the parameter @p ids specifies the place at which to insert the @p sub_tree.
    * This function allows to combine different timer trees in a modular way.
-   * If a non empty string new_name is provided, the id of  sub_tree is
-   * replaced by new_name when inserted into the tree.
+   * If a non empty string @p new_name is provided, the id of @p sub_tree is
+   * replaced by @p new_name when inserted into the tree.
    */
   void
   insert(std::vector<std::string> const         ids,
@@ -203,8 +202,9 @@ public:
    * a wall time has been set for the parent of these children. In this
    * case, an additional item `other` is created in order to give insights
    * to which extent the code has been covered with timers and to which
-   * extend time is spent is other code paths that are currently not
-   * covered by timers.
+   * extend time is spent in other code paths that are currently not
+   * covered by timers. The parameter @p level specifies the level for which
+   * to print results, where a value of 0 corresponds to the high level module.
    */
   void
   print_level(ConditionalOStream const &pcout, unsigned int const level) const

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 1998 - 2020 by the deal.II authors
+// Copyright (C) 2021 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -135,9 +135,9 @@ public:
    * replaced by new_name when inserted into the tree.
    */
   void
-  insert(std::vector<std::string>   ids,
-         std::shared_ptr<TimerTree> sub_tree,
-         std::string const          new_name = "")
+  insert(std::vector<std::string> const         ids,
+         std::shared_ptr<TimerTree const> const sub_tree,
+         std::string const                      new_name = "")
   {
     AssertThrow(ids.size() > 0, ExcMessage("Empty ID specified."));
     AssertThrow(id == ids[0], ExcMessage("Invalid ID specified."));
@@ -221,7 +221,7 @@ private:
    * Copy function.
    */
   void
-  copy_from(std::shared_ptr<TimerTree> other)
+  copy_from(std::shared_ptr<TimerTree const> const other)
   {
     *this = *other;
   }

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -37,18 +37,6 @@ public:
   {}
 
   /**
-   * Copy assignment operator.
-   */
-  TimerTree &
-  operator=(TimerTree const &other)
-  {
-    this->id        = other.id;
-    this->data      = other.data;
-    this->sub_trees = other.sub_trees;
-    this->comm      = other.comm;
-  }
-
-  /**
    * Clears the content of this tree. Sub trees inserted
    * into this tree via pointers to external trees are not touched.
    */

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -31,7 +31,7 @@ public:
   /**
    * Constructor.
    */
-  TimerTree(MPI_Comm const &comm)
+  TimerTree(const MPI_Comm &comm)
     : id("")
     , comm(comm)
   {}
@@ -56,7 +56,7 @@ public:
    * entry already existing in the tree.
    */
   void
-  insert(std::vector<std::string> const ids, double const wall_time)
+  insert(const std::vector<std::string> &ids, const double wall_time)
   {
     Assert(
       ids.size() > 0,
@@ -145,9 +145,9 @@ public:
    * program uses the same module multiple times but for different purposes.
    */
   void
-  insert(std::vector<std::string> const         ids,
-         std::shared_ptr<TimerTree const> const sub_tree,
-         std::string const                      new_name = "")
+  insert(const std::vector<std::string> &       ids,
+         const std::shared_ptr<const TimerTree> sub_tree,
+         const std::string &                    new_name = "")
   {
     Assert(
       ids.size() > 0,
@@ -210,9 +210,9 @@ public:
    * the relative share of the children.
    */
   void
-  print_plain(ConditionalOStream const &pcout) const
+  print_plain(const ConditionalOStream &pcout) const
   {
-    unsigned int const length = get_length();
+    const unsigned int length = get_length();
 
     pcout << std::endl;
 
@@ -231,9 +231,9 @@ public:
    * to print results, where a value of 0 corresponds to the high level module.
    */
   void
-  print_level(ConditionalOStream const &pcout, unsigned int const level) const
+  print_level(const ConditionalOStream &pcout, const unsigned int level) const
   {
-    unsigned int const length = get_length();
+    const unsigned int length = get_length();
 
     pcout << std::endl;
 
@@ -245,7 +245,7 @@ private:
    * This function erases the first entry of the vector.
    */
   std::vector<std::string>
-  erase_first(std::vector<std::string> const &in) const
+  erase_first(const std::vector<std::string> &in) const
   {
     Assert(
       in.size() > 0,
@@ -262,7 +262,7 @@ private:
    * Returns average wall-time over all MPI processes for the root of this tree.
    */
   double
-  get_average_wall_time(double const wall_time) const
+  get_average_wall_time(const double wall_time) const
   {
     Utilities::MPI::MinMaxAvg time_data =
       Utilities::MPI::min_max_avg(wall_time, comm);
@@ -294,9 +294,9 @@ private:
    * call this function recursively and to produce formatted output.
    */
   void
-  do_print_plain(ConditionalOStream const &pcout,
-                 unsigned int const        offset,
-                 unsigned int const        length) const
+  do_print_plain(const ConditionalOStream &pcout,
+                 const unsigned int        offset,
+                 const unsigned int        length) const
   {
     if (id.empty())
       return;
@@ -315,10 +315,10 @@ private:
    * parameters @p offset and @p length to produce formatted output.
    */
   void
-  do_print_level(ConditionalOStream const &pcout,
-                 unsigned int const        level,
-                 unsigned int const        offset,
-                 unsigned int const        length) const
+  do_print_level(const ConditionalOStream &pcout,
+                 const unsigned int        level,
+                 const unsigned int        offset,
+                 const unsigned int        length) const
   {
     if (id.empty())
       return;
@@ -363,9 +363,9 @@ private:
    * Prints id of a tree. The parameters @p offset and @p length produce formatted output.
    */
   void
-  print_id(ConditionalOStream const &pcout,
-           unsigned int const        offset,
-           unsigned int const        length) const
+  print_id(const ConditionalOStream &pcout,
+           const unsigned int        offset,
+           const unsigned int        length) const
   {
     pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left
           << id;
@@ -378,20 +378,20 @@ private:
    * If @p relative is true, the wall time is additionally printed in '%' of @p ref_time.
    */
   void
-  print_id_and_data(ConditionalOStream const &pcout,
-                    unsigned int const        offset,
-                    unsigned int const        length,
-                    bool const                relative = false,
-                    double const              ref_time = -1.0) const
+  print_id_and_data(const ConditionalOStream &pcout,
+                    const unsigned int        offset,
+                    const unsigned int        length,
+                    const bool                relative = false,
+                    const double              ref_time = -1.0) const
   {
     pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left
           << id;
 
-    double const ref_time_avg = get_average_wall_time(ref_time);
+    const double ref_time_avg = get_average_wall_time(ref_time);
 
     if (data.get())
       {
-        double const time_avg = get_average_wall_time(data->wall_time);
+        const double time_avg = get_average_wall_time(data->wall_time);
 
         pcout << std::setprecision(precision) << std::scientific
               << std::setw(10) << std::right << time_avg << " s";
@@ -410,11 +410,11 @@ private:
    * in '%' of @p ref_time.
    */
   void
-  print_direct_children(ConditionalOStream const &pcout,
-                        unsigned int const        offset,
-                        unsigned int const        length,
-                        bool const                relative = false,
-                        double const              ref_time = -1.0) const
+  print_direct_children(const ConditionalOStream &pcout,
+                        const unsigned int        offset,
+                        const unsigned int        length,
+                        const bool                relative = false,
+                        const double              ref_time = -1.0) const
   {
     TimerTree other = TimerTree(comm);
     if (relative && sub_trees.size() > 0)

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -104,14 +104,14 @@ public:
             std::vector<std::string> remaining_id = erase_first(ids);
 
             bool found = false;
-            for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+            for (const auto it : sub_trees)
               {
                 // find out where to insert item
-                if ((*it)->id == remaining_id[0])
+                if (it->id == remaining_id[0])
                   {
                     found = true;
 
-                    (*it)->insert(remaining_id, wall_time);
+                    it->insert(remaining_id, wall_time);
                   }
               }
 
@@ -165,11 +165,11 @@ public:
     bool found = false;
     if (remaining_id.size() > 0)
       {
-        for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+        for (const auto it : sub_trees)
           {
-            if ((*it)->id == remaining_id[0])
+            if (it->id == remaining_id[0])
               {
-                (*it)->insert(remaining_id, sub_tree, new_name);
+                it->insert(remaining_id, sub_tree, new_name);
                 found = true;
               }
           }
@@ -279,9 +279,9 @@ private:
   {
     unsigned int length = id.length();
 
-    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+    for (const auto it : sub_trees)
       {
-        length = std::max(length, (*it)->get_length() + offset_per_level);
+        length = std::max(length, it->get_length() + offset_per_level);
       }
 
     return length;
@@ -303,9 +303,9 @@ private:
 
     print_id_and_data(pcout, offset, length);
 
-    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+    for (const auto it : sub_trees)
       {
-        (*it)->do_print_plain(pcout, offset + offset_per_level, length);
+        it->do_print_plain(pcout, offset + offset_per_level, length);
       }
   }
 
@@ -349,12 +349,12 @@ private:
 
         // recursively print sub trees (decreasing the level and incrementing
         // the offset)
-        for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+        for (const auto it : sub_trees)
           {
-            (*it)->do_print_level(pcout,
-                                  level - 1,
-                                  offset + offset_per_level,
-                                  length);
+            it->do_print_level(pcout,
+                               level - 1,
+                               offset + offset_per_level,
+                               length);
           }
       }
   }
@@ -424,14 +424,14 @@ private:
         other.data->wall_time = ref_time;
       }
 
-    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+    for (const auto it : sub_trees)
       {
-        if ((*it)->data.get())
+        if (it->data.get())
           {
-            (*it)->print_id_and_data(pcout, offset, length, relative, ref_time);
+            it->print_id_and_data(pcout, offset, length, relative, ref_time);
 
             if (relative)
-              other.data->wall_time -= (*it)->data->wall_time;
+              other.data->wall_time -= it->data->wall_time;
           }
       }
 

--- a/include/deal.II/base/timer_tree.h
+++ b/include/deal.II/base/timer_tree.h
@@ -1,0 +1,423 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 1998 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_timer_tree_h
+#define dealii_timer_tree_h
+
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/timer.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+/**
+ * A class for wall-time measurements enabling a modular coupling of modules in
+ * a minimally invasive way.
+ *
+ */
+class TimerTree
+{
+public:
+  /**
+   * Constructor.
+   */
+  TimerTree()
+    : id("")
+  {}
+
+  /**
+   * Clears the content of this tree. Sub trees inserted
+   * into this tree via pointers to external trees are not touched.
+   */
+  void
+  clear()
+  {
+    this->id = "";
+    data     = nullptr;
+    sub_trees.clear();
+  }
+
+  /**
+   * Inserts a measured wall_time into the tree, by
+   * either creating a new entry in the tree if this function is called
+   * the first time with this ID, or by adding the wall_time to an
+   * entry already existing in the tree.
+   */
+  void
+  insert(std::vector<std::string> const ids, double const wall_time)
+  {
+    AssertThrow(ids.size() > 0, ExcMessage("empty name."));
+
+    if (this->id == "") // the tree is currently empty
+      {
+        AssertThrow(sub_trees.empty(),
+                    ExcMessage("invalid state found. aborting."));
+
+        this->id = ids[0];
+
+        if (ids.size() == 1) // leaves of tree reached, insert the data
+          {
+            data.reset(new Data());
+            data->wall_time += wall_time;
+
+            return;
+          }
+        else // go deeper
+          {
+            std::vector<std::string> remaining_id = erase_first(ids);
+
+            std::shared_ptr<TimerTree> new_tree;
+            new_tree.reset(new TimerTree());
+            new_tree->insert(remaining_id, wall_time);
+            sub_trees.push_back(new_tree);
+          }
+      }
+    else if (this->id == ids[0]) // the tree already has some entries
+      {
+        if (ids.size() == 1) // leaves of tree reached, insert the data
+          {
+            if (data.get() == nullptr)
+              data.reset(new Data());
+
+            data->wall_time += wall_time;
+
+            return;
+          }
+        else // find correct sub-tree or insert new sub-tree
+          {
+            std::vector<std::string> remaining_id = erase_first(ids);
+
+            bool found = false;
+            for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+              {
+                // find out where to insert item
+                if ((*it)->id == remaining_id[0])
+                  {
+                    found = true;
+
+                    (*it)->insert(remaining_id, wall_time);
+                  }
+              }
+
+            if (found == false)
+              {
+                std::shared_ptr<TimerTree> new_tree;
+                new_tree.reset(new TimerTree());
+                new_tree->insert(remaining_id, wall_time);
+                sub_trees.push_back(new_tree);
+              }
+          }
+      }
+    else // the provided name does not fit to this tree
+      {
+        AssertThrow(false,
+                    ExcMessage("The name provided is " + ids[0] +
+                               ", but must be " + id + " instead."));
+      }
+  }
+
+  /**
+   * Inserts a whole sub_tree into an existing tree, where
+   * the parameter names specifies the place at which to insert the sub_tree.
+   * This function allows to combine different timer trees in a modular way.
+   * If a non empty string new_name is provided, the id of  sub_tree is
+   * replaced by new_name when inserted into the tree.
+   */
+  void
+  insert(std::vector<std::string>   ids,
+         std::shared_ptr<TimerTree> sub_tree,
+         std::string const          new_name = "")
+  {
+    AssertThrow(ids.size() > 0, ExcMessage("Empty ID specified."));
+    AssertThrow(id == ids[0], ExcMessage("Invalid ID specified."));
+
+    std::vector<std::string> remaining_id = erase_first(ids);
+
+    bool found = false;
+    if (remaining_id.size() > 0)
+      {
+        for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+          {
+            if ((*it)->id == remaining_id[0])
+              {
+                (*it)->insert(remaining_id, sub_tree, new_name);
+                found = true;
+              }
+          }
+      }
+
+    if (found == false)
+      {
+        AssertThrow(
+          remaining_id.size() == 0,
+          ExcMessage(
+            "Subtree can not be inserted since the specified ID does not exist in this tree."));
+
+        std::shared_ptr<TimerTree> new_tree(new TimerTree());
+        new_tree->copy_from(sub_tree);
+        if (!new_name.empty())
+          new_tree->id = new_name;
+
+        // Make sure that the new tree does not already exist
+        for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+          {
+            AssertThrow(
+              new_tree->id != (*it)->id,
+              ExcMessage(
+                "Subtree can not be inserted since the tree already contains a subtree with the same ID."));
+          }
+
+        sub_trees.push_back(new_tree);
+      }
+  }
+
+  /**
+   * Prints wall time of all items of a tree without an analysis of
+   * the relative share of the children.
+   */
+  void
+  print_plain(ConditionalOStream const &pcout) const
+  {
+    unsigned int const length = get_length();
+
+    pcout << std::endl;
+
+    do_print_plain(pcout, 0, length);
+  }
+
+  /**
+   * This is the actual function of interest of this class, i.e., an
+   * analysis of wall times with a hierarchical formatting of results.
+   * Relative wall times are printed for all children of a sub-tree if
+   * a wall time has been set for the parent of these children. In this
+   * case, an additional item `other` is created in order to give insights
+   * to which extent the code has been covered with timers and to which
+   * extend time is spent is other code paths that are currently not
+   * covered by timers.
+   */
+  void
+  print_level(ConditionalOStream const &pcout, unsigned int const level) const
+  {
+    unsigned int const length = get_length();
+
+    pcout << std::endl;
+
+    do_print_level(pcout, level, 0, length);
+  }
+
+private:
+  /*
+   * Copy function.
+   */
+  void
+  copy_from(std::shared_ptr<TimerTree> other)
+  {
+    *this = *other;
+  }
+
+  /*
+   * This function erases the first entry of the vector.
+   */
+  std::vector<std::string>
+  erase_first(std::vector<std::string> const &in) const
+  {
+    AssertThrow(in.size() > 0, ExcMessage("empty name."));
+
+    std::vector<std::string> out(in);
+    out.erase(out.begin());
+
+    return out;
+  }
+
+  /*
+   * Returns average wall-time over all MPI processes for the root of this tree.
+   */
+  double
+  get_average_wall_time() const
+  {
+    Utilities::MPI::MinMaxAvg time_data =
+      Utilities::MPI::min_max_avg(data->wall_time, MPI_COMM_WORLD);
+    return time_data.avg;
+  }
+
+  /*
+   * print functions
+   */
+  unsigned int
+  get_length() const
+  {
+    unsigned int length = id.length();
+
+    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+      {
+        length = std::max(length, (*it)->get_length() + offset_per_level);
+      }
+
+    return length;
+  }
+
+  void
+  do_print_plain(ConditionalOStream const &pcout,
+                 unsigned int const        offset,
+                 unsigned int const        length) const
+  {
+    if (id.empty())
+      return;
+
+    print_own(pcout, offset, length);
+
+    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+      {
+        (*it)->do_print_plain(pcout, offset + offset_per_level, length);
+      }
+  }
+
+  void
+  do_print_level(ConditionalOStream const &pcout,
+                 unsigned int const        level,
+                 unsigned int const        offset,
+                 unsigned int const        length) const
+  {
+    if (id.empty())
+      return;
+
+    if (level == 0)
+      {
+        if (data.get())
+          print_own(pcout, offset, length);
+      }
+    else if (level == 1)
+      {
+        if (sub_trees.size() > 0)
+          {
+            print_own(pcout, offset, length, true, data->wall_time);
+
+            bool const relative = (data.get() != nullptr);
+            print_direct_children(pcout,
+                                  offset + offset_per_level,
+                                  length,
+                                  relative,
+                                  data->wall_time);
+          }
+      }
+    else
+      {
+        // only print name
+        print_name(pcout, offset, length);
+
+        // recursively print sub trees (decreasing the level and incrementing
+        // the offset)
+        for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+          {
+            (*it)->do_print_level(pcout,
+                                  level - 1,
+                                  offset + offset_per_level,
+                                  length);
+          }
+      }
+  }
+
+  void
+  print_name(ConditionalOStream const &pcout,
+             unsigned int const        offset,
+             unsigned int const        length) const
+  {
+    pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left
+          << id;
+
+    pcout << std::endl;
+  }
+
+  void
+  print_own(ConditionalOStream const &pcout,
+            unsigned int const        offset,
+            unsigned int const        length,
+            bool const                relative = false,
+            double const              ref_time = -1.0) const
+  {
+    pcout << std::setw(offset) << "" << std::setw(length - offset) << std::left
+          << id;
+
+    Utilities::MPI::MinMaxAvg ref_time_data =
+      Utilities::MPI::min_max_avg(ref_time, MPI_COMM_WORLD);
+    double const ref_time_avg = ref_time_data.avg;
+
+    if (data.get())
+      {
+        double const time_avg = get_average_wall_time();
+
+        pcout << std::setprecision(precision) << std::scientific
+              << std::setw(10) << std::right << time_avg << " s";
+
+        if (relative)
+          pcout << std::setprecision(precision) << std::fixed << std::setw(10)
+                << std::right << time_avg / ref_time_avg * 100.0 << " %";
+      }
+
+    pcout << std::endl;
+  }
+
+  void
+  print_direct_children(ConditionalOStream const &pcout,
+                        unsigned int const        offset,
+                        unsigned int const        length,
+                        bool const                relative = false,
+                        double const              ref_time = -1.0) const
+  {
+    TimerTree other;
+    if (relative && sub_trees.size() > 0)
+      {
+        other.id = "Other";
+        other.data.reset(new Data());
+        other.data->wall_time = ref_time;
+      }
+
+    for (auto it = sub_trees.begin(); it != sub_trees.end(); ++it)
+      {
+        if ((*it)->data.get())
+          {
+            (*it)->print_own(pcout, offset, length, relative, ref_time);
+
+            if (relative)
+              other.data->wall_time -= (*it)->data->wall_time;
+          }
+      }
+
+    if (relative && sub_trees.size() > 0)
+      other.print_own(pcout, offset, length, relative, ref_time);
+  }
+
+  std::string id;
+
+  struct Data
+  {
+    Data()
+      : wall_time(0.0)
+    {}
+
+    double wall_time;
+  };
+
+  std::shared_ptr<Data> data;
+
+  std::vector<std::shared_ptr<TimerTree>> sub_trees;
+
+  static unsigned int const offset_per_level = 2;
+  static unsigned int const precision        = 2;
+};
+
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif

--- a/tests/base/timer_tree_01.cc
+++ b/tests/base/timer_tree_01.cc
@@ -42,7 +42,7 @@ test1()
   Timer timer;
   timer.restart();
 
-  TimerTree tree;
+  TimerTree tree = TimerTree(MPI_COMM_WORLD);
 
   for (unsigned int i = 0; i < 1000; ++i)
     {
@@ -95,11 +95,11 @@ test2()
   Timer timer;
   timer.restart();
 
-  TimerTree tree;
+  TimerTree tree = TimerTree(MPI_COMM_WORLD);
   tree.insert({"FSI"}, 100.);
 
-  std::shared_ptr<TimerTree> tree_fluid;
-  tree_fluid.reset(new TimerTree());
+  std::shared_ptr<TimerTree> tree_fluid =
+    std::make_shared<TimerTree>(TimerTree(MPI_COMM_WORLD));
   // overall time can be inserted first ...
   tree_fluid->insert({"Fluid"}, 70.);
   tree_fluid->insert({"Fluid", "Pressure Poisson"}, 40.);
@@ -107,8 +107,8 @@ test2()
   tree_fluid->insert({"Fluid", "ALE update"}, 15.);
 
 
-  std::shared_ptr<TimerTree> tree_structure;
-  tree_structure.reset(new TimerTree());
+  std::shared_ptr<TimerTree> tree_structure =
+    std::make_shared<TimerTree>(TimerTree(MPI_COMM_WORLD));
   tree_structure->insert({"Elasticity", "Right-hand side"}, 2.);
   tree_structure->insert({"Elasticity", "Assemble"}, 9.);
   tree_structure->insert({"Elasticity", "Solve"}, 14.);

--- a/tests/base/timer_tree_01.cc
+++ b/tests/base/timer_tree_01.cc
@@ -1,6 +1,6 @@
 // ---------------------------------------------------------------------
 //
-// Copyright (C) 2020 by the deal.II authors
+// Copyright (C) 2021 by the deal.II authors
 //
 // This file is part of the deal.II library.
 //

--- a/tests/base/timer_tree_01.cc
+++ b/tests/base/timer_tree_01.cc
@@ -100,6 +100,7 @@ test2()
 
   std::shared_ptr<TimerTree> tree_fluid;
   tree_fluid.reset(new TimerTree());
+  // overall time can be inserted first ...
   tree_fluid->insert({"Fluid"}, 70.);
   tree_fluid->insert({"Fluid", "Pressure Poisson"}, 40.);
   tree_fluid->insert({"Fluid", "Postprocessing"}, 10.);
@@ -108,12 +109,19 @@ test2()
 
   std::shared_ptr<TimerTree> tree_structure;
   tree_structure.reset(new TimerTree());
-  tree_structure->insert({"Structure", "Right-hand side"}, 2.);
-  tree_structure->insert({"Structure", "Assemble"}, 9.);
-  tree_structure->insert({"Structure", "Solve"}, 14.);
-  tree_structure->insert({"Structure"}, 25.);
+  tree_structure->insert({"Elasticity", "Right-hand side"}, 2.);
+  tree_structure->insert({"Elasticity", "Assemble"}, 9.);
+  tree_structure->insert({"Elasticity", "Solve"}, 14.);
+  // ... but can also be inserted last
+  tree_structure->insert({"Elasticity"}, 25.);
 
+  // Inserting sub-trees
+
+  // inserting a sub-tree multiple times does not change the results
   tree.insert({"FSI"}, tree_fluid);
+  tree.insert({"FSI"}, tree_fluid);
+
+  // a new name can be provided for a sub-tree
   tree.insert({"FSI"}, tree_structure, "Structure");
 
   pcout << std::endl << "timings for level = 0:" << std::endl;

--- a/tests/base/timer_tree_01.cc
+++ b/tests/base/timer_tree_01.cc
@@ -1,0 +1,191 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// tests basic functionality of TimerTree
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/timer_tree.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+using namespace dealii;
+
+void
+test1()
+{
+  ConditionalOStream pcout(std::cout,
+                           Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) ==
+                             0);
+
+  // clang-format off
+  pcout << std::endl
+        << std::endl
+        << "Timer: test 1 (basic)"
+        << std::endl
+        << std::endl;
+  // clang-format on
+
+  Timer timer;
+  timer.restart();
+
+  TimerTree tree;
+
+  for (unsigned int i = 0; i < 1000; ++i)
+    {
+      tree.insert({"General"}, 20.0);
+
+      tree.insert({"General", "Part 1"}, 2.0);
+
+      tree.insert({"General", "Part 2"}, 3.0);
+
+      tree.insert({"General", "Part 2", "Sub a"}, 0.75);
+
+      tree.insert({"General", "Part 2", "Sub b"}, 0.9);
+
+      tree.insert({"General", "Part 3"}, 4.0);
+
+      tree.insert({"General", "Part 3", "Sub a"}, 0.5);
+
+      tree.insert({"General", "Part 3", "Sub a", "sub-sub a"}, 0.04);
+
+      tree.insert({"General", "Part 3", "Sub b"}, 0.98765);
+
+      tree.insert({"General"}, 2.0);
+    }
+
+  pcout << std::endl << "timings for level = 0:" << std::endl;
+  tree.print_level(pcout, 0);
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree.print_level(pcout, 1);
+  pcout << std::endl << "timings for level = 2:" << std::endl;
+  tree.print_level(pcout, 2);
+  pcout << std::endl << "timings all:" << std::endl;
+  tree.print_plain(pcout);
+}
+
+void
+test2()
+{
+  ConditionalOStream pcout(std::cout,
+                           Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) ==
+                             0);
+
+  // clang-format off
+  pcout << std::endl
+        << std::endl
+        << "TimerTree: test 2 (modular coupling)"
+        << std::endl
+        << std::endl;
+  // clang-format on
+
+  Timer timer;
+  timer.restart();
+
+  TimerTree tree;
+  tree.insert({"FSI"}, 100.);
+
+  std::shared_ptr<TimerTree> tree_fluid;
+  tree_fluid.reset(new TimerTree());
+  tree_fluid->insert({"Fluid"}, 70.);
+  tree_fluid->insert({"Fluid", "Pressure Poisson"}, 40.);
+  tree_fluid->insert({"Fluid", "Postprocessing"}, 10.);
+  tree_fluid->insert({"Fluid", "ALE update"}, 15.);
+
+
+  std::shared_ptr<TimerTree> tree_structure;
+  tree_structure.reset(new TimerTree());
+  tree_structure->insert({"Structure", "Right-hand side"}, 2.);
+  tree_structure->insert({"Structure", "Assemble"}, 9.);
+  tree_structure->insert({"Structure", "Solve"}, 14.);
+  tree_structure->insert({"Structure"}, 25.);
+
+  tree.insert({"FSI"}, tree_fluid);
+  tree.insert({"FSI"}, tree_structure, "Structure");
+
+  pcout << std::endl << "timings for level = 0:" << std::endl;
+  tree.print_level(pcout, 0);
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree.print_level(pcout, 1);
+  pcout << std::endl << "timings for level = 2:" << std::endl;
+  tree.print_level(pcout, 2);
+  pcout << std::endl << "timings all:" << std::endl;
+  tree.print_plain(pcout);
+
+  tree.clear();
+
+  // should be empty after clear()
+  pcout << std::endl << "timings for level = 0:" << std::endl;
+  tree.print_level(pcout, 0);
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree.print_level(pcout, 1);
+  pcout << std::endl << "timings for level = 2:" << std::endl;
+  tree.print_level(pcout, 2);
+  pcout << std::endl << "timings all:" << std::endl;
+  tree.print_plain(pcout);
+
+  // clear() must no touch sub-trees
+  pcout << std::endl << "timings for level = 0:" << std::endl;
+  tree_structure->print_level(pcout, 0);
+  pcout << std::endl << "timings for level = 1:" << std::endl;
+  tree_structure->print_level(pcout, 1);
+  pcout << std::endl << "timings for level = 2:" << std::endl;
+  tree_structure->print_level(pcout, 2);
+  pcout << std::endl << "timings all:" << std::endl;
+  tree_structure->print_plain(pcout);
+}
+
+int
+main(int argc, char **argv)
+{
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+
+      deallog.depth_console(0);
+
+      test1();
+
+      test2();
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+
+  return 0;
+}

--- a/tests/base/timer_tree_01.cc
+++ b/tests/base/timer_tree_01.cc
@@ -15,7 +15,9 @@
 
 // tests basic functionality of TimerTree
 
+#include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/timer.h>
 #include <deal.II/base/timer_tree.h>
 
 #include <fstream>

--- a/tests/base/timer_tree_01.output
+++ b/tests/base/timer_tree_01.output
@@ -94,11 +94,11 @@ timings all:
 
 timings for level = 0:
 
-Structure          2.50e+01 s
+Elasticity         2.50e+01 s
 
 timings for level = 1:
 
-Structure          2.50e+01 s    100.00 %
+Elasticity         2.50e+01 s    100.00 %
   Right-hand side  2.00e+00 s      8.00 %
   Assemble         9.00e+00 s     36.00 %
   Solve            1.40e+01 s     56.00 %
@@ -106,11 +106,11 @@ Structure          2.50e+01 s    100.00 %
 
 timings for level = 2:
 
-Structure        
+Elasticity       
 
 timings all:
 
-Structure          2.50e+01 s
+Elasticity         2.50e+01 s
   Right-hand side  2.00e+00 s
   Assemble         9.00e+00 s
   Solve            1.40e+01 s

--- a/tests/base/timer_tree_01.output
+++ b/tests/base/timer_tree_01.output
@@ -1,0 +1,116 @@
+
+
+Timer: test 1 (basic)
+
+
+timings for level = 0:
+
+General          2.20e+04 s
+
+timings for level = 1:
+
+General          2.20e+04 s    100.00 %
+  Part 1         2.00e+03 s      9.09 %
+  Part 2         3.00e+03 s     13.64 %
+  Part 3         4.00e+03 s     18.18 %
+  Other          1.30e+04 s     59.09 %
+
+timings for level = 2:
+
+General        
+  Part 2         3.00e+03 s    100.00 %
+    Sub a        7.50e+02 s     25.00 %
+    Sub b        9.00e+02 s     30.00 %
+    Other        1.35e+03 s     45.00 %
+  Part 3         4.00e+03 s    100.00 %
+    Sub a        5.00e+02 s     12.50 %
+    Sub b        9.88e+02 s     24.69 %
+    Other        2.51e+03 s     62.81 %
+
+timings all:
+
+General          2.20e+04 s
+  Part 1         2.00e+03 s
+  Part 2         3.00e+03 s
+    Sub a        7.50e+02 s
+    Sub b        9.00e+02 s
+  Part 3         4.00e+03 s
+    Sub a        5.00e+02 s
+      sub-sub a  4.00e+01 s
+    Sub b        9.88e+02 s
+
+
+TimerTree: test 2 (modular coupling)
+
+
+timings for level = 0:
+
+FSI                   1.00e+02 s
+
+timings for level = 1:
+
+FSI                   1.00e+02 s    100.00 %
+  Fluid               7.00e+01 s     70.00 %
+  Structure           2.50e+01 s     25.00 %
+  Other               5.00e+00 s      5.00 %
+
+timings for level = 2:
+
+FSI                 
+  Fluid               7.00e+01 s    100.00 %
+    Pressure Poisson  4.00e+01 s     57.14 %
+    Postprocessing    1.00e+01 s     14.29 %
+    ALE update        1.50e+01 s     21.43 %
+    Other             5.00e+00 s      7.14 %
+  Structure           2.50e+01 s    100.00 %
+    Right-hand side   2.00e+00 s      8.00 %
+    Assemble          9.00e+00 s     36.00 %
+    Solve             1.40e+01 s     56.00 %
+    Other             0.00e+00 s      0.00 %
+
+timings all:
+
+FSI                   1.00e+02 s
+  Fluid               7.00e+01 s
+    Pressure Poisson  4.00e+01 s
+    Postprocessing    1.00e+01 s
+    ALE update        1.50e+01 s
+  Structure           2.50e+01 s
+    Right-hand side   2.00e+00 s
+    Assemble          9.00e+00 s
+    Solve             1.40e+01 s
+
+timings for level = 0:
+
+
+timings for level = 1:
+
+
+timings for level = 2:
+
+
+timings all:
+
+
+timings for level = 0:
+
+Structure          2.50e+01 s
+
+timings for level = 1:
+
+Structure          2.50e+01 s    100.00 %
+  Right-hand side  2.00e+00 s      8.00 %
+  Assemble         9.00e+00 s     36.00 %
+  Solve            1.40e+01 s     56.00 %
+  Other            0.00e+00 s      0.00 %
+
+timings for level = 2:
+
+Structure        
+
+timings all:
+
+Structure          2.50e+01 s
+  Right-hand side  2.00e+00 s
+  Assemble         9.00e+00 s
+  Solve            1.40e+01 s


### PR DESCRIPTION
This PR proposes a new implementation for wall-time measurements that can be used in a flexible and modular way in complex codes.

**Design:** 
The underlying design principle are mainly the open-closed principle and the dependency inversion principle.

As far as I understand the existing `dealii::TimerOutput`, it can be used easily in a dealii tutorial where everything is plugged together within one file, or for use within a certain class. However, for complex applications, timer measurements are spread over many software layers from high-level to low-level code. The low-level code, of course, does not know for which purpose it is used. Instead, a module should be able to query the timings from its sub-modules and plug them together in a hierarchical way.

**Example:**
To give a concrete example consider the application of fluid-structure interaction solved in a partitioned way by plugging together different modules for the solution of the single-field problems. In my opinion, the present PR proposes a minimally invasive way of how to implement useful timing measurements for such problems, without touching low-level code (in this case the single-field solvers). One design (not chosen here) would be to pass a string with an ``id`` to a sub-module that indicates for which purpose this module is used, for example "FSI - fluid" handed to the constructor of the fluid class in case of an FSI application, instead of just "fluid" for a pure fluid solver. Such a design is, however, not minimally invasive and requires to touch many interfaces. The present design, instead, is that the FSI solver asks its sub-module (dependency inversion!), the fluid solver, for its timings by a member function of the fluid class, ``Fluid::get_timings()`` (open-closed!), and the FSI class has to take care of how to insert that sub-tree into the outer timer tree for the FSI application.

**Tests and usability:**
A test shows the capabilities of ``TimerTree`` and how to use this class.

Note that a main strength of this class is in my opinion that it always computes the share of time not covered by measurements (called "Other"), so that the developer/user always sees immediately whether there is a portion of the code that did not get attention regarding timings but must actually be quite important in terms of run-time, giving indications that the measurements need to be extended to improve the understanding of where the code spends its time.

This class is not intended for use in micro-benchmarks or inner-most loops (just as the `Timer` class), since the overhead accompanied by this class would certainly be no longer negligible. This effect is, however, negligible when measuring different parts of one solver module (preprocessing, linear solver, postprocessing) or when coupling different modules.