### PR TITLE
Add two missing tutorial programs to the changelog.

### DIFF
--- a/doc/news/9.2.0-vs-9.3.0.h
+++ b/doc/news/9.2.0-vs-9.3.0.h
@@ -457,6 +457,18 @@ inconvenience this causes.
 <ol>
 
  <li>
+  New: The step-78 tutorial program solves the Black-Scholes equations.
+  <br>
+  (Tylor Anderson, 2021/05/19)
+ </li>
+
+ <li>
+  New: The step-79 tutorial program demonstrates solution of a topology optimization problem.
+  <br>
+  (Justin O'Connor, 2021/05/19)
+ </li>
+
+ <li>
   New: The step-66 tutorial program shows how to solve a nonlinear PDE in parallel
   with MatrixFree methods.
   <br>


### PR DESCRIPTION
I don't remember the exact date that these were merged, but this is correct plus or minus a few days and that should be good enough.

In principle, we should go back to the 9.3 release branch as well, but I don't think that's necessary and it would also be a lot of work.