### PR TITLE
Implement cache to speed up TriaAccessor::vertex_index()

### DIFF
--- a/doc/news/changes/minor/20210504MartinKronbichler
+++ b/doc/news/changes/minor/20210504MartinKronbichler
@@ -1,0 +1,5 @@
+Improved: There is now a cache for TriaAccessor::vertex_index() for the cells
+of a mesh, which considerably speeds up operations with intensive use of
+`cell->vertex()` or `cell->vertex_index()`.
+<br>
+(Martin Kronbichler, 2021/05/04)

--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3898,6 +3898,12 @@ private:
   reset_global_cell_indices();
 
   /**
+   * Reset cache for the cells' vertex indices.
+   */
+  void
+  reset_cell_vertex_indices_cache();
+
+  /**
    * Refine all cells on all levels which were previously flagged for
    * refinement.
    *
@@ -4255,6 +4261,7 @@ Triangulation<dim, spacedim>::load(Archive &ar, const unsigned int)
         level->global_active_cell_indices.resize(level->refine_flags.size());
         level->global_level_cell_indices.resize(level->refine_flags.size());
       }
+    reset_cell_vertex_indices_cache();
     reset_active_cell_indices();
     reset_global_cell_indices();
   }

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -225,6 +225,14 @@ namespace internal
       std::vector<dealii::ReferenceCell> reference_cell;
 
       /**
+       * A cache for the vertex indices of the cells (`structdim == dim`), in
+       * order to more quickly retrieve these frequently accessed quantities.
+       * For simplified addressing, the information is indexed by the maximum
+       * number of vertices possible for a cell (quadrilateral/hexahedron).
+       */
+      std::vector<unsigned int> cell_vertex_indices_cache;
+
+      /**
        * Determine an estimate for the memory consumption (in bytes) of this
        * object.
        */
@@ -250,9 +258,9 @@ namespace internal
 
       ar &refine_flags &coarsen_flags;
 
-      // do not serialize 'active_cell_indices' here. instead of storing them
-      // to the stream and re-reading them again later, we just rebuild them
-      // in Triangulation::load()
+      // do not serialize `active_cell_indices` and `vertex_indices_cache`
+      // here. instead of storing them to the stream and re-reading them again
+      // later, we just rebuild them in Triangulation::load()
 
       ar &neighbors;
       ar &subdomain_ids;


### PR DESCRIPTION
Fixes #5437.

In implementing this functionality, I think I opted for the simplest case, letting `Triangulation::reset_cell_vertex_indices_cache` do all allocation and setting of the data. In other data structures, like the active cell indices, we do an indirection via the accessor also for setting the data, but I don't see why it would help here. Instead, it rather makes things more complicated because we need additional interfaces that essentially just do a single step, and split up the work into three places, one for the allocation, one for the loop, and one for the actual storage of the index. But I might be missing something here, so I'd be happy to hear opinions.

I ran the full test suite (to the extent of third-party libraries I have installed) and it passed, so this functionality should be tested thousands of times.