### PR TITLE
Optimize FEPointEvaluation::integrate() with tensor product path

### DIFF
--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -245,15 +245,38 @@ public:
    * As compared to the other transform functions that rely on pre-computed
    * information of InternalDataBase, this function chooses the flexible
    * evaluation path on the cell and points passed in to the current
-   * function. The types `Number` and `Number2` of the input and output arrays
-   * must be such that `Number2 = apply_transformation(DerivativeForm<1,
-   * spacedim, dim>, Number)`.
+   * function.
+   *
+   * @param cell The cell where to evaluate the mapping
+   *
+   * @param kind Select the kind of the mapping to be applied; currently, this
+   * class only implements `mapping_covariant`.
+   *
+   * @param apply_from_left If true, the mapping is applied to a input
+   * vector from the left, the usual choice for the transformation of field
+   * variables. If false, the mapping is applied to the vector from the right,
+   * representing the transpose of the initial operation; this is the choice
+   * to be used for implementing the action by a test function in an
+   * integration step.
+   *
+   * @param unit_points The points in reference coordinates where the
+   * transformation should be computed and applied to the vector.
+   *
+   * @param input The array of vectors (e.g., gradients for
+   * `mapping_covariant`) to be transformed.
+   *
+   * @param output The array where the result will be stored. The types
+   * `Number` and `Number2` of the input and output arrays must be such that
+   * `Number2 = apply_transformation(DerivativeForm<1, spacedim, dim>,
+   * Number)`. In case the two number types match, this array can be the same
+   * as input array.
    */
   template <typename Number, typename Number2>
   void
   transform_variable(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const MappingKind                                           kind,
+    const bool                                                  apply_from_left,
     const ArrayView<const Point<dim>> &                         unit_points,
     const ArrayView<const Number> &                             input,
     const ArrayView<Number2> &                                  output) const;
@@ -937,6 +960,7 @@ inline void
 MappingQGeneric<dim, spacedim>::transform_variable(
   const typename Triangulation<dim, spacedim>::cell_iterator &cell,
   const MappingKind                                           kind,
+  const bool                                                  apply_from_left,
   const ArrayView<const Point<dim>> &                         unit_points,
   const ArrayView<const Number> &                             input,
   const ArrayView<Number2> &                                  output) const
@@ -976,15 +1000,31 @@ MappingQGeneric<dim, spacedim>::transform_variable(
             renumber_lexicographic_to_hierarchic)
             .second;
 
-        const DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac =
-          grad.transpose().covariant_form();
-        for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
+        if (apply_from_left)
           {
-            DerivativeForm<1, spacedim, dim> jac_j;
-            for (unsigned int d = 0; d < spacedim; ++d)
-              for (unsigned int e = 0; e < dim; ++e)
-                jac_j[d][e] = jac[d][e][j];
-            output[i + j] = apply_transformation(jac_j, input[i + j]);
+            const DerivativeForm<1, spacedim, dim, VectorizedArray<double>>
+              jac = grad.transpose().covariant_form();
+            for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
+              {
+                DerivativeForm<1, spacedim, dim> jac_j;
+                for (unsigned int d = 0; d < spacedim; ++d)
+                  for (unsigned int e = 0; e < dim; ++e)
+                    jac_j[d][e] = jac[d][e][j];
+                output[i + j] = apply_transformation(jac_j, input[i + j]);
+              }
+          }
+        else
+          {
+            const DerivativeForm<1, dim, spacedim, VectorizedArray<double>>
+              jac = grad.covariant_form();
+            for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
+              {
+                DerivativeForm<1, dim, spacedim> jac_j;
+                for (unsigned int d = 0; d < dim; ++d)
+                  for (unsigned int e = 0; e < spacedim; ++e)
+                    jac_j[d][e] = jac[d][e][j];
+                output[i + j] = apply_transformation(jac_j, input[i + j]);
+              }
           }
       }
     else
@@ -997,8 +1037,11 @@ MappingQGeneric<dim, spacedim>::transform_variable(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic)
             .second;
-        output[i] =
-          apply_transformation(grad.transpose().covariant_form(), input[i]);
+        if (apply_from_left)
+          output[i] =
+            apply_transformation(grad.transpose().covariant_form(), input[i]);
+        else
+          output[i] = apply_transformation(grad.covariant_form(), input[i]);
       }
 }
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -2524,25 +2524,60 @@ namespace internal
    */
   template <int dim, typename Number, typename Number2>
   inline void
