### PR TITLE
Fix typo in `TriaAccessor`.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -722,7 +722,7 @@ public:
 
   /**
    * The copy constructor is not deleted but copied constructed elements should
-   * not be modified, also the comments to the copy assignemtn operator.
+   * not be modified, also the comments to the copy assignment operator.
    */
   TriaAccessor(const TriaAccessor &) = default;
 


### PR DESCRIPTION
We've merged #12294 into `master` which contained a typo by accident.

The same mechanic will be part of the 9.3 release with a separate PR #12298. There, @Rombur noticed the typo, and it can still be fixed.