### PR TITLE
Remove CUDAWrappers::FEEvaluation overloads taking dof index or quadrature point

### DIFF
--- a/doc/news/changes/incompatibilities/20210526DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20210526DanielArndt-1
@@ -1,0 +1,5 @@
+Removed: The overloads in CUDAWrappers::FEEvaluation that take a local dof index
+or a quadrature point as arguement have been removed.
+Use the ones that don't use these arguments in their interface instead.
+<br>
+(Daniel Arndt, 2021/05/26)

--- a/include/deal.II/matrix_free/cuda_fe_evaluation.h
+++ b/include/deal.II/matrix_free/cuda_fe_evaluation.h
@@ -176,29 +176,11 @@ namespace CUDAWrappers
     integrate(const bool integrate_val, const bool integrate_grad);
 
     /**
-     * Return the value of a finite element function at quadrature point
-     * number @p q_point after a call to @p evaluate(true,...).
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ value_type
-                                  get_value(const unsigned int q_point) const;
-
-    /**
      * Same as above, except that the quadrature point is computed from thread
      * id.
      */
     __device__ value_type
                get_value() const;
-
-    /**
-     * Return the value of a finite element function at degree of freedom
-     * @p dof after a call to integrate() or before a call to evaluate().
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ value_type
-                                  get_dof_value(const unsigned int dof) const;
 
     /**
      * Same as above, except that the local dof index is computed from the
@@ -208,33 +190,11 @@ namespace CUDAWrappers
                get_dof_value() const;
 
     /**
-     * Write a value to the field containing the values on quadrature points
-     * with component @p q_point. Access to the same fields as through @p
-     * get_value(). This specifies the value which is tested by all basis
-     * function on the current cell and integrated over.
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ void
-                       submit_value(const value_type &val_in, const unsigned int q_point);
-
-    /**
      * Same as above, except that the quadrature point is computed from the
      * thread id.
      */
     __device__ void
     submit_value(const value_type &val_in);
-
-    /**
-     * Write a value to the field containing the values for the degree of
-     * freedom with index @p dof after a call to integrate() or before
-     * calling evaluate(). Access through the same fields as through
-     * get_dof_value().
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ void
-                       submit_dof_value(const value_type &val_in, const unsigned int dof);
 
     /**
      * Same as above, except that the local dof index is computed from the
@@ -244,15 +204,6 @@ namespace CUDAWrappers
     submit_dof_value(const value_type &val_in);
 
     /**
-     * Return the gradient of a finite element function at quadrature point
-     * number @p q_point after a call to @p evaluate(...,true).
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ gradient_type
-                                  get_gradient(const unsigned int q_point) const;
-
-    /**
      * Same as above, except that the quadrature point is computed from the
      * thread id.
      */
@@ -260,39 +211,11 @@ namespace CUDAWrappers
                get_gradient() const;
 
     /**
-     * Write a contribution that is tested by the gradient to the field
-     * containing the values on quadrature points with component @p q_point.
-     *
-     * @deprecated Use the version without parameters instead.
-     */
-    DEAL_II_DEPRECATED __device__ void
-                       submit_gradient(const gradient_type &grad_in, const unsigned int q_point);
-
-
-    /**
      * Same as above, except that the quadrature point is computed from the
      * thread id.
      */
     __device__ void
     submit_gradient(const gradient_type &grad_in);
