### PR TITLE
Bugfix step-75: Call `get_fe()` only on locally owned cells.

### DIFF
--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -745,17 +745,20 @@ namespace Step75
             auto cell_other = dof_handler_fine.begin_active();
             for (auto &cell : dof_handler_coarse.active_cell_iterators())
               {
-                const unsigned int next_degree =
-                  MGTransferGlobalCoarseningTools::
-                    create_next_polynomial_coarsening_degree(
-                      cell_other->get_fe().degree, mg_data.transfer.p_sequence);
-                Assert(fe_index_for_degree.find(next_degree) !=
-                         fe_index_for_degree.end(),
-                       ExcMessage("Next polynomial degree in sequence "
-                                  "does not exist in FECollection."));
-
                 if (cell->is_locally_owned())
-                  cell->set_active_fe_index(fe_index_for_degree[next_degree]);
+                  {
+                    const unsigned int next_degree =
+                      MGTransferGlobalCoarseningTools::
+                        create_next_polynomial_coarsening_degree(
+                          cell_other->get_fe().degree,
+                          mg_data.transfer.p_sequence);
+                    Assert(fe_index_for_degree.find(next_degree) !=
+                             fe_index_for_degree.end(),
+                           ExcMessage("Next polynomial degree in sequence "
+                                      "does not exist in FECollection."));
+
+                    cell->set_active_fe_index(fe_index_for_degree[next_degree]);
+                  }
                 cell_other++;
               }
           }


### PR DESCRIPTION
`step-75` can not be run in `debug` mode as we access active FE indices on artificial cells. This fix adds another conditional to ignore these cells.

I overlooked this bug as I was running the tutorial only in release mode from some point on. This change has no effect on the results. I would like to make this part of Release 9.3.