### PR TITLE
CellwiseInverseMassMatrix::transform_from_q_points_to_basis() extension

### DIFF
--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -178,11 +178,12 @@ namespace internal
 
     static void
     transform_from_q_points_to_basis(
-      const unsigned int                        n_components,
-      const unsigned int                        fe_degree,
-      const AlignedVector<VectorizedArrayType> &inverse_shape,
-      const VectorizedArrayType *               in_array,
-      VectorizedArrayType *                     out_array);
+      const unsigned int n_components,
+      const unsigned int fe_degree,
+      const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
+        &                        fe_eval,
+      const VectorizedArrayType *in_array,
+      VectorizedArrayType *      out_array);
   };
 
 } // end of namespace internal

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -387,22 +387,18 @@ namespace internal
   void
   CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
     transform_from_q_points_to_basis(
-      const unsigned int                        n_components,
-      const unsigned int                        fe_degree,
-      const AlignedVector<VectorizedArrayType> &inverse_shape,
-      const VectorizedArrayType *               in_array,
-      VectorizedArrayType *                     out_array)
+      const unsigned int n_components,
+      const unsigned int fe_degree,
+      const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
+        &                        fe_eval,
+      const VectorizedArrayType *in_array,
+      VectorizedArrayType *      out_array)
   {
     instantiation_helper_run<
       1,
       CellwiseInverseMassMatrixImplTransformFromQPoints<dim,
                                                         VectorizedArrayType>>(
-      fe_degree,
-      fe_degree + 1,
-      n_components,
-      inverse_shape,
-      in_array,
-      out_array);
+      fe_degree, fe_degree + 1, n_components, fe_eval, in_array, out_array);
   }
 
 } // end of namespace internal

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1067,9 +1067,7 @@ namespace MatrixFreeOperators
     internal::CellwiseInverseMassMatrixImplTransformFromQPoints<
       dim,
       VectorizedArrayType>::template run<fe_degree>(n_actual_components,
-                                                    fe_eval.get_shape_info()
-                                                      .data.front()
-                                                      .inverse_shape_values_eo,
+                                                    fe_eval,
                                                     in_array,
                                                     out_array);
   }


### PR DESCRIPTION
I am trying to accomplish the following:
- make the function work for `degree = -1` and 
- make the function work for `degree+1!=q_points_1d`

The first one is working. The second one is not working, yet. Is `inverse_shape_values` the correct matrix to use in this case?