-
-    // clang-format off
-    /**
-     * Apply the functor @p func on every quadrature point.
-     *
-     * @p func needs to define
-     * \code
-     * __device__ void operator()(
-     *   CUDAWrappers::FEEvaluation<dim, fe_degree, n_q_points_1d, n_components, Number> *fe_eval,
-     *   const unsigned int                                                               q_point) const;
-     * \endcode
-     *
-     * @deprecated Use apply_for_each_quad_point() instead.
-     */
-    // clang-format on
-    template <typename Functor>
-    DEAL_II_DEPRECATED __device__ void
-                       apply_quad_point_operations(const Functor &func);
 
     // clang-format off
     /**
@@ -493,47 +416,11 @@ namespace CUDAWrappers
                                    n_q_points_1d,
                                    n_components_,
                                    Number>::value_type
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::get_value(
-    const unsigned int q_point) const
-  {
-    return values[q_point];
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ typename FEEvaluation<dim,
-                                   fe_degree,
-                                   n_q_points_1d,
-                                   n_components_,
-                                   Number>::value_type
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     get_value() const
   {
     const unsigned int q_point = internal::compute_index<dim, n_q_points_1d>();
     return values[q_point];
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ typename FEEvaluation<dim,
-                                   fe_degree,
-                                   n_q_points_1d,
-                                   n_components_,
-                                   Number>::value_type
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    get_dof_value(const unsigned int dof) const
-  {
-    return values[dof];
   }
 
 
@@ -564,20 +451,6 @@ namespace CUDAWrappers
             typename Number>
   __device__ void
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    submit_value(const value_type &val_in, const unsigned int q_point)
-  {
-    values[q_point] = val_in * JxW[q_point];
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ void
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     submit_value(const value_type &val_in)
   {
     const unsigned int q_point = internal::compute_index<dim, n_q_points_1d>();
@@ -593,56 +466,10 @@ namespace CUDAWrappers
             typename Number>
   __device__ void
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    submit_dof_value(const value_type &val_in, const unsigned int dof)
-  {
-    values[dof] = val_in;
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ void
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     submit_dof_value(const value_type &val_in)
   {
     const unsigned int dof = internal::compute_index<dim, fe_degree + 1>();
     values[dof]            = val_in;
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ typename FEEvaluation<dim,
-                                   fe_degree,
-                                   n_q_points_1d,
-                                   n_components_,
-                                   Number>::gradient_type
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    get_gradient(const unsigned int q_point) const
-  {
-    static_assert(n_components_ == 1, "This function only supports FE with one \
-                  components");
-    // TODO optimize if the mesh is uniform
-    const Number *inv_jacobian = &inv_jac[q_point];
-    gradient_type grad;
-    for (int d_1 = 0; d_1 < dim; ++d_1)
-      {
-        Number tmp = 0.;
-        for (int d_2 = 0; d_2 < dim; ++d_2)
-          tmp += inv_jacobian[padding_length * n_cells * (dim * d_2 + d_1)] *
-                 gradients[d_2][q_point];
-        grad[d_1] = tmp;
-      }
-
-    return grad;
   }
 
 
@@ -688,29 +515,6 @@ namespace CUDAWrappers
             typename Number>
   __device__ void
   FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    submit_gradient(const gradient_type &grad_in, const unsigned int q_point)
-  {
-    // TODO optimize if the mesh is uniform
-    const Number *inv_jacobian = &inv_jac[q_point];
-    for (int d_1 = 0; d_1 < dim; ++d_1)
-      {
-        Number tmp = 0.;
-        for (int d_2 = 0; d_2 < dim; ++d_2)
-          tmp += inv_jacobian[n_cells * padding_length * (dim * d_1 + d_2)] *
-                 grad_in[d_2];
-        gradients[d_1][q_point] = tmp * JxW[q_point];
-      }
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  __device__ void
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
     submit_gradient(const gradient_type &grad_in)
   {
     // TODO optimize if the mesh is uniform
@@ -724,23 +528,6 @@ namespace CUDAWrappers
                  grad_in[d_2];
         gradients[d_1][q_point] = tmp * JxW[q_point];
       }
-  }
-
-
-
-  template <int dim,
-            int fe_degree,
-            int n_q_points_1d,
-            int n_components_,
-            typename Number>
-  template <typename Functor>
-  __device__ void
-  FEEvaluation<dim, fe_degree, n_q_points_1d, n_components_, Number>::
-    apply_quad_point_operations(const Functor &func)
-  {
-    func(this, internal::compute_index<dim, n_q_points_1d>());
-
-    __syncthreads();
   }
 
 


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/8838.