### PR TITLE
added check not to call faces if dim == 1 when clearing user data

### DIFF
--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -10992,7 +10992,8 @@ Triangulation<dim, spacedim>::clear_user_data()
 {
   // let functions in anonymous namespace do their work
   dealii::clear_user_data(levels);
-  dealii::clear_user_data(faces.get());
+  if (dim > 1)
+    dealii::clear_user_data(faces.get());
 }
 
 


### PR DESCRIPTION
If clear_user_data is called using a one dimensional grid faces is a null ptr and it results in a segfault. I added a check to call the clearing on faces only if dim > 1.