### PR TITLE
Do not actually define the general Table class.

### DIFF
--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -663,8 +663,7 @@ protected:
  * @ingroup data
  */
 template <int N, typename T>
-class Table : public TableBase<N, T>
-{};
+class Table;
 
 
 /**


### PR DESCRIPTION
The class is exclusively used through its specializations. There is no need to
provide a general implementation. It is also currently unusable since the
class has no non-trivial constructors, so nobody could have used the general
template for anything useful.

/rebuild