### PR TITLE
Ignore MPI warning in linux-debug-parallel-simplex

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,6 +85,11 @@ jobs:
         make -j 2
     - name: test
       run: |
+        # Remove warning: "A high-performance Open MPI point-to-point
+        # messaging module was unable to find any relevant network
+        # interfaces."
+        export OMPI_MCA_btl_base_warn_component_unused='0'
+        
         cd build
         make -j 2 setup_tests_simplex
         ctest --output-on-failure -j 2


### PR DESCRIPTION
... as suggested in https://github.com/dealii/dealii/pull/11795#issuecomment-791722326. Needed for #11795 and #11552.