### PR TITLE
Use initlog in some tests.

### DIFF
--- a/tests/simplex/step-17.mpirun=1.with_petsc=true.output
+++ b/tests/simplex/step-17.mpirun=1.with_petsc=true.output
@@ -1,3 +1,4 @@
-   Number of active cells:       200
-   Number of degrees of freedom: 242 (by partition: 242)
-   Solver converged in 10 iterations.
+
+DEAL::   Number of active cells:       200
+DEAL::   Number of degrees of freedom: 242 (by partition: 242)
+DEAL::Solver stopped within 8 - 12 iterations

--- a/tests/simplex/step-17.mpirun=4.with_petsc=true.output
+++ b/tests/simplex/step-17.mpirun=4.with_petsc=true.output
@@ -1,3 +1,4 @@
-   Number of active cells:       200
-   Number of degrees of freedom: 242 (by partition: 74+58+58+52)
-   Solver converged in 28 iterations.
+
+DEAL::   Number of active cells:       200
+DEAL::   Number of degrees of freedom: 242 (by partition: 74+58+58+52)
+DEAL::Solver stopped within 26 - 30 iterations

--- a/tests/simplex/step-40.mpirun=1.with_petsc=true.output
+++ b/tests/simplex/step-40.mpirun=1.with_petsc=true.output
@@ -1,4 +1,6 @@
-Running with PETSc on 1 MPI rank(s)...
-   Number of active cells:       512
-   Number of degrees of freedom: 1089
-0.0124965
+
+DEAL::Running with PETSc on 1 MPI rank(s)...
+DEAL::   Number of active cells:       512
+DEAL::   Number of degrees of freedom: 1089
+DEAL::Solver stopped within 5 - 9 iterations
+DEAL::0.0124965

--- a/tests/simplex/step-40.mpirun=4.with_petsc=true.with_metis=true.output
+++ b/tests/simplex/step-40.mpirun=4.with_petsc=true.with_metis=true.output
@@ -1,4 +1,6 @@
-Running with PETSc on 4 MPI rank(s)...
-   Number of active cells:       512
-   Number of degrees of freedom: 1089
-0.0124965
+
+DEAL::Running with PETSc on 4 MPI rank(s)...
+DEAL::   Number of active cells:       512
+DEAL::   Number of degrees of freedom: 1089
+DEAL::Solver stopped within 5 - 9 iterations
+DEAL::0.0124965


### PR DESCRIPTION
We forgot to call mpi_initlog() in these tests, which caused the tests to compare stderr + stdout as output - this is why we had a bunch of problems with testers collecting additional MPI error output.