### PR TITLE
Try to see whether we can avoid special-casing for MS VC in one place.

### DIFF
--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -882,11 +882,6 @@ namespace VectorTools
           const Quadrature<dim - 1> &q_boundary,
           const bool                 project_to_boundary_first)
   {
-#ifdef _MSC_VER
-    Assert(false,
-           ExcMessage("Please specify the mapping explicitly "
-                      "when building with MSVC!"));
-#else
     project(get_default_linear_mapping(dof.get_triangulation()),
             dof,
             constraints,
@@ -896,7 +891,6 @@ namespace VectorTools
             enforce_zero_boundary,
             q_boundary,
             project_to_boundary_first);
-#endif
   }
 
 


### PR DESCRIPTION
This error is currently triggered when running step-21. It is possible that with the move
to get_default_linear_mapping(dof.get_triangulation()) we no longer need this.

/rebuild