### PR TITLE
Rename ParticleHandler::locally_relevant_ids() to locally_owned_particles()

### DIFF
--- a/doc/news/changes/incompatibilities/20210501Munch
+++ b/doc/news/changes/incompatibilities/20210501Munch
@@ -1,0 +1,4 @@
+Renamed: The function ParticleHandler::locally_relevant_ids() has been deprecated.
+Please use the new function ParticleHandler::locally_owned_particle_ids() instead.
+<br>
+(Peter Munch, 2021/05/01)

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1062,7 +1062,7 @@ namespace Step70
     // successive vector elements (this is what the IndexSet::tensor_priduct()
     // function does).
     locally_owned_tracer_particle_coordinates =
-      tracer_particle_handler.locally_relevant_ids().tensor_product(
+      tracer_particle_handler.locally_owned_particle_ids().tensor_product(
         complete_index_set(spacedim));
 
     // At the beginning of the simulation, all particles are in their original
@@ -1865,7 +1865,7 @@ namespace Step70
           tracer_particle_velocities *= time_step;
 
           locally_relevant_tracer_particle_coordinates =
-            tracer_particle_handler.locally_relevant_ids().tensor_product(
+            tracer_particle_handler.locally_owned_particle_ids().tensor_product(
               complete_index_set(spacedim));
 
           relevant_tracer_particle_displacements.reinit(

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -444,10 +444,10 @@ namespace Particles
      *
      * The vector @p input_vector should have read access to the indices
      * created by extracting the locally relevant ids with
-     * locally_relevant_ids(), and taking its tensor
+     * locally_owned_particle_ids(), and taking its tensor
      * product with the index set representing the range `[0, spacedim)`, i.e.:
      * @code
-     * IndexSet ids = particle_handler.locally_relevant_ids().
+     * IndexSet ids = particle_handler.locally_owned_particle_ids().
      *  tensor_product(complete_index_set(spacedim));
      * @endcode
      *
@@ -497,7 +497,7 @@ namespace Particles
      * get_particle_positions() function, and then modify the resulting vector.
      *
      * @param [in] new_positions A vector of points of dimension
-     * particle_handler.n_locally_owned_particles()
+     * particle_handler.n_locally_owned_particle_ids()
      *
      * @param [in] displace_particles When true, this function adds the value
      * of the vector of points to the
@@ -641,7 +641,7 @@ namespace Particles
      * triangulation.
      */
     types::particle_index
-    n_locally_owned_particles() const;
+    n_locally_owned_particle_ids() const;
 
     /**
      * Return the next free particle index in the global set
@@ -666,9 +666,30 @@ namespace Particles
      *
      * @return An IndexSet of size get_next_free_particle_index(), containing
      * n_locally_owned_particle() indices.
+     *
+     * @deprecated Use locally_owned_particle_ids() instead.
+     */
+    DEAL_II_DEPRECATED IndexSet
+                       locally_relevant_ids() const;
+
+    /**
+     * Extract an IndexSet with global dimensions equal to
+     * get_next_free_particle_index(), containing the locally owned
+     * particle indices.
+     *
+     * This function can be used to construct distributed vectors and matrices
+     * to manipulate particles using linear algebra operations.
+     *
+     * Notice that it is the user's responsibility to guarantee that particle
+     * indices are unique, and no check is performed to verify that this is the
+     * case, nor that the union of all IndexSet objects on each mpi process is
+     * complete.
+     *
+     * @return An IndexSet of size get_next_free_particle_index(), containing
+     * n_locally_owned_particle() indices.
      */
     IndexSet
-    locally_relevant_ids() const;
+    locally_owned_particle_ids() const;
 
     /**
      * Return the number of properties each particle has.
@@ -1144,6 +1165,15 @@ namespace Particles
       output_vector.compress(VectorOperation::add);
     else
       output_vector.compress(VectorOperation::insert);
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline IndexSet
+  ParticleHandler<dim, spacedim>::locally_relevant_ids() const
+  {
+    return this->locally_owned_particle_ids();
   }
 
 } // namespace Particles

--- a/include/deal.II/particles/utilities.h
+++ b/include/deal.II/particles/utilities.h
@@ -191,7 +191,7 @@ namespace Particles
       OutputVectorType &                               interpolated_field,
       const ComponentMask &field_comps = ComponentMask())
     {
-      if (particle_handler.n_locally_owned_particles() == 0)
+      if (particle_handler.n_locally_owned_particle_ids() == 0)
         {
           interpolated_field.compress(VectorOperation::add);
           return; // nothing else to do here

--- a/source/particles/data_out.cc
+++ b/source/particles/data_out.cc
@@ -40,7 +40,7 @@ namespace Particles
         "belong to a single vector or tensor."));
 
     if ((data_component_names.size() > 0) &&
-        (particles.n_locally_owned_particles() > 0))
+        (particles.n_locally_owned_particle_ids() > 0))
       {
         Assert(
           particles.begin()->has_properties(),
@@ -75,7 +75,7 @@ namespace Particles
     const unsigned int n_property_components = data_component_names.size();
     const unsigned int n_data_components     = dataset_names.size();
 
-    patches.resize(particles.n_locally_owned_particles());
+    patches.resize(particles.n_locally_owned_particle_ids());
 
     auto particle = particles.begin();
     for (unsigned int i = 0; particle != particles.end(); ++particle, ++i)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -767,7 +767,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   types::particle_index
-  ParticleHandler<dim, spacedim>::n_locally_owned_particles() const
+  ParticleHandler<dim, spacedim>::n_locally_owned_particle_ids() const
   {
     return particles.size();
   }
@@ -794,7 +794,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   IndexSet
-  ParticleHandler<dim, spacedim>::locally_relevant_ids() const
+  ParticleHandler<dim, spacedim>::locally_owned_particle_ids() const
   {
     IndexSet set(get_next_free_particle_index());
     for (const auto &p : *this)
@@ -812,7 +812,7 @@ namespace Particles
     const bool                    add_to_output_vector)
   {
     // There should be one point per particle to gather
-    AssertDimension(positions.size(), n_locally_owned_particles());
+    AssertDimension(positions.size(), n_locally_owned_particle_ids());
 
     unsigned int i = 0;
     for (auto it = begin(); it != end(); ++it, ++i)
@@ -833,7 +833,7 @@ namespace Particles
     const bool                          displace_particles)
   {
     // There should be one point per particle to fix the new position
-    AssertDimension(new_positions.size(), n_locally_owned_particles());
+    AssertDimension(new_positions.size(), n_locally_owned_particle_ids());
 
     unsigned int i = 0;
     for (auto it = begin(); it != end(); ++it, ++i)
@@ -929,7 +929,7 @@ namespace Particles
     // processes around (with an invalid cell).
 
     std::vector<particle_iterator> particles_out_of_cell;
-    particles_out_of_cell.reserve(n_locally_owned_particles());
+    particles_out_of_cell.reserve(n_locally_owned_particle_ids());
 
     // Now update the reference locations of the moved particles
     std::vector<Point<spacedim>> real_locations;

--- a/source/particles/utilities.cc
+++ b/source/particles/utilities.cc
@@ -36,7 +36,7 @@ namespace Particles
       const AffineConstraints<number> &                constraints,
       const ComponentMask &                            space_comps)
     {
-      if (particle_handler.n_locally_owned_particles() == 0)
+      if (particle_handler.n_locally_owned_particle_ids() == 0)
         return; // nothing to do here
 
       const auto &tria = space_dh.get_triangulation();
@@ -119,7 +119,7 @@ namespace Particles
       const AffineConstraints<typename MatrixType::value_type> &constraints,
       const ComponentMask &                                     space_comps)
     {
-      if (particle_handler.n_locally_owned_particles() == 0)
+      if (particle_handler.n_locally_owned_particle_ids() == 0)
         {
           matrix.compress(VectorOperation::add);
           return; // nothing else to do here

--- a/tests/particles/extract_index_set_01.cc
+++ b/tests/particles/extract_index_set_01.cc
@@ -13,7 +13,7 @@
 //
 // ---------------------------------------------------------------------
 
-// Test ParticleHandler::locally_relevant_ids().
+// Test ParticleHandler::locally_owned_particle_ids().
 
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/utilities.h>
@@ -63,7 +63,7 @@ test()
   auto cpu_to_index =
     particle_handler.insert_global_particles(points, global_bounding_boxes);
 
-  const auto set = particle_handler.locally_relevant_ids();
+  const auto set = particle_handler.locally_owned_particle_ids();
   deallog << "Local set: ";
   set.print(deallog);
   deallog << std::endl;

--- a/tests/particles/interpolate_on_particle_01.cc
+++ b/tests/particles/interpolate_on_particle_01.cc
@@ -78,7 +78,7 @@ test()
             << particle_handler.n_global_particles() << std::endl;
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/particle_interpolation_01.cc
+++ b/tests/particles/particle_interpolation_01.cc
@@ -99,7 +99,7 @@ test()
     space_dh, particle_handler, dsp, constraints, space_mask);
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/particle_interpolation_02.cc
+++ b/tests/particles/particle_interpolation_02.cc
@@ -103,7 +103,7 @@ test()
     space_dh, particle_handler, dsp, constraints, space_mask);
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/particle_interpolation_03.cc
+++ b/tests/particles/particle_interpolation_03.cc
@@ -102,7 +102,7 @@ test()
     space_dh, particle_handler, dsp, constraints, space_mask);
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/particle_interpolation_04.cc
+++ b/tests/particles/particle_interpolation_04.cc
@@ -97,7 +97,7 @@ test()
     space_dh, particle_handler, dsp, constraints, space_mask);
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/particle_interpolation_05.cc
+++ b/tests/particles/particle_interpolation_05.cc
@@ -99,7 +99,7 @@ test()
     space_dh, particle_handler, dsp, constraints, space_mask);
 
   const auto n_local_particles_dofs =
-    particle_handler.n_locally_owned_particles() * n_comps;
+    particle_handler.n_locally_owned_particle_ids() * n_comps;
 
   auto particle_sizes =
     Utilities::MPI::all_gather(MPI_COMM_WORLD, n_local_particles_dofs);

--- a/tests/particles/set_particle_positions_01.cc
+++ b/tests/particles/set_particle_positions_01.cc
@@ -65,7 +65,7 @@ test()
   auto cpu_to_index =
     particle_handler.insert_global_particles(points, global_bounding_boxes);
 
-  const auto set = particle_handler.locally_relevant_ids().tensor_product(
+  const auto set = particle_handler.locally_owned_particle_ids().tensor_product(
     complete_index_set(spacedim));
 
   TrilinosWrappers::MPI::Vector vector(set, MPI_COMM_WORLD);
@@ -81,8 +81,9 @@ test()
 
   // Make sure we have a new index set
 
-  const auto new_set = particle_handler.locally_relevant_ids().tensor_product(
-    complete_index_set(spacedim));
+  const auto new_set =
+    particle_handler.locally_owned_particle_ids().tensor_product(
+      complete_index_set(spacedim));
 
   TrilinosWrappers::MPI::Vector new_vector(new_set, MPI_COMM_WORLD);
 

--- a/tests/particles/set_particle_positions_02.cc
+++ b/tests/particles/set_particle_positions_02.cc
@@ -72,10 +72,10 @@ test()
   Tensor<1, spacedim> displacement;
   displacement[0] = 0.1;
   std::vector<Point<spacedim>> new_particle_positions(
-    particle_handler.n_locally_owned_particles());
+    particle_handler.n_locally_owned_particle_ids());
 
   std::vector<Point<spacedim>> old_particle_positions(
-    particle_handler.n_locally_owned_particles());
+    particle_handler.n_locally_owned_particle_ids());
   particle_handler.get_particle_positions(old_particle_positions);
 
   for (unsigned int i = 0; i < old_particle_positions.size(); ++i)


### PR DESCRIPTION
closes #10263

I took the liberty to directly deprecate the function, since it is a rather new function.

FYI @bangerth @gassmoeller @luca-heltai @blaisb 