### PR TITLE
Bugfix: `hp::Refinement::predict_error` - cast to int

### DIFF
--- a/doc/news/changes/minor/20210421Fehling
+++ b/doc/news/changes/minor/20210421Fehling
@@ -1,0 +1,4 @@
+Fixed: The function hp::Refinement::predict_error() produced incorrect
+results for p-coarsening.
+<br>
+(Marc Fehling, 2021/04/21)

--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -634,7 +634,8 @@ namespace hp
             if (cell->future_fe_index_set())
               {
                 predicted_errors[cell->active_cell_index()] *=
-                  std::pow(gamma_p, future_fe_degree - cell->get_fe().degree);
+                  std::pow(gamma_p,
+                           int(future_fe_degree) - int(cell->get_fe().degree));
               }
 
             // step 2: algebraic decay with h-adaptation

--- a/tests/hp/error_prediction_01.output
+++ b/tests/hp/error_prediction_01.output
@@ -1,71 +1,71 @@
 
 DEAL:1d::pre_adaptation
 DEAL:1d:: ncells:5
-DEAL:1d:: cell:1_0: fe_deg:1 error:10.0000 predicted:5.00000 refining
-DEAL:1d:: cell:2_0: fe_deg:1 error:10.0000 predicted:2.50000 future_fe_deg:3
-DEAL:1d:: cell:3_0: fe_deg:1 error:10.0000 predicted:10.0000
-DEAL:1d:: cell:0_1:0 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:1d:: cell:0_1:1 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
+DEAL:1d:: cell:1_0: fe_deg:2 error:10.0000 predicted:2.50000 refining
+DEAL:1d:: cell:2_0: fe_deg:2 error:10.0000 predicted:5.00000 future_fe_deg:3
+DEAL:1d:: cell:3_0: fe_deg:2 error:10.0000 predicted:20.0000 future_fe_deg:1
+DEAL:1d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:1d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
 DEAL:1d::post_adaptation
 DEAL:1d:: ncells:5
-DEAL:1d:: cell:0_0: fe_deg:1 transferred:28.2843
-DEAL:1d:: cell:2_0: fe_deg:3 transferred:2.50000
-DEAL:1d:: cell:3_0: fe_deg:1 transferred:10.0000
-DEAL:1d:: cell:1_1:0 fe_deg:1 transferred:3.53553
-DEAL:1d:: cell:1_1:1 fe_deg:1 transferred:3.53553
+DEAL:1d:: cell:0_0: fe_deg:2 transferred:56.5685
+DEAL:1d:: cell:2_0: fe_deg:3 transferred:5.00000
+DEAL:1d:: cell:3_0: fe_deg:1 transferred:20.0000
+DEAL:1d:: cell:1_1:0 fe_deg:2 transferred:1.76777
+DEAL:1d:: cell:1_1:1 fe_deg:2 transferred:1.76777
 DEAL:1d::predicted_error_norms
-DEAL:1d:: pre_adaptation:30.5164
-DEAL:1d:: post_adaptation:30.5164
+DEAL:1d:: pre_adaptation:60.2599
+DEAL:1d:: post_adaptation:60.2599
 DEAL:1d::OK
 DEAL:2d::pre_adaptation
 DEAL:2d:: ncells:7
-DEAL:2d:: cell:1_0: fe_deg:1 error:10.0000 predicted:5.00000 refining
-DEAL:2d:: cell:2_0: fe_deg:1 error:10.0000 predicted:2.50000 future_fe_deg:3
-DEAL:2d:: cell:3_0: fe_deg:1 error:10.0000 predicted:10.0000
-DEAL:2d:: cell:0_1:0 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:2d:: cell:0_1:1 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:2d:: cell:0_1:2 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:2d:: cell:0_1:3 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
+DEAL:2d:: cell:1_0: fe_deg:2 error:10.0000 predicted:2.50000 refining
+DEAL:2d:: cell:2_0: fe_deg:2 error:10.0000 predicted:5.00000 future_fe_deg:3
+DEAL:2d:: cell:3_0: fe_deg:2 error:10.0000 predicted:20.0000 future_fe_deg:1
+DEAL:2d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:2d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:2d:: cell:0_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:2d:: cell:0_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
 DEAL:2d::post_adaptation
 DEAL:2d:: ncells:7
