### PR TITLE
Fix a mistake in a formula.

### DIFF
--- a/doc/doxygen/headers/vector_valued.h
+++ b/doc/doxygen/headers/vector_valued.h
@@ -677,7 +677,6 @@
   \right)_\Omega
   +
   2
-  \sum_{i,j}
   \left(
   \mu \varepsilon(\mathbf u), \varepsilon(\mathbf v)
   \right)_\Omega,


### PR DESCRIPTION
The sum symbol is a copy-paste error from higher up on that page.

As pointed out here: https://scicomp.stackexchange.com/questions/37587/confusion-about-bilinear-form-for-elasticity-equation-in-deal-ii-tutorial
