### PR TITLE
Fix base/aligned_vector_replicate_03.mpirun=3.release

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -1510,6 +1510,10 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
           new (&aligned_shmem_pointer[i]) T(std::move(elements[i]));
     }
 
+  // Make sure that the shared memory host has copied the data before we try to
+  // access it.
+  MPI_Barrier(shmem_group_communicator);
+
   // **** Step 7 ****
   // Finally, we need to set the pointers of this object to what we just
   // learned. This also releases all memory that may have been in use
@@ -1552,10 +1556,6 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
   // allocated elements in the original objects.
   used_elements_end      = elements.get() + array_size;
   allocated_elements_end = used_elements_end;
-
-  // Make sure that the shared memory host has copied the data before we try to
-  // access it.
-  MPI_Barrier(shmem_group_communicator);
 
   // **** Consistency check ****
   // At this point, each process should have a copy of the data.

--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -1553,6 +1553,10 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
   used_elements_end      = elements.get() + array_size;
   allocated_elements_end = used_elements_end;
 
+  // Make sure that the shared memory host has copied the data before we try to
+  // access it.
+  MPI_Barrier(shmem_group_communicator);
+
   // **** Consistency check ****
   // At this point, each process should have a copy of the data.
   // Verify this in some sort of round-about way


### PR DESCRIPTION
Fixes https://cdash.43-1.org/test/3872385. I believe we might have accessed the data before setting it on all processes correctly.