### PR TITLE
Deprecate Thread and ThreadGroup.

### DIFF
--- a/examples/step-13/step-13.cc
+++ b/examples/step-13/step-13.cc
@@ -913,10 +913,10 @@ namespace Step13
     // independent, we do that in parallel (if the library was configured to
     // use concurrency, at least; otherwise, the actions are performed
     // sequentially). Note that we start only one thread, and do the second
-    // action in the main thread. Since only one thread is generated, we don't
-    // use the <code>Threads::ThreadGroup</code> class here, but rather use
-    // the one created thread object directly to wait for this particular
-    // thread's exit.
+    // action in the main thread. Since only one task is generated, we don't
+    // use the <code>Threads::TaskGroup</code> class here, but rather use
+    // the one created task object directly to wait for this particular
+    // task's exit.
     //
     // Note that taking up the address of the
     // <code>DoFTools::make_hanging_node_constraints</code> function is a

--- a/examples/step-14/step-14.cc
+++ b/examples/step-14/step-14.cc
@@ -617,9 +617,9 @@ namespace Step14
     // at least; otherwise, the actions are performed
     // sequentially). Note that we start only one thread, and do the
     // second action in the main thread. Since only one thread is
-    // generated, we don't use the <code>Threads::ThreadGroup</code>
-    // class here, but rather use the one created thread object
-    // directly to wait for this particular thread's exit. The
+    // generated, we don't use the <code>Threads::TaskGroup</code>
+    // class here, but rather use the one created task object
+    // directly to wait for this particular task's exit. The
     // approach is generally the same as the one we have used in
     // <code>Solver::assemble_linear_system()</code> above.
     //

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -569,7 +569,12 @@ namespace Threads
    * omit the template argument.
    *
    * @ingroup threads
-   * @ingroup threads
+   *
+   * @deprecated Use Task instead.
+   *
+   * @note Since this class is used in ThreadGroup, its constructors, rather
+   * than the class itself, are deprecated to allow compilation with
+   * -Werror=deprecated-declarations.
    */
   template <typename RT = void>
   class Thread
@@ -578,6 +583,7 @@ namespace Threads
     /**
      * Construct a thread object with a function object.
      */
+    DEAL_II_DEPRECATED_EARLY
     Thread(const std::function<RT()> &function)
       : thread_descriptor(new internal::ThreadDescriptor<RT>())
     {
@@ -590,11 +596,13 @@ namespace Threads
      * this way, except for assigning it a thread object that holds data
      * created by the new_thread() functions.
      */
+    DEAL_II_DEPRECATED_EARLY
     Thread() = default;
 
     /**
      * Copy constructor.
      */
+    DEAL_II_DEPRECATED_EARLY
     Thread(const Thread<RT> &t)
       : thread_descriptor(t.thread_descriptor)
     {}
@@ -885,9 +893,11 @@ namespace Threads
    * value for the called function.
    *
    * @ingroup threads
+   *
+   * @deprecated Use TaskGroup instead.
    */
   template <typename RT = void>
-  class ThreadGroup
+  class DEAL_II_DEPRECATED_EARLY ThreadGroup
   {
   public:
     /**


### PR DESCRIPTION
We should be using higher-level threading constructs, and these aren't used anywhere right now anyway.