### PR TITLE
Simplify some type computations in FEValuesViews.

### DIFF
--- a/doc/news/changes/minor/20210425Bangerth
+++ b/doc/news/changes/minor/20210425Bangerth
@@ -1,0 +1,10 @@
+Deprecated: The FEValuesViews::Scalar, FEValuesViews::Vector,
+FEValuesViews::Tensor, and FEValuesViews::SymmetricTensor classes all
+have `OutputType` structures that defined the types of evaluating
+the values and derivatives of finite element fields at quadrature
+points. These structures have been deprecated, and the corresponding
+types are now defined via local `using` declarations in the classes
+mentioned above.
+<br>
+(Wolfgang Bangerth, 2021/04/25)
+

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -224,6 +224,56 @@ namespace FEValuesViews
       typename ProductType<Number, third_derivative_type>::type;
 
     /**
+     * A struct that provides the output type for the product of the value
+     * and derivatives of basis functions of the Scalar view and any @p Number type.
+     *
+     * @deprecated Use the types defined in the surrounding class instead.
+     */
+    template <typename Number>
+    struct DEAL_II_DEPRECATED_EARLY OutputType
+    {
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * values of the view the Scalar class.
+       */
+      using value_type =
+        typename ProductType<Number,
+                             typename Scalar<dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * gradients of the view the Scalar class.
+       */
+      using gradient_type = typename ProductType<
+        Number,
+        typename Scalar<dim, spacedim>::gradient_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * laplacians of the view the Scalar class.
+       */
+      using laplacian_type =
+        typename ProductType<Number,
+                             typename Scalar<dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * hessians of the view the Scalar class.
+       */
+      using hessian_type = typename ProductType<
+        Number,
+        typename Scalar<dim, spacedim>::hessian_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * third derivatives of the view the Scalar class.
+       */
+      using third_derivative_type = typename ProductType<
+        Number,
+        typename Scalar<dim, spacedim>::third_derivative_type>::type;
+    };
+
+    /**
      * A structure where for each shape function we pre-compute a bunch of
      * data that will make later accesses much cheaper.
      */
@@ -736,6 +786,80 @@ namespace FEValuesViews
     template <typename Number>
     using solution_third_derivative_type =
       typename ProductType<Number, third_derivative_type>::type;
+
+    /**
+     * A struct that provides the output type for the product of the value
+     * and derivatives of basis functions of the Vector view and any @p Number type.
+     *
+     * @deprecated Use the types defined in the surrounding class instead.
+     */
+    template <typename Number>
+    struct DEAL_II_DEPRECATED_EARLY OutputType
+    {
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * values of the view the Vector class.
+       */
+      using value_type =
+        typename ProductType<Number,
+                             typename Vector<dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * gradients of the view the Vector class.
+       */
+      using gradient_type = typename ProductType<
+        Number,
+        typename Vector<dim, spacedim>::gradient_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * symmetric gradients of the view the Vector class.
+       */
+      using symmetric_gradient_type = typename ProductType<
+        Number,
+        typename Vector<dim, spacedim>::symmetric_gradient_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * divergences of the view the Vector class.
+       */
+      using divergence_type = typename ProductType<
+        Number,
+        typename Vector<dim, spacedim>::divergence_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * laplacians of the view the Vector class.
+       */
+      using laplacian_type =
+        typename ProductType<Number,
+                             typename Vector<dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * curls of the view the Vector class.
+       */
+      using curl_type =
+        typename ProductType<Number,
+                             typename Vector<dim, spacedim>::curl_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * hessians of the view the Vector class.
+       */
+      using hessian_type = typename ProductType<
+        Number,
+        typename Vector<dim, spacedim>::hessian_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * third derivatives of the view the Vector class.
+       */
+      using third_derivative_type = typename ProductType<
+        Number,
+        typename Vector<dim, spacedim>::third_derivative_type>::type;
+    };
 
     /**
      * A structure where for each shape function we pre-compute a bunch of
@@ -1343,6 +1467,33 @@ namespace FEValuesViews
     using solution_divergence_type =
       typename ProductType<Number, divergence_type>::type;
 
+
+    /**
+     * A struct that provides the output type for the product of the value
+     * and derivatives of basis functions of the SymmetricTensor view and any @p Number type.
+     *
+     * @deprecated Use the types defined in the surrounding class instead.
+     */
+    template <typename Number>
+    struct DEAL_II_DEPRECATED_EARLY OutputType
+    {
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * values of the view the SymmetricTensor class.
+       */
+      using value_type = typename ProductType<
+        Number,
+        typename SymmetricTensor<2, dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * divergences of the view the SymmetricTensor class.
+       */
+      using divergence_type = typename ProductType<
+        Number,
+        typename SymmetricTensor<2, dim, spacedim>::divergence_type>::type;
+    };
+
     /**
      * A structure where for each shape function we pre-compute a bunch of
      * data that will make later accesses much cheaper.
@@ -1643,6 +1794,41 @@ namespace FEValuesViews
     template <typename Number>
     using solution_gradient_type =
       typename ProductType<Number, gradient_type>::type;
+
+
+    /**
+     * A struct that provides the output type for the product of the value
+     * and derivatives of basis functions of the Tensor view and any @p Number type.
+     *
+     * @deprecated Use the types defined in the surrounding class instead.
+     */
+    template <typename Number>
+    struct DEAL_II_DEPRECATED_EARLY OutputType
+    {
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * values of the view the Tensor class.
+       */
+      using value_type = typename ProductType<
+        Number,
+        typename Tensor<2, dim, spacedim>::value_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * divergences of the view the Tensor class.
+       */
+      using divergence_type = typename ProductType<
+        Number,
+        typename Tensor<2, dim, spacedim>::divergence_type>::type;
+
+      /**
+       * An alias for the data type of the product of a @p Number and the
+       * gradient of the view the Tensor class.
+       */
+      using gradient_type = typename ProductType<
+        Number,
+        typename Tensor<2, dim, spacedim>::gradient_type>::type;
+    };
 
     /**
      * A structure where for each shape function we pre-compute a bunch of

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -175,52 +175,53 @@ namespace FEValuesViews
     using third_derivative_type = dealii::Tensor<3, spacedim>;
 
     /**
-     * A struct that provides the output type for the product of the value
-     * and derivatives of basis functions of the Scalar view and any @p Number type.
+     * An alias for the data type of the product of a @p Number and the
+     * values of the view this class provides. This is the data type of
+     * scalar components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
      */
     template <typename Number>
