### PR TITLE
Fix lac/vector_memory for Clang12

### DIFF
--- a/tests/lac/vector_memory.debug.output.clang12
+++ b/tests/lac/vector_memory.debug.output.clang12
@@ -1,0 +1,25 @@
+
+DEAL::GrowingVectorMemory:Overall allocated vectors: 10
+DEAL::GrowingVectorMemory:Maximum allocated vectors: 6
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<>::~GrowingVectorMemory() [VectorType = dealii::Vector<double>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    Destroying memory handler while 1 objects are still allocated.
+--------------------------------------------------------
+
+DEAL::Exception: StandardExceptions::ExcMemoryLeak(current_alloc)
+DEAL::
+--------------------------------------------------------
+An error occurred in file <vector_memory.templates.h> in function
+    virtual dealii::GrowingVectorMemory<dealii::Vector<float>>::~GrowingVectorMemory() [VectorType = dealii::Vector<float>]
+The violated condition was: 
+    current_alloc == 0
+Additional information: 
+    Destroying memory handler while 1 objects are still allocated.
+--------------------------------------------------------
+


### PR DESCRIPTION
Fixes https://cdash.43-1.org/test/2046462. The diff to the current `clang` file is
```diff
8c8
<     virtual dealii::GrowingVectorMemory<>::~GrowingVectorMemory() [VectorType = dealii::Vector<double>]
---
>     virtual dealii::GrowingVectorMemory<dealii::Vector<double> >::~GrowingVectorMemory() [VectorType = dealii::Vector<double>]
19c19
<     virtual dealii::GrowingVectorMemory<dealii::Vector<float>>::~GrowingVectorMemory() [VectorType = dealii::Vector<float>]
---
>     virtual dealii::GrowingVectorMemory<dealii::Vector<float> >::~GrowingVectorMemory() [VectorType = dealii::Vector<float>]
```