-  integrate_tensor_product_value_and_gradient(
-    const std::vector<Polynomials::Polynomial<double>> &      poly,
-    const std::vector<Number> &                               values,
-    const typename ProductTypeNoPoint<Number, Number2>::type &value,
-    const Tensor<1, dim, typename ProductTypeNoPoint<Number, Number2>::type>
-      &                              gradient,
-    const Point<dim, Number2> &      p,
-    const bool                       d_linear = false,
-    const std::vector<unsigned int> &renumber = {})
+  integrate_add_tensor_product_value_and_gradient(
+    const std::vector<Polynomials::Polynomial<double>> &poly,
+    const Number2 &                                     value,
+    const Tensor<1, dim, Number2> &                     gradient,
+    const Point<dim, Number> &                          p,
+    AlignedVector<Number2> &                            values,
+    const std::vector<unsigned int> &                   renumber = {})
   {
-    Assert(false, ExcNotImplemented());
+    static_assert(dim >= 1 && dim <= 3, "Only dim=1,2,3 implemented");
 
-    (void)poly;
-    (void)values;
-    (void)value;
-    (void)gradient;
-    (void)p;
-    (void)d_linear;
-    (void)renumber;
+    const unsigned int n_shapes = poly.size();
+    AssertDimension(Utilities::pow(n_shapes, dim), values.size());
+    Assert(renumber.empty() || renumber.size() == values.size(),
+           ExcDimensionMismatch(renumber.size(), values.size()));
+
+    AssertIndexRange(n_shapes, 200);
+    std::array<Number, 2 * dim * 200> shapes;
+
+    // Evaluate 1D polynomials and their derivatives
+    for (unsigned int d = 0; d < dim; ++d)
+      for (unsigned int i = 0; i < n_shapes; ++i)
+        poly[i].value(p[d], 1, shapes.data() + 2 * (d * n_shapes + i));
+
+    // Implement the transpose of the function above
+    for (unsigned int i2 = 0, i = 0; i2 < (dim > 2 ? n_shapes : 1); ++i2)
+      {
+        const Number2 test_value_z =
+          dim > 2 ? (value * shapes[4 * n_shapes + 2 * i2] +
+                     gradient[2] * shapes[4 * n_shapes + 2 * i2 + 1]) :
+                    value;
+        const Number2 test_grad_x =
+          dim > 2 ? gradient[0] * shapes[4 * n_shapes + 2 * i2] : gradient[0];
+        const Number2 test_grad_y =
+          dim > 2 ? gradient[1] * shapes[4 * n_shapes + 2 * i2] :
+                    (dim > 1 ? gradient[1] : Number2());
+        for (unsigned int i1 = 0; i1 < (dim > 1 ? n_shapes : 1); ++i1)
+          {
+            const Number2 test_value_y =
+              dim > 1 ? (test_value_z * shapes[2 * n_shapes + 2 * i1] +
+                         test_grad_y * shapes[2 * n_shapes + 2 * i1 + 1]) :
+                        test_value_z;
+            const Number2 test_grad_xy =
+              dim > 1 ? test_grad_x * shapes[2 * n_shapes + 2 * i1] :
+                        test_grad_x;
+            if (renumber.empty())
+              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+                values[i] += shapes[2 * i0] * test_value_y +
+                             shapes[2 * i0 + 1] * test_grad_xy;
+            else
+              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+                values[renumber[i]] += shapes[2 * i0] * test_value_y +
+                                       shapes[2 * i0 + 1] * test_grad_xy;
+          }
+      }
   }
 
 

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -2397,7 +2397,11 @@ namespace internal
 
     using Number3 = typename ProductTypeNoPoint<Number, Number2>::type;
 
-    const unsigned int n_shapes = poly.size();
+    // use `int` type for this variable and the loops below to inform the
+    // compiler that the loops below will never overflow, which allows it to
+    // generate more optimized code for the variable loop bounds in the
+    // present context
+    const int n_shapes = poly.size();
     AssertDimension(Utilities::pow(n_shapes, dim), values.size());
     Assert(renumber.empty() || renumber.size() == values.size(),
            ExcDimensionMismatch(renumber.size(), values.size()));
@@ -2456,16 +2460,16 @@ namespace internal
 
     // Evaluate 1D polynomials and their derivatives
     for (unsigned int d = 0; d < dim; ++d)
