### PR TITLE
Deal with the other DoFTools::extract_boundary_dofs() function

### DIFF
--- a/doc/news/changes/minor/20210330Bangerth-2
+++ b/doc/news/changes/minor/20210330Bangerth-2
@@ -1,0 +1,7 @@
+Deprecated: The version of DoFTools::extract_boundary_dofs() that
+returns its information via an `IndexSet` reference argument has been
+deprecated. Use the version of the function that returns information
+via an IndexSet return type instead.
+<br>
+(Wolfgang Bangerth, 2021/03/30)
+

--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -132,36 +132,22 @@ namespace Step11
     solution.reinit(dof_handler.n_dofs());
     system_rhs.reinit(dof_handler.n_dofs());
 
-    // Next task is to construct the object representing the constraint that
+    // The next task is to construct the object representing the constraint that
     // the mean value of the degrees of freedom on the boundary shall be
-    // zero. For this, we first want a list of those nodes which are actually
+    // zero. For this, we first want a list of those nodes that are actually
     // at the boundary. The <code>DoFTools</code> namespace has a function
-    // that returns an array of Boolean values where <code>true</code>
-    // indicates that the node is at the boundary. The second argument denotes
-    // a mask selecting which components of vector valued finite elements we
-    // want to be considered. This sort of information is encoded using the
-    // ComponentMask class (see also @ref GlossComponentMask). Since we have a
-    // scalar finite element anyway, this mask in reality should have only one
-    // entry with a <code>true</code> value. However, the ComponentMask class
-    // has semantics that allow it to represents a mask of indefinite size
-    // whose every element equals <code>true</code> when one just default
-    // constructs such an object, so this is what we'll do here.
-    std::vector<bool> boundary_dofs(dof_handler.n_dofs(), false);
-    DoFTools::extract_boundary_dofs(dof_handler,
-                                    ComponentMask(),
-                                    boundary_dofs);
+    // that returns an IndexSet object that contains the indices of all those
+    // degrees of freedom that are at the boundary.
+    //
+    // Once we have this index set, we wanted to know which is the first
+    // index corresponding to a degree of freedom on the boundary. We need
+    // this because we wanted to constrain one of the nodes on the boundary by
+    // the values of all other DoFs on the boundary. To get the index of this
+    // "first" degree of freedom is easy enough using the IndexSet class:
+    const IndexSet boundary_dofs = DoFTools::extract_boundary_dofs(dof_handler);
 
-    // Now first for the generation of the constraints: as mentioned in the
-    // introduction, we constrain one of the nodes on the boundary by the
-    // values of all other DoFs on the boundary. So, let us first pick out the
-    // first boundary node from this list. We do that by searching for the
-    // first <code>true</code> value in the array (note that
-    // <code>std::find</code> returns an iterator to this element), and
-    // computing its distance to the overall first element in the array to get
-    // its index:
-    const unsigned int first_boundary_dof = std::distance(
-      boundary_dofs.begin(),
-      std::find(boundary_dofs.begin(), boundary_dofs.end(), true));
+    const types::global_dof_index first_boundary_dof =
+      boundary_dofs.nth_index_in_set(0);
 
     // Then generate a constraints object with just this one constraint. First
     // clear all previous content (which might reside there from the previous
@@ -172,8 +158,8 @@ namespace Step11
     // of what is to come later:
     mean_value_constraints.clear();
     mean_value_constraints.add_line(first_boundary_dof);
-    for (unsigned int i = first_boundary_dof + 1; i < dof_handler.n_dofs(); ++i)
-      if (boundary_dofs[i] == true)
+    for (types::global_dof_index i : boundary_dofs)
+      if (i != first_boundary_dof)
         mean_value_constraints.add_entry(first_boundary_dof, i, -1);
     mean_value_constraints.close();
 

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1505,7 +1505,7 @@ namespace DoFTools
    * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
