### PR TITLE
Fix warning about unused function in PETScWrappers source file

### DIFF
--- a/source/lac/petsc_precondition.cc
+++ b/source/lac/petsc_precondition.cc
@@ -463,6 +463,7 @@ namespace PETScWrappers
 
 
 
+#  ifdef DEAL_II_PETSC_WITH_HYPRE
   namespace
   {
     /**
@@ -537,6 +538,7 @@ namespace PETScWrappers
       return string_type;
     }
   } // namespace
+#  endif
 
   PreconditionBoomerAMG::PreconditionBoomerAMG(
     const MPI_Comm &      comm,


### PR DESCRIPTION
Should fix the warnings in https://cdash.43-1.org/viewBuildError.php?type=1&buildid=290.