### PR TITLE
Deprecate DoFTools::extract_boundary_dofs() with std::vector<bool> argument

### DIFF
--- a/doc/news/changes/minor/20210330Bangerth
+++ b/doc/news/changes/minor/20210330Bangerth
@@ -1,0 +1,7 @@
+Deprecated: The version of DoFTools::extract_boundary_dofs() that
+returns its information via a `std::vector<bool>` has been
+deprecated. Use the version of the function that returns information
+via an IndexSet instead.
+<br>
+(Wolfgang Bangerth, 2021/03/30)
+

--- a/doc/news/changes/minor/20210330Bangerth-2
+++ b/doc/news/changes/minor/20210330Bangerth-2
@@ -1,0 +1,7 @@
+Deprecated: The version of DoFTools::extract_boundary_dofs() that
+returns its information via an `IndexSet` reference argument has been
+deprecated. Use the version of the function that returns information
+via an IndexSet return type instead.
+<br>
+(Wolfgang Bangerth, 2021/03/30)
+

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -132,36 +132,22 @@ namespace Step11
     solution.reinit(dof_handler.n_dofs());
     system_rhs.reinit(dof_handler.n_dofs());
 
-    // Next task is to construct the object representing the constraint that
+    // The next task is to construct the object representing the constraint that
     // the mean value of the degrees of freedom on the boundary shall be
-    // zero. For this, we first want a list of those nodes which are actually
+    // zero. For this, we first want a list of those nodes that are actually
     // at the boundary. The <code>DoFTools</code> namespace has a function
-    // that returns an array of Boolean values where <code>true</code>
-    // indicates that the node is at the boundary. The second argument denotes
-    // a mask selecting which components of vector valued finite elements we
-    // want to be considered. This sort of information is encoded using the
-    // ComponentMask class (see also @ref GlossComponentMask). Since we have a
-    // scalar finite element anyway, this mask in reality should have only one
-    // entry with a <code>true</code> value. However, the ComponentMask class
-    // has semantics that allow it to represents a mask of indefinite size
-    // whose every element equals <code>true</code> when one just default
-    // constructs such an object, so this is what we'll do here.
-    std::vector<bool> boundary_dofs(dof_handler.n_dofs(), false);
-    DoFTools::extract_boundary_dofs(dof_handler,
-                                    ComponentMask(),
-                                    boundary_dofs);
+    // that returns an IndexSet object that contains the indices of all those
+    // degrees of freedom that are at the boundary.
+    //
+    // Once we have this index set, we wanted to know which is the first
+    // index corresponding to a degree of freedom on the boundary. We need
+    // this because we wanted to constrain one of the nodes on the boundary by
+    // the values of all other DoFs on the boundary. To get the index of this
+    // "first" degree of freedom is easy enough using the IndexSet class:
+    const IndexSet boundary_dofs = DoFTools::extract_boundary_dofs(dof_handler);
 
-    // Now first for the generation of the constraints: as mentioned in the
-    // introduction, we constrain one of the nodes on the boundary by the
-    // values of all other DoFs on the boundary. So, let us first pick out the
-    // first boundary node from this list. We do that by searching for the
-    // first <code>true</code> value in the array (note that
-    // <code>std::find</code> returns an iterator to this element), and
-    // computing its distance to the overall first element in the array to get
-    // its index:
-    const unsigned int first_boundary_dof = std::distance(
-      boundary_dofs.begin(),
-      std::find(boundary_dofs.begin(), boundary_dofs.end(), true));
+    const types::global_dof_index first_boundary_dof =
+      boundary_dofs.nth_index_in_set(0);
 
     // Then generate a constraints object with just this one constraint. First
     // clear all previous content (which might reside there from the previous
@@ -172,8 +158,8 @@ namespace Step11
     // of what is to come later:
     mean_value_constraints.clear();
     mean_value_constraints.add_line(first_boundary_dof);
-    for (unsigned int i = first_boundary_dof + 1; i < dof_handler.n_dofs(); ++i)
-      if (boundary_dofs[i] == true)
+    for (types::global_dof_index i : boundary_dofs)
+      if (i != first_boundary_dof)
         mean_value_constraints.add_entry(first_boundary_dof, i, -1);
     mean_value_constraints.close();
 

