### PR TITLE
Add a test for AlignedVector.

### DIFF
--- a/tests/base/aligned_vector_memory_01.cc
+++ b/tests/base/aligned_vector_memory_01.cc
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2012 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test AlignedVector. This class does some complex data management,
+// explicitly allocating objects with placement-new expressions and
+// explicitly releasing memory. Make sure this is all works as
+// expected.
+
+#include <deal.II/base/aligned_vector.h>
+#include <deal.II/base/logstream.h>
+
+#include "../tests.h"
+
+
+int object_number     = 0;
+int objects_destroyed = 0;
+
+class C
+{
+public:
+  C()
+  {
+    object_number = ::object_number++;
+    deallog << "Default constructor. Object number " << object_number
+            << std::endl;
+  }
+
+  C(const C &c)
+  {
+    object_number = ::object_number++;
+    deallog << "copy constructor from " << c.object_number << ". Object number "
+            << object_number << std::endl;
+  }
+
+  C(const C &&c)
+  {
+    object_number = ::object_number++;
+    deallog << "move constructor from " << c.object_number << ". Object number "
+            << object_number << std::endl;
+  }
+
+  ~C()
+  {
+    deallog << "destructor. Object number " << object_number << std::endl;
+    ++objects_destroyed;
+  }
+
+  template <typename Archive>
+  void
+  serialize(Archive &ar, const unsigned int)
+  {
+    ar &object_number;
+  }
+
+
+private:
+  unsigned int object_number;
+};
+
+
+
+void
+test()
+{
+  {
+    deallog << "Check 1:" << std::endl;
+    AlignedVector<C> v(2);
+  }
+
+  {
+    deallog << "Check 2:" << std::endl;
+    AlignedVector<C> v(2);
+    v.resize(0);
+  }
+
+  {
+    deallog << "Check 3:" << std::endl;
+    AlignedVector<C> v(2);
+    v.resize(1);
+    v.resize(3);
+  }
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  initlog();
+
+  test();
+
+  deallog << "Objects created: " << object_number << std::endl;
+  deallog << "Objects destroyed: " << objects_destroyed << std::endl;
+}

--- a/tests/base/aligned_vector_memory_01.output
+++ b/tests/base/aligned_vector_memory_01.output
@@ -1,0 +1,30 @@
+
+DEAL::Check 1:
+DEAL::Default constructor. Object number 0
+DEAL::copy constructor from 0. Object number 1
+DEAL::copy constructor from 0. Object number 2
+DEAL::destructor. Object number 0
+DEAL::destructor. Object number 2
+DEAL::destructor. Object number 1
+DEAL::Check 2:
+DEAL::Default constructor. Object number 3
+DEAL::copy constructor from 3. Object number 4
+DEAL::copy constructor from 3. Object number 5
+DEAL::destructor. Object number 3
+DEAL::destructor. Object number 5
+DEAL::destructor. Object number 4
+DEAL::Check 3:
+DEAL::Default constructor. Object number 6
+DEAL::copy constructor from 6. Object number 7
+DEAL::copy constructor from 6. Object number 8
+DEAL::destructor. Object number 6
+DEAL::destructor. Object number 8
+DEAL::move constructor from 7. Object number 9
+DEAL::destructor. Object number 7
+DEAL::Default constructor. Object number 10
+DEAL::Default constructor. Object number 11
+DEAL::destructor. Object number 11
+DEAL::destructor. Object number 10
+DEAL::destructor. Object number 9
+DEAL::Objects created: 12
+DEAL::Objects destroyed: 12


### PR DESCRIPTION
`AlignedVector` does a lot of memory management with explicit placement-`new` construction of objects and explicit calls to destructors. This test verifies that this all works as expected and, in particular, that the number of constructor calls equals the number of destructor calls.

I convinced myself that the output of this test is correct, line by line. It's a bit difficult to follow along when objects are created etc, but it is all correct.

Part of #12008.

/rebuild