### PR TITLE
Fix memory leak in step-34 

### DIFF
--- a/examples/step-34/step-34.cc
+++ b/examples/step-34/step-34.cc
@@ -885,14 +885,12 @@ namespace Step34
     Assert(index < fe.n_dofs_per_cell(),
            ExcIndexRange(0, fe.n_dofs_per_cell(), index));
 
-    static Quadrature<1> *q_pointer = nullptr;
-    if (q_pointer)
-      delete q_pointer;
-
-    q_pointer = new QGaussLogR<1>(singular_quadrature_order,
-                                  fe.get_unit_support_points()[index],
-                                  1. / cell->measure(),
-                                  true);
+    static std::unique_ptr<Quadrature<1>> q_pointer;
+    q_pointer =
+      std::make_unique<QGaussLogR<1>>(singular_quadrature_order,
+                                      fe.get_unit_support_points()[index],
+                                      1. / cell->measure(),
+                                      true);
     return (*q_pointer);
   }
 


### PR DESCRIPTION
The memory allocated last for `q_pointer` was never released before.