### PR TITLE
Mark members in ParticleAccessor as 'private'.

### DIFF
--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -239,7 +239,7 @@ namespace Particles
     bool
     operator==(const ParticleAccessor<dim, spacedim> &other) const;
 
-  protected:
+  private:
     /**
      * Construct an invalid accessor. Such an object is not usable.
      */
@@ -247,7 +247,7 @@ namespace Particles
 
     /**
      * Construct an accessor from a reference to a map and an iterator to the
-     * map. This constructor is protected so that it can only be accessed by
+     * map. This constructor is `private` so that it can only be accessed by
      * friend classes.
      */
     ParticleAccessor(


### PR DESCRIPTION
This class is not meant to be derived from, and I *think* that the reason why
these members were only 'protected' and not 'private' is to somehow indicate
that these are members that 'friend' classes might access. But that is too
complicated an interpretation. Let's just make everything 'private', as
usual.

/rebuild