### PR TITLE
Added `p:d:TemporarilyMatchRefineFlags`.

### DIFF
--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -3559,6 +3559,92 @@ namespace parallel
 
 
 
+namespace internal
+{
+  namespace parallel
+  {
+    namespace distributed
+    {
+      template <int dim, int spacedim>
+      TemporarilyMatchRefineFlags<dim, spacedim>::TemporarilyMatchRefineFlags(
+        Triangulation<dim, spacedim> &tria)
+        : distributed_tria(
+            dynamic_cast<
+              dealii::parallel::distributed::Triangulation<dim, spacedim> *>(
+              &tria))
+      {
+#ifdef DEAL_II_WITH_P4EST
+        if (distributed_tria != nullptr)
+          {
+            // Save the current set of refinement flags, and adjust the
+            // refinement flags to be consistent with the p4est oracle.
+            distributed_tria->save_coarsen_flags(saved_coarsen_flags);
+            distributed_tria->save_refine_flags(saved_refine_flags);
+
+            for (const auto &pair : distributed_tria->local_cell_relations)
+              {
+                const auto &cell   = pair.first;
+                const auto &status = pair.second;
+
+                switch (status)
+                  {
+                    case dealii::Triangulation<dim, spacedim>::CELL_PERSIST:
+                      // cell remains unchanged
+                      cell->clear_refine_flag();
+                      cell->clear_coarsen_flag();
+                      break;
+
+                    case dealii::Triangulation<dim, spacedim>::CELL_REFINE:
+                      // cell will be refined
+                      cell->clear_coarsen_flag();
+                      cell->set_refine_flag();
+                      break;
+
+                    case dealii::Triangulation<dim, spacedim>::CELL_COARSEN:
+                      // children of this cell will be coarsened
+                      for (const auto &child : cell->child_iterators())
+                        {
+                          child->clear_refine_flag();
+                          child->set_coarsen_flag();
+                        }
+                      break;
+
+                    case dealii::Triangulation<dim, spacedim>::CELL_INVALID:
+                      // do nothing as cell does not exist yet
+                      break;
+
+                    default:
+                      Assert(false, ExcInternalError());
+                      break;
+                  }
+              }
+          }
+#endif
+      }
+
+
+
+      template <int dim, int spacedim>
+      TemporarilyMatchRefineFlags<dim, spacedim>::~TemporarilyMatchRefineFlags()
+      {
+#ifdef DEAL_II_WITH_P4EST
+        if (distributed_tria)
+          {
+            // Undo the refinement flags modification.
+            distributed_tria->load_coarsen_flags(saved_coarsen_flags);
+            distributed_tria->load_refine_flags(saved_refine_flags);
+          }
+#else
+        // pretend that this destructor does something to silence clang-tidy
+        (void)distributed_tria;
+#endif
+      }
+    } // namespace distributed
+  }   // namespace parallel
+} // namespace internal
+
+
+
 /*-------------- Explicit Instantiations -------------------------------*/
 #include "tria.inst"
 

--- a/source/distributed/tria.inst.in
+++ b/source/distributed/tria.inst.in
@@ -15,19 +15,30 @@
 
 
 
-for (deal_II_dimension : DIMENSIONS)
+for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
   {
     namespace parallel
     \{
       namespace distributed
       \{
-        template class Triangulation<deal_II_dimension>;
-#if deal_II_dimension < 3
-        template class Triangulation<deal_II_dimension, deal_II_dimension + 1>;
+#if deal_II_dimension <= deal_II_space_dimension
+        template class Triangulation<deal_II_dimension,
+                                     deal_II_space_dimension>;
 #endif
-#if deal_II_dimension < 2
-        template class Triangulation<deal_II_dimension, deal_II_dimension + 2>;
+      \}
+    \}
+
+    namespace internal
+    \{
+      namespace parallel
+      \{
+        namespace distributed
+        \{
+#if deal_II_dimension <= deal_II_space_dimension
+          template class TemporarilyMatchRefineFlags<deal_II_dimension,
+                                                     deal_II_space_dimension>;
 #endif
+        \}
       \}
     \}
   }

--- a/tests/mpi/limit_p_level_difference_03.cc
+++ b/tests/mpi/limit_p_level_difference_03.cc
@@ -90,13 +90,20 @@ test(const unsigned int fes_size, const unsigned int max_difference)
       cell->set_active_fe_index(sequence.back());
   dofh.distribute_dofs(fes);
 
-  const bool fe_indices_changed =
-    hp::Refinement::limit_p_level_difference(dofh,
-                                             max_difference,
-                                             contains_fe_index);
+  bool fe_indices_changed = false;
+  tria.signals.post_p4est_refinement.connect(
+    [&]() {
+      const internal::parallel::distributed::TemporarilyMatchRefineFlags<dim>
+        refine_modifier(tria);
+      fe_indices_changed =
+        hp::Refinement::limit_p_level_difference(dofh,
+                                                 max_difference,
+                                                 contains_fe_index);
+    },
+    boost::signals2::at_front);
+
   tria.execute_coarsening_and_refinement();
 
-  (void)fe_indices_changed;
   Assert(fe_indices_changed, ExcInternalError());
 
 #ifdef DEBUG


### PR DESCRIPTION
~Blocked by #11969.~ (EDIT: Has been merged.)

`p4est` might refine differently than indicated by refine and coarsen flags in the `Triangulation` class, see #8647.

Some `hp::Refinement` functions rely on correctly set refine flags, i.e., `limit_p_level_difference()` and `predict_error()`. Thus we need a way to mirror the refine flags from the `parallel_forest` object.

This PR proposes a class `p:d:TemporarilyMatchRefineFlags` for this purpose, similar to `p:s:TemporarilyRestoreSubdomainIds`.

Necessary for step-75 #11254.