### PR TITLE
Fix base/unsubscribe_subscriptor for clang

### DIFF
--- a/tests/base/unsubscribe_subscriptor.debug.output.clang-6
+++ b/tests/base/unsubscribe_subscriptor.debug.output.clang-6
@@ -7,7 +7,8 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
-    No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+    No subscriber with identifier <b> subscribes to this object of class
+    N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
 --------------------------------------------------------
 
 DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything about the supplied pointer!")
@@ -18,6 +19,7 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 
-    This Subscriptor object does not know anything about the supplied pointer!
+    This Subscriptor object does not know anything about the supplied
+    pointer!
 --------------------------------------------------------
 


### PR DESCRIPTION
Should fix https://cdash.43-1.org/test/2044524. I remember us breaking lines error messages as well in some patch and it looks like this is one of the tests we forgot to update.