### PR TITLE
Step 78 edits

### DIFF
--- a/examples/step-78/doc/intro.dox
+++ b/examples/step-78/doc/intro.dox
@@ -131,11 +131,10 @@ refinement and time step choice. There is also the issue that the diffusion term
 
 <h3>Scheme for the numerical solution</h3>
 
-We will solve this problem using the fractional step method (of which the
-Crank-Nicolson method is a special case with $\theta=\frac 12$; the explicit
-Euler method corresponds to $\theta=0$ and the implicit Euler method to
-$\theta=1$). So, we first discretize in time, where we would like $V^n(S)$ to
-approximate $V(S,\tau_n)$:
+We will solve this problem using an IMEX method. In particular, we first discretize
+in time with the theta method and will later pick different values of theta for
+the advective and diffusive terms.
+Let $V^n(S)$ approximate $V(S,\tau_n)$:
 @f{align*}{
     0=&-\frac{V^n(S)-V^{n-1}(S)}{k_n} \\
     &+\frac{\sigma^2S^2}{2}\left[(1-\theta)\frac{d^2V^{n-1}(S)}{dS^2} + \

--- a/examples/step-78/doc/intro.dox
+++ b/examples/step-78/doc/intro.dox
@@ -66,8 +66,8 @@ In practice, for us to use a finite element method to solve this, we are going
 to need to bound $\Omega$. Since this equation describes prices, and it doesn't
 make sense to talk about prices being negative, we will set the lower bound of
 $\Omega$ to be 0. Then, for an upper bound, we will choose a very large number,
-one that $S$ is not very likely to ever get to. We will call this $S_\text{max}$
-. So, $\Omega=[0,S_\text{max}]$.
+one that $S$ is not very likely to ever get to. We will call this $S_\text{max}$.
+So, $\Omega=[0,S_\text{max}]$.
 
 Second, after truncating the domain, we need to ask what boundary values we
 should pose at this now finite boundary. To take care of this, we use "put-call"
@@ -101,7 +101,7 @@ what solving these equations is all about.
 This means that this is not an equation that is posed going forward in
 time, but in fact going *backward* in time. Thus it makes sense to solve this
 problem in reverse by making the change of variables $\tau=T-t$ where now $\tau$
-denotes "time before the strike time $T$".
+denotes the time before the strike time $T$.
 
 With all of this, we finally end up with the following problem:
 @f{align*}{
@@ -229,8 +229,8 @@ applicable, we arrive at the following for (2):
 @f}
 But, because the matrix $\textbf{B}$ involves an advective term, we will choose
 $\theta=0$ there -- in other words, we use an explicit Euler method to treat
-advection. Conversely, since the matrix $\textbf{D}$ involves the diffusive term
-, we will choose $\theta=1/2$ there -- i.e., we treat diffusion using the second
+advection. Conversely, since the matrix $\textbf{D}$ involves the diffusive term,
+we will choose $\theta=1/2$ there -- i.e., we treat diffusion using the second
 order Crank-Nicolson method.
 
 So, we arrive at the following:

--- a/examples/step-78/doc/intro.dox
+++ b/examples/step-78/doc/intro.dox
@@ -71,7 +71,7 @@ So, $\Omega=[0,S_\text{max}]$.
 
 Second, after truncating the domain, we need to ask what boundary values we
 should pose at this now finite boundary. To take care of this, we use "put-call"
-parity @cite stoll1969relationship. A "pull option" is one in which I am
+parity @cite stoll1969relationship. A "pull option" is one in which we are
 allowed, but not required, to *sell* a stock at price $K$ to someone at a future
 time $T$. This says
 @f{align*}{
@@ -88,10 +88,10 @@ $S_\text{max}$.
 
 The second complication of the Block-Scholes equation is that we are given a
 final condition, and not an initial condition. This is because we know what the
-option is worth at time $t=T$: If the stock price at $T$ is $S<K$, then I have
-no incentive to use my option of buying a price $K$ because I can buy that stock
+option is worth at time $t=T$: If the stock price at $T$ is $S<K$, then we have
+no incentive to use our option of buying a price $K$ because we can buy that stock
 for cheaper on the open market. So $V(S,T)=0$ for $S<K$. On the other hand, if
-at time $T$ we have $S>K$, then I can buy my stock at price $K$ via the option
+at time $T$ we have $S>K$, then we can buy the stock at price $K$ via the option
 and immediately sell it again on the market for price $S$, giving me a profit of
 $S-K$. In other words, $V(S,T)=S-K$ for $S>K$. So, we only know
 values for $V$ at the *end time* but not the initial time -- in fact, finding

--- a/examples/step-78/doc/results.dox
+++ b/examples/step-78/doc/results.dox
@@ -46,7 +46,7 @@ n cells         H1                  L2
 @endcode
 
 What is more interesting is the output of the convergence tables. They are
-outputted into the console, as well into a LaTex file. The convergence tables
+outputted into the console, as well into a LaTeX file. The convergence tables
 are shown above. Here, you can see that the the solution has a convergence rate
 of $\mathcal{O}(h)$ with respect to the $H^1$-norm, and the solution has a convergence rate
 of $\mathcal{O}(h^2)$ with respect to the $L^2$-norm.

--- a/examples/step-78/doc/results.dox
+++ b/examples/step-78/doc/results.dox
@@ -7,21 +7,18 @@ Below is the output of the program:
 Number of active cells: 1
 Number of degrees of freedom: 2
 
-Time step 1 at t=0.0002
-     0 CG iterations.
+Time step 0 at t=0.0002
 [...]
-===========================================
+
+Cycle 7:
 Number of active cells: 128
 Number of degrees of freedom: 129
 
-Time step 1 at t=0.0002
-     2 CG iterations.
-[...]
-Time step 5001 at t=1.0002
-     5 CG iterations.
-Cycle 7:
-   Number of active cells:       128
-   Number of degrees of freedom: 129
+Time step 0 at t=0.0002
+Time step 1000 at t=0.2002
+Time step 2000 at t=0.4002
+Time step 3000 at t=0.6002
+Time step 4000 at t=0.8002
 
 cells dofs    L2        H1      Linfty
     1    2 1.667e-01 5.774e-01 2.222e-01
@@ -30,8 +27,8 @@ cells dofs    L2        H1      Linfty
     8    9 2.405e-03 7.218e-02 3.419e-03
    16   17 5.967e-04 3.609e-02 8.597e-04
    32   33 1.457e-04 1.804e-02 2.155e-04
-   64   65 3.306e-05 9.022e-03 5.388e-05
-  128  129 5.014e-06 4.511e-03 1.342e-05
+   64   65 3.307e-05 9.022e-03 5.388e-05
+  128  129 5.016e-06 4.511e-03 1.342e-05
 
 n cells         H1                  L2
       1 5.774e-01    -    - 1.667e-01    -    -
@@ -40,9 +37,8 @@ n cells         H1                  L2
       8 7.218e-02 2.00 1.00 2.405e-03 4.02 2.01
      16 3.609e-02 2.00 1.00 5.967e-04 4.03 2.01
      32 1.804e-02 2.00 1.00 1.457e-04 4.10 2.03
-     64 9.022e-03 2.00 1.00 3.306e-05 4.41 2.14
-    128 4.511e-03 2.00 1.00 5.014e-06 6.59 2.72
-
+     64 9.022e-03 2.00 1.00 3.307e-05 4.41 2.14
+    128 4.511e-03 2.00 1.00 5.016e-06 6.59 2.72
 @endcode
 
 What is more interesting is the output of the convergence tables. They are

--- a/examples/step-78/step-78.cc
+++ b/examples/step-78/step-78.cc
@@ -334,12 +334,12 @@ namespace BlackScholesSolver
     Vector<double> solution;
     Vector<double> system_rhs;
 
-    double       time;
-    double       time_step;
-    unsigned int timestep_number;
+    double time;
+    double time_step;
 
     const double       theta;
     const unsigned int n_cycles;
+    const unsigned int n_time_steps;
 
     DataOutStack<dim>        data_out_stack;
     std::vector<std::string> solution_names;
@@ -366,9 +366,9 @@ namespace BlackScholesSolver
     , fe(1)
     , dof_handler(triangulation)
     , time(0.0)
-    , timestep_number(0)
     , theta(0.5)
-    , n_cycles(3)
+    , n_cycles(4)
+    , n_time_steps(5000)
   {
     Assert(dim == 1, ExcNotImplemented());
   }
@@ -388,7 +388,7 @@ namespace BlackScholesSolver
   {
     dof_handler.distribute_dofs(fe);
 
-    time_step = maturity_time / 5000.;
+    time_step = maturity_time / n_time_steps;
 
     constraints.clear();
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);
@@ -712,8 +712,7 @@ namespace BlackScholesSolver
         if (cycle != 0)
           {
             refine_grid();
-            time            = 0.0;
-            timestep_number = 0;
+            time = 0.0;
           }
 
         setup_system();
@@ -745,10 +744,10 @@ namespace BlackScholesSolver
         // vector:
         vmult_result.reinit(dof_handler.n_dofs());
         forcing_terms.reinit(dof_handler.n_dofs());
-        while (time < maturity_time)
+        for (unsigned int timestep_number = 0; timestep_number < n_time_steps;
+             ++timestep_number)
           {
             time += time_step;
-            ++timestep_number;
 
             if (timestep_number % 1000 == 0)
               std::cout << "Time step " << timestep_number << " at t=" << time

--- a/examples/step-78/step-78.cc
+++ b/examples/step-78/step-78.cc
@@ -533,8 +533,6 @@ namespace BlackScholesSolver
     preconditioner.initialize(system_matrix, 1.0);
     cg.solve(system_matrix, solution, system_rhs, preconditioner);
     constraints.distribute(solution);
-    std::cout << "     " << solver_control.last_step() << " CG iterations."
-              << std::endl;
   }
 
   // @sect4{<code>BlackScholes::add_results_for_output</code>}
@@ -751,8 +749,10 @@ namespace BlackScholesSolver
           {
             time += time_step;
             ++timestep_number;
-            std::cout << "Time step " << timestep_number << " at t=" << time
-                      << std::endl;
+
+            if (timestep_number % 1000 == 0)
+              std::cout << "Time step " << timestep_number << " at t=" << time
+                        << std::endl;
 
             mass_matrix.vmult(system_rhs, solution);
 

--- a/examples/step-78/step-78.cc
+++ b/examples/step-78/step-78.cc
@@ -277,7 +277,7 @@ namespace BlackScholesSolver
   // when the option expires.\n
   // - <code>asset_volatility</code>: The volatility of the stock price.\n
   // - <code>interest_rate</code>: The risk free interest rate.\n
-  // - <code>strike_price</code>: The aggreed upon price that the buyer will
+  // - <code>strike_price</code>: The agreed upon price that the buyer will
   // have the option of purchasing  the stocks at the expiration time.
   //
   // Some slight differences between this program and step-26 are the creation
@@ -354,7 +354,7 @@ namespace BlackScholesSolver
   // they are fairly normal values for these parameters. Although the stock
   // price has no upper bound in reality (it is in fact infinite), we impose
   // an upper bound that is twice the strike price. This is a somewhat arbitrary
-  // choice to be twice the strike price, but it is large enought to see the
+  // choice to be twice the strike price, but it is large enough to see the
   // interesting parts of the solution.
   template <int dim>
   BlackScholes<dim>::BlackScholes()
@@ -539,7 +539,7 @@ namespace BlackScholesSolver
 
   // @sect4{<code>BlackScholes::add_results_for_output</code>}
 
-  // This is simply the function to stitch the solution peices together. For
+  // This is simply the function to stitch the solution pieces together. For
   // this, we create a new layer at each time, and then add the solution vector
   // for that timestep. The function then stitches this together with the old
   // solutions using 'build_patches'.
@@ -650,7 +650,7 @@ namespace BlackScholesSolver
     convergence_table.write_tex(error_table_file);
 
     // Next, we will make the convergence table. We will again write this to
-    // the console and to the convergence LaTex file.
+    // the console and to the convergence LaTeX file.
     convergence_table.add_column_to_supercolumn("cells", "n cells");
     std::vector<std::string> new_order;
     new_order.emplace_back("n cells");

--- a/examples/step-78/step-78.cc
+++ b/examples/step-78/step-78.cc
@@ -69,7 +69,7 @@ namespace BlackScholesSolver
   // @sect3{Solution Class}
 
   // This section creates a class for the known solution when testing using the
-  // MMS. Here I am using $v(\tau,S) = -\tau^2 -S^2 + 6$ for my solution. We
+  // MMS. Here we are using $v(\tau,S) = -\tau^2 -S^2 + 6$ for the solution. We
   // need to include the solution equation and the gradient for the H1 seminorm
   // calculation.
   template <int dim>


### PR DESCRIPTION
Follow up to #12035 with a bunch of minor fixes:
- avoid using `I`
- print less output to the screen
- fix some typos
- avoid a floating point problem by counting time step numbers, not time to maturity