### PR TITLE
[WIP] Fix compilation with Epetra and Tpetra but no MPI

### DIFF
--- a/include/deal.II/fe/fe_tools_interpolate.templates.h
+++ b/include/deal.II/fe/fe_tools_interpolate.templates.h
@@ -481,6 +481,7 @@ namespace FETools
 
 
 
+#  ifdef DEAL_II_WITH_MPI
     template <int dim, int spacedim>
     void
     back_interpolate(
@@ -496,7 +497,9 @@ namespace FETools
       AssertThrow(false, ExcNotImplemented());
     }
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+
+
+#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
     template <int dim, int spacedim, typename Number>
     void
     back_interpolate(
@@ -511,6 +514,7 @@ namespace FETools
     {
       AssertThrow(false, ExcNotImplemented());
     }
+#    endif
 #  endif
 #endif
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -218,7 +218,6 @@ namespace LinearAlgebra
 
 
 #ifdef DEAL_II_WITH_TRILINOS
-#  ifdef DEAL_II_WITH_MPI
     /**
      * Initialize this ReadWriteVector by supplying access to all locally
      * available entries in the given ghosted or non-ghosted vector.
@@ -232,7 +231,6 @@ namespace LinearAlgebra
      */
     void
     reinit(const TrilinosWrappers::MPI::Vector &trilinos_vec);
-#  endif
 #endif
 
     /**
@@ -648,7 +646,7 @@ namespace LinearAlgebra
     //@}
 
   protected:
-#ifdef DEAL_II_WITH_TRILINOS
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
     /**
      * Import all the elements present in the vector's IndexSet from the input

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -53,7 +53,7 @@ namespace LinearAlgebra
   {
     // In the import_from_ghosted_array_finish we need to calculate the
     // maximal and minimal value for the given number type, which is not
-    // straight forward for complex numbers. Therefore, comparison of complex
+    // straightforward for complex numbers. Therefore, comparison of complex
     // numbers is prohibited and throws an assert.
     template <typename Number>
     Number
@@ -299,7 +299,7 @@ namespace LinearAlgebra
 
 
 
-#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
+#ifdef DEAL_II_WITH_TRILINOS
   template <typename Number>
   void
   ReadWriteVector<Number>::reinit(
@@ -828,8 +828,11 @@ namespace LinearAlgebra
     else
       AssertThrow(false, ExcNotImplemented());
   }
+#endif
 
 
+
+#ifdef DEAL_II_WITH_TRILINOS
   template <typename Number>
   void
   ReadWriteVector<Number>::import(
@@ -851,9 +854,11 @@ namespace LinearAlgebra
            trilinos_vec.get_mpi_communicator(),
            communication_pattern);
   }
+#endif
 
 
 
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
 #  ifdef DEAL_II_TRILINOS_WITH_TPETRA
   template <typename Number>
   void

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -649,7 +649,7 @@ namespace internal
 
 
 
-#ifdef DEAL_II_WITH_TRILINOS
+#if defined(DEAL_II_WITH_TRILINOS) && defined(DEAL_II_WITH_MPI)
     template <>
     inline void
     VectorHelper<LinearAlgebra::EpetraWrappers::Vector>::extract(
@@ -661,11 +661,10 @@ namespace internal
       // TODO: we don't have element access
       Assert(false, ExcNotImplemented());
     }
-#endif
 
 
 
-#if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
+#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
     template <>
     inline void
     VectorHelper<LinearAlgebra::TpetraWrappers::Vector<double>>::extract(
@@ -689,6 +688,7 @@ namespace internal
       // TODO: we don't have element access
       Assert(false, ExcNotImplemented());
     }
+#  endif
 #endif
 
 

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -566,7 +566,7 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
 #    ifdef DEAL_II_WITH_MPI
       Teuchos::rcp(new Teuchos::MpiComm<int>(communicator))
 #    else
-      Teuchos::rcp(new Teuchos::Comm<int>())
+      Teuchos::rcp(new Teuchos::SerialComm<int>())
 #    endif
     );
   else
@@ -583,7 +583,7 @@ IndexSet::make_tpetra_map(const MPI_Comm &communicator,
 #    ifdef DEAL_II_WITH_MPI
         Teuchos::rcp(new Teuchos::MpiComm<int>(communicator))
 #    else
-        Teuchos::rcp(new Teuchos::Comm<int>())
+        Teuchos::rcp(new Teuchos::SerialComm<int>())
 #    endif
       );
     }

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -70,10 +70,9 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #    include <deal.II/lac/vector_memory.h>
 
 #    include <Epetra_MpiComm.h>
-#    include <Teuchos_DefaultComm.hpp>
 #  endif
 #  include <Epetra_SerialComm.h>
-#  include <Teuchos_RCP.hpp>
+#  include <Teuchos_DefaultComm.hpp>
 #endif
 
 DEAL_II_NAMESPACE_OPEN
@@ -1101,7 +1100,7 @@ namespace Utilities
         new Teuchos::MpiComm<int>(MPI_COMM_SELF));
 #  else
       static auto communicator =
-        Teuchos::RCP<const Teuchos::Comm<int>>(new Teuchos::Comm<int>());
+        Teuchos::RCP<const Teuchos::Comm<int>>(new Teuchos::SerialComm<int>());
 #  endif
 
       return communicator;

--- a/source/lac/affine_constraints.cc
+++ b/source/lac/affine_constraints.cc
@@ -135,7 +135,7 @@ INSTANTIATE_DLTG_MATRIX(TrilinosWrappers::SparseMatrix);
 INSTANTIATE_DLTG_MATRIX(TrilinosWrappers::BlockSparseMatrix);
 
 #  ifndef DOXYGEN
-#    ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#    if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
 // FIXME: This mixed variant is needed for multigrid and matrix free.
 template void
 dealii::AffineConstraints<double>::distribute<

--- a/source/lac/trilinos_precondition_ml.cc
+++ b/source/lac/trilinos_precondition_ml.cc
@@ -297,7 +297,11 @@ namespace TrilinosWrappers
     trilinos_matrix->reinit(distributor,
                             distributor,
                             deal_ii_sparse_matrix,
+#ifdef DEAL_II_WITH_MPI
                             communicator.Comm(),
+#else
+                            MPI_COMM_WORLD,
+#endif
                             drop_tolerance,
                             true,
                             use_this_sparsity);

--- a/source/lac/trilinos_precondition_muelu.cc
+++ b/source/lac/trilinos_precondition_muelu.cc
@@ -228,7 +228,11 @@ namespace TrilinosWrappers
     trilinos_matrix->reinit(distributor,
                             distributor,
                             deal_ii_sparse_matrix,
+#ifdef DEAL_II_WITH_MPI
                             communicator.Comm(),
+#else
+                            MPI_COMM_WORLD,
+#endif
                             drop_tolerance,
                             true,
                             use_this_sparsity);

--- a/source/numerics/vector_tools_integrate_difference.inst.in
+++ b/source/numerics/vector_tools_integrate_difference.inst.in
@@ -225,7 +225,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -312,7 +312,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -389,7 +389,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -462,7 +462,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -542,7 +542,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -616,7 +616,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -696,7 +696,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,
@@ -770,7 +770,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const Function<deal_II_space_dimension> *,
         const double);
 
-#  ifdef DEAL_II_TRILINOS_WITH_TPETRA
+#  if defined(DEAL_II_TRILINOS_WITH_TPETRA) && defined(DEAL_II_WITH_MPI)
       template void
       integrate_difference<deal_II_dimension,
                            LinearAlgebra::TpetraWrappers::Vector<float>,


### PR DESCRIPTION
Currently, deal.II fails to build when Epetra and Tpetra are enabled but MPI isn't. This PR fixes deal.II's compilation failures when Epetra is enabled but Tpetra and MPI aren't, but unfortunately fails to completely fix the problem when Tpetra is enabled (either the build fails or, with some different changes, at least one example fails to link).

Note that I am not sure about the `MPI_COMM_WORLD` substitution I made in the preconditioner files.

The root cause of the compilation problem in an Epetra-only–enabled build is that it is not entirely clear that EpetraWrappers (and TpetraWrappers) is available only when MPI is enabled, presumably leading to accidentally omitted guards (plus the `Teuchos::SerialComm` issue). As for the Tpetra-enabled build, I'm not certain, since I haven't managed to get it to build (and link).

The problematic files when Tpetra is enabled are the various `read_write_vector` headers and sources. The PR in its current state results in the following build log (with the beginning lines removed):

```
[ 20%] Building CXX object source/lac/CMakeFiles/obj_lac_release.dir/read_write_vector.cc.o
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:17:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h: In instantiation of 'void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = double]':
/home/paul/src/github.com/paulapatience/dealii/build/source/lac/read_write_vector.inst:12:17:   required from here
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: error: no matching function for call to 'dealii::LinearAlgebra::ReadWriteVector<double>::import(const Epetra_MultiVector&, dealii::IndexSet, dealii::VectorOperation::values&, const MPI_Comm&, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&)'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::Vector<OtherNumber>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = double]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::Vector<Number>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = double]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note:   candidate expects 3 arguments, 5 provided
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:16:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note: candidate: template<class MemorySpace> void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with MemorySpace = MemorySpace; Number = double]
     import(const distributed::Vector<Number, MemorySpace> &vec,
     ^~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note:   template argument deduction/substitution failed:
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:17:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: note:   'const Epetra_MultiVector' is not derived from 'const dealii::LinearAlgebra::distributed::Vector<double, MemorySpace>'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = double]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h: In instantiation of 'void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = float]':
/home/paul/src/github.com/paulapatience/dealii/build/source/lac/read_write_vector.inst:19:17:   required from here
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: error: no matching function for call to 'dealii::LinearAlgebra::ReadWriteVector<float>::import(const Epetra_MultiVector&, dealii::IndexSet, dealii::VectorOperation::values&, const MPI_Comm&, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&)'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::Vector<OtherNumber>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = float]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::Vector<Number>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = float]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note:   candidate expects 3 arguments, 5 provided
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:16:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note: candidate: template<class MemorySpace> void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with MemorySpace = MemorySpace; Number = float]
     import(const distributed::Vector<Number, MemorySpace> &vec,
     ^~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note:   template argument deduction/substitution failed:
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:17:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: note:   'const Epetra_MultiVector' is not derived from 'const dealii::LinearAlgebra::distributed::Vector<float, MemorySpace>'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = float]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h: In instantiation of 'void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<double>]':
/home/paul/src/github.com/paulapatience/dealii/build/source/lac/read_write_vector.inst:58:17:   required from here
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: error: no matching function for call to 'dealii::LinearAlgebra::ReadWriteVector<std::complex<double> >::import(const Epetra_MultiVector&, dealii::IndexSet, dealii::VectorOperation::values&, const MPI_Comm&, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&)'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::Vector<OtherNumber>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<double>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::Vector<Number>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<double>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note:   candidate expects 3 arguments, 5 provided
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:16:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note: candidate: template<class MemorySpace> void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with MemorySpace = MemorySpace; Number = std::complex<double>]
     import(const distributed::Vector<Number, MemorySpace> &vec,
     ^~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note:   template argument deduction/substitution failed:
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:17:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: note:   'const Epetra_MultiVector' is not derived from 'const dealii::LinearAlgebra::distributed::Vector<std::complex<double>, MemorySpace>'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<double>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h: In instantiation of 'void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<float>]':
/home/paul/src/github.com/paulapatience/dealii/build/source/lac/read_write_vector.inst:65:17:   required from here
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: error: no matching function for call to 'dealii::LinearAlgebra::ReadWriteVector<std::complex<float> >::import(const Epetra_MultiVector&, dealii::IndexSet, dealii::VectorOperation::values&, const MPI_Comm&, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&)'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::Vector<OtherNumber>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<float>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:448:3: note:   candidate expects 3 arguments, 5 provided
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::Vector<Number>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<float>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:463:3: note:   candidate expects 3 arguments, 5 provided
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:16:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note: candidate: template<class MemorySpace> void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::LinearAlgebra::distributed::Vector<Number, MemorySpace>&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with MemorySpace = MemorySpace; Number = std::complex<float>]
     import(const distributed::Vector<Number, MemorySpace> &vec,
     ^~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.h:328:5: note:   template argument deduction/substitution failed:
In file included from /home/paul/src/github.com/paulapatience/dealii/source/lac/read_write_vector.cc:17:0:
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:852:11: note:   'const Epetra_MultiVector' is not derived from 'const dealii::LinearAlgebra::distributed::Vector<std::complex<float>, MemorySpace>'
     import(trilinos_vec.trilinos_vector(),
     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            trilinos_vec.locally_owned_elements(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            operation,
            ~~~~~~~~~~
            trilinos_vec.get_mpi_communicator(),
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            communication_pattern);
            ~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note: candidate: void dealii::LinearAlgebra::ReadWriteVector<Number>::import(const dealii::TrilinosWrappers::MPI::Vector&, dealii::VectorOperation::values, const std::shared_ptr<const dealii::Utilities::MPI::CommunicationPatternBase>&) [with Number = std::complex<float>]
   ReadWriteVector<Number>::import(
   ^~~~~~~~~~~~~~~~~~~~~~~
/home/paul/src/github.com/paulapatience/dealii/include/deal.II/lac/read_write_vector.templates.h:839:3: note:   candidate expects 3 arguments, 5 provided
make[2]: *** [source/lac/CMakeFiles/obj_lac_release.dir/build.make:284: source/lac/CMakeFiles/obj_lac_release.dir/read_write_vector.cc.o] Error 1
make[2]: Leaving directory '/home/paul/src/github.com/paulapatience/dealii/build'
make[1]: *** [CMakeFiles/Makefile2:2173: source/lac/CMakeFiles/obj_lac_release.dir/all] Error 2
make[1]: Leaving directory '/home/paul/src/github.com/paulapatience/dealii/build'
make: *** [Makefile:130: all] Error 2
```

I've also tried enabling `reinit(const TrilinosWrappers::MPI::Vector &)` and `import(const TrilinosWrappers::MPI::Vector &, ...)` only with MPI (in `read_write_vector.h` and `read_write_vector.templates.h`), but then the link step fails:

```
[ 77%] Linking CXX executable ../bin/step_3_mixed.release
ld: ../lib/libdeal_II.so.10.0.0-pre: undefined reference to `dealii::LinearAlgebra::ReadWriteVector<double>::import(dealii::TrilinosWrappers::MPI::Vector const&, dealii::VectorOperation::values, std::shared_ptr<dealii::Utilities::MPI::CommunicationPatternBase const> const&)'
ld: ../lib/libdeal_II.so.10.0.0-pre: undefined reference to `dealii::LinearAlgebra::ReadWriteVector<std::complex<double> >::import(dealii::TrilinosWrappers::MPI::Vector const&, dealii::VectorOperation::values, std::shared_ptr<dealii::Utilities::MPI::CommunicationPatternBase const> const&)'
ld: ../lib/libdeal_II.so.10.0.0-pre: undefined reference to `dealii::LinearAlgebra::ReadWriteVector<float>::import(dealii::TrilinosWrappers::MPI::Vector const&, dealii::VectorOperation::values, std::shared_ptr<dealii::Utilities::MPI::CommunicationPatternBase const> const&)'
ld: ../lib/libdeal_II.so.10.0.0-pre: undefined reference to `dealii::LinearAlgebra::ReadWriteVector<std::complex<float> >::import(dealii::TrilinosWrappers::MPI::Vector const&, dealii::VectorOperation::values, std::shared_ptr<dealii::Utilities::MPI::CommunicationPatternBase const> const&)'
collect2: error: ld returned 1 exit status
make[2]: *** [examples/CMakeFiles/step_3_mixed.release.dir/build.make:184: bin/step_3_mixed.release] Error 1
make[2]: Leaving directory '/home/paul/src/github.com/paulapatience/dealii/build'
make[1]: *** [CMakeFiles/Makefile2:3793: examples/CMakeFiles/step_3_mixed.release.dir/all] Error 2
make[1]: Leaving directory '/home/paul/src/github.com/paulapatience/dealii/build'
make: *** [Makefile:130: all] Error 2
```

As I am yet a deal.II neophyte, I don't quite know where to go from here, so any help would be much appreciated.