### PR TITLE
Avoid warning about out-of-bound access in Tensor

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1293,7 +1293,7 @@ constexpr DEAL_II_ALWAYS_INLINE
   AssertIndexRange(i, dim);
 #  endif
 
-  return values[i];
+  return values[i < dim ? i : 0];
 }
 
 


### PR DESCRIPTION
This should fix https://cdash.43-1.org/build/287. I'm not quite sure if this is too costly or not, though.