### PR TITLE
Unify the spelling of a section name in the tutorial programs.

### DIFF
--- a/examples/step-1/doc/results.dox
+++ b/examples/step-1/doc/results.dox
@@ -32,7 +32,7 @@ has found its way into the literature: see @cite Mu05. Apparently it is
 good for some things at least.)
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 <h4> Different adaptive refinement strategies </h4>
 

--- a/examples/step-16/doc/results.dox
+++ b/examples/step-16/doc/results.dox
@@ -57,7 +57,7 @@ obviously in part due to the simple nature of the problem solved, but
 it shows the power of multigrid methods.
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 
 We encourage you to generate timings for the solve() call and compare to

--- a/examples/step-18/doc/results.dox
+++ b/examples/step-18/doc/results.dox
@@ -404,7 +404,7 @@ Without such a formulation we cannot expect anything to make physical sense,
 even if it produces nice pictures!
 
 
-<h3>Possible directions for extensions</h3>
+<h3>Possibilities for extensions</h3>
 
 The program as is does not really solve an equation that has many applications
 in practice: quasi-static material deformation based on a purely elastic law

--- a/examples/step-2/doc/results.dox
+++ b/examples/step-2/doc/results.dox
@@ -26,7 +26,7 @@ nonzero entries is the same in both pictures, of course.
 
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 Just as with step-1, you may want to play with the program a bit to
 familiarize yourself with deal.II. For example, in the

--- a/examples/step-22/doc/results.dox
+++ b/examples/step-22/doc/results.dox
@@ -278,7 +278,7 @@ is not a good choice in 3D - a full decomposition needs many new entries that
 
 
 
-<h3>Possible Extensions</h3>
+<h3>Possibilities for extensions</h3>
 
 <a name="improved-solver">
 <h4>Improved linear solver in 3D</h4>

--- a/examples/step-31/doc/results.dox
+++ b/examples/step-31/doc/results.dox
@@ -585,7 +585,7 @@ more accurate; the program therefore uses these higher order elements,
 despite the penalty we pay in terms of smaller time steps.
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 There are various ways to extend the current program. Of particular interest
 is, of course, to make it faster and/or increase the resolution of the

--- a/examples/step-35/doc/results.dox
+++ b/examples/step-35/doc/results.dox
@@ -131,7 +131,7 @@ resolutions, as described below.
 
 
 <a name="extensions"></a>
-<h3> Possible Extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 This program can be extended in the following directions:
 <ul>

--- a/examples/step-49/doc/results.dox
+++ b/examples/step-49/doc/results.dox
@@ -334,7 +334,7 @@ the nice detail of the boundary fitted mesh if we refine two more times:
      alt="" width="400" height="355">
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 <h4> Assigning different boundary ids </h4>
 

--- a/examples/step-50/doc/results.dox
+++ b/examples/step-50/doc/results.dox
@@ -266,7 +266,7 @@ same problem on the same number of processors in about one eighth the
 time.
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 <h4> Testing convergence and higher order elements </h4>
 

--- a/examples/step-56/doc/results.dox
+++ b/examples/step-56/doc/results.dox
@@ -189,7 +189,7 @@ solve time.
 4. GMG needs slightly more memory than ILU to store the level and interface
 matrices.
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 <h4> Check higher order discretizations </h4>
 

--- a/examples/step-64/doc/results.dox
+++ b/examples/step-64/doc/results.dox
@@ -43,7 +43,7 @@ using a better preconditioner than the identity matrix we have used here.
 
 
 <a name="extensions"></a>
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 Currently, this program uses no preconditioner at all. This is mainly
 since constructing an efficient matrix-free preconditioner is

--- a/examples/step-7/doc/results.dox
+++ b/examples/step-7/doc/results.dox
@@ -260,7 +260,7 @@ norms into one global norm as we already do in the program, by calling
 
 
 
-<h3> Possible extensions </h3>
+<h3> Possibilities for extensions </h3>
 
 <h4> Higher Order Elements </h4>
 


### PR DESCRIPTION
We use 'Possibilities for extensions' in about 40 existing tutorial programs. Use the same heading in about a dozen others.

/rebuild