### PR TITLE
Simplify particle transfer during refinement/serialization

### DIFF
--- a/doc/news/changes/major/20210606Gassmoeller
+++ b/doc/news/changes/major/20210606Gassmoeller
@@ -2,4 +2,4 @@ Improved: The internal particle handler storage structure has been reworked to
 allow for significantly faster particle sorting and iteration as well as for
 future improvements and extensions.
 <br>
-(Rene Gassmoeller, 2021/06/06)
+(Rene Gassmoeller, Bruno Blais, Martin Kronbichler, Peter Munch, 2021/06/06)

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -392,17 +392,13 @@ namespace Step68
     background_triangulation.refine_global(par.fluid_refinement);
 
     // In order to consider the particles when repartitioning the triangulation
-    // the algorithm needs to know three things:
+    // the algorithm needs to know how much weight to assign to each cell
+    // (how many particles are in there).
     //
-    // 1. How much weight to assign to each cell (how many particles are in
-    // there);
-    // 2. How to pack the particles before shipping data around;
-    // 3. How to unpack the particles after repartitioning.
-    //
-    // We attach the correct functions to the signals inside
-    // parallel::distributed::Triangulation. These signal will be called every
-    // time the repartition() function is called. These connections only need to
-    // be created once, so we might as well have set them up in the constructor
+    // We attach a weight function to the signal inside
+    // parallel::distributed::Triangulation. This signal will be called every
+    // time the repartition() function is called. This connection only needs to
+    // be created once, so we might as well have set it up in the constructor
     // of this class, but for the purpose of this example we want to group the
     // particle related instructions.
     background_triangulation.signals.cell_weight.connect(
@@ -411,12 +407,6 @@ namespace Step68
           &cell,
         const typename parallel::distributed::Triangulation<dim>::CellStatus
           status) -> unsigned int { return this->cell_weight(cell, status); });
-
-    background_triangulation.signals.pre_distributed_repartition.connect(
-      [this]() { this->particle_handler.register_store_callback_function(); });
-
-    background_triangulation.signals.post_distributed_repartition.connect(
-      [&]() { this->particle_handler.register_load_callback_function(false); });
 
     // This initializes the background triangulation where the particles are
     // living and the number of properties of the particles.
@@ -704,7 +694,10 @@ namespace Step68
 
     pcout << "Repartitioning triangulation after particle generation"
           << std::endl;
+
+    particle_handler.prepare_for_coarsening_and_refinement();
     background_triangulation.repartition();
+    particle_handler.unpack_after_coarsening_and_refinement();
 
     // We set the initial property of the particles by doing an
     // explicit Euler iteration with a time-step of 0 both in the case
@@ -730,7 +723,10 @@ namespace Step68
 
         if ((discrete_time.get_step_number() % par.repartition_frequency) == 0)
           {
+            particle_handler.prepare_for_coarsening_and_refinement();
             background_triangulation.repartition();
+            particle_handler.unpack_after_coarsening_and_refinement();
+
             if (interpolated_velocity)
               setup_background_dofs();
           }

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -65,6 +65,7 @@ namespace Particles
     , store_callback()
     , load_callback()
     , handle(numbers::invalid_unsigned_int)
+    , tria_listeners()
   {}
 
 
@@ -86,17 +87,12 @@ namespace Particles
     , store_callback()
     , load_callback()
     , handle(numbers::invalid_unsigned_int)
+    , triangulation_cache(
+        std::make_unique<GridTools::Cache<dim, spacedim>>(triangulation,
+                                                          mapping))
+    , tria_listeners()
   {
-    triangulation_cache =
-      std::make_unique<GridTools::Cache<dim, spacedim>>(triangulation, mapping);
-
-    triangulation.signals.create.connect([&]() { this->clear_particles(); });
-    triangulation.signals.post_refinement.connect(
-      [&]() { this->clear_particles(); });
-    triangulation.signals.post_distributed_repartition.connect(
-      [&]() { this->clear_particles(); });
-    triangulation.signals.post_distributed_load.connect(
-      [&]() { this->clear_particles(); });
+    connect_to_triangulation_signals();
   }
 
 
