### PR TITLE
silence gcc 11 warning

### DIFF
--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -430,6 +430,7 @@ _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
 _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
 _Pragma("GCC diagnostic ignored \"-Wnested-anon-types\"")               \
 _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")                \
+_Pragma("GCC diagnostic ignored \"-Wnonnull\"")                         \
 _Pragma("GCC diagnostic ignored \"-Woverflow\"")                        \
 _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")              \
 _Pragma("GCC diagnostic ignored \"-Wpedantic\"")                        \


### PR DESCRIPTION
silence boost warning
```
../bundled/boost-1.70.0/include/boost/concept/usage.hpp:16:48: warning:
'this' pointer is null [-Wnonnull]
   16 |     ~usage_requirements() { ((Model*)0)->~Model(); }
```