### PR TITLE
Updated references doc

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -3,13 +3,14 @@
 %-------------------------------------------------------------------------------
 
 @article{Mu05,
-  author =  {Mo Mu},
+  author =  {M. Mu},
   title =   {{PDE.M}art: A Network-based Problem-solving Environment for {PDE}s},
-  journal = {ACM Trans. Math. Software.},
+  journal = {ACM Transactions on Mathematical Software},
   year =    2005,
   volume =  31,
   number =  4,
-  pages =   {508--531}
+  pages =   {508--531},
+  url =     {https://doi.org/10.1145/1114268.1114272}
 }
 
 %-------------------------------------------------------------------------------
@@ -17,13 +18,14 @@
 %-------------------------------------------------------------------------------
 
 @article{Kel74,
-  author =  {R. Bruce Kellogg},
+  author =  {R.B. Kellogg},
   title =   {On the {P}oisson equation with intersecting interfaces},
   journal = {Applicable Analysis},
   year  =   1974,
   volume =  4,
   number =  2,
-  pages =   {101--129}
+  pages =   {101--129},
+  url =     {https://doi.org/10.1080/00036817408839086}
 }
 
 %-------------------------------------------------------------------------------
@@ -31,16 +33,14 @@
 %-------------------------------------------------------------------------------
 
 @article{Li2019,
-  doi = {10.1007/s10915-019-01102-1},
-  url = {https://doi.org/10.1007/s10915-019-01102-1},
-  year = {2019},
-  month = dec,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume = {82},
-  number = {1},
-  author = {Hao Li and Xiangxiong Zhang},
-  title = {Superconvergence of $C^0-Q^k$ Finite Element Method for Elliptic Equations with Approximated Coefficients},
-  journal = {Journal of Scientific Computing}
+  author =  {H. Li and X. Zhang},
+  title =   {Superconvergence of {C}$^0$-{Q}$^k$ Finite Element Method for Elliptic Equations with Approximated Coefficients},
+  journal = {Journal of Scientific Computing},
+  year =    {2020},
+  volume =  {82},
+  number =  {1}, 
+  doi =     {10.1007/s10915-019-01102-1},
+  url =     {https://doi.org/10.1007/s10915-019-01102-1}
 }
 
 %-------------------------------------------------------------------------------
@@ -48,15 +48,14 @@
 %-------------------------------------------------------------------------------
 
 @incollection{Cangiani2012,
-  doi = {10.1007/978-3-642-33134-3_34},
-  url = {https://doi.org/10.1007/978-3-642-33134-3_34},
-  year = {2012},
-  month = nov,
+  author =    {A. Cangiani and J. Chapman and E.H. Georgoulis and M. Jensen},
+  title =     {Implementation of the Continuous-Discontinuous {G}alerkin Finite Element Method},
+  booktitle = {Numerical Mathematics and Advanced Applications 2011},
   publisher = {Springer Berlin Heidelberg},
-  pages = {315--322},
-  author = {A. Cangiani and J. Chapman and E. H. Georgoulis and M. Jensen},
-  title = {Implementation of the Continuous-Discontinuous Galerkin Finite Element Method},
-  booktitle = {Numerical Mathematics and Advanced Applications 2011}
+  year =      {2012},  
+  pages =     {315--322},  
+  doi =       {10.1007/978-3-642-33134-3_34},
+  url =       {https://doi.org/10.1007/978-3-642-33134-3_34}
 }
 
 %-------------------------------------------------------------------------------
@@ -64,32 +63,26 @@
 %-------------------------------------------------------------------------------
 
 @inproceedings{Ban00w,
-  author =  {Wolfgang Bangerth},
-  title =   {Mesh Adaptivity and Error Control for a Finite Element
-             Approximation of the Elastic Wave Equation},
-  booktitle =   {Proceedings of the Fifth International Conference on Mathematical
-                 and Numerical Aspects of Wave Propagation (Waves2000), Santiago
-                 de Compostela, Spain, 2000},
-  year =    2000,
-  editor =  {Alfredo Berm\'udez and Dolores G\'omez and Christophe Hazard and
-             Patrick Joly and Jean E. Roberts},
-  publisher =   {SIAM},
-  pages =   {725--729}
+  author =    {W. Bangerth},
+  title =     {Mesh Adaptivity and Error Control for a Finite Element Approximation of the Elastic Wave Equation},
+  booktitle = {Proceedings of the Fifth International Conference on Mathematical and Numerical Aspects of Wave Propagation (Waves2000), Santiago de Compostela, Spain, 2000},
+  editor =    {Alfredo Berm\'udez and Dolores G\'omez and Christophe Hazard and Patrick Joly and Jean E. Roberts},
+  publisher = SIAM,
+  year =      2000,
+  pages =     {725--729}
 }
 
 @phdthesis{Ban02,
-  author =  {Wolfgang Bangerth},
-  title =   {Adaptive Finite Element Methods for the Identification
-             of Distributed Parameters in Partial Differential Equations},
+  author =  {W. Bangerth},
+  title =   {Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations},
   school =  {University of Heidelberg},
   year =    2002
 }
 
 @article{BR99b,
-  author =  {Wolfgang Bangerth and Rolf Rannacher},
-  title =   {Finite element approximation of the acoustic wave equation: {E}rror
-             control and mesh adaptation},
-  journal = {East--West J. Numer. Math.},
+  author =  {W. Bangerth and R. Rannacher},
+  title =   {Finite element approximation of the acoustic wave equation: Error control and mesh adaptation},
+  journal = {East--West Journal of Numerical Mathematics},
   year =    1999,
   volume =  7,
   number =  4,
@@ -97,154 +90,153 @@
 }
 
 @book{BR03,
-  author =  {Wolfgang Bangerth and Rolf Rannacher},
-  title =   {Adaptive Finite Element Methods for Differential Equations},
-  publisher =   {Birkh{\"a}user Verlag},
-  year =    2003
+  author =    {W. Bangerth and R. Rannacher},
+  title =     {Adaptive Finite Element Methods for Differential Equations},
+  publisher = {Birkh{\"a}user Verlag},
+  year =      2003,
+  url =       {https://doi.org/10.1007/978-3-0348-7605-6}
 }
 
 @article{BR01a,
-  author =  {Wolfgang Bangerth and Rolf Rannacher},
+  author =  {W. Bangerth and R. Rannacher},
   title =   {Adaptive Finite Element Techniques for the Acoustic Wave Equation},
-  journal = {J. Comput. Acoustics},
+  journal = {Journal of Computational Acoustics},
   year =    2001,
   volume =  9,
   number =  2,
-  pages =   {575--591}
+  pages =   {575--591},
+  url =     {https://doi.org/10.1142/S0218396X01000668}
 }
 
 @article{BR01,
-  author =  {Roland Becker and Rolf Rannacher},
-  title =   {An optimal control approach to error estimation and mesh
-             adaptation in finite element methods.},
+  author =  {R. Becker and R. Rannacher},
+  title =   {An optimal control approach to error estimation and mesh adaptation in finite element methods},
   journal = {Acta Numerica},
   year =    2001,
   volume =  10,
-  pages =   {1--102}
+  pages =   {1--102},
+  url =     {https://doi.org/10.1017/S0962492901000010}
 }
 
 @phdthesis{Bec95,
-  author =  {Roland Becker},
-  title =   {An Adaptive Finite Element Method for the Incompressible
-             {N}avier-{S}tokes Equations on Time-dependent Domains},
+  author =  {R. Becker},
+  title =   {An Adaptive Finite Element Method for the Incompressible {N}avier--{S}tokes Equations on Time-dependent Domains},
   school =  {Universit{\"a}t Heidelberg},
   type =    {Dissertation},
   year =    1995
 }
 
 @techreport{Bec98,
-  author =  {Roland Becker},
-  title =   {Weighted Error Estimators for the Incompressible {N}avier-{S}tokes Equations},
+  author =      {R. Becker},
+  title =       {Weighted Error Estimators for the Incompressible {N}avier--{S}tokes Equations},
   institution = {Universit{\"a}t Heidelberg},
-  type =    {Preprint 98-20},
-  year =    1998
+  type =        {Preprint 98-20},
+  year =        1998
 }
 
 @article{BR96r,
-  author =  {Roland Becker and Rolf Rannacher},
-  title =   {A Feed-Back Approach to Error Control in Finite Element Methods:
-             Basic Analysis and Examples},
-  journal = {East-West J. Numer. Math},
+  author =  {R. Becker and R. Rannacher},
+  title =   {A Feed-Back Approach to Error Control in Finite Element Methods: Basic Analysis and Examples},
+  journal = {East--West Journal of Numerical Mathematics},
   volume =  4,
   year =    1996,
   pages =   {237--264}
 }
 
 @inproceedings{BR95,
-  author =  {Roland Becker and Rolf Rannacher},
-  title =   {Weighted A Posteriori Error Control in {FE} Methods},
-  booktitle =   {ENUMATH 97},
-  editor =  {H. G. Bock et al.},
-  publisher =   {World Scientific Publ., Singapore},
-  year =    1998,
-  pages =   {621--637}
+  author =    {R. Becker and R. Rannacher},
+  title =     {Weighted A Posteriori Error Control in {FE} Methods},
+  booktitle = {ENUMATH 97},
+  editor =    {H. G. Bock et al.},
+  publisher = {World Scientific Publishing, Singapore},
+  year =      1998,
+  pages =     {621--637}
 }
 
 @article{FK97,
-  author =  {Christian F{\"u}hrer and Guido Kanschat},
+  author =  {C. F{\"u}hrer and G. Kanschat},
   title =   {A posteriori error control in radiative transfer},
   journal = {Computing},
   year =    1997,
   volume =  58,
   number =  4,
-  pages =   {317--334}
+  pages =   {317--334},
+  url =     {https://doi.org/10.1007/BF02684345}
 }
 
 @phdthesis{Har02,
-  author =  {Ralf Hartmann},
+  author =  {R. Hartmann},
   title =   {Adaptive Finite Element Methods for the Compressible {E}uler Equations},
   school =  {Universit{\"a}t Heidelberg},
   year =    2002
 }
 
 @article{HH01,
-  author =  {Ralf Hartmann and Paul Houston},
-  title =   {Adaptive Discontinuous {G}alerkin Finite Element Methods for
-             Nonlinear Hyperbolic Conservation Laws},
-  publisher =   {SIAM}
-  journal = {Journal on Scientific Computing},
-  year =    2003,
-  volume =  24,
-  number =  3,
-  pages =   {979--1004}
+  author =    {R. Hartmann and P. Houston},
+  title =     {Adaptive Discontinuous {G}alerkin Finite Element Methods for Nonlinear Hyperbolic Conservation Laws},
+  publisher = SIAM,
+  journal =   {Journal on Scientific Computing},
+  year =      2003,
+  volume =    24,
+  number =    3,
+  pages =     {979--1004}
 }
 
 @article{HH01b,
-  author =  {Ralf Hartmann and Paul Houston},
-  title =   {Adaptive Discontinuous {G}alerkin Finite Element Methods for the
-             Compressible {E}uler Equations},
+  author =  {R. Hartmann and P. Houston},
+  title =   {Adaptive Discontinuous {G}alerkin Finite Element Methods for the Compressible {E}uler Equations},
   journal = {Journal of Computational Physics},
   year =    2002,
   volume =  183,
   number =  2,
-  pages =   {508--532}
+  pages =   {508--532},
+  url =     {https://doi.org/10.1137/S1064827501389084}
 }
 
 @phdthesis{Kan96,
-  author =  {Guido Kanschat},
-  title =   {Parallel and Adaptive Galerkin Methods for Radiative Transfer Problems},
+  author =  {G. Kanschat},
+  title =   {Parallel and Adaptive {G}alerkin Methods for Radiative Transfer Problems},
   school =  {Universit{\"a}t Heidelberg},
   type =    {Dissertation},
   year =    1996
 }
 
 @article{RS97,
-  author =  {Rolf Rannacher and Franz-Theo Suttmeier},
-  title =   {A feed-back approach to error control in finite element methods:
-             Application to linear elasticity},
+  author =  {R. Rannacher and F.-T. Suttmeier},
+  title =   {A feed-back approach to error control in finite element methods: Application to linear elasticity},
   journal = {Computational Mechanics},
   year =    1997,
   volume =  19,
   number =  5,
-  pages =   {434--446}
+  pages =   {434--446},
+  url =     {https://doi.org/10.1007/s004660050191}
 }
 
 @article{RS98c,
-  author =  {Rolf Rannacher and Franz-Theo Suttmeier},
-  title =   {A posteriori error control in finite element methods via duality
-             techniques: Application to perfect plasticity},
+  author =  {R. Rannacher and F.-T. Suttmeier},
+  title =   {A posteriori error control in finite element methods via duality techniques: Application to perfect plasticity},
   journal = {Computational Mechanics},
   year =    1998,
   volume =  21,
   number =  2,
-  pages =   {123--133}
+  pages =   {123--133},
+  url =     {https://doi.org/10.1007/s004660050288}
 }
 
 @article{RS99,
-  author =  {Rolf Rannacher and Franz-Theo Suttmeier},
-  title =   {A posteriori error estimation and mesh adaptation for finite
-             element models in elasto-plasticity},
+  author =  {R. Rannacher and F.-T. Suttmeier},
+  title =   {A posteriori error estimation and mesh adaptation for finite element models in elasto-plasticity},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year =    1999,
   volume =  176,
   number =  1,
-  pages =   {333--361}
+  pages =   {333--361},
+  url =     {https://doi.org/10.1016/S0045-7825(98)00344-2}
 }
 
 @phdthesis{Sut96,
-  author =  {Franz-Theo Suttmeier},
-  title =   {Adaptive Finite Element Approximation of Problems in
-             Elasto-Plasticity Theory},
+  author =  {F.-T. Suttmeier},
+  title =   {Adaptive Finite Element Approximation of Problems in Elasto-Plasticity Theory},
   school =  {Universit{\"a}t Heidelberg},
   type =    {Dissertation},
   year =    1996
@@ -256,20 +248,22 @@
 %-------------------------------------------------------------------------------
 
 
+@book{GNS08,
+  author =    {I. Griva and S.G. Nash and A. Sofer},
+  title =     {Linear and nonlinear optimization},
+  publisher = SIAM,
+  year =      2008,
+  edition =   {2nd},
+  url =       {https://doi.org/10.1007/978-1-4939-7055-1}
+}
 
-@Book{GNS08,
-  author =    {I. Griva and S. G. Nash and A. Sofer},
-  title =        {Linear and nonlinear optimization},
-  publisher =    {SIAM},
-  year =         2008,
-  edition =   {2nd}}
-
-@Book{NW99,
-  author =	 {J. Nocedal and S. J. Wright},
-  title = 	 {Numerical Optimization},
-  publisher = 	 {Springer, New York},
-  year = 	 1999,
-  series =	 {Springer Series in Operations Research}
+@book{NW99,
+  author =    {J. Nocedal and S.J. Wright},
+  title =     {Numerical Optimization},
+  publisher = {Springer, New York},
+  year =      1999,
+  series =    {Springer Series in Operations Research},
+  url =       {https://doi.org/10.1007%2F978-0-387-40065-5}
 }
 
 
@@ -279,23 +273,25 @@
 %-------------------------------------------------------------------------------
 
 @article{CTZ04,
-  author =  {Stéphane Commend and Andrzej Truty and Thomas Zimmermann},
-  title =   {Stabilized finite elements applied to elastoplasticity: I. Mixed displacement–pressure formulation},
+  author =  {S. Commend and A. Truty and T. Zimmermann},
+  title =   {Stabilized finite elements applied to elastoplasticity: I. {M}ixed displacement–pressure formulation},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year =    2004,
   volume =  193,
   number =  33,
-  pages =   {3559--3586}
+  pages =   {3559--3586},
+  url =     {https://doi.org/10.1016/j.cma.2004.01.007}
 }
 
 @article{DL05,
-  author =  {Huo-Yuan Duan and Qun Lin},
+  author =  {H.-Y. Duan and Q. Lin},
   title =   {Mixed finite elements of least-squares type for elasticity},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year =    2005,
   volume =  194,
   number =  9,
-  pages =   {1093--1112}
+  pages =   {1093--1112},
+  url =     {https://doi.org/10.1016/j.cma.2004.06.033}
 }
 
 
@@ -303,14 +299,15 @@
 % Step 22
 % ------------------------------------
 
-@Article{SW94,
-  author = 	 {D. Silvester and A. Wathen},
-  title = 	 {Fast iterative solution of stabilised {S}tokes systems. {P}art
-                  {II}: {U}sing general block preconditioners},
-  journal = 	 {SIAM J. Numer. Anal.},
-  year = 	 1994,
-  volume = 	 31,
-  pages = 	 {1352--1367}}
+@article{SW94,
+  author =  {D. Silvester and A. Wathen},
+  title =   {Fast iterative solution of stabilised {S}tokes systems. {P}art {II}: Using general block preconditioners},
+  journal = {SIAM Journal on Numerical Analysis},
+  year =    1994,
+  volume =  31,
+  pages =   {1352--1367},
+  url =     {https://doi.org/10.1137/0731070}
+}
 
 
 % ------------------------------------
@@ -318,8 +315,8 @@
 % ------------------------------------
 
 @phdthesis{fehling2020,
-  author    = {Marc Fehling},
-  title     = {Algorithms for massively parallel generic hp-adaptive finite element methods},
+  author    = {M. Fehling},
+  title     = {Algorithms for massively parallel generic \textit{hp}-adaptive finite element methods},
   publisher = {Forschungszentrum Jülich GmbH Zentralbibliothek, Verlag},
   school    = {Bergische Universität Wuppertal},
   year      = {2020},
@@ -334,71 +331,67 @@
 % ------------------------------------
 
 @article{Brenner2005,
-  doi = {10.1007/s10915-004-4135-7},
-  url = {https://doi.org/10.1007/s10915-004-4135-7},
-  year = {2005},
-  month = jun,
+  author =    {S.C. Brenner and L.-Y. Sung},
+  title =     {C$^0$ Interior Penalty Methods for Fourth Order Elliptic Boundary Value Problems on Polygonal Domains},
+  journal =   {Journal of Scientific Computing},
   publisher = {Springer Science and Business Media {LLC}},
-  volume = {22-23},
-  number = {1-3},
-  pages = {83--118},
-  author = {Susanne C. Brenner and Li-Yeng Sung},
-  title = {$C^0$ Interior Penalty Methods for Fourth Order Elliptic Boundary Value Problems on Polygonal Domains},
-  journal = {Journal of Scientific Computing}
+  year =      {2005},
+  volume =    {22},
+  number =    {1},
+  pages =     {83--118},
+  doi =       {10.1007/s10915-004-4135-7},
+  url =       {https://doi.org/10.1007/s10915-004-4135-7}
 }
 
 
 @incollection{Brenner2011,
-  doi = {10.1007/978-3-642-23914-4_2},
-  url = {https://doi.org/10.1007/978-3-642-23914-4_2},
-  year = {2011},
+  author =    {S.C. Brenner},
+  title =     {C$^0$ Interior Penalty Methods},
+  booktitle = {Lecture Notes in Computational Science and Engineering},
   publisher = {Springer Berlin Heidelberg},
-  pages = {79--147},
-  author = {Susanne C. Brenner},
-  title = {$C^0$ Interior Penalty Methods},
-  booktitle = {Lecture Notes in Computational Science and Engineering}
+  year =      {2011},
+  pages =     {79--147},
+  doi =       {10.1007/978-3-642-23914-4_2},
+  url =       {https://doi.org/10.1007/978-3-642-23914-4_2}
 }
 
 @article{Engel2002,
-  doi = {10.1016/s0045-7825(02)00286-4},
-  url = {https://doi.org/10.1016/s0045-7825(02)00286-4},
-  year = {2002},
-  month = jul,
-  publisher = {Elsevier {BV}},
-  volume = {191},
-  number = {34},
-  pages = {3669--3750},
-  author = {G. Engel and K. Garikipati and T.J.R. Hughes and M.G. Larson and L. Mazzei and R.L. Taylor},
-  title = {Continuous/discontinuous finite element approximations of fourth-order elliptic problems in structural and continuum mechanics with applications to thin beams and plates,  and strain gradient elasticity},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  author =    {G. Engel and K. Garikipati and T.J.R. Hughes and M.G. Larson and L. Mazzei and R.L. Taylor},
+  title =     {Continuous/discontinuous finite element approximations of fourth-order elliptic problems in structural and continuum mechanics with applications to thin beams and plates,  and strain gradient elasticity},
+  journal =   {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier BV},
+  year =      {2002},
+  volume =    {191},
+  number =    {34},
+  pages =     {3669--3750},
+  doi =       {10.1016/s0045-7825(02)00286-4},
+  url =       {https://doi.org/10.1016/s0045-7825(02)00286-4}
 }
 
 @article{Brenner2009,
-  doi = {10.1093/imanum/drn057},
-  url = {https://doi.org/10.1093/imanum/drn057},
-  year = {2009},
-  month = mar,
+  author =    {S.C. Brenner and T. Gudi and L.-Y. Sung},
+  title =     {An a posteriori error estimator for a quadratic C0-interior penalty method for the biharmonic problem},
+  journal =   {IMA Journal of Numerical Analysis},
   publisher = {Oxford University Press ({OUP})},
-  volume = {30},
-  number = {3},
-  pages = {777--798},
-  author = {S. C. Brenner and T. Gudi and L.-Y. Sung},
-  title = {An a posteriori error estimator for a quadratic C0-interior penalty method for the biharmonic problem},
-  journal = {{IMA} Journal of Numerical Analysis}
+  year =      {2009},
+  volume =    {30},
+  number =    {3},
+  pages =     {777--798},
+  doi =       {10.1093/imanum/drn057},
+  url =       {https://doi.org/10.1093/imanum/drn057}
 }
 
 @article{Wells2007,
-  doi = {10.1016/j.cma.2007.03.008},
-  url = {https://doi.org/10.1016/j.cma.2007.03.008},
-  year = {2007},
-  month = jul,
-  publisher = {Elsevier {BV}},
-  volume = {196},
-  number = {35-36},
-  pages = {3370--3380},
-  author = {Garth N. Wells and Nguyen Tien Dung},
-  title = {A C0 discontinuous Galerkin formulation for Kirchhoff plates},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  author =    {G.N. Wells and N.T. Dung},
+  title =     {A {C}$^0$ discontinuous {G}alerkin formulation for {K}irchhoff plates},
+  journal =   {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier BV},
+  year =      {2007},
+  volume =    {196},
+  number =    {35-36},
+  pages =     {3370--3380},      
+  doi =       {10.1016/j.cma.2007.03.008},
+  url =       {https://doi.org/10.1016/j.cma.2007.03.008}
 }
 
 % ------------------------------------
@@ -406,14 +399,15 @@
 % ------------------------------------
 
 @article{karakashian2003posteriori,
-  title={A posteriori error estimates for a discontinuous Galerkin approximation of second-order elliptic problems},
-  author={Karakashian, Ohannes A and Pascal, Frederic},
-  journal={SIAM Journal on Numerical Analysis},
-  volume={41},
-  number={6},
-  pages={2374--2399},
-  year={2003},
-  publisher={SIAM}
+  author =    {O.A. Karakashian and F. Pascal},
+  title =     {A posteriori error estimates for a discontinuous {G}alerkin approximation of second-order elliptic problems},
+  journal =   {SIAM Journal on Numerical Analysis},
+  publisher = SIAM,
+  year =      {2003},  
+  volume =    {41},
+  number =    {6},
+  pages =     {2374--2399},
+  url =       {https://doi.org/10.1137/S0036142902405217}
 }
 
 % ------------------------------------
@@ -421,89 +415,77 @@
 % ------------------------------------
 
 @article {Ngu2012,
-    AUTHOR = {Nguyen, N. C. and Peraire, J.},
-     TITLE = {Hybridizable discontinuous {G}alerkin methods for partial
-              differential equations in continuum mechanics},
-   JOURNAL = {J. Comput. Phys.},
-  FJOURNAL = {Journal of Computational Physics},
-    VOLUME = {231},
+    AUTHOR = {N.C. Nguyen and J. Peraire},
+     TITLE = {Hybridizable discontinuous {G}alerkin methods for partial differential equations in continuum mechanics},
+   JOURNAL = {Journal of Computational Physics},
       YEAR = {2012},
+    VOLUME = {231},      
     NUMBER = {18},
      PAGES = {5955--5988},
-      ISSN = {0021-9991},
-   MRCLASS = {65N30},
-  MRNUMBER = {2954837},
        DOI = {10.1016/j.jcp.2012.02.033},
-       URL = {https://doi.org/10.1016/j.jcp.2012.02.033},
+       URL = {https://doi.org/10.1016/j.jcp.2012.02.033}
 }
 
 @incollection{F65,
-  author = {Fraeijs de Veubeke, B. X.},
-  title = {Displacement and equilibrium models in the finite element method},
+  author =    {B.X. Fraeijs de Veubeke},
+  title =     {Displacement and equilibrium models in the finite element method},
   booktitle = {Stress Analysis},
   publisher = {Wiley, New York},
-  editor = {Zienkiewicz, O. C. and Holister, G. S.},
-  year = {1965},
-  pages = {275-284},
-  URL = {https://ci.nii.ac.jp/naid/10003737730/en/},
+  editor =    {O.C. Zienkiewicz and G.S. Holister},
+  year =      {1965},
+  pages =     {275-284},
+  URL =       {https://ci.nii.ac.jp/naid/10003737730/en/}
 }
 
 @article{G65,
-  doi = {10.2514/3.2874},
-  url = {https://doi.org/10.2514/3.2874},
-  year  = {1965},
-  month = {feb},
+  author =    {R.J. Guyan},
+  title =     {Reduction of stiffness and mass matrices},
+  journal =   {AIAA Journal},
   publisher = {American Institute of Aeronautics and Astronautics ({AIAA})},
-  volume = {3},
-  number = {2},
-  pages = {380--380},
-  author = {R. J. Guyan},
-  title = {Reduction of stiffness and mass matrices},
-  journal = {{AIAA} Journal}
+  year  =     {1965},
+  volume =    {3},
+  number =    {2},
+  pages =     {380--380},
+  doi =       {10.2514/3.2874},
+  url =       {https://doi.org/10.2514/3.2874}
 }
 
 @article {CGL2009,
-    AUTHOR = {Cockburn, Bernardo and Gopalakrishnan, Jayadeep and Lazarov, Raytcho},
-     TITLE = {Unified hybridization of discontinuous {G}alerkin, mixed, and
-              continuous {G}alerkin methods for second order elliptic
-              problems},
-   JOURNAL = {SIAM J. Numer. Anal.},
-  FJOURNAL = {SIAM Journal on Numerical Analysis},
-    VOLUME = {47},
+    AUTHOR = {B. Cockburn and J. Gopalakrishnan and R. Lazarov},
+     TITLE = {Unified hybridization of discontinuous {G}alerkin, mixed, and continuous {G}alerkin methods for second order elliptic problems},
+   JOURNAL = {SIAM Journal on Numerical Analysis},
       YEAR = {2009},
+    VOLUME = {47},
     NUMBER = {2},
      PAGES = {1319--1365},
-      ISSN = {0036-1429},
-   MRCLASS = {65N30},
-  MRNUMBER = {2485455},
-MRREVIEWER = {Jose Luis Gracia},
        DOI = {10.1137/070706616},
-       URL = {http://dx.doi.org/10.1137/070706616},
+       URL = {https://doi.org/10.1137/070706616}
 }
 
 % ------------------------------------
 % Step 55
 % ------------------------------------
 
-@Book{elman2005,
+@book{elman2005,
+  Author                   = {H.C. Elman and D.J. Silvester and A.J. Wathen},
   Title                    = {Finite Elements and Fast Iterative Solvers with Applications in Incompressible Fluid Dynamics},
-  Author                   = {Elman, H. C. and Silvester, D. J. and Wathen, A. J.},
   Publisher                = {Oxford University Press},
   Year                     = {2005},
   Address                  = {Oxford, New York},
   Series                   = {Numerical Mathematics and Scientific Computation},
-  ISBN                     = {0-19-852868-X},
+  Url                      = {https://doi.org/10.1093/acprof:oso/9780199678792.001.0001}
 }
 
 @inproceedings{kovasznay1948laminar,
-  title={Laminar flow behind a two-dimensional grid},
-  author={Kovasznay, LIG},
-  booktitle={Mathematical Proceedings of the Cambridge Philosophical Society},
-  volume={44},
-  number={1},
-  pages={58--62},
-  year={1948},
-  organization={Cambridge University Press}
+  author =       {L.I.G. Kovasznay},
+  title =        {Laminar flow behind a two-dimensional grid},
+  booktitle =    {Mathematical Proceedings of the Cambridge Philosophical Society},
+  organization = {Cambridge University Press},
+  year =         {1948},
+  volume =       {44},
+  number =       {1},
+  pages =        {58--62},
+  url =          {https://doi.org/10.1017/S0305004100023999}
 }
 
 
@@ -512,14 +494,14 @@ MRREVIEWER = {Jose Luis Gracia},
 % ------------------------------------
 
 @incollection{Wang2019,
-  doi = {10.1007/978-3-030-22747-0_37},
-  url = {https://doi.org/10.1007/978-3-030-22747-0_37},
-  year = {2019},
+  author =    {Z. Wang and G. Harper and P. O'Leary and J. Liu and S. Tavener},
+  title =     {deal.{II} Implementation of a Weak {G}alerkin Finite Element Solver for Darcy Flow},
+  booktitle = {Lecture Notes in Computer Science},
   publisher = {Springer International Publishing},
-  pages = {495--509},
-  author = {Zhuoran Wang and Graham Harper and Patrick O'Leary and Jiangguo Liu and Simon Tavener},
-  title = {deal.{II} Implementation of a Weak Galerkin Finite Element Solver for Darcy Flow},
-  booktitle = {Lecture Notes in Computer Science}
+  year =      {2019},
+  pages =     {495--509},
+  doi =       {10.1007/978-3-030-22747-0_37},
+  url =       {https://doi.org/10.1007/978-3-030-22747-0_37}
 }
 
 % ------------------------------------
@@ -527,34 +509,36 @@ MRREVIEWER = {Jose Luis Gracia},
 % ------------------------------------
 
 @incollection{john2006discontinuity,
-  title={On discontinuity—capturing methods for convection—diffusion equations},
-  author={John, Volker and Knobloch, Petr},
-  booktitle={Numerical Mathematics and Advanced Applications},
-  pages={336--344},
-  year={2006},
-  publisher={Springer}
+  author =    {V. John and P. Knobloch},
+  title =     {On discontinuity—capturing methods for convection—diffusion equations},
+  booktitle = {Numerical Mathematics and Advanced Applications},
+  publisher = {Springer},
+  year =      {2006},
+  pages =     {336--344},
+  url =       {https://doi.org/10.1007/978-3-540-34288-5_27}
 }
 
 @article{KanschatNotesIterative,
-  title={Notes on Applied Mathematics: Iterative methods, Schwarz preconditioners and multigrid},
-  author={Kanschat, Guido},
-  year={2015},
-  url={https://www.mathsim.eu/~gkanscha/notes/C.pdf}
+  author = {G. Kanschat},
+  title =  {Notes on Applied Mathematics: Iterative methods, Schwarz preconditioners and multigrid},
+  year =   {2015},
+  url =    {https://www.mathsim.eu/~gkanscha/notes/C.pdf}
 }
 
 @book{smith2004domain,
-  title={Domain decomposition: parallel multilevel methods for elliptic partial differential equations},
-  author={Smith, Barry and Bjorstad, Petter and Gropp, William},
-  year={2004},
-  publisher={Cambridge University Press}
+  author =    {B. Smith and P. Bjorstad and W. Gropp},
+  title =     {Domain decomposition: parallel multilevel methods for elliptic partial differential equations},
+  publisher = {Cambridge University Press},
+  year =      {2004}  
 }
 
 @book{toselli2006domain,
-  title={Domain decomposition methods-algorithms and theory},
-  author={Toselli, Andrea and Widlund, Olof},
-  volume={34},
-  year={2006},
-  publisher={Springer Science \& Business Media}
+  author =    {A. Toselli and O. Widlund},
+  title =     {Domain decomposition methods-algorithms and theory},
+  publisher = {Springer Science \& Business Media},
+  year =      {2006},
+  volume =    {34},
+  url =       {https://doi.org/10.1007/b137868}
 }
 
 % ------------------------------------
@@ -562,17 +546,18 @@ MRREVIEWER = {Jose Luis Gracia},
 % ------------------------------------
 
 @book{bebernes1989mathematical,
+  author    = {J. Bebernes and D. Eberly},
   title     = {Mathematical Problems from Combustion Theory},
-  author    = {Bebernes, J. and Eberly, D.},
+  publisher = {Springer-Verlag, New York, NY},
+  year      = {1989},
   volume    = {83},
   series    = {Applied Mathematical Sciences},
-  publisher = {Springer-Verlag, New York, NY},
-  year      = {1989}
+  url       = {https://doi.org/10.1007/978-1-4612-4546-9}
 }
 
 @phdthesis{castelli2021numerical,
   author = {Castelli, G. F.},
-  title  = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
+  title  = {Numerical Investigation of {C}ahn--{H}illiard-Type Phase-Field Models for Battery Active Particles},
   school = {Karlsruhe Institute of Technology (KIT)},
   year   = {2021},
   note   = {(To be published)}
@@ -583,87 +568,85 @@ MRREVIEWER = {Jose Luis Gracia},
 % ------------------------------------
 
 @article{KennedyCarpenterLewis2000,
-author = {Kennedy, Christopher A. and Carpenter, Mark H. and Lewis, R. Micheal},
-title = {Low-storage, explicit {R}unge--{K}utta schemes for the compressible {N}avier--{S}tokes equations},
-journal = {Applied Numerical Mathematics},
-volume = 35,
-year = 2000,
-pages = {177--219},
-doi = {10.1016/S0168-9274(99)00141-5},
-url = {https://doi.org/10.1016/S0168-9274(99)00141-5}
+  author =  {C.A. Kennedy and M.H. Carpenter and R.M. Lewis},
+  title =   {Low-storage, explicit {R}unge--{K}utta schemes for the compressible {N}avier--{S}tokes equations},
+  journal = {Applied Numerical Mathematics},
+  year =    2000,
+  volume =  35,  
+  pages =   {177--219},
+  doi =     {10.1016/S0168-9274(99)00141-5},
+  url =     {https://doi.org/10.1016/S0168-9274(99)00141-5}
 }
 
 @article{TseliosSimos2007,
-author = {Tselios, Kostas and Simos, Theodore E.},
-title = {Optimized {R}unge--{K}utta methods with minimal dispersion and dissipation for problems arising from computational acoustics},
-journal = {Physics Letters A},
-volume = 363,
-year = 2007,
-pages = {38--48},
-doi = {10.1016/j.physleta.2006.10.072},
-url = {https://doi.org/10.1016/j.physleta.2006.10.072}
+  author =  {K. Tselios and T.E. Simos},
+  title =   {Optimized {R}unge--{K}utta methods with minimal dispersion and dissipation for problems arising from computational acoustics},
+  journal = {Physics Letters A},
+  year =    2007,  
+  volume =  363,
+  pages =   {38--48},
+  doi =     {10.1016/j.physleta.2006.10.072},
+  url =     {https://doi.org/10.1016/j.physleta.2006.10.072}
 }
 
 @article{KronbichlerSchoeder2016,
-author = {Kronbichler, Martin and Schoeder, Svenja and M\"uller, Christopher and Wall, Wolfgang A.},
-title = {Comparison of implicit and explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
-journal = {International Journal for Numerical Methods in Engineering},
-volume = "106",
-number = 9,
-pages = "712--739",
-doi = {10.1002/nme.5137},
-url = {https://doi.org/10.1002/nme.5137},
-year = {2016}
+  author =  {M. Kronbichler and S. Schoeder and C. M\"uller and W.A. Wall},
+  title =   {Comparison of implicit and explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
+  journal = {International Journal for Numerical Methods in Engineering},
+  year =    {2016}
+  volume =  {106},
+  number =  {9},
+  pages =   {712--739},
+  doi =     {10.1002/nme.5137},
+  url =     {https://doi.org/10.1002/nme.5137}
 }
 
 @article{SchoederKormann2018,
-  title={Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
-  author={Schoeder, Svenja and Kormann, Katharina and Wall, Wolfgang A. and  Kronbichler, Martin},
-  journal={SIAM J. Sci. Comput.},
-  pages = {C803--C826},
-  volume = 40,
-  number = 6,
-  year={2018},
-  doi={10.1137/18M1185399},
-  url={https://doi.org/10.1137/18M1185399}
+  author =  {S. Schoeder and K. Kormann and W.A. Wall and M. Kronbichler},
+  title =   {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
+  journal = {SIAM Journal on Scientific Computing},
+  year =    {2018},
+  volume =  40,
+  number =  6,
+  pages =   {C803--C826},
+  doi =     {10.1137/18M1185399},
+  url =     {https://doi.org/10.1137/18M1185399}
 }
 
-
 @article{FehnWallKronbichler2019,
-author = {Fehn, Niklas and Wall, Wolfgang A. and Kronbichler, Martin},
-title = {A matrix-free high-order discontinuous {G}alerkin compressible {N}avier--{S}tokes solver:
-A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
-journal = {International Journal for Numerical Methods in Fluids},
-volume = {89},
-number = {3},
-pages = {71--102},
-year = {2019},
-doi = {10.1002/fld.4683},
-url = {https://doi.org/10.1002/fld.4683}
+  author =  {N. Fehn and W.A. Wall and M. Kronbichler},
+  title =   {A matrix-free high-order discontinuous {G}alerkin compressible {N}avier--{S}tokes solver: A performance comparison of compressible and incompressible formulations for turbulent incompressible flows},
+  journal = {International Journal for Numerical Methods in Fluids},
+  year =    {2019},
+  volume =  {89},
+  number =  {3},
+  pages =   {71--102},
+%  doi =     {10.1002/fld.4683},  
+  url =     {https://doi.org/10.1002/fld.4683}
 }
 
 @article{KronbichlerKormann2019,
-author = {Kronbichler, Martin and Kormann, Katharina},
-title  = {Fast matrix-free evaluation of discontinuous {G}alerkin finite element operators},
-journal = {ACM Transactions on Mathematical Software},
-volume = {45},
-number = {3},
-pages = {29:1--29:40},
-year = {2019},
-doi = {10.1145/3325864},
-url = {https://doi.org/10.1145/3325864}
+  author =  {M. Kronbichler and K. Kormann},
+  title  =  {Fast matrix-free evaluation of discontinuous {G}alerkin finite element operators},
+  journal = {ACM Transactions on Mathematical Software},
+  year =    {2019},
+  volume =  {45},
+  number =  {3},
+  pages =   {29:1--29:40},
+  doi =     {10.1145/3325864},
+  url =     {https://doi.org/10.1145/3325864}
 }
 
 @article{Gassner2013,
-  doi = {10.1137/120890144},
-  url = {https://doi.org/10.1137/120890144},
-  year = {2013},
-  volume = {35},
-  number = {3},
-  pages = {A1233--A1253},
-  author = {Gregor J. Gassner},
-  title = {A Skew-Symmetric Discontinuous {G}alerkin Spectral Element Discretization and Its Relation to {SBP}-{SAT} Finite Difference Methods},
-  journal = {{SIAM} Journal on Scientific Computing}
+  author =  {G.J. Gassner},
+  title =   {A Skew-Symmetric Discontinuous {G}alerkin Spectral Element Discretization and Its Relation to {SBP}-{SAT} Finite Difference Methods},
+  journal = {SIAM Journal on Scientific Computing},
+  year =    {2013},
+  volume =  {35},
+  number =  {3},
+  pages =   {A1233--A1253},
+  doi =     {10.1137/120890144},
+  url =     {https://doi.org/10.1137/120890144}
 }
 
 % ------------------------------------
@@ -671,35 +654,38 @@ url = {https://doi.org/10.1145/3325864}
 % ------------------------------------
 
 @article{Blais2013,
-  title={Dealing with more than two materials in the FVCF--ENIP method},
-  author={Blais, Bruno and Braeunig, Jean-Philippe and Chauveheid, Daniel and Ghidaglia, Jean-Michel and Loub{\`e}re, Rapha{\"e}l},
-  journal={European Journal of Mechanics-B/Fluids},
-  volume={42},
-  pages={1--9},
-  year={2013},
-  publisher={Elsevier}
+  author =    {B. Blais and J.-P. Braeunig and D. Chauveheid and J.-M. Ghidaglia and R. Loub{\`e}re},
+  title =     {Dealing with more than two materials in the {FVCF}--{ENIP} method},
+  journal =   {European Journal of Mechanics-B/Fluids},
+  publisher = {Elsevier},
+  year =      {2013},
+  volume =    {42},
+  pages =     {1--9},
+  url =       {https://doi.org/10.1016/j.euromechflu.2013.05.001}
 }
 
 @article{Blais2019,
-  title={Experimental Methods in Chemical Engineering: Discrete Element Method—DEM},
-  author={Blais, Bruno and Vidal, David and Bertrand, Francois and Patience, Gregory S and Chaouki, Jamal},
-  journal={The Canadian Journal of Chemical Engineering},
-  volume={97},
-  number={7},
-  pages={1964--1973},
-  year={2019},
-  publisher={Wiley Online Library}
+  author =    {B. Blais and D. Vidal and F. Bertrand and G.S. Patience and J. Chaouki},
+  title =     {Experimental Methods in Chemical Engineering: Discrete Element Method--{DEM}},
+  journal =   {The Canadian Journal of Chemical Engineering},
+  publisher = {Wiley Online Library},
+  year =      {2019},
+  volume =    {97},
+  number =    {7},
+  pages =     {1964--1973},
+  url =       {https://doi.org/10.1002/cjce.23501}
 }
 
 @article{Gassmoller2019,
-  title={Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible Stokes flow},
-  author={Gassm{\"o}ller, Rene and Lokavarapu, Harsha and Bangerth, Wolfgang and Puckett, Elbridge Gerry},
-  journal={Geophysical Journal International},
-  volume={219},
-  number={3},
-  pages={1915--1938},
-  year={2019},
-  publisher={Oxford University Press}
+  author =    {R. Gassm{\"o}ller and H. Lokavarapu and W. Bangerth and E.G. Puckett},
+  title =     {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible {S}tokes flow},
+  journal =   {Geophysical Journal International},
+  publisher = {Oxford University Press},
+  year =      {2019},    
+  volume =    {219},
+  number =    {3},
+  pages =     {1915--1938},
+  url =       {https://doi.org/10.1093/gji/ggz405}
 }
 
 
@@ -708,107 +694,96 @@ url = {https://doi.org/10.1145/3325864}
 % ------------------------------------
 
 @article {GuermondPopov2016,
-    AUTHOR = {Guermond, Jean-Luc and Popov, Bojan},
-     TITLE = {Invariant domains and first-order continuous finite element
-              approximation for hyperbolic systems},
-   JOURNAL = {SIAM J. Numer. Anal.},
-  FJOURNAL = {SIAM Journal on Numerical Analysis},
-    VOLUME = {54},
+    AUTHOR = {J.-L. Guermond and B. Popov},
+     TITLE = {Invariant domains and first-order continuous finite element approximation for hyperbolic systems},
+   JOURNAL = {SIAM Journal on Numerical Analysis},
       YEAR = {2016},
+    VOLUME = {54},
     NUMBER = {4},
      PAGES = {2466--2489},
-      ISSN = {0036-1429},
        DOI = {10.1137/16M1074291},
+       URL = {https://doi.org/10.1137/16M1074291}       
 }
 
 @article {GuermondPopov2016b,
-    AUTHOR = {Guermond, Jean-Luc and Popov, Bojan},
-     TITLE = {Fast estimation of the maximum wave speed in the Riemann problem for the Euler equations},
-   JOURNAL = {J. Comput. Phys.},
-  FJOURNAL = {Journal of Computational Physics},
-    VOLUME = {321},
+    AUTHOR = {J.-L. Guermond and B. Popov},
+     TITLE = {Fast estimation of the maximum wave speed in the {R}iemann problem for the {E}uler equations},
+   JOURNAL = {Journal of Computational Physics},
       YEAR = {2016},
+    VOLUME = {321},
      PAGES = {908--926},
-      ISSN = {0021-9991},
        DOI = {10.1016/j.jcp.2016.05.054},
+       URL = {https://doi.org/10.1016/j.jcp.2016.05.054}       
 }
 
 @article {GuermondEtAl2018,
-    AUTHOR = {Guermond, Jean-Luc and Nazarov, Murtazo and Popov, Bojan and
-              Tomas, Ignacio},
-     TITLE = {Second-order invariant domain preserving approximation of the
-              {E}uler equations using convex limiting},
-   JOURNAL = {SIAM J. Sci. Comput.},
-  FJOURNAL = {SIAM Journal on Scientific Computing},
-    VOLUME = {40},
+    AUTHOR = {J.-L. Guermond and M. Nazarov and B. Popov and I. Tomas},
+     TITLE = {Second-order invariant domain preserving approximation of the {E}uler equations using convex limiting},
+   JOURNAL = {SIAM Journal on Scientific Computing},
       YEAR = {2018},
+    VOLUME = {40},
     NUMBER = {5},
      PAGES = {A3211--A3239},
-      ISSN = {1064-8275},
        DOI = {10.1137/17M1149961},
+       URL = {http://doi.org/10.1137/17M1149961}
 }
 
 @book {GuermondErn2004,
-    AUTHOR = {Ern, Alexandre and Guermond, Jean-Luc},
+    AUTHOR = {A. Ern and J.-L. Guermond},
      TITLE = {Theory and practice of finite elements},
     SERIES = {Applied Mathematical Sciences},
     VOLUME = {159},
  PUBLISHER = {Springer-Verlag, New York},
       YEAR = {2004},
      PAGES = {xiv+524},
-      ISBN = {0-387-20574-8},
        DOI = {10.1007/978-1-4757-4355-5},
+       URL = {https://doi.org/10.1007/978-1-4757-4355-5}       
 }
 
 @article {Brooks1982,
-    AUTHOR = {Brooks, Alexander N. and Hughes, Thomas J. R.},
-     TITLE = {Streamline upwind/{P}etrov-{G}alerkin formulations for
-              convection dominated flows with particular emphasis on the
-              incompressible {N}avier-{S}tokes equations},
+    AUTHOR = {A.N. Brooks and T.J.R. Hughes},
+     TITLE = {Streamline upwind/{P}etrov-{G}alerkin formulations for convection dominated flows with particular emphasis on the incompressible {N}avier-{S}tokes equations},
       NOTE = {FENOMECH ''81, Part I (Stuttgart, 1981)},
-   JOURNAL = {Comput. Methods Appl. Mech. Engrg.},
-  FJOURNAL = {Computer Methods in Applied Mechanics and Engineering},
-    VOLUME = {32},
+   JOURNAL = {Computer Methods in Applied Mechanics and Engineering},
       YEAR = {1982},
+    VOLUME = {32},
     NUMBER = {1-3},
      PAGES = {199--259},
-      ISSN = {0045-7825},
        DOI = {10.1016/0045-7825(82)90071-8},
+       URL = {https://doi.org/10.1016/0045-7825(82)90071-8}
 }
 
 @article {Johnson1986,
-    AUTHOR = {Johnson, C. and Pitk\"{a}ranta, J.},
-     TITLE = {An analysis of the discontinuous {G}alerkin method for a
-              scalar hyperbolic equation},
-   JOURNAL = {Math. Comp.},
-  FJOURNAL = {Mathematics of Computation},
+    AUTHOR = {C. Johnson and J. Pitk\"{a}ranta},
+     TITLE = {An analysis of the discontinuous {G}alerkin method for a scalar hyperbolic equation},
+   JOURNAL = {Mathematics of Computation},
+      YEAR = {1986},   
     VOLUME = {46},
-      YEAR = {1986},
     NUMBER = {173},
      PAGES = {1--26},
-      ISSN = {0025-5718},
        DOI = {10.2307/2008211},
+       URL = {https://doi.org/10.2307/2008211}
 }
 
 @book{Rainald2008,
-author = {Lohner, Rainald},
-publisher = {John Wiley & Sons, Ltd},
-isbn = {9780470989746},
-title = {Edge-Based Compressible Flow Solvers},
-booktitle = {Applied Computational Fluid Dynamics Techniques},
-chapter = {10},
-pages = {187-200},
-doi = {10.1002/9780470989746.ch10},
-year = {2008},
+  author =    {R. Lohner},
+  title =     {Edge-Based Compressible Flow Solvers},
+  booktitle = {Applied Computational Fluid Dynamics Techniques},
+  publisher = {John Wiley & Sons, Ltd},
+  year =      {2008},
+  chapter =   {10},
+  pages =     {187-200},
+  doi =       {10.1002/9780470989746.ch10},
+  url =       {https://doi.org/10.1002/9780470989746.ch10}  
 }
 
 @book {Toro2009,
-  AUTHOR = {Eleuterio F. Toro},
+  AUTHOR =    {F.T. Eleuterio},
+  TITLE =     {Riemann Solvers and Numerical Methods for Fluid Dynamics},
   PUBLISHER = {Springer-Verlag, Berlin, Heidelberg},
-  ISBN = {9783540252023},
-  TITLE ={Riemann Solvers and Numerical Methods for Fluid Dynamics},
-  doi = {10.1007/b79761},
-  year = {2009}
+  year =      {2009},
+  doi =       {10.1007/b79761},
+  url =       {https:doi.org/10.1007/b79761}  
 }
 
 
@@ -817,84 +792,76 @@ year = {2008},
 % ------------------------------------
 
 
-
-@InProceedings{Freund1995,
-  author =       {Freund, J. and Stenberg, R.},
-  title =        {On weakly imposed boundary conditions for
-  second order problems},
-  booktitle = {Proceedings of the Ninth International Conference on
-                  Finite Elements in Fluids},
+@inproceedings{Freund1995,
+  author =    {J. Freund and R. Stenberg},
+  title =     {On weakly imposed boundary conditions for second order problems},
+  booktitle = {Proceedings of the Ninth International Conference on Finite Elements in Fluids},
   year =      1995,
-  pages =     {327--336}}
-
-@article{Angot1999,
-  doi = {10.1007/s002110050401},
-  url = {https://doi.org/10.1007/s002110050401},
-  year = {1999},
-  month = feb,
-  publisher = {Springer Science and Business Media {LLC}},
-  volume = {81},
-  number = {4},
-  pages = {497--520},
-  author = {Philippe Angot and Charles-Henri Bruneau and Pierre Fabrie},
-  title = {A penalization method to take into account obstacles in incompressible viscous flows},
-  journal = {Numerische Mathematik}
+  pages =     {327--336}
 }
 
+@article{Angot1999,
+  author =    {P. Angot and C.-H. Bruneau and P. Fabrie},
+  title =     {A penalization method to take into account obstacles in incompressible viscous flows},
+  journal =   {Numerische Mathematik},
+  publisher = {Springer Science and Business Media {LLC}},
+  year =      {1999},
+  volume =    {81},
+  number =    {4},
+  pages =     {497--520},
+  doi =       {10.1007/s002110050401},
+  url =       {https://doi.org/10.1007/s002110050401}
+}
 
 @article{Glowinski1999,
-  doi = {10.1016/s0301-9322(98)00048-2},
-  url = {https://doi.org/10.1016/s0301-9322(98)00048-2},
-  year = {1999},
-  month = aug,
-  publisher = {Elsevier {BV}},
-  volume = {25},
-  number = {5},
-  pages = {755--794},
-  author = {R. Glowinski and T.-W. Pan and T.I. Hesla and D.D. Joseph},
-  title = {A distributed Lagrange multiplier/fictitious domain method for particulate flows},
-  journal = {International Journal of Multiphase Flow}
+  author =    {R. Glowinski and T.-W. Pan and T.I. Hesla and D.D. Joseph},
+  title =     {A distributed Lagrange multiplier/fictitious domain method for particulate flows},
+  journal =   {International Journal of Multiphase Flow},
+  publisher = {Elsevier BV},
+  year =      {1999},
+  volume =    {25},
+  number =    {5},
+  pages =     {755--794},
+  doi =       {10.1016/s0301-9322(98)00048-2},
+  url =       {https://doi.org/10.1016/s0301-9322(98)00048-2}
 }
 
 @article{Boffi2008,
-  doi = {10.1016/j.cma.2007.09.015},
-  url = {https://doi.org/10.1016/j.cma.2007.09.015},
-  year = {2008},
-  month = apr,
-  publisher = {Elsevier {BV}},
-  volume = {197},
-  number = {25-28},
-  pages = {2210--2231},
-  author = {Daniele Boffi and Lucia Gastaldi and Luca Heltai and Charles S. Peskin},
-  title = {On the hyper-elastic formulation of the immersed boundary method},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  author =    {D. Boffi and L. Gastaldi and L. Heltai and Ch.S. Peskin},
+  title =     {On the hyper-elastic formulation of the immersed boundary method},
+  journal =   {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier BV},
+  year =      {2008},
+  volume =    {197},
+  number =    {25-28},
+  pages =     {2210--2231},
+  doi =       {10.1016/j.cma.2007.09.015},
+  url =       {https://doi.org/10.1016/j.cma.2007.09.015}
 }
 
-
 @article{Heltai2012,
-  doi = {10.1016/j.cma.2012.04.001},
-  url = {https://doi.org/10.1016/j.cma.2012.04.001},
-  year = {2012},
-  month = jul,
-  publisher = {Elsevier {BV}},
-  volume = {229-232},
-  pages = {110--127},
-  author = {Luca Heltai and Francesco Costanzo},
-  title = {Variational implementation of immersed finite element methods},
-  journal = {Computer Methods in Applied Mechanics and Engineering}
+  author =    {L. Heltai and F. Costanzo},
+  title =     {Variational implementation of immersed finite element methods},
+  journal =   {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier BV},
+  year =      {2012},
+  volume =    {229-232},
+  pages =     {110--127},
+  doi =       {10.1016/j.cma.2012.04.001},
+  url =       {https://doi.org/10.1016/j.cma.2012.04.001}
 }
 
 @article{Riviere1999,
-  doi = {10.1023/a:1011591328604},
-  url = {https://doi.org/10.1023/a:1011591328604},
-  year = {1999},
+  author =    {B. Rivi{\`{e}}re and M.F. Wheeler and V. Girault},
+  title =     {Improved energy estimates for interior penalty, constrained and discontinuous {G}alerkin methods for elliptic problems. {P}art {I}},
+  journal =   {Computational Geosciences},
   publisher = {Springer Science and Business Media {LLC}},
-  volume = {3},
-  number = {3/4},
-  pages = {337--360},
-  author = {B{\'{e}}atrice Rivi{\`{e}}re and Mary F. Wheeler and Vivette Girault},
-  journal = {Computational Geosciences},
-  title = {Improved energy estimates for interior penalty, constrained and discontinuous {G}alerkin methods for elliptic problems. {P}art {I}}
+  year =      {1999},
+  volume =    {3},
+  number =    {3},
+  pages =     {337--360},
+  doi =       {10.1023/a:1011591328604},
+  url =       {https://doi.org/10.1023/a:1011591328604}
 }
 
 
@@ -904,15 +871,13 @@ year = {2008},
 
 
 @book{Pelteret2019a,
-  author    = {Pelteret, J-P. V. and Steinmann, P.},
-  publisher = {De Gruyter Mouton},
+  author    = {J.-P. Pelteret and P. Steinmann},
   title     = {Magneto-active polymers: Fabrication, characterisation, modelling and simulation at the micro- and macro-scale},
+  publisher = {De Gruyter Mouton},
   year      = {2019},
   edition   = {1},
-  isbn      = {9783110419511},
-  comment   = {In collaboration with: B. Brands, G. Chatzigeorgiou, D. Davydov, M. Hossain, A. Javili, D. Pivovarov, P. Saxena, F. Vogel, D.K. Vu, B. Walter and R. Zabihyan},
   doi       = {10.1515/9783110418576},
-  url       = {https://www.degruyter.com/document/doi/10.1515/9783110418576/html},
+  url       = {https://www.degruyter.com/document/doi/10.1515/9783110418576/html}
 }
 
 @book{Logg2012a,
@@ -920,130 +885,130 @@ year = {2008},
   publisher = {Springer Berlin Heidelberg},
   year      = {2012},
   editor    = {A. Logg and K.-A. Mardal and G. Wells},
-  isbn      = {978-3-642-23098-1},
   doi       = {10.1007/978-3-642-23099-8},
+  url       = {https://doi.org/10.1007/978-3-642-23099-8}
 }
 
 @book{Korelc2016a,
+  author    = {J. Korelc and P. Wriggers},
   title     = {Automation of Finite Element Methods},
   publisher = {Springer Nature},
   year      = {2016},
-  author    = {J. Korelc and P. Wriggers},
-  isbn      = {978-3-319-39003-1},
   doi       = {10.1007/978-3-319-39005-5},
+  url       = {https://doi.org/10.1007/978-3-319-39005-5}
 }
 
 @inbook{Truesdell1960a,
+  author    = {C. Truesdell and R. Toupin},
+  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statics},    
   chapter   = {2: The classical field theories},
-  pages     = {226--794},
-  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statics},
   publisher = {Springer-Verlag Berlin Heidelberg},
-  year      = {1960},
-  author    = {Truesdell, C. and Toupin, R.},
-  editor    = {Fl\"{u}gge, S.},
-  volume    = {1},
-  isbn      = {978-3-540-02547-4},
+  year      = {1960},  
+  editor    = {S. Fl\"{u}gge},
+  volume    = {1},  
+  pages     = {226--794},
   doi       = {10.1007/978-3-642-45943-6},
+  url       = {https://doi.org/10.1007/978-3-642-45943-6}
 }
 
-@Article{Coleman1963a,
-  author    = {Coleman, B. D. and Noll, W.},
+@article{Coleman1963a,
+  author    = {B.D. Coleman and W. Noll},
   title     = {The thermodynamics of elastic materials with heat conduction and viscosity},
   journal   = {Archive for Rational Mechanics and Analysis},
+  publisher = {Springer},
   year      = {1963},
   volume    = {13},
   number    = {1},
   pages     = {167--178},
-  month     = dec,
   doi       = {10.1007/BF01262690},
-  publisher = {Springer},
+  url       = {https://doi.org/10.1007/BF01262690}  
 }
 
-@Article{Coleman1967a,
-  author    = {Coleman, B. D. and Gurtin, M. E.},
+@article{Coleman1967a,
+  author    = {B.D. Coleman and M.E. Gurtin},
   title     = {Thermodynamics with internal state variables},
+  journal   = {The Journal of Chemical Physics},
+  publisher = {{AIP} Publishing},
   year      = {1967},
   volume    = {47},
   number    = {2},
   pages     = {597--613},
   doi       = {10.1063/1.1711937},
-  journal   = {The Journal of Chemical Physics},
-  publisher = {AIP Publishing},
+  url       = {https://doi.org/10.1063/1.1711937}
 }
 
-@InCollection{Pao1978a,
-  author    = {Pao, Y. H.},
+@incollection{Pao1978a,
+  author    = {Y.H. Pao},
   title     = {Electromagnetic Forces in Deformable Continua},
   booktitle = {Mechanics Today},
   publisher = {Elsevier},
   year      = {1978},
-  editor    = {Nemat-Nasser, S.},
+  editor    = {S. Nemat-Nasser},
   volume    = {4},
   series    = {Pergamon Mechanics Today Series},
   chapter   = {IV},
   pages     = {209--305},
   address   = {New York},
-  isbn      = {978-0-08-021792-5},
   doi       = {10.1016/b978-0-08-021792-5.50012-4},
+  url       = {https://doi.org/10.1016/b978-0-08-021792-5.50012-4}  
 }
 
-@Article{Holzapfel1996a,
-  author    = {Holzapfel, G. A. and Simo, J. C.},
+@article{Holzapfel1996a,
+  author    = {G.A. Holzapfel and J.C. Simo},
   title     = {A new viscoelastic constitutive model for continuous media at finite thermomechanical changes},
   journal   = {International Journal of Solids and Structures},
+  publisher = {Elsevier},
   year      = {1996},
   volume    = {33},
   number    = {20--22},
   pages     = {3019--3034},
-  month     = aug,
-  doi       = {10.1016/0020-7683(95)00263-4},
-  publisher = {Elsevier},
+%  doi       = {10.1016/0020-7683(95)00263-4},
+  url       = {https://doi.org/10.1016/0020-7683(95)00263-4}
 }
 
-@Book{Holzapfel2007a,
+@book{Holzapfel2007a,
+  author    = {G.A. Holzapfel},
   title     = {Nonlinear Solid Mechanics: A Continuum Approach for Engineering},
   publisher = {John Wiley \& Sons Ltd.},
   year      = {2007},
-  author    = {Holzapfel, G. A.},
-  address   = {West Sussex, England},
-  isbn      = {0-471-82304-X}
+  address   = {West Sussex, England}
 }
 
-@Article{Linder2011a,
-  author    = {Linder, C. and Tkachuk, M. and Miehe, C.},
+@article{Linder2011a,
+  author    = {C. Linder and M. Tkachuk and C. Miehe},
   title     = {A micromechanically motivated diffusion-based transient network model and its incorporation into finite rubber viscoelasticity},
   journal   = {Journal of the Mechanics and Physics of Solids},
+  publisher = {Elsevier},  
   year      = {2011},
   volume    = {59},
   number    = {10},
   pages     = {2134--2156},
-  month     = oct,
-  doi       = {10.1016/j.jmps.2011.05.005},
-  publisher = {Elsevier},
+%  doi       = {10.1016/j.jmps.2011.05.005},
+  url       = {https://doi.org/10.1016/j.jmps.2011.05.005}  
 }
 
-@Article{Pelteret2018a,
-  author    = {Pelteret, J.-P. V. and Walter, B. and Steinmann, P.},
+@article{Pelteret2018a,
+  author    = {J.-P. Pelteret and B. Walter and P. Steinmann},
   title     = {Application of metaheuristic algorithms to the identification of nonlinear magneto-viscoelastic constitutive parameters},
   journal   = {Journal of Magnetism and Magnetic Materials},
+  publisher = {Elsevier BV},
   year      = {2018},
   volume    = {464},
   pages     = {116--131},
-  month     = oct,
   doi       = {10.1016/j.jmmm.2018.02.094},
-  publisher = {Elsevier {BV}},
+  url       = {https://doi.org/10.1016/j.jmmm.2018.02.094}
 }
 
-@Article{Koprowski-Theiss2011a,
-  author    = {Koprowski-Theiss, N. and Johlitz, M. and Diebels, S.},
+@article{Koprowski-Theiss2011a,
+  author    = {N. Koprowski-Theiss and M. Johlitz and S. Diebels},
   title     = {Characterizing the time dependence of filled {EPDM}},
   journal   = {Rubber Chemistry and Technology},
   year      = {2011},
   volume    = {84},
   number    = {2},
   pages     = {147--165},
-  month     = jun,
-  doi       = {10.5254/1.3570527}
+  doi       = {10.5254/1.3570527},
+  url       = {https://doi.org/10.5254/1.3570527}
 }
 
 
@@ -1052,22 +1017,24 @@ year = {2008},
 % ------------------------------------
 
 @book{di2011mathematical,
-  title={Mathematical aspects of discontinuous Galerkin methods},
-  author={Di Pietro, Daniele Antonio and Ern, Alexandre},
-  volume={69},
-  year={2011},
-  publisher={Springer Science \& Business Media}
+  author =    {D.A. Di Pietro and A. Ern},
+  title =     {Mathematical aspects of discontinuous {G}alerkin methods},
+  publisher = {Springer Science \& Business Media},
+  volume =    {69},
+  year =      {2011},
+  url =       {https://doi.org/10.1007/978-3-642-22980-0}
 }
 
 @article{ainsworth2007posteriori,
-  title={A posteriori error estimation for discontinuous Galerkin finite element approximation},
-  author={Ainsworth, Mark},
-  journal={SIAM Journal on Numerical Analysis},
-  volume={45},
-  number={4},
-  pages={1777--1798},
-  year={2007},
-  publisher={SIAM}
+  author =    {M. Ainsworth},
+  title =     {A posteriori error estimation for discontinuous {G}alerkin finite element approximation},
+  journal =   {SIAM Journal on Numerical Analysis},
+  publisher = SIAM,
+  year =      {2007},
+  volume =    {45},
+  number =    {4},
+  pages =     {1777--1798},
+  url =       {https://doi.org/10.1137/060665993}
 }
 
 
@@ -1076,41 +1043,38 @@ year = {2008},
 % ------------------------------------
 
 @book{brenner2008,
-  title     = {The {{Mathematical Theory}} of {{Finite Element Methods}}},
-  author    = {Brenner, Susanne and Scott, Ridgway},
+  author    = {S. Brenner and R. Scott},
+  title     = {The {{Mathematical Theory}} of {{Finite Element Methods}}},  
+  publisher = {{Springer-Verlag}},
   year      = {2008},
   edition   = {3},
-  publisher = {{Springer-Verlag}},
+  series    = {Texts in {{Applied Mathematics}}},
   location  = {{New York}},
-  url       = {https://www.springer.com/de/book/9780387759333},
-  isbn      = {978-0-387-75933-3},
-  series    = {Texts in {{Applied Mathematics}}}
+  url       = {https://www.springer.com/de/book/9780387759333}
 }
 
 @article{mitchell2010hpmg,
+  author  = {W.F. Mitchell},
   title   = {The \textit{hp}‐multigrid method applied to \textit{hp}‐adaptive refinement of triangular grids},
-  author  = {Mitchell, William F.},
-  year    = {2010},
-  month   = {Apr},
   journal = {Numerical Linear Algebra with Applications},
+  year    = {2010},
   volume  = {17},
-  pages   = {211--228},
-  issn    = {1070-5325},
-  doi     = {10.1002/nla.700},
   number  = {2-3}
+  pages   = {211--228},
+  doi     = {10.1002/nla.700},
+  url     = {https://doi.org/10.1002/nla.700}  
 }
 
 @article{mitchell2014hp,
-  title   = {A {{Comparison}} of \textit{hp}-{{Adaptive Strategies}} for {{Elliptic Partial Differential Equations}}},
-  author  = {Mitchell, William F. and McClain, Marjorie A.},
+  author  = {W.F. Mitchell and M.A. McClain},
+  title   = {A Comparison of \textit{hp}-Adaptive Strategies for Elliptic Partial Differential Equations},
+  journal = {ACM Transactions on Mathematical Software},
   year    = {2014},
-  month   = {Oct},
-  journal = {ACM Trans. Math. Softw.},
   volume  = {41},
-  pages   = {2/1-39},
-  issn    = {0098-3500},
-  doi     = {10.1145/2629459},
   number  = {1}
+  pages   = {2/1-39},
+  doi     = {10.1145/2629459},
+  url     = {https://doi.org/10.1145/2629459}
 }
 
 
@@ -1119,12 +1083,12 @@ year = {2008},
 % ------------------------------------
 
 @misc{munch2020hyperdeal,
-  title={hyper.deal: An efficient, matrix-free finite-element library for high-dimensional partial differential equations},
-  author={Peter Munch and Katharina Kormann and Martin Kronbichler},
-  year={2020},
-  eprint={2002.08110},
-  archivePrefix={arXiv},
-  primaryClass={cs.MS}
+  author =        {P. Munch and K. Kormann and M. Kronbichler},
+  title =         {hyper.deal: An efficient, matrix-free finite-element library for high-dimensional partial differential equations},
+  year =          {2020},
+  eprint =        {2002.08110},
+  archivePrefix = {arXiv},
+  primaryClass =  {cs.MS}
 }
 
 
@@ -1134,16 +1098,15 @@ year = {2008},
 
 
 @article{eiwa96,
-author = {Stanley C. Eisenstat and Homer F. Walker},
-title = {Choosing the Forcing Terms in an Inexact {N}ewton Method},
-journal = {SIAM Journal on Scientific Computing},
-volume = {17},
-number = {1},
-pages = {16-32},
-year = {1996},
-doi = {10.1137/0917003},
-URL = {http://dx.doi.org/10.1137/0917003},
-eprint = {http://dx.doi.org/10.1137/0917003}
+  author = {C.E. Stanley and F.W. Homer},
+  title = {Choosing the Forcing Terms in an Inexact {N}ewton Method},
+  journal = {SIAM Journal on Scientific Computing},
+  year = {1996},
+  volume = {17},
+  number = {1},
+  pages = {16--32},
+  doi = {10.1137/0917003},
+  URL = {https://doi.org/10.1137/0917003}
 }
 
 
@@ -1152,24 +1115,26 @@ eprint = {http://dx.doi.org/10.1137/0917003}
 % ------------------------------------
 
 @article{black1973pricing,
-  title={The Pricing of Options and Corporate Liabilities},
-  author={Black, Fischer and Scholes, Myron},
-  journal={The Journal of Political Economy},
-  volume={81},
-  number={3},
-  pages={637--654},
-  year={1973}
+  author =  {F. Black and M. Scholes},
+  title =   {The Pricing of Options and Corporate Liabilities},
+  journal = {The Journal of Political Economy},
+  year =    {1973},
+  volume =  {81},
+  number =  {3},
+  pages =   {637--654},
+  url =     {https://doi.org/10.1086/260062}
 }
 
 @article{stoll1969relationship,
-  title={The relationship between put and call option prices},
-  author={Stoll, Hans R},
-  journal={The Journal of Finance},
-  volume={24},
-  number={5},
-  pages={801--824},
-  year={1969},
-  publisher={Wiley Online Library}
+  author =    {H.R. Stoll},
+  title =     {The relationship between put and call option prices},
+  journal =   {The Journal of Finance},
+  publisher = {Wiley Online Library},
+  year =      {1969},
+  volume =    {24},
+  number =    {5},
+  pages =     {801--824},
+  url =       {https://doi.org/10.1111/j.1540-6261.1969.tb01694.x}
 }
 
 
@@ -1178,62 +1143,60 @@ eprint = {http://dx.doi.org/10.1137/0917003}
 % ------------------------------------
 
 @book{Bendse2004,
-  doi = {10.1007/978-3-662-05086-6},
-  url = {https://doi.org/10.1007/978-3-662-05086-6},
-  year = {2004},
+  author =    {M.P. Bends{\o}e and O. Sigmund},
+  title =     {Topology Optimization},
   publisher = {Springer Berlin Heidelberg},
-  author = {Martin P. Bends{\o}e and Ole Sigmund},
-  title = {Topology Optimization}
+  year =      {2004},
+  doi =       {10.1007/978-3-662-05086-6},
+  url =       {https://doi.org/10.1007/978-3-662-05086-6}
 }
 
 @book{Nocedal2006,
-  doi = {10.1007/978-0-387-40065-5},
-  url = {https://doi.org/10.1007/978-0-387-40065-5},
-  year = {2006},
+  author =    {J. Nocedal and S. Wright},
+  title =     {Numerical Optimization},
   publisher = {Springer New York},
-  author = {Jorge Nocedal and Stephen Wright},
-  title = {Numerical Optimization}
+  year =      {2006},
+  doi =       {10.1007/978-0-387-40065-5},
+  url =       {https://doi.org/10.1007/978-0-387-40065-5}
 }
 
 @article{Waechter2005,
-  doi = {10.1007/s10107-004-0559-y},
-  url = {https://doi.org/10.1007/s10107-004-0559-y},
-  year = {2005},
-  month = apr,
+  author =    {A. W\"{a}chter and L.T. Biegler},
+  title =     {On the implementation of an interior-point filter line-search algorithm for large-scale nonlinear programming},
+  journal =   {Mathematical Programming},
   publisher = {Springer Science and Business Media {LLC}},
-  volume = {106},
-  number = {1},
-  pages = {25--57},
-  author = {Andreas W\"{a}chter and Lorenz T. Biegler},
-  title = {On the implementation of an interior-point filter line-search algorithm for large-scale nonlinear programming},
-  journal = {Mathematical Programming}
+  year =      {2005},
+  volume =    {106},
+  number =    {1},
+  pages =     {25--57},
+  doi =       {10.1007/s10107-004-0559-y},
+  url =       {https://doi.org/10.1007/s10107-004-0559-y}
 }
 
 @article{Nocedal2009,
-  doi = {10.1137/060649513},
-  url = {https://doi.org/10.1137/060649513},
-  year = {2009},
-  month = jan,
-  publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
-  volume = {19},
-  number = {4},
-  pages = {1674--1693},
-  author = {Jorge Nocedal and Andreas W\"{a}chter and Richard A. Waltz},
-  title = {Adaptive Barrier Update Strategies for Nonlinear Interior Methods},
-  journal = {{SIAM} Journal on Optimization}
+  author =    {J. Nocedal and A. W\"{a}chter and R.A. Waltz},
+  title =     {Adaptive Barrier Update Strategies for Nonlinear Interior Methods},
+  journal =   {SIAM Journal on Optimization},
+  publisher = {Society for Industrial {\&} Applied Mathematics (SIAM)},    
+  year =      {2009},
+  volume =    {19},
+  number =    {4},
+  pages =     {1674--1693},
+  doi =       {10.1137/060649513},
+  url =       {https://doi.org/10.1137/060649513}
 }
 
 @article{Benson2002,
-  doi = {10.1023/a:1020533003783},
-  url = {https://doi.org/10.1023/a:1020533003783},
-  year = {2002},
+  author =    {H.Y. Benson and R.J. Vanderbei and D.F. Shanno},
+  title =     {Interior-Point Methods for Nonconvex Nonlinear Programs: Filter Methods and Merit Functions},
+  journal =   {Computational Optimization and Applications},
   publisher = {Springer Science and Business Media {LLC}},
-  volume = {23},
-  number = {2},
-  pages = {257--272},
-  author = {Hande Y. Benson and Robert J. Vanderbei and David F. Shanno},
-  journal = {Computational Optimization and Applications},
-  title = {Interior-Point Methods for Nonconvex Nonlinear Programs: Filter Methods and Merit Functions}
+  year =      {2002},
+  volume =    {23},
+  number =    {2},
+  pages =     {257--272},
+  doi =       {10.1023/a:1020533003783},
+  url =       {https://doi.org/10.1023/a:1020533003783}
 }
 
 
@@ -1242,45 +1205,44 @@ eprint = {http://dx.doi.org/10.1137/0917003}
 % ------------------------------------
 
 @article{KGZB83,
-  author  = {Kelly, D. W. and {De S. R. Gago}, J. P. and Zienkiewicz, O. C.
-             and Babu\v{s}ka, I.},
-  title   = {A posteriori error analysis and adaptive processes in the
-             finite element method: Part {I}--Error Analysis},
-  journal = {Int. J. Num. Meth. Engrg.},
+  author  = {D.W. Kelly and J.P. De S. R. Gago and O.C. Zienkiewicz and I. Babu\v{s}ka},
+  title   = {A posteriori error analysis and adaptive processes in the finite element method: Part {I}--Error Analysis},
+  journal = {International Journal for Numerical Methods in Engineering},
   year    = {1983},
   volume  = {19},
-  pages   = {1593--1619}
+  pages   = {1593--1619},
+  url     = {https://doi.org/10.1002/nme.1620191103}
 }
 
 @article{park2003p,
-   title     = {P1-nonconforming quadrilateral finite element methods for
-                second-order elliptic problems},
-   author    = {Park, Chunjae and Sheen, Dongwoo},
+   author    = {C. Park and D. Sheen},
+   title     = {P1-nonconforming quadrilateral finite element methods for second-order elliptic problems},
    journal   = {SIAM Journal on Numerical Analysis},
+   publisher = SIAM,
+   year      = {2003},
    volume    = {41},
    number    = {2},
    pages     = {624--640},
-   year      = {2003},
-   publisher = {SIAM},
-   doi       = {10.1137/S0036142902404923}
+   doi       = {10.1137/S0036142902404923},
+   url       = {https://doi.org/10.1137/S0036142902404923}
 }
 
 @article{GLHPW2018,
-  doi = {10.1029/2018gc007508},
-  url = {https://doi.org/10.1029/2018gc007508},
-  year = {2018},
-  publisher = {American Geophysical Union ({AGU})},
-  volume = {19},
-  number = {9},
-  pages = {3596--3604},
-  author = {Rene Gassm\"{o}ller and Harsha Lokavarapu and Eric Heien and Elbridge Gerry Puckett and Wolfgang Bangerth},
-  title = {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
-  journal = {Geochemistry,  Geophysics,  Geosystems}
+  author =    {R. Gassm\"{o}ller and H. Lokavarapu and E. Heien and E.G. Puckett and W. Bangerth},
+  title =     {Flexible and Scalable Particle-in-Cell Methods With Adaptive Mesh Refinement for Geodynamic Computations},
+  journal =   {Geochemistry,  Geophysics,  Geosystems},
+  publisher = {American Geophysical Union (AGU)},
+  year =      {2018},
+  volume =    {19},
+  number =    {9},
+  pages =     {3596--3604},
+  doi =       {10.1029/2018gc007508},
+  url =       {https://doi.org/10.1029/2018gc007508}
 }
 
-@TechReport{Saad1991,
-  Title                    = {{A {F}lexible {I}nner-{O}uter {P}reconditioned {GMRES} {A}lgorithm}},
+@techreport{Saad1991,
   Author                   = {Y. Saad},
+  Title                    = {{A Flexible Inner-Outer Preconditioned {GMRES} Algorithm}},
   Institution              = {Minnesota Supercomputer Institute},
   Year                     = {1991},
   Address                  = {University of Minnesota},
@@ -1289,202 +1251,211 @@ eprint = {http://dx.doi.org/10.1137/0917003}
 }
 
 @article{ainsworth1998hp,
-  author    = {Ainsworth, Mark and Senior, Bill},
-  title     = {An adaptive refinement strategy for hp-finite element computations},
-  journal   = {{Applied Numerical Mathematics}},
+  author    = {M. Ainsworth and B. Senior},
+  title     = {An adaptive refinement strategy for \textit{hp}-finite element computations},
+  journal   = {Applied Numerical Mathematics},
+  publisher = {Elsevier},
+  year      = {1998},
   volume    = {26},
   number    = {1--2},
   pages     = {165--178},
-  publisher = {Elsevier},
-  year      = {1998},
-  doi       = {10.1016/S0168-9274(97)00083-4}
+  doi       = {10.1016/S0168-9274(97)00083-4},
+  url       = {https://doi.org/10.1016/S0168-9274(97)00083-4}  
 }
 
 @article{melenk2001hp,
-  author    = {Melenk, Jens Markus and Wohlmuth, Barbara I.},
-  title     = {{On residual-based a posteriori error estimation in hp-FEM}},
-  journal   = {{Advances in Computational Mathematics}},
+  author    = {J.M. Melenk and B.I. Wohlmuth},
+  title     = {On residual-based a posteriori error estimation in \textit{hp}-{FEM}},
+  journal   = {Advances in Computational Mathematics},
+  publisher = {Springer US},
+  year      = {2001},
   volume    = {15},
   number    = {1},
   pages     = {311--331},
-  publisher = {Springer US},
-  year      = {2001},
-  doi       = {10.1023/A:1014268310921}
+  doi       = {10.1023/A:1014268310921},
+  url       = {https://doi.org/10.1023/A:1014268310921}
 }
 
 @article{mavriplis1994hp,
-  author    = {Mavriplis, Catherine},
+  author    = {C. Mavriplis},
   title     = {Adaptive mesh strategies for the spectral element method},
-  journal   = {{Computer Methods in Applied Mechanics and Engineering}},
+  journal   = {Computer Methods in Applied Mechanics and Engineering},
+  publisher = {Elsevier},
   year      = {1994},
   volume    = {116},
   number    = {1},
   pages     = {77--86},
-  publisher = {Elsevier},
-  doi       = {10.1016/S0045-7825(94)80010-3}
+  url       = {https://doi.org/10.1016/S0045-7825(94)80010-3}
 }
 
 @article{houston2005hp,
-  author    = {Houston, Paul and S{\"u}li, Endre},
-  title     = {A note on the design of hp-adaptive finite element methods for elliptic partial differential equations},
-  journal   = {{Computer Methods in Applied Mechanics and Engineering}},
-  number    = {2},
-  pages     = {229--243},
+  author    = {P. Houston and E. S{\"u}li},
+  title     = {A note on the design of \textit{hp}-adaptive finite element methods for elliptic partial differential equations},
+  journal   = {Computer Methods in Applied Mechanics and Engineering},
   publisher = {Elsevier},
-  volume    = {194},
   year      = {2005},
-  doi       = {10.1016/j.cma.2004.04.009}
+  number    = {2},
+  volume    = {194},
+  pages     = {229--243},
+  doi       = {10.1016/j.cma.2004.04.009},
+  url       = {https://doi.org/10.1016/j.cma.2004.04.009}
 }
 
 @article{eibner2007hp,
-  author    = {Eibner, Tino and Melenk, Jens Markus},
-  title     = {{An adaptive strategy for hp-FEM based on testing for analyticity}},
-  journal   = {{Computational Mechanics}},
+  author    = {T. Eibner and J.M. Melenk},
+  title     = {An adaptive strategy for \textit{hp}-{FEM} based on testing for analyticity},
+  journal   = {Computational Mechanics},
+  publisher = {Springer},
   year      = {2007},
   volume    = {39},
   number    = {5},
   pages     = {575--595},
-  publisher = {Springer},
-  doi       = {10.1007/s00466-006-0107-0}
+  doi       = {10.1007/s00466-006-0107-0},
+  url       = {https://doi.org/10.1007/s00466-006-0107-0}
 }
 
 @article{davydov2017hp,
-  author  = {Davydov, Denis and Gerasimov, Tymofiy and Pelteret, Jean-Paul and Steinmann, Paul},
-  title   = {{Convergence study of the h-adaptive PUM and the hp-adaptive FEM applied to eigenvalue problems in quantum mechanics}},
-  journal = {{Advanced Modeling and Simulation in Engineering Sciences}},
+  author  = {D. Davydov and T. Gerasimov and J.-P. Pelteret and P. Steinmann},
+  title   = {Convergence study of the \textit{h}-adaptive {PUM} and the \textit{hp}-adaptive {FEM} applied to eigenvalue problems in quantum mechanics},
+  journal = {Advanced Modeling and Simulation in Engineering Sciences},
   year    = {2017},
   volume  = {4},
   number  = {1},
   pages   = {7},
-  issn    = {2213-7467},
-  doi     = {10.1186/s40323-017-0093-0}
+%  doi     = {10.1186/s40323-017-0093-0},
+  url     = {https://doi.org/10.1186/s40323-017-0093-0}
 }
 
-@Article{clevenger_par_gmg,
-  Title                    = {A Flexible, Parallel, Adaptive Geometric Multigrid method for FEM},
-  Author                   = {Thomas C. Clevenger and Timo Heister and Guido Kanschat and Martin Kronbichler},
+@article{clevenger_par_gmg,
+  Author                   = {T.C. Clevenger and T. Heister and G. Kanschat and M. Kronbichler},
+  Title                    = {A Flexible, Parallel, Adaptive Geometric Multigrid method for {FEM}},
   Journal                  = {submitted},
   Year                     = {2019},
   Url                      = {https://arxiv.org/abs/1904.03317}
 }
 
 
-
-@Book{CodeComplete,
-  author =    {Steve McConnell},
-  title =        {Code Complete},
-  publisher =    {Microsoft Press},
-  year =         2004,
+@book{CodeComplete,
+  author =    {S. McConnell},
+  title =     {Code Complete},
+  publisher = {Microsoft Press},
+  year =      2004,
   edition =   {second}
 }
 
 @article{gottlieb2001strong,
-  title={Strong stability-preserving high-order time discretization methods},
-  author={Gottlieb, Sigal and Shu, Chi-Wang and Tadmor, Eitan},
-  journal={SIAM review},
-  volume={43},
-  number={1},
-  pages={89--112},
-  year={2001},
-  publisher={SIAM}
+  author =    {S. Gottlieb and C.-W. Shu and E. Tadmor},
+  title =     {Strong stability-preserving high-order time discretization methods},
+  journal =   {SIAM review},
+  publisher = SIAM,
+  year =      {2001},
+  volume =    {43},
+  number =    {1},
+  pages =     {89--112},
+  url =       {https://doi.org/10.1137/S003614450036757X}
 }
 
 @article{melenk1996,
+  author  = {J.M. Melenk and I. Babu\v{s}ka},
   title   = {The partition of unity finite element method: Basic theory and applications},
-  author  = {Melenk, J.M. and Babu\v{s}ka, I.},
   journal = {Computer Methods in Applied Mechanics and Engineering},
   year    = {1996},
   number  = {1--4},
-  pages   = {289 -- 314},
   volume  = {139},
-  doi     = {10.1016/S0045-7825(96)01087-0}
+  pages   = {289--314},
+  doi     = {10.1016/S0045-7825(96)01087-0},
+  url     = {https://doi.org/10.1016/S0045-7825(96)01087-0}
 }
 
 @article{babuska1997,
+  author  = {I. Babu\v{s}ka and J.M. Melenk},
   title   = {The partition of unity method},
-  author  = {Babu\v{s}ka, I. and Melenk, J. M.},
   journal = {International Journal for Numerical Methods in Engineering},
   year    = {1997},
   number  = {4},
-  pages   = {727--758},
   volume  = {40},
-  doi     = {10.1002/(SICI)1097-0207(19970228)40:4<727::AID-NME86>3.0.CO;2-N}
+  pages   = {727--758},
+  doi     = {10.1002/(SICI)1097-0207(19970228)40:4<727::AID-NME86>3.0.CO;2-N},
+  url     = {https://doi.org/10.1002/(SICI)1097-0207(19970228)40:4<727::AID-NME86>3.0.CO;2-N}
 }
 
 @article{Bartels2004,
-  doi = {10.1007/s00211-004-0548-3},
-  url = {https://doi.org/10.1007/s00211-004-0548-3},
-  year = {2004},
-  month = sep,
+  author =    {S. Bartels and C. Carstensen and G. Dolzmann},
+  title =     {Inhomogeneous Dirichlet conditions in a priori and a posteriori finite element error analysis},
+  journal =   {Numerische Mathematik},
   publisher = {Springer Science and Business Media {LLC}},
-  volume = {99},
-  number = {1},
-  pages = {1--24},
-  author = {S. Bartels and C. Carstensen and G. Dolzmann},
-  title = {Inhomogeneous Dirichlet conditions in a priori and a posteriori finite element error analysis},
-  journal = {Numerische Mathematik}
+  year =      {2004},
+  volume =    {99},
+  number =    {1},
+  pages =     {1--24},
+  doi =       {10.1007/s00211-004-0548-3},
+  url =       {https://doi.org/10.1007/s00211-004-0548-3}
 }
 
 @article{fried1975finite,
-  title={Finite element mass matrix lumping by numerical integration with no convergence rate loss},
-  author={Fried, Isaac and Malkus, David S},
-  journal={International Journal of Solids and Structures},
-  volume={11},
-  number={4},
-  pages={461--466},
-  year={1975},
-  publisher={Elsevier}
+  author =    {I. Fried and D.S. Malkus},
+  title =     {Finite element mass matrix lumping by numerical integration with no convergence rate loss},
+  journal =   {International Journal of Solids and Structures},
+  publisher = {Elsevier},
+  year =      {1975},
+  volume =    {11},
+  number =    {4},
+  pages =     {461--466},
+  url =       {https://doi.org/10.1016/0020-7683(75)90081-5}
 }
 
 @article{Geevers_2018,
-   title={New Higher-Order Mass-Lumped Tetrahedral Elements for Wave Propagation Modelling},
-   volume={40},
-   ISSN={1095-7197},
-   url={http://dx.doi.org/10.1137/18M1175549},
-   DOI={10.1137/18m1175549},
-   number={5},
-   journal={SIAM Journal on Scientific Computing},
-   publisher={Society for Industrial & Applied Mathematics (SIAM)},
-   author={Geevers, S. and Mulder, W. A. and van der Vegt, J. J. W.},
-   year={2018},
-   month={Jan},
-   pages={A2830–A2857}
+   author =    {S. Geevers and W.A. Mulder and J.J.W. van der Vegt},
+   title =     {New Higher-Order Mass-Lumped Tetrahedral Elements for Wave Propagation Modelling},
+   journal =   {SIAM Journal on Scientific Computing},
+   publisher = {Society for Industrial & Applied Mathematics (SIAM)},
+   year =      {2018},
+   number =    {5},
+   volume =    {40},
+   pages =     {A2830--A2857},
+   DOI =       {10.1137/18m1175549},
+   url =       {https://doi.org/10.1137/18m1175549}
 }
 
 @article{witherden2015identification,
-  title={On the identification of symmetric quadrature rules for finite element methods},
-  author={Witherden, Freddie D and Vincent, Peter E},
-  journal={Computers \& Mathematics with Applications},
-  volume={69},
-  number={10},
-  pages={1232--1241},
-  year={2015},
-  publisher={Elsevier}
+  author =    {F.D. Witherden and P.E. Vincent},
+  title =     {On the identification of symmetric quadrature rules for finite element methods},
+  journal =   {Computers \& Mathematics with Applications},
+  publisher = {Elsevier},
+  year =      {2015},
+  volume =    {69},
+  number =    {10},
+  pages =     {1232--1241},
+  url =       {https://doi.org/10.1016/j.camwa.2015.03.017}
 }
 
 @online{quadpy,
-  author = {Schl{\"o}mer, Nico},
-  title = {quadpy: Your one-stop shop for numerical integration in Python},
-  year = 2021,
-  url = {https://github.com/nschloe/quadpy/},
+  author =  {N. Schl{\"o}mer},
+  title =   {quadpy: Your one-stop shop for numerical integration in {P}ython},
+  year =    2021,
+  url =     {https://github.com/nschloe/quadpy/},
   urldate = {2021-02-08}
 }
 
 @Article{AABB17,
-  author =       {R. Agelek and M. Anderson and W. Bangerth and W. L. Barth},
-  title =        {On orienting edges of unstructured two- and three-dimensional meshes},
-  journal =      {ACM Transactions on Mathematical Software},
-  year =         2017,
-  volume =    44,
-  pages =     {5/1--22}}
+  author =  {R. Agelek and M. Anderson and W. Bangerth and W.L. Barth},
+  title =   {On orienting edges of unstructured two- and three-dimensional meshes},
+  journal = {ACM Transactions on Mathematical Software},
+  year =    {2017},
+  volume =  {44},
+  number =  {1},
+  pages =   {5/1--22},
+  url =     {https://doi.org/10.1145/3061708}
+}
 
 @article{hoefler2010scalable,
-  title={Scalable communication protocols for dynamic sparse data exchange},
-  author={Hoefler, Torsten and Siebert, Christian and Lumsdaine, Andrew},
-  journal={ACM Sigplan Notices},
-  volume={45},
-  number={5},
-  pages={159--168},
-  year={2010},
-  publisher={ACM New York, NY, USA}
+  author =    {T. Hoefler and C. Siebert and A. Lumsdaine},
+  title =     {Scalable communication protocols for dynamic sparse data exchange},
+  journal =   {ACM Sigplan Notices},
+  publisher = {ACM New York, NY, USA},
+  year =      {2010},
+  volume =    {45},
+  number =    {5},
+  pages =     {159--168},
+  url =       {https://doi.org/10.1145/1837853.1693476}
 }

--- a/doc/news/changes/minor/20210622DianeGuignard
+++ b/doc/news/changes/minor/20210622DianeGuignard
@@ -1,4 +1,4 @@
-Improved: i) Standarized the format of the references in the file
+Improved: i) Standardized the format of the references in the file
              doc/doxygen/references.bib using in particular the convention
              "M. Mo" or "R.B. Kellogg" for names and the full name for journals.
          ii) Fixed the display of some titles (e.g., upper case for proper noun).

--- a/doc/news/changes/minor/20210622DianeGuignard
+++ b/doc/news/changes/minor/20210622DianeGuignard
@@ -1,0 +1,7 @@
+Improved: i) Standarized the format of the references in the file
+             doc/doxygen/references.bib using in particular the convention
+             "M. Mo" or "R.B. Kellogg" for names and the full name for journals.
+         ii) Fixed the display of some titles (e.g., upper case for proper noun).
+        iii) Added an URL entry for the references with a DOI.
+<br>
+(Diane Guignard, 2021/06/22)


### PR DESCRIPTION
Standardization of the format of the references in the file doc/doxygen/references.bib. In particular, I used the conventions

1. "M. Mo" or "R.B. Kellogg" for the names of the authors;
2. Full name for the journal.

I also took the opportunity to add an URL entry for the contributions for which I found a DOI.

Remark: For some references, the DOI entry is commented. If not commented, then the references are not displayed properly, similarly to entry [34] at

https://www.dealii.org/current/doxygen/deal.II/citelist.html

I could not identify the reason for that (example: from references.bib of version 9.3, removing the month entry fixed the issue in some case (e.g., ref "Coleman1963a"), while in others, doing so added the issue (e.g., ref "Holzapfel1996a"))...