### PR TITLE
Rename VectorTools::evaluate_at_points() -> VectorTools::point_values()

### DIFF
--- a/doc/news/9.2.0-vs-9.3.0.h
+++ b/doc/news/9.2.0-vs-9.3.0.h
@@ -518,7 +518,7 @@ inconvenience this causes.
 
  <li>
   New: The class Utilities::MPI::RemotePointEvaluation and the function
-  VectorTools::evaluate_at_points() allow to work on arbitrary distributed
+  VectorTools::point_values() allow to work on arbitrary distributed
   points.
   <br>
   (Peter Munch, Martin Kronbichler, Magdalena Schreter, Niklas Fehn, 2021/02/28)

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -32,12 +32,12 @@ DEAL_II_NAMESPACE_OPEN
 namespace VectorTools
 {
   /**
-   * Namespace for the flags for evaluate_at_points().
+   * Namespace for the flags for point_values().
    */
   namespace EvaluationFlags
   {
     /**
-     * Flags for evaluate_at_points().
+     * Flags for point_values().
      */
     enum EvaluationFlags
     {
@@ -73,7 +73,7 @@ namespace VectorTools
    */
   template <int n_components, int dim, int spacedim, typename VectorType>
   std::vector<typename FEPointEvaluation<n_components, dim>::value_type>
-  evaluate_at_points(
+  point_values(
     const Mapping<dim> &                                  mapping,
     const DoFHandler<dim, spacedim> &                     dof_handler,
     const VectorType &                                    vector,
@@ -94,7 +94,7 @@ namespace VectorTools
    */
   template <int n_components, int dim, int spacedim, typename VectorType>
   std::vector<typename FEPointEvaluation<n_components, dim>::value_type>
-  evaluate_at_points(
+  point_values(
     const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
     const DoFHandler<dim, spacedim> &                           dof_handler,
     const VectorType &                                          vector,
@@ -108,17 +108,16 @@ namespace VectorTools
 #ifndef DOXYGEN
   template <int n_components, int dim, int spacedim, typename VectorType>
   inline std::vector<typename FEPointEvaluation<n_components, dim>::value_type>
-  evaluate_at_points(
-    const Mapping<dim> &                                  mapping,
-    const DoFHandler<dim, spacedim> &                     dof_handler,
-    const VectorType &                                    vector,
-    const std::vector<Point<spacedim>> &                  evaluation_points,
-    Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
-    const EvaluationFlags::EvaluationFlags                flags)
+  point_values(const Mapping<dim> &                mapping,
+               const DoFHandler<dim, spacedim> &   dof_handler,
+               const VectorType &                  vector,
+               const std::vector<Point<spacedim>> &evaluation_points,
+               Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
+               const EvaluationFlags::EvaluationFlags                flags)
   {
     cache.reinit(evaluation_points, dof_handler.get_triangulation(), mapping);
 
-    return evaluate_at_points<n_components>(cache, dof_handler, vector, flags);
+    return point_values<n_components>(cache, dof_handler, vector, flags);
   }
 
 
@@ -184,7 +183,7 @@ namespace VectorTools
 
   template <int n_components, int dim, int spacedim, typename VectorType>
   inline std::vector<typename FEPointEvaluation<n_components, dim>::value_type>
-  evaluate_at_points(
+  point_values(
     const Utilities::MPI::RemotePointEvaluation<dim, spacedim> &cache,
     const DoFHandler<dim, spacedim> &                           dof_handler,
     const VectorType &                                          vector,
@@ -197,7 +196,7 @@ namespace VectorTools
            ExcMessage(
              "Utilities::MPI::RemotePointEvaluation is not ready yet! "
              "Please call Utilities::MPI::RemotePointEvaluation::reinit() "
-             "yourself or the other evaluate_at_points(), which does this for"
+             "yourself or the other point_values(), which does this for"
              "you."));
 
     Assert(

--- a/tests/remote_point_evaluation/mapping_01.cc
+++ b/tests/remote_point_evaluation/mapping_01.cc
@@ -62,17 +62,17 @@ test(const bool enforce_unique_map)
   Utilities::MPI::RemotePointEvaluation<dim> eval(1e-6, enforce_unique_map);
 
   const auto result_avg =
-    VectorTools::evaluate_at_points<1>(mapping,
-                                       dof_handler,
-                                       vec,
-                                       evaluation_points,
-                                       eval,
-                                       VectorTools::EvaluationFlags::avg);
-  const auto result_min = VectorTools::evaluate_at_points<1>(
+    VectorTools::point_values<1>(mapping,
+                                 dof_handler,
+                                 vec,
+                                 evaluation_points,
+                                 eval,
+                                 VectorTools::EvaluationFlags::avg);
+  const auto result_min = VectorTools::point_values<1>(
     eval, dof_handler, vec, VectorTools::EvaluationFlags::min);
-  const auto result_max = VectorTools::evaluate_at_points<1>(
+  const auto result_max = VectorTools::point_values<1>(
     eval, dof_handler, vec, VectorTools::EvaluationFlags::max);
-  const auto result_insert = VectorTools::evaluate_at_points<1>(
+  const auto result_insert = VectorTools::point_values<1>(
     eval, dof_handler, vec, VectorTools::EvaluationFlags::insert);
 
   for (unsigned int i = 0; i < evaluation_points.size(); ++i)

--- a/tests/remote_point_evaluation/remote_point_evaluation_03.cc
+++ b/tests/remote_point_evaluation/remote_point_evaluation_03.cc
@@ -312,9 +312,7 @@ test_2(const Triangulation<dim, spacedim> &surface_mesh,
   eval.reinit(integration_points, dof_handler_dim.get_triangulation(), mapping);
 
   const auto evaluation_point_results =
-    VectorTools::evaluate_at_points<spacedim>(eval,
-                                              dof_handler_dim,
-                                              normal_solution);
+    VectorTools::point_values<spacedim>(eval, dof_handler_dim, normal_solution);
 
   for (unsigned int i = 0; i < evaluation_point_results.size(); ++i)
     {

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_01.cc
@@ -212,7 +212,7 @@ test()
 
   vector_1.update_ghost_values();
   Utilities::MPI::RemotePointEvaluation<dim> evaluation_cache;
-  const auto evaluation_point_results = VectorTools::evaluate_at_points<1>(
+  const auto evaluation_point_results = VectorTools::point_values<1>(
     mapping_1, dof_handler_1, vector_1, evaluation_points, evaluation_cache);
   vector_1.zero_out_ghosts();
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_02.cc
@@ -180,11 +180,11 @@ public:
       solution_other.update_ghost_values();
       Utilities::MPI::RemotePointEvaluation<dim> evaluation_cache;
       const auto                                 evaluation_point_results =
-        VectorTools::evaluate_at_points<1>(mapping_other,
-                                           dof_handler_other,
-                                           solution_other,
-                                           evaluation_points,
-                                           evaluation_cache);
+        VectorTools::point_values<1>(mapping_other,
+                                     dof_handler_other,
+                                     solution_other,
+                                     evaluation_points,
+                                     evaluation_cache);
       solution_other.zero_out_ghosts();
       for (unsigned int i = 0; i < evaluation_points.size(); ++i)
         {

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_03.cc
@@ -190,7 +190,7 @@ test()
 
   vector_1.update_ghost_values();
   Utilities::MPI::RemotePointEvaluation<dim> evaluation_cache;
-  const auto evaluation_point_results = VectorTools::evaluate_at_points<1>(
+  const auto evaluation_point_results = VectorTools::point_values<1>(
     mapping_1, dof_handler_1, vector_1, evaluation_points, evaluation_cache);
   vector_1.zero_out_ghosts();
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_04.cc
@@ -153,7 +153,7 @@ test()
 
   vector_1.update_ghost_values();
   Utilities::MPI::RemotePointEvaluation<dim> evaluation_cache;
-  const auto evaluation_point_results = VectorTools::evaluate_at_points<1>(
+  const auto evaluation_point_results = VectorTools::point_values<1>(
     mapping_1, dof_handler_1, vector_1, evaluation_points, evaluation_cache);
   vector_1.zero_out_ghosts();
 

--- a/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
+++ b/tests/remote_point_evaluation/vector_tools_evaluate_at_points_05.cc
@@ -178,7 +178,7 @@ test()
   // evaluate vector of background mesh for slice support points
   vector_1.update_ghost_values();
   Utilities::MPI::RemotePointEvaluation<dim> evaluation_cache;
-  const auto evaluation_point_results = VectorTools::evaluate_at_points<1>(
+  const auto evaluation_point_results = VectorTools::point_values<1>(
     mapping_1, dof_handler_1, vector_1, evaluation_points, evaluation_cache);
   vector_1.zero_out_ghosts();
 


### PR DESCRIPTION
... to be consistent with `VectorTools::point_value()`.

If possible, I would like to make this change part of release 9.3, since this is a new function.

FYI @mschreter 