### PR TITLE
fix: Updated dotgdbinit to work with version 9.3

### DIFF
--- a/contrib/utilities/dotgdbinit.py
+++ b/contrib/utilities/dotgdbinit.py
@@ -57,13 +57,17 @@ class AlignedVectorPrinter(object):
     def __init__(self, typename, val):
         self.typename = typename
         self.val = val
-        self.length = int(self.val['data_end'] - self.val['data_begin'])
+        self.end = self.val['used_elements_end']
+        # evaluate the get() method of the unique_ptr
+        eval_string = "(*("+str(self.val['elements'].type)+"*)("+str(self.val['elements'].address)+")).get()"
+        self.begin = gdb.parse_and_eval(eval_string);
+        self.length = int(self.end - self.begin )
 
     def children(self):
         # The first entry (see the "Pretty Printing API" documentation of GDB)
         # in the tuple should be a name for the child, which should be nothing
         # (the array elements don't have individual names) here.
-        return (("", (self.val['data_begin'] + count).dereference())
+        return (("", (self.begin + count).dereference())
                 for count in range(self.length))
 
     def to_string(self):
@@ -120,7 +124,11 @@ class VectorPrinter(object):
         self.typename = typename
         self.val = val
         a_vec = self.val['values']
-        self.length = int(a_vec['data_end'] - a_vec['data_begin'])
+        self.end = a_vec['used_elements_end']
+        # evaluate the elements.get() method of the AlignedVector member
+        eval_string = "(*("+str(a_vec['elements'].type)+"*)("+str(a_vec['elements'].address)+")).get()"
+        self.begin = gdb.parse_and_eval(eval_string);
+        self.length = int(self.end - self.begin )
 
     def children(self):
         return (("values", self.val['values']),


### PR DESCRIPTION
Fixed VectorPrinters and AlignedVectorPrinters dependency on
deprecated members data_begin and data_end.

Resolved issue #12522 ("GDB Pretty Printing of Vector depents on deprecated member")