### PR TITLE
Specify scalar operation result type

### DIFF
--- a/include/deal.II/physics/elasticity/kinematics.h
+++ b/include/deal.II/physics/elasticity/kinematics.h
@@ -34,15 +34,14 @@ namespace Physics
     /**
      * A collection of tensor definitions for deformation and strain measures,
      * as well as a few special transformations, that conform to notation used
-     in
-     * standard scientific literature, in particular the books of
+     * in standard scientific literature, in particular the books of
      * Holzapfel (2007) and Wriggers (2008). The citation for these references,
      * as well as other notation used here, can be found in the description for
      * the Physics::Elasticity namespace.
 
-     * @note These hold specifically for the codimension
-     * 0 case, where the metric tensor is the identity tensor.
-*/
+     * @note These hold specifically for the codimension 0 case,
+     * where the metric tensor is the identity tensor.
+     */
     namespace Kinematics
     {
       /**
@@ -289,7 +288,9 @@ template <int dim, typename Number>
 inline Tensor<2, dim, Number>
 Physics::Elasticity::Kinematics::F_iso(const Tensor<2, dim, Number> &F)
 {
-  return std::pow(determinant(F), -1.0 / dim) * F;
+  return internal::NumberType<Number>::value(
+           std::pow(determinant(F), -1.0 / dim)) *
+         F;
 }
 
 

--- a/include/deal.II/physics/elasticity/standard_tensors.h
+++ b/include/deal.II/physics/elasticity/standard_tensors.h
@@ -373,7 +373,8 @@ DEAL_II_CONSTEXPR SymmetricTensor<2, dim, Number>
                   Physics::Elasticity::StandardTensors<dim>::ddet_F_dC(
   const Tensor<2, dim, Number> &F)
 {
-  return Number(0.5) * determinant(F) * symmetrize(invert(transpose(F) * F));
+  return internal::NumberType<Number>::value(0.5 * determinant(F)) *
+         symmetrize(invert(transpose(F) * F));
 }
 
 

--- a/tests/ad_common_tests/symmetric_tensor_functions_04.h
+++ b/tests/ad_common_tests/symmetric_tensor_functions_04.h
@@ -110,7 +110,8 @@ struct IncompressibleNeoHookeanPrincipalStretches
       {
         const NumberType &                lambda_squared = eig_C[d].first;
         const Tensor<1, dim, NumberType> &N              = eig_C[d].second;
-        C_inv += (1.0 / lambda_squared) * symmetrize(outer_product(N, N));
+        C_inv +=
+          NumberType(1.0 / lambda_squared) * symmetrize(outer_product(N, N));
       }
 
     const SymmetricTensor<2, dim, NumberType> I =


### PR DESCRIPTION
Fixes issue with Sacado expression templates, where we do not know how to multiply a Sacado math operation result (expression template) with a Tensor or SymmetricTensor.