### PR TITLE
Remove deprecated TriangulationBase::compute_vertices_with_ghost_neighbors()

### DIFF
--- a/doc/news/changes/incompatibilities/20210607DanielArndt-1
+++ b/doc/news/changes/incompatibilities/20210607DanielArndt-1
@@ -1,0 +1,4 @@
+Removed: The deprecated member function
+TriangulationBase::compute_vertices_with_ghost_neighbors() has been removed.
+<br>
+(Daniel Arndt, 2021/06/07)

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -216,18 +216,6 @@ namespace parallel
     global_level_cell_index_partitioner(const unsigned int level) const;
 
     /**
-     * Return a map that, for each vertex, lists all the processors whose
-     * subdomains are adjacent to that vertex.
-     *
-     * @deprecated Use GridTools::compute_vertices_with_ghost_neighbors()
-     * instead of
-     * parallel::TriangulationBase::compute_vertices_with_ghost_neighbors().
-     */
-    DEAL_II_DEPRECATED virtual std::map<unsigned int,
-                                        std::set<dealii::types::subdomain_id>>
-    compute_vertices_with_ghost_neighbors() const;
-
-    /**
      * @copydoc dealii::Triangulation::get_boundary_ids()
      *
      * @note This function involves a global communication gathering all current

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -343,16 +343,6 @@ namespace parallel
 
 
   template <int dim, int spacedim>
-  std::map<unsigned int, std::set<dealii::types::subdomain_id>>
-  TriangulationBase<dim, spacedim>::compute_vertices_with_ghost_neighbors()
-    const
-  {
-    return GridTools::compute_vertices_with_ghost_neighbors(*this);
-  }
-
-
-
-  template <int dim, int spacedim>
   std::vector<types::boundary_id>
   TriangulationBase<dim, spacedim>::get_boundary_ids() const
   {


### PR DESCRIPTION
Deprecated in #9944.