### PR TITLE
Simplify particle accessor structure

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -75,7 +75,7 @@ namespace Particles
      * A type for the storage container for particles.
      */
     using particle_container =
-      std::vector<std::vector<Particle<dim, spacedim>>>;
+      std::vector<std::vector<typename PropertyPool<dim, spacedim>::Handle>>;
 
     /**
      * Default constructor.
@@ -97,7 +97,7 @@ namespace Particles
     /**
      * Destructor.
      */
-    virtual ~ParticleHandler() override = default;
+    virtual ~ParticleHandler();
 
     /**
      * Initialize the particle handler. This function does not clear the
@@ -975,8 +975,8 @@ namespace Particles
     void
     send_recv_particles(
       const std::map<types::subdomain_id, std::vector<particle_iterator>>
-        &                                                particles_to_send,
-      std::vector<std::vector<Particle<dim, spacedim>>> &received_particles,
+        &                 particles_to_send,
+      particle_container &received_particles,
       const std::map<
         types::subdomain_id,
         std::vector<
@@ -1007,8 +1007,8 @@ namespace Particles
     void
     send_recv_particles_properties_and_location(
       const std::map<types::subdomain_id, std::vector<particle_iterator>>
-        &                                                particles_to_send,
-      std::vector<std::vector<Particle<dim, spacedim>>> &received_particles);
+        &                 particles_to_send,
+      particle_container &received_particles);
 
 
 #endif
@@ -1067,7 +1067,7 @@ namespace Particles
     for (const auto &cell : triangulation->active_cell_iterators())
       if (cell->is_locally_owned() &&
           particles[cell->active_cell_index()].size() != 0)
-        return particle_iterator(particles, cell, 0);
+        return particle_iterator(particles, *property_pool, cell, 0);
 
     return end();
   }
@@ -1087,7 +1087,10 @@ namespace Particles
   inline typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::end()
   {
-    return particle_iterator(particles, triangulation->end(), 0);
+    return particle_iterator(particles,
+                             *property_pool,
+                             triangulation->end(),
+                             0);
   }
 
 
@@ -1111,7 +1114,7 @@ namespace Particles
     for (const auto &cell : triangulation->active_cell_iterators())
       if (cell->is_locally_owned() == false &&
           ghost_particles[cell->active_cell_index()].size() != 0)
-        return particle_iterator(ghost_particles, cell, 0);
+        return particle_iterator(ghost_particles, *property_pool, cell, 0);
 
     return end_ghost();
   }
@@ -1131,7 +1134,10 @@ namespace Particles
   inline typename ParticleHandler<dim, spacedim>::particle_iterator
   ParticleHandler<dim, spacedim>::end_ghost()
   {
-    return particle_iterator(ghost_particles, triangulation->end(), 0);
+    return particle_iterator(ghost_particles,
+                             *property_pool,
+                             triangulation->end(),
+                             0);
   }
 
 

--- a/include/deal.II/particles/particle_iterator.h
+++ b/include/deal.II/particles/particle_iterator.h
@@ -40,6 +40,12 @@ namespace Particles
   {
   public:
     /**
+     * A type for the storage container for particles.
+     */
+    using particle_container =
+      std::vector<std::vector<typename PropertyPool<dim, spacedim>::Handle>>;
+
+    /**
      * Empty constructor. Such an object is not usable!
      */
     ParticleIterator() = default;
@@ -50,7 +56,8 @@ namespace Particles
      * cell.
      */
     ParticleIterator(
-      const std::vector<std::vector<Particle<dim, spacedim>>> &   particles,
+      const particle_container &                                  particles,
+      const PropertyPool<dim, spacedim> &                         property_pool,
       const typename Triangulation<dim, spacedim>::cell_iterator &cell,
       const unsigned int particle_index_within_cell);
 
@@ -152,10 +159,11 @@ namespace Particles
 
   template <int dim, int spacedim>
   inline ParticleIterator<dim, spacedim>::ParticleIterator(
-    const std::vector<std::vector<Particle<dim, spacedim>>> &   particles,
+    const particle_container &                                  particles,
+    const PropertyPool<dim, spacedim> &                         property_pool,
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const unsigned int particle_index_within_cell)
-    : accessor(particles, cell, particle_index_within_cell)
+    : accessor(particles, property_pool, cell, particle_index_within_cell)
   {}
 
 

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -123,6 +123,13 @@ namespace Particles
       ExcMessage(
         "This handle is invalid and cannot be deallocated. This can happen if the "
         "handle was deallocated already before calling this function."));
+
+    Assert(
+      currently_available_handles.size() < locations.size(),
+      ExcMessage(
+        "Trying to deallocate a particle when none are allocated. This can happen if all "
+        "handles were deallocated already before calling this function."));
+
     currently_available_handles.push_back(handle);
     handle = invalid_handle;
 

--- a/tests/particles/particle_handler_08.cc
+++ b/tests/particles/particle_handler_08.cc
@@ -125,23 +125,19 @@ test()
 
     create_regular_particle_distribution(particle_handler, tr);
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "Before refinement particle id " << particle->get_id()
-              << " has first property " << particle->get_properties()[0]
-              << " and second property " << particle->get_properties()[1]
+    for (const auto &particle : particle_handler)
+      deallog << "Before refinement particle id " << particle.get_id()
+              << " has first property " << particle.get_properties()[0]
+              << " and second property " << particle.get_properties()[1]
               << std::endl;
 
     // Check that all particles are moved to children
     tr.refine_global(1);
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After refinement particle id " << particle->get_id()
-              << " has first property " << particle->get_properties()[0]
-              << " and second property " << particle->get_properties()[1]
+    for (const auto &particle : particle_handler)
+      deallog << "After refinement particle id " << particle.get_id()
+              << " has first property " << particle.get_properties()[0]
+              << " and second property " << particle.get_properties()[1]
               << std::endl;
 
     // Reverse the refinement and check again
@@ -150,12 +146,10 @@ test()
 
     tr.execute_coarsening_and_refinement();
 
-    for (auto particle = particle_handler.begin();
-         particle != particle_handler.end();
-         ++particle)
-      deallog << "After coarsening particle id " << particle->get_id()
-              << " has first property " << particle->get_properties()[0]
-              << " and second property " << particle->get_properties()[1]
+    for (const auto &particle : particle_handler)
+      deallog << "After coarsening particle id " << particle.get_id()
+              << " has first property " << particle.get_properties()[0]
+              << " and second property " << particle.get_properties()[1]
               << std::endl;
   }
 


### PR DESCRIPTION
This modifies the particle container structure inside ParticleHandler to only store handles into the property pool instead of objects of type Particle. This cuts the size of the container in half (one handle per particle, instead of a handle and a pointer to the property pool), and removes one layer of indirect function calling (old: particle_accessor->particle->propertypool; new: particle_accessor->property_pool). I wonder if we could simplify this further by making particle_accessor a friend of PropertyPool and allowing it direct access to the members of the pool. But that is something for later.

As long as nobody created particle_iterators manually (like the tests do) instead of using ParticleHandler.begin() this should not change anything about the interface. We may be able to optimize things further by using less objects of type Particle internally in ParticleHandler, but that would be optimizations for the future. I already benchmarked that this give a further 20% speedup in particle sorting.

Opinions about the current approach?