### PR TITLE
Bug in weighting_callback for uninitialized DoFHandlers.

### DIFF
--- a/include/deal.II/distributed/cell_weights.h
+++ b/include/deal.II/distributed/cell_weights.h
@@ -40,6 +40,9 @@ namespace parallel
    * a DoFHandler. One can choose from predefined weighting algorithms provided
    * by this class or provide a custom one.
    *
+   * If the associated DoFHandler has not been initialized yet, i.e., its
+   * hp::FECollection is empty, all cell weights will be evaluated as zero.
+   *
    * This class offers two different ways of connecting the chosen weighting
    * function to the corresponding signal of the linked
    * parallel::TriangulationBase. The recommended way involves creating an
@@ -282,7 +285,8 @@ namespace parallel
      * A callback function that will be connected to the cell_weight signal of
      * the @p triangulation, to which the @p dof_handler is attached. Ultimately
      * returns the weight for each cell, determined by the @p weighting_function
-     * provided as a parameter.
+     * provided as a parameter. Returns zero if @p dof_handler has not been
+     * initialized yet.
      */
     static unsigned int
     weighting_callback(

--- a/source/distributed/cell_weights.cc
+++ b/source/distributed/cell_weights.cc
@@ -176,6 +176,10 @@ namespace parallel
              "Triangulation associated with the DoFHandler has changed!"));
     (void)triangulation;
 
+    // Skip if the DoFHandler has not been initialized yet.
+    if (dof_handler.get_fe_collection().size() == 0)
+      return 0;
+
     // Convert cell type from Triangulation to DoFHandler to be able
     // to access the information about the degrees of freedom.
     const typename DoFHandler<dim, spacedim>::cell_iterator cell(*cell_,


### PR DESCRIPTION
`parallel::CellWeights` connects to a signal in `Triangulation` and expects an initialized `DoFHandler`.

If the `Triangulation` gets created and will be refined globally before `distribute_dofs` is called, an assertion will be triggered. Checking for the size of the `FECollection` solves this.