-      for (unsigned int i = 0; i < n_shapes; ++i)
+      for (int i = 0; i < n_shapes; ++i)
         poly[i].value(p[d], 1, shapes.data() + 2 * (d * n_shapes + i));
 
     // Go through the tensor product of shape functions and interpolate
     // with optimal algorithm
     std::pair<Number3, Tensor<1, dim, Number3>> result = {};
-    for (unsigned int i2 = 0, i = 0; i2 < (dim > 2 ? n_shapes : 1); ++i2)
+    for (int i2 = 0, i = 0; i2 < (dim > 2 ? n_shapes : 1); ++i2)
       {
         Number3 value_y = {}, deriv_x = {}, deriv_y = {};
-        for (unsigned int i1 = 0; i1 < (dim > 1 ? n_shapes : 1); ++i1)
+        for (int i1 = 0; i1 < (dim > 1 ? n_shapes : 1); ++i1)
           {
             // Interpolation + derivative x direction
             Number3 value = {}, deriv = {};
@@ -2473,13 +2477,13 @@ namespace internal
             // Distinguish the inner loop based on whether we have a
             // renumbering or not
             if (renumber.empty())
-              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+              for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
                 {
                   value += shapes[2 * i0] * values[i];
                   deriv += shapes[2 * i0 + 1] * values[i];
                 }
             else
-              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+              for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
                 {
                   value += shapes[2 * i0] * values[renumber[i]];
                   deriv += shapes[2 * i0 + 1] * values[renumber[i]];
@@ -2534,7 +2538,8 @@ namespace internal
   {
     static_assert(dim >= 1 && dim <= 3, "Only dim=1,2,3 implemented");
 
-    const unsigned int n_shapes = poly.size();
+    // as in evaluate, use `int` type to produce better code in this context
+    const int n_shapes = poly.size();
     AssertDimension(Utilities::pow(n_shapes, dim), values.size());
     Assert(renumber.empty() || renumber.size() == values.size(),
            ExcDimensionMismatch(renumber.size(), values.size()));
@@ -2544,11 +2549,11 @@ namespace internal
 
     // Evaluate 1D polynomials and their derivatives
     for (unsigned int d = 0; d < dim; ++d)
-      for (unsigned int i = 0; i < n_shapes; ++i)
+      for (int i = 0; i < n_shapes; ++i)
         poly[i].value(p[d], 1, shapes.data() + 2 * (d * n_shapes + i));
 
     // Implement the transpose of the function above
-    for (unsigned int i2 = 0, i = 0; i2 < (dim > 2 ? n_shapes : 1); ++i2)
+    for (int i2 = 0, i = 0; i2 < (dim > 2 ? n_shapes : 1); ++i2)
       {
         const Number2 test_value_z =
           dim > 2 ? (value * shapes[4 * n_shapes + 2 * i2] +
@@ -2559,7 +2564,7 @@ namespace internal
         const Number2 test_grad_y =
           dim > 2 ? gradient[1] * shapes[4 * n_shapes + 2 * i2] :
                     (dim > 1 ? gradient[1] : Number2());
-        for (unsigned int i1 = 0; i1 < (dim > 1 ? n_shapes : 1); ++i1)
+        for (int i1 = 0; i1 < (dim > 1 ? n_shapes : 1); ++i1)
           {
             const Number2 test_value_y =
               dim > 1 ? (test_value_z * shapes[2 * n_shapes + 2 * i1] +
@@ -2569,11 +2574,11 @@ namespace internal
               dim > 1 ? test_grad_x * shapes[2 * n_shapes + 2 * i1] :
                         test_grad_x;
             if (renumber.empty())
-              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+              for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
                 values[i] += shapes[2 * i0] * test_value_y +
                              shapes[2 * i0 + 1] * test_grad_xy;
             else
-              for (unsigned int i0 = 0; i0 < n_shapes; ++i0, ++i)
+              for (int i0 = 0; i0 < n_shapes; ++i0, ++i)
                 values[renumber[i]] += shapes[2 * i0] * test_value_y +
                                        shapes[2 * i0 + 1] * test_grad_xy;
           }


### PR DESCRIPTION
Fixes #11865. This is a bit late for the release, so I would certainly not insist in getting it in. The important discussion we should have before the release is about the interface we have in `MappingQGeneric::transform_variable` because we should not change that again.