### PR TITLE
A better assert in FE_Q_Base::get_subface_interpolation_matrix

### DIFF
--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -632,10 +632,10 @@ FE_Q_Base<dim, spacedim>::get_subface_interpolation_matrix(
          ExcDimensionMismatch(interpolation_matrix.m(),
                               source_fe.n_dofs_per_face(face_no)));
 
-  // see if source is a Q or P element
-  if ((dynamic_cast<const FE_Q_Base<dim, spacedim> *>(&source_fe) != nullptr) ||
-      (dynamic_cast<const FE_SimplexPoly<dim, spacedim> *>(&source_fe) !=
-       nullptr))
+  Assert(source_fe.n_components() == this->n_components(),
+         ExcDimensionMismatch(source_fe.n_components(), this->n_components()));
+
+  if (source_fe.has_face_support_points(face_no))
     {
       // have this test in here since a table of size 2x0 reports its size as
       // 0x0


### PR DESCRIPTION
The previous assert checked that the element derived from FE_Q_Base
or FE_SimplexPoly. This isn't right for FE_Bernstein, which derives
from FE_Q_Base, but doesn't have support points. Instead of throwing
ExcInterpolationNotImplemented, using FE_Bernstein resulted in an
exception which was hard to understand. Change the assert so that it
checks if the incoming element has support points on the face.