### PR TITLE
Use a better filename for SUNDIALS finding.

### DIFF
--- a/cmake/modules/FindSUNDIALS.cmake
+++ b/cmake/modules/FindSUNDIALS.cmake
@@ -64,7 +64,7 @@ DEAL_II_FIND_LIBRARY(SUNDIALS_LIB_SER NAMES sundials_nvecserial
   PATH_SUFFIXES lib${LIB_SUFFIX} lib64 lib
   )
 
-DEAL_II_FIND_PATH(SUNDIALS_INCLUDE_DIR sundials/sundials_nvector.h
+DEAL_II_FIND_PATH(SUNDIALS_INCLUDE_DIR sundials/sundials_version.h
   HINTS ${SUNDIALS_DIR}
   PATH_SUFFIXES include
 )


### PR DESCRIPTION
The SUNDIALS nvector module is relatively new. Let's use a file name for finding the headers directory that has been around for longer (at least SUNDIALS 4.0).

/rebuild