@@ -105,6 +101,9 @@ namespace Particles
   ParticleHandler<dim, spacedim>::~ParticleHandler()
   {
     clear_particles();
+
+    for (const auto &connection : tria_listeners)
+      connection.disconnect();
   }
 
 
@@ -121,19 +120,6 @@ namespace Particles
     triangulation = &new_triangulation;
     mapping       = &new_mapping;
 
-    // Note that we connect all signals 'at_front' in case user code
-    // connected the register_store_callback_function and
-    // register_load_callback_function functions already to the new
-    // triangulation. We want to clear before loading.
-    triangulation->signals.create.connect([&]() { this->clear_particles(); },
-                                          boost::signals2::at_front);
-    triangulation->signals.post_distributed_refinement.connect(
-      [&]() { this->clear_particles(); }, boost::signals2::at_front);
-    triangulation->signals.post_distributed_repartition.connect(
-      [&]() { this->clear_particles(); }, boost::signals2::at_front);
-    triangulation->signals.post_distributed_load.connect(
-      [&]() { this->clear_particles(); }, boost::signals2::at_front);
-
     // Create the memory pool that will store all particle properties
     property_pool = std::make_unique<PropertyPool<dim, spacedim>>(n_properties);
 
@@ -144,6 +130,8 @@ namespace Particles
                                                         new_mapping);
 
     particles.resize(triangulation->n_active_cells());
+
+    connect_to_triangulation_signals();
   }
 
 
@@ -1862,39 +1850,131 @@ namespace Particles
   }
 
 
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::connect_to_triangulation_signals()
+  {
+    // First disconnect existing connections
+    for (const auto &connection : tria_listeners)
+      connection.disconnect();
+
+    tria_listeners.clear();
+
+    tria_listeners.push_back(triangulation->signals.create.connect([&]() {
+      this->initialize(*(this->triangulation),
+                       *(this->mapping),
+                       this->property_pool->n_properties_per_slot());
+    }));
+
+    this->tria_listeners.push_back(
+      this->triangulation->signals.clear.connect([&]() { this->clear(); }));
+
+    // for distributed triangulations, connect to distributed signals
+    if (dynamic_cast<const parallel::DistributedTriangulationBase<dim, spacedim>
+                       *>(&(*triangulation)) != nullptr)
+      {
+        tria_listeners.push_back(
+          triangulation->signals.post_distributed_refinement.connect(
+            [&]() { this->post_mesh_change_action(); }));
+        tria_listeners.push_back(
+          triangulation->signals.post_distributed_repartition.connect(
+            [&]() { this->post_mesh_change_action(); }));
+        tria_listeners.push_back(
+          triangulation->signals.post_distributed_load.connect(
+            [&]() { this->post_mesh_change_action(); }));
+      }
+    else
+      {
+        tria_listeners.push_back(triangulation->signals.post_refinement.connect(
+          [&]() { this->post_mesh_change_action(); }));
+      }
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::post_mesh_change_action()
+  {
+    Assert(triangulation != nullptr, ExcInternalError());
+
+    const bool distributed_triangulation =
+      dynamic_cast<
+        const parallel::DistributedTriangulationBase<dim, spacedim> *>(
+        &(*triangulation)) != nullptr;
+    (void)distributed_triangulation;
+
+    Assert(
+      distributed_triangulation || local_number_of_particles == 0,
+      ExcMessage(
+        "Mesh refinement in a non-distributed triangulation is not supported "
+        "by the ParticleHandler class. Either insert particles after mesh "
+        "creation, or use a distributed triangulation."));
+
+    // Resize the container if it is possible without
+    // transferring particles
+    if (local_number_of_particles == 0)
+      particles.resize(triangulation->n_active_cells());
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::prepare_for_coarsening_and_refinement()
+  {
+    register_data_attach();
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::prepare_for_serialization()
+  {
+    register_data_attach();
+  }
+
+
 
   template <int dim, int spacedim>
   void
   ParticleHandler<dim, spacedim>::register_store_callback_function()
   {
+    register_data_attach();
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::register_data_attach()
+  {
     parallel::distributed::Triangulation<dim, spacedim>
-      *non_const_triangulation =
+      *distributed_triangulation =
         const_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
           dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim>
                          *>(&(*triangulation)));
-    (void)non_const_triangulation;
+    (void)distributed_triangulation;
 
-    Assert(non_const_triangulation != nullptr, dealii::ExcNotImplemented());
+    Assert(
+      distributed_triangulation != nullptr,
+      ExcMessage(
+        "Mesh refinement in a non-distributed triangulation is not supported "
+        "by the ParticleHandler class. Either insert particles after mesh "
+        "creation and do not refine afterwards, or use a distributed triangulation."));
 
 #ifdef DEAL_II_WITH_P4EST
-    // Only save and load particles if there are any, we might get here for
-    // example if somebody created a ParticleHandler but generated 0
-    // particles.
-    update_cached_numbers();
+    const auto callback_function =
+      [this](
+        const typename Triangulation<dim, spacedim>::cell_iterator
+          &                                                     cell_iterator,
+        const typename Triangulation<dim, spacedim>::CellStatus cell_status) {
+        return this->pack_callback(cell_iterator, cell_status);
+      };
 
-    if (global_max_particles_per_cell > 0)
-      {
-        const auto callback_function =
-          [this](const typename Triangulation<dim, spacedim>::cell_iterator
-                   &cell_iterator,
-                 const typename Triangulation<dim, spacedim>::CellStatus
-                   cell_status) {
-            return this->store_particles(cell_iterator, cell_status);
-          };
-
-        handle = non_const_triangulation->register_data_attach(
-          callback_function, /*returns_variable_size_data=*/true);
-      }
+    handle = distributed_triangulation->register_data_attach(
+      callback_function, /*returns_variable_size_data=*/true);
 #endif
   }
 
@@ -1902,36 +1982,62 @@ namespace Particles
 
   template <int dim, int spacedim>
   void
+  ParticleHandler<dim, spacedim>::unpack_after_coarsening_and_refinement()
+  {
+    const bool serialization = false;
+    notify_ready_to_unpack(serialization);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::deserialize()
+  {
+    const bool serialization = true;
+    notify_ready_to_unpack(serialization);
+  }
+
+
+  template <int dim, int spacedim>
+  void
   ParticleHandler<dim, spacedim>::register_load_callback_function(
     const bool serialization)
   {
+    notify_ready_to_unpack(serialization);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  ParticleHandler<dim, spacedim>::notify_ready_to_unpack(
+    const bool serialization)
+  {
     parallel::distributed::Triangulation<dim, spacedim>
-      *non_const_triangulation =
+      *distributed_triangulation =
         const_cast<parallel::distributed::Triangulation<dim, spacedim> *>(
           dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim>
                          *>(&(*triangulation)));
-    (void)non_const_triangulation;
+    (void)distributed_triangulation;
 
-    Assert(non_const_triangulation != nullptr, dealii::ExcNotImplemented());
+    Assert(
+      distributed_triangulation != nullptr,
+      ExcMessage(
+        "Mesh refinement in a non-distributed triangulation is not supported "
+        "by the ParticleHandler class. Either insert particles after mesh "
+        "creation and do not refine afterwards, or use a distributed triangulation."));
+
+    // First prepare container for insertion
+    clear();
 
 #ifdef DEAL_II_WITH_P4EST
     // If we are resuming from a checkpoint, we first have to register the
-    // store function again, to set the triangulation in the same state as
-    // before the serialization. Only by this it knows how to deserialize the
-    // data correctly. Only do this if something was actually stored.
-    if (serialization && (global_max_particles_per_cell > 0))
-      {
-        const auto callback_function =
-          [this](const typename Triangulation<dim, spacedim>::cell_iterator
-                   &cell_iterator,
-                 const typename Triangulation<dim, spacedim>::CellStatus
-                   cell_status) {
-            return this->store_particles(cell_iterator, cell_status);
-          };
-
-        handle = non_const_triangulation->register_data_attach(
-          callback_function, /*returns_variable_size_data=*/true);
-      }
+    // store function again, to set the triangulation to the same state as
+    // before the serialization. Only afterwards we know how to deserialize the
+    // data correctly.
+    if (serialization)
+      register_data_attach();
 
     // Check if something was stored and load it
     if (handle != numbers::invalid_unsigned_int)
@@ -1943,14 +2049,13 @@ namespace Particles
             const typename Triangulation<dim, spacedim>::CellStatus cell_status,
             const boost::iterator_range<std::vector<char>::const_iterator>
               &range_iterator) {
-            this->load_particles(cell_iterator, cell_status, range_iterator);
+            this->unpack_callback(cell_iterator, cell_status, range_iterator);
           };
 
-        non_const_triangulation->notify_ready_to_unpack(handle,
-                                                        callback_function);
+        distributed_triangulation->notify_ready_to_unpack(handle,
+                                                          callback_function);
 
-        // Reset handle and update global number of particles. The number
-        // can change because of discarded or newly generated particles
+        // Reset handle and update global numbers.
         handle = numbers::invalid_unsigned_int;
         update_cached_numbers();
       }
@@ -1963,7 +2068,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   std::vector<char>
-  ParticleHandler<dim, spacedim>::store_particles(
+  ParticleHandler<dim, spacedim>::pack_callback(
     const typename Triangulation<dim, spacedim>::cell_iterator &cell,
     const typename Triangulation<dim, spacedim>::CellStatus     status) const
   {
@@ -2016,7 +2121,7 @@ namespace Particles
 
   template <int dim, int spacedim>
   void
-  ParticleHandler<dim, spacedim>::load_particles(
+  ParticleHandler<dim, spacedim>::unpack_callback(
     const typename Triangulation<dim, spacedim>::cell_iterator &    cell,
     const typename Triangulation<dim, spacedim>::CellStatus         status,
     const boost::iterator_range<std::vector<char>::const_iterator> &data_range)

--- a/tests/particles/particle_handler_05.cc
+++ b/tests/particles/particle_handler_05.cc
@@ -98,22 +98,6 @@ test()
 
     Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
 
-    // TODO: Move this into the Particle handler class. Unfortunately, there are
-    // some interactions with the SolutionTransfer class that prevent us from
-    // doing this at the moment. When doing this, check that transferring a
-    // solution and particles during the same refinement is possible (in
-    // particular that the order of serialization/deserialization is preserved).
-    tr.signals.pre_distributed_refinement.connect(std::bind(
-      &Particles::ParticleHandler<dim,
-                                  spacedim>::register_store_callback_function,
-      &particle_handler));
-
-    tr.signals.post_distributed_refinement.connect(std::bind(
-      &Particles::ParticleHandler<dim,
-                                  spacedim>::register_load_callback_function,
-      &particle_handler,
-      false));
-
     create_regular_particle_distribution(particle_handler, tr);
 
     for (const auto &particle : particle_handler)
@@ -122,7 +106,9 @@ test()
               << std::endl;
 
     // Check that all particles are moved to children
+    particle_handler.prepare_for_coarsening_and_refinement();
     tr.refine_global(1);
+    particle_handler.unpack_after_coarsening_and_refinement();
 
     for (const auto &particle : particle_handler)
       deallog << "After refinement particle id " << particle.get_id()
@@ -133,7 +119,9 @@ test()
     for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
       cell->set_coarsen_flag();
 
+    particle_handler.prepare_for_coarsening_and_refinement();
     tr.execute_coarsening_and_refinement();
+    particle_handler.unpack_after_coarsening_and_refinement();
 
     for (const auto &particle : particle_handler)
       deallog << "After coarsening particle id " << particle.get_id()

--- a/tests/particles/particle_handler_08.cc
+++ b/tests/particles/particle_handler_08.cc
@@ -107,22 +107,6 @@ test()
                                                                mapping,
                                                                n_properties);
 
-    // TODO: Move this into the Particle handler class. Unfortunately, there are
-    // some interactions with the SolutionTransfer class that prevent us from
-    // doing this at the moment. When doing this, check that transferring a
-    // solution and particles during the same refinement is possible (in
-    // particular that the order of serialization/deserialization is preserved).
-    tr.signals.pre_distributed_refinement.connect(std::bind(
-      &Particles::ParticleHandler<dim,
-                                  spacedim>::register_store_callback_function,
-      &particle_handler));
-
-    tr.signals.post_distributed_refinement.connect(std::bind(
-      &Particles::ParticleHandler<dim,
-                                  spacedim>::register_load_callback_function,
-      &particle_handler,
-      false));
-
     create_regular_particle_distribution(particle_handler, tr);
 
     for (const auto &particle : particle_handler)
@@ -132,7 +116,9 @@ test()
               << std::endl;
 
     // Check that all particles are moved to children
+    particle_handler.prepare_for_coarsening_and_refinement();
     tr.refine_global(1);
+    particle_handler.unpack_after_coarsening_and_refinement();
 
     for (const auto &particle : particle_handler)
       deallog << "After refinement particle id " << particle.get_id()
@@ -144,7 +130,9 @@ test()
     for (auto cell = tr.begin_active(); cell != tr.end(); ++cell)
       cell->set_coarsen_flag();
 
+    particle_handler.prepare_for_coarsening_and_refinement();
     tr.execute_coarsening_and_refinement();
+    particle_handler.unpack_after_coarsening_and_refinement();
 
     for (const auto &particle : particle_handler)
       deallog << "After coarsening particle id " << particle.get_id()

--- a/tests/particles/particle_handler_14.cc
+++ b/tests/particles/particle_handler_14.cc
@@ -54,16 +54,9 @@ test()
   particle_handler.insert_particle(particle, cell);
   particle_handler.update_cached_numbers();
 
-  // initiate data transfer
-  tr.signals.pre_distributed_repartition.connect([&particle_handler]() {
-    particle_handler.register_store_callback_function();
-  });
-
-  tr.signals.post_distributed_repartition.connect([&particle_handler]() {
-    particle_handler.register_load_callback_function(false);
-  });
-
+  particle_handler.prepare_for_coarsening_and_refinement();
   tr.repartition();
+  particle_handler.unpack_after_coarsening_and_refinement();
 
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
The way particles are transferred during mesh refinement and serialization at the moment is in essence identical to how DoFHandler and SolutionTransfer do the same to solution vectors. However, the function names and how they are used is completely different, and not well documented for the particle handler. This PR deprecates the old function names and introduces new functions modeled after the SolutionTransfer class. It also adds more documentation to the corresponding functions in the particle handler class to describe how they are used, and updates all examples and tests that use them.

Main changes:
- to transfer particles across a refinement instead of connecting `register_store/load_callback_function` to the triangulation signals, you now call `prepare_for_coarsening_and_refinement` before and `transfer_after_coarsening_and_refinement` after the refinement. Just like we expect SolutionTransfer to work. The old way will still work if users want to keep it, but it is not advertised anymore, because it fails for mappings like MappingQCache and MappingEulerian.
- I reworked the transfer functions so that they throw exceptions when called with triangulations that are not supported for refinement. Before #12434 we had undefined behavior in that case, after #12434 particles would just disappear. I think throwing an exception is the right thing to do, until we have a working transfer for those cases (I have a WIP, but will handle that in a separate PR)
- I kept one special case and that is, if you create a particle handler, and change its connected triangulation (shared or distributed) before adding particles, the particle handler will not complain and resize its internal container accordingly without needing calls to the `prepare...` and `transfer...` functions. In other words you can use a particle handler with serial and shared triangulations, as long as you never do refinement while particles exist. This will keep step-19 working and is also important for other cases that change the triangulation after creating the particle handler, but before creating particles, like @blaisb does in https://github.com/lethe-cfd/lethe.
- Keep the connections between triangulation and particle handler stored, to be able to disconnect them and avoid duplicating them when copying particle handlers.

I am open for suggestions about the names of the functions, or the general behavior. 