--- a/examples/step-15/step-15.cc
+++ b/examples/step-15/step-15.cc
@@ -541,17 +541,15 @@ namespace Step15
     // thing on every cell and so we didn't not want to deal with the question
     // of whether a particular degree of freedom sits at the boundary in the
     // integration above. Rather, we will simply set to zero these entries
-    // after the fact. To this end, we first need to determine which degrees
+    // after the fact. To this end, we need to determine which degrees
     // of freedom do in fact belong to the boundary and then loop over all of
     // those and set the residual entry to zero. This happens in the following
-    // lines which we have already seen used in step-11:
+    // lines which we have already seen used in step-11, using the appropriate
+    // function from namespace DoFTools:
     hanging_node_constraints.condense(residual);
 
-    IndexSet boundary_dofs(dof_handler.n_dofs());
-    DoFTools::extract_boundary_dofs(dof_handler,
-                                    ComponentMask(),
-                                    boundary_dofs);
-    for (types::global_dof_index i : boundary_dofs)
+    for (types::global_dof_index i :
+         DoFTools::extract_boundary_dofs(dof_handler))
       residual(i) = 0;
 
     // At the end of the function, we return the norm of the residual:

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1486,21 +1486,33 @@ namespace DoFTools
    * @param[in] component_mask A mask denoting the vector components of the
    * finite element that should be considered (see also
    * @ref GlossComponentMask).
-   * @param[out] selected_dofs The IndexSet object that is returned and that
-   * will contain the indices of degrees of freedom that are located on the
-   * boundary (and correspond to the selected vector components and boundary
-   * indicators, depending on the values of the @p component_mask and @p
-   * boundary_ids arguments).
    * @param[in] boundary_ids If empty, this function extracts the indices of the
    * degrees of freedom for all parts of the boundary. If it is a non- empty
    * list, then the function only considers boundary faces with the boundary
    * indicators listed in this argument.
+   * @return The IndexSet object that
+   * will contain the indices of degrees of freedom that are located on the
+   * boundary (and correspond to the selected vector components and boundary
+   * indicators, depending on the values of the @p component_mask and @p
+   * boundary_ids arguments).
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim>
-  void
+  IndexSet
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
+                        const ComponentMask &               component_mask,
+                        const std::set<types::boundary_id> &boundary_ids = {});
+
+  /**
+   * The same as the previous function, except that it returns its information
+   * via the third argument.
+   *
+   * @deprecated Use the previous function instead.
+   */
+  template <int dim, int spacedim>
+  DEAL_II_DEPRECATED_EARLY void
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
                         const ComponentMask &               component_mask,
                         IndexSet &                          selected_dofs,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1485,9 +1485,11 @@ namespace DoFTools
    * live on which cell.
    * @param[in] component_mask A mask denoting the vector components of the
    * finite element that should be considered (see also
-   * @ref GlossComponentMask).
+   * @ref GlossComponentMask). If left at the default, the component mask
+   * indicates that all vector components of the finite element should be
+   * considered.
    * @param[in] boundary_ids If empty, this function extracts the indices of the
-   * degrees of freedom for all parts of the boundary. If it is a non- empty
+   * degrees of freedom for all parts of the boundary. If it is a non-empty
    * list, then the function only considers boundary faces with the boundary
    * indicators listed in this argument.
    * @return The IndexSet object that
@@ -1501,8 +1503,8 @@ namespace DoFTools
    */
   template <int dim, int spacedim>
   IndexSet
