### PR TITLE
Introduce `patch_dim` and `patch_spacedim` in DataOut classes.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -2456,8 +2456,8 @@ namespace DataOutBase
  * This class is thought as a base class to classes actually generating data
  * for output. It has two abstract virtual functions, get_patches() and
  * get_dataset_names() produce the data which is actually needed. These are
- * the only functions that need to be overloaded by a derived class.  In
- * additional to that, it has a function for each output format supported by
+ * the only functions that need to be overloaded by a derived class. In
+ * addition to that, it has a function for each output format supported by
  * the underlying base class which gets the output data using these two
  * virtual functions and passes them to the raw output functions.
  *

--- a/include/deal.II/numerics/data_out_faces.h
+++ b/include/deal.II/numerics/data_out_faces.h
@@ -100,28 +100,30 @@ namespace internal
  * applications certainly exist, for which the author is not imaginative
  * enough.
  *
- * @pre This class only makes sense if the first template argument,
- * <code>dim</code> equals the dimension of the DoFHandler type given as the
- * second template argument, i.e., if <code>dim ==
- * DoFHandlerType::dimension</code>. This redundancy is a historical relic
- * from the time where the library had only a single DoFHandler class and this
- * class consequently only a single template argument.
- *
  * @todo Reimplement this whole class using actual FEFaceValues and
  * MeshWorker.
  *
  * @ingroup output
  */
 template <int dim, int spacedim = dim>
-class DataOutFaces : public DataOut_DoFData<dim, dim - 1, spacedim, dim>
+class DataOutFaces : public DataOut_DoFData<dim, dim - 1, spacedim, spacedim>
 {
+  static_assert(dim == spacedim, "Not implemented for dim != spacedim.");
+
 public:
+  /**
+   * Dimension parameters for the patches.
+   */
+  static constexpr int patch_dim      = dim - 1;
+  static constexpr int patch_spacedim = spacedim;
+
   /**
    * Alias to the iterator type of the dof handler class under
    * consideration.
    */
   using cell_iterator =
-    typename DataOut_DoFData<dim, dim - 1, spacedim, dim>::cell_iterator;
+    typename DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::
+      cell_iterator;
 
   /**
    * Constructor determining whether a surface mesh (default) or the whole
@@ -167,8 +169,8 @@ public:
    * hp::MappingCollection in case of a DoFHandler with hp-capabilities.
    */
   virtual void
-  build_patches(const Mapping<dim> &mapping,
-                const unsigned int  n_subdivisions = 0);
+  build_patches(const Mapping<dim, spacedim> &mapping,
+                const unsigned int            n_subdivisions = 0);
 
   /**
    * Declare a way to describe a face which we would like to generate output
@@ -229,9 +231,9 @@ private:
    */
   void
   build_one_patch(
-    const FaceDescriptor *                                        cell_and_face,
-    internal::DataOutFacesImplementation::ParallelData<dim, dim> &data,
-    DataOutBase::Patch<dim - 1, spacedim> &                       patch);
+    const FaceDescriptor *cell_and_face,
+    internal::DataOutFacesImplementation::ParallelData<dim, spacedim> &data,
+    DataOutBase::Patch<patch_dim, patch_spacedim> &                    patch);
 };
 
 namespace Legacy

--- a/include/deal.II/numerics/data_out_rotation.h
+++ b/include/deal.II/numerics/data_out_rotation.h
@@ -109,25 +109,28 @@ namespace internal
  * It is in the responsibility of the user to make sure that the radial
  * variable attains only non-negative values.
  *
- * @pre This class only makes sense if the first template argument,
- * <code>dim</code> equals the dimension of the DoFHandler type given as the
- * second template argument, i.e., if <code>dim ==
- * DoFHandlerType::dimension</code>. This redundancy is a historical relic
- * from the time where the library had only a single DoFHandler class and this
- * class consequently only a single template argument.
- *
  * @ingroup output
  */
 template <int dim, int spacedim = dim>
