### PR TITLE
Improve the scalar assignment exception message.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -1082,9 +1082,16 @@ namespace StandardExceptions
    * argument zero. In other cases, this exception is thrown.
    */
   DeclExceptionMsg(ExcScalarAssignmentOnlyForZeroValue,
-                   "You are trying an operation of the form 'vector=s' with "
-                   "a nonzero scalar value 's'. However, such assignments "
-                   "are only allowed if the right hand side is zero.");
+                   "You are trying an operation of the form 'vector = C', "
+                   "'matrix = C', or 'tensor = C' with a nonzero scalar value "
+                   "'C'. However, such assignments are only allowed if the "
+                   "C is zero, since the semantics for assigning any other "
+                   "value are not clear. For example: one could interpret "
+                   "assigning a matrix a value of 1 to mean the matrix has a "
+                   "norm of 1, the matrix is the identity matrix, or the "
+                   "matrix contains only 1s. Similar problems exist with "
+                   "vectors and tensors. Hence, to avoid this ambiguity, such "
+                   "assignments are not permitted.");
 
   /**
    * This function requires support for the LAPACK library.

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1381,8 +1381,7 @@ template <int rank_, int dim, typename Number>
 DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE Tensor<rank_, dim, Number> &
 Tensor<rank_, dim, Number>::operator=(const Number &d)
 {
-  Assert(numbers::value_is_zero(d),
-         ExcMessage("Only assignment with zero is allowed"));
+  Assert(numbers::value_is_zero(d), ExcScalarAssignmentOnlyForZeroValue());
   (void)d;
 
   for (unsigned int i = 0; i < dim; ++i)


### PR DESCRIPTION
This is from a question I got from a student today in class - we should use the exception in `Tensor` and be a bit more explicit about why this operation is not allowed.