### PR TITLE
Fix a function for non-quads/hexes.

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -389,7 +389,7 @@ namespace
       triangulation.n_vertices(), 0);
 
     for (const auto &cell : triangulation.active_cell_iterators())
-      for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
+      for (const unsigned int v : cell->vertex_indices())
         {
           min_adjacent_cell_level[cell->vertex_index(v)] =
             std::min<unsigned int>(


### PR DESCRIPTION
I'm not quite sure how to test this -- the function is only called in an `Assert` statement. But it seems obviously wrong as-is, so might as well fix it.

/rebuild