### PR TITLE
Add a 0-dimensional face support point on FE_Q<1>.

### DIFF
--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -978,10 +978,6 @@ void
 FE_Q_Base<dim, spacedim>::initialize_unit_face_support_points(
   const std::vector<Point<1>> &points)
 {
-  // no faces in 1d, so nothing to do
-  if (dim == 1)
-    return;
-
   // TODO: the implementation makes the assumption that all faces have the
   // same number of dofs
   AssertDimension(this->n_unique_faces(), 1);
@@ -989,6 +985,11 @@ FE_Q_Base<dim, spacedim>::initialize_unit_face_support_points(
 
   this->unit_face_support_points[face_no].resize(
     Utilities::fixed_power<dim - 1>(q_degree + 1));
+
+  // In 1D, there is only one 0-dimensional support point, so there is nothing
+  // more to be done.
+  if (dim == 1)
+    return;
 
   // find renumbering of faces and assign from values of quadrature
   const std::vector<unsigned int> face_index_map =

--- a/tests/fe/fe_data_test.output
+++ b/tests/fe/fe_data_test.output
@@ -50,7 +50,7 @@ DEAL::blocks=1:[2]->2
 DEAL::degree=1
 DEAL::conformity= Hcurl Hdiv H1
 DEAL::unit_support_points=2
-DEAL::unit_face_support_points=0
+DEAL::unit_face_support_points=1
 DEAL::generalized_support_points=2
 DEAL::face_to_equivalent_cell_index: 0
 DEAL::face_to_cell_index: 0
@@ -76,7 +76,7 @@ DEAL::blocks=1:[3]->3
 DEAL::degree=2
 DEAL::conformity= Hcurl Hdiv H1
 DEAL::unit_support_points=3
-DEAL::unit_face_support_points=0
+DEAL::unit_face_support_points=1
 DEAL::generalized_support_points=3
 DEAL::face_to_equivalent_cell_index: 0
 DEAL::face_to_cell_index: 0
@@ -102,7 +102,7 @@ DEAL::blocks=1:[5]->5
 DEAL::degree=4
 DEAL::conformity= Hcurl Hdiv H1
 DEAL::unit_support_points=5
-DEAL::unit_face_support_points=0
+DEAL::unit_face_support_points=1
 DEAL::generalized_support_points=5
 DEAL::face_to_equivalent_cell_index: 0
 DEAL::face_to_cell_index: 0

--- a/tests/fe/fe_support_points_q.cc
+++ b/tests/fe/fe_support_points_q.cc
@@ -25,6 +25,8 @@ main()
 {
   initlog();
 
+  CHECK_ALL(Q, 1, 1);
+
   CHECK_ALL(Q, 1, 2);
   CHECK_ALL(Q, 2, 2);
   CHECK_ALL(Q, 3, 2);

--- a/tests/fe/fe_support_points_q.output
+++ b/tests/fe/fe_support_points_q.output
@@ -1,4 +1,14 @@
 
+DEAL::Q1<1> cell support points
+DEAL::0.00
+DEAL::1.00
+DEAL::Q1<1> face 0 support points
+DEAL::0.00
+DEAL::Q1<1> face 1 support points
+DEAL::1.00
+DEAL::Q1<1> cell generalized support points
+DEAL::0.00
+DEAL::1.00
 DEAL::Q1<2> cell support points
 DEAL::0.00 0.00
 DEAL::1.00 0.00


### PR DESCRIPTION
In several places QProjector is used to map the dim-1 dimensional face support points to dim dimensional points, but this is not possible in 1D because unit_face_support_points currently contains no points for FE_Q<1>. Add a single 0-dimensional point to unit_face_support_points to fix this.

Does this make sense or is it a specific choice that FE_Q<1> should NOT have face support points? I couldn't find anything about this in the documentation.