### PR TITLE
Fix typo in GridTools::collect_periodic_faces

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2796,9 +2796,9 @@ namespace GridTools
    *
    * Instead of defining a 'first' and 'second' boundary with the help of two
    * boundary_ids this function defines a 'left' boundary as all faces with
-   * local face index <code>2*dimension</code> and boundary indicator @p b_id
+   * local face index <code>2*direction</code> and boundary indicator @p b_id
    * and, similarly, a 'right' boundary consisting of all face with local face
-   * index <code>2*dimension+1</code> and boundary indicator @p b_id. Faces
+   * index <code>2*direction+1</code> and boundary indicator @p b_id. Faces
    * with coordinates only differing in the @p direction component are
    * identified.
    *


### PR DESCRIPTION
We don't use "dimension" anywhere in the function signature and this should really be the same as "direction".