### PR TITLE
MG test: Remove update_cell_dof_indices_cache for mg dof numbers

### DIFF
--- a/tests/multigrid/constrained_dofs_01.cc
+++ b/tests/multigrid/constrained_dofs_01.cc
@@ -121,7 +121,6 @@ check_fe(FiniteElement<dim> &fe)
         std::vector<types::global_dof_index> &renumbered =
           mgdofmap[cell->id().to_string()];
         cell->set_mg_dof_indices(renumbered);
-        cell->update_cell_dof_indices_cache();
       }
 
     mg_constrained_dofs_ref.initialize(dofhref);

--- a/tests/multigrid/constrained_dofs_02.cc
+++ b/tests/multigrid/constrained_dofs_02.cc
@@ -182,7 +182,6 @@ check_fe(FiniteElement<dim> &fe)
         std::vector<types::global_dof_index> &renumbered =
           mgdofmap[cell->id().to_string()];
         cell->set_mg_dof_indices(renumbered);
-        cell->update_cell_dof_indices_cache();
       }
 
     mg_constrained_dofs_ref.initialize(dofhref);


### PR DESCRIPTION
It does not seem to make sense to update the cache for the dof indices on the multigrid levels, as we use it for the dofs on active cells (if I read our code base correctly). This seems to be responsible for the failure of the `multigrid/constrained_dofs_02` test as far as I can see, even though the error message https://cdash.43-1.org/test/3595692 does not really indicate what happens. What I see by running it through valgrind is an invalid write beyond the array bounds, so I think we better remove it.