+  DEAL_II_DEPRECATED_EARLY void
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
                         const ComponentMask &               component_mask,
                         IndexSet &                          selected_dofs,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1477,21 +1477,33 @@ namespace DoFTools
    * @param[in] component_mask A mask denoting the vector components of the
    * finite element that should be considered (see also
    * @ref GlossComponentMask).
-   * @param[out] selected_dofs The IndexSet object that is returned and that
-   * will contain the indices of degrees of freedom that are located on the
-   * boundary (and correspond to the selected vector components and boundary
-   * indicators, depending on the values of the @p component_mask and @p
-   * boundary_ids arguments).
    * @param[in] boundary_ids If empty, this function extracts the indices of the
    * degrees of freedom for all parts of the boundary. If it is a non- empty
    * list, then the function only considers boundary faces with the boundary
    * indicators listed in this argument.
+   * @return The IndexSet object that
+   * will contain the indices of degrees of freedom that are located on the
+   * boundary (and correspond to the selected vector components and boundary
+   * indicators, depending on the values of the @p component_mask and @p
+   * boundary_ids arguments).
    *
    * @see
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   template <int dim, int spacedim>
-  void
+  IndexSet
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
+                        const ComponentMask &               component_mask,
+                        const std::set<types::boundary_id> &boundary_ids = {});
+
+  /**
+   * The same as the previous function, except that it returns its information
+   * via the third argument.
+   *
+   * @deprecated Use the previous function instead.
+   */
+  template <int dim, int spacedim>
+  DEAL_II_DEPRECATED void
   extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
                         const ComponentMask &               component_mask,
                         IndexSet &                          selected_dofs,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1476,9 +1476,11 @@ namespace DoFTools
    * live on which cell.
    * @param[in] component_mask A mask denoting the vector components of the
    * finite element that should be considered (see also
-   * @ref GlossComponentMask).
+   * @ref GlossComponentMask). If left at the default, the component mask
+   * indicates that all vector components of the finite element should be
+   * considered.
    * @param[in] boundary_ids If empty, this function extracts the indices of the
-   * degrees of freedom for all parts of the boundary. If it is a non- empty
+   * degrees of freedom for all parts of the boundary. If it is a non-empty
    * list, then the function only considers boundary faces with the boundary
    * indicators listed in this argument.
    * @return The IndexSet object that
@@ -1492,8 +1494,8 @@ namespace DoFTools
    */
   template <int dim, int spacedim>
   IndexSet
