### PR TITLE
Use a better exception for handling missing sparsity patterns.

### DIFF
--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -1424,7 +1424,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::size_type
 ChunkSparseMatrix<number>::m() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->rows;
 }
 
@@ -1433,7 +1433,7 @@ template <typename number>
 inline typename ChunkSparseMatrix<number>::size_type
 ChunkSparseMatrix<number>::n() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->cols;
 }
 
@@ -1443,7 +1443,7 @@ template <typename number>
 inline const ChunkSparsityPattern &
 ChunkSparseMatrix<number>::get_sparsity_pattern() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return *cols;
 }
 
@@ -1476,7 +1476,7 @@ ChunkSparseMatrix<number>::set(const size_type i,
 {
   AssertIsFinite(value);
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   // it is allowed to set elements of the matrix that are not part of the
   // sparsity pattern, if the value to which we set it is zero
   const size_type index = compute_location(i, j);
@@ -1497,7 +1497,7 @@ ChunkSparseMatrix<number>::add(const size_type i,
 {
   AssertIsFinite(value);
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
 
   if (std::abs(value) != 0.)
     {
@@ -1532,7 +1532,7 @@ template <typename number>
 inline ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::operator*=(const number factor)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   const size_type chunk_size = cols->get_chunk_size();
@@ -1557,7 +1557,7 @@ template <typename number>
 inline ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::operator/=(const number factor)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(std::abs(factor) != 0, ExcDivideByZero());
 
@@ -1587,7 +1587,7 @@ inline number
 ChunkSparseMatrix<number>::operator()(const size_type i,
                                       const size_type j) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   AssertThrow(compute_location(i, j) != SparsityPattern::invalid_entry,
               ExcInvalidIndex(i, j));
   return val[compute_location(i, j)];
@@ -1599,7 +1599,7 @@ template <typename number>
 inline number
 ChunkSparseMatrix<number>::el(const size_type i, const size_type j) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   const size_type index = compute_location(i, j);
 
   if (index != ChunkSparsityPattern::invalid_entry)
@@ -1614,7 +1614,7 @@ template <typename number>
 inline number
 ChunkSparseMatrix<number>::diag_element(const size_type i) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(m() == n(), ExcNotQuadratic());
   AssertIndexRange(i, m());
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -377,7 +377,7 @@ ChunkSparseMatrix<number>::operator=(const double d)
   (void)d;
   Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->sparsity_pattern.compressed || cols->empty(),
          ChunkSparsityPattern::ExcNotCompressed());
 
@@ -489,7 +489,7 @@ template <typename number>
 typename ChunkSparseMatrix<number>::size_type
 ChunkSparseMatrix<number>::n_nonzero_elements() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->n_nonzero_elements();
 }
 
@@ -499,7 +499,7 @@ template <typename number>
 typename ChunkSparseMatrix<number>::size_type
 ChunkSparseMatrix<number>::n_actually_nonzero_elements() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
 
   // count those elements that are nonzero, even if they lie in the padding
   // around the matrix. since we have the invariant that padding elements are
@@ -517,7 +517,7 @@ template <typename number>
 void
 ChunkSparseMatrix<number>::symmetrize()
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->rows == cols->cols, ExcNotQuadratic());
 
   Assert(false, ExcNotImplemented());
@@ -531,7 +531,7 @@ ChunkSparseMatrix<number> &
 ChunkSparseMatrix<number>::copy_from(
   const ChunkSparseMatrix<somenumber> &matrix)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(cols == matrix.cols, ExcDifferentChunkSparsityPatterns());
 
@@ -570,7 +570,7 @@ void
 ChunkSparseMatrix<number>::add(const number                         factor,
                                const ChunkSparseMatrix<somenumber> &matrix)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(cols == matrix.cols, ExcDifferentChunkSparsityPatterns());
 
@@ -650,7 +650,7 @@ template <class OutVector, class InVector>
 void
 ChunkSparseMatrix<number>::vmult(OutVector &dst, const InVector &src) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -671,13 +671,13 @@ void
 ChunkSparseMatrix<number>::Tvmult(OutVector &dst, const InVector &src) const
 {
   Assert(val != nullptr, ExcNotInitialized());
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(n() == dst.size(), ExcDimensionMismatch(n(), dst.size()));
   Assert(m() == src.size(), ExcDimensionMismatch(m(), src.size()));
 
   Assert(!PointerComparison::equal(&src, &dst), ExcSourceEqualsDestination());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -697,7 +697,7 @@ template <class OutVector, class InVector>
 void
 ChunkSparseMatrix<number>::vmult_add(OutVector &dst, const InVector &src) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -729,7 +729,7 @@ template <class OutVector, class InVector>
 void
 ChunkSparseMatrix<number>::Tvmult_add(OutVector &dst, const InVector &src) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -818,7 +818,7 @@ template <typename somenumber>
 somenumber
 ChunkSparseMatrix<number>::matrix_norm_square(const Vector<somenumber> &v) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
   Assert(n() == v.size(), ExcDimensionMismatch(n(), v.size()));
@@ -919,7 +919,7 @@ ChunkSparseMatrix<number>::matrix_scalar_product(
   const Vector<somenumber> &u,
   const Vector<somenumber> &v) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == u.size(), ExcDimensionMismatch(m(), u.size()));
   Assert(n() == v.size(), ExcDimensionMismatch(n(), v.size()));
@@ -1015,7 +1015,7 @@ template <typename number>
 typename ChunkSparseMatrix<number>::real_type
 ChunkSparseMatrix<number>::l1_norm() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   const size_type n_chunk_rows = cols->sparsity_pattern.n_rows();
@@ -1047,7 +1047,7 @@ template <typename number>
 typename ChunkSparseMatrix<number>::real_type
 ChunkSparseMatrix<number>::linfty_norm() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   // this function works like l1_norm(). it can be made more efficient
@@ -1102,7 +1102,7 @@ ChunkSparseMatrix<number>::residual(Vector<somenumber> &      dst,
                                     const Vector<somenumber> &u,
                                     const Vector<somenumber> &b) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(m() == b.size(), ExcDimensionMismatch(m(), b.size()));
@@ -1214,7 +1214,7 @@ ChunkSparseMatrix<number>::precondition_Jacobi(Vector<somenumber> &      dst,
 {
   (void)dst;
   (void)src;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1238,7 +1238,7 @@ ChunkSparseMatrix<number>::precondition_SSOR(Vector<somenumber> &      dst,
   // CVS archives to see the original version which is much clearer...
   (void)dst;
   (void)src;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1257,7 +1257,7 @@ ChunkSparseMatrix<number>::precondition_SOR(Vector<somenumber> &      dst,
                                             const Vector<somenumber> &src,
                                             const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1275,7 +1275,7 @@ ChunkSparseMatrix<number>::precondition_TSOR(Vector<somenumber> &      dst,
                                              const Vector<somenumber> &src,
                                              const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1293,7 +1293,7 @@ ChunkSparseMatrix<number>::SOR(Vector<somenumber> &dst,
                                const number /*om*/) const
 {
   (void)dst;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1310,7 +1310,7 @@ ChunkSparseMatrix<number>::TSOR(Vector<somenumber> &dst,
                                 const number /*om*/) const
 {
   (void)dst;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1332,7 +1332,7 @@ ChunkSparseMatrix<number>::PSOR(
   (void)dst;
   (void)permutation;
   (void)inverse_permutation;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1359,7 +1359,7 @@ ChunkSparseMatrix<number>::TPSOR(
   (void)dst;
   (void)permutation;
   (void)inverse_permutation;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1384,7 +1384,7 @@ ChunkSparseMatrix<number>::SOR_step(Vector<somenumber> &      v,
 {
   (void)v;
   (void)b;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1406,7 +1406,7 @@ ChunkSparseMatrix<number>::TSOR_step(Vector<somenumber> &      v,
 {
   (void)v;
   (void)b;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1439,7 +1439,7 @@ ChunkSparseMatrix<number>::SSOR(Vector<somenumber> &dst,
                                 const number /*om*/) const
 {
   (void)dst;
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == n(),
          ExcMessage("This operation is only valid on square matrices."));
@@ -1457,7 +1457,7 @@ ChunkSparseMatrix<number>::print(std::ostream &out) const
 {
   AssertThrow(out, ExcIO());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   Assert(false, ExcNotImplemented());
@@ -1477,7 +1477,7 @@ ChunkSparseMatrix<number>::print_formatted(std::ostream &     out,
 {
   AssertThrow(out, ExcIO());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   unsigned int width = width_;
@@ -1526,7 +1526,7 @@ ChunkSparseMatrix<number>::print_pattern(std::ostream &out,
 {
   AssertThrow(out, ExcIO());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   const size_type chunk_size = cols->get_chunk_size();

--- a/include/deal.II/lac/exceptions.h
+++ b/include/deal.II/lac/exceptions.h
@@ -46,6 +46,16 @@ namespace LACExceptions
   DeclException0(ExcDifferentBlockIndices);
 
   /**
+   * The operation requires a sparsity pattern.
+   */
+  DeclExceptionMsg(
+    ExcNeedsSparsityPattern,
+    "This function requires that the current object have a "
+    "sparsity pattern attached to it, but no sparsity pattern "
+    "is available. This usually means that there is a missing "
+    "reinit() call which would have added the sparsity pattern.");
+
+  /**
    * Exception thrown when a PETSc function reports an error. If possible,
    * this exception uses the message provided by
    * <code>PetscErrorMessage</code> to print a description of the error.

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -1763,7 +1763,7 @@ template <typename number>
 inline typename SparseMatrix<number>::size_type
 SparseMatrix<number>::m() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->rows;
 }
 
@@ -1772,7 +1772,7 @@ template <typename number>
 inline typename SparseMatrix<number>::size_type
 SparseMatrix<number>::n() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->cols;
 }
 
@@ -1961,7 +1961,7 @@ template <typename number>
 inline SparseMatrix<number> &
 SparseMatrix<number>::operator*=(const number factor)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   number *            val_ptr = val.get();
@@ -1979,7 +1979,7 @@ template <typename number>
 inline SparseMatrix<number> &
 SparseMatrix<number>::operator/=(const number factor)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(factor != number(), ExcDivideByZero());
 
@@ -2000,7 +2000,7 @@ template <typename number>
 inline const number &
 SparseMatrix<number>::operator()(const size_type i, const size_type j) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->operator()(i, j) != SparsityPattern::invalid_entry,
          ExcInvalidIndex(i, j));
   return val[cols->operator()(i, j)];
@@ -2012,7 +2012,7 @@ template <typename number>
 inline number &
 SparseMatrix<number>::operator()(const size_type i, const size_type j)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->operator()(i, j) != SparsityPattern::invalid_entry,
          ExcInvalidIndex(i, j));
   return val[cols->operator()(i, j)];
@@ -2024,7 +2024,7 @@ template <typename number>
 inline number
 SparseMatrix<number>::el(const size_type i, const size_type j) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   const size_type index = cols->operator()(i, j);
 
   if (index != SparsityPattern::invalid_entry)
@@ -2039,7 +2039,7 @@ template <typename number>
 inline number
 SparseMatrix<number>::diag_element(const size_type i) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(m() == n(), ExcNotQuadratic());
   AssertIndexRange(i, m());
 
@@ -2054,7 +2054,7 @@ template <typename number>
 inline number &
 SparseMatrix<number>::diag_element(const size_type i)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(m() == n(), ExcNotQuadratic());
   AssertIndexRange(i, m());
 
@@ -2466,7 +2466,7 @@ SparseMatrix<number>::print(StreamType &out,
                             const bool  across,
                             const bool  diagonal_first) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   bool   hanging_diagonal = false;

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -192,7 +192,7 @@ SparseMatrix<number>::operator=(const double d)
   (void)d;
   Assert(d == 0, ExcScalarAssignmentOnlyForZeroValue());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->compressed || cols->empty(),
          SparsityPattern::ExcNotCompressed());
 
@@ -305,7 +305,7 @@ template <typename number>
 typename SparseMatrix<number>::size_type
 SparseMatrix<number>::get_row_length(const size_type row) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->row_length(row);
 }
 
@@ -315,7 +315,7 @@ template <typename number>
 std::size_t
 SparseMatrix<number>::n_nonzero_elements() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return cols->n_nonzero_elements();
 }
 
@@ -325,7 +325,7 @@ template <typename number>
 std::size_t
 SparseMatrix<number>::n_actually_nonzero_elements(const double threshold) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(threshold >= 0, ExcMessage("Negative threshold!"));
   size_type         nnz       = 0;
   const std::size_t nnz_alloc = n_nonzero_elements();
@@ -341,7 +341,7 @@ template <typename number>
 void
 SparseMatrix<number>::symmetrize()
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(cols->rows == cols->cols, ExcNotQuadratic());
 
   const size_type n_rows = m();
@@ -381,7 +381,7 @@ template <typename somenumber>
 SparseMatrix<number> &
 SparseMatrix<number>::copy_from(const SparseMatrix<somenumber> &matrix)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(cols == matrix.cols, ExcDifferentSparsityPatterns());
 
@@ -464,7 +464,7 @@ void
 SparseMatrix<number>::add(const number                    factor,
                           const SparseMatrix<somenumber> &matrix)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(cols == matrix.cols, ExcDifferentSparsityPatterns());
 
@@ -540,7 +540,7 @@ SparseMatrix<number>::add(const size_type  row,
                           const bool       elide_zero_values,
                           const bool       col_indices_are_sorted)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   AssertIndexRange(row, m());
 
   // if we have sufficiently many columns
@@ -689,7 +689,7 @@ SparseMatrix<number>::set(const size_type  row,
                           const number2 *  values,
                           const bool       elide_zero_values)
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   AssertIndexRange(row, m());
 
   // First, search all the indices to find
@@ -768,7 +768,7 @@ template <class OutVector, class InVector>
 void
 SparseMatrix<number>::vmult(OutVector &dst, const InVector &src) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -800,7 +800,7 @@ void
 SparseMatrix<number>::Tvmult(OutVector &dst, const InVector &src) const
 {
   Assert(val != nullptr, ExcNotInitialized());
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(n() == dst.size(), ExcDimensionMismatch(n(), dst.size()));
   Assert(m() == src.size(), ExcDimensionMismatch(m(), src.size()));
 
@@ -826,7 +826,7 @@ template <class OutVector, class InVector>
 void
 SparseMatrix<number>::vmult_add(OutVector &dst, const InVector &src) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(n() == src.size(), ExcDimensionMismatch(n(), src.size()));
@@ -858,7 +858,7 @@ void
 SparseMatrix<number>::Tvmult_add(OutVector &dst, const InVector &src) const
 {
   Assert(val != nullptr, ExcNotInitialized());
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(n() == dst.size(), ExcDimensionMismatch(n(), dst.size()));
   Assert(m() == src.size(), ExcDimensionMismatch(m(), src.size()));
 
@@ -918,7 +918,7 @@ template <typename somenumber>
 somenumber
 SparseMatrix<number>::matrix_norm_square(const Vector<somenumber> &v) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
   Assert(n() == v.size(), ExcDimensionMismatch(n(), v.size()));
@@ -986,7 +986,7 @@ somenumber
 SparseMatrix<number>::matrix_scalar_product(const Vector<somenumber> &u,
                                             const Vector<somenumber> &v) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == u.size(), ExcDimensionMismatch(m(), u.size()));
   Assert(n() == v.size(), ExcDimensionMismatch(n(), v.size()));
@@ -1019,9 +1019,9 @@ SparseMatrix<number>::mmult(SparseMatrix<numberC> &      C,
 {
   const bool use_vector = V.size() == n() ? true : false;
   Assert(n() == B.m(), ExcDimensionMismatch(n(), B.m()));
-  Assert(cols != nullptr, ExcNotInitialized());
-  Assert(B.cols != nullptr, ExcNotInitialized());
-  Assert(C.cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
+  Assert(B.cols != nullptr, ExcNeedsSparsityPattern());
+  Assert(C.cols != nullptr, ExcNeedsSparsityPattern());
 
   const SparsityPattern &sp_A = *cols;
   const SparsityPattern &sp_B = *B.cols;
@@ -1125,9 +1125,9 @@ SparseMatrix<number>::Tmmult(SparseMatrix<numberC> &      C,
 {
   const bool use_vector = V.size() == m() ? true : false;
   Assert(m() == B.m(), ExcDimensionMismatch(m(), B.m()));
-  Assert(cols != nullptr, ExcNotInitialized());
-  Assert(B.cols != nullptr, ExcNotInitialized());
-  Assert(C.cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
+  Assert(B.cols != nullptr, ExcNeedsSparsityPattern());
+  Assert(C.cols != nullptr, ExcNeedsSparsityPattern());
 
   const SparsityPattern &sp_A = *cols;
   const SparsityPattern &sp_B = *B.cols;
@@ -1226,7 +1226,7 @@ template <typename number>
 typename SparseMatrix<number>::real_type
 SparseMatrix<number>::l1_norm() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   Vector<real_type> column_sums(n());
@@ -1245,7 +1245,7 @@ template <typename number>
 typename SparseMatrix<number>::real_type
 SparseMatrix<number>::linfty_norm() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   const number *val_ptr = &val[cols->rowstart[0]];
@@ -1332,7 +1332,7 @@ SparseMatrix<number>::residual(Vector<somenumber> &      dst,
                                const Vector<somenumber> &u,
                                const Vector<somenumber> &b) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
   Assert(m() == b.size(), ExcDimensionMismatch(m(), b.size()));
@@ -1400,7 +1400,7 @@ SparseMatrix<number>::precondition_Jacobi(Vector<somenumber> &      dst,
                                           const Vector<somenumber> &src,
                                           const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   AssertDimension(dst.size(), n());
@@ -1447,7 +1447,7 @@ SparseMatrix<number>::precondition_SSOR(
   // you may want to take a look at the CVS
   // archives to see the original version
   // which is much clearer...
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   AssertDimension(dst.size(), n());
@@ -1574,7 +1574,7 @@ SparseMatrix<number>::precondition_SOR(Vector<somenumber> &      dst,
                                        const Vector<somenumber> &src,
                                        const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   dst = src;
@@ -1589,7 +1589,7 @@ SparseMatrix<number>::precondition_TSOR(Vector<somenumber> &      dst,
                                         const Vector<somenumber> &src,
                                         const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   dst = src;
@@ -1602,7 +1602,7 @@ template <typename somenumber>
 void
 SparseMatrix<number>::SOR(Vector<somenumber> &dst, const number om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   AssertDimension(dst.size(), n());
@@ -1629,7 +1629,7 @@ template <typename somenumber>
 void
 SparseMatrix<number>::TSOR(Vector<somenumber> &dst, const number om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   AssertDimension(dst.size(), n());
@@ -1662,7 +1662,7 @@ SparseMatrix<number>::PSOR(Vector<somenumber> &          dst,
                            const std::vector<size_type> &inverse_permutation,
                            const number                  om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
 
@@ -1701,7 +1701,7 @@ SparseMatrix<number>::TPSOR(Vector<somenumber> &          dst,
                             const std::vector<size_type> &inverse_permutation,
                             const number                  om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
 
@@ -1738,7 +1738,7 @@ SparseMatrix<number>::Jacobi_step(Vector<somenumber> &      v,
                                   const Vector<somenumber> &b,
                                   const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
 
@@ -1769,7 +1769,7 @@ SparseMatrix<number>::SOR_step(Vector<somenumber> &      v,
                                const Vector<somenumber> &b,
                                const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
@@ -1797,7 +1797,7 @@ SparseMatrix<number>::TSOR_step(Vector<somenumber> &      v,
                                 const Vector<somenumber> &b,
                                 const number              om) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   Assert(m() == v.size(), ExcDimensionMismatch(m(), v.size()));
@@ -1840,7 +1840,7 @@ SparseMatrix<number>::SSOR(Vector<somenumber> &dst, const number om) const
   // missing
   Assert(false, ExcNotImplemented());
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
   AssertDimension(m(), n());
   Assert(m() == dst.size(), ExcDimensionMismatch(m(), dst.size()));
@@ -1890,7 +1890,7 @@ template <typename number>
 const SparsityPattern &
 SparseMatrix<number>::get_sparsity_pattern() const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   return *cols;
 }
 
@@ -1905,7 +1905,7 @@ SparseMatrix<number>::print_formatted(std::ostream &     out,
                                       const char *       zero_string,
                                       const double       denominator) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   unsigned int width = width_;
@@ -1950,7 +1950,7 @@ void
 SparseMatrix<number>::print_pattern(std::ostream &out,
                                     const double  threshold) const
 {
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   for (size_type i = 0; i < m(); ++i)
@@ -1979,7 +1979,7 @@ SparseMatrix<number>::print_as_numpy_arrays(std::ostream &     out,
 
   out.precision(precision);
 
-  Assert(cols != nullptr, ExcNotInitialized());
+  Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   std::vector<number> rows;


### PR DESCRIPTION
This recently came up on the mailing list. Part of #610.