### PR TITLE
Avoid warning in MatrixFreeTools::compute_diagonal

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -611,7 +611,7 @@ namespace MatrixFreeTools
     // initialize vector
     matrix_free.initialize_dof_vector(diagonal_global, dof_no);
 
-    int dummy;
+    int dummy = 0;
 
     matrix_free.template cell_loop<VectorType, int>(
       [&](const MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,


### PR DESCRIPTION
Fixes https://cdash.43-1.org/viewBuildError.php?type=1&buildid=1057.