### PR TITLE
Remove a destructor now no longer necessary.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -90,7 +90,7 @@ public:
   /**
    * Destructor.
    */
-  ~AlignedVector();
+  ~AlignedVector() = default;
 
   /**
    * Copy constructor.
@@ -838,14 +838,6 @@ inline AlignedVector<T>::AlignedVector(const size_type size, const T &init)
 {
   if (size > 0)
     resize(size, init);
-}
-
-
-
-template <class T>
-inline AlignedVector<T>::~AlignedVector()
-{
-  clear();
 }
 
 


### PR DESCRIPTION
Leave the declaration in place but =default it, so that we continue to implement
the rule of 7.

Can wait till past 9.3.

/rebuild