### PR TITLE
Fix unused variable warning in fe_interface_values.h

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -1393,6 +1393,7 @@ inline const FEInterfaceViews::Vector<dim, spacedim>
     (fe.n_components() >= Tensor<1, spacedim>::n_independent_components ?
        fe.n_components() - Tensor<1, spacedim>::n_independent_components + 1 :
        0);
+  (void)n_vectors;
   AssertIndexRange(vector.first_vector_component, n_vectors);
   return FEInterfaceViews::Vector<dim, spacedim>(*this,
                                                  vector.first_vector_component);


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?type=1&onlydeltap&buildid=682.