### PR TITLE
Deprecate TriaAccessor::number_of_children.

### DIFF
--- a/doc/news/changes/minor/20210420Bangerth
+++ b/doc/news/changes/minor/20210420Bangerth
@@ -1,0 +1,6 @@
+Deprecated: The TriaAccessor::number_of_children() function has been
+deprecated in favor of the new TriaAccessor::n_active_descendants()
+function.
+<br>
+(Wolfgang Bangerth, 2021/04/20)
+

--- a/examples/step-30/doc/intro.dox
+++ b/examples/step-30/doc/intro.dox
@@ -283,11 +283,11 @@ write code that works for both isotropic and anisotropic refinement:
 @endcode
      Here the number of subfaces is three. It is important to note the subtle
   differences between, for a face, TriaAccessor::n_children() and
-  TriaAccessor::number_of_children(). The first function returns the number of
+  TriaAccessor::n_active_descendants(). The first function returns the number of
   immediate children, which would be two for the above example, whereas the
   second returns the number of active offspring (i.e., including children,
   grandchildren, and further descendants), which is the correct three in
-  the example above. Using <code>face->number_of_children()</code> works for
+  the example above. Using <code>face->n_active_descendants()</code> works for
   isotropic and anisotropic as well as 2D and 3D cases, so it should always be
   used. It should be noted that if any of the cells behind the two
   small subfaces on the left side of the rightmost image is further

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -497,7 +497,7 @@ namespace Step30
                     // Now we loop over all subfaces, i.e. the children and
                     // possibly grandchildren of the current face.
                     for (unsigned int subface_no = 0;
-                         subface_no < face->number_of_children();
+                         subface_no < face->n_active_descendants();
                          ++subface_no)
                       {
                         // To get the cell behind the current subface we can
@@ -747,7 +747,7 @@ namespace Step30
                       unsigned int neighbor2 = cell->neighbor_face_no(face_no);
                       // Now we loop over all subfaces,
                       for (unsigned int subface_no = 0;
-                           subface_no < face->number_of_children();
+                           subface_no < face->n_active_descendants();
                            ++subface_no)
                         {
                           // get an iterator pointing to the cell behind the
@@ -840,7 +840,7 @@ namespace Step30
                                  ExcInternalError());
                           Assert(neighbor_face_subface.second <
                                    neighbor->face(neighbor_face_subface.first)
-                                     ->number_of_children(),
+                                     ->n_active_descendants(),
                                  ExcInternalError());
                           Assert(neighbor->neighbor_child_on_subface(
                                    neighbor_face_subface.first,

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3487,7 +3487,7 @@ namespace GridTools
                 // out which border to the present
                 // cell
                 for (unsigned int c = 0;
-                     c < cell->face(n)->number_of_children();
+                     c < cell->face(n)->n_active_descendants();
                      ++c)
                   active_neighbors.push_back(
                     cell->neighbor_child_on_subface(n, c));

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -954,6 +954,13 @@ public:
   n_children() const;
 
   /**
+   * @deprecated Use n_active_descendants() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY
+  unsigned int
+  number_of_children() const;
+
+  /**
    * Compute and return the number of active descendants of this objects. For
    * example, if all of the eight children of a hex are further refined
    * isotropically exactly once, the returned number will be 64, not 80.
@@ -967,7 +974,7 @@ public:
    * current object is not further refined, the answer is one.
    */
   unsigned int
-  number_of_children() const;
+  n_active_descendants() const;
 
   /**
    * Return the number of times that this object is refined. Note that not all
@@ -2128,7 +2135,15 @@ public:
    * Always zero.
    */
   static unsigned int
+  n_active_descendants();
+
+  /**
+   * @deprecated Use n_active_descendants() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY
+  static unsigned int
   number_of_children();
+
 
   /**
    * Return the number of times that this object is refined. Always 0.
@@ -2586,7 +2601,15 @@ public:
    * Always zero.
    */
   static unsigned int
+  n_active_descendants();
+
+  /**
+   * @deprecated Use n_active_descendants() instead.
+   */
+  DEAL_II_DEPRECATED_EARLY
+  static unsigned int
   number_of_children();
+
 
   /**
    * Return the number of times that this object is refined. Always 0.

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1801,13 +1801,22 @@ template <int structdim, int dim, int spacedim>
 unsigned int
 TriaAccessor<structdim, dim, spacedim>::number_of_children() const
 {
+  return n_active_descendants();
+}
+
+
+
+template <int structdim, int dim, int spacedim>
+unsigned int
+TriaAccessor<structdim, dim, spacedim>::n_active_descendants() const
+{
   if (!this->has_children())
     return 1;
   else
     {
       unsigned int sum = 0;
       for (unsigned int c = 0; c < n_children(); ++c)
-        sum += this->child(c)->number_of_children();
+        sum += this->child(c)->n_active_descendants();
       return sum;
     }
 }
@@ -2568,6 +2577,15 @@ TriaAccessor<0, dim, spacedim>::number_of_children()
 
 template <int dim, int spacedim>
 inline unsigned int
+TriaAccessor<0, dim, spacedim>::n_active_descendants()
+{
+  return 0;
+}
+
+
+
+template <int dim, int spacedim>
+inline unsigned int
 TriaAccessor<0, dim, spacedim>::max_refinement_depth()
 {
   return 0;
@@ -2983,6 +3001,15 @@ TriaAccessor<0, 1, spacedim>::n_children()
 template <int spacedim>
 inline unsigned int
 TriaAccessor<0, 1, spacedim>::number_of_children()
+{
+  return 0;
+}
+
+
+
+template <int spacedim>
+inline unsigned int
+TriaAccessor<0, 1, spacedim>::n_active_descendants()
 {
   return 0;
 }

--- a/source/dofs/dof_tools_constraints.cc
+++ b/source/dofs/dof_tools_constraints.cc
@@ -1139,7 +1139,7 @@ namespace DoFTools
 
                 if (dof_handler.has_hp_capabilities())
                   for (unsigned int c = 0;
-                       c < cell->face(face)->number_of_children();
+                       c < cell->face(face)->n_active_descendants();
                        ++c)
                     {
                       const auto subcell =

--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -608,7 +608,7 @@ namespace DoFTools
                   if (neighbor->has_children())
                     {
                       for (unsigned int sub_nr = 0;
-                           sub_nr != cell_face->number_of_children();
+                           sub_nr != cell_face->n_active_descendants();
                            ++sub_nr)
                         {
                           const typename DoFHandler<dim, spacedim>::

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -5052,10 +5052,10 @@ FESubfaceValues<dim, spacedim>::reinit(
                        0,
                        GeometryInfo<dim>::max_children_per_face));
   Assert(!cell->face(face_no)->has_children() ||
-           subface_no < cell->face(face_no)->number_of_children(),
+           subface_no < cell->face(face_no)->n_active_descendants(),
          ExcIndexRange(subface_no,
                        0,
-                       cell->face(face_no)->number_of_children()));
+                       cell->face(face_no)->n_active_descendants()));
   Assert(cell->has_children() == false,
          ExcMessage("You can't use subface data for cells that are "
                     "already refined. Iterate over their children "

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -5326,7 +5326,7 @@ namespace internal
                           if (face_ref_case ==
                               RefinementCase<dim - 1>::isotropic_refinement)
                             {
-                              if (aface->number_of_children() < 4)
+                              if (aface->n_active_descendants() < 4)
                                 // we use user_flags to denote needed
                                 // isotropic refinement
                                 aface->set_user_flag();

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2981,7 +2981,7 @@ CellAccessor<dim, spacedim>::neighbor_child_on_subface(
               const typename Triangulation<dim, spacedim>::face_iterator
                                  mother_face = this->face(face);
               const unsigned int total_children =
-                mother_face->number_of_children();
+                mother_face->n_active_descendants();
               AssertIndexRange(subface, total_children);
               Assert(total_children <= GeometryInfo<3>::max_children_per_face,
                      ExcInternalError());

--- a/tests/aniso/mesh_3d_21.cc
+++ b/tests/aniso/mesh_3d_21.cc
@@ -66,7 +66,7 @@ void check_this(Triangulation<3> &tria)
     for (const unsigned int face_no : GeometryInfo<3>::face_indices())
       if (!cell->at_boundary(face_no) && cell->face(face_no)->has_children())
         for (unsigned int subface_no = 0;
-             subface_no < cell->face(face_no)->number_of_children();
+             subface_no < cell->face(face_no)->n_active_descendants();
              ++subface_no)
           {
             unsigned int neighbor_neighbor = cell->neighbor_face_no(face_no);


### PR DESCRIPTION
Use TriaAccessor::n_active_descendants() instead. Fixes #10205.

/rebuild