### PR TITLE
Unify particle creation

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -807,7 +807,7 @@ namespace Particles
       const Point<dim> &          reference_position,
       const types::particle_index particle_index,
       const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
-      const ArrayView<const double>     &properties = {});
+      const ArrayView<const double> &properties = {});
 
     /**
      * Address of the triangulation to work on.

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -796,6 +796,20 @@ namespace Particles
       const typename Triangulation<dim, spacedim>::active_cell_iterator &cell);
 
     /**
+     * Insert a particle into the collection of particles given all the
+     * properties necessary for a particle. This function is used internally to
+     * efficiently generate particles without the detour through a Particle
+     * object.
+     */
+    particle_iterator
+    insert_particle(
+      const Point<spacedim> &     position,
+      const Point<dim> &          reference_position,
+      const types::particle_index particle_index,
+      const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+      const ArrayView<const double>     &properties = {});
+
+    /**
      * Address of the triangulation to work on.
      */
     SmartPointer<const Triangulation<dim, spacedim>,

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -475,7 +475,7 @@ namespace Particles
     const Point<dim> &          reference_position,
     const types::particle_index particle_index,
     const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
-    const ArrayView<const double>     &properties)
+    const ArrayView<const double> &properties)
   {
     Assert(triangulation != nullptr, ExcInternalError());
     Assert(cell.state() == IteratorState::valid, ExcInternalError());

--- a/tests/particles/generators_10.cc
+++ b/tests/particles/generators_10.cc
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
 {
   Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-  initlog();
+  MPILogInitAll();
 
   {
     deallog.push("2d/2d");

--- a/tests/particles/generators_10.with_p4est=true.mpirun=3.output
+++ b/tests/particles/generators_10.with_p4est=true.mpirun=3.output
@@ -1,11 +1,12 @@
 
+
+
+
+
+DEAL:2d/2d::Locally owned active cells: 0
+DEAL:2d/2d::Global particles: 2
 DEAL:2d/2d::OK
-DEAL:2d/3d::OK
-DEAL:3d/3d::OK
-DEAL:2d/2d::OK
-DEAL:2d/3d::OK
-DEAL:3d/3d::OK
-EAL:2d/3d::Locally owned active cells: 0
+DEAL:2d/3d::Locally owned active cells: 0
 DEAL:2d/3d::Global particles: 2
 DEAL:2d/3d::OK
 DEAL:3d/3d::Locally owned active cells: 0


### PR DESCRIPTION
This adds a private function to ParticleHandler that inserts a particle based on all the data needed to create it. This unifies some code from different places that were so far inserting particles manually.