### PR TITLE
Doc: Add changelog for `p:d:TemporarilyMatchRefineFlags`.

### DIFF
--- a/doc/news/changes/minor/20210329Fehling
+++ b/doc/news/changes/minor/20210329Fehling
@@ -1,0 +1,5 @@
+New: Class parallel::distributed::TemporarilyMatchRefineFlags that
+temporarily modifies the refine and coarsen flags of all active cells
+on a parallel::distributed::Triangulation to match its p4est oracle.
+<br>
+(Marc Fehling, 2021/03/29)


### PR DESCRIPTION
We introduced this class in the `internal` namespace in #11981, but moved it to the general namespace in #12154. This deserves being mentioned in the changelog.