### PR TITLE
Fix hp-coarsening on p:s:Triangulation.

### DIFF
--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -1821,6 +1821,21 @@ namespace internal
     namespace DoFHandlerImplementation
     {
       /**
+       * Given a DoFHandler object in hp-mode, make sure that the
+       * future FE indices that a user has set for locally owned cells are
+       * communicated to all other relevant cells as well.
+       *
+       * For parallel::shared::Triangulation objects,
+       * this information is distributed on both ghost and artificial cells.
+       *
+       * In case a parallel::distributed::Triangulation is used,
+       * indices are communicated only to ghost cells.
+       */
+      template <int dim, int spacedim>
+      void
+      communicate_future_fe_indices(DoFHandler<dim, spacedim> &dof_handler);
+
+      /**
        * Return the index of the finite element from the entire hp::FECollection
        * that is dominated by those assigned as future finite elements to the
        * children of @p parent.
@@ -1837,6 +1852,12 @@ namespace internal
        *
        * @note This function can only be called on direct parent cells, i.e.,
        * non-active cells whose children are all active.
+       *
+       * @note On parallel::shared::Triangulation objects where sibling cells
+       * can be ghost cells, make sure that future FE indices have been properly
+       * communicated with communicate_future_fe_indices() first. Otherwise,
+       * results might differ on different processors. There is no check for
+       * consistency of future FE indices.
        */
       template <int dim, int spacedim = dim>
       unsigned int

--- a/source/dofs/dof_handler.inst.in
+++ b/source/dofs/dof_handler.inst.in
@@ -19,15 +19,31 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : DIMENSIONS)
 #if deal_II_dimension <= deal_II_space_dimension
     template class DoFHandler<deal_II_dimension, deal_II_space_dimension>;
 
-    template std::string internal::policy_to_string(
-      const dealii::internal::DoFHandlerImplementation::Policy::
-        PolicyBase<deal_II_dimension, deal_II_space_dimension> &policy);
+    namespace internal
+    \{
+      template std::string
+      policy_to_string(const DoFHandlerImplementation::Policy::PolicyBase<
+                       deal_II_dimension,
+                       deal_II_space_dimension> &);
 
-    template unsigned int internal::hp::DoFHandlerImplementation::
-      dominated_future_fe_on_children<deal_II_dimension,
-                                      deal_II_space_dimension>(
-        const typename DoFHandler<deal_II_dimension,
-                                  deal_II_space_dimension>::cell_iterator &);
+      namespace hp
+      \{
+        namespace DoFHandlerImplementation
+        \{
+          template void
+          communicate_future_fe_indices<deal_II_dimension,
+                                        deal_II_space_dimension>(
+            DoFHandler<deal_II_dimension, deal_II_space_dimension> &);
+
+          template unsigned int
+          dominated_future_fe_on_children<deal_II_dimension,
+                                          deal_II_space_dimension>(
+            const typename DoFHandler<deal_II_dimension,
+                                      deal_II_space_dimension>::cell_iterator
+              &);
+        \}
+      \}
+    \}
 #endif
   }
 

--- a/tests/sharedtria/hp_choose_p_over_h.cc
+++ b/tests/sharedtria/hp_choose_p_over_h.cc
@@ -69,11 +69,11 @@ test()
           for (unsigned int i = 0; i < cell->n_children(); ++i)
             {
               const auto &child = cell->child(i);
+
+              child->set_coarsen_flag();
+
               if (child->is_locally_owned())
-                {
-                  child->set_future_fe_index(1);
-                  child->set_coarsen_flag();
-                }
+                child->set_future_fe_index(1);
             }
         }
       else if (cell->id().to_string() == "1_0:")
