### PR TITLE
Remove deprecated FETools::lexicographic/hierarchc_to_hierarchic/lexicographic_numbering

### DIFF
--- a/doc/news/changes/incompatibilities/20210603DanielArndt-2
+++ b/doc/news/changes/incompatibilities/20210603DanielArndt-2
@@ -1,0 +1,5 @@
+Removed: The deprecated overloads of 
+FETools::lexicographic_to_hierarchic_numbering() and
+FETools::hierarchic_to_lexicographic_numbering() have been removed.
+<br>
+(Daniel Arndt, 2021/06/03)

--- a/include/deal.II/fe/fe_tools.h
+++ b/include/deal.II/fe/fe_tools.h
@@ -881,38 +881,6 @@ namespace FETools
   hierarchic_to_lexicographic_numbering(unsigned int degree);
 
   /**
-   * Like the previous function but instead of returning its result as a value
-   * return it through the last argument.
-   *
-   * @deprecated Use the function that returns the renumbering in a vector
-   * instead.
-   */
-  template <int dim>
-  DEAL_II_DEPRECATED void
-  hierarchic_to_lexicographic_numbering(unsigned int               degree,
-                                        std::vector<unsigned int> &h2l);
-
-  /**
-   * Like the previous functions but using a FiniteElementData instead of the
-   * polynomial degree.
-   *
-   * @deprecated Use the function that returns the renumbering in a vector and
-   * uses the degree of the basis as an argument instead.
-   */
-  template <int dim>
-  DEAL_II_DEPRECATED void
-  hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data,
-                                        std::vector<unsigned int> &   h2l);
-
-  /**
-   * @deprecated Use the function that uses the degree of the basis as an
-   * argument instead.
-   */
-  template <int dim>
-  DEAL_II_DEPRECATED std::vector<unsigned int>
-                     hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe_data);
-
-  /**
    * This is the reverse function to the above one, generating the map from
    * the lexicographic to the hierarchical numbering for a given polynomial
    * degree of a continuous finite element. All the remarks made about the
@@ -921,24 +889,6 @@ namespace FETools
   template <int dim>
   std::vector<unsigned int>
   lexicographic_to_hierarchic_numbering(unsigned int degree);
-
-  /**
-   * @deprecated Use the function that returns the renumbering in a vector and
-   * uses the degree of the basis as an argument instead.
-   */
-  template <int dim>
-  DEAL_II_DEPRECATED void
-  lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe_data,
-                                        std::vector<unsigned int> &   l2h);
-
-  /**
-   * @deprecated Use the function that uses the degree of the basis as an
-   * argument instead.
-   */
-  template <int dim>
-  DEAL_II_DEPRECATED std::vector<unsigned int>
-                     lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe_data);
-
 
   /**
    * A namespace that contains functions that help setting up internal

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -3153,66 +3153,12 @@ namespace FETools
 
 
   template <int dim>
-  void
-  hierarchic_to_lexicographic_numbering(const unsigned int         degree,
-                                        std::vector<unsigned int> &h2l)
-  {
-    AssertDimension(h2l.size(), Utilities::fixed_power<dim>(degree + 1));
-    h2l = hierarchic_to_lexicographic_numbering<dim>(degree);
-  }
-
-
-
-  template <int dim>
-  void
-  hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe,
-                                        std::vector<unsigned int> &   h2l)
-  {
-    Assert(h2l.size() == fe.n_dofs_per_cell(),
-           ExcDimensionMismatch(h2l.size(), fe.n_dofs_per_cell()));
-    hierarchic_to_lexicographic_numbering<dim>(fe.n_dofs_per_line() + 1, h2l);
-  }
-
-
-
-  template <int dim>
-  std::vector<unsigned int>
-  hierarchic_to_lexicographic_numbering(const FiniteElementData<dim> &fe)
-  {
-    Assert(fe.n_components() == 1, ExcInvalidFE());
-    return hierarchic_to_lexicographic_numbering<dim>(fe.n_dofs_per_line() + 1);
-  }
-
-
-
-  template <int dim>
   std::vector<unsigned int>
   lexicographic_to_hierarchic_numbering(const unsigned int degree)
   {
     return Utilities::invert_permutation(
       hierarchic_to_lexicographic_numbering<dim>(degree));
   }
-
-
-
-  template <int dim>
-  void
-  lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe,
-                                        std::vector<unsigned int> &   l2h)
-  {
-    l2h = lexicographic_to_hierarchic_numbering(fe);
-  }
-
-
-
-  template <int dim>
-  std::vector<unsigned int>
-  lexicographic_to_hierarchic_numbering(const FiniteElementData<dim> &fe)
-  {
-    return Utilities::invert_permutation(
-      hierarchic_to_lexicographic_numbering(fe));
-  }
-
 } // namespace FETools
 
 

--- a/source/fe/fe_tools.cc
+++ b/source/fe/fe_tools.cc
@@ -133,10 +133,6 @@ namespace FETools
     return std::make_unique<FE_DGQArbitraryNodes<3>>(quad);
   }
 
-  template void
-  hierarchic_to_lexicographic_numbering<0>(unsigned int,
-                                           std::vector<unsigned int> &);
-
   template std::vector<unsigned int>
   hierarchic_to_lexicographic_numbering<0>(unsigned int);
 

--- a/source/fe/fe_tools.inst.in
+++ b/source/fe/fe_tools.inst.in
@@ -254,34 +254,11 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         FullMatrix<double> &);
 #  endif
 
-      template void
-      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
-        unsigned int,
-        std::vector<unsigned int> &);
-
-      template void
-      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
-        const FiniteElementData<deal_II_dimension> &,
-        std::vector<unsigned int> &);
-
-      template void
-      lexicographic_to_hierarchic_numbering<deal_II_dimension>(
-        const FiniteElementData<deal_II_dimension> &,
-        std::vector<unsigned int> &);
-
       template std::vector<unsigned int>
       hierarchic_to_lexicographic_numbering<deal_II_dimension>(unsigned int);
 
       template std::vector<unsigned int>
       lexicographic_to_hierarchic_numbering<deal_II_dimension>(unsigned int);
-
-      template std::vector<unsigned int>
-      hierarchic_to_lexicographic_numbering<deal_II_dimension>(
-        const FiniteElementData<deal_II_dimension> &);
-
-      template std::vector<unsigned int>
-      lexicographic_to_hierarchic_numbering<deal_II_dimension>(
-        const FiniteElementData<deal_II_dimension> &);
 
 #endif
     \}


### PR DESCRIPTION
Deprecated in https://github.com/dealii/dealii/pull/9829.