### PR TITLE
Fix mistake in parameter description

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -157,10 +157,8 @@ namespace GridGenerator
    * @param tria The triangulation to create. It needs to be empty upon
    * calling this function.
    *
-   * @param repetitions A vector of @p dim positive values denoting the number
-   * of cells to generate in that direction. For example, the first component of
-   * the vector specifies the number of cells in the x-direction, the second
-   * component specifies that for the y-direction for dim=2.
+   * @param repetitions An unsigned integer denoting the number of cells to
+   * generate in each direction.
    *
    * @param left Lower bound for the interval used to create the hyper cube.
    *


### PR DESCRIPTION
`repetitions` here is an integer unlike in [subdivided_hyper_rectangle()](https://www.dealii.org/current/doxygen/deal.II/namespaceGridGenerator.html#ac76417d7404b75cf53c732f456e6e971) where it is a vector of integers.