@@ -84,12 +84,12 @@ test()
           for (unsigned int i = 0; i < cell->n_children(); ++i)
             {
               const auto &child = cell->child(i);
+
+              child->set_coarsen_flag();
+
               if (child->is_locally_owned())
-                {
-                  if (i == 0)
-                    child->set_future_fe_index(1);
-                  child->set_coarsen_flag();
-                }
+                if (i == 0)
+                  child->set_future_fe_index(1);
             }
         }
     }

--- a/tests/sharedtria/limit_p_level_difference_04.cc
+++ b/tests/sharedtria/limit_p_level_difference_04.cc
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// verify restrictions on level differences imposed by
+// DoFHandler::prepare_coarsening_and_refinement()
+// on h-coarsened grids
+
+
+#include <deal.II/distributed/shared_tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/refinement.h>
+
+#include "../tests.h"
+
+#include "../test_grids.h"
+
+
+template <int dim>
+void
+test(const unsigned int max_difference, const bool allow_artificial_cells)
+{
+  Assert(max_difference > 0, ExcInternalError());
+
+  // setup FE collection
+  const unsigned int fes_size = 2 * max_difference + 2;
+
+  hp::FECollection<dim> fes;
+  while (fes.size() < fes_size)
+    fes.push_back(FE_Q<dim>(1));
+
+  const unsigned int contains_fe_index = 0;
+  const auto         sequence = fes.get_hierarchy_sequence(contains_fe_index);
+
+  // set up line grid
+  // - refine central cell and flag them for coarsening
+  // - assign highest p-level to leftmost cell
+  //
+  // +-------+---+---+-------+
+  // |       | c | c |       |
+  // |       +---+---+       |
+  // |       | c | c |       |
+  // +-------+---+---+-------+
+  //
+  // after prepare_coarsening_and_refinement(), the p-levels should propagate
+  // through the central cells as if they were already coarsened
+
+  parallel::shared::Triangulation<dim> tria(MPI_COMM_WORLD,
+                                            Triangulation<dim>::none,
+                                            allow_artificial_cells);
+  TestGrids::hyper_line(tria, 3);
+
+  // refine the central cell
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  // now flag these cells for coarsening
+  for (const auto &cell : tria.active_cell_iterators())
+    if (cell->center()[0] > 1. && cell->center()[0] < 2.)
+      cell->set_coarsen_flag();
+
+  DoFHandler<dim> dofh(tria);
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned() && cell->center()[0] < 1.)
+      cell->set_active_fe_index(sequence.back());
+  dofh.distribute_dofs(fes);
+
+  const bool fe_indices_changed =
+    hp::Refinement::limit_p_level_difference(dofh,
+                                             max_difference,
+                                             contains_fe_index);
+  (void)fe_indices_changed;
+  Assert(fe_indices_changed, ExcInternalError());
+
+  deallog << "future FE indices before adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      deallog << " " << cell->id().to_string() << " " << cell->future_fe_index()
+              << std::endl;
+
+  tria.execute_coarsening_and_refinement();
+
+  deallog << "active FE indices after adaptation:" << std::endl;
+  for (const auto &cell : dofh.active_cell_iterators())
+    if (cell->is_locally_owned())
+      deallog << " " << cell->id().to_string() << " " << cell->active_fe_index()
+              << std::endl;
+
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  deallog << std::boolalpha;
+  for (const bool allow_artificial_cells : {false, true})
+    {
+      deallog << "artificial cells: " << allow_artificial_cells << std::endl;
+      test<2>(1, allow_artificial_cells);
+      test<2>(2, allow_artificial_cells);
+      test<2>(3, allow_artificial_cells);
+    }
+}

