### PR TITLE
RemotePointEvaluation: fix race condition if called multiple times

### DIFF
--- a/include/deal.II/base/mpi_remote_point_evaluation.h
+++ b/include/deal.II/base/mpi_remote_point_evaluation.h
@@ -282,6 +282,9 @@ namespace Utilities
       (void)buffer;
       (void)evaluation_function;
 #else
+      static CollectiveMutex      mutex;
+      CollectiveMutex::ScopedLock lock(mutex, tria->get_communicator());
+
       output.resize(point_ptrs.back());
       buffer.resize(send_permutation.size() * 2);
       ArrayView<T> buffer_1(buffer.data(), buffer.size() / 2);
@@ -399,6 +402,9 @@ namespace Utilities
       (void)buffer;
       (void)evaluation_function;
 #else
+      static CollectiveMutex      mutex;
+      CollectiveMutex::ScopedLock lock(mutex, tria->get_communicator());
+
       const auto &ptr = this->get_point_ptrs();
 
       std::map<unsigned int, std::vector<T>> temp_recv_map;


### PR DESCRIPTION
... as reported by @mschreter 

This is a temporal solution for the release; I have tried out `MPI_Issend` and `MPI_Irsend` but both did not fix the issue.