-class DataOutRotation : public DataOut_DoFData<dim, dim + 1, spacedim, dim + 1>
+class DataOutRotation
+  : public DataOut_DoFData<dim, dim + 1, spacedim, spacedim + 1>
 {
+  static_assert(dim == spacedim, "Not implemented for dim != spacedim.");
+
 public:
+  /**
+   * Dimension parameters for the patches.
+   */
+  static constexpr int patch_dim      = dim + 1;
+  static constexpr int patch_spacedim = spacedim + 1;
+
   /**
    * Typedef to the iterator type of the dof handler class under
    * consideration.
    */
   using cell_iterator =
-    typename DataOut_DoFData<dim, dim + 1, spacedim, dim + 1>::cell_iterator;
+    typename DataOut_DoFData<dim, patch_dim, spacedim, patch_spacedim>::
+      cell_iterator;
 
   /**
    * This is the central function of this class since it builds the list of
@@ -196,7 +199,7 @@ private:
   build_one_patch(
     const cell_iterator *                                                 cell,
     internal::DataOutRotationImplementation::ParallelData<dim, spacedim> &data,
-    std::vector<DataOutBase::Patch<dim + 1, spacedim + 1>> &my_patches);
+    std::vector<DataOutBase::Patch<patch_dim, patch_spacedim>> &my_patches);
 };
 
 namespace Legacy

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -386,8 +386,9 @@ private:
    * data in the form of Patch structures (declared in the base class
    * DataOutBase) to the actual output function.
    */
-  virtual const std::vector<
-    dealii::DataOutBase::Patch<patch_dim, patch_spacedim>> &
+  virtual const std::vector<dealii::DataOutBase::Patch<
+    DataOutStack<dim, spacedim, void>::patch_dim,
+    DataOutStack<dim, spacedim, void>::patch_spacedim>> &
   get_patches() const override;
 
 

--- a/include/deal.II/numerics/data_out_stack.h
+++ b/include/deal.II/numerics/data_out_stack.h
@@ -131,9 +131,18 @@ public:
  * @ingroup output
  */
 template <int dim, int spacedim>
-class DataOutStack<dim, spacedim, void> : public DataOutInterface<dim + 1>
+class DataOutStack<dim, spacedim, void>
+  : public DataOutInterface<dim + 1, spacedim + 1>
 {
+  static_assert(dim == spacedim, "Not implemented for dim != spacedim.");
+
 public:
+  /**
+   * Dimension parameters for the patches.
+   */
+  static constexpr int patch_dim      = dim + 1;
+  static constexpr int patch_spacedim = spacedim + 1;
+
   /**
    * Data type declaring the two types of vectors which are used in this
    * class.
@@ -336,7 +345,7 @@ private:
   /**
    * List of patches of all past and present parameter value data sets.
    */
-  std::vector<dealii::DataOutBase::Patch<dim + 1, dim + 1>> patches;
+  std::vector<dealii::DataOutBase::Patch<patch_dim, patch_spacedim>> patches;
 
   /**
    * Structure holding data vectors (cell and dof data) for the present
@@ -377,7 +386,8 @@ private:
    * data in the form of Patch structures (declared in the base class
    * DataOutBase) to the actual output function.
    */
-  virtual const std::vector<dealii::DataOutBase::Patch<dim + 1, dim + 1>> &
+  virtual const std::vector<
+    dealii::DataOutBase::Patch<patch_dim, patch_spacedim>> &
   get_patches() const override;
 
 

--- a/source/numerics/data_out_stack.cc
+++ b/source/numerics/data_out_stack.cc
@@ -308,15 +308,16 @@ DataOutStack<dim, spacedim, void>::build_patches(
   // patch with n_q_points (in the plane
   // of the cells) times n_subdivisions+1 (in
   // the time direction) points
-  dealii::DataOutBase::Patch<dim + 1, dim + 1> default_patch;
+  dealii::DataOutBase::Patch<patch_dim, patch_spacedim> default_patch;
   default_patch.n_subdivisions = n_subdivisions;
   default_patch.data.reinit(n_datasets, n_q_points * (n_subdivisions + 1));
   patches.insert(patches.end(), n_patches, default_patch);
 
   // now loop over all cells and
   // actually create the patches
-  typename std::vector<dealii::DataOutBase::Patch<dim + 1, dim + 1>>::iterator
-               patch       = patches.begin() + (patches.size() - n_patches);
+  typename std::vector<
+    dealii::DataOutBase::Patch<patch_dim, patch_spacedim>>::iterator patch =
+    patches.begin() + (patches.size() - n_patches);
   unsigned int cell_number = 0;
   for (typename DoFHandler<dim, spacedim>::active_cell_iterator cell =
          dof_handler->begin_active();
@@ -451,7 +452,7 @@ template <int dim, int spacedim>
 std::size_t
 DataOutStack<dim, spacedim, void>::memory_consumption() const
 {
-  return (DataOutInterface<dim + 1>::memory_consumption() +
+  return (DataOutInterface<patch_dim, patch_spacedim>::memory_consumption() +
           MemoryConsumption::memory_consumption(parameter) +
           MemoryConsumption::memory_consumption(parameter_step) +
           MemoryConsumption::memory_consumption(dof_handler) +
@@ -463,8 +464,11 @@ DataOutStack<dim, spacedim, void>::memory_consumption() const
 
 
 template <int dim, int spacedim>
-const std::vector<dealii::DataOutBase::Patch<dim + 1, dim + 1>> &
-DataOutStack<dim, spacedim, void>::get_patches() const
+const std::vector<
+  dealii::DataOutBase::Patch<DataOutStack<dim, spacedim, void>::patch_dim,
+                             DataOutStack<dim, spacedim, void>::patch_spacedim>>
+  &
+  DataOutStack<dim, spacedim, void>::get_patches() const
 {
   return patches;
 }


### PR DESCRIPTION
Follow-up to #11221. Part of #10333.

Reading through the implementation of the DataOut classes in #11221 left me confused about which of the `dim` template parameters belonged to the dof_handler and which to the actual patch.

This is an attempt to make the interface more descriptive by introducing `patch_dim` and `patch_spacedim` static variables for classes
- `DataOutFaces`
- `DataOutRotatation`
- `DataOutStack`

I believe that I found some copy&paste errors along the way.

We could also use these new parameters to overhaul the actual implementation (e.g. by replacing some `Point<dim>` by `Point<patch_spacedim>`). However, to do this properly, we would need actual tests for `dim != spacedim`, which we don't have currently. Let's leave this as a future task.

@bangerth -- FYI