### PR TITLE
Define NDEBUG in release mode

### DIFF
--- a/cmake/setup_compiler_flags_gnu.cmake
+++ b/cmake/setup_compiler_flags_gnu.cmake
@@ -188,6 +188,12 @@ IF (CMAKE_BUILD_TYPE MATCHES "Release")
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-fstrict-aliasing")
 
   #
+  # Disable assert() in deal.II and user projects in release mode
+  #
+  LIST(APPEND DEAL_II_DEFINITIONS_RELEASE "NDEBUG")
+  LIST(APPEND DEAL_II_USER_DEFINITIONS_RELEASE "NDEBUG")
+
+  #
   # There are many places in the library where we create a new typedef and then
   # immediately use it in an Assert. Hence, only ignore unused typedefs in Release
   # mode.

--- a/cmake/setup_compiler_flags_intel.cmake
+++ b/cmake/setup_compiler_flags_intel.cmake
@@ -183,6 +183,12 @@ IF (CMAKE_BUILD_TYPE MATCHES "Release")
 
   ADD_FLAGS(DEAL_II_CXX_FLAGS_RELEASE "-O2")
 
+  #
+  # Disable assert() in deal.II and user projects in release mode
+  #
+  LIST(APPEND DEAL_II_DEFINITIONS_RELEASE "NDEBUG")
+  LIST(APPEND DEAL_II_USER_DEFINITIONS_RELEASE "NDEBUG")
+
   # equivalent to -fno-strict-aliasing:
   ENABLE_IF_SUPPORTED(DEAL_II_CXX_FLAGS_RELEASE "-no-ansi-alias")
 

--- a/cmake/setup_compiler_flags_msvc.cmake
+++ b/cmake/setup_compiler_flags_msvc.cmake
@@ -99,6 +99,13 @@ IF (CMAKE_BUILD_TYPE MATCHES "Release")
   # General optimization flags: (very basic for now)
   #
   ADD_FLAGS(DEAL_II_CXX_FLAGS_RELEASE "/O2")
+
+  #
+  # Disable assert() in deal.II and user projects in release mode
+  #
+  LIST(APPEND DEAL_II_DEFINITIONS_RELEASE "NDEBUG")
+  LIST(APPEND DEAL_II_USER_DEFINITIONS_RELEASE "NDEBUG")
+
 ENDIF()
 
 


### PR DESCRIPTION
Let me start by saying I am not fully aware of the impact of this. This is more of a question: By default cmake would define NDEBUG in anything but debug mode, to disable asserts in the standard library. Deal.II overwrites this default in the `DEAL_II_INITIALIZE_CACHED_VARIABLES` macro, when it resets CMAKE_CXX_FLAGS and it never defines it itself (it instead uses DEBUG to activate asserts in debug mode). I am not sure if this was made on purpose, but inside ASPECT we have some downstream projects (specifically https://github.com/GeodynamicWorldBuilder/WorldBuilder) that rely on NDEBUG to decide whether to activate asserts or not. Does it make sense to keep cmake's default behavior of defining NDEBUG in release mode? This may even give some performance benefits, but I do not know if it was removed no purpose.