### PR TITLE
Fix number of locally owned particles in particle handler

### DIFF
--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -830,10 +830,10 @@ namespace Particles
     types::particle_index global_number_of_particles;
 
     /**
-     * This variable stores how many particles are stored locally. It is
+     * This variable stores how many particles are locally owned. It is
      * calculated by update_cached_numbers().
      */
-    types::particle_index local_number_of_particles;
+    types::particle_index number_of_locally_owned_particles;
 
     /**
      * The maximum number of particles per cell in the global domain. This

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -212,6 +212,12 @@ namespace Particles
     n_properties_per_slot() const;
 
     /**
+     * Return how many slots are currently registered in the pool.
+     */
+    unsigned int
+    n_registered_slots() const;
+
+    /**
      * This function makes sure that all internally stored memory blocks
      * are sorted in the same order as one would loop over the @p handles_to_sort
      * container. This makes sure memory access is contiguous with actual

--- a/source/particles/property_pool.cc
+++ b/source/particles/property_pool.cc
@@ -167,6 +167,29 @@ namespace Particles
     return n_properties;
   }
 
+
+
+  template <int dim, int spacedim>
+  unsigned int
+  PropertyPool<dim, spacedim>::n_registered_slots() const
+  {
+    Assert(locations.size() == reference_locations.size(),
+           ExcMessage("Number of registered locations is not equal to number "
+                      "of registered reference locations."));
+
+    Assert(locations.size() == ids.size(),
+           ExcMessage("Number of registered locations is not equal to number "
+                      "of registered ids."));
+
+    Assert(locations.size() * n_properties == properties.size(),
+           ExcMessage("Number of registered locations is not equal to number "
+                      "of registered property slots."));
+
+    return locations.size() - currently_available_handles.size();
+  }
+
+
+
   template <int dim, int spacedim>
   void
   PropertyPool<dim, spacedim>::sort_memory_slots(

--- a/tests/particles/exchange_ghosts_01.cc
+++ b/tests/particles/exchange_ghosts_01.cc
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// like particle_handler_06, but tests that the particle handlers function
+// n_locally_owned_particles only counts locally owned particles.
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test()
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(2);
+    MappingQ<dim, spacedim> mapping(1);
+
+    // both processes create a particle handler with a particle in a
+    // position that is in a ghost cell to the other process
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    Point<spacedim> position;
+    Point<dim>      reference_position;
+
+    if (Utilities::MPI::this_mpi_process(tr.get_communicator()) == 0)
+      for (unsigned int i = 0; i < dim; ++i)
+        position(i) = 0.475;
+    else
+      for (unsigned int i = 0; i < dim; ++i)
+        position(i) = 0.525;
+
+    Particles::Particle<dim, spacedim> particle(
+      position,
+      reference_position,
+      Utilities::MPI::this_mpi_process(tr.get_communicator()));
+
+    // We give a local random cell hint to check that sorting and
+    // transferring ghost particles works.
+    typename Triangulation<dim, spacedim>::active_cell_iterator cell =
+      tr.begin_active();
+    while (!cell->is_locally_owned())
+      ++cell;
+
+    particle_handler.insert_particle(particle, cell);
+
+    particle_handler.sort_particles_into_subdomains_and_cells();
+
+    deallog << "Before ghost exchange: "
+            << particle_handler.n_locally_owned_particles()
+            << " locally owned particles on process "
+            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << std::endl;
+
+    deallog << "Before ghost exchange: "
+            << particle_handler.get_property_pool().n_registered_slots()
+            << " stored particles on process "
+            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << std::endl;
+
+    particle_handler.exchange_ghost_particles();
+
+    // Usually this update is unnecessary, because exchanging ghost particles
+    // does not change anything about the cache. However, there was a bug
+    // that ghost particles were counted as locally owned, so make sure
+    // this does not happen again.
+    particle_handler.update_cached_numbers();
+
+    deallog << "After ghost exchange: "
+            << particle_handler.n_locally_owned_particles()
+            << " locally owned particles on process "
+            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << std::endl;
+
+    deallog << "After ghost exchange: "
+            << particle_handler.get_property_pool().n_registered_slots()
+            << " stored particles on process "
+            << Utilities::MPI::this_mpi_process(tr.get_communicator())
+            << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll all;
+
+  deallog.push("2d/2d");
+  test<2, 2>();
+  deallog.pop();
+  deallog.push("3d/3d");
+  test<3, 3>();
+  deallog.pop();
+}

--- a/tests/particles/exchange_ghosts_01.with_p4est=true.mpirun=2.output
+++ b/tests/particles/exchange_ghosts_01.with_p4est=true.mpirun=2.output
@@ -1,0 +1,23 @@
+
+DEAL:0:2d/2d::Before ghost exchange: 1 locally owned particles on process 0
+DEAL:0:2d/2d::Before ghost exchange: 1 stored particles on process 0
+DEAL:0:2d/2d::After ghost exchange: 1 locally owned particles on process 0
+DEAL:0:2d/2d::After ghost exchange: 2 stored particles on process 0
+DEAL:0:2d/2d::OK
+DEAL:0:3d/3d::Before ghost exchange: 1 locally owned particles on process 0
+DEAL:0:3d/3d::Before ghost exchange: 1 stored particles on process 0
+DEAL:0:3d/3d::After ghost exchange: 1 locally owned particles on process 0
+DEAL:0:3d/3d::After ghost exchange: 2 stored particles on process 0
+DEAL:0:3d/3d::OK
+
+DEAL:1:2d/2d::Before ghost exchange: 1 locally owned particles on process 1
+DEAL:1:2d/2d::Before ghost exchange: 1 stored particles on process 1
+DEAL:1:2d/2d::After ghost exchange: 1 locally owned particles on process 1
+DEAL:1:2d/2d::After ghost exchange: 2 stored particles on process 1
+DEAL:1:2d/2d::OK
+DEAL:1:3d/3d::Before ghost exchange: 1 locally owned particles on process 1
+DEAL:1:3d/3d::Before ghost exchange: 1 stored particles on process 1
+DEAL:1:3d/3d::After ghost exchange: 1 locally owned particles on process 1
+DEAL:1:3d/3d::After ghost exchange: 2 stored particles on process 1
+DEAL:1:3d/3d::OK
+


### PR DESCRIPTION
Another subtle bug introduced during the particle rework. `n_locally_owned_particles` should not count ghost_particles as locally owned. This happened automatically when we still had two separate containers for particles and ghost particles, but that is not longer the case, so only increase/decrease the cached number when the cell the particle is in is locally owned (when inserting particles we dont have to check, because we assert that particles can only be inserted in locally owned cells at the moment). Also added a test.