### PR TITLE
Remove deprecated DoFTools::extract_*dofs overloads

### DIFF
--- a/doc/news/changes/incompatibilities/20210528DanielArndt
+++ b/doc/news/changes/incompatibilities/20210528DanielArndt
@@ -1,0 +1,4 @@
+Removed: The deprecated overloads for DoFTools::extract_hanging_node_dofs(),
+and DoFTools::extract_dofs() have been removed.
+<br>
+(Daniel Arndt, 2021/05/28)

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1199,8 +1199,12 @@ namespace DoFTools
    */
 
   /**
-   * Same as above but return the selected DoFs as IndexSet. In particular,
-   * for parallel::TriangulationBase objects this function should be preferred.
+   * Return an IndexSet describing all dofs that will be constrained by
+   * interface constraints, i.e. all hanging nodes.
+   *
+   * In case of a parallel::shared::Triangulation or a
+   * parallel::distributed::Triangulation only locally relevant dofs are
+   * considered.
    */
   template <int dim, int spacedim>
   IndexSet

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1199,83 +1199,12 @@ namespace DoFTools
    */
 
   /**
-   * Select all dofs that will be constrained by interface constraints, i.e.
-   * all hanging nodes.
-   *
-   * The size of @p selected_dofs shall equal <tt>dof_handler.n_dofs()</tt>.
-   * Previous contents of this array or overwritten.
-   *
-   * In case of a parallel::shared::Triangulation or a
-   * parallel::distributed::Triangulation only locally relevant dofs are
-   * considered. Note that the vector returned through the second argument still
-   * has size <tt>dof_handler.n_dofs()</tt>. Consequently, it can be very large
-   * for large parallel computations -- in fact, it may be too large to store on
-   * each processor. In that case, you may want to choose the variant of this
-   * function that returns an IndexSet object.
-   *
-   * @deprecated For the reason stated above, this function is deprecated in
-   *   favor of the following function.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  extract_hanging_node_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-                            std::vector<bool> &              selected_dofs);
-
-  /**
    * Same as above but return the selected DoFs as IndexSet. In particular,
    * for parallel::TriangulationBase objects this function should be preferred.
    */
   template <int dim, int spacedim>
   IndexSet
   extract_hanging_node_dofs(const DoFHandler<dim, spacedim> &dof_handler);
-
-  /**
-   * Extract the indices of the degrees of freedom belonging to certain vector
-   * components of a vector-valued finite element. The @p component_mask
-   * defines which components or blocks of an FESystem are to be extracted
-   * from the DoFHandler @p dof. The entries in the output array @p
-   * selected_dofs corresponding to degrees of freedom belonging to these
-   * components are then flagged @p true, while all others are set to @p
-   * false.
-   *
-   * If the finite element under consideration is not primitive, i.e., some or
-   * all of its shape functions are non-zero in more than one vector component
-   * (which holds, for example, for FE_Nedelec or FE_RaviartThomas elements),
-   * then shape functions cannot be associated with a single vector component.
-   * In this case, if <em>one</em> shape vector component of this element is
-   * flagged in @p component_mask (see
-   * @ref GlossComponentMask),
-   * then this is equivalent to selecting <em>all</em> vector components
-   * corresponding to this non-primitive base element.
-   *
-   * @param[in] dof_handler The DoFHandler whose enumerated degrees of freedom
-   *   are to be filtered by this function.
-   * @param[in] component_mask A mask that states which components you want
-   *   to select. The size of this mask must be compatible with the number of
-   *   components in the FiniteElement used by the @p dof_handler. See
-   *   @ref GlossComponentMask "the glossary entry on component masks"
-   *   for more information.
-   * @param[out] selected_dofs A vector that will hold @p true or @p false
-   *   values for each degree of freedom depending on whether or not it
-   *   corresponds to a vector component selected by the mask above. The size
-   *   of this array must equal DoFHandler::n_locally_owned_dofs(), which for
-   *   sequential computations of course equals DoFHandler::n_dofs(). The
-   *   previous contents of this array are overwritten. Note that the resulting
-   *   vector just holds the locally owned extracted degrees of freedom, which
-   *   first have to be mapped to the global degrees of freedom, to correspond
-   *   with them.
-   *
-   * @deprecated This function is difficult to use in parallel contexts because
-   *   it returns a vector that needs to be indexed based on the position
-   *   of a degree of freedom within the set of locally owned degrees of
-   *   freedom. It is consequently deprecated in favor of the following
-   *   function.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  extract_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-               const ComponentMask &            component_mask,
-               std::vector<bool> &              selected_dofs);
 
   /**
    * Extract the (locally owned) indices of the degrees of freedom belonging to
@@ -1313,42 +1242,6 @@ namespace DoFTools
   IndexSet
   extract_dofs(const DoFHandler<dim, spacedim> &dof_handler,
                const ComponentMask &            component_mask);
-
-  /**
-   * This function is the equivalent to the DoFTools::extract_dofs() functions
-   * above except that the selection of which degrees of freedom to extract is
-   * not done based on components (see
-   * @ref GlossComponent)
-   * but instead based on whether they are part of a particular block (see
-   * @ref GlossBlock).
-   * Consequently, the second argument is not a ComponentMask but a BlockMask
-   * object.
-   *
-   * @param[in] dof_handler The DoFHandler whose enumerated degrees of freedom
-   *   are to be filtered by this function.
-   * @param[in] block_mask A mask that states which blocks you want
-   *   to select. The size of this mask must be compatible with the number of
-   *   blocks in the FiniteElement used by the @p dof_handler. See
-   *   @ref GlossBlockMask "the glossary entry on block masks"
-   *   for more information.
-   * @param[out] selected_dofs A vector that will hold @p true or @p false
-   *   values for each degree of freedom depending on whether or not it
-   *   corresponds to a vector block selected by the mask above. The size
-   *   of this array must equal DoFHandler::n_locally_owned_dofs(), which for
-   *   sequential computations of course equals DoFHandler::n_dofs(). The
-   *   previous contents of this array are overwritten.
-   *
-   * @deprecated This function is difficult to use in parallel contexts because
-   *   it returns a vector that needs to be indexed based on the position
-   *   of a degree of freedom within the set of locally owned degrees of
-   *   freedom. It is consequently deprecated in favor of the following
-   *   function.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  extract_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-               const BlockMask &                block_mask,
-               std::vector<bool> &              selected_dofs);
 
   /**
    * This function is the equivalent to the DoFTools::extract_dofs() functions

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -389,53 +389,6 @@ namespace DoFTools
 
 
   template <int dim, int spacedim>
-  void
-  extract_dofs(const DoFHandler<dim, spacedim> &dof,
-               const ComponentMask &            component_mask,
-               std::vector<bool> &              selected_dofs)
-  {
-    Assert(component_mask.represents_n_components(
-             dof.get_fe_collection().n_components()),
-           ExcMessage(
-             "The given component mask is not sized correctly to represent the "
-             "components of the given finite element."));
-    Assert(selected_dofs.size() == dof.n_locally_owned_dofs(),
-           ExcDimensionMismatch(selected_dofs.size(),
-                                dof.n_locally_owned_dofs()));
-
-    // two special cases: no component is selected, and all components are
-    // selected; both rather stupid, but easy to catch
-    if (component_mask.n_selected_components(
-          dof.get_fe_collection().n_components()) == 0)
-      {
-        std::fill_n(selected_dofs.begin(), dof.n_locally_owned_dofs(), false);
-        return;
-      }
-    else if (component_mask.n_selected_components(
-               dof.get_fe_collection().n_components()) ==
-             dof.get_fe_collection().n_components())
-      {
-        std::fill_n(selected_dofs.begin(), dof.n_locally_owned_dofs(), true);
-        return;
-      }
-
-
-    // preset all values by false
-    std::fill_n(selected_dofs.begin(), dof.n_locally_owned_dofs(), false);
-
-    // get the component association of each DoF and then select the ones
-    // that match the given set of components
-    std::vector<unsigned char> dofs_by_component(dof.n_locally_owned_dofs());
-    internal::get_component_association(dof, component_mask, dofs_by_component);
-
-    for (types::global_dof_index i = 0; i < dof.n_locally_owned_dofs(); ++i)
-      if (component_mask[dofs_by_component[i]] == true)
-        selected_dofs[i] = true;
-  }
-
-
-
-  template <int dim, int spacedim>
   IndexSet
   extract_dofs(const DoFHandler<dim, spacedim> &dof,
                const ComponentMask &            component_mask)
@@ -472,19 +425,6 @@ namespace DoFTools
     IndexSet result(dof.n_dofs());
     result.add_indices(selected_dofs.begin(), selected_dofs.end());
     return result;
-  }
-
-
-
-  template <int dim, int spacedim>
-  void
-  extract_dofs(const DoFHandler<dim, spacedim> &dof,
-               const BlockMask &                block_mask,
-               std::vector<bool> &              selected_dofs)
-  {
-    // simply forward to the function that works based on a component mask
-    extract_dofs<dim, spacedim>(
-      dof, dof.get_fe_collection().component_mask(block_mask), selected_dofs);
   }
 
 
@@ -1071,23 +1011,6 @@ namespace DoFTools
       }
     } // namespace
   }   // namespace internal
-
-
-
-  template <int dim, int spacedim>
-  void
-  extract_hanging_node_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-                            std::vector<bool> &              selected_dofs)
-  {
-    const IndexSet selected_dofs_as_index_set =
-      extract_hanging_node_dofs(dof_handler);
-    Assert(selected_dofs.size() == dof_handler.n_dofs(),
-           ExcDimensionMismatch(selected_dofs.size(), dof_handler.n_dofs()));
-    // preset all values by false
-    std::fill(selected_dofs.begin(), selected_dofs.end(), false);
-    for (const auto index : selected_dofs_as_index_set)
-      selected_dofs[index] = true;
-  }
 
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -93,22 +93,6 @@ for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
           DoFHandler<deal_II_dimension,
                      deal_II_space_dimension>::active_cell_iterator> &patch);
 
-      // extract_dofs(): Deprecated versions that return information through
-      // the last argument
-      template void
-      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const ComponentMask &,
-        std::vector<bool> &);
-
-      template void
-      extract_dofs<deal_II_dimension, deal_II_space_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        const BlockMask &,
-        std::vector<bool> &);
-
-
-      // extract_dofs(): New versions that return information as an IndexSet
       template IndexSet
       extract_dofs<deal_II_dimension, deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
@@ -203,9 +187,6 @@ for (deal_II_dimension : DIMENSIONS)
 
     template IndexSet DoFTools::extract_hanging_node_dofs(
       const DoFHandler<deal_II_dimension> &);
-
-    template void DoFTools::extract_hanging_node_dofs(
-      const DoFHandler<deal_II_dimension> &, std::vector<bool> &);
 
     template void DoFTools::extract_subdomain_dofs<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &dof_handler,
@@ -361,10 +342,6 @@ for (deal_II_dimension : DIMENSIONS)
     template IndexSet DoFTools::extract_hanging_node_dofs(
       const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &);
 
-    template void DoFTools::extract_hanging_node_dofs(
-      const DoFHandler<deal_II_dimension, deal_II_dimension + 1> &,
-      std::vector<bool> &);
-
 #endif
 
 #if deal_II_dimension == 3
@@ -379,9 +356,6 @@ for (deal_II_dimension : DIMENSIONS)
 
     template IndexSet DoFTools::extract_hanging_node_dofs(
       const DoFHandler<1, 3> &);
-
-    template void DoFTools::extract_hanging_node_dofs(const DoFHandler<1, 3> &,
-                                                      std::vector<bool> &);
 
 #endif
   }


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/9182.