### PR TITLE
No longer require active_fe_index when calling cell->vertex_dof_index().

### DIFF
--- a/doc/news/changes/minor/20210702Bangerth
+++ b/doc/news/changes/minor/20210702Bangerth
@@ -1,0 +1,10 @@
+New: When calling `cell->vertex_dof_index(...)` on a DoFHandler that
+uses the hp capability, then one needed to provide the last argument
+indicating what the active fe index is. But for cells, there can only
+be one active fe index, so leaving the last argument at its default
+value is now interpreted as using the active fe index of the cell. The
+argument still needs to be provided if the `vertex_dof_index()`
+function is called on faces, edges, or vertices.
+<br>
+(Wolfgang Bangerth, 2021/07/02)
+

--- a/include/deal.II/dofs/dof_accessor.h
+++ b/include/deal.II/dofs/dof_accessor.h
@@ -477,14 +477,18 @@ public:
    * ::DoFHandler class, this value must be equal to its default value since
    * that class only supports the same finite element on all cells anyway.
    *
-   * However, when hp-capabilities are enabled, different finite element
-   * objects may be used on different cells. On faces between two cells, as
-   * well as vertices, there may therefore be two sets of degrees of freedom,
-   * one for each of the finite elements used on the adjacent cells.  In order
-   * to specify which set of degrees of freedom to work on, the last argument
-   * is used to disambiguate. Finally, if this function is called for a cell
+   * However, when hp-capabilities are enabled, different finite
+   * element objects may be used on different cells. On faces between
+   * two cells, as well as vertices, there may therefore be two sets
+   * of degrees of freedom, one for each of the finite elements used
+   * on the adjacent cells.  In order to specify which set of degrees
+   * of freedom to work on, the last argument is used to
+   * disambiguate. Finally, if this function is called for a cell
    * object, there can only be a single set of degrees of freedom, and
-   * fe_index has to match the result of active_fe_index().
+   * `fe_index` has to match the result of
+   * `cell->active_fe_index()`. Alternatively, if `fe_index` is left
+   * to its default value when this function is called on a cell, then
+   * this is interpreted as equal to `cell->active_fe_index()`.
    */
   types::global_dof_index
   vertex_dof_index(const unsigned int vertex,

--- a/tests/hp/vertex_dof_index.cc
+++ b/tests/hp/vertex_dof_index.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// check cell->vertex_dof_index() in the hp case when called on a cell
+// where the active_fe_index should be clear.
+
+
+#include <deal.II/dofs/dof_accessor.h>
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  // create 2 triangulations with the
+  // same coarse grid, and refine
+  // them differently
+  Triangulation<dim> tria;
+
+  GridGenerator::hyper_cube(tria);
+  tria.refine_global(2);
+
+  hp::FECollection<dim> fe;
+  fe.push_back(FE_Q<dim>(1));
+  fe.push_back(FE_Q<dim>(2));
+  DoFHandler<dim> dh(tria);
+  dh.begin_active()->set_active_fe_index(1);
+  dh.distribute_dofs(fe);
+
+  deallog << dh.begin_active()->vertex_dof_index(0, 0) << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test<1>();
+  test<2>();
+  test<3>();
+}

--- a/tests/hp/vertex_dof_index.output
+++ b/tests/hp/vertex_dof_index.output
@@ -1,0 +1,4 @@
+
+DEAL::0
+DEAL::0
+DEAL::0


### PR DESCRIPTION
Fixes #12534.

/rebuild