### PR TITLE
fix cmake underlinkage error

### DIFF
--- a/cmake/modules/FindMPI.cmake
+++ b/cmake/modules/FindMPI.cmake
@@ -136,7 +136,9 @@ CHECK_COMPILER_SETUP(
   ${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_C_LIBRARIES}
   )
 
-IF(NOT MPI_UNDERLINKAGE_OK)
+IF(NOT MPI_UNDERLINKAGE_OK AND NOT "${MPI_CXX_LIBRARIES}" STREQUAL "")
+  # This check only works if MPI_CXX_LIBRARIES is non-empty, otherwise we will just give up
+  # and hope for the best...
   MESSAGE(STATUS "Trying to avoid underlinkage by expliclitly adding libopen-pal to link line")
 
   LIST(GET MPI_CXX_LIBRARIES 0 _lib)


### PR DESCRIPTION
The underlinkage MPI check under Ubuntu fails if MPI_CXX_LIBRARIES is
empty, which happens if you configure with CXX=mpicxx (even though you
should not).

In this situation, just disable this hack. Errors look like this:

CMake Error at cmake/modules/FindMPI.cmake:143 (LIST):
  LIST GET given empty list
Call Stack (most recent call first):
  cmake/macros/macro_find_package.cmake:27 (_FIND_PACKAGE)
  cmake/configure/configure_1_mpi.cmake:28 (FIND_PACKAGE)
/a/CMakeFiles/CMakeTmp/evaluate_expression.tmp:1
(FEATURE_MPI_FIND_EXTERNAL)
  cmake/macros/macro_evaluate_expression.cmake:30 (INCLUDE)
  cmake/macros/macro_configure_feature.cmake:237 (EVALUATE_EXPRESSION)
  cmake/configure/configure_1_mpi.cmake:81 (CONFIGURE_FEATURE)
  cmake/macros/macro_verbose_include.cmake:19 (INCLUDE)
  CMakeLists.txt:121 (VERBOSE_INCLUDE)

CMake Error at cmake/modules/FindMPI.cmake:144 (GET_FILENAME_COMPONENT):
  GET_FILENAME_COMPONENT called with incorrect number of arguments
Call Stack (most recent call first):
  cmake/macros/macro_find_package.cmake:27 (_FIND_PACKAGE)
  cmake/configure/configure_1_mpi.cmake:28 (FIND_PACKAGE)
/a/CMakeFiles/CMakeTmp/evaluate_expression.tmp:1
(FEATURE_MPI_FIND_EXTERNAL)
  cmake/macros/macro_evaluate_expression.cmake:30 (INCLUDE)
  cmake/macros/macro_configure_feature.cmake:237 (EVALUATE_EXPRESSION)
  cmake/configure/configure_1_mpi.cmake:81 (CONFIGURE_FEATURE)
  cmake/macros/macro_verbose_include.cmake:19 (INCLUDE)
  CMakeLists.txt:121 (VERBOSE_INCLUDE)

-- _mpi_libopen_pal_library not found! The call was:
--     FIND_LIBRARY(_mpi_libopen_pal_library NAMES open-pal HINTS
NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH
NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH)