### PR TITLE
Utilities::MPI::mpi_sum_avg: create MPI_Datatype and MPI_Op once

### DIFF
--- a/doc/news/changes/minor/20210418Maier
+++ b/doc/news/changes/minor/20210418Maier
@@ -1,0 +1,5 @@
+Fixed: Work around a memory leak issue in OpenMPI 4.1.0 triggered by our
+Utilities::MPI::min_max_avg() function by repeatedly allocating and freeing
+MPI_Datatype handles.
+<br>
+(Matthias Maier, 2021/04/18)

--- a/doc/news/changes/minor/20210419Maier
+++ b/doc/news/changes/minor/20210419Maier
@@ -1,0 +1,8 @@
+Added: The MPI_InitFinalize RAII class has gained an
+MPI_InitFinalize::signals::at_mpi_init and an
+MPI_InitFinalize::signals::at_mpi_finalize signal that are triggered
+immediately after initializing the MPI context with <code>MPI_Init</code>
+and immediately before deinitializing the MPI context with
+<code>MPI_Finalize</code>.
+<br>
+(Matthias Maier, 2021/04/19)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -23,6 +23,8 @@
 #include <deal.II/base/mpi_tags.h>
 #include <deal.II/base/numbers.h>
 
+#include <boost/signals2.hpp>
+
 #include <map>
 #include <numeric>
 #include <set>
@@ -990,6 +992,32 @@ namespace Utilities
        */
       static void
       unregister_request(MPI_Request &request);
+
+      /**
+       * A structure that has boost::signal objects to register a call back
+       * to run after MPI init or finalize.
+       *
+       * For documentation on signals, see
+       * http://www.boost.org/doc/libs/release/libs/signals2 .
+       */
+      struct Signals
+      {
+        /**
+         * A signal that is triggered immediately after we have
+         * initialized the MPI context with <code>MPI_Init()</code>.
+         */
+        boost::signals2::signal<void()> at_mpi_init;
+
+        /**
+         * A signal that is triggered just before we close the MPI context
+         * with <code>MPI_Finalize()</code>. It can be used to deallocate
+         * statically allocated MPI resources that need to be deallocated
+         * before <code>MPI_Finalize()</code> is called.
+         */
+        boost::signals2::signal<void()> at_mpi_finalize;
+      };
+
+      static Signals signals;
 
     private:
       /**

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -922,6 +922,9 @@ namespace Utilities
           // finally set this number of threads
           MultithreadInfo::set_thread_limit(n_threads);
         }
+
+      // As a final step call the at_mpi_init() signal handler.
+      signals.at_mpi_init();
     }
 
 
@@ -954,6 +957,9 @@ namespace Utilities
 
     MPI_InitFinalize::~MPI_InitFinalize()
     {
+      // First, call the at_mpi_finalize() signal handler.
+      signals.at_mpi_finalize();
+
       // make memory pool release all PETSc/Trilinos/MPI-based vectors that
       // are no longer used at this point. this is relevant because the static
       // object destructors run for these vectors at the end of the program

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -786,6 +786,9 @@ namespace Utilities
 
 #endif
 
+    /* Force initialization of static struct: */
+    MPI_InitFinalize::Signals MPI_InitFinalize::signals =
+      MPI_InitFinalize::Signals();
 
 
     MPI_InitFinalize::MPI_InitFinalize(int &              argc,

--- a/tests/base/mpi_init_finalize_signals_01.cc
+++ b/tests/base/mpi_init_finalize_signals_01.cc
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Test signals in MPI_InitFinalize
+
+#include <deal.II/base/mpi.h>
+
+#include "../tests.h"
+
+int
+main(int argc, char *argv[])
+{
+  initlog();
+
+  Utilities::MPI::MPI_InitFinalize::signals.at_mpi_init.connect([=]() {
+    deallog << "called via MPI_InitFinalize::signals.at_mpi_init" << std::endl;
+  });
+
+  Utilities::MPI::MPI_InitFinalize::signals.at_mpi_finalize.connect([=]() {
+    deallog << "called via MPI_InitFinalize::signals.at_mpi_finalize"
+            << std::endl;
+  });
+
+  deallog << "before MPI initialization" << std::endl;
+  {
+    Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+    deallog << "after MPI initialization" << std::endl;
+  }
+  deallog << "after MPI finalization" << std::endl;
+}

--- a/tests/base/mpi_init_finalize_signals_01.mpirun=1.output
+++ b/tests/base/mpi_init_finalize_signals_01.mpirun=1.output
@@ -1,0 +1,6 @@
+
+DEAL::before MPI initialization
+DEAL::called via MPI_InitFinalize::signals.at_mpi_init
+DEAL::after MPI initialization
+DEAL::called via MPI_InitFinalize::signals.at_mpi_finalize
+DEAL::after MPI finalization


### PR DESCRIPTION
Instead of repeatedly creating and freeing an MPI_Datatype and MPI_Op for
every invocation of Utilities::MPI::mpi_sum_avg let us define these objects
statically and create them only once.

This works around a memory leak issue with OpenMPI 4.1.0 that will leak 
memory in the subsequent MPI_Allreduce call.

Upstream bug report: https://github.com/open-mpi/ompi/issues/8827