### PR TITLE
Clarify requirment for MPI with Trilinos in documentation

### DIFF
--- a/doc/external-libs/trilinos.html
+++ b/doc/external-libs/trilinos.html
@@ -111,9 +111,8 @@
     make install
       </pre>
       You will need to adjust the path into which you want to install Trilinos
-      in the CMAKE_INSTALL_PREFIX line. If you do not have MPI installed you
-      should use <code>-DTPL_ENABLE_MPI=OFF</code> instead. Additionally, if
-      your computer has enough memory available, it may also be useful to pass
+      in the CMAKE_INSTALL_PREFIX line. If your computer has enough memory
+      available, it may also be useful to pass
       the flag <code>-DTrilinos_ENABLE_EXPLICIT_INSTANTIATION=ON</code>, which
       will improve compilation times of deal.II programs that use Trilinos.
     </p>


### PR DESCRIPTION
Follow-up to https://github.com/dealii/dealii/pull/12381. Also document the requirement for `MPI` in the "external libraries" page.