### PR TITLE
Performance improvement of MGTwoLevelTransfer

### DIFF
--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.h
@@ -299,8 +299,11 @@ private:
   std::shared_ptr<const Utilities::MPI::Partitioner> partitioner_coarse;
 
   /**
-   * Internal vector needed for collecting all degrees of freedom of the
-   * fine cells.
+   * Internal vector needed for collecting all degrees of freedom of the fine
+   * cells. It is only initialized if the fine-level DoF indices touch DoFs
+   * other than the locally active ones (which we always assume can be
+   * accessed by the given vectors in the prolongate/restrict functions),
+   * otherwise it is left at size zero.
    */
   mutable LinearAlgebra::distributed::Vector<Number> vec_fine;
 

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2184,7 +2184,7 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::prolongate(
                     weights[i];
               else
                 for (unsigned int i = 0; i < scheme.dofs_per_cell_fine; ++i)
-                  dst.local_element(indices_fine[i]) =
+                  this->vec_fine.local_element(indices_fine[i]) =
                     this->vec_coarse.local_element(indices_coarse[i]);
 
               indices_fine += scheme.dofs_per_cell_fine;
@@ -2264,7 +2264,8 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::prolongate(
                       evaluation_data_fine[i][v] * weights[i];
                 else
                   for (unsigned int i = 0; i < scheme.dofs_per_cell_fine; ++i)
-                    dst.local_element(indices[i]) = evaluation_data_fine[i][v];
+                    this->vec_fine.local_element(indices[i]) =
+                      evaluation_data_fine[i][v];
 
                 indices += scheme.dofs_per_cell_fine;
 
@@ -2279,10 +2280,10 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::prolongate(
                                             // in do_restrict_add does not work
 
   if (schemes.size() > 0 && schemes.front().fine_element_is_continuous)
-    {
-      this->vec_fine.compress(VectorOperation::add);
-      dst.copy_locally_owned_data_from(this->vec_fine);
-    }
+    this->vec_fine.compress(VectorOperation::add);
+
+  if (true || schemes.size() > 0 && schemes.front().fine_element_is_continuous)
+    dst.copy_locally_owned_data_from(this->vec_fine);
 }
 
 
@@ -2352,7 +2353,8 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
               else
                 for (unsigned int i = 0; i < scheme.dofs_per_cell_fine; ++i)
                   distribute_local_to_global(indices_coarse[i],
-                                             src.local_element(indices_fine[i]),
+                                             this->vec_fine.local_element(
+                                               indices_fine[i]),
                                              this->vec_coarse);
 
               indices_fine += scheme.dofs_per_cell_fine;
@@ -2401,7 +2403,8 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
                       this->vec_fine.local_element(indices[i]) * weights[i];
                 else
                   for (unsigned int i = 0; i < scheme.dofs_per_cell_fine; ++i)
-                    evaluation_data_fine[i][v] = src.local_element(indices[i]);
+                    evaluation_data_fine[i][v] =
+                      this->vec_fine.local_element(indices[i]);
 
                 indices += scheme.dofs_per_cell_fine;
 

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -2139,7 +2139,6 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::prolongate(
   const bool fine_vectors_are_compatible =
     this->vec_fine.get_partitioner()->is_globally_compatible(
       *dst.get_partitioner());
-  std::cout << static_cast<int>(fine_vectors_are_compatible) << std::endl;
 
   const auto vec_fine_ptr =
     fine_vectors_are_compatible ? &dst : &this->vec_fine;
@@ -2321,7 +2320,6 @@ MGTwoLevelTransfer<dim, LinearAlgebra::distributed::Vector<Number>>::
   const bool fine_vectors_are_compatible =
     this->vec_fine.get_partitioner()->is_globally_compatible(
       *src.get_partitioner());
-  std::cout << static_cast<int>(fine_vectors_are_compatible) << std::endl;
 
   const auto vec_fine_ptr =
     fine_vectors_are_compatible ? &src : &this->vec_fine;


### PR DESCRIPTION
The idea of this PR is to improve the performance of the two level transfer in a few scenarios:
- Cast from `double` to `float` implied by `1.0`; since the code in question is very short we can simply duplicate the loop
- Avoid zeroing the vector when we can overwrite things
- Do not involve an additional `vec_fine` for the case of discontinuous elements because there is no ghost.

There are some doubts I cannot resolve quickly with the time I have right now, so I wanted to discuss them with @peterrum: The first one is that the current optimization might be invalid in case we do h-transfer between discontinuous elements, and we would need the fine side to still import additional ghosts. Is that right? If yes, we might need to add another check for that. The other one is that we might want to further optimize the access e.g. by vectorizing things. The last one is whether we can skip the parts with constraints in `prolongate` in case we have discontinuous elements.