### PR TITLE
[9.3] Take over #12315: Remove noexcept on TriaAccessor move constructor and assignment operator

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -729,7 +729,7 @@ public:
   /**
    * Move constructor.
    */
-  TriaAccessor(TriaAccessor &&) noexcept = default;
+  TriaAccessor(TriaAccessor &&) = default; // NOLINT
 
   /**
    * Conversion constructor. This constructor exists to make certain
@@ -769,7 +769,7 @@ public:
    * Move assignment operator. Moving is allowed.
    */
   TriaAccessor &
-  operator=(TriaAccessor &&) noexcept = default;
+  operator=(TriaAccessor &&) = default; // NOLINT
 
   /**
    * Defaulted destructor.


### PR DESCRIPTION
To avoid a compilation error with clang 6.0.0.

Closes #12313