### PR TITLE
Minor simplification in particle accessor

### DIFF
--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -713,7 +713,7 @@ namespace Particles
 
     ++particle_index_within_cell;
 
-    if (particle_index_within_cell > (*particles)[active_cell_index].size() - 1)
+    if (particle_index_within_cell >= (*particles)[active_cell_index].size())
       {
         const bool particle_is_locally_owned = cell->is_locally_owned();
 
@@ -725,7 +725,7 @@ namespace Particles
             ++active_cell_index;
           }
         while (cell.state() == IteratorState::valid &&
-               ((*particles)[active_cell_index].size() == 0 ||
+               ((*particles)[active_cell_index].empty() ||
                 cell->is_locally_owned() != particle_is_locally_owned));
       }
   }


### PR DESCRIPTION
I observed some very minor thing in the particle code; it won't matter, and probably the compiler is even able to replace `> size()-1` by `>= size()`, but I think it would be slightly simpler this way.