### PR TITLE
Improve error messages during configuration.

### DIFF
--- a/cmake/macros/macro_deal_ii_find_file.cmake
+++ b/cmake/macros/macro_deal_ii_find_file.cmake
@@ -18,11 +18,14 @@
 #
 
 MACRO(DEAL_II_FIND_FILE _file_name)
+  # Save a string representation of the arguments before cmake's
+  # FIND_FILE gets its hands on it.
+  TO_STRING(_str ${ARGN})
+
   FIND_FILE(${_file_name} ${ARGN})
 
   IF(${_file_name} MATCHES "-NOTFOUND")
-    MESSAGE(STATUS "${_file_name} not found! Call:")
-    TO_STRING(_str ${ARGN})
+    MESSAGE(STATUS "${_file_name} not found! The call was:")
     MESSAGE(STATUS "    FIND_FILE(${_file_name} ${_str})")
   ELSE()
     MESSAGE(STATUS "Found ${_file_name}")

--- a/cmake/macros/macro_deal_ii_find_library.cmake
+++ b/cmake/macros/macro_deal_ii_find_library.cmake
@@ -18,11 +18,14 @@
 #
 
 MACRO(DEAL_II_FIND_LIBRARY _library_name)
+  # Save a string representation of the arguments before cmake's
+  # FIND_FILE gets its hands on it.
+  TO_STRING(_str ${ARGN})
+
   FIND_LIBRARY(${_library_name} ${ARGN})
 
   IF(${_library_name} MATCHES "-NOTFOUND")
-    MESSAGE(STATUS "${_library_name} not found! Call:")
-    TO_STRING(_str ${ARGN})
+    MESSAGE(STATUS "${_library_name} not found! The call was:")
     MESSAGE(STATUS "    FIND_LIBRARY(${_library_name} ${_str})")
   ELSE()
     MESSAGE(STATUS "Found ${_library_name}")

--- a/cmake/macros/macro_deal_ii_find_path.cmake
+++ b/cmake/macros/macro_deal_ii_find_path.cmake
@@ -18,11 +18,14 @@
 #
 
 MACRO(DEAL_II_FIND_PATH _path_name)
+  # Save a string representation of the arguments before cmake's
+  # FIND_PATH gets its hands on it.
+  TO_STRING(_str ${ARGN})
+
   FIND_PATH(${_path_name} ${ARGN})
 
   IF(${_path_name} MATCHES "-NOTFOUND")
-    MESSAGE(STATUS "${_path_name} not found! Call:")
-    TO_STRING(_str ${ARGN})
+    MESSAGE(STATUS "${_path_name} not found! The call was:")
     MESSAGE(STATUS "    FIND_PATH(${_path_name} ${_str})")
   ELSE()
     MESSAGE(STATUS "Found ${_path_name}")

--- a/cmake/macros/macro_deal_ii_find_program.cmake
+++ b/cmake/macros/macro_deal_ii_find_program.cmake
@@ -18,11 +18,14 @@
 #
 
 MACRO(DEAL_II_FIND_PROGRAM _file_name)
+  # Save a string representation of the arguments before cmake's
+  # FIND_PROGRAM gets its hands on it.
+  TO_STRING(_str ${ARGN})
+
   FIND_PROGRAM(${_file_name} ${ARGN})
 
   IF(${_file_name} MATCHES "-NOTFOUND")
-    MESSAGE(STATUS "${_file_name} not found! Call:")
-    TO_STRING(_str ${ARGN})
+    MESSAGE(STATUS "${_file_name} not found! The call was:")
     MESSAGE(STATUS "    FIND_PROGRAM(${_file_name} ${_str})")
   ELSE()
     MESSAGE(STATUS "Found ${_file_name}")


### PR DESCRIPTION
We print an error message in our wrappers to the `FIND_` macros that shows a string representation of arguments to the macro. But cmake has a habit of clobbering these arguments and overwriting with values that are not useful to output. We should output the original set of arguments, so let's save them.

Example
```
-- SUNDIALS_CONFIG_H not found! Call:
--     FIND_FILE(SUNDIALS_CONFIG_H NAMES sundials_config.h HINTS SUNDIALS_INCLUDE_DIR-NOTFOUND/sundials)
```
Note the appearance of the `SUNDIALS_INCLUDE_DIR-NOTFOUND` text.

/rebuild