### PR TITLE
Triangulation::locally_owned_subdomain() return 0

### DIFF
--- a/include/deal.II/grid/tria.h
+++ b/include/deal.II/grid/tria.h
@@ -3201,10 +3201,10 @@ public:
   max_adjacent_cells() const;
 
   /**
-   * This function always returns @p invalid_subdomain_id but is there for
-   * compatibility with the derived @p parallel::distributed::Triangulation
-   * class. For distributed parallel triangulations this function returns the
-   * subdomain id of those cells that are owned by the current processor.
+   * This function returns the locally owned subdomain. For a serial
+   * triangulation, the returned value is always zero. For parallel
+   * triangulations the value corresponds to the rank of current process
+   * within the MPI communicator passed to their constructors.
    */
   virtual types::subdomain_id
   locally_owned_subdomain() const;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -13254,7 +13254,7 @@ template <int dim, int spacedim>
 types::subdomain_id
 Triangulation<dim, spacedim>::locally_owned_subdomain() const
 {
-  return numbers::invalid_subdomain_id;
+  return 0;
 }
 
 


### PR DESCRIPTION
I strongly recommend the following change to be consistent with:
- `CellAccessor::subdomain_id()` and `CellAccessor::level_subdomain_id()`
- the fact that `Triangulation::get_communicator()` return MPI_COMM_SELF

In PR #12280, I need to check `if (cell->level_subdomain_id() == tria.locally_owned_subdomain())`. The code worked fine for `p:d:T` and crashed for a serial triangulation, since the above statement was always false.