### PR TITLE
Remove references to DEAL_II_WITH_THREADS.

### DIFF
--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -229,7 +229,6 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_WITH_SYMENGINE=1 \
                          DEAL_II_SYMENGINE_WITH_LLVM=1 \
                          DEAL_II_WITH_TBB=1 \
-                         DEAL_II_WITH_THREADS=1 \
                          DEAL_II_WITH_TRILINOS=1 \
                          DEAL_II_TRILINOS_WITH_EPETRAEXT=1 \
                          DEAL_II_TRILINOS_WITH_MUELU=1 \

--- a/doc/external-libs/cuda.html
+++ b/doc/external-libs/cuda.html
@@ -70,7 +70,7 @@
       Using CUDA in combination with architecture-specific C++ compiler flags
       like <code>-march=native</code> is known to be fragile and there might be
       compatibility issues with other libraries, e.g. using CUDA 10.1 with
-      <code>-DDEAL_II_WITH_THREADS=ON</code> and
+      <code>-DDEAL_II_WITH_TBB=ON</code> and
       <code>-DDEAL_II_CXX_FLAGS=-march=native</code> results in compile time
       errors like:
       <pre>

--- a/doc/readme.html
+++ b/doc/readme.html
@@ -327,7 +327,7 @@
         <li>
             <p>
                 <i>Threading</i>: By default, deal.II supports parallelism between multiple cores on the same machine using threads and a task-based model built on the
-                <a href="http://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>. You can switch threading off by passing the <code>-DDEAL_II_WITH_THREADS=OFF</code> argument to <code>cmake</code>.
+                <a href="http://threadingbuildingblocks.org/" target="_top">Threading Building Blocks</a>. You can switch threading inside the library off by passing the <code>-DDEAL_II_WITH_TBB=OFF</code> argument to <code>cmake</code>.
             </p>
         </li>
 

--- a/doc/users/cmake_dealii.html
+++ b/doc/users/cmake_dealii.html
@@ -473,19 +473,15 @@ DEAL_II_WITH_SCALAPACK
 DEAL_II_WITH_SLEPC
 DEAL_II_WITH_SUNDIALS
 DEAL_II_WITH_SYMENGINE
-DEAL_II_WITH_THREADS
+DEAL_II_WITH_TBB
 DEAL_II_WITH_TRILINOS
 DEAL_II_WITH_UMFPACK
 DEAL_II_WITH_ZLIB
 </pre>
-      They all have standard meaning with the exception of
-      two:
+      They all have standard meanings with the exception of one:
       <ul>
         <li> <code>DEAL_II_WITH_BOOST</code> is always <code>ON</code>
-          since BOOST is a mandatory build time dependency.
-
-        <li> <code>DEAL_II_WITH_THREADS</code> enables threading support
-          with the help of the Threading Building Blocks (TBB) library.
+          since BOOST is a mandatory build time dependency.</li>
       </ul>
     </p>
 

--- a/doc/users/config.sample
+++ b/doc/users/config.sample
@@ -437,13 +437,13 @@
 
 
 #
-# Threading support:
+# TBB support:
 #
-# SET(DEAL_II_WITH_THREADS ON CACHE BOOL
-#   "Build deal.II with support for threads"
+# SET(DEAL_II_WITH_TBB ON CACHE BOOL
+#   "Build deal.II with support for threads via TBB"
 #   )
 #
-# SET(DEAL_II_FORCE_BUNDLED_THREADS TRUE CACHE BOOL
+# SET(DEAL_II_FORCE_BUNDLED_TBB TRUE CACHE BOOL
 #   "Always use the bundled tbb library instead of an external one."
 #   )
 #

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -66,11 +66,12 @@
 #cmakedefine DEAL_II_WITH_ZLIB
 
 #ifdef DEAL_II_WITH_TBB
-/*
- * Backward compatibility setting:
- * FIXME: Update once transition to taskflow is complete
+/**
+ * For backwards compatibility, continue defining DEAL_II_WITH_THREADS when the
+ * library is configured with TBB.
  */
 #define DEAL_II_WITH_THREADS
+
 #define TBB_SUPPRESS_DEPRECATED_MESSAGES 1
 #endif
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1318,14 +1318,8 @@ namespace Threads
    *
    * @note Threads::new_task() is, in essence, equivalent to calling
    *   `std::async(std::launch::async, ...)` in that it runs the given task
-   *   in the background. (See https://en.cppreference.com/w/cpp/thread/async
-   *   for more information.) The only difference is if you configured deal.II
-   *   with `DEAL_II_WITH_THREADS=OFF`, then the operation described by the
-   *   arguments of this function are executed immediately and the returned
-   *   value is placed in the Task object returned here. This is useful for
-   *   cases where one wants to run a program in a way where deal.II does not
-   *   internally create parallel tasks, for example because one is already
-   *   using one MPI process per core in a parallel computation.
+   *   in the background. See https://en.cppreference.com/w/cpp/thread/async
+   *   for more information.
    *
    * @ingroup threads
    */
@@ -1408,14 +1402,8 @@ namespace Threads
    *
    * @note Threads::new_task() is, in essence, equivalent to calling
    *   `std::async(std::launch::async, ...)` in that it runs the given task
-   *   in the background. (See https://en.cppreference.com/w/cpp/thread/async
-   *   for more information.) The only difference is if you configured deal.II
-   *   with `DEAL_II_WITH_THREADS=OFF`, then the operation described by the
-   *   arguments of this function are executed immediately and the returned
-   *   value is placed in the Task object returned here. This is useful for
-   *   cases where one wants to run a program in a way where deal.II does not
-   *   internally create parallel tasks, for example because one is already
-   *   using one MPI process per core in a parallel computation.
+   *   in the background. See https://en.cppreference.com/w/cpp/thread/async
+   *   for more information.
    *
    * @ingroup CPP11
    */

--- a/include/deal.II/lac/sparse_vanka.templates.h
+++ b/include/deal.II/lac/sparse_vanka.templates.h
@@ -106,9 +106,6 @@ SparseVanka<number>::compute_inverses()
   Assert(matrix != nullptr, ExcNotInitialized());
   Assert(selected != nullptr, ExcNotInitialized());
 
-#ifndef DEAL_II_WITH_THREADS
-  compute_inverses(0, matrix->m());
-#else
   const size_type n_inverses =
     std::count(selected->begin(), selected->end(), true);
   // somewhat arbitrarily set up an equal number of tasks as we have threads
@@ -161,7 +158,6 @@ SparseVanka<number>::compute_inverses()
       this->compute_inverses(blocking[i].first, blocking[i].second);
     });
   tasks.join_all();
-#endif
 }
 
 


### PR DESCRIPTION
Part of #10391.

I neither added nor removed references to taskflow in this PR since, AFAIK, it is not ready as a full replacement for TBB on `master` right now.

The sole remaining usage of `DEAL_II_WITH_THREADS` (after this PR) in the library was explicitly added in #10384 - @tamiko can that be removed now?