### PR TITLE
Don't use references where necessary.

### DIFF
--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -218,7 +218,7 @@ public:
    * an assertion.
    */
   void
-  extend(const Number &amount);
+  extend(const Number amount);
 
   /**
    * Compute the volume (i.e. the dim-dimensional measure) of the BoundingBox.
@@ -487,7 +487,7 @@ operator!=(const BoundingBox<spacedim, Number> &box) const
 
 template <int spacedim, typename Number>
 inline void
-BoundingBox<spacedim, Number>::extend(const Number &amount)
+BoundingBox<spacedim, Number>::extend(const Number amount)
 {
   for (unsigned int d = 0; d < spacedim; ++d)
     {

--- a/source/base/bounding_box.cc
+++ b/source/base/bounding_box.cc
@@ -39,6 +39,8 @@ BoundingBox<spacedim, Number>::point_inside(const Point<spacedim, Number> &p,
   return true;
 }
 
+
+
 template <int spacedim, typename Number>
 void
 BoundingBox<spacedim, Number>::merge_with(
@@ -54,6 +56,8 @@ BoundingBox<spacedim, Number>::merge_with(
                  other_bbox.boundary_points.second[i]);
     }
 }
+
+
 
 template <int spacedim, typename Number>
 NeighborType


### PR DESCRIPTION
In principle, `Number` could be some complicated AD type, but I think that even in those cases we have in the past not made these variables references, have we?

/rebuild