### PR TITLE
Un-deprecate PETScWrappers::VectorBase::set.

### DIFF
--- a/include/deal.II/lac/petsc_vector_base.h
+++ b/include/deal.II/lac/petsc_vector_base.h
@@ -458,10 +458,7 @@ namespace PETScWrappers
      * vector, this function allows to set a whole set of elements at once.
      * The indices of the elements to be set are stated in the first argument,
      * the corresponding values in the second.
-     *
-     * @deprecated Use import() instead.
      */
-    DEAL_II_DEPRECATED
     void
     set(const std::vector<size_type> &  indices,
         const std::vector<PetscScalar> &values);


### PR DESCRIPTION
Fixes #12001.

We didn't implement import so there is no reason to deprecate this function yet.

Partially reverts 20a81f91beae2d022acebc833c1bca2321c67155.