### PR TITLE
Support different KINSOL versions.

### DIFF
--- a/include/deal.II/sundials/kinsol.h
+++ b/include/deal.II/sundials/kinsol.h
@@ -33,7 +33,7 @@
 #  include <boost/signals2.hpp>
 
 #  include <kinsol/kinsol.h>
-#  if DEAL_II_SUNDIALS_VERSION_LT(5, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_LT(4, 1, 0)
 #    include <kinsol/kinsol_impl.h>
 #  endif
 #  include <nvector/nvector_serial.h>

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -160,7 +160,7 @@ namespace SUNDIALS
 
 
 
-#  if DEAL_II_SUNDIALS_VERSION_LT(5, 0, 0)
+#  if DEAL_II_SUNDIALS_VERSION_LT(4, 1, 0)
     template <typename VectorType>
     int
     setup_jacobian_callback(KINMem kinsol_mem)
@@ -431,13 +431,25 @@ namespace SUNDIALS
     if (solve_jacobian_system) // user assigned a function object to the solver
                                // slot
       {
-#  if DEAL_II_SUNDIALS_VERSION_LT(5, 0, 0)
+/* interface up to and including 4.0 */
+#  if DEAL_II_SUNDIALS_VERSION_LT(4, 1, 0)
         auto KIN_mem        = static_cast<KINMem>(kinsol_mem);
         KIN_mem->kin_lsolve = solve_with_jacobian_callback<VectorType>;
         if (setup_jacobian) // user assigned a function object to the Jacobian
           // set-up slot
           KIN_mem->kin_lsetup = setup_jacobian_callback<VectorType>;
-#  else
+
+/* interface up to and including 4.1 */
+#  elif DEAL_II_SUNDIALS_VERSION_LT(5, 0, 0)
+
+        // deal.II does not currently have support for KINSOL in
+        // SUNDIALS 4.1. One could write this and update this section,
+        // but it does not seem worthwhile spending the time to
+        // interface with an old version of SUNDIAL given that the
+        // code below supports modern SUNDIAL versions just fine.
+        Assert(false, ExcNotImplemented());
+
+#  else /* interface starting with SUNDIALS 5.0 */
         // Set the operations we care for in the sun_linear_solver object
         // and attach it to the KINSOL object. The functions that will get
         // called do not actually receive the KINSOL object, just the LS


### PR DESCRIPTION
In #11908, I made the assumption that the current KINSOL interface was introduced in SUNDIALS 5.0, but did not check. I now downloaded a whole bunch of SUNDIALS versions and checked that things compile. It's not so easy. The old interface worked until 4.0, they made changes in 4.1, and then again switched to a new interface for 5.0 and later. In practice, that meant that deal.II didn't compile when using SUNDIALS 4.1.

I made the minimal change set to make things compile for 4.0, 4.1, 5.0, and 5.7 with this patch. The interfaces even work correctly for 4.0, 5.0, 5.7 (and presumably everything between 5.1 ... 5.6 as well). I just put an assert in for the case of 4.1. One could in principle spend a bunch of time to get that working as well, but I saw relatively little point spending an hour or two supporting one very specific old version of SUNDIALS when they have already brought out 8 other releases since then that work for us.

Related to #5027.

/rebuild