-  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
-                        const ComponentMask &               component_mask,
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &dof_handler,
+                        const ComponentMask &component_mask = ComponentMask(),
                         const std::set<types::boundary_id> &boundary_ids = {});
 
   /**

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1405,9 +1405,9 @@ namespace DoFTools
    * specified components of the solution. The function returns its results in
    * the last non-default-valued parameter which contains @p true if a degree
    * of freedom is at the boundary and belongs to one of the selected
-   * components, and @p false otherwise. The function is used in step-15.
+   * components, and @p false otherwise.
    *
-   * By specifying the @p boundary_id variable, you can select which boundary
+   * By specifying the @p boundary_ids variable, you can select which boundary
    * indicators the faces have to have on which the degrees of freedom are
    * located that shall be extracted. If it is an empty list, then all
    * boundary indicators are accepted.
@@ -1424,13 +1424,15 @@ namespace DoFTools
    * component mask is used that corresponds to the first non-zero components.
    * Elements in the mask corresponding to later components are ignored.
    *
-   * @note This function will not work for DoFHandler objects that are built
+   * @deprecated This function will not work for DoFHandler objects that are built
    * on a parallel::distributed::Triangulation object. The reasons is that the
    * output argument @p selected_dofs has to have a length equal to <i>all</i>
    * global degrees of freedom. Consequently, this does not scale to very
-   * large problems. If you need the functionality of this function for
+   * large problems, and this is also why the function is deprecated. If you
+   * need the functionality of this function for
    * parallel triangulations, then you need to use the other
-   * DoFTools::extract_boundary_dofs function.
+   * DoFTools::extract_boundary_dofs() function that returns its information
+   * via an IndexSet object.
    *
    * @param[in] dof_handler The object that describes which degrees of freedom
    * live on which cell.
@@ -1453,24 +1455,31 @@ namespace DoFTools
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim>
-  void
+  DEAL_II_DEPRECATED_EARLY void
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
                         const ComponentMask &               component_mask,
                         std::vector<bool> &                 selected_dofs,
-                        const std::set<types::boundary_id> &boundary_ids =
-                          std::set<types::boundary_id>());
+                        const std::set<types::boundary_id> &boundary_ids = {});
 
   /**
-   * This function does the same as the previous one but it returns its result
-   * as an IndexSet rather than a std::vector@<bool@>. Thus, it can also be
-   * called for DoFHandler objects that are defined on
-   * parallel::distributed::Triangulation objects.
+   * Extract all degrees of freedom which are at the boundary and belong to
+   * specified components of the solution. The function returns its results in
+   * the form of an IndexSet that contains those entries that correspond to
+   * these selected degrees of freedom, i.e., which are at the boundary and
+   * belong to one of the selected components.
    *
-   * @note If the DoFHandler object is indeed defined on a
-   * parallel::distributed::Triangulation, then the @p selected_dofs index set
+   * By specifying the @p boundary_ids variable, you can select which boundary
+   * indicators the faces have to have on which the degrees of freedom are
+   * located that shall be extracted. If it is an empty list (the default), then
+   * all boundary indicators are accepted.
+   *
+   * @note If the DoFHandler object is defined on a
+   * parallel Triangulation object, then the computed index set
    * will contain only those degrees of freedom on the boundary that belong to
    * the locally relevant set (see
-   * @ref GlossLocallyRelevantDof "locally relevant DoFs").
+   * @ref GlossLocallyRelevantDof "locally relevant DoFs"), i.e., the function
+   * only considers faces of locally owned and ghost cells, but not of
+   * artificial cells.
    *
    * @param[in] dof_handler The object that describes which degrees of freedom
    * live on which cell.
@@ -1495,8 +1504,7 @@ namespace DoFTools
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
                         const ComponentMask &               component_mask,
                         IndexSet &                          selected_dofs,
-                        const std::set<types::boundary_id> &boundary_ids =
-                          std::set<types::boundary_id>());
+                        const std::set<types::boundary_id> &boundary_ids = {});
 
   /**
    * This function is similar to the extract_boundary_dofs() function but it

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -634,6 +634,7 @@ namespace DoFTools
   }
 
 
+
   template <int dim, int spacedim>
   void
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
@@ -675,7 +676,6 @@ namespace DoFTools
     // boundary line is also part of a boundary face which we will be
     // visiting sooner or later
     for (const auto &cell : dof_handler.active_cell_iterators())
-
       // only work on cells that are either locally owned or at least ghost
       // cells
       if (cell->is_artificial() == false)

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -642,6 +642,19 @@ namespace DoFTools
                         IndexSet &                          selected_dofs,
                         const std::set<types::boundary_id> &boundary_ids)
   {
+    // Simply forward to the other function
+    selected_dofs =
+      extract_boundary_dofs(dof_handler, component_mask, boundary_ids);
+  }
+
+
+
+  template <int dim, int spacedim>
+  IndexSet
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
+                        const ComponentMask &               component_mask,
+                        const std::set<types::boundary_id> &boundary_ids)
+  {
     Assert(component_mask.represents_n_components(
              dof_handler.get_fe_collection().n_components()),
            ExcMessage("Component mask has invalid size."));
@@ -649,9 +662,7 @@ namespace DoFTools
              boundary_ids.end(),
            ExcInvalidBoundaryIndicator());
 
-    // first reset output argument
-    selected_dofs.clear();
-    selected_dofs.set_size(dof_handler.n_dofs());
+    IndexSet selected_dofs(dof_handler.n_dofs());
 
     // let's see whether we have to check for certain boundary indicators
     // or whether we can accept all
@@ -760,6 +771,8 @@ namespace DoFTools
                         }
                     }
               }
+
+    return selected_dofs;
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -188,6 +188,12 @@ for (deal_II_dimension : DIMENSIONS)
       IndexSet &,
       const std::set<types::boundary_id> &);
 
+    template IndexSet
+    DoFTools::extract_boundary_dofs<deal_II_dimension, deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      const std::set<types::boundary_id> &);
+
     template void DoFTools::extract_dofs_with_support_on_boundary<
       deal_II_dimension,
       deal_II_dimension>(const DoFHandler<deal_II_dimension> &,

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -431,7 +431,7 @@ namespace Step22
 
       /*std::vector<bool> boundary_dofs (dof_handler.n_dofs(), false);
 
-      std::vector<bool>boundary_mask (dim+1, false);
+      std::vector<bool> boundary_mask (dim+1, false);
       boundary_mask[dim]=true;
 
       DoFTools::extract_boundary_dofs (dof_handler,boundary_mask,boundary_dofs);

--- a/tests/mpi/constraint_matrix_condense_01.cc
+++ b/tests/mpi/constraint_matrix_condense_01.cc
@@ -59,10 +59,8 @@ test()
   AffineConstraints<PetscScalar> constraints(locally_relevant_dofs);
   constraints.clear();
   {
-    IndexSet boundary_dofs(dof_handler.n_dofs());
-    DoFTools::extract_boundary_dofs(dof_handler,
-                                    std::vector<bool>(1, true),
-                                    boundary_dofs);
+    const IndexSet boundary_dofs =
+      DoFTools::extract_boundary_dofs(dof_handler, std::vector<bool>(1, true));
 
     unsigned int first_nboundary_dof = 0;
     while (boundary_dofs.is_element(first_nboundary_dof))

--- a/tests/mpi/extract_boundary_dofs.cc
+++ b/tests/mpi/extract_boundary_dofs.cc
@@ -43,15 +43,14 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet relevant_set, boundary_dofs;
-  DoFTools::extract_boundary_dofs(dofh,
-                                  std::vector<bool>(1, true),
-                                  boundary_dofs);
+  const IndexSet boundary_dofs =
+    DoFTools::extract_boundary_dofs(dofh, std::vector<bool>(1, true));
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     boundary_dofs.write(deallog.get_file_stream());
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
+  IndexSet relevant_set;
   DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());

--- a/tests/simplex/extract_boundary_dofs.cc
+++ b/tests/simplex/extract_boundary_dofs.cc
@@ -49,15 +49,14 @@ test()
   DoFHandler<dim>        dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet relevant_set, boundary_dofs;
-  DoFTools::extract_boundary_dofs(dofh,
-                                  std::vector<bool>(1, true),
-                                  boundary_dofs);
+  IndexSet boundary_dofs =
+    DoFTools::extract_boundary_dofs(dofh, std::vector<bool>(1, true));
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     boundary_dofs.write(deallog.get_file_stream());
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
+  IndexSet relevant_set;
   DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());


### PR DESCRIPTION
We have slowly been replacing these by functions using `IndexSet` instead, and indeed such a function already exists. The function here is not particularly widely used.

/rebuild