### PR TITLE
Uncover bug in N_VClone()

### DIFF
--- a/tests/sundials/n_vector_clone_01.cc
+++ b/tests/sundials/n_vector_clone_01.cc
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 - 2021 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+// Test SUNDIALS' clones on our own vectors.
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/n_vector.h>
+
+#include "../tests.h"
+
+using namespace SUNDIALS::internal;
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int N = 4;
+  using VectorType     = Vector<double>;
+
+  VectorType y_dealii(N);
+  y_dealii = 1.0;
+
+  // The commented version works, the other one segfaults.
+  // auto y_sundials = make_nvector_view(y_dealii);
+  N_Vector y_sundials     = make_nvector_view(y_dealii);
+  N_Vector scale_sundials = N_VClone(y_sundials);
+
+  // scale_sundials = 2*y_sundials
+  N_VScale(2.0, y_sundials, scale_sundials);
+
+  const auto *scale_dealii = unwrap_nvector<VectorType>(scale_sundials);
+
+  deallog << "Deal.II Norm: " << y_dealii.l2_norm() << std::endl;
+  deallog << "Twice deal.II Norm: " << scale_dealii->l2_norm() << std::endl;
+
+  return 0;
+}

--- a/tests/sundials/n_vector_clone_01.with_sundials=on.output
+++ b/tests/sundials/n_vector_clone_01.with_sundials=on.output
@@ -1,0 +1,3 @@
+
+DEAL::Deal.II Norm: 2.00000
+DEAL::Twice deal.II Norm: 4.00000

--- a/tests/sundials/n_vector_clone_02.cc
+++ b/tests/sundials/n_vector_clone_02.cc
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 - 2021 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+// Test SUNDIALS' clones on our own vectors.
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/n_vector.h>
+
+#include "../tests.h"
+
+using namespace SUNDIALS::internal;
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int N = 4;
+  using VectorType     = Vector<double>;
+
+  VectorType y_dealii(N);
+  y_dealii = 1.0;
+
+  auto     y_sundials     = make_nvector_view(y_dealii);
+  N_Vector y_clone        = N_VClone(y_sundials);
+  N_Vector scale_sundials = N_VClone(y_clone);
+
+  // scale_sundials = 2*y_sundials
+  N_VScale(2.0, y_clone, scale_sundials);
+
+  const auto *scale_dealii = unwrap_nvector<VectorType>(scale_sundials);
+
+  deallog << "Deal.II Norm: " << y_dealii.l2_norm() << std::endl;
+  deallog << "Twice deal.II Norm: " << scale_dealii->l2_norm() << std::endl;
+
+  return 0;
+}

--- a/tests/sundials/n_vector_clone_02.with_sundials=on.output
+++ b/tests/sundials/n_vector_clone_02.with_sundials=on.output
@@ -1,0 +1,3 @@
+
+DEAL::Deal.II Norm: 2.00000
+DEAL::Twice deal.II Norm: 0.00000

--- a/tests/sundials/n_vector_clone_03.cc
+++ b/tests/sundials/n_vector_clone_03.cc
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2020 - 2021 by the deal.II authors
+//
+//    This file is part of the deal.II library.
+//
+//    The deal.II library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE.md at
+//    the top level directory of deal.II.
+//
+//-----------------------------------------------------------
+
+// Test SUNDIALS' clones on our own vectors.
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/sundials/n_vector.h>
+
+#include "../tests.h"
+
+using namespace SUNDIALS::internal;
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int N = 4;
+  using VectorType     = Vector<double>;
+
+  VectorType y_dealii(N);
+  y_dealii = 1.0;
+
+  auto     y_sundials = make_nvector_view(y_dealii);
+  N_Vector y_clone    = N_VClone(y_sundials);
+  N_VDestroy(y_clone);
+  N_Vector scale_sundials = N_VClone(y_sundials);
+
+  // scale_sundials = 2*y_sundials
+  N_VScale(2.0, y_sundials, scale_sundials);
+
+  const auto *scale_dealii = unwrap_nvector<VectorType>(scale_sundials);
+
+  deallog << "Deal.II Norm: " << y_dealii.l2_norm() << std::endl;
+  deallog << "Twice deal.II Norm: " << scale_dealii->l2_norm() << std::endl;
+
+  return 0;
+}

--- a/tests/sundials/n_vector_clone_03.with_sundials=on.output
+++ b/tests/sundials/n_vector_clone_03.with_sundials=on.output
@@ -1,0 +1,3 @@
+
+DEAL::Deal.II Norm: 2.00000
+DEAL::Twice deal.II Norm: 4.00000


### PR DESCRIPTION
This is linked with #12223.

The issue is that KINSOL needs to create internally some clones of the N_Vector types passed in input (e.g., to generate Anderson Acceleration vectors). 

When calling 
```c++
NVectorView<VectorType> a = make_nvector_view(some_dealii_vector);
N_Vector y = N_VClone(a);
```
everything works fine. However SUNDIALS knows nothing about `NVectorView<VectorType>`, and internally it calls it as if a was actually a `N_Vector` object, and not a `NVectorView<VectorType>`:
```c++
N_Vector a = make_nvector_view(some_dealii_vector);
N_Vector y = N_VClone(a);
```

This segfaults currently, and it is the source of errors in KINSOL with fixed point and picard iterations.

The included test shows what should happen, and how it segfaults. @nicola-giuliani  and I are working on a fix. If @sebproell has ideas, they are more than welcome. 

:)

