### PR TITLE
Particle sort: Use find_active_cell_around_point with cache

### DIFF
--- a/doc/news/changes/minor/20210512MartinKronbichler
+++ b/doc/news/changes/minor/20210512MartinKronbichler
@@ -1,0 +1,5 @@
+Improved: ParticleHandler::sort_particles_into_subdomains_and_cells()
+now uses a faster method to identify particles in cells farther away
+from their previous cell.
+<br>
+(Martin Kronbichler, 2021/05/12)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1093,7 +1093,7 @@ namespace Particles
                               Point<dim>>
                 current_cell_and_position =
                   GridTools::find_active_cell_around_point<>(
-                    *mapping, *triangulation, out_particle->get_location());
+                    *triangulation_cache, out_particle->get_location());
               current_cell               = current_cell_and_position.first;
               current_reference_position = current_cell_and_position.second;
 


### PR DESCRIPTION
While looking at #11276, I realized that we should be able to call the `find_active_cell_around_point` function with the `triangulation_cache` argument. Does anyone see a reason why we should use the slow version? I ran all tests containing the name `particle` and they pass for me locally.

FYI @blaisb 