### PR TITLE
Simplify use of a function in ReferenceCell.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -169,7 +169,7 @@ public:
    * cell is a pyramid), or with FE_WedgeP (if the reference cell is
    * a wedge).
    */
-  template <int dim, int spacedim>
+  template <int dim, int spacedim = dim>
   std::unique_ptr<Mapping<dim, spacedim>>
   get_default_mapping(const unsigned int degree) const;
 
@@ -184,7 +184,7 @@ public:
    * understood as $d$-linear (i.e., bilinear or trilinear) for some of the
    * coordinate directions.
    */
-  template <int dim, int spacedim>
+  template <int dim, int spacedim = dim>
   const Mapping<dim, spacedim> &
   get_default_linear_mapping() const;
 


### PR DESCRIPTION
One has to provide the template arguments for this function explicitly. But we can default `spacedim` to `dim`.

/rebuild