-DEAL:2d:: cell:0_0: fe_deg:1 transferred:40.0000
-DEAL:2d:: cell:2_0: fe_deg:3 transferred:2.50000
-DEAL:2d:: cell:3_0: fe_deg:1 transferred:10.0000
-DEAL:2d:: cell:1_1:0 fe_deg:1 transferred:2.50000
-DEAL:2d:: cell:1_1:1 fe_deg:1 transferred:2.50000
-DEAL:2d:: cell:1_1:2 fe_deg:1 transferred:2.50000
-DEAL:2d:: cell:1_1:3 fe_deg:1 transferred:2.50000
+DEAL:2d:: cell:0_0: fe_deg:2 transferred:80.0000
+DEAL:2d:: cell:2_0: fe_deg:3 transferred:5.00000
+DEAL:2d:: cell:3_0: fe_deg:1 transferred:20.0000
+DEAL:2d:: cell:1_1:0 fe_deg:2 transferred:1.25000
+DEAL:2d:: cell:1_1:1 fe_deg:2 transferred:1.25000
+DEAL:2d:: cell:1_1:2 fe_deg:2 transferred:1.25000
+DEAL:2d:: cell:1_1:3 fe_deg:2 transferred:1.25000
 DEAL:2d::predicted_error_norms
-DEAL:2d:: pre_adaptation:41.6083
-DEAL:2d:: post_adaptation:41.6083
+DEAL:2d:: pre_adaptation:82.6514
+DEAL:2d:: post_adaptation:82.6514
 DEAL:2d::OK
 DEAL:3d::pre_adaptation
 DEAL:3d:: ncells:11
-DEAL:3d:: cell:1_0: fe_deg:1 error:10.0000 predicted:5.00000 refining
-DEAL:3d:: cell:2_0: fe_deg:1 error:10.0000 predicted:2.50000 future_fe_deg:3
-DEAL:3d:: cell:3_0: fe_deg:1 error:10.0000 predicted:10.0000
-DEAL:3d:: cell:0_1:0 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:1 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:2 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:3 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:4 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:5 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:6 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
-DEAL:3d:: cell:0_1:7 fe_deg:1 error:10.0000 predicted:20.0000 coarsening
+DEAL:3d:: cell:1_0: fe_deg:2 error:10.0000 predicted:2.50000 refining
+DEAL:3d:: cell:2_0: fe_deg:2 error:10.0000 predicted:5.00000 future_fe_deg:3
+DEAL:3d:: cell:3_0: fe_deg:2 error:10.0000 predicted:20.0000 future_fe_deg:1
+DEAL:3d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:4 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:5 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:6 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
+DEAL:3d:: cell:0_1:7 fe_deg:2 error:10.0000 predicted:40.0000 coarsening
 DEAL:3d::post_adaptation
 DEAL:3d:: ncells:11
-DEAL:3d:: cell:0_0: fe_deg:1 transferred:56.5685
-DEAL:3d:: cell:2_0: fe_deg:3 transferred:2.50000
-DEAL:3d:: cell:3_0: fe_deg:1 transferred:10.0000
-DEAL:3d:: cell:1_1:0 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:1 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:2 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:3 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:4 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:5 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:6 fe_deg:1 transferred:1.76777
-DEAL:3d:: cell:1_1:7 fe_deg:1 transferred:1.76777
+DEAL:3d:: cell:0_0: fe_deg:2 transferred:113.137
+DEAL:3d:: cell:2_0: fe_deg:3 transferred:5.00000
+DEAL:3d:: cell:3_0: fe_deg:1 transferred:20.0000
+DEAL:3d:: cell:1_1:0 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:1 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:2 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:3 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:4 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:5 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:6 fe_deg:2 transferred:0.883883
+DEAL:3d:: cell:1_1:7 fe_deg:2 transferred:0.883883
 DEAL:3d::predicted_error_norms
-DEAL:3d:: pre_adaptation:57.7170
-DEAL:3d:: post_adaptation:57.7170
+DEAL:3d:: pre_adaptation:115.027
+DEAL:3d:: post_adaptation:115.027
 DEAL:3d::OK

--- a/tests/hp/error_prediction_02.output
+++ b/tests/hp/error_prediction_02.output
@@ -1,0 +1,93 @@
+
+DEAL:1d::pre_adaptation
+DEAL:1d:: ncells:6
+DEAL:1d:: cell:2_0: fe_deg:2 error:10.0000 predicted:0.625000 refining future_fe_deg:3
+DEAL:1d:: cell:3_0: fe_deg:2 error:10.0000 predicted:10.0000 refining future_fe_deg:1
+DEAL:1d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:1d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:1d:: cell:1_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:1d:: cell:1_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:1d::post_adaptation
+DEAL:1d:: ncells:6
+DEAL:1d:: cell:0_0: fe_deg:3 transferred:56.5685
+DEAL:1d:: cell:1_0: fe_deg:1 transferred:56.5685
+DEAL:1d:: cell:2_1:0 fe_deg:3 transferred:0.441942
+DEAL:1d:: cell:2_1:1 fe_deg:3 transferred:0.441942
+DEAL:1d:: cell:3_1:0 fe_deg:1 transferred:7.07107
+DEAL:1d:: cell:3_1:1 fe_deg:1 transferred:7.07107
+DEAL:1d::predicted_error_norms
+DEAL:1d:: pre_adaptation:80.6250
+DEAL:1d:: post_adaptation:80.6250
+DEAL:1d::OK
+DEAL:2d::pre_adaptation
+DEAL:2d:: ncells:10
+DEAL:2d:: cell:2_0: fe_deg:2 error:10.0000 predicted:0.625000 refining future_fe_deg:3
+DEAL:2d:: cell:3_0: fe_deg:2 error:10.0000 predicted:10.0000 refining future_fe_deg:1
+DEAL:2d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:2d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:2d:: cell:0_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:2d:: cell:0_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:2d:: cell:1_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:2d:: cell:1_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:2d:: cell:1_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:2d:: cell:1_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:2d::post_adaptation
+DEAL:2d:: ncells:10
+DEAL:2d:: cell:0_0: fe_deg:3 transferred:80.0000
+DEAL:2d:: cell:1_0: fe_deg:1 transferred:80.0000
+DEAL:2d:: cell:2_1:0 fe_deg:3 transferred:0.312500
+DEAL:2d:: cell:2_1:1 fe_deg:3 transferred:0.312500
+DEAL:2d:: cell:2_1:2 fe_deg:3 transferred:0.312500
+DEAL:2d:: cell:2_1:3 fe_deg:3 transferred:0.312500
+DEAL:2d:: cell:3_1:0 fe_deg:1 transferred:5.00000
+DEAL:2d:: cell:3_1:1 fe_deg:1 transferred:5.00000
+DEAL:2d:: cell:3_1:2 fe_deg:1 transferred:5.00000
+DEAL:2d:: cell:3_1:3 fe_deg:1 transferred:5.00000
+DEAL:2d::predicted_error_norms
+DEAL:2d:: pre_adaptation:113.580
+DEAL:2d:: post_adaptation:113.580
+DEAL:2d::OK
+DEAL:3d::pre_adaptation
+DEAL:3d:: ncells:18
+DEAL:3d:: cell:2_0: fe_deg:2 error:10.0000 predicted:0.625000 refining future_fe_deg:3
+DEAL:3d:: cell:3_0: fe_deg:2 error:10.0000 predicted:10.0000 refining future_fe_deg:1
+DEAL:3d:: cell:0_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:4 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:5 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:6 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:0_1:7 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:3
+DEAL:3d:: cell:1_1:0 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:1 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:2 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:3 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:4 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:5 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:6 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d:: cell:1_1:7 fe_deg:2 error:10.0000 predicted:40.0000 coarsening future_fe_deg:1
+DEAL:3d::post_adaptation
+DEAL:3d:: ncells:18
+DEAL:3d:: cell:0_0: fe_deg:3 transferred:113.137
+DEAL:3d:: cell:1_0: fe_deg:1 transferred:113.137
+DEAL:3d:: cell:2_1:0 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:1 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:2 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:3 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:4 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:5 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:6 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:2_1:7 fe_deg:3 transferred:0.220971
+DEAL:3d:: cell:3_1:0 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:1 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:2 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:3 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:4 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:5 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:6 fe_deg:1 transferred:3.53553
+DEAL:3d:: cell:3_1:7 fe_deg:1 transferred:3.53553
+DEAL:3d::predicted_error_norms
+DEAL:3d:: pre_adaptation:160.313
+DEAL:3d:: post_adaptation:160.313
+DEAL:3d::OK


### PR DESCRIPTION
Error prediction fails for p-coarsening. Subtracting two `unsigned ints` is dangerous.

Added and adjusted tests to verify p-coarsening.