### PR TITLE
Fix a static_assert to actually make sense.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -449,7 +449,7 @@ template <int rank_, int dim, typename Number>
 class Tensor
 {
 public:
-  static_assert(rank_ >= 0,
+  static_assert(rank_ >= 1,
                 "Tensors must have a rank greater than or equal to one.");
   static_assert(dim >= 0,
                 "Tensors must have a dimension greater than or equal to one.");


### PR DESCRIPTION
More specifically, there is a specialization Tensor<0,dim,Number> so we should reallly never get here with rank==0.

There is of course another funny-looking static assertion in the next line that one might investigate (will do next) but that is a separate matter.

/rebuild