--- a/tests/sharedtria/limit_p_level_difference_04.with_mpi=true.mpirun=1.output
+++ b/tests/sharedtria/limit_p_level_difference_04.with_mpi=true.mpirun=1.output
@@ -1,0 +1,75 @@
+
+DEAL:0::artificial cells: false
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 2
+DEAL:0:: 1_1:1 2
+DEAL:0:: 1_1:2 2
+DEAL:0:: 1_1:3 2
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 1_0: 2
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 3
+DEAL:0:: 1_1:1 3
+DEAL:0:: 1_1:2 3
+DEAL:0:: 1_1:3 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 1_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 4
+DEAL:0:: 1_1:1 4
+DEAL:0:: 1_1:2 4
+DEAL:0:: 1_1:3 4
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 1_0: 4
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::artificial cells: true
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 2
+DEAL:0:: 1_1:1 2
+DEAL:0:: 1_1:2 2
+DEAL:0:: 1_1:3 2
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 3
+DEAL:0:: 1_0: 2
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 3
+DEAL:0:: 1_1:1 3
+DEAL:0:: 1_1:2 3
+DEAL:0:: 1_1:3 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 5
+DEAL:0:: 1_0: 3
+DEAL:0:: 2_0: 1
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 2_0: 1
+DEAL:0:: 1_1:0 4
+DEAL:0:: 1_1:1 4
+DEAL:0:: 1_1:2 4
+DEAL:0:: 1_1:3 4
+DEAL:0::active FE indices after adaptation:
+DEAL:0:: 0_0: 7
+DEAL:0:: 1_0: 4
+DEAL:0:: 2_0: 1
+DEAL:0::OK

--- a/tests/sharedtria/limit_p_level_difference_04.with_mpi=true.mpirun=4.output
+++ b/tests/sharedtria/limit_p_level_difference_04.with_mpi=true.mpirun=4.output
@@ -1,0 +1,141 @@
+
+DEAL:0::artificial cells: false
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 2
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 4
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::artificial cells: true
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 2
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 3
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+DEAL:0::future FE indices before adaptation:
+DEAL:0:: 1_1:3 4
+DEAL:0::active FE indices after adaptation:
+DEAL:0::OK
+
+DEAL:1::artificial cells: false
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 2
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 2
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 3
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 3
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 4
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 4
+DEAL:1::OK
+DEAL:1::artificial cells: true
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 2
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 2
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 3
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 3
+DEAL:1::OK
+DEAL:1::future FE indices before adaptation:
+DEAL:1:: 2_0: 1
+DEAL:1:: 1_1:1 4
+DEAL:1::active FE indices after adaptation:
+DEAL:1:: 1_0: 4
+DEAL:1::OK
+
+
+DEAL:2::artificial cells: false
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 2
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 3
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 4
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+DEAL:2::artificial cells: true
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 2
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 3
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+DEAL:2::future FE indices before adaptation:
+DEAL:2:: 1_1:2 4
+DEAL:2::active FE indices after adaptation:
+DEAL:2:: 2_0: 1
+DEAL:2::OK
+
+
+DEAL:3::artificial cells: false
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 3
+DEAL:3:: 1_1:0 2
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 3
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 5
+DEAL:3:: 1_1:0 3
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 5
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 7
+DEAL:3:: 1_1:0 4
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 7
+DEAL:3::OK
+DEAL:3::artificial cells: true
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 3
+DEAL:3:: 1_1:0 2
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 3
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 5
+DEAL:3:: 1_1:0 3
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 5
+DEAL:3::OK
+DEAL:3::future FE indices before adaptation:
+DEAL:3:: 0_0: 7
+DEAL:3:: 1_1:0 4
+DEAL:3::active FE indices after adaptation:
+DEAL:3:: 0_0: 7
+DEAL:3::OK
+


### PR DESCRIPTION
We need information about future FE indices on locally relevant cells for `DoFHandlers` on `parallel::shared::Triangulations`. Siblings of active cells might be ghost cells here. In case of hp-coarsening, we need access to their future FE indices to determine the active FE index on the parent cell.

A test in #11943 did not work for `parallel::shared::Triangulations` for that reason. It will be reintroduced in this PR as a consequence of #11961.

This circumstance is further responsible for a bug in `hp::Refinement::choose_p_over_h()` and will fix #11902.