### PR TITLE
Allow DEAL_II_DEPRECATED_EARLY in user code

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -163,7 +163,10 @@
  * deprecated prior to a release until <em>after</em> that release has been
  * finalized - see DEAL_II_EARLY_DEPRECATIONS for more information.
  */
+#ifndef DEAL_II_DEPRECATED_EARLY
+// guard to allow user to override DEAL_II_DEPRECATED_EARLY
 #cmakedefine DEAL_II_DEPRECATED_EARLY @DEAL_II_DEPRECATED_EARLY@
+#endif
 #cmakedefine DEAL_II_FALLTHROUGH @DEAL_II_FALLTHROUGH@
 #cmakedefine DEAL_II_CONSTEXPR @DEAL_II_CONSTEXPR@
 


### PR DESCRIPTION
This way I can write simply:
```cmake
add_compile_definitions(${libName} PUBLIC DEAL_II_DEPRECATED_EARLY=[[deprecated]])
```
to enable early deprecation in an application code even if deal.II has not been configured that way.

Does anyone know a better way to accomplish the same? I am happy for alternative and maybe cleaner approaches!

closes #12349