### PR TITLE
Remove hp::DoFHandler from tutorial list.

### DIFF
--- a/doc/doxygen/tutorial/tutorial.h.in
+++ b/doc/doxygen/tutorial/tutorial.h.in
@@ -326,7 +326,7 @@
  *   <tr valign="top">
  *       <td>step-27</td>
  *       <td> The hp-finite element method.
- *       <br/> Keywords: hp::DoFHandler, hp::FECollection, hp::QCollection,
+ *       <br/> Keywords: hp::FECollection, hp::QCollection, hp::Refinement,
  *       FESeries::Fourier, Triangulation::create_triangulation()
  *       </td></tr>
  *


### PR DESCRIPTION
After merging both DoFHandlers in #10328, we should not refer to the deprecated class anymore.