### PR TITLE
Fix up tests for ICC 2018

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1532,12 +1532,7 @@ public:
      * automatically generated destructor would have a different one due to
      * member objects.
      */
-#ifdef __INTEL_COMPILER
-    virtual ~DistortedCellList() noexcept override
-    {}
-#else
-    virtual ~DistortedCellList() noexcept override = default;
-#endif
+    virtual ~DistortedCellList() noexcept override;
 
     /**
      * A list of those cells among the coarse mesh cells that are deformed or

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -1532,7 +1532,12 @@ public:
      * automatically generated destructor would have a different one due to
      * member objects.
      */
+#ifdef __INTEL_COMPILER
+    virtual ~DistortedCellList() noexcept override
+    {}
+#else
     virtual ~DistortedCellList() noexcept override = default;
+#endif
 
     /**
      * A list of those cells among the coarse mesh cells that are deformed or

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -15246,6 +15246,12 @@ Triangulation<dim, spacedim>::memory_consumption() const
 }
 
 
+
+template <int dim, int spacedim>
+Triangulation<dim, spacedim>::DistortedCellList::~DistortedCellList() noexcept =
+  default;
+
+
 // explicit instantiations
 #include "tria.inst"
 

--- a/tests/base/unsubscribe_subscriptor.debug.output.intel
+++ b/tests/base/unsubscribe_subscriptor.debug.output.intel
@@ -7,7 +7,8 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     it != counter_map.end()
 Additional information: 
-    No subscriber with identifier <b> subscribes to this object of class N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
+    No subscriber with identifier <b> subscribes to this object of class
+    N6dealii11SubscriptorE. Consequently, it cannot be unsubscribed.
 --------------------------------------------------------
 
 DEAL::Exception: ExcMessage( "This Subscriptor object does not know anything about the supplied pointer!")
@@ -18,6 +19,7 @@ An error occurred in file <subscriptor.cc> in function
 The violated condition was: 
     validity_ptr_it != validity_pointers.end()
 Additional information: 
-    This Subscriptor object does not know anything about the supplied pointer!
+    This Subscriptor object does not know anything about the supplied
+    pointer!
 --------------------------------------------------------
 

--- a/tests/parameter_handler/parameter_handler_25.output2
+++ b/tests/parameter_handler/parameter_handler_25.output2
@@ -18,11 +18,14 @@ An error occurred in file <parameter_handler.cc> in function
 The violated condition was: 
     entries_wrongly_not_set.size() == 0
 Additional information: 
-    Not all entries of the parameter handler that were declared with `has_to_be_set = true` have been set. The following parameters 
-
-  General.Precision
-  General.dim
-
- have not been set. A possible reason might be that you did not add these parameter to the input file or that their spelling is not correct.
+    Not all entries of the parameter handler that were declared with
+    `has_to_be_set = true` have been set. The following parameters
+    
+    General.Precision
+    General.dim
+    
+    have not been set. A possible reason might be that you did not add
+    these parameter to the input file or that their spelling is not
+    correct.
 --------------------------------------------------------
 


### PR DESCRIPTION
Related to #12098 and #12096, fixes tests in https://cdash.43-1.org/viewTest.php?onlyfailed&buildid=413. I also needed to provide a user-provided destructor for `DistortedCellList` to avoid linker errors.