### PR TITLE
Guard SUNDIALS variables more carefully

### DIFF
--- a/include/deal.II/sundials/sundials_backport.h
+++ b/include/deal.II/sundials/sundials_backport.h
@@ -105,14 +105,18 @@ namespace SUNDIALS
       ops->nvwsqrsumlocal     = nullptr;
       ops->nvwsqrsummasklocal = nullptr;
 
+#    if DEAL_II_SUNDIALS_VERSION_GTE(5, 4, 0)
       /* XBraid interface operations */
       ops->nvbufsize   = nullptr;
       ops->nvbufpack   = nullptr;
       ops->nvbufunpack = nullptr;
+#    endif
 
+#    if DEAL_II_SUNDIALS_VERSION_GTE(5, 3, 0)
       /* debugging functions (called when SUNDIALS_DEBUG_PRINTVEC is defined) */
       ops->nvprint     = nullptr;
       ops->nvprintfile = nullptr;
+#    endif
 #  endif
 
       /* attach ops and initialize content to nullptr */
@@ -213,14 +217,18 @@ namespace SUNDIALS
       v->ops->nvwsqrsumlocal     = w->ops->nvwsqrsumlocal;
       v->ops->nvwsqrsummasklocal = w->ops->nvwsqrsummasklocal;
 
+#    if DEAL_II_SUNDIALS_VERSION_GTE(5, 4, 0)
       /* XBraid interface operations */
       v->ops->nvbufsize   = w->ops->nvbufsize;
       v->ops->nvbufpack   = w->ops->nvbufpack;
       v->ops->nvbufunpack = w->ops->nvbufunpack;
+#    endif
 
+#    if DEAL_II_SUNDIALS_VERSION_GTE(5, 3, 0)
       /* debugging functions (called when SUNDIALS_DEBUG_PRINTVEC is defined) */
       v->ops->nvprint     = w->ops->nvprint;
       v->ops->nvprintfile = w->ops->nvprintfile;
+#    endif
 #  endif
 
       return (0);


### PR DESCRIPTION
Looking at https://github.com/LLNL/sundials/blame/73c280cd55ca2b42019c8a9aa54af10e41e27b9d/src/sundials/sundials_nvector.c, we need to introduce some more guards.
Should fix https://cdash.43-1.org/test/1218759.