### PR TITLE
Improve the documentation of TriaAccessor::is_ghost().

### DIFF
--- a/include/deal.II/distributed/shared_tria.h
+++ b/include/deal.II/distributed/shared_tria.h
@@ -351,7 +351,7 @@ namespace parallel
       get_true_level_subdomain_ids_of_cells(const unsigned int level) const;
 
       /**
-       * Return allow_artificial_cells , namely true if artificial cells are
+       * Return allow_artificial_cells, namely true if artificial cells are
        * allowed.
        */
       bool

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -3678,14 +3678,18 @@ public:
   is_locally_owned_on_level() const;
 
   /**
-   * Return whether this cell exists in the global mesh but (i) is owned by
-   * another processor, i.e. has a subdomain_id different from the one the
-   * current processor owns and (ii) is adjacent to a cell owned by the
-   * current processor.
+   * Return true if:
+   * <ol>
+   * <li>This cell exists in the global mesh (i.e., it is not artificial),
+   * and</li>
+   * <li>This cell is owned by another processor (i.e., has a subdomain_id
+   * different from Triangulation::locally_owned_subdomain())</li>
+   * </ol>
    *
-   * This function only makes sense if the triangulation used is of kind
-   * parallel::distributed::Triangulation. In all other cases, the returned
-   * value is always false.
+   * In all other cases the returned value is false. In particular, only
+   * parallel Triangulations (i.e., Triangulations inheriting from
+   * parallel::TriangulationBase) can have ghost cells, so for a serial
+   * Triangulation the returned value is false.
    *
    * See the
    * @ref GlossGhostCell "glossary"
@@ -3696,7 +3700,13 @@ public:
    * @post The returned value is equal to <code>!is_locally_owned() &&
    * !is_artificial()</code>.
    *
-   * @note Whether a cell is a ghost cell, artificial, or is locally owned or
+   * @note For parallel::distributed::Triangulation and
+   * parallel::fullydistributed::Triangulation, ghost cells are always adjacent
+   * to locally owned cells. For parallel::shared::Triangulation they may not
+   * be, dependent on whether or not the triangulation uses artificial cells -
+   * see parallel::shared::Triangulation::Triangulation() for more information.
+   *
+   * @note Whether a cell is a ghost cell, artificial, or is locally owned
    * is a property that only pertains to cells that are active. Consequently,
    * you can only call this function if the cell it refers to has no children.
    */


### PR DESCRIPTION
The documentation isn't quite right for p::s::T. Now that we have three parallel
Triangulation classes we should be a bit more careful in describing some of
their distinctions.

Here's how doxygen renders the new version:
![Screenshot 2021-06-29 at 10-27-43 The deal II Library CellAccessor dim, spacedim Class Template Reference](https://user-images.githubusercontent.com/3917035/123815833-ce398d80-d8c4-11eb-9591-acdc5c4d66e0.png)
