### PR TITLE
Make `hp::FEValuesBase` derive from `Subscriptor`.

### DIFF
--- a/include/deal.II/hp/fe_values.h
+++ b/include/deal.II/hp/fe_values.h
@@ -66,7 +66,7 @@ namespace hp
    * @ingroup hp
    */
   template <int dim, int q_dim, class FEValuesType>
-  class FEValuesBase
+  class FEValuesBase : public Subscriptor
   {
   public:
     /**

--- a/source/hp/fe_values.cc
+++ b/source/hp/fe_values.cc
@@ -135,7 +135,8 @@ namespace hp
   template <int dim, int q_dim, class FEValuesType>
   FEValuesBase<dim, q_dim, FEValuesType>::FEValuesBase(
     const FEValuesBase<dim, q_dim, FEValuesType> &other)
-    : fe_collection(other.fe_collection)
+    : Subscriptor(other)
+    , fe_collection(other.fe_collection)
     , mapping_collection(other.mapping_collection)
     , q_collection(other.q_collection)
     , q_collections(other.q_collections)


### PR DESCRIPTION
I wanted to create a `SmartPointer` to an `hp::FEValues` object, but that didn't work.

The non-hp `FEValuesBase` class [already derives from `Subscriptor`](https://github.com/dealii/dealii/blob/bcd1a32da88cab396a3708cb3880049d1b98106b/include/deal.II/fe/fe_values.h#L2412), so I don't see any issue why the hp variant shouldn't do the same.