### PR TITLE
New Triangulation signal `post_p4est_refinement`.

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -2220,6 +2220,15 @@ public:
     boost::signals2::signal<void()> pre_distributed_refinement;
 
     /**
+     * This signal is triggered during execution of the
+     * parallel::distributed::Triangulation::execute_coarsening_and_refinement()
+     * function. At the time this signal is triggered, the p4est oracle has been
+     * refined and the cell relations have been updated. The triangulation is
+     * unchanged otherwise, and the p4est oracle has not yet been repartitioned.
+     */
+    boost::signals2::signal<void()> post_p4est_refinement;
+
+    /**
      * This signal is triggered at the end of execution of the
      * parallel::distributed::Triangulation::execute_coarsening_and_refinement()
      * function when the triangulation has reached its final state. This signal

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2689,6 +2689,10 @@ namespace parallel
       // has happened, we need to update the quadrant cell relations
       update_cell_relations();
 
+      // signals that parallel_forest has been refined and cell relations have
+      // been updated
+      this->signals.post_p4est_refinement();
+
       // before repartitioning the mesh, save a copy of the current positions of
       // quadrants
       // only if data needs to be transferred later

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -20,6 +20,7 @@
 #include <deal.II/base/mpi.templates.h>
 
 #include <deal.II/distributed/cell_data_transfer.templates.h>
+#include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/shared_tria.h>
 #include <deal.II/distributed/tria.h>
 
@@ -3049,8 +3050,14 @@ DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
   // attach corresponding callback functions dealing with the transfer of
   // active FE indices depending on the type of triangulation
   if (dynamic_cast<
-        const dealii::parallel::DistributedTriangulationBase<dim, spacedim> *>(
-        &this->get_triangulation()))
+        const dealii::parallel::fullydistributed::Triangulation<dim, spacedim>
+          *>(&this->get_triangulation()))
+    {
+      // no transfer of active FE indices for this class
+    }
+  else if (dynamic_cast<
+             const dealii::parallel::distributed::Triangulation<dim, spacedim>
+               *>(&this->get_triangulation()))
     {
       // repartitioning signals
       this->tria_listeners_for_transfer.push_back(
@@ -3067,7 +3074,7 @@ DoFHandler<dim, spacedim>::connect_to_triangulation_signals()
 
       // refinement signals
       this->tria_listeners_for_transfer.push_back(
-        this->tria->signals.pre_distributed_refinement.connect(
+        this->tria->signals.post_p4est_refinement.connect(
           [this]() { this->pre_distributed_transfer_action(); }));
       this->tria_listeners_for_transfer.push_back(
         this->tria->signals.post_distributed_refinement.connect(


### PR DESCRIPTION
Follow-up to #11888.

This PR introduces a new signal `post_p4est_refinement` that gets triggered after the oracle has been refined, but before any changes to the Triangulation have been made or the oracle has been repartitioned. This is necessary as p4est might perform refinement slightly different than intended via refine and coarsen flags of the Triangulation, see #8647.

In this PR, we only connect preparations for the transfer of active FE indices to it and move it from the `pre_distributed_refinement` signal. As the `parallel::fullydistributed::Triangulation` does not use any boost signals by now in the context of refinement and partitioning, we no longer connect to these particular signals anymore for this class.

Some hp-functionalities might connect to this signal, i.e., for error prediction and limiting p-level differences across the grid. I will deal with this in follow-up PRs.