-  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
-                        const ComponentMask &               component_mask,
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &dof_handler,
+                        const ComponentMask &component_mask = ComponentMask(),
                         const std::set<types::boundary_id> &boundary_ids = {});
 
   /**

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -641,6 +641,19 @@ namespace DoFTools
                         IndexSet &                          selected_dofs,
                         const std::set<types::boundary_id> &boundary_ids)
   {
+    // Simply forward to the other function
+    selected_dofs =
+      extract_boundary_dofs(dof_handler, component_mask, boundary_ids);
+  }
+
+
+
+  template <int dim, int spacedim>
+  IndexSet
+  extract_boundary_dofs(const DoFHandler<dim, spacedim> &   dof_handler,
+                        const ComponentMask &               component_mask,
+                        const std::set<types::boundary_id> &boundary_ids)
+  {
     Assert(component_mask.represents_n_components(
              dof_handler.get_fe_collection().n_components()),
            ExcMessage("Component mask has invalid size."));
@@ -648,9 +661,7 @@ namespace DoFTools
              boundary_ids.end(),
            ExcInvalidBoundaryIndicator());
 
-    // first reset output argument
-    selected_dofs.clear();
-    selected_dofs.set_size(dof_handler.n_dofs());
+    IndexSet selected_dofs(dof_handler.n_dofs());
 
     // let's see whether we have to check for certain boundary indicators
     // or whether we can accept all
@@ -760,6 +771,8 @@ namespace DoFTools
                         }
                     }
               }
+
+    return selected_dofs;
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -188,6 +188,12 @@ for (deal_II_dimension : DIMENSIONS)
       IndexSet &,
       const std::set<types::boundary_id> &);
 
+    template IndexSet
+    DoFTools::extract_boundary_dofs<deal_II_dimension, deal_II_dimension>(
+      const DoFHandler<deal_II_dimension> &,
+      const ComponentMask &,
+      const std::set<types::boundary_id> &);
+
     template void DoFTools::extract_dofs_with_support_on_boundary<
       deal_II_dimension,
       deal_II_dimension>(const DoFHandler<deal_II_dimension> &,

--- a/tests/fe/fe_q_dg0.cc
+++ b/tests/fe/fe_q_dg0.cc
@@ -431,7 +431,7 @@ namespace Step22
 
       /*std::vector<bool> boundary_dofs (dof_handler.n_dofs(), false);
 
-      std::vector<bool>boundary_mask (dim+1, false);
+      std::vector<bool> boundary_mask (dim+1, false);
       boundary_mask[dim]=true;
 
       DoFTools::extract_boundary_dofs (dof_handler,boundary_mask,boundary_dofs);

--- a/tests/mpi/constraint_matrix_condense_01.cc
+++ b/tests/mpi/constraint_matrix_condense_01.cc
@@ -59,10 +59,8 @@ test()
   AffineConstraints<PetscScalar> constraints(locally_relevant_dofs);
   constraints.clear();
   {
-    IndexSet boundary_dofs(dof_handler.n_dofs());
-    DoFTools::extract_boundary_dofs(dof_handler,
-                                    std::vector<bool>(1, true),
-                                    boundary_dofs);
+    const IndexSet boundary_dofs =
+      DoFTools::extract_boundary_dofs(dof_handler, std::vector<bool>(1, true));
 
     unsigned int first_nboundary_dof = 0;
     while (boundary_dofs.is_element(first_nboundary_dof))

--- a/tests/mpi/extract_boundary_dofs.cc
+++ b/tests/mpi/extract_boundary_dofs.cc
@@ -43,15 +43,14 @@ test()
   DoFHandler<dim> dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet relevant_set, boundary_dofs;
-  DoFTools::extract_boundary_dofs(dofh,
-                                  std::vector<bool>(1, true),
-                                  boundary_dofs);
+  const IndexSet boundary_dofs =
+    DoFTools::extract_boundary_dofs(dofh, std::vector<bool>(1, true));
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     boundary_dofs.write(deallog.get_file_stream());
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
+  IndexSet relevant_set;
   DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());

--- a/tests/simplex/extract_boundary_dofs.cc
+++ b/tests/simplex/extract_boundary_dofs.cc
@@ -49,15 +49,14 @@ test()
   DoFHandler<dim>        dofh(tr);
   dofh.distribute_dofs(fe);
 
-  IndexSet relevant_set, boundary_dofs;
-  DoFTools::extract_boundary_dofs(dofh,
-                                  std::vector<bool>(1, true),
-                                  boundary_dofs);
+  const IndexSet boundary_dofs =
+    DoFTools::extract_boundary_dofs(dofh, std::vector<bool>(1, true));
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
     boundary_dofs.write(deallog.get_file_stream());
 
   // the result of extract_boundary_dofs is supposed to be a subset of the
   // locally relevant dofs, so test this
+  IndexSet relevant_set;
   DoFTools::extract_locally_relevant_dofs(dofh, relevant_set);
   boundary_dofs.subtract_set(relevant_set);
   AssertThrow(boundary_dofs.n_elements() == 0, ExcInternalError());


### PR DESCRIPTION
This is a follow-up to #11995: There are currently two variants of the function `DoFTools::extract_boundary_dofs()`, both of which return information through a reference argument. One does so via `std::vector<bool>` (deprecated in #11995) whereas the other uses `IndexSet`. But it is easiest (and plays nicer with default arguments) if one would just return objects. We didn't do that in the olden days because there were no move constructors, but there are now and so there is no reason not to do that any more -- and indeed, we've done that with a number of `DoFTools` functions in the recent past.

So this function deprecates the function that returns by reference argument and introduces one that just returns the information. I used this to simplify the code in step-11 a bit.

/rebuild