### PR TITLE
Switch order of parameters in GridGenerator::reference_cell()

### DIFF
--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -1584,7 +1584,7 @@ namespace FETools
 
     // First, create a local mass matrix for the unit cell
     Triangulation<dim, spacedim> tr;
-    GridGenerator::reference_cell(reference_cell, tr);
+    GridGenerator::reference_cell(tr, reference_cell);
 
     const auto &mapping =
       reference_cell.template get_default_linear_mapping<dim, spacedim>();
@@ -1792,7 +1792,7 @@ namespace FETools
         // Set up meshes, one with a single
         // reference cell and refine it once
         Triangulation<dim, spacedim> tria;
-        GridGenerator::reference_cell(reference_cell, tria);
+        GridGenerator::reference_cell(tria, reference_cell);
         tria.begin_active()->set_refine_flag(RefinementCase<dim>(ref_case));
         tria.execute_coarsening_and_refinement();
 
@@ -2183,7 +2183,7 @@ namespace FETools
     {
       // set up a triangulation for coarse cell
       Triangulation<dim, spacedim> tr;
-      GridGenerator::reference_cell(reference_cell, tr);
+      GridGenerator::reference_cell(tr, reference_cell);
 
       FEValues<dim, spacedim> coarse(mapping,
                                      fe,
@@ -2239,7 +2239,7 @@ namespace FETools
 
         // create a respective refinement on the triangulation
         Triangulation<dim, spacedim> tr;
-        GridGenerator::reference_cell(reference_cell, tr);
+        GridGenerator::reference_cell(tr, reference_cell);
         tr.begin_active()->set_refine_flag(RefinementCase<dim>(ref_case));
         tr.execute_coarsening_and_refinement();
 

--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -136,8 +136,8 @@ namespace GridGenerator
    */
   template <int dim, int spacedim>
   void
-  reference_cell(const ReferenceCell &         reference_cell,
-                 Triangulation<dim, spacedim> &tria);
+  reference_cell(Triangulation<dim, spacedim> &tria,
+                 const ReferenceCell &         reference_cell);
 
 
   /**

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -1719,8 +1719,8 @@ namespace GridGenerator
 
   template <int dim, int spacedim>
   void
-  reference_cell(const ReferenceCell &         reference_cell,
-                 Triangulation<dim, spacedim> &tria)
+  reference_cell(Triangulation<dim, spacedim> &tria,
+                 const ReferenceCell &         reference_cell)
   {
     AssertDimension(dim, reference_cell.get_dimension());
 

--- a/source/grid/grid_generator.inst.in
+++ b/source/grid/grid_generator.inst.in
@@ -271,8 +271,8 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #if deal_II_dimension <= deal_II_space_dimension
       template void
       reference_cell<deal_II_dimension, deal_II_space_dimension>(
-        const ReferenceCell &,
-        Triangulation<deal_II_dimension, deal_II_space_dimension> &);
+        Triangulation<deal_II_dimension, deal_II_space_dimension> &,
+        const ReferenceCell &);
 
       template void
       convert_hypercube_to_simplex_mesh(

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -203,7 +203,7 @@ ReferenceCell::get_nodal_type_quadrature() const
   // reference cell
   const auto create_quadrature = [](const ReferenceCell &reference_cell) {
     Triangulation<dim> tria;
-    GridGenerator::reference_cell(reference_cell, tria);
+    GridGenerator::reference_cell(tria, reference_cell);
 
     return Quadrature<dim>(tria.get_vertices());
   };

--- a/tests/simplex/fe_p_bubbles_02.cc
+++ b/tests/simplex/fe_p_bubbles_02.cc
@@ -51,7 +51,7 @@ compute_nodal_quadrature(const FiniteElement<dim, spacedim> &fe)
   const Quadrature<dim> q_gauss =
     type.get_gauss_type_quadrature<dim>(fe.tensor_degree() + 1);
   Triangulation<dim, spacedim> tria;
-  GridGenerator::reference_cell(type, tria);
+  GridGenerator::reference_cell(tria, type);
   const Mapping<dim, spacedim> &mapping =
     type.template get_default_linear_mapping<dim, spacedim>();
 

--- a/tests/simplex/orientation_02.cc
+++ b/tests/simplex/orientation_02.cc
@@ -30,7 +30,7 @@ test(const unsigned int orientation)
 
 
   Triangulation<3> dummy, tria;
-  GridGenerator::reference_cell(ReferenceCells::Tetrahedron, dummy);
+  GridGenerator::reference_cell(dummy, ReferenceCells::Tetrahedron);
 
   auto vertices = dummy.get_vertices();
 


### PR DESCRIPTION
... to make it consistent to the other functions in the namespace.