### PR TITLE
Remove deprecated multigrid transfer build_matrices() functions

### DIFF
--- a/doc/news/changes/incompatibilities/20210601DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20210601DanielArndt-1
@@ -1,0 +1,4 @@
+Removed: The deprecated build_matrices() member functions
+in various multigrid transfer classes have been removed.
+<br>
+(Daniel Arndt, 2021/06/01)

--- a/include/deal.II/multigrid/mg_transfer.h
+++ b/include/deal.II/multigrid/mg_transfer.h
@@ -674,15 +674,6 @@ public:
   build(const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
-   * Actually build the prolongation matrices for each level.
-   *
-   * @deprecated use build() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(const DoFHandler<dim, spacedim> &dof_handler);
-
-  /**
    * Prolongate a vector from level <tt>to_level-1</tt> to level
    * <tt>to_level</tt> using the embedding matrices of the underlying finite
    * element. The previous content of <tt>dst</tt> is overwritten.

--- a/include/deal.II/multigrid/mg_transfer_block.h
+++ b/include/deal.II/multigrid/mg_transfer_block.h
@@ -90,20 +90,6 @@ protected:
   build(const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
-   * Actually build the prolongation matrices for each level.
-   *
-   * This function is only called by derived classes. These can also set the
-   * member variables #selected and others to restrict the transfer matrices
-   * to certain blocks.
-   *
-   * @deprecated Use build() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(const DoFHandler<dim, spacedim> &dof,
-                 const DoFHandler<dim, spacedim> &mg_dof);
-
-  /**
    * Flag of selected blocks.
    *
    * The transfer operators only act on the blocks having a <tt>true</tt>
@@ -227,20 +213,6 @@ public:
   build(const DoFHandler<dim, spacedim> &dof_handler,
         const std::vector<bool> &        selected);
 
-  /**
-   * Build the prolongation matrices for each level.
-   *
-   * This function is a front-end for the same function in
-   * MGTransferBlockBase.
-   *
-   * @deprecated Use the build() function instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(const DoFHandler<dim, spacedim> &dof,
-                 const DoFHandler<dim, spacedim> &mg_dof,
-                 const std::vector<bool> &        selected);
-
   virtual void
   prolongate(const unsigned int         to_level,
              BlockVector<number> &      dst,
@@ -354,25 +326,6 @@ public:
   template <int dim, int spacedim>
   void
   build(const DoFHandler<dim, spacedim> &dof_handler, unsigned int selected);
-
-  /**
-   * Actually build the prolongation matrices for grouped blocks.
-   *
-   * This function is a front-end for the same function in
-   * MGTransferBlockBase.
-   *
-   * @param dof The DoFHandler for the active degrees of freedom to use.
-   * @param mg_dof The DoFHandler for the level degrees of freedom to use.
-   * @param selected Number of the block of the global vector to be copied from
-   * and to the multilevel vector.
-   *
-   * @deprecated Use build() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(const DoFHandler<dim, spacedim> &dof,
-                 const DoFHandler<dim, spacedim> &mg_dof,
-                 unsigned int                     selected);
 
   /**
    * Change selected block. Handle with care!

--- a/include/deal.II/multigrid/mg_transfer_component.h
+++ b/include/deal.II/multigrid/mg_transfer_component.h
@@ -84,23 +84,6 @@ protected:
   build(const DoFHandler<dim, spacedim> &dof_handler);
 
   /**
-   * Actually build the prolongation matrices for each level.
-   *
-   * This function is only called by derived classes. These can also set the
-   * member variables <code>selected_component</code> and
-   * <code>mg_selected_component</code> member variables to restrict the
-   * transfer matrices to certain components. Furthermore, they use
-   * <code>target_component</code> and <code>mg_target_component</code> for
-   * re-ordering and grouping of components.
-   *
-   * @deprecated Use build() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(const DoFHandler<dim, spacedim> &dof,
-                 const DoFHandler<dim, spacedim> &mg_dof);
-
-  /**
    * Flag of selected components.
    *
    * The transfer operators only act on the components having a <tt>true</tt>
@@ -208,47 +191,6 @@ public:
   virtual ~MGTransferSelect() override = default;
 
   // TODO: rewrite docs; make sure defaulted args are actually allowed
-  /**
-   * Actually build the prolongation matrices for grouped components.
-   *
-   * This function is a front-end for the same function in
-   * MGTransferComponentBase.
-   *
-   * @arg selected: Number of the block of the global vector to be copied from
-   * and to the multilevel vector. This number refers to the renumbering by
-   * <tt>target_component</tt>.
-   *
-   * @arg mg_selected: Number of the block for which the transfer matrices
-   * should be built.
-   *
-   * If <tt>mg_target_component</tt> is present, this refers to the renumbered
-   * components.
-   *
-   * @arg target_component: this argument allows grouping and renumbering of
-   * components in the fine-level vector (see DoFRenumbering::component_wise).
-   *
-   * @arg mg_target_component: this argument allows grouping and renumbering
-   * of components in the level vectors (see DoFRenumbering::component_wise).
-   * It also affects the behavior of the <tt>selected</tt> argument
-   *
-   * @arg boundary_indices: holds the boundary indices on each level.
-   *
-   * @deprecated Use build() instead.
-   */
-  template <int dim, int spacedim>
-  DEAL_II_DEPRECATED void
-  build_matrices(
-    const DoFHandler<dim, spacedim> &dof,
-    const DoFHandler<dim, spacedim> &mg_dof,
-    unsigned int                     selected,
-    unsigned int                     mg_selected,
-    const std::vector<unsigned int> &target_component =
-      std::vector<unsigned int>(),
-    const std::vector<unsigned int> &mg_target_component =
-      std::vector<unsigned int>(),
-    const std::vector<std::set<types::global_dof_index>> &boundary_indices =
-      std::vector<std::set<types::global_dof_index>>());
-
   /**
    * Actually build the prolongation matrices for grouped components.
    *

--- a/source/multigrid/mg_transfer_block.cc
+++ b/source/multigrid/mg_transfer_block.cc
@@ -204,17 +204,6 @@ MGTransferBlock<number>::copy_to_mg(
 
 template <int dim, int spacedim>
 void
-MGTransferBlockBase::build_matrices(
-  const DoFHandler<dim, spacedim> & /*dof*/,
-  const DoFHandler<dim, spacedim> &mg_dof_handler)
-{
-  build(mg_dof_handler);
-}
-
-
-
-template <int dim, int spacedim>
-void
 MGTransferBlockBase::build(const DoFHandler<dim, spacedim> &dof_handler)
 {
   const FiniteElement<dim> &fe            = dof_handler.get_fe();
@@ -480,17 +469,6 @@ MGTransferBlockBase::build(const DoFHandler<dim, spacedim> &dof_handler)
 template <typename number>
 template <int dim, int spacedim>
 void
-MGTransferBlockSelect<number>::build_matrices(
-  const DoFHandler<dim, spacedim> & /*dof*/,
-  const DoFHandler<dim, spacedim> &mg_dof,
-  unsigned int                     select)
-{
-  build(mg_dof, select);
-}
-
-template <typename number>
-template <int dim, int spacedim>
-void
 MGTransferBlockSelect<number>::build(
   const DoFHandler<dim, spacedim> &dof_handler,
   unsigned int                     select)
@@ -575,17 +553,6 @@ MGTransferBlockSelect<number>::build(
     }
 }
 
-
-template <typename number>
-template <int dim, int spacedim>
-void
-MGTransferBlock<number>::build_matrices(
-  const DoFHandler<dim, spacedim> & /*dof*/,
-  const DoFHandler<dim, spacedim> &mg_dof,
-  const std::vector<bool> &        sel)
-{
-  build(mg_dof, sel);
-}
 
 template <typename number>
 template <int dim, int spacedim>

--- a/source/multigrid/mg_transfer_block.inst.in
+++ b/source/multigrid/mg_transfer_block.inst.in
@@ -29,30 +29,6 @@ for (deal_II_dimension : DIMENSIONS)
     template void MGTransferBlockSelect<double>::build<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &, const unsigned int);
 
-    // deprecated:
-    template void MGTransferBlock<float>::build_matrices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &,
-      const DoFHandler<deal_II_dimension> &,
-      const std::vector<bool> &);
-
-    // deprecated:
-    template void MGTransferBlock<double>::build_matrices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &,
-      const DoFHandler<deal_II_dimension> &,
-      const std::vector<bool> &);
-
-    // deprecated:
-    template void MGTransferBlockSelect<float>::build_matrices<
-      deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
-                         const DoFHandler<deal_II_dimension> &,
-                         const unsigned int);
-
-    // deprecated:
-    template void MGTransferBlockSelect<double>::build_matrices<
-      deal_II_dimension>(const DoFHandler<deal_II_dimension> &,
-                         const DoFHandler<deal_II_dimension> &,
-                         const unsigned int);
-
     template void MGTransferBlock<float>::copy_to_mg(
       const DoFHandler<deal_II_dimension> &,
       MGLevelObject<BlockVector<float>> &,

--- a/source/multigrid/mg_transfer_component.cc
+++ b/source/multigrid/mg_transfer_component.cc
@@ -254,16 +254,6 @@ MGTransferSelect<number>::do_copy_to_mg(
 
 template <int dim, int spacedim>
 void
-MGTransferComponentBase::build_matrices(const DoFHandler<dim, spacedim> &,
-                                        const DoFHandler<dim, spacedim> &mg_dof)
-{
-  build(mg_dof);
-}
-
-
-
-template <int dim, int spacedim>
-void
 MGTransferComponentBase::build(const DoFHandler<dim, spacedim> &mg_dof)
 {
   // Fill target component with
@@ -564,23 +554,6 @@ MGTransferComponentBase::build(const DoFHandler<dim, spacedim> &mg_dof)
                 }
         }
     }
-}
-
-
-
-template <typename number>
-template <int dim, int spacedim>
-void
-MGTransferSelect<number>::build_matrices(
-  const DoFHandler<dim, spacedim> & /*dof*/,
-  const DoFHandler<dim, spacedim> &                     mg_dof,
-  unsigned int                                          select,
-  unsigned int                                          mg_select,
-  const std::vector<unsigned int> &                     t_component,
-  const std::vector<unsigned int> &                     mg_t_component,
-  const std::vector<std::set<types::global_dof_index>> &bdry_indices)
-{
-  build(mg_dof, select, mg_select, t_component, mg_t_component, bdry_indices);
 }
 
 

--- a/source/multigrid/mg_transfer_component.inst.in
+++ b/source/multigrid/mg_transfer_component.inst.in
@@ -33,26 +33,6 @@ for (deal_II_dimension : DIMENSIONS)
       const std::vector<unsigned int> &,
       const std::vector<std::set<types::global_dof_index>> &);
 
-    // deprecated:
-    template void MGTransferSelect<float>::build_matrices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &d,
-      const DoFHandler<deal_II_dimension> &,
-      unsigned int,
-      unsigned int,
-      const std::vector<unsigned int> &,
-      const std::vector<unsigned int> &,
-      const std::vector<std::set<types::global_dof_index>> &);
-
-    // deprecated:
-    template void MGTransferSelect<double>::build_matrices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &d,
-      const DoFHandler<deal_II_dimension> &,
-      unsigned int,
-      unsigned int,
-      const std::vector<unsigned int> &,
-      const std::vector<unsigned int> &,
-      const std::vector<std::set<types::global_dof_index>> &);
-
     template void MGTransferSelect<float>::copy_to_mg(
       const DoFHandler<deal_II_dimension> &,
       MGLevelObject<Vector<float>> &,

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -346,17 +346,6 @@ MGTransferPrebuilt<VectorType>::build(
 
 
 template <typename VectorType>
-template <int dim, int spacedim>
-void
-MGTransferPrebuilt<VectorType>::build_matrices(
-  const DoFHandler<dim, spacedim> &dof_handler)
-{
-  build(dof_handler);
-}
-
-
-
-template <typename VectorType>
 void
 MGTransferPrebuilt<VectorType>::print_matrices(std::ostream &os) const
 {

--- a/source/multigrid/mg_transfer_prebuilt.inst.in
+++ b/source/multigrid/mg_transfer_prebuilt.inst.in
@@ -24,7 +24,4 @@ for (deal_II_dimension : DIMENSIONS; V1 : VECTORS_WITH_MATRIX)
   {
     template void MGTransferPrebuilt<V1>::build<deal_II_dimension>(
       const DoFHandler<deal_II_dimension> &mg_dof);
-
-    template void MGTransferPrebuilt<V1>::build_matrices<deal_II_dimension>(
-      const DoFHandler<deal_II_dimension> &mg_dof);
   }

--- a/tests/multigrid/mg_data_out_03.cc
+++ b/tests/multigrid/mg_data_out_03.cc
@@ -77,7 +77,7 @@ do_test()
 
     MGTransferPrebuilt<Vector<double>> transfer;
 
-    transfer.build_matrices(dof_handler);
+    transfer.build(dof_handler);
 
     // This is not quite the correct thing to do, but "interpolate_to_mg"
     // doesn't exist for serial vectors. Here it means that the level 0 is 0


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/9280.