### PR TITLE
More work on AlignedVector

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -899,17 +899,14 @@ AlignedVector<T>::reserve(const size_type new_allocated_size)
       // if we continuously increase the size of the vector, we might be
       // reallocating a lot of times. therefore, try to increase the size more
       // aggressively
-      size_type new_size = new_allocated_size;
-      if (new_allocated_size < (2 * old_allocated_size))
-        new_size = 2 * old_allocated_size;
-
-      const size_type size_actual_allocate = new_size * sizeof(T);
+      const size_type new_size =
+        std::max(new_allocated_size, 2 * old_allocated_size);
 
       // allocate and align along 64-byte boundaries (this is enough for all
       // levels of vectorization currently supported by deal.II)
       T *new_data_ptr;
       Utilities::System::posix_memalign(
-        reinterpret_cast<void **>(&new_data_ptr), 64, size_actual_allocate);
+        reinterpret_cast<void **>(&new_data_ptr), 64, new_size * sizeof(T));
       std::unique_ptr<T[], void (*)(T *)> new_data(new_data_ptr, [](T *ptr) {
         std::free(ptr);
       });

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -185,7 +185,7 @@ public:
    * destructor at the old location).
    */
   void
-  reserve(const size_type size_alloc);
+  reserve(const size_type new_allocated_size);
 
   /**
    * Releases all previously allocated memory and leaves the vector in a state
@@ -890,18 +890,18 @@ AlignedVector<T>::resize(const size_type size_in, const T &init)
 
 template <class T>
 inline void
-AlignedVector<T>::reserve(const size_type size_alloc)
+AlignedVector<T>::reserve(const size_type new_allocated_size)
 {
-  const size_type old_size       = used_elements_end - elements.get();
-  const size_type allocated_size = allocated_elements_end - elements.get();
-  if (size_alloc > allocated_size)
+  const size_type old_size           = used_elements_end - elements.get();
+  const size_type old_allocated_size = allocated_elements_end - elements.get();
+  if (new_allocated_size > old_allocated_size)
     {
       // if we continuously increase the size of the vector, we might be
       // reallocating a lot of times. therefore, try to increase the size more
       // aggressively
-      size_type new_size = size_alloc;
-      if (size_alloc < (2 * allocated_size))
-        new_size = 2 * allocated_size;
+      size_type new_size = new_allocated_size;
+      if (new_allocated_size < (2 * old_allocated_size))
+        new_size = 2 * old_allocated_size;
 
       const size_type size_actual_allocate = new_size * sizeof(T);
 
@@ -915,7 +915,7 @@ AlignedVector<T>::reserve(const size_type size_alloc)
       });
 
       // copy whatever elements we need to retain
-      if (size_alloc > 0)
+      if (new_allocated_size > 0)
         dealii::internal::AlignedVectorMove<T>(elements.get(),
                                                elements.get() + old_size,
                                                new_data.get());
@@ -927,7 +927,7 @@ AlignedVector<T>::reserve(const size_type size_alloc)
       used_elements_end      = elements.get() + old_size;
       allocated_elements_end = elements.get() + new_size;
     }
-  else if (size_alloc == 0)
+  else if (new_allocated_size == 0)
     clear();
   else // size_alloc < allocated_size
     {} // nothing to do here


### PR DESCRIPTION
Next update to #12009.

This PR has a bunch of commits, but really only the first one ("Simplify the logic...") has anything interesting. In the previous iteration, the function first swapped the old and new pointers, and then copied data. This looked funny because it copied from variables called "new" to variables called "old". It is easier to read to move the copying forward. That patch does this.

The remaining patches rename a bunch of variables in a few places and update documentation. They're all self-contained and so I think should remain as they are.

/rebuild