### PR TITLE
Fix a segmentation fault in MappingQGeneric.

### DIFF
--- a/doc/news/changes/minor/20210617DavidWells
+++ b/doc/news/changes/minor/20210617DavidWells
@@ -1,0 +1,5 @@
+Fixed: Removed some pointers in MappingQGeneric and MappingFE that could cause
+segmentation faults at high optimization levels due to compiler assumptions
+about data alignment.
+<br>
+(David Wells, 2021/06/17)

--- a/include/deal.II/fe/mapping_q_generic.h
+++ b/include/deal.II/fe/mapping_q_generic.h
@@ -386,14 +386,14 @@ public:
      *
      * Computed once.
      */
-    std::vector<double> shape_values;
+    AlignedVector<double> shape_values;
 
     /**
      * Values of shape function derivatives. Access by function @p derivative.
      *
      * Computed once.
      */
-    std::vector<Tensor<1, dim>> shape_derivatives;
+    AlignedVector<Tensor<1, dim>> shape_derivatives;
 
     /**
      * Values of shape function second derivatives. Access by function @p
@@ -401,7 +401,7 @@ public:
      *
      * Computed once.
      */
-    std::vector<Tensor<2, dim>> shape_second_derivatives;
+    AlignedVector<Tensor<2, dim>> shape_second_derivatives;
 
     /**
      * Values of shape function third derivatives. Access by function @p
@@ -409,7 +409,7 @@ public:
      *
      * Computed once.
      */
-    std::vector<Tensor<3, dim>> shape_third_derivatives;
+    AlignedVector<Tensor<3, dim>> shape_third_derivatives;
 
     /**
      * Values of shape function fourth derivatives. Access by function @p
@@ -417,7 +417,7 @@ public:
      *
      * Computed once.
      */
-    std::vector<Tensor<4, dim>> shape_fourth_derivatives;
+    AlignedVector<Tensor<4, dim>> shape_fourth_derivatives;
 
     /**
      * Unit tangential vectors. Used for the computation of boundary forms and
@@ -515,7 +515,7 @@ public:
      *
      * Computed on each cell.
      */
-    mutable std::vector<DerivativeForm<1, dim, spacedim>> covariant;
+    mutable AlignedVector<DerivativeForm<1, dim, spacedim>> covariant;
 
     /**
      * Tensors of contravariant transformation at each of the quadrature
@@ -524,12 +524,12 @@ public:
      *
      * Computed on each cell.
      */
-    mutable std::vector<DerivativeForm<1, dim, spacedim>> contravariant;
+    mutable AlignedVector<DerivativeForm<1, dim, spacedim>> contravariant;
 
     /**
      * Auxiliary vectors for internal use.
      */
-    mutable std::vector<std::vector<Tensor<1, spacedim>>> aux;
+    mutable std::vector<AlignedVector<Tensor<1, spacedim>>> aux;
 
     /**
      * Stores the support points of the mapping shape functions on the @p
@@ -547,7 +547,7 @@ public:
      * The determinant of the Jacobian in each quadrature point. Filled if
      * #update_volume_elements.
      */
-    mutable std::vector<double> volume_elements;
+    mutable AlignedVector<double> volume_elements;
   };
 
 

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1881,7 +1881,7 @@ namespace internal
                                         GeometryInfo<dim>::faces_per_cell * d]),
                 mapping_contravariant,
                 data,
-                make_array_view(data.aux[d]));
+                make_array_view(data.aux[d].begin(), data.aux[d].end()));
             }
 
           if (update_flags & update_boundary_forms)

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1308,25 +1308,21 @@ namespace internal
 
             Assert(data.n_shape_functions > 0, ExcInternalError());
 
-            const Tensor<1, spacedim> *supp_pts =
-              data.mapping_support_points.data();
-
             for (unsigned int point = 0; point < n_q_points; ++point)
               {
-                const Tensor<1, dim> *data_derv =
-                  &data.derivative(point + data_set, 0);
-
                 double result[spacedim][dim];
 
                 // peel away part of sum to avoid zeroing the
                 // entries and adding for the first time
                 for (unsigned int i = 0; i < spacedim; ++i)
                   for (unsigned int j = 0; j < dim; ++j)
-                    result[i][j] = data_derv[0][j] * supp_pts[0][i];
+                    result[i][j] = data.derivative(point + data_set, 0)[j] *
+                                   data.mapping_support_points[0][i];
                 for (unsigned int k = 1; k < data.n_shape_functions; ++k)
                   for (unsigned int i = 0; i < spacedim; ++i)
                     for (unsigned int j = 0; j < dim; ++j)
-                      result[i][j] += data_derv[k][j] * supp_pts[k][i];
+                      result[i][j] += data.derivative(point + data_set, k)[j] *
+                                      data.mapping_support_points[k][i];
 
                 // write result into contravariant data. for
                 // j=dim in the case dim<spacedim, there will

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -329,25 +329,22 @@ namespace internal
 
               Assert(data.n_shape_functions > 0, ExcInternalError());
 
-              const Tensor<1, spacedim> *supp_pts =
-                data.mapping_support_points.data();
-
               for (unsigned int point = 0; point < n_q_points; ++point)
                 {
-                  const Tensor<1, dim> *data_derv =
-                    &data.derivative(point + data_set, 0);
-
                   double result[spacedim][dim];
 
                   // peel away part of sum to avoid zeroing the
                   // entries and adding for the first time
                   for (unsigned int i = 0; i < spacedim; ++i)
                     for (unsigned int j = 0; j < dim; ++j)
-                      result[i][j] = data_derv[0][j] * supp_pts[0][i];
+                      result[i][j] = data.derivative(point + data_set, 0)[j] *
+                                     data.mapping_support_points[0][i];
                   for (unsigned int k = 1; k < data.n_shape_functions; ++k)
                     for (unsigned int i = 0; i < spacedim; ++i)
                       for (unsigned int j = 0; j < dim; ++j)
-                        result[i][j] += data_derv[k][j] * supp_pts[k][i];
+                        result[i][j] +=
+                          data.derivative(point + data_set, k)[j] *
+                          data.mapping_support_points[k][i];
 
                   // write result into contravariant data. for
                   // j=dim in the case dim<spacedim, there will

--- a/source/fe/mapping_q_generic.cc
+++ b/source/fe/mapping_q_generic.cc
@@ -239,7 +239,7 @@ MappingQGeneric<dim, spacedim>::InternalData::initialize_face(
            update_JxW_values | update_inverse_jacobians))
         {
           aux.resize(dim - 1,
-                     std::vector<Tensor<1, spacedim>>(n_original_q_points));
+                     AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
 
           // Compute tangentials to the unit cell.
           for (const unsigned int i : GeometryInfo<dim>::face_indices())


### PR DESCRIPTION
While I was at it I made the same fix in MappingFE.

I don't completely understand this but accessing these pointers causes segmentation faults. It's not due to type aliasing (i.e., converting `Point *` to `Tensor *`) - converting both to `const auto *` does not fix the issue.

Since the compiler is trying to vectorize here lets oblige and align these internal arrays.