### PR TITLE
Avoid usage of the ArborX access traits in polymorphic contexts

### DIFF
--- a/include/deal.II/arborx/access_traits.h
+++ b/include/deal.II/arborx/access_traits.h
@@ -62,8 +62,9 @@ namespace ArborXWrappers
    * This class defines a predicate used by ArborXWrappers::BVH to determine
    * for given points which of the bounding boxes used to build the
    * ArborXWrappers::BVH intersect with them.
+   * @note The class is not supposed to be used in polymorphic context.
    */
-  class PointIntersectPredicate : public PointPredicate
+  class PointIntersectPredicate : private PointPredicate
   {
   public:
     /**
@@ -73,6 +74,10 @@ namespace ArborXWrappers
     template <int dim, typename Number>
     PointIntersectPredicate(
       const std::vector<dealii::Point<dim, Number>> &points);
+
+    // We need these since we inherit privately to avoid polymorphic use.
+    using PointPredicate::get;
+    using PointPredicate::size;
   };
 
 
@@ -81,8 +86,9 @@ namespace ArborXWrappers
    * This class defines a predicate used by ArborXWrappers::BVH to determine
    * for given points which are the nearest bounding boxes/points among the ones
    * used to build the ArborXWrappers::BVH.
+   * @note The class is not supposed to be used in polymorphic context.
    */
-  class PointNearestPredicate : public PointPredicate
+  class PointNearestPredicate : private PointPredicate
   {
   public:
     /**
@@ -99,6 +105,10 @@ namespace ArborXWrappers
      */
     unsigned int
     get_n_nearest_neighbors() const;
+
+    // We need these since we inherit privately to avoid polymorphic use.
+    using PointPredicate::get;
+    using PointPredicate::size;
 
   private:
     unsigned int n_nearest_neighbors;
@@ -142,8 +152,9 @@ namespace ArborXWrappers
    * This class is used by ArborXWrappers::BVH to determine for given bounding
    * boxes which of the bounding boxes used to build the ArborXWrappers::BVH
    * intersect with them.
+   * @note The class is not supposed to be used in polymorphic context.
    */
-  class BoundingBoxIntersectPredicate : public BoundingBoxPredicate
+  class BoundingBoxIntersectPredicate : private BoundingBoxPredicate
   {
   public:
     /**
@@ -153,6 +164,10 @@ namespace ArborXWrappers
     template <int dim, typename Number>
     BoundingBoxIntersectPredicate(
       const std::vector<dealii::BoundingBox<dim, Number>> &bounding_boxes);
+
+    // We need these since we inherit privately to avoid polymorphic use.
+    using BoundingBoxPredicate::get;
+    using BoundingBoxPredicate::size;
   };
 
 
@@ -160,8 +175,9 @@ namespace ArborXWrappers
    * This class is used by ArborXWrappers::BVH to determine for given bounding
    * boxes which are the nearest bounding boxes/points among the ones used to
    * build the ArborXWrappers::BVH.
+   * @note The class is not supposed to be used in polymorphic context.
    */
-  class BoundingBoxNearestPredicate : public BoundingBoxPredicate
+  class BoundingBoxNearestPredicate : private BoundingBoxPredicate
   {
   public:
     /**
@@ -179,6 +195,10 @@ namespace ArborXWrappers
      */
     unsigned int
     get_n_nearest_neighbors() const;
+
+    // We need these since we inherit privately to avoid polymorphic use.
+    using BoundingBoxPredicate::get;
+    using BoundingBoxPredicate::size;
 
   private:
     unsigned int n_nearest_neighbors;

--- a/include/deal.II/arborx/access_traits.h
+++ b/include/deal.II/arborx/access_traits.h
@@ -29,11 +29,12 @@ DEAL_II_NAMESPACE_OPEN
 namespace ArborXWrappers
 {
   /**
-   * Base class for Point-based predicates.
+   * Base class for Point-based predicates providing basic functionality for
+   * dericed classes, not supposed to be used on its own.
    */
   class PointPredicate
   {
-  public:
+  protected:
     /**
      * Constructor. @p points is a list of points used by the predicate.
      */
@@ -62,7 +63,7 @@ namespace ArborXWrappers
    * This class defines a predicate used by ArborXWrappers::BVH to determine
    * for given points which of the bounding boxes used to build the
    * ArborXWrappers::BVH intersect with them.
-   * @note The class is not supposed to be used in polymorphic context.
+   * @note The class is not supposed to be used in a polymorphic context.
    */
   class PointIntersectPredicate : private PointPredicate
   {
@@ -86,7 +87,7 @@ namespace ArborXWrappers
    * This class defines a predicate used by ArborXWrappers::BVH to determine
    * for given points which are the nearest bounding boxes/points among the ones
    * used to build the ArborXWrappers::BVH.
-   * @note The class is not supposed to be used in polymorphic context.
+   * @note The class is not supposed to be used in a polymorphic context.
    */
   class PointNearestPredicate : private PointPredicate
   {
@@ -117,11 +118,12 @@ namespace ArborXWrappers
 
 
   /**
-   * Base class for BoundingBox predicates.
+   * Base class for BoundingBox predicates providing basic functionality for
+   * dericed classes, not supposed to be used on its own.
    */
   class BoundingBoxPredicate
   {
-  public:
+  protected:
     /**
      * Constructor. @p bounding_boxes is a list of bounding boxes used by the
      * predicate.
@@ -152,7 +154,7 @@ namespace ArborXWrappers
    * This class is used by ArborXWrappers::BVH to determine for given bounding
    * boxes which of the bounding boxes used to build the ArborXWrappers::BVH
    * intersect with them.
-   * @note The class is not supposed to be used in polymorphic context.
+   * @note The class is not supposed to be used in a polymorphic context.
    */
   class BoundingBoxIntersectPredicate : private BoundingBoxPredicate
   {
@@ -175,7 +177,7 @@ namespace ArborXWrappers
    * This class is used by ArborXWrappers::BVH to determine for given bounding
    * boxes which are the nearest bounding boxes/points among the ones used to
    * build the ArborXWrappers::BVH.
-   * @note The class is not supposed to be used in polymorphic context.
+   * @note The class is not supposed to be used in a polymorphic context.
    */
   class BoundingBoxNearestPredicate : private BoundingBoxPredicate
   {


### PR DESCRIPTION
A discussed in https://github.com/dealii/dealii/pull/11963#issuecomment-811072031.

@Rombur Please test that this actually works for you.