### PR TITLE
Fix clang-tidy issues with #12246.

### DIFF
--- a/source/numerics/derivative_approximation.cc
+++ b/source/numerics/derivative_approximation.cc
@@ -801,7 +801,11 @@ namespace DerivativeApproximation
                                                           solution,
                                                           component);
       // ...and the place where it lives
-      const Point<dim> this_center = fe_midpoint_value.quadrature_point(0);
+      // This needs to be a copy. If it was a reference, it would be changed
+      // after the next `reinit` call of the FEValues object. clang-tidy
+      // complains about this not being a reference, so we suppress the warning.
+      const Point<dim> this_center =
+        fe_midpoint_value.quadrature_point(0); // NOLINT
 
       // loop over all neighbors and
       // accumulate the difference


### PR DESCRIPTION
Initially, I wanted to run the `clang-tidy` script locally on my notebook after applying the patch from #12246, but it took forever on my weak companion.

During that session, this was the only remaining issue I've found that was overlooked in #12264 and should help the CI for #12246.

Related to #12244.