### PR TITLE
Add documentation about shape function ordering for `FE_DGQLegendre`

### DIFF
--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -438,11 +438,12 @@ public:
  * space Polynomials::Legendre. The tensor product is achieved using
  * TensorProductPolynomials and the ordering of shape functions, like in
  * TensorProductPolynomials, is lexicographic. For instance, the ordering in 2d
- * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),\
- * \ldots,\ P_n(x)P_1(y),\ \ldots,\ P_0(x)P_n(y),\ \ldots,\ P_n(x)P_n(y)$ when
- * <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional Legendre
- * polynomials defined on $[0,1]$. As opposed to the basic FE_DGQ element,
- * these elements are not interpolatory and no support points are defined.
+ * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),
+ * \ \ldots,\ P_n(x)P_1(y),\ \ldots,\ P_0(x)P_n(y),\ \ldots,\ P_n(x)P_n(y)$
+ * when <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional
+ * Legendre polynomials defined on $[0,1]$. As opposed to the basic FE_DGQ
+ * element, these elements are not interpolatory and no support points are
+ * defined.
  *
  * See the base class documentation in FE_DGQ for details.
  */

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -435,8 +435,14 @@ public:
 /**
  * Implementation of scalar, discontinuous tensor product elements based on
  * Legendre polynomials, described by the tensor product of the polynomial
- * space Polynomials::Legendre. As opposed to the basic FE_DGQ element, these
- * elements are not interpolatory and no support points are defined.
+ * space Polynomials::Legendre. The tensor product is achieved using
+ * TensorProductPolynomials and the ordering of shape functions, like in
+ * TensorProductPolynomials, is lexicographic. For instance, the ordering in 2d
+ * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),\ 
+ * \ldots,\ P_n(x)P_1(y),\ \ldots,\ P_0(x)P_n(y),\ \ldots,\ P_n(x)P_n(y)$ when
+ * <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional Lagrange
+ * polynomials defined on $[0,1]$. As opposed to the basic FE_DGQ element,
+ * these elements are not interpolatory and no support points are defined.
  *
  * See the base class documentation in FE_DGQ for details.
  */

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -440,7 +440,7 @@ public:
  * TensorProductPolynomials, is lexicographic. For instance, the ordering in 2d
  * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),\ 
  * \ldots,\ P_n(x)P_1(y),\ \ldots,\ P_0(x)P_n(y),\ \ldots,\ P_n(x)P_n(y)$ when
- * <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional Lagrange
+ * <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional Legendre
  * polynomials defined on $[0,1]$. As opposed to the basic FE_DGQ element,
  * these elements are not interpolatory and no support points are defined.
  *

--- a/include/deal.II/fe/fe_dgq.h
+++ b/include/deal.II/fe/fe_dgq.h
@@ -438,7 +438,7 @@ public:
  * space Polynomials::Legendre. The tensor product is achieved using
  * TensorProductPolynomials and the ordering of shape functions, like in
  * TensorProductPolynomials, is lexicographic. For instance, the ordering in 2d
- * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),\ 
+ * is $P_0(x)P_0(y),\ P_1(x)P_0(y),\ \ldots,\ P_n(x)P_0(y),\ P_0(x)P_1(y),\
  * \ldots,\ P_n(x)P_1(y),\ \ldots,\ P_0(x)P_n(y),\ \ldots,\ P_n(x)P_n(y)$ when
  * <tt>degree=n</tt> where $\{P_i\}_{i=0}^{n}$ are the one-dimensional Legendre
  * polynomials defined on $[0,1]$. As opposed to the basic FE_DGQ element,


### PR DESCRIPTION
This pull request was motivated by this thread in the discussion forum
https://groups.google.com/g/dealii/c/HuuKX0xT5EA

The lexicographic ordering was verified as follows. Let $\phi_i$ be the shape functions of `FE_DGQLegendre<3>(n)` and $\{P_i\}_{i=0}^{n}$ be the Legendre polynomials. The shape functions of `FE_DGQLegendre<1>(n)` are $\{P_i\}_{i=0}^{n}$, in the same ordering, as is clear from
https://www.dealii.org/current/doxygen/deal.II/polynomial_8cc_source.html#l00877.

Compute the error
$$
E_i := L^2_{[0,1]^3} \bigl( \phi_i(x,y,z) - P_{i_1}(x), P_{i_2}(y) P_{i_3}(z) \bigr)
$$
for $i_1,\ i_2,\ i_3=0,\ \ldots,\ n$ and $i=i_1 + i_2(n+1) + i_3(n+1)^2$. If the ordering is lexicographic, then $E_i=0\ \forall i$.