### PR TITLE
Wrap boost error message in ParameterHandler::parse_input_from_json()

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -761,7 +761,19 @@ ParameterHandler::parse_input_from_json(std::istream &in,
   boost::property_tree::ptree node_tree;
   // This boost function will raise an exception if this is not a valid JSON
   // file.
-  read_json(in, node_tree);
+  try
+    {
+      read_json(in, node_tree);
+    }
+  catch (const std::exception &e)
+    {
+      AssertThrow(
+        false,
+        ExcMessage(
+          "The provided JSON file is not valid. Boost aborted with the "
+          "following assert message: \n\n" +
+          std::string(e.what())));
+    }
 
   // The xml function is reused to read in the xml into the parameter file.
   // This means that only mangled files can be read.


### PR DESCRIPTION
References #11628. The error message when providing an empty file used to be a bit cryptic:
```
terminate called after throwing an instance of 'boost::wrapexcept<boost::property_tree::json_parser::json_parser_error>'
  what():  <unspecified file>(1): expected value
```

This PR proposes to wrap the error message and amend the error message:
```
terminate called after throwing an instance of 'dealii::StandardExceptions::ExcMessage'
  what():  
--------------------------------------------------------
An error occurred in line <769> of file </home/munch/sw-index/dealii2/source/base/parameter_handler.cc> in function
    virtual void dealii::ParameterHandler::parse_input_from_json(std::istream&, bool)
The violated condition was: 
    false
Additional information: 
    The provided JSON file is not valid. Boost aborted with the following
    assert message:
    
    <unspecified file>(1): expected value
--------------------------------------------------------
```

FYI @nfehn 