### PR TITLE
Add ParticleAccessor::get_local_index

### DIFF
--- a/doc/news/changes/minor/20210706MartinKronbichler
+++ b/doc/news/changes/minor/20210706MartinKronbichler
@@ -1,0 +1,5 @@
+New: ParticleAccessor::get_local_index() is a new function returning particle
+indices local to each MPI process, which is useful for direct access into
+arrays with temporary results associated to particles.
+<br>
+(Martin Kronbichler, 2021/07/06)

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -135,13 +135,18 @@ namespace Particles
      * enables the direct array access (similar to
      * LinearAlgebra::distributed::Vector::local_element()) to quantities used
      * for local computations. Use
-     * ParticleHandler::get_max_local_particle_index() to query the largest
-     * index for suitable array sizes.
+     * ParticleHandler::get_max_local_particle_index() to query suitable array
+     * sizes.
      *
      * @note The number returned by this function is not stable between calls
      * of ParticleHandler::sort_particles_into_subdomains_and_cells() and
-     * therefore it cannot be used to track quantities across those calls. Use
-     * particle properties for storing persistent information.
+     * therefore it cannot be used to track quantities across those
+     * calls. Furthermore, the numbers returned by this function are typically
+     * not refreshed in case individual particles are removed from the
+     * underlying ParticleHandler object, which means that the returned
+     * indices of all particles on an MPI process typically do not form a
+     * contiguous interval of numbers. Use particle properties for storing
+     * persistent information and checkpointing the actual data.
      */
     types::particle_index
     get_local_index() const;

--- a/include/deal.II/particles/particle_accessor.h
+++ b/include/deal.II/particles/particle_accessor.h
@@ -131,6 +131,22 @@ namespace Particles
     get_id() const;
 
     /**
+     * Return a particle ID number local to each MPI process. This number
+     * enables the direct array access (similar to
+     * LinearAlgebra::distributed::Vector::local_element()) to quantities used
+     * for local computations. Use
+     * ParticleHandler::get_max_local_particle_index() to query the largest
+     * index for suitable array sizes.
+     *
+     * @note The number returned by this function is not stable between calls
+     * of ParticleHandler::sort_particles_into_subdomains_and_cells() and
+     * therefore it cannot be used to track quantities across those calls. Use
+     * particle properties for storing persistent information.
+     */
+    types::particle_index
+    get_local_index() const;
+
+    /**
      * Return whether this particle has a valid property pool and a valid
      * handle to properties.
      */
@@ -575,6 +591,17 @@ namespace Particles
     Assert(state() == IteratorState::valid, ExcInternalError());
 
     return property_pool->get_id(get_handle());
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline types::particle_index
+  ParticleAccessor<dim, spacedim>::get_local_index() const
+  {
+    Assert(state() == IteratorState::valid, ExcInternalError());
+
+    return get_handle();
   }
 
 

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -661,12 +661,17 @@ namespace Particles
     n_properties_per_particle() const;
 
     /**
-     * Return the maximal local index (in MPI-local index space) returned by
-     * ParticleAccessor::get_local_index(). More precisely, the returned value
-     * is one larger than the largest index that will be returned, which makes
-     * this value useful for resizing vectors. This number can be larger than
-     * locally_owned_particle_ids().n_elements(), because local indices can
-     * contain gaps in the range 0 to get_max_local_particle_index().
+     * Return one past the largest local index (in MPI-local index space)
+     * returned by ParticleAccessor::get_local_index(). This number can be
+     * larger than locally_owned_particle_ids().n_elements(), because local
+     * indices are not necessarily forming a contiguous range and can contain
+     * gaps in the range 0 to get_max_local_particle_index(). As a
+     * consequence, the number is not updated upon calls to remove_particle()
+     * or similar functions, and refreshed only as new particles get added or
+     * in sort_particles_into_subdomains_and_cells().
+     *
+     * This function is appropriate for resizing vectors working with
+     * ParticleAccessor::get_local_index().
      */
     types::particle_index
     get_max_local_particle_index() const;

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -661,6 +661,17 @@ namespace Particles
     n_properties_per_particle() const;
 
     /**
+     * Return the maximal local index (in MPI-local index space) returned by
+     * ParticleAccessor::get_local_index(). More precisely, the returned value
+     * is one larger than the largest index that will be returned, which makes
+     * this value useful for resizing vectors. This number can be larger than
+     * locally_owned_particle_ids().n_elements(), because local indices can
+     * contain gaps in the range 0 to get_max_local_particle_index().
+     */
+    types::particle_index
+    get_max_local_particle_index() const;
+
+    /**
      * Return a reference to the property pool that owns all particle
      * properties, and organizes them physically.
      */

--- a/include/deal.II/particles/property_pool.h
+++ b/include/deal.II/particles/property_pool.h
@@ -137,7 +137,7 @@ namespace Particles
 
     /**
      * Return a new handle that allows a particle to store information such as
-     * properties and locations. This also allocated memory in this PropertyPool
+     * properties and locations. This also allocates memory in this PropertyPool
      * variable.
      */
     Handle
@@ -210,6 +210,13 @@ namespace Particles
      */
     unsigned int
     n_properties_per_slot() const;
+
+    /**
+     * Return the total number of slots in the pool, including both registered
+     * and unregistered ones.
+     */
+    unsigned int
+    n_slots() const;
 
     /**
      * Return how many slots are currently registered in the pool.
@@ -437,6 +444,15 @@ namespace Particles
                       "before trying to access the properties."));
 
     return ArrayView<double>(properties.data() + data_index, n_properties);
+  }
+
+
+
+  template <int dim, int spacedim>
+  inline unsigned int
+  PropertyPool<dim, spacedim>::n_slots() const
+  {
+    return locations.size();
   }
 
 

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -919,11 +919,23 @@ namespace Particles
   IndexSet
   ParticleHandler<dim, spacedim>::locally_owned_particle_ids() const
   {
-    IndexSet set(get_next_free_particle_index());
+    IndexSet                           set(get_next_free_particle_index());
+    std::vector<types::particle_index> indices;
+    indices.reserve(n_locally_owned_particles());
     for (const auto &p : *this)
-      set.add_index(p.get_id());
+      indices.push_back(p.get_id());
+    set.add_indices(indices.begin(), indices.end());
     set.compress();
     return set;
+  }
+
+
+
+  template <int dim, int spacedim>
+  types::particle_index
+  ParticleHandler<dim, spacedim>::get_max_local_particle_index() const
+  {
+    return property_pool->n_slots();
   }
 
 

--- a/tests/particles/local_particle_index.cc
+++ b/tests/particles/local_particle_index.cc
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check ParticleAccessor::local_particle_index
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_system.h>
+#include <deal.II/fe/mapping_q_generic.h>
+
+#include <deal.II/grid/filtered_iterator.h>
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include <fstream>
+#include <iomanip>
+
+#include "../tests.h"
+
+
+
+template <int dim>
+void
+test()
+{
+  // create similar mesh as step-68
+  parallel::distributed::Triangulation<dim> background_triangulation(
+    MPI_COMM_WORLD);
+
+  GridGenerator::hyper_cube(background_triangulation, 0, 1);
+  background_triangulation.refine_global(6 - dim);
+
+  const MappingQGeneric<dim> mapping(1);
+
+  Particles::ParticleHandler<dim> particle_handler;
+  particle_handler.initialize(background_triangulation, mapping, 1);
+
+  Point<dim> center;
+  for (unsigned int d = 0; d < dim; ++d)
+    center[d] = 0.5;
+
+  const double outer_radius = 0.15;
+  const double inner_radius = 0.01;
+
+  parallel::distributed::Triangulation<dim> particle_triangulation(
+    MPI_COMM_WORLD);
+
+  GridGenerator::hyper_shell(
+    particle_triangulation, center, inner_radius, outer_radius, 6);
+  particle_triangulation.refine_global(5 - dim);
+
+  const auto my_bounding_box = GridTools::compute_mesh_predicate_bounding_box(
+    background_triangulation, IteratorFilters::LocallyOwnedCell());
+  const auto global_bounding_boxes =
+    Utilities::MPI::all_gather(MPI_COMM_WORLD, my_bounding_box);
+
+  std::vector<std::vector<double>> properties(
+    particle_triangulation.n_locally_owned_active_cells(),
+    std::vector<double>(1, 0.));
+  Particles::Generators::quadrature_points(particle_triangulation,
+                                           QMidpoint<dim>(),
+                                           global_bounding_boxes,
+                                           particle_handler,
+                                           mapping,
+                                           properties);
+
+  for (unsigned int i = 0; i < 2; ++i)
+    {
+      // Write out some information about the local particles
+      deallog << "Number of global particles: "
+              << particle_handler.n_global_particles() << std::endl;
+      deallog << "Number of locally owned particles: "
+              << particle_handler.n_locally_owned_particles() << std::endl;
+      deallog << "Maximal local particle index: "
+              << particle_handler.get_max_local_particle_index() << std::endl;
+
+      std::vector<types::particle_index> my_particle_numbers(
+        particle_handler.get_max_local_particle_index(),
+        numbers::invalid_dof_index);
+
+      // set the id numbers for the particles
+      unsigned int count = 0;
+      for (auto particle = particle_handler.begin();
+           particle != particle_handler.end();
+           ++particle, ++count)
+        my_particle_numbers[particle->get_local_index()] = particle->get_id();
+
+      for (auto particle = particle_handler.begin_ghost();
+           particle != particle_handler.end_ghost();
+           ++particle, ++count)
+        my_particle_numbers[particle->get_local_index()] = particle->get_id();
+
+      deallog << "Set information of " << count << " particles" << std::endl;
+
+      unsigned int n_unset = 0;
+      for (const types::particle_index id : my_particle_numbers)
+        if (id == numbers::invalid_dof_index)
+          ++n_unset;
+
+      deallog << "Number of particles not set: " << n_unset << std::endl;
+
+      particle_handler.exchange_ghost_particles();
+    }
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  MPILogInitAll                    log;
+
+  test<2>();
+  test<3>();
+}

--- a/tests/particles/local_particle_index.with_p4est=true.mpirun=3.output
+++ b/tests/particles/local_particle_index.with_p4est=true.mpirun=3.output
@@ -1,0 +1,71 @@
+
+DEAL:0::Number of global particles: 384
+DEAL:0::Number of locally owned particles: 96
+DEAL:0::Maximal local particle index: 96
+DEAL:0::Set information of 96 particles
+DEAL:0::Number of particles not set: 0
+DEAL:0::Number of global particles: 384
+DEAL:0::Number of locally owned particles: 96
+DEAL:0::Maximal local particle index: 263
+DEAL:0::Set information of 262 particles
+DEAL:0::Number of particles not set: 1
+DEAL:0::OK
+DEAL:0::Number of global particles: 384
+DEAL:0::Number of locally owned particles: 96
+DEAL:0::Maximal local particle index: 96
+DEAL:0::Set information of 96 particles
+DEAL:0::Number of particles not set: 0
+DEAL:0::Number of global particles: 384
+DEAL:0::Number of locally owned particles: 96
+DEAL:0::Maximal local particle index: 385
+DEAL:0::Set information of 384 particles
+DEAL:0::Number of particles not set: 1
+DEAL:0::OK
+
+DEAL:1::Number of global particles: 384
+DEAL:1::Number of locally owned particles: 192
+DEAL:1::Maximal local particle index: 192
+DEAL:1::Set information of 192 particles
+DEAL:1::Number of particles not set: 0
+DEAL:1::Number of global particles: 384
+DEAL:1::Number of locally owned particles: 192
+DEAL:1::Maximal local particle index: 365
+DEAL:1::Set information of 364 particles
+DEAL:1::Number of particles not set: 1
+DEAL:1::OK
+DEAL:1::Number of global particles: 384
+DEAL:1::Number of locally owned particles: 192
+DEAL:1::Maximal local particle index: 192
+DEAL:1::Set information of 192 particles
+DEAL:1::Number of particles not set: 0
+DEAL:1::Number of global particles: 384
+DEAL:1::Number of locally owned particles: 192
+DEAL:1::Maximal local particle index: 385
+DEAL:1::Set information of 384 particles
+DEAL:1::Number of particles not set: 1
+DEAL:1::OK
+
+
+DEAL:2::Number of global particles: 384
+DEAL:2::Number of locally owned particles: 96
+DEAL:2::Maximal local particle index: 96
+DEAL:2::Set information of 96 particles
+DEAL:2::Number of particles not set: 0
+DEAL:2::Number of global particles: 384
+DEAL:2::Number of locally owned particles: 96
+DEAL:2::Maximal local particle index: 263
+DEAL:2::Set information of 262 particles
+DEAL:2::Number of particles not set: 1
+DEAL:2::OK
+DEAL:2::Number of global particles: 384
+DEAL:2::Number of locally owned particles: 96
+DEAL:2::Maximal local particle index: 96
+DEAL:2::Set information of 96 particles
+DEAL:2::Number of particles not set: 0
+DEAL:2::Number of global particles: 384
+DEAL:2::Number of locally owned particles: 96
+DEAL:2::Maximal local particle index: 385
+DEAL:2::Set information of 384 particles
+DEAL:2::Number of particles not set: 1
+DEAL:2::OK
+


### PR DESCRIPTION
This PR is inspired by bottlenecks @blaisb and I observed in Lethe, https://github.com/lethe-cfd/lethe/pull/181. The main motivation for the new function is that one can have additional data structures associated to particles that are not handled by the property pool, e.g. because they hold some temporary results in a calculation.

Even though one could have done that before with the global particle index that then gets translated somehow into a local one, that approach would simply not have been efficient. On a Lethe example code this saves around 20% of run time, in what is otherwise a very well-optimized software. The observation that we need to provide direct array access for local computations is not new, as this is mirroring what we provide via the `LinearAlgebra::distributed::Vector::local_element` function to access the local data.

@gassmoeller what do you think?

(I need to admit that I played around a bit with the `get_max_local_particle_index` function to instead provide `n_locally_owned_or_ghost_particles()`, but I could not find a stable solution there as we might have some holes in the index numbers when particles are temporarily added. You can see that in the test output, we have one slot open.)