### PR TITLE
Give reasonable error messages when trying to use p::d::Triangulation without p4est

### DIFF
--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -973,10 +973,11 @@ namespace parallel
        * constructed (see also the class documentation).
        */
       explicit Triangulation(
-        const MPI_Comm &mpi_communicator,
+        const MPI_Comm & /*mpi_communicator*/,
         const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
-                       smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
-        const Settings settings    = default_setting) = delete;
+        /*smooth_grid*/
+        = (dealii::Triangulation<dim, spacedim>::none),
+        const Settings /*settings*/ = default_setting) = delete;
 
       /**
        * Dummy replacement to allow for better error messages when compiling
@@ -993,7 +994,7 @@ namespace parallel
        * this class.
        */
       virtual void
-      save(const std::string &filename) const override
+      save(const std::string & /*filename*/) const override
       {}
 
       /**
@@ -1001,8 +1002,8 @@ namespace parallel
        * this class.
        */
       virtual void
-      load(const std::string &filename,
-           const bool         autopartition = true) override
+      load(const std::string & /*filename*/,
+           const bool /*autopartition*/ = true) override
       {}
 
       /**

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -958,10 +958,60 @@ namespace parallel
     {
     public:
       /**
+       * Dummy settings to allow defining the deleted constructor.
+       */
+      enum Settings
+      {
+        default_setting                          = 0x0,
+        mesh_reconstruction_after_repartitioning = 0x1,
+        construct_multigrid_hierarchy            = 0x2,
+        no_automatic_repartitioning              = 0x4
+      };
+
+      /**
        * Constructor. Deleted to make sure that objects of this type cannot be
        * constructed (see also the class documentation).
        */
-      Triangulation() = delete;
+      explicit Triangulation(
+        const MPI_Comm &mpi_communicator,
+        const typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
+                       smooth_grid = (dealii::Triangulation<dim, spacedim>::none),
+        const Settings settings    = default_setting) = delete;
+
+      /**
+       * Dummy replacement to allow for better error messages when compiling
+       * this class.
+       */
+      virtual bool
+      is_multilevel_hierarchy_constructed() const override
+      {
+        return false;
+      }
+
+      /**
+       * Dummy replacement to allow for better error messages when compiling
+       * this class.
+       */
+      virtual void
+      save(const std::string &filename) const override
+      {}
+
+      /**
+       * Dummy replacement to allow for better error messages when compiling
+       * this class.
+       */
+      virtual void
+      load(const std::string &filename,
+           const bool         autopartition = true) override
+      {}
+
+      /**
+       * Dummy replacement to allow for better error messages when compiling
+       * this class.
+       */
+      virtual void
+      update_cell_relations() override
+      {}
     };
   } // namespace distributed
 } // namespace parallel


### PR DESCRIPTION
Fixes #10807. Also, match the constructor of the "real" implementation.