### PR TITLE
Fix DataOut for TrilinosWrappers::MPI::Vector

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -791,6 +791,21 @@ namespace internal
         dst.import(temp2, VectorOperation::insert);
       }
 
+#ifdef DEAL_II_WITH_TRILINOS
+      template <typename Number>
+      void
+      copy_locally_owned_data_from(
+        const TrilinosWrappers::MPI::Vector &       src,
+        LinearAlgebra::distributed::Vector<Number> &dst)
+      {
+        // ReadWriteVector does not work for ghosted
+        // TrilinosWrappers::MPI::Vector objects. Fall back to copy the
+        // entries manually.
+        for (const auto i : dst.locally_owned_elements())
+          dst[i] = src[i];
+      }
+#endif
+
       /**
        * Create a ghosted-copy of a block dof vector.
        */


### PR DESCRIPTION
references https://github.com/dealii/dealii/pull/11594#issuecomment-859939631

This is a dirty fix. One should probably fix `ReadWriteVector` in the long run but I don't know the background of the comment:
https://github.com/dealii/dealii/blob/c92c73f66035d477e0e03f4c4f3d2cf7fb120647/include/deal.II/lac/read_write_vector.templates.h#L843-L849

FYI @gassmoeller  @tjhei 