-    struct OutputType
-    {
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * values of the view the Scalar class.
-       */
-      using value_type =
-        typename ProductType<Number,
-                             typename Scalar<dim, spacedim>::value_type>::type;
+    using solution_value_type = typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * gradients of the view the Scalar class.
-       */
-      using gradient_type = typename ProductType<
-        Number,
-        typename Scalar<dim, spacedim>::gradient_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * gradients of the view this class provides. This is the data type of
+     * scalar components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_gradient_type =
+      typename ProductType<Number, gradient_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * laplacians of the view the Scalar class.
-       */
-      using laplacian_type =
-        typename ProductType<Number,
-                             typename Scalar<dim, spacedim>::value_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * laplacians of the view this class provides. This is the data type of
+     * scalar components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_laplacian_type =
+      typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * hessians of the view the Scalar class.
-       */
-      using hessian_type = typename ProductType<
-        Number,
-        typename Scalar<dim, spacedim>::hessian_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * hessians of the view this class provides. This is the data type of
+     * scalar components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_hessian_type =
+      typename ProductType<Number, hessian_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * third derivatives of the view the Scalar class.
-       */
-      using third_derivative_type = typename ProductType<
-        Number,
-        typename Scalar<dim, spacedim>::third_derivative_type>::type;
-    };
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * third derivatives of the view this class provides. This is the data type
+     * of scalar components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_third_derivative_type =
+      typename ProductType<Number, third_derivative_type>::type;
 
     /**
      * A structure where for each shape function we pre-compute a bunch of
@@ -348,8 +349,7 @@ namespace FEValuesViews
     void
     get_function_values(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -390,8 +390,7 @@ namespace FEValuesViews
     void
     get_function_values_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::value_type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -415,8 +414,7 @@ namespace FEValuesViews
     void
     get_function_gradients(
       const InputVector &fe_function,
-      std::vector<typename ProductType<gradient_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
     /**
@@ -429,8 +427,7 @@ namespace FEValuesViews
     void
     get_function_gradients_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::gradient_type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
     /**
@@ -454,8 +451,7 @@ namespace FEValuesViews
     void
     get_function_hessians(
       const InputVector &fe_function,
-      std::vector<typename ProductType<hessian_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_hessian_type<typename InputVector::value_type>>
         &hessians) const;
 
     /**
@@ -468,8 +464,7 @@ namespace FEValuesViews
     void
     get_function_hessians_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::hessian_type>
+      std::vector<solution_hessian_type<typename InputVector::value_type>>
         &hessians) const;
 
 
@@ -495,8 +490,7 @@ namespace FEValuesViews
     void
     get_function_laplacians(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_laplacian_type<typename InputVector::value_type>>
         &laplacians) const;
 
     /**
@@ -509,8 +503,7 @@ namespace FEValuesViews
     void
     get_function_laplacians_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::laplacian_type>
+      std::vector<solution_laplacian_type<typename InputVector::value_type>>
         &laplacians) const;
 
 
@@ -536,8 +529,8 @@ namespace FEValuesViews
     void
     get_function_third_derivatives(
       const InputVector &fe_function,
-      std::vector<typename ProductType<third_derivative_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<
+        solution_third_derivative_type<typename InputVector::value_type>>
         &third_derivatives) const;
 
     /**
@@ -549,9 +542,10 @@ namespace FEValuesViews
     template <class InputVector>
     void
     get_function_third_derivatives_from_local_dof_values(
-      const InputVector &                   dof_values,
-      std::vector<typename OutputType<typename InputVector::value_type>::
-                    third_derivative_type> &third_derivatives) const;
+      const InputVector &dof_values,
+      std::vector<
+        solution_third_derivative_type<typename InputVector::value_type>>
+        &third_derivatives) const;
 
 
   private:
@@ -666,76 +660,82 @@ namespace FEValuesViews
     using third_derivative_type = dealii::Tensor<4, spacedim>;
 
     /**
-     * A struct that provides the output type for the product of the value
-     * and derivatives of basis functions of the Vector view and any @p Number type.
+     * An alias for the data type of the product of a @p Number and the
+     * values of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
      */
     template <typename Number>
-    struct OutputType
-    {
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * values of the view the Vector class.
-       */
-      using value_type =
-        typename ProductType<Number,
-                             typename Vector<dim, spacedim>::value_type>::type;
+    using solution_value_type = typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * gradients of the view the Vector class.
-       */
-      using gradient_type = typename ProductType<
-        Number,
-        typename Vector<dim, spacedim>::gradient_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * gradients of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_gradient_type =
+      typename ProductType<Number, gradient_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * symmetric gradients of the view the Vector class.
-       */
-      using symmetric_gradient_type = typename ProductType<
-        Number,
-        typename Vector<dim, spacedim>::symmetric_gradient_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * symmetric gradients of the view this class provides. This is the data
+     * type of vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_symmetric_gradient_type =
+      typename ProductType<Number, symmetric_gradient_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * divergences of the view the Vector class.
-       */
-      using divergence_type = typename ProductType<
-        Number,
-        typename Vector<dim, spacedim>::divergence_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * divergences of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_divergence_type =
+      typename ProductType<Number, divergence_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * laplacians of the view the Vector class.
-       */
-      using laplacian_type =
-        typename ProductType<Number,
-                             typename Vector<dim, spacedim>::value_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * laplacians of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_laplacian_type =
+      typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * curls of the view the Vector class.
-       */
-      using curl_type =
-        typename ProductType<Number,
-                             typename Vector<dim, spacedim>::curl_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * curls of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_curl_type = typename ProductType<Number, curl_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * hessians of the view the Vector class.
-       */
-      using hessian_type = typename ProductType<
-        Number,
-        typename Vector<dim, spacedim>::hessian_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * hessians of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_hessian_type =
+      typename ProductType<Number, hessian_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * third derivatives of the view the Vector class.
-       */
-      using third_derivative_type = typename ProductType<
-        Number,
-        typename Vector<dim, spacedim>::third_derivative_type>::type;
-    };
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * third derivatives of the view this class provides. This is the data type
+     * of vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_third_derivative_type =
+      typename ProductType<Number, third_derivative_type>::type;
 
     /**
      * A structure where for each shape function we pre-compute a bunch of
@@ -940,8 +940,7 @@ namespace FEValuesViews
     void
     get_function_values(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -982,8 +981,7 @@ namespace FEValuesViews
     void
     get_function_values_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::value_type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -1007,8 +1005,7 @@ namespace FEValuesViews
     void
     get_function_gradients(
       const InputVector &fe_function,
-      std::vector<typename ProductType<gradient_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
     /**
@@ -1021,8 +1018,7 @@ namespace FEValuesViews
     void
     get_function_gradients_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::gradient_type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
     /**
@@ -1052,8 +1048,8 @@ namespace FEValuesViews
     void
     get_function_symmetric_gradients(
       const InputVector &fe_function,
-      std::vector<typename ProductType<symmetric_gradient_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<
+        solution_symmetric_gradient_type<typename InputVector::value_type>>
         &symmetric_gradients) const;
 
     /**
@@ -1065,9 +1061,10 @@ namespace FEValuesViews
     template <class InputVector>
     void
     get_function_symmetric_gradients_from_local_dof_values(
-      const InputVector &                     dof_values,
-      std::vector<typename OutputType<typename InputVector::value_type>::
-                    symmetric_gradient_type> &symmetric_gradients) const;
+      const InputVector &dof_values,
+      std::vector<
+        solution_symmetric_gradient_type<typename InputVector::value_type>>
+        &symmetric_gradients) const;
 
     /**
      * Return the divergence of the selected vector components of the finite
@@ -1091,8 +1088,7 @@ namespace FEValuesViews
     void
     get_function_divergences(
       const InputVector &fe_function,
-      std::vector<typename ProductType<divergence_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
     /**
@@ -1105,8 +1101,7 @@ namespace FEValuesViews
     void
     get_function_divergences_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::divergence_type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
     /**
@@ -1131,9 +1126,8 @@ namespace FEValuesViews
     void
     get_function_curls(
       const InputVector &fe_function,
-      std::vector<
-        typename ProductType<curl_type, typename InputVector::value_type>::type>
-        &curls) const;
+      std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
+      const;
 
     /**
      * This function relates to get_function_curls() in the same way
@@ -1145,9 +1139,8 @@ namespace FEValuesViews
     void
     get_function_curls_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::curl_type>
-        &curls) const;
+      std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
+      const;
 
     /**
      * Return the Hessians of the selected vector components of the finite
@@ -1170,8 +1163,7 @@ namespace FEValuesViews
     void
     get_function_hessians(
       const InputVector &fe_function,
-      std::vector<typename ProductType<hessian_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_hessian_type<typename InputVector::value_type>>
         &hessians) const;
 
     /**
@@ -1184,8 +1176,7 @@ namespace FEValuesViews
     void
     get_function_hessians_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::hessian_type>
+      std::vector<solution_hessian_type<typename InputVector::value_type>>
         &hessians) const;
 
     /**
@@ -1210,8 +1201,7 @@ namespace FEValuesViews
     void
     get_function_laplacians(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_laplacian_type<typename InputVector::value_type>>
         &laplacians) const;
 
     /**
@@ -1224,8 +1214,7 @@ namespace FEValuesViews
     void
     get_function_laplacians_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::laplacian_type>
+      std::vector<solution_laplacian_type<typename InputVector::value_type>>
         &laplacians) const;
 
     /**
@@ -1250,8 +1239,8 @@ namespace FEValuesViews
     void
     get_function_third_derivatives(
       const InputVector &fe_function,
-      std::vector<typename ProductType<third_derivative_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<
+        solution_third_derivative_type<typename InputVector::value_type>>
         &third_derivatives) const;
 
     /**
@@ -1263,9 +1252,10 @@ namespace FEValuesViews
     template <class InputVector>
     void
     get_function_third_derivatives_from_local_dof_values(
-      const InputVector &                   dof_values,
-      std::vector<typename OutputType<typename InputVector::value_type>::
-                    third_derivative_type> &third_derivatives) const;
+      const InputVector &dof_values,
+      std::vector<
+        solution_third_derivative_type<typename InputVector::value_type>>
+        &third_derivatives) const;
 
   private:
     /**
@@ -1335,28 +1325,23 @@ namespace FEValuesViews
     using divergence_type = dealii::Tensor<1, spacedim>;
 
     /**
-     * A struct that provides the output type for the product of the value
-     * and derivatives of basis functions of the SymmetricTensor view and any @p Number type.
+     * An alias for the data type of the product of a @p Number and the
+     * values of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
      */
     template <typename Number>
-    struct OutputType
-    {
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * values of the view the SymmetricTensor class.
-       */
-      using value_type = typename ProductType<
-        Number,
-        typename SymmetricTensor<2, dim, spacedim>::value_type>::type;
+    using solution_value_type = typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * divergences of the view the SymmetricTensor class.
-       */
-      using divergence_type = typename ProductType<
-        Number,
-        typename SymmetricTensor<2, dim, spacedim>::divergence_type>::type;
-    };
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * divergences of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_divergence_type =
+      typename ProductType<Number, divergence_type>::type;
 
     /**
      * A structure where for each shape function we pre-compute a bunch of
@@ -1484,8 +1469,7 @@ namespace FEValuesViews
     void
     get_function_values(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -1526,8 +1510,7 @@ namespace FEValuesViews
     void
     get_function_values_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::value_type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -1555,8 +1538,7 @@ namespace FEValuesViews
     void
     get_function_divergences(
       const InputVector &fe_function,
-      std::vector<typename ProductType<divergence_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
     /**
@@ -1569,8 +1551,7 @@ namespace FEValuesViews
     void
     get_function_divergences_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::divergence_type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
   private:
@@ -1635,36 +1616,33 @@ namespace FEValuesViews
     using gradient_type = dealii::Tensor<3, spacedim>;
 
     /**
-     * A struct that provides the output type for the product of the value
-     * and derivatives of basis functions of the Tensor view and any @p Number type.
+     * An alias for the data type of the product of a @p Number and the
+     * values of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
      */
     template <typename Number>
-    struct OutputType
-    {
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * values of the view the Tensor class.
-       */
-      using value_type = typename ProductType<
-        Number,
-        typename Tensor<2, dim, spacedim>::value_type>::type;
+    using solution_value_type = typename ProductType<Number, value_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * divergences of the view the Tensor class.
-       */
-      using divergence_type = typename ProductType<
-        Number,
-        typename Tensor<2, dim, spacedim>::divergence_type>::type;
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * divergences of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_divergence_type =
+      typename ProductType<Number, divergence_type>::type;
 
-      /**
-       * An alias for the data type of the product of a @p Number and the
-       * gradient of the view the Tensor class.
-       */
-      using gradient_type = typename ProductType<
-        Number,
-        typename Tensor<2, dim, spacedim>::gradient_type>::type;
-    };
+    /**
+     * An alias for the data type of the product of a @p Number and the
+     * gradient of the view this class provides. This is the data type of
+     * vector components of a finite element field whose degrees of
+     * freedom are described by a vector with elements of type @p Number.
+     */
+    template <typename Number>
+    using solution_gradient_type =
+      typename ProductType<Number, gradient_type>::type;
 
     /**
      * A structure where for each shape function we pre-compute a bunch of
@@ -1809,8 +1787,7 @@ namespace FEValuesViews
     void
     get_function_values(
       const InputVector &fe_function,
-      std::vector<typename ProductType<value_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -1851,8 +1828,7 @@ namespace FEValuesViews
     void
     get_function_values_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::value_type>
+      std::vector<solution_value_type<typename InputVector::value_type>>
         &values) const;
 
     /**
@@ -1880,8 +1856,7 @@ namespace FEValuesViews
     void
     get_function_divergences(
       const InputVector &fe_function,
-      std::vector<typename ProductType<divergence_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
     /**
@@ -1894,8 +1869,7 @@ namespace FEValuesViews
     void
     get_function_divergences_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::divergence_type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const;
 
     /**
@@ -1918,8 +1892,7 @@ namespace FEValuesViews
     void
     get_function_gradients(
       const InputVector &fe_function,
-      std::vector<typename ProductType<gradient_type,
-                                       typename InputVector::value_type>::type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
     /**
@@ -1932,8 +1905,7 @@ namespace FEValuesViews
     void
     get_function_gradients_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::gradient_type>
+      std::vector<solution_gradient_type<typename InputVector::value_type>>
         &gradients) const;
 
   private:

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -36,17 +36,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace MeshWorker
 {
-  namespace internal
-  {
-    /**
-     * Alias used to deduce the OutputType when asking for values or gradients
-     * of shape functions multiplied with the given @p NumberType.
-     */
-    template <int dim, int spacedim, typename NumberType, typename Extractor>
-    using OutputType = typename FEValuesViews::View<dim, spacedim, Extractor>::
-      template OutputType<NumberType>;
-  } // namespace internal
-
   /**
    * A helper class to simplify the parallel assembly of linear and non-linear
    * problems, and the evaluation of finite element fields.
@@ -606,9 +595,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        value_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_value_type<Number>> &
     get_values(const std::string &global_vector_name,
                const Extractor &  variable,
                const Number       dummy = Number(0));
@@ -635,9 +623,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        gradient_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_gradient_type<Number>> &
     get_gradients(const std::string &global_vector_name,
                   const Extractor &  variable,
                   const Number       dummy = Number(0));
@@ -665,9 +652,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        symmetric_gradient_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_symmetric_gradient_type<Number>> &
     get_symmetric_gradients(const std::string &global_vector_name,
                             const Extractor &  variable,
                             const Number       dummy = Number(0));
@@ -694,9 +680,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        divergence_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_divergence_type<Number>> &
     get_divergences(const std::string &global_vector_name,
                     const Extractor &  variable,
                     const Number       dummy = Number(0));
@@ -723,12 +708,11 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<typename internal::
-                        OutputType<dim, spacedim, Number, Extractor>::curl_type>
-      &
-      get_curls(const std::string &global_vector_name,
-                const Extractor &  variable,
-                const Number       dummy = Number(0));
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_curl_type<Number>> &
+    get_curls(const std::string &global_vector_name,
+              const Extractor &  variable,
+              const Number       dummy = Number(0));
 
     /**
      * For the solution vector identified by @p global_vector_name, compute
@@ -752,9 +736,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        hessian_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_hessian_type<Number>> &
     get_hessians(const std::string &global_vector_name,
                  const Extractor &  variable,
                  const Number       dummy = Number(0));
@@ -781,9 +764,8 @@ namespace MeshWorker
      * the documentation of the FEValues class for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        laplacian_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_laplacian_type<Number>> &
     get_laplacians(const std::string &global_vector_name,
                    const Extractor &  variable,
                    const Number       dummy = Number(0));
@@ -810,9 +792,8 @@ namespace MeshWorker
      * FiniteElement" in the documentation of the FEValues for more information.
      */
     template <typename Extractor, typename Number = double>
-    const std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        third_derivative_type> &
+    const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                        template solution_third_derivative_type<Number>> &
     get_third_derivatives(const std::string &global_vector_name,
                           const Extractor &  variable,
                           const Number       dummy = Number(0));
@@ -1054,13 +1035,11 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::value_type>
-    &
-    ScratchData<dim, spacedim>::get_values(
-      const std::string &global_vector_name,
-      const Extractor &  variable,
-      const Number       dummy)
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_value_type<Number>> &
+  ScratchData<dim, spacedim>::get_values(const std::string &global_vector_name,
+                                         const Extractor &  variable,
+                                         const Number       dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_local_dof_values(global_vector_name, dummy);
@@ -1074,8 +1053,8 @@ namespace MeshWorker
 
     // Now build the return type
     using RetType =
-      std::vector<typename internal::
-                    OutputType<dim, spacedim, Number, Extractor>::value_type>;
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_value_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1092,9 +1071,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      gradient_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_gradient_type<Number>> &
   ScratchData<dim, spacedim>::get_gradients(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1111,9 +1089,9 @@ namespace MeshWorker
       global_vector_name, variable, "_gradients_q", n_q_points, dummy);
 
     // Now build the return type
-    using RetType = std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        gradient_type>;
+    using RetType =
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_gradient_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1130,9 +1108,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      hessian_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_hessian_type<Number>> &
   ScratchData<dim, spacedim>::get_hessians(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1150,8 +1127,8 @@ namespace MeshWorker
 
     // Now build the return type
     using RetType =
-      std::vector<typename internal::
-                    OutputType<dim, spacedim, Number, Extractor>::hessian_type>;
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_hessian_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1169,9 +1146,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      laplacian_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_laplacian_type<Number>> &
   ScratchData<dim, spacedim>::get_laplacians(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1188,9 +1164,9 @@ namespace MeshWorker
       global_vector_name, variable, "_laplacians_q", n_q_points, dummy);
 
     // Now build the return type
-    using RetType = std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        laplacian_type>;
+    using RetType =
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_laplacian_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1208,9 +1184,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      third_derivative_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_third_derivative_type<Number>> &
   ScratchData<dim, spacedim>::get_third_derivatives(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1227,9 +1202,9 @@ namespace MeshWorker
       global_vector_name, variable, "_third_derivatives_q", n_q_points, dummy);
 
     // Now build the return type
-    using RetType = std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        third_derivative_type>;
+    using RetType =
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_third_derivative_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1247,9 +1222,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      symmetric_gradient_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_symmetric_gradient_type<Number>> &
   ScratchData<dim, spacedim>::get_symmetric_gradients(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1267,9 +1241,9 @@ namespace MeshWorker
 
 
     // Now build the return type
-    using RetType = std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        symmetric_gradient_type>;
+    using RetType =
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_symmetric_gradient_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1286,9 +1260,8 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::
-      divergence_type> &
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_divergence_type<Number>> &
   ScratchData<dim, spacedim>::get_divergences(
     const std::string &global_vector_name,
     const Extractor &  variable,
@@ -1305,9 +1278,9 @@ namespace MeshWorker
       global_vector_name, variable, "_divergence_q", n_q_points, dummy);
 
     // Now build the return type
-    using RetType = std::vector<
-      typename internal::OutputType<dim, spacedim, Number, Extractor>::
-        divergence_type>;
+    using RetType =
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_divergence_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(
@@ -1325,12 +1298,11 @@ namespace MeshWorker
 
   template <int dim, int spacedim>
   template <typename Extractor, typename Number>
-  const std::vector<
-    typename internal::OutputType<dim, spacedim, Number, Extractor>::curl_type>
-    &
-    ScratchData<dim, spacedim>::get_curls(const std::string &global_vector_name,
-                                          const Extractor &  variable,
-                                          const Number       dummy)
+  const std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                      template solution_curl_type<Number>> &
+  ScratchData<dim, spacedim>::get_curls(const std::string &global_vector_name,
+                                        const Extractor &  variable,
+                                        const Number       dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_local_dof_values(global_vector_name, dummy);
@@ -1344,8 +1316,8 @@ namespace MeshWorker
 
     // Now build the return type
     using RetType =
-      std::vector<typename internal::
-                    OutputType<dim, spacedim, Number, Extractor>::curl_type>;
+      std::vector<typename FEValuesViews::View<dim, spacedim, Extractor>::
+                    template solution_curl_type<Number>>;
 
     RetType &ret =
       internal_data_storage.template get_or_add_object_with_name<RetType>(

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -525,17 +525,18 @@ namespace FEValuesViews
       const ArrayView<Number> &                    dof_values,
       const Table<2, dealii::Tensor<2, spacedim>> &shape_hessians,
       const std::vector<typename Scalar<dim, spacedim>::ShapeFunctionData>
-        &                         shape_function_data,
-      std::vector<typename Scalar<dim, spacedim>::template OutputType<
-        Number>::laplacian_type> &laplacians)
+        &shape_function_data,
+      std::vector<typename Scalar<dim, spacedim>::
+                    template solution_laplacian_type<Number>> &laplacians)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = laplacians.size();
 
-      std::fill(laplacians.begin(),
-                laplacians.end(),
-                typename Scalar<dim, spacedim>::template OutputType<
-                  Number>::laplacian_type());
+      std::fill(
+        laplacians.begin(),
+        laplacians.end(),
+        typename Scalar<dim,
+                        spacedim>::template solution_laplacian_type<Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -763,17 +764,18 @@ namespace FEValuesViews
       const ArrayView<Number> &                    dof_values,
       const Table<2, dealii::Tensor<1, spacedim>> &shape_gradients,
       const std::vector<typename Vector<dim, spacedim>::ShapeFunctionData>
-        &                          shape_function_data,
-      std::vector<typename Vector<dim, spacedim>::template OutputType<
-        Number>::divergence_type> &divergences)
+        &shape_function_data,
+      std::vector<typename Vector<dim, spacedim>::
+                    template solution_divergence_type<Number>> &divergences)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = divergences.size();
 
-      std::fill(divergences.begin(),
-                divergences.end(),
-                typename Vector<dim, spacedim>::template OutputType<
-                  Number>::divergence_type());
+      std::fill(
+        divergences.begin(),
+        divergences.end(),
+        typename Vector<dim,
+                        spacedim>::template solution_divergence_type<Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -1087,17 +1089,18 @@ namespace FEValuesViews
       const ArrayView<Number> &                    dof_values,
       const Table<2, dealii::Tensor<2, spacedim>> &shape_hessians,
       const std::vector<typename Vector<dim, spacedim>::ShapeFunctionData>
-        &                         shape_function_data,
-      std::vector<typename Vector<dim, spacedim>::template OutputType<
-        Number>::laplacian_type> &laplacians)
+        &shape_function_data,
+      std::vector<typename Vector<dim, spacedim>::
+                    template solution_laplacian_type<Number>> &laplacians)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = laplacians.size();
 
-      std::fill(laplacians.begin(),
-                laplacians.end(),
-                typename Vector<dim, spacedim>::template OutputType<
-                  Number>::laplacian_type());
+      std::fill(
+        laplacians.begin(),
+        laplacians.end(),
+        typename Vector<dim,
+                        spacedim>::template solution_laplacian_type<Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -1228,15 +1231,15 @@ namespace FEValuesViews
         typename SymmetricTensor<2, dim, spacedim>::ShapeFunctionData>
         &shape_function_data,
       std::vector<typename SymmetricTensor<2, dim, spacedim>::
-                    template OutputType<Number>::divergence_type> &divergences)
+                    template solution_divergence_type<Number>> &divergences)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = divergences.size();
 
       std::fill(divergences.begin(),
                 divergences.end(),
-                typename SymmetricTensor<2, dim, spacedim>::template OutputType<
-                  Number>::divergence_type());
+                typename SymmetricTensor<2, dim, spacedim>::
+                  template solution_divergence_type<Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -1402,17 +1405,18 @@ namespace FEValuesViews
       const ArrayView<Number> &                    dof_values,
       const Table<2, dealii::Tensor<1, spacedim>> &shape_gradients,
       const std::vector<typename Tensor<2, dim, spacedim>::ShapeFunctionData>
-        &                          shape_function_data,
-      std::vector<typename Tensor<2, dim, spacedim>::template OutputType<
-        Number>::divergence_type> &divergences)
+        &shape_function_data,
+      std::vector<typename Tensor<2, dim, spacedim>::
+                    template solution_divergence_type<Number>> &divergences)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = divergences.size();
 
-      std::fill(divergences.begin(),
-                divergences.end(),
-                typename Tensor<2, dim, spacedim>::template OutputType<
-                  Number>::divergence_type());
+      std::fill(
+        divergences.begin(),
+        divergences.end(),
+        typename Tensor<2, dim, spacedim>::template solution_divergence_type<
+          Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -1471,17 +1475,18 @@ namespace FEValuesViews
       const ArrayView<Number> &                    dof_values,
       const Table<2, dealii::Tensor<1, spacedim>> &shape_gradients,
       const std::vector<typename Tensor<2, dim, spacedim>::ShapeFunctionData>
-        &                        shape_function_data,
-      std::vector<typename Tensor<2, dim, spacedim>::template OutputType<
-        Number>::gradient_type> &gradients)
+        &shape_function_data,
+      std::vector<typename Tensor<2, dim, spacedim>::
+                    template solution_gradient_type<Number>> &gradients)
     {
       const unsigned int dofs_per_cell       = dof_values.size();
       const unsigned int n_quadrature_points = gradients.size();
 
-      std::fill(gradients.begin(),
-                gradients.end(),
-                typename Tensor<2, dim, spacedim>::template OutputType<
-                  Number>::gradient_type());
+      std::fill(
+        gradients.begin(),
+        gradients.end(),
+        typename Tensor<2, dim, spacedim>::template solution_gradient_type<
+          Number>());
 
       for (unsigned int shape_function = 0; shape_function < dofs_per_cell;
            ++shape_function)
@@ -1541,9 +1546,8 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_values(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1573,9 +1577,8 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_values_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::value_type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1598,8 +1601,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_gradients(
     const InputVector &fe_function,
-    std::vector<typename ProductType<gradient_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -1629,8 +1631,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_gradients_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::gradient_type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -1654,8 +1655,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_hessians(
     const InputVector &fe_function,
-    std::vector<typename ProductType<hessian_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -1685,8 +1685,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_hessians_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::hessian_type>
+    std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -1710,8 +1709,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_laplacians(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
+    std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -1741,8 +1739,7 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_laplacians_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::laplacian_type>
+    std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -1766,8 +1763,8 @@ namespace FEValuesViews
   void
   Scalar<dim, spacedim>::get_function_third_derivatives(
     const InputVector &fe_function,
-    std::vector<typename ProductType<third_derivative_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<
+      solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
@@ -1796,9 +1793,10 @@ namespace FEValuesViews
   template <class InputVector>
   void
   Scalar<dim, spacedim>::get_function_third_derivatives_from_local_dof_values(
-    const InputVector &                   dof_values,
-    std::vector<typename OutputType<typename InputVector::value_type>::
-                  third_derivative_type> &third_derivatives) const
+    const InputVector &dof_values,
+    std::vector<
+      solution_third_derivative_type<typename InputVector::value_type>>
+      &third_derivatives) const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1821,9 +1819,8 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_values(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1852,9 +1849,8 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_values_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::value_type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1877,8 +1873,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_gradients(
     const InputVector &fe_function,
-    std::vector<typename ProductType<gradient_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -1908,8 +1903,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_gradients_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::gradient_type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -1933,8 +1927,8 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_symmetric_gradients(
     const InputVector &fe_function,
-    std::vector<typename ProductType<symmetric_gradient_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<
+      solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -1963,9 +1957,10 @@ namespace FEValuesViews
   template <class InputVector>
   void
   Vector<dim, spacedim>::get_function_symmetric_gradients_from_local_dof_values(
-    const InputVector &                     dof_values,
-    std::vector<typename OutputType<typename InputVector::value_type>::
-                  symmetric_gradient_type> &symmetric_gradients) const
+    const InputVector &dof_values,
+    std::vector<
+      solution_symmetric_gradient_type<typename InputVector::value_type>>
+      &symmetric_gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -1988,8 +1983,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_divergences(
     const InputVector &fe_function,
-    std::vector<typename ProductType<divergence_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2020,8 +2014,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_divergences_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::divergence_type>
+    std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2045,9 +2038,8 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_curls(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<curl_type, typename InputVector::value_type>::type>
-      &curls) const
+    std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
+    const
   {
     Assert(fe_values->update_flags & update_gradients,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2076,8 +2068,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_curls_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::curl_type> &curls)
+    std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2101,8 +2092,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_hessians(
     const InputVector &fe_function,
-    std::vector<typename ProductType<hessian_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -2132,8 +2122,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_hessians_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::hessian_type>
+    std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -2157,8 +2146,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_laplacians(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
+    std::vector<solution_value_type<typename InputVector::value_type>>
       &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -2193,8 +2181,7 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_laplacians_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::laplacian_type>
+    std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
     Assert(fe_values->update_flags & update_hessians,
@@ -2221,8 +2208,8 @@ namespace FEValuesViews
   void
   Vector<dim, spacedim>::get_function_third_derivatives(
     const InputVector &fe_function,
-    std::vector<typename ProductType<third_derivative_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<
+      solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
@@ -2251,9 +2238,10 @@ namespace FEValuesViews
   template <class InputVector>
   void
   Vector<dim, spacedim>::get_function_third_derivatives_from_local_dof_values(
-    const InputVector &                   dof_values,
-    std::vector<typename OutputType<typename InputVector::value_type>::
-                  third_derivative_type> &third_derivatives) const
+    const InputVector &dof_values,
+    std::vector<
+      solution_third_derivative_type<typename InputVector::value_type>>
+      &third_derivatives) const
   {
     Assert(fe_values->update_flags & update_3rd_derivatives,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2276,9 +2264,8 @@ namespace FEValuesViews
   void
   SymmetricTensor<2, dim, spacedim>::get_function_values(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2307,9 +2294,8 @@ namespace FEValuesViews
   void
   SymmetricTensor<2, dim, spacedim>::get_function_values_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::value_type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2332,8 +2318,7 @@ namespace FEValuesViews
   void
   SymmetricTensor<2, dim, spacedim>::get_function_divergences(
     const InputVector &fe_function,
-    std::vector<typename ProductType<divergence_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2365,8 +2350,7 @@ namespace FEValuesViews
   SymmetricTensor<2, dim, spacedim>::
     get_function_divergences_from_local_dof_values(
       const InputVector &dof_values,
-      std::vector<
-        typename OutputType<typename InputVector::value_type>::divergence_type>
+      std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2390,9 +2374,8 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_values(
     const InputVector &fe_function,
-    std::vector<
-      typename ProductType<value_type, typename InputVector::value_type>::type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2421,9 +2404,8 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_values_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::value_type>
-      &values) const
+    std::vector<solution_value_type<typename InputVector::value_type>> &values)
+    const
   {
     Assert(fe_values->update_flags & update_values,
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
@@ -2446,8 +2428,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_divergences(
     const InputVector &fe_function,
-    std::vector<typename ProductType<divergence_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2478,8 +2459,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_divergences_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::divergence_type>
+    std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2503,8 +2483,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_gradients(
     const InputVector &fe_function,
-    std::vector<typename ProductType<gradient_type,
-                                     typename InputVector::value_type>::type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,
@@ -2535,8 +2514,7 @@ namespace FEValuesViews
   void
   Tensor<2, dim, spacedim>::get_function_gradients_from_local_dof_values(
     const InputVector &dof_values,
-    std::vector<
-      typename OutputType<typename InputVector::value_type>::gradient_type>
+    std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
     Assert(fe_values->update_flags & update_gradients,

--- a/source/fe/fe_values.inst.in
+++ b/source/fe/fe_values.inst.in
@@ -249,119 +249,110 @@ for (VEC : GENERAL_CONTAINER_TYPES; Number : ALL_SCALAR_TYPES;
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_values_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::value_type> &) const;
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::gradient_type> &) const;
+        const VEC<Number> &, std::vector<solution_gradient_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::hessian_type> &) const;
+        const VEC<Number> &, std::vector<solution_hessian_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::value_type> &) const;
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void
     FEValuesViews::Scalar<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives_from_local_dof_values<VEC<Number>>(
         const VEC<Number> &,
-        std::vector<typename OutputType<Number>::third_derivative_type> &)
-        const;
+        std::vector<solution_third_derivative_type<Number>> &) const;
 
 
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_values_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::value_type> &) const;
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::gradient_type> &) const;
+        const VEC<Number> &, std::vector<solution_gradient_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_symmetric_gradients_from_local_dof_values<VEC<Number>>(
         const VEC<Number> &,
-        std::vector<typename OutputType<Number>::symmetric_gradient_type> &)
-        const;
+        std::vector<solution_symmetric_gradient_type<Number>> &) const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_divergences_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::divergence_type> &) const;
+        const VEC<Number> &, std::vector<solution_divergence_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_curls_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::curl_type> &) const;
+        const VEC<Number> &, std::vector<solution_curl_type<Number>> &) const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_hessians_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::hessian_type> &) const;
+        const VEC<Number> &, std::vector<solution_hessian_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_laplacians_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::value_type> &) const;
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void
     FEValuesViews::Vector<deal_II_dimension, deal_II_space_dimension>::
       get_function_third_derivatives_from_local_dof_values<VEC<Number>>(
         const VEC<Number> &,
-        std::vector<typename OutputType<Number>::third_derivative_type> &)
-        const;
+        std::vector<solution_third_derivative_type<Number>> &) const;
 
 
 
-    template void FEValuesViews::
-      SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
-        get_function_values_from_local_dof_values<VEC<Number>>(
-          const VEC<Number> &,
-          std::vector<typename OutputType<Number>::value_type> &) const;
+    template void FEValuesViews::SymmetricTensor<2,
+                                                 deal_II_dimension,
+                                                 deal_II_space_dimension>::
+      get_function_values_from_local_dof_values<VEC<Number>>(
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void FEValuesViews::
       SymmetricTensor<2, deal_II_dimension, deal_II_space_dimension>::
         get_function_divergences_from_local_dof_values<VEC<Number>>(
-          const VEC<Number> &,
-          std::vector<typename OutputType<Number>::divergence_type> &) const;
+          const VEC<Number> &, std::vector<solution_divergence_type<Number>> &)
+          const;
 
 
 
     template void
     FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
       get_function_values_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::value_type> &) const;
+        const VEC<Number> &, std::vector<solution_value_type<Number>> &) const;
 
     template void
     FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
       get_function_divergences_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::divergence_type> &) const;
+        const VEC<Number> &, std::vector<solution_divergence_type<Number>> &)
+        const;
 
     template void
     FEValuesViews::Tensor<2, deal_II_dimension, deal_II_space_dimension>::
       get_function_gradients_from_local_dof_values<VEC<Number>>(
-        const VEC<Number> &,
-        std::vector<typename OutputType<Number>::gradient_type> &) const;
+        const VEC<Number> &, std::vector<solution_gradient_type<Number>> &)
+        const;
 #endif
   }
 

--- a/tests/fe/fe_values_view_get_function_from_local_dof_values_01.cc
+++ b/tests/fe/fe_values_view_get_function_from_local_dof_values_01.cc
@@ -59,7 +59,6 @@ test_view(const Vector<double> &            solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using gradient_type =
@@ -73,36 +72,41 @@ test_view(const Vector<double> &            solution,
                          NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
-  std::vector<value_type>                      qp_values_global(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+                          qp_values_local(n_q_points);
+  std::vector<value_type> qp_values_global(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
   fe_values_view.get_function_values(solution, qp_values_global);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
-  std::vector<gradient_type>                      qp_grads_global(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+                             qp_grads_local(n_q_points);
+  std::vector<gradient_type> qp_grads_global(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
   fe_values_view.get_function_gradients(solution, qp_grads_global);
 
   // Hessians
-  std::vector<typename OutputType::hessian_type> qp_hess_local(n_q_points);
-  std::vector<hessian_type>                      qp_hess_global(n_q_points);
+  std::vector<typename View::template solution_hessian_type<NumberType>>
+                            qp_hess_local(n_q_points);
+  std::vector<hessian_type> qp_hess_global(n_q_points);
   fe_values_view.get_function_hessians_from_local_dof_values(local_dof_values,
                                                              qp_hess_local);
   fe_values_view.get_function_hessians(solution, qp_hess_global);
 
   // Laplacians
-  std::vector<typename OutputType::laplacian_type> qp_laplace_local(n_q_points);
+  std::vector<typename View::template solution_laplacian_type<NumberType>>
+                              qp_laplace_local(n_q_points);
   std::vector<laplacian_type> qp_laplace_global(n_q_points);
   fe_values_view.get_function_laplacians_from_local_dof_values(
     local_dof_values, qp_laplace_local);
   fe_values_view.get_function_laplacians(solution, qp_laplace_global);
 
   // Third derivatives
-  std::vector<typename OutputType::third_derivative_type> qp_third_deriv_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_third_derivative_type<NumberType>>
+                                     qp_third_deriv_local(n_q_points);
   std::vector<third_derivative_type> qp_third_deriv_global(n_q_points);
   fe_values_view.get_function_third_derivatives_from_local_dof_values(
     local_dof_values, qp_third_deriv_local);
@@ -145,7 +149,6 @@ test_view(const Vector<double> &            solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using gradient_type =
@@ -166,22 +169,25 @@ test_view(const Vector<double> &            solution,
                          NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
-  std::vector<value_type>                      qp_values_global(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+                          qp_values_local(n_q_points);
+  std::vector<value_type> qp_values_global(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
   fe_values_view.get_function_values(solution, qp_values_global);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
-  std::vector<gradient_type>                      qp_grads_global(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+                             qp_grads_local(n_q_points);
+  std::vector<gradient_type> qp_grads_global(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
   fe_values_view.get_function_gradients(solution, qp_grads_global);
 
   // Symmetric gradients
-  std::vector<typename OutputType::symmetric_gradient_type> qp_symm_grads_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_symmetric_gradient_type<NumberType>>
+                                       qp_symm_grads_local(n_q_points);
   std::vector<symmetric_gradient_type> qp_symm_grads_global(n_q_points);
   fe_values_view.get_function_symmetric_gradients_from_local_dof_values(
     local_dof_values, qp_symm_grads_local);
@@ -189,36 +195,41 @@ test_view(const Vector<double> &            solution,
                                                   qp_symm_grads_global);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
-  std::vector<divergence_type>                      qp_divs_global(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+                               qp_divs_local(n_q_points);
+  std::vector<divergence_type> qp_divs_global(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
   fe_values_view.get_function_divergences(solution, qp_divs_global);
 
   // Curls
-  std::vector<typename OutputType::curl_type> qp_curls_local(n_q_points);
-  std::vector<curl_type>                      qp_curls_global(n_q_points);
+  std::vector<typename View::template solution_curl_type<NumberType>>
+                         qp_curls_local(n_q_points);
+  std::vector<curl_type> qp_curls_global(n_q_points);
   fe_values_view.get_function_curls_from_local_dof_values(local_dof_values,
                                                           qp_curls_local);
   fe_values_view.get_function_curls(solution, qp_curls_global);
 
   // Hessians
-  std::vector<typename OutputType::hessian_type> qp_hess_local(n_q_points);
-  std::vector<hessian_type>                      qp_hess_global(n_q_points);
+  std::vector<typename View::template solution_hessian_type<NumberType>>
+                            qp_hess_local(n_q_points);
+  std::vector<hessian_type> qp_hess_global(n_q_points);
   fe_values_view.get_function_hessians_from_local_dof_values(local_dof_values,
                                                              qp_hess_local);
   fe_values_view.get_function_hessians(solution, qp_hess_global);
 
   // Laplacians
-  std::vector<typename OutputType::laplacian_type> qp_laplace_local(n_q_points);
+  std::vector<typename View::template solution_laplacian_type<NumberType>>
+                              qp_laplace_local(n_q_points);
   std::vector<laplacian_type> qp_laplace_global(n_q_points);
   fe_values_view.get_function_laplacians_from_local_dof_values(
     local_dof_values, qp_laplace_local);
   fe_values_view.get_function_laplacians(solution, qp_laplace_global);
 
   // Third derivatives
-  std::vector<typename OutputType::third_derivative_type> qp_third_deriv_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_third_derivative_type<NumberType>>
+                                     qp_third_deriv_local(n_q_points);
   std::vector<third_derivative_type> qp_third_deriv_global(n_q_points);
   fe_values_view.get_function_third_derivatives_from_local_dof_values(
     local_dof_values, qp_third_deriv_local);
@@ -275,22 +286,23 @@ test_view(const Vector<double> &                        solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using divergence_type =
     typename ProductType<typename View::divergence_type, NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
-  std::vector<value_type>                      qp_values_global(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+                          qp_values_local(n_q_points);
+  std::vector<value_type> qp_values_global(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
   fe_values_view.get_function_values(solution, qp_values_global);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
-  std::vector<divergence_type>                      qp_divs_global(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+                               qp_divs_local(n_q_points);
+  std::vector<divergence_type> qp_divs_global(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
   fe_values_view.get_function_divergences(solution, qp_divs_global);
@@ -321,7 +333,6 @@ test_view(const Vector<double> &               solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using gradient_type =
@@ -330,22 +341,25 @@ test_view(const Vector<double> &               solution,
     typename ProductType<typename View::divergence_type, NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
-  std::vector<value_type>                      qp_values_global(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+                          qp_values_local(n_q_points);
+  std::vector<value_type> qp_values_global(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
   fe_values_view.get_function_values(solution, qp_values_global);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
-  std::vector<divergence_type>                      qp_divs_global(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+                               qp_divs_local(n_q_points);
+  std::vector<divergence_type> qp_divs_global(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
   fe_values_view.get_function_divergences(solution, qp_divs_global);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
-  std::vector<gradient_type>                      qp_grads_global(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+                             qp_grads_local(n_q_points);
+  std::vector<gradient_type> qp_grads_global(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
   fe_values_view.get_function_gradients(solution, qp_grads_global);

--- a/tests/fe/fe_values_view_get_function_from_local_dof_values_02.cc
+++ b/tests/fe/fe_values_view_get_function_from_local_dof_values_02.cc
@@ -65,31 +65,34 @@ test_view(const Vector<double> &            solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
-
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+    qp_values_local(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+    qp_grads_local(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
 
   // Hessians
-  std::vector<typename OutputType::hessian_type> qp_hess_local(n_q_points);
+  std::vector<typename View::template solution_hessian_type<NumberType>>
+    qp_hess_local(n_q_points);
   fe_values_view.get_function_hessians_from_local_dof_values(local_dof_values,
                                                              qp_hess_local);
 
   // Laplacians
-  std::vector<typename OutputType::laplacian_type> qp_laplace_local(n_q_points);
+  std::vector<typename View::template solution_laplacian_type<NumberType>>
+    qp_laplace_local(n_q_points);
   fe_values_view.get_function_laplacians_from_local_dof_values(
     local_dof_values, qp_laplace_local);
 
   // Third derivatives
-  std::vector<typename OutputType::third_derivative_type> qp_third_deriv_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_third_derivative_type<NumberType>>
+    qp_third_deriv_local(n_q_points);
   fe_values_view.get_function_third_derivatives_from_local_dof_values(
     local_dof_values, qp_third_deriv_local);
 }
@@ -108,47 +111,53 @@ test_view(const Vector<double> &            solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
-
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+    qp_values_local(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+    qp_grads_local(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
 
   // Symmetric gradients
-  std::vector<typename OutputType::symmetric_gradient_type> qp_symm_grads_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_symmetric_gradient_type<NumberType>>
+    qp_symm_grads_local(n_q_points);
   fe_values_view.get_function_symmetric_gradients_from_local_dof_values(
     local_dof_values, qp_symm_grads_local);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+    qp_divs_local(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
 
   // Curls
-  std::vector<typename OutputType::curl_type> qp_curls_local(n_q_points);
+  std::vector<typename View::template solution_curl_type<NumberType>>
+    qp_curls_local(n_q_points);
   fe_values_view.get_function_curls_from_local_dof_values(local_dof_values,
                                                           qp_curls_local);
 
   // Hessians
-  std::vector<typename OutputType::hessian_type> qp_hess_local(n_q_points);
+  std::vector<typename View::template solution_hessian_type<NumberType>>
+    qp_hess_local(n_q_points);
   fe_values_view.get_function_hessians_from_local_dof_values(local_dof_values,
                                                              qp_hess_local);
 
   // Laplacians
-  std::vector<typename OutputType::laplacian_type> qp_laplace_local(n_q_points);
+  std::vector<typename View::template solution_laplacian_type<NumberType>>
+    qp_laplace_local(n_q_points);
   fe_values_view.get_function_laplacians_from_local_dof_values(
     local_dof_values, qp_laplace_local);
 
   // Third derivatives
-  std::vector<typename OutputType::third_derivative_type> qp_third_deriv_local(
-    n_q_points);
+  std::vector<
+    typename View::template solution_third_derivative_type<NumberType>>
+    qp_third_deriv_local(n_q_points);
   fe_values_view.get_function_third_derivatives_from_local_dof_values(
     local_dof_values, qp_third_deriv_local);
 }
@@ -167,19 +176,20 @@ test_view(const Vector<double> &                        solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using divergence_type =
     typename ProductType<typename View::divergence_type, NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+    qp_values_local(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+    qp_divs_local(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
 }
@@ -198,7 +208,6 @@ test_view(const Vector<double> &               solution,
   const View &fe_values_view = fe_values[extractor];
 
   // Typedefs
-  using OutputType = typename View::template OutputType<NumberType>;
   using value_type =
     typename ProductType<typename View::value_type, NumberType>::type;
   using gradient_type =
@@ -207,17 +216,20 @@ test_view(const Vector<double> &               solution,
     typename ProductType<typename View::divergence_type, NumberType>::type;
 
   // Values
-  std::vector<typename OutputType::value_type> qp_values_local(n_q_points);
+  std::vector<typename View::template solution_value_type<NumberType>>
+    qp_values_local(n_q_points);
   fe_values_view.get_function_values_from_local_dof_values(local_dof_values,
                                                            qp_values_local);
 
   // Divergences
-  std::vector<typename OutputType::divergence_type> qp_divs_local(n_q_points);
+  std::vector<typename View::template solution_divergence_type<NumberType>>
+    qp_divs_local(n_q_points);
   fe_values_view.get_function_divergences_from_local_dof_values(
     local_dof_values, qp_divs_local);
 
   // Gradients
-  std::vector<typename OutputType::gradient_type> qp_grads_local(n_q_points);
+  std::vector<typename View::template solution_gradient_type<NumberType>>
+    qp_grads_local(n_q_points);
   fe_values_view.get_function_gradients_from_local_dof_values(local_dof_values,
                                                               qp_grads_local);
 }

--- a/tests/fe/fe_values_views_types.cc
+++ b/tests/fe/fe_values_views_types.cc
@@ -25,11 +25,13 @@ template <int dim, int spacedim, typename Extractor>
 void
 test(const Extractor &)
 {
-  typename FEValuesViews::View<dim, spacedim, Extractor>::template OutputType<
-    double>::value_type t1;
+  typename FEValuesViews::View<dim, spacedim, Extractor>::
+    template solution_value_type<double>
+      t1;
 
-  typename FEValuesViews::View<dim, spacedim, Extractor>::template OutputType<
-    double>::gradient_type t2;
+  typename FEValuesViews::View<dim, spacedim, Extractor>::
+    template solution_gradient_type<double>
+      t2;
 
   deallog << "Test<" << Utilities::dim_string(dim, spacedim) << ">" << std::endl
           << Utilities::type_to_string(t1) << std::endl


### PR DESCRIPTION
Specifically, instead of using a nested class, just use a template type alias. While there, also fix a few places where we should have used the existing type alias but instead had repeated the same type computation used in the definition of the type alias.

This patch is pretty repetitive. It's unlikely going to be fun to look over, but at least should be very well covered by the test suite. I'll try not to write any such patches any more until the release and focus on the things that *actually* need to be done.

/rebuild