### PR TITLE
Play with include files

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -21,15 +21,19 @@
 #include <deal.II/base/exceptions.h>
 #include <deal.II/base/memory_space.h>
 #include <deal.II/base/symmetric_tensor.h>
-#include <deal.II/base/table.h>
 #include <deal.II/base/tensor.h>
-
-#include <deal.II/lac/lapack_full_matrix.h>
 
 #include <type_traits>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
+
+// Forward declaration
+template <int N, typename T>
+class Table;
+
+template <typename number>
+class LAPACKFullMatrix;
 
 
 /**

--- a/include/deal.II/base/incremental_function.h
+++ b/include/deal.II/base/incremental_function.h
@@ -22,6 +22,9 @@
 #include <deal.II/base/function.h>
 #include <deal.II/base/thread_management.h>
 
+#include <deal.II/lac/vector.h>
+
+
 DEAL_II_NAMESPACE_OPEN
 
 // Forward declaration

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -19,6 +19,7 @@
 #include <deal.II/base/config.h>
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/index_set.h>
 #include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/numbers.h>
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -22,6 +22,8 @@
 #include <deal.II/base/index_set.h>
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/mpi.h>
+#include <deal.II/base/parallel.h>
+#include <deal.II/base/subscriptor.h>
 #include <deal.II/base/template_constraints.h>
 #include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>

--- a/tests/base/array_view_04.cc
+++ b/tests/base/array_view_04.cc
@@ -17,6 +17,7 @@
 // test for class ArrayView. check make_array_view for Table arguments
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/table.h>
 
 #include "../tests.h"
 

--- a/tests/base/array_view_05.cc
+++ b/tests/base/array_view_05.cc
@@ -17,6 +17,7 @@
 // test for class ArrayView. check make_array_view for Table arguments
 
 #include <deal.II/base/array_view.h>
+#include <deal.II/base/table.h>
 
 #include "../tests.h"
 

--- a/tests/base/functions_incremental_01.cc
+++ b/tests/base/functions_incremental_01.cc
@@ -18,6 +18,8 @@
 
 #include <deal.II/base/incremental_function.h>
 
+#include <deal.II/lac/vector.h>
+
 #include "../tests.h"
 
 // homogeneous linear in time function

--- a/tests/base/functions_incremental_02.cc
+++ b/tests/base/functions_incremental_02.cc
@@ -19,6 +19,8 @@
 
 #include <deal.II/base/incremental_function.h>
 
+#include <deal.II/lac/vector.h>
+
 #include "../tests.h"
 
 // homogeneous linear in time function


### PR DESCRIPTION
I ran into a circular header file issue when working on #12008 and needed to play with things. The solution is that `array_view.h` does not actually need to `#include` header files for all of the types it can wrap: If someone wants to call an `ArrayView` function with a specific type, then they will have created an object of that type, and will have the complete declaration of that type already. The header file only needs to know a forward declaration for these types if these types have a template argument because then every use of these types in the implementation of functions in `array_view.h` will be deferred due to ADL anyway.

/rebuild