### PR TITLE
Forward declare explicit template specializations for copy_connectivity

### DIFF
--- a/include/deal.II/distributed/p4est_wrappers.h
+++ b/include/deal.II/distributed/p4est_wrappers.h
@@ -587,6 +587,16 @@ namespace internal
     template <int dim>
     typename types<dim>::connectivity *
     copy_connectivity(const typename types<dim>::connectivity *connectivity);
+
+#  ifndef DOXYGEN
+    template <>
+    typename types<2>::connectivity *
+    copy_connectivity<2>(const typename types<2>::connectivity *connectivity);
+
+    template <>
+    typename types<3>::connectivity *
+    copy_connectivity<3>(const typename types<3>::connectivity *connectivity);
+#  endif
   } // namespace p4est
 } // namespace internal
 


### PR DESCRIPTION
Should fix https://cdash.43-1.org/build/249.