### PR TITLE
Fix compilation with gcc-5.

### DIFF
--- a/source/hp/refinement.cc
+++ b/source/hp/refinement.cc
@@ -828,8 +828,7 @@ namespace hp
       // possible
       using level_type =
         typename dealii::DoFHandler<dim, spacedim>::active_fe_index_type;
-      static const level_type invalid_level =
-        dealii::DoFHandler<dim, spacedim>::invalid_active_fe_index;
+      const auto invalid_level = static_cast<level_type>(-1);
 
       // map from FE index to level in hierarchy
       // FE indices that are not covered in the hierarchy are not in the map
@@ -888,8 +887,8 @@ namespace hp
       // Function that updates the level of neighbor to fulfill difference
       // criterion, and returns whether it was changed.
       const auto update_neighbor_level =
-        [&future_levels, max_difference](const auto &     neighbor,
-                                         const level_type cell_level) -> bool {
+        [&future_levels, max_difference, invalid_level](
+          const auto &neighbor, const level_type cell_level) -> bool {
         Assert(neighbor->is_active(), ExcInternalError());
         // We only care about locally owned neighbors. If neighbor is a ghost
         // cell, its future FE index will be updated on the owning process and


### PR DESCRIPTION
The compiler generates identical symbols for each static declaration, which leads to a problem in the assembler. Work around it by not declaring the variable as static.