### PR TITLE
Remove noexcept on DoFAccessor move constructor and assignment operator

### DIFF
--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -277,8 +277,9 @@ public:
   /**
    * Move constructor.
    */
-  DoFAccessor(DoFAccessor<structdim, dim, spacedim, level_dof_access>
-                &&) noexcept = default;
+  DoFAccessor(                                                    // NOLINT
+    DoFAccessor<structdim, dim, spacedim, level_dof_access> &&) = // NOLINT
+    default;                                                      // NOLINT
 
   /**
    * Destructor.
@@ -330,9 +331,10 @@ public:
   /**
    * Move assignment operator.
    */
-  DoFAccessor<structdim, dim, spacedim, level_dof_access> &
-  operator=(DoFAccessor<structdim, dim, spacedim, level_dof_access>
-              &&) noexcept = default;
+  DoFAccessor<structdim, dim, spacedim, level_dof_access> &       // NOLINT
+  operator=(                                                      // NOLINT
+    DoFAccessor<structdim, dim, spacedim, level_dof_access> &&) = // NOLINT
+    default;                                                      // NOLINT
 
   /**
    * @}
@@ -1455,9 +1457,9 @@ public:
   /**
    * Move constructor.
    */
-  DoFCellAccessor(
-    DoFCellAccessor<dimension_, space_dimension_, level_dof_access>
-      &&) noexcept = default;
+  DoFCellAccessor(                                                  // NOLINT
+    DoFCellAccessor<dimension_, space_dimension_, level_dof_access> // NOLINT
+      &&) = default;                                                // NOLINT
 
   /**
    * Destructor
@@ -1481,9 +1483,10 @@ public:
   /**
    * Move assignment operator.
    */
-  DoFCellAccessor<dimension_, space_dimension_, level_dof_access> &
-  operator=(DoFCellAccessor<dimension_, space_dimension_, level_dof_access>
-              &&) noexcept = default;
+  DoFCellAccessor<dimension_, space_dimension_, level_dof_access> & // NOLINT
+  operator=(                                                        // NOLINT
+    DoFCellAccessor<dimension_, space_dimension_, level_dof_access> // NOLINT
+      &&) = default;                                                // NOLINT
 
   /**
    * @}


### PR DESCRIPTION
I can't can't compile master with clang 6.0.0 without removing the `noexcept` keyword on DoFAccessor:

```
In file included from /home/simon/workspace/dealiiCloseToMaster/source/numerics/data_out.cc:18:                                                                          
/home/simon/workspace/dealiiCloseToMaster/include/deal.II/dofs/dof_accessor.h:280:3: error: exception specification of explicitly defaulted move constructor does not    
      match the calculated one                                                                                                                                           
  DoFAccessor(DoFAccessor<structdim, dim, spacedim, level_dof_access>                                                                                                    
  ^                                                                                                                                                                      
/home/simon/workspace/dealiiCloseToMaster/include/deal.II/dofs/dof_accessor.h:1367:32: note: in instantiation of template class 'dealii::DoFAccessor<1, 1, 1, false>'    
      requested here                                                                                                                                                     
class DoFCellAccessor : public DoFAccessor<dimension_,                                                                                                                   
                               ^                                                                                                                                         
/home/simon/workspace/dealiiCloseToMaster/include/deal.II/grid/tria_iterator.h:277:25: note: in instantiation of template class 'dealii::DoFCellAccessor<1, 1, false>'   
      requested here                                                                                                                                                     
    const Triangulation<Accessor::dimension, Accessor::space_dimension> *parent,                                                                                         
                        ^                                                                                                                                                
/home/simon/workspace/dealiiCloseToMaster/include/deal.II/grid/tria_iterator.h:577:29: note: in instantiation of template class                                          
      'dealii::TriaRawIterator<dealii::DoFCellAccessor<1, 1, false> >' requested here                                                                                    
class TriaIterator : public TriaRawIterator<Accessor>                                                                                                                    
                            ^                                                                                                                                            
/home/simon/workspace/dealiiCloseToMaster/source/numerics/data_out.cc:233:21: note: in instantiation of template class 'dealii::TriaIterator<dealii::DoFCellAccessor<1,  
      1, false> >' requested here
                    dh_cell(&cell_and_index->first->get_triangulation(),
                    ^
/home/simon/workspace/dealiiCloseToMaster/build/source/numerics/data_out.inst:127:16: note: in instantiation of member function 'dealii::DataOut<1, 1>::build_one_patch'
      requested here
template class DataOut< 1 >;
```
Same problem as #12313.
