### PR TITLE
Fix declaration of PoisseuilleFlow constructor

### DIFF
--- a/include/deal.II/base/flow_function.h
+++ b/include/deal.II/base/flow_function.h
@@ -158,7 +158,7 @@ namespace Functions
      * Construct an object for the given channel radius <tt>r</tt> and the
      * Reynolds number <tt>Re</tt>.
      */
-    PoisseuilleFlow<dim>(const double r, const double Re);
+    PoisseuilleFlow(const double r, const double Re);
 
     virtual ~PoisseuilleFlow() override = default;
 


### PR DESCRIPTION
After I had updated to GCC 11, I faced a compiling error related to `PoisseuilleFlow`, pointing out that the constructor's declaration is not found. This PR should fix this misbehavior by removing the template parameter `dim` from the constructor's declaration.

FYI: @peterrum 

```bash
In file included from dealii/source/base/flow_function.cc:16:
dealii/include/deal.II/base/flow_function.h:161:26: error: expected unqualified-id before ‘const’ 
 161 |     PoisseuilleFlow<dim>(const double r, const double Re);
    |                          ^~~~~
dealii/include/deal.II/base/flow_function.h:161:26: error: expected ‘)’ before ‘const’ 
 161 |     PoisseuilleFlow<dim>(const double r, const double Re); 
     |                         ~^~~~~  
     |                          )
dealii/source/base/flow_function.cc:191:3: error: no declaration matches ‘dealii::Functions::PoisseuilleFlow<dim>::PoisseuilleFlow(double, double)’ 
 191 |   PoisseuilleFlow<dim>::PoisseuilleFlow(const double r, const double Re) 
     |   ^~~~~~~~~~~~~~~~~~~~
```