### PR TITLE
Simplify some calls to make compiler inline function

### DIFF
--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -374,18 +374,7 @@ namespace internal
     TriaObjects::n_objects() const
     {
       // assume that each cell has the same number of faces
-
-      unsigned int faces_per_cell = 1;
-
-      if (this->structdim == 1)
-        faces_per_cell = GeometryInfo<1>::faces_per_cell;
-      else if (this->structdim == 2)
-        faces_per_cell = GeometryInfo<2>::faces_per_cell;
-      else if (this->structdim == 3)
-        faces_per_cell = GeometryInfo<3>::faces_per_cell;
-      else
-        AssertThrow(false, ExcNotImplemented());
-
+      const unsigned int faces_per_cell = 2 * this->structdim;
       return cells.size() / faces_per_cell;
     }
 
@@ -395,18 +384,7 @@ namespace internal
     TriaObjects::get_bounding_object_indices(const unsigned int index)
     {
       // assume that each cell has the same number of faces
-
-      unsigned int faces_per_cell = 1;
-
-      if (this->structdim == 1)
-        faces_per_cell = GeometryInfo<1>::faces_per_cell;
-      else if (this->structdim == 2)
-        faces_per_cell = GeometryInfo<2>::faces_per_cell;
-      else if (this->structdim == 3)
-        faces_per_cell = GeometryInfo<3>::faces_per_cell;
-      else
-        AssertThrow(false, ExcNotImplemented());
-
+      const unsigned int faces_per_cell = 2 * this->structdim;
       return ArrayView<int>(cells.data() + index * faces_per_cell,
                             faces_per_cell);
     }


### PR DESCRIPTION
I realize that this PR, replacing some `GeometryInfo::faces_per_cell` by `2*dim`, is making an implicit assumption about the number of faces (`2 * dim`), but I think a single line is so much more readable than than the the current version with its many `if` statements. Also, the `GeometryInfo` struct is something outdated anyway. If 18 deleted lines are not enough of an argument, let me state that this single change results in much better performance of an actual benchmark: With gcc-7, I get a speedup for a simple code that generates a mesh of a cube (with `GridGenerator::subdivided_hyper_cube(tria, 20, 0, 1)` followed by a few `tria.refine_global()` of about 15% in both 2D and 3D, with clang-12 it is around 20%. The reason is that the function is in the hot path for various functions (e.g. `quad_index` in 3D), and the compiler does not inline the basic version whereas it does it with my change.

Related to #5437 and the recent slowdown we observed by introducing the simplex elements.