### PR TITLE
step-79: Avoid using constructor which are incompatible to Intel 18.

### DIFF
--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -279,11 +279,11 @@ namespace SAND
   SANDTopOpt<dim>::SANDTopOpt()
     : fe(FE_DGQ<dim>(0),
          1,
-         (FESystem<dim>(FE_Q<dim>(1) ^ dim)),
+         FESystem<dim>(FE_Q<dim>(1), dim),
          1,
          FE_DGQ<dim>(0),
          1,
-         (FESystem<dim>(FE_Q<dim>(1) ^ dim)),
+         FESystem<dim>(FE_Q<dim>(1), dim),
          1,
          FE_DGQ<dim>(0),
          5)


### PR DESCRIPTION
As reported in https://github.com/xsdk-project/xsdk-issues/issues/148#issuecomment-872382060.

The examples cannot be compiled with `Intel 18` compilers: we are using constructors for the `FESystem` class in `step-79` that cause problems with that particular compiler.

Would have been a candidate for the point release I guess :sweat_smile: