### PR TITLE
Add `constexpr` to type check.

### DIFF
--- a/include/deal.II/base/utilities.h
+++ b/include/deal.II/base/utilities.h
@@ -1334,7 +1334,11 @@ namespace Utilities
     // see if the object is small and copyable via memcpy. if so, use
     // this fast path. otherwise, we have to go through the BOOST
     // serialization machinery
+#ifdef DEAL_II_HAVE_CXX17
+    if constexpr (std::is_trivially_copyable<T>() && sizeof(T) < 256)
+#else
     if (std::is_trivially_copyable<T>() && sizeof(T) * N < 256)
+#endif
       {
         Assert(std::distance(cbegin, cend) == sizeof(T) * N,
                ExcInternalError());


### PR DESCRIPTION
Follow-up to #12406.

Since the generalization of `unpack` didn't work, we should apply the `constexpr` change to all variants of `pack/unpack`. I forgot to add it to this particular overload.