### PR TITLE
Remove deprecated CellAccessor::active()

### DIFF
--- a/contrib/python-bindings/source/cell_accessor_wrapper.cc
+++ b/contrib/python-bindings/source/cell_accessor_wrapper.cc
@@ -679,11 +679,11 @@ namespace python
   CellAccessorWrapper::active() const
   {
     if ((dim == 2) && (spacedim == 2))
-      return internal::cell_cast<2, 2>(cell_accessor)->active();
+      return internal::cell_cast<2, 2>(cell_accessor)->is_active();
     else if ((dim == 2) && (spacedim == 3))
-      return internal::cell_cast<2, 3>(cell_accessor)->active();
+      return internal::cell_cast<2, 3>(cell_accessor)->is_active();
     else
-      return internal::cell_cast<3, 3>(cell_accessor)->active();
+      return internal::cell_cast<3, 3>(cell_accessor)->is_active();
   }
 
 

--- a/doc/news/changes/incompatibilities/20210603DanielArndt
+++ b/doc/news/changes/incompatibilities/20210603DanielArndt
@@ -1,0 +1,3 @@
+Removed: The deprecated member function CellAccessor::active() has been removed.
+<br>
+(Daniel Arndt, 2021/06/03)

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3644,23 +3644,6 @@ public:
    * See the
    * @ref GlossActive "glossary"
    * for more information.
-   *
-   * @deprecated This function is deprecated. Use the is_active()
-   *   function instead, which satisfies the naming scheme of other
-   *   functions inquiring about yes/no properties of cells (e.g.,
-   *   is_ghost(), is_locally_owned(), etc.).
-   */
-  DEAL_II_DEPRECATED
-  bool
-  active() const;
-
-  /**
-   * Test that the cell has no children (this is the criterion for whether a
-   * cell is called "active").
-   *
-   * See the
-   * @ref GlossActive "glossary"
-   * for more information.
    */
   bool
   is_active() const;

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3661,15 +3661,6 @@ CellAccessor<dim, spacedim>::neighbor(const unsigned int face_no) const
 
 template <int dim, int spacedim>
 inline bool
-CellAccessor<dim, spacedim>::active() const
-{
-  return !this->has_children();
-}
-
-
-
-template <int dim, int spacedim>
-inline bool
 CellAccessor<dim, spacedim>::is_active() const
 {
   return !this->has_children();

--- a/tests/base/mpi_noncontiguous_partitioner_02.cc
+++ b/tests/base/mpi_noncontiguous_partitioner_02.cc
@@ -75,7 +75,7 @@ test(const MPI_Comm &comm, const bool do_revert, const unsigned int dir)
 
   // ... has (symm)
   for (const auto &cell : dof_handler.active_cell_iterators())
-    if (cell->active() && cell->is_locally_owned())
+    if (cell->is_active() && cell->is_locally_owned())
       {
         auto c = cell->center();
         for (unsigned int i = 0; i < dim; i++)

--- a/tests/matrix_free/compute_diagonal_01.cc
+++ b/tests/matrix_free/compute_diagonal_01.cc
@@ -33,7 +33,8 @@ test()
 
   tria.refine_global();
   for (auto &cell : tria.active_cell_iterators())
-    if (cell->active() && cell->is_locally_owned() && cell->center()[0] < 0.0)
+    if (cell->is_active() && cell->is_locally_owned() &&
+        cell->center()[0] < 0.0)
       cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 

--- a/tests/matrix_free/compute_diagonal_04.cc
+++ b/tests/matrix_free/compute_diagonal_04.cc
@@ -32,7 +32,8 @@ test()
 
   tria.refine_global();
   for (auto &cell : tria.active_cell_iterators())
-    if (cell->active() && cell->is_locally_owned() && cell->center()[0] < 0.0)
+    if (cell->is_active() && cell->is_locally_owned() &&
+        cell->center()[0] < 0.0)
       cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_a_01.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_01.cc
@@ -68,7 +68,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
     tria.refine_global();
 
     for (auto &cell : tria.active_cell_iterators())
-      if (cell->active() && cell->center()[0] < 0.5)
+      if (cell->is_active() && cell->center()[0] < 0.5)
         cell->set_refine_flag();
     tria.execute_coarsening_and_refinement();
   };

--- a/tests/multigrid-global-coarsening/mg_transfer_a_02.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_02.cc
@@ -55,7 +55,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
     tria.refine_global();
 
     for (auto &cell : tria.active_cell_iterators())
-      if (cell->active() && cell->center()[0] < 0.5)
+      if (cell->is_active() && cell->center()[0] < 0.5)
         cell->set_refine_flag();
     tria.execute_coarsening_and_refinement();
   };

--- a/tests/multigrid-global-coarsening/mg_transfer_a_03.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_a_03.cc
@@ -55,7 +55,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
     tria.refine_global();
 
     for (auto &cell : tria.active_cell_iterators())
-      if (cell->active() && cell->center()[0] < 0.5)
+      if (cell->is_active() && cell->center()[0] < 0.5)
         cell->set_refine_flag();
     tria.execute_coarsening_and_refinement();
   };

--- a/tests/multigrid-global-coarsening/mg_transfer_p_01.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_01.cc
@@ -70,7 +70,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   tria.refine_global();
 
   for (auto &cell : tria.active_cell_iterators())
-    if (cell->active() && cell->center()[0] < 0.5)
+    if (cell->is_active() && cell->center()[0] < 0.5)
       cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_03.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_03.cc
@@ -57,7 +57,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
   tria.refine_global();
 
   for (auto &cell : tria.active_cell_iterators())
-    if (cell->active() && cell->center()[0] < 0.5)
+    if (cell->is_active() && cell->center()[0] < 0.5)
       cell->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 

--- a/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
+++ b/tests/multigrid-global-coarsening/mg_transfer_p_04.cc
@@ -94,7 +94,7 @@ do_test(const FiniteElement<dim> &fe_fine, const FiniteElement<dim> &fe_coarse)
     tria.refine_global();
 
     for (auto &cell : tria.active_cell_iterators())
-      if (cell->active() && cell->center()[0] < 0.5)
+      if (cell->is_active() && cell->center()[0] < 0.5)
         cell->set_refine_flag();
     tria.execute_coarsening_and_refinement();
   };

--- a/tests/multigrid/mg_data_out_01.cc
+++ b/tests/multigrid/mg_data_out_01.cc
@@ -36,7 +36,8 @@ print(DataOut<dim> &data_out, const Triangulation<dim> &tria)
   for (auto cell = p.first(tria); cell.state() == IteratorState::valid;
        cell      = p.second(tria, cell))
     {
-      deallog << " cell lvl=" << cell->level() << " active=" << cell->active()
+      deallog << " cell lvl=" << cell->level()
+              << " active=" << cell->is_active()
               << " id=" << cell->id().to_string() << std::endl;
     }
 }

--- a/tests/multigrid/mg_data_out_02.cc
+++ b/tests/multigrid/mg_data_out_02.cc
@@ -37,7 +37,8 @@ print(DataOut<dim> &data_out, const Triangulation<dim> &tria)
   for (auto cell = p.first(tria); cell.state() == IteratorState::valid;
        cell      = p.second(tria, cell))
     {
-      deallog << " cell lvl=" << cell->level() << " active=" << cell->active()
+      deallog << " cell lvl=" << cell->level()
+              << " active=" << cell->is_active()
               << " owner=" << static_cast<int>(cell->level_subdomain_id())
               << " id=" << cell->id().to_string() << std::endl;
     }


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/9352.