### PR TITLE
Add a single point in Quadrature<0> constructor taking Quadrature<1>

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -124,6 +124,9 @@ public:
    * This constructor does not require that constant functions are integrated
    * exactly. Therefore, it is appropriate if the one-dimensional formula
    * is defined with respect to a weighting function.
+   *
+   * If dim == 0, the resulting quadrature formula will be a single Point<0>
+   * having unit weight.
    */
   explicit Quadrature(const Quadrature<dim != 1 ? 1 : 0> &quadrature_1d);
 

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -206,9 +206,8 @@ Quadrature<1>::Quadrature(const SubQuadrature &, const Quadrature<1> &q2)
 template <>
 Quadrature<0>::Quadrature(const Quadrature<1> &)
   : Subscriptor()
-  ,
-  // quadrature_points(1),
-  weights(1, 1.)
+  , quadrature_points(1)
+  , weights(1, 1.)
   , is_tensor_product_flag(false)
 {}
 


### PR DESCRIPTION
The constructor currently adds a single weight but no points. This appears to be a mistake, since points and weights get different sizes. Fix this and add an comment in the documentation.

Following the discussion in #12378.