### PR TITLE
Sort property pool

### DIFF
--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -211,6 +211,9 @@ namespace Particles
     unsigned int
     n_properties_per_slot() const;
 
+    void
+    sort_memory_slots(std::vector<std::vector<Handle>> &sorted_handles);
+
   private:
     /**
      * The number of properties that are reserved per particle.

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -211,8 +211,17 @@ namespace Particles
     unsigned int
     n_properties_per_slot() const;
 
+    /**
+     * This function makes sure that all internally stored memory blocks
+     * are sorted in the same order as one would loop over the @p handles_to_sort
+     * container. This makes sure memory access is contiguous with actual
+     * memory location. Because the ordering is given in the input argumet
+     * the complexity of this function is $O(N)$ where N is the number of
+     * elements in the input argument. This function creates a temporary copy of
+     * all currently registered memory blocks.
+     */
     void
-    sort_memory_slots(std::vector<std::vector<Handle>> &sorted_handles);
+    sort_memory_slots(std::vector<std::vector<Handle>> &handles_to_sort);
 
   private:
     /**

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -215,13 +215,12 @@ namespace Particles
      * This function makes sure that all internally stored memory blocks
      * are sorted in the same order as one would loop over the @p handles_to_sort
      * container. This makes sure memory access is contiguous with actual
-     * memory location. Because the ordering is given in the input argumet
-     * the complexity of this function is $O(N)$ where N is the number of
-     * elements in the input argument. This function creates a temporary copy of
-     * all currently registered memory blocks.
+     * memory location. Because the ordering is given in the input argument
+     * the complexity of this function is $O(N)$ where $N$ is the number of
+     * elements in the input argument.
      */
     void
-    sort_memory_slots(std::vector<std::vector<Handle>> &handles_to_sort);
+    sort_memory_slots(const std::vector<Handle> &handles_to_sort);
 
   private:
     /**

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1291,6 +1291,7 @@ namespace Particles
 
     // remove_particles also calls update_cached_numbers()
     remove_particles(particles_out_of_cell);
+    property_pool->sort_memory_slots(particles);
   } // namespace Particles
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1291,7 +1291,21 @@ namespace Particles
 
     // remove_particles also calls update_cached_numbers()
     remove_particles(particles_out_of_cell);
-    property_pool->sort_memory_slots(particles);
+
+    // now make sure particle data is sorted in order of iteration
+    std::vector<typename PropertyPool<dim, spacedim>::Handle> unsorted_handles;
+    unsorted_handles.reserve(local_number_of_particles);
+
+    typename PropertyPool<dim, spacedim>::Handle sorted_handle = 0;
+    for (auto &particles_in_cell : particles)
+      for (auto &particle : particles_in_cell)
+        {
+          unsorted_handles.push_back(particle);
+          particle = sorted_handle++;
+        }
+
+    property_pool->sort_memory_slots(unsorted_handles);
+
   } // namespace Particles
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1291,35 +1291,7 @@ namespace Particles
 
     // remove_particles also calls update_cached_numbers()
     remove_particles(particles_out_of_cell);
-
-    // Sort the particle memory if we noticed during sorting
-    // the particles above that more than 10% of particle
-    // handles are non-consecutive. We do not want to do this
-    // if it is not necessary, because it involves a copy of
-    // all particle memory.
-    types::particle_index                        n_fragmented_handles = 0;
-    typename PropertyPool<dim, spacedim>::Handle last_handle =
-      PropertyPool<dim, spacedim>::invalid_handle;
-    for (const auto &particles_in_cell : particles)
-      for (const auto &particle : particles_in_cell)
-        {
-          if (last_handle == PropertyPool<dim, spacedim>::invalid_handle)
-            {
-              last_handle = particle;
-              continue;
-            }
-
-          if (particle != last_handle + 1)
-            ++n_fragmented_handles;
-
-          last_handle = particle;
-        }
-
-    if (n_fragmented_handles > n_locally_owned_particles() / 3)
-      {
-        property_pool->sort_memory_slots(particles);
-      }
-
+    property_pool->sort_memory_slots(particles);
   } // namespace Particles
 
 

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -178,7 +178,7 @@ namespace Particles
     std::vector<types::particle_index> sorted_ids(ids.size());
     std::vector<double>                sorted_properties(properties.size());
 
-    Handle i = 0;
+    unsigned int i = 0;
     for (auto &handles_in_cell : sorted_handles)
       for (auto &handle : handles_in_cell)
         {

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -170,7 +170,7 @@ namespace Particles
   template <int dim, int spacedim>
   void
   PropertyPool<dim, spacedim>::sort_memory_slots(
-    std::vector<std::vector<Handle>> &handles_to_sort)
+    const std::vector<Handle> &handles_to_sort)
   {
     std::vector<Point<spacedim>>       sorted_locations;
     std::vector<Point<dim>>            sorted_reference_locations;
@@ -182,24 +182,19 @@ namespace Particles
     sorted_ids.reserve(ids.size());
     sorted_properties.reserve(properties.size());
 
-    Handle i = 0;
-    for (auto &handles_in_cell : handles_to_sort)
-      for (auto &handle : handles_in_cell)
-        {
-          Assert(handle != invalid_handle,
-                 ExcMessage(
-                   "Invalid handle detected during sorting particle memory."));
+    for (auto &handle : handles_to_sort)
+      {
+        Assert(handle != invalid_handle,
+               ExcMessage(
+                 "Invalid handle detected during sorting particle memory."));
 
-          sorted_locations.push_back(locations[handle]);
-          sorted_reference_locations.push_back(reference_locations[handle]);
-          sorted_ids.push_back(ids[handle]);
+        sorted_locations.push_back(locations[handle]);
+        sorted_reference_locations.push_back(reference_locations[handle]);
+        sorted_ids.push_back(ids[handle]);
 
-          for (unsigned int j = 0; j < n_properties; ++j)
-            sorted_properties.push_back(properties[handle * n_properties + j]);
-
-          handle = i;
-          ++i;
-        }
+        for (unsigned int j = 0; j < n_properties; ++j)
+          sorted_properties.push_back(properties[handle * n_properties + j]);
+      }
 
     Assert(sorted_locations.size() ==
              locations.size() - currently_available_handles.size(),
@@ -207,10 +202,10 @@ namespace Particles
              "Number of sorted property handles is not equal to number "
              "of currently registered handles."));
 
-    locations.swap(sorted_locations);
-    reference_locations.swap(sorted_reference_locations);
-    ids.swap(sorted_ids);
-    properties.swap(sorted_properties);
+    locations           = std::move(sorted_locations);
+    reference_locations = std::move(sorted_reference_locations);
+    ids                 = std::move(sorted_ids);
+    properties          = std::move(sorted_properties);
 
     currently_available_handles.clear();
   }

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -178,7 +178,7 @@ namespace Particles
     std::vector<types::particle_index> sorted_ids(ids.size());
     std::vector<double>                sorted_properties(properties.size());
 
-    unsigned int i = 0;
+    Handle i = 0;
     for (auto &handles_in_cell : sorted_handles)
       for (auto &handle : handles_in_cell)
         {

--- a/tests/particles/generators_05.cc
+++ b/tests/particles/generators_05.cc
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  initlog();
+  MPILogInitAll();
 
   {
     deallog.push("2d/2d");

--- a/tests/particles/generators_05.with_p4est=true.mpirun=2.output
+++ b/tests/particles/generators_05.with_p4est=true.mpirun=2.output
@@ -1,11 +1,9 @@
 
-DEAL:2d/2d::OK
-DEAL:2d/3d::OK
-DEAL:3d/3d::OK
-DEAL:2d/2d::OK
-DEAL:2d/3d::OK
-DEAL:3d/3d::OK
-l 1.0 has 4 particles.
+
+
+DEAL:2d/2d::Locally owned active cells: 4
+DEAL:2d/2d::Global particles: 16
+DEAL:2d/2d::Cell 1.0 has 4 particles.
 DEAL:2d/2d::Cell 1.1 has 4 particles.
 DEAL:2d/2d::Cell 1.2 has 4 particles.
 DEAL:2d/2d::Cell 1.3 has 4 particles.

--- a/tests/particles/property_pool_03.cc
+++ b/tests/particles/property_pool_03.cc
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2017 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// test the sorting of memory chunks inside the property pool
+
+#include <deal.II/particles/property_pool.h>
+
+#include <fstream>
+#include <iomanip>
+
+#include "../tests.h"
+
+
+void
+test()
+{
+  {
+    const int dim      = 2;
+    const int spacedim = 2;
+
+    const unsigned int                     n_properties = 3;
+    Particles::PropertyPool<dim, spacedim> pool(n_properties);
+
+    std::vector<
+      std::vector<typename Particles::PropertyPool<dim, spacedim>::Handle>>
+      particle_handles;
+    particle_handles.resize(2);
+
+    // Allocate some space in non-contigous locations
+    particle_handles[1].push_back(pool.register_particle());
+    particle_handles[0].push_back(pool.register_particle());
+    particle_handles[1].push_back(pool.register_particle());
+    particle_handles[0].push_back(pool.register_particle());
+    particle_handles[1].push_back(pool.register_particle());
+    particle_handles[0].push_back(pool.register_particle());
+
+    unsigned int i = 0;
+    for (auto &particles_in_cell : particle_handles)
+      for (auto &particle : particles_in_cell)
+        pool.set_id(particle, i++);
+
+    for (const auto &particles_in_cell : particle_handles)
+      for (const auto &particle : particles_in_cell)
+        deallog << "Before removal unsorted ID: " << pool.get_id(particle)
+                << ". Handle: " << particle << std::endl;
+
+    pool.sort_memory_slots(particle_handles);
+
+    for (const auto &particles_in_cell : particle_handles)
+      for (const auto &particle : particles_in_cell)
+        deallog << "Before removal sorted ID: " << pool.get_id(particle)
+                << ". Handle: " << particle << std::endl;
+
+    // Deallocate some space in the same way the particle handler would
+    // remove particles
+    pool.deregister_particle(particle_handles[1][1]);
+    pool.deregister_particle(particle_handles[0][2]);
+
+    particle_handles[1][1] = particle_handles[1].back();
+    particle_handles[1].resize(particle_handles[1].size() - 1);
+    particle_handles[0].resize(particle_handles[0].size() - 1);
+
+    for (const auto &particles_in_cell : particle_handles)
+      for (const auto &particle : particles_in_cell)
+        deallog << "After removal unsorted ID: " << pool.get_id(particle)
+                << ". Handle: " << particle << std::endl;
+
+    pool.sort_memory_slots(particle_handles);
+
+    for (const auto &particles_in_cell : particle_handles)
+      for (const auto &particle : particles_in_cell)
+        deallog << "After removal sorted ID: " << pool.get_id(particle)
+                << ". Handle: " << particle << std::endl;
+
+    for (auto &particles_in_cell : particle_handles)
+      for (auto &particle : particles_in_cell)
+        pool.deregister_particle(particle);
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main()
+{
+  initlog();
+  test();
+}

--- a/tests/particles/property_pool_03.cc
+++ b/tests/particles/property_pool_03.cc
@@ -35,60 +35,62 @@ test()
     const unsigned int                     n_properties = 3;
     Particles::PropertyPool<dim, spacedim> pool(n_properties);
 
-    std::vector<
-      std::vector<typename Particles::PropertyPool<dim, spacedim>::Handle>>
+    std::vector<typename Particles::PropertyPool<dim, spacedim>::Handle>
       particle_handles;
-    particle_handles.resize(2);
 
     // Allocate some space in non-contigous locations
-    particle_handles[1].push_back(pool.register_particle());
-    particle_handles[0].push_back(pool.register_particle());
-    particle_handles[1].push_back(pool.register_particle());
-    particle_handles[0].push_back(pool.register_particle());
-    particle_handles[1].push_back(pool.register_particle());
-    particle_handles[0].push_back(pool.register_particle());
+    particle_handles.push_back(pool.register_particle());
+    particle_handles.insert(particle_handles.begin(), pool.register_particle());
+    particle_handles.push_back(pool.register_particle());
+    particle_handles.insert(particle_handles.begin(), pool.register_particle());
+    particle_handles.push_back(pool.register_particle());
+    particle_handles.insert(particle_handles.begin(), pool.register_particle());
 
     unsigned int i = 0;
-    for (auto &particles_in_cell : particle_handles)
-      for (auto &particle : particles_in_cell)
-        pool.set_id(particle, i++);
+    for (auto &particle : particle_handles)
+      pool.set_id(particle, i++);
 
-    for (const auto &particles_in_cell : particle_handles)
-      for (const auto &particle : particles_in_cell)
-        deallog << "Before removal unsorted ID: " << pool.get_id(particle)
-                << ". Handle: " << particle << std::endl;
+    for (const auto &particle : particle_handles)
+      deallog << "Before removal unsorted ID: " << pool.get_id(particle)
+              << ". Handle: " << particle << std::endl;
 
     pool.sort_memory_slots(particle_handles);
 
-    for (const auto &particles_in_cell : particle_handles)
-      for (const auto &particle : particles_in_cell)
-        deallog << "Before removal sorted ID: " << pool.get_id(particle)
-                << ". Handle: " << particle << std::endl;
+    typename Particles::PropertyPool<dim, spacedim>::Handle h = 0;
+    for (auto &particle : particle_handles)
+      particle = h++;
+
+    for (const auto &particle : particle_handles)
+      deallog << "Before removal sorted ID: " << pool.get_id(particle)
+              << ". Handle: " << particle << std::endl;
 
     // Deallocate some space in the same way the particle handler would
     // remove particles
-    pool.deregister_particle(particle_handles[1][1]);
-    pool.deregister_particle(particle_handles[0][2]);
+    pool.deregister_particle(particle_handles[2]);
+    pool.deregister_particle(particle_handles[3]);
 
-    particle_handles[1][1] = particle_handles[1].back();
-    particle_handles[1].resize(particle_handles[1].size() - 1);
-    particle_handles[0].resize(particle_handles[0].size() - 1);
+    particle_handles[2] = particle_handles.back();
+    particle_handles.resize(particle_handles.size() - 1);
 
-    for (const auto &particles_in_cell : particle_handles)
-      for (const auto &particle : particles_in_cell)
-        deallog << "After removal unsorted ID: " << pool.get_id(particle)
-                << ". Handle: " << particle << std::endl;
+    particle_handles[3] = particle_handles.back();
+    particle_handles.resize(particle_handles.size() - 1);
+
+    for (const auto &particle : particle_handles)
+      deallog << "After removal unsorted ID: " << pool.get_id(particle)
+              << ". Handle: " << particle << std::endl;
 
     pool.sort_memory_slots(particle_handles);
 
-    for (const auto &particles_in_cell : particle_handles)
-      for (const auto &particle : particles_in_cell)
-        deallog << "After removal sorted ID: " << pool.get_id(particle)
-                << ". Handle: " << particle << std::endl;
+    h = 0;
+    for (auto &particle : particle_handles)
+      particle = h++;
 
-    for (auto &particles_in_cell : particle_handles)
-      for (auto &particle : particles_in_cell)
-        pool.deregister_particle(particle);
+    for (const auto &particle : particle_handles)
+      deallog << "After removal sorted ID: " << pool.get_id(particle)
+              << ". Handle: " << particle << std::endl;
+
+    for (auto &particle : particle_handles)
+      pool.deregister_particle(particle);
   }
 
   deallog << "OK" << std::endl;

--- a/tests/particles/property_pool_03.output
+++ b/tests/particles/property_pool_03.output
@@ -1,0 +1,22 @@
+
+DEAL::Before removal unsorted ID: 0. Handle: 1
+DEAL::Before removal unsorted ID: 1. Handle: 3
+DEAL::Before removal unsorted ID: 2. Handle: 5
+DEAL::Before removal unsorted ID: 3. Handle: 0
+DEAL::Before removal unsorted ID: 4. Handle: 2
+DEAL::Before removal unsorted ID: 5. Handle: 4
+DEAL::Before removal sorted ID: 0. Handle: 0
+DEAL::Before removal sorted ID: 1. Handle: 1
+DEAL::Before removal sorted ID: 2. Handle: 2
+DEAL::Before removal sorted ID: 3. Handle: 3
+DEAL::Before removal sorted ID: 4. Handle: 4
+DEAL::Before removal sorted ID: 5. Handle: 5
+DEAL::After removal unsorted ID: 0. Handle: 0
+DEAL::After removal unsorted ID: 1. Handle: 1
+DEAL::After removal unsorted ID: 3. Handle: 3
+DEAL::After removal unsorted ID: 5. Handle: 5
+DEAL::After removal sorted ID: 0. Handle: 0
+DEAL::After removal sorted ID: 1. Handle: 1
+DEAL::After removal sorted ID: 3. Handle: 2
+DEAL::After removal sorted ID: 5. Handle: 3
+DEAL::OK

--- a/tests/particles/property_pool_03.output
+++ b/tests/particles/property_pool_03.output
@@ -1,7 +1,7 @@
 
-DEAL::Before removal unsorted ID: 0. Handle: 1
+DEAL::Before removal unsorted ID: 0. Handle: 5
 DEAL::Before removal unsorted ID: 1. Handle: 3
-DEAL::Before removal unsorted ID: 2. Handle: 5
+DEAL::Before removal unsorted ID: 2. Handle: 1
 DEAL::Before removal unsorted ID: 3. Handle: 0
 DEAL::Before removal unsorted ID: 4. Handle: 2
 DEAL::Before removal unsorted ID: 5. Handle: 4
@@ -13,10 +13,10 @@ DEAL::Before removal sorted ID: 4. Handle: 4
 DEAL::Before removal sorted ID: 5. Handle: 5
 DEAL::After removal unsorted ID: 0. Handle: 0
 DEAL::After removal unsorted ID: 1. Handle: 1
-DEAL::After removal unsorted ID: 3. Handle: 3
 DEAL::After removal unsorted ID: 5. Handle: 5
+DEAL::After removal unsorted ID: 4. Handle: 4
 DEAL::After removal sorted ID: 0. Handle: 0
 DEAL::After removal sorted ID: 1. Handle: 1
-DEAL::After removal sorted ID: 3. Handle: 2
-DEAL::After removal sorted ID: 5. Handle: 3
+DEAL::After removal sorted ID: 5. Handle: 2
+DEAL::After removal sorted ID: 4. Handle: 3
 DEAL::OK


### PR DESCRIPTION
A function that sorts the internally stored property pool slots for particles in the order they are accessed when iterating over particles. I need to check the performance implications of this first, but would be interested in feedback about the interface. This somewhat exposes the internal data structure of the particle handler, but the property pool currently does not know about iterators, and iterators would be slower anyway and also only provide indirect access to the particles container.