### PR TITLE
Doc: Function has been renamed

### DIFF
--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -148,7 +148,7 @@ namespace hp
      * The same applies to coarsening.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -166,7 +166,7 @@ namespace hp
      * cell.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -197,7 +197,7 @@ namespace hp
      * cell.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -240,7 +240,7 @@ namespace hp
      * in the interval $[0,1]$.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -284,7 +284,7 @@ namespace hp
      * in the interval $[0,1]$.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -322,7 +322,7 @@ namespace hp
      * For more theoretical details see @cite ainsworth1998hp .
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -348,7 +348,7 @@ namespace hp
      * correspond to an active cell.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -562,7 +562,7 @@ namespace hp
      * @note We want to predict the error by how adaptation will actually happen.
      *   Thus, this function needs to be called after
      *   Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement().
+     *   hp::Refinement::limit_p_level_difference().
      */
     template <int dim, typename Number, int spacedim>
     void
@@ -589,7 +589,7 @@ namespace hp
      * @p future_fe_index assigned.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */
@@ -637,7 +637,7 @@ namespace hp
      *   would have made later on.
      *
      * @note Triangulation::prepare_coarsening_and_refinement() and
-     *   DoFHandler::prepare_coarsening_and_refinement() may change
+     *   hp::Refinement::limit_p_level_difference() may change
      *   refine and coarsen flags as well as future finite element indices.
      *   Avoid calling them before this particular function.
      */

--- a/tests/hp/limit_p_level_difference_01.cc
+++ b/tests/hp/limit_p_level_difference_01.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // set the center cell to the highest p-level in a hyper_cross geometry
 // and verify that all other cells comply to the level difference

--- a/tests/hp/limit_p_level_difference_02.cc
+++ b/tests/hp/limit_p_level_difference_02.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // sequentially increase the p-level of the center cell in a hyper_cross
 // geometry and verify that all other comply to the level difference

--- a/tests/hp/limit_p_level_difference_03.cc
+++ b/tests/hp/limit_p_level_difference_03.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-refined grids
 
 

--- a/tests/hp/limit_p_level_difference_04.cc
+++ b/tests/hp/limit_p_level_difference_04.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-coarsened grids
 
 

--- a/tests/mpi/limit_p_level_difference_01.cc
+++ b/tests/mpi/limit_p_level_difference_01.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // set the center cell to the highest p-level in a hyper_cross geometry
 // and verify that all other cells comply to the level difference

--- a/tests/mpi/limit_p_level_difference_02.cc
+++ b/tests/mpi/limit_p_level_difference_02.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // sequentially increase the p-level of the center cell in a hyper_cross
 // geometry and verify that all other comply to the level difference

--- a/tests/mpi/limit_p_level_difference_03.cc
+++ b/tests/mpi/limit_p_level_difference_03.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-refined grids
 
 

--- a/tests/mpi/limit_p_level_difference_04.cc
+++ b/tests/mpi/limit_p_level_difference_04.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-coarsened grids
 
 

--- a/tests/sharedtria/limit_p_level_difference_01.cc
+++ b/tests/sharedtria/limit_p_level_difference_01.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // set the center cell to the highest p-level in a hyper_cross geometry
 // and verify that all other cells comply to the level difference

--- a/tests/sharedtria/limit_p_level_difference_02.cc
+++ b/tests/sharedtria/limit_p_level_difference_02.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 //
 // sequentially increase the p-level of the center cell in a hyper_cross
 // geometry and verify that all other comply to the level difference

--- a/tests/sharedtria/limit_p_level_difference_03.cc
+++ b/tests/sharedtria/limit_p_level_difference_03.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-refined grids
 
 

--- a/tests/sharedtria/limit_p_level_difference_04.cc
+++ b/tests/sharedtria/limit_p_level_difference_04.cc
@@ -15,7 +15,7 @@
 
 
 // verify restrictions on level differences imposed by
-// DoFHandler::prepare_coarsening_and_refinement()
+// hp::Refinement::limit_p_level_difference()
 // on h-coarsened grids
 
 


### PR DESCRIPTION
The function `DoFHandler::prepare_coarsening_and_refinement()` has been renamed to `hp::Refinement::limit_p_level_difference()` in #11937. We missed a few mentions in the documentation.