### PR TITLE
Remove deprecated versions of the DoFTools::count_dofs_per_*()

### DIFF
--- a/doc/news/changes/incompatibilities/20210601DanielArndt
+++ b/doc/news/changes/incompatibilities/20210601DanielArndt
@@ -1,0 +1,4 @@
+Removed: The deprecated versions of DoFTools::count_dofs_per_component()
+and DoFTools::count_dofs_per_block() have been removed.
+<br>
+(Daniel Arndt, 2021/06/01)

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -2077,18 +2077,6 @@ namespace DoFTools
     const std::vector<unsigned int> &target_component   = {});
 
   /**
-   * @deprecated A version of the previous function that returns its
-   * information through the non-`const` second argument.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  count_dofs_per_component(
-    const DoFHandler<dim, spacedim> &     dof_handler,
-    std::vector<types::global_dof_index> &dofs_per_component,
-    const bool                            vector_valued_once = false,
-    const std::vector<unsigned int> &     target_component   = {});
-
-  /**
    * Count the degrees of freedom in each block. This function is similar to
    * count_dofs_per_component(), with the difference that the counting is done
    * by blocks. See
@@ -2109,17 +2097,6 @@ namespace DoFTools
   count_dofs_per_fe_block(const DoFHandler<dim, spacedim> &dof,
                           const std::vector<unsigned int> &target_block =
                             std::vector<unsigned int>());
-
-  /**
-   * @deprecated A version of the previous function that returns its
-   * information through the non-`const` second argument.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  count_dofs_per_block(const DoFHandler<dim, spacedim> &     dof,
-                       std::vector<types::global_dof_index> &dofs_per_block,
-                       const std::vector<unsigned int> &     target_block =
-                         std::vector<unsigned int>());
 
   /**
    * For each active cell of a DoFHandler, extract the active finite element

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1846,21 +1846,6 @@ namespace DoFTools
 
 
 
-  // deprecated function
-  template <int dim, int spacedim>
-  void
-  count_dofs_per_component(
-    const DoFHandler<dim, spacedim> &     dof_handler,
-    std::vector<types::global_dof_index> &dofs_per_component,
-    const bool                            only_once,
-    const std::vector<unsigned int> &     target_component)
-  {
-    dofs_per_component =
-      count_dofs_per_fe_component(dof_handler, only_once, target_component);
-  }
-
-
-
   template <int dim, int spacedim>
   std::vector<types::global_dof_index>
   count_dofs_per_fe_component(
@@ -1949,18 +1934,6 @@ namespace DoFTools
 #endif
 
     return dofs_per_component;
-  }
-
-
-
-  // deprecated function
-  template <int dim, int spacedim>
-  void
-  count_dofs_per_block(const DoFHandler<dim, spacedim> &     dof_handler,
-                       std::vector<types::global_dof_index> &dofs_per_block,
-                       const std::vector<unsigned int> &     target_block)
-  {
-    dofs_per_block = count_dofs_per_fe_block(dof_handler, target_block);
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -54,21 +54,6 @@ for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
           &                  dof_handler,
         const ComponentMask &components);
 
-      // deprecated versions of the count_dofs_per_*() functions
-      template void
-      count_dofs_per_component<deal_II_dimension, deal_II_space_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        std::vector<types::global_dof_index> &,
-        const bool,
-        const std::vector<unsigned int> &);
-
-      template void
-      count_dofs_per_block<deal_II_dimension, deal_II_space_dimension>(
-        const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,
-        std::vector<types::global_dof_index> &,
-        const std::vector<unsigned int> &);
-
-      // new versions of the count_dofs_per_*() functions
       template std::vector<types::global_dof_index>
       count_dofs_per_fe_component<deal_II_dimension, deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension> &,

--- a/tests/symengine/sd_common_tests/step-44-sd-quadrature_level.h
+++ b/tests/symengine/sd_common_tests/step-44-sd-quadrature_level.h
@@ -1055,9 +1055,8 @@ namespace Step44
     dof_handler_ref.distribute_dofs(fe);
     DoFRenumbering::Cuthill_McKee(dof_handler_ref);
     DoFRenumbering::component_wise(dof_handler_ref, block_component);
-    DoFTools::count_dofs_per_block(dof_handler_ref,
-                                   dofs_per_block,
-                                   block_component);
+    dofs_per_block =
+      DoFTools::count_dofs_per_block(dof_handler_ref, block_component);
     std::cout << "Triangulation:"
               << "\n\t Number of active cells: "
               << triangulation.n_active_cells()


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/9272.