### PR TITLE
Throw ExcImpossibleInDim(0) in Quadrature<0> constructor taking Quadrature<1>.

### DIFF
--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -210,7 +210,10 @@ Quadrature<0>::Quadrature(const Quadrature<1> &)
   // quadrature_points(1),
   weights(1, 1.)
   , is_tensor_product_flag(false)
-{}
+{
+  Assert(false, ExcImpossibleInDim(0));
+}
+
 
 
 template <>


### PR DESCRIPTION
The constructor should create a tensor product of the incoming 1D-quadrature, but this doesn't make sense if dim = 0.