### PR TITLE
Use std::numeric_limits::lowest() instead of -max().

### DIFF
--- a/include/deal.II/lac/eigen.h
+++ b/include/deal.II/lac/eigen.h
@@ -321,7 +321,7 @@ EigenInverse<VectorType>::solve(double &          value,
   x *= 1. / length;
 
   // Main loop
-  double    res  = -std::numeric_limits<double>::max();
+  double    res  = std::numeric_limits<double>::lowest();
   size_type iter = 0;
   for (; conv == SolverControl::iterate; iter++)
     {

--- a/include/deal.II/lac/solver_gmres.h
+++ b/include/deal.II/lac/solver_gmres.h
@@ -825,7 +825,7 @@ SolverGMRES<VectorType>::solve(const MatrixType &        A,
   unsigned int dim = 0;
 
   SolverControl::State iteration_state = SolverControl::iterate;
-  double               last_res        = -std::numeric_limits<double>::max();
+  double               last_res        = std::numeric_limits<double>::lowest();
 
   // switch to determine whether we want a left or a right preconditioner. at
   // present, left is default, but both ways are implemented
@@ -1216,7 +1216,7 @@ SolverFGMRES<VectorType>::solve(const MatrixType &        A,
   Vector<double> y;
 
   // Iteration starts here
-  double res = -std::numeric_limits<double>::max();
+  double res = std::numeric_limits<double>::lowest();
 
   typename VectorMemory<VectorType>::Pointer aux(this->memory);
   aux->reinit(x);

--- a/include/deal.II/lac/solver_richardson.h
+++ b/include/deal.II/lac/solver_richardson.h
@@ -197,7 +197,7 @@ SolverRichardson<VectorType>::solve(const MatrixType &        A,
 {
   SolverControl::State conv = SolverControl::iterate;
 
-  double last_criterion = -std::numeric_limits<double>::max();
+  double last_criterion = std::numeric_limits<double>::lowest();
 
   unsigned int iter = 0;
 
@@ -253,7 +253,7 @@ SolverRichardson<VectorType>::Tsolve(const MatrixType &        A,
                                      const PreconditionerType &preconditioner)
 {
   SolverControl::State conv           = SolverControl::iterate;
-  double               last_criterion = -std::numeric_limits<double>::max();
+  double               last_criterion = std::numeric_limits<double>::lowest();
 
   unsigned int iter = 0;
 

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -514,7 +514,7 @@ namespace internal
         default:
           {
             Assert(false, ExcNotImplemented());
-            return -std::numeric_limits<double>::max();
+            return std::numeric_limits<double>::lowest();
           }
       }
   }
@@ -558,7 +558,7 @@ namespace internal
         default:
           {
             Assert(false, ExcNotImplemented());
-            return -std::numeric_limits<double>::max();
+            return std::numeric_limits<double>::lowest();
           }
       }
   }
@@ -604,7 +604,7 @@ namespace internal
         default:
           {
             Assert(false, ExcNotImplemented());
-            return -std::numeric_limits<double>::max();
+            return std::numeric_limits<double>::lowest();
           }
       }
   }
@@ -639,7 +639,7 @@ namespace internal
         default:
           {
             Assert(false, ExcNotImplemented());
-            return -std::numeric_limits<double>::max();
+            return std::numeric_limits<double>::lowest();
           }
       }
   }

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -576,7 +576,7 @@ namespace Utilities
       // result with a default value already...
       MinMaxAvg dummy = {0.,
                          std::numeric_limits<double>::max(),
-                         -std::numeric_limits<double>::max(),
+                         std::numeric_limits<double>::lowest(),
                          0,
                          0,
                          0.};

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -344,7 +344,7 @@ namespace Patterns
 
 
 
-  const double Double::min_double_value = -std::numeric_limits<double>::max();
+  const double Double::min_double_value = std::numeric_limits<double>::lowest();
   const double Double::max_double_value = std::numeric_limits<double>::max();
 
   const char *Double::description_init = "[Double";

--- a/source/grid/grid_refinement.cc
+++ b/source/grid/grid_refinement.cc
@@ -354,7 +354,7 @@ GridRefinement::refine_and_coarsen_fixed_number(
       if (refine_cells)
         {
           if (static_cast<size_t>(refine_cells) == criteria.size())
-            refine(tria, criteria, -std::numeric_limits<double>::max());
+            refine(tria, criteria, std::numeric_limits<double>::lowest());
           else
             {
               std::nth_element(tmp.begin(),

--- a/tests/arpack/step-36_ar.cc
+++ b/tests/arpack/step-36_ar.cc
@@ -198,7 +198,7 @@ namespace Step36
 
 
     double min_spurious_eigenvalue = std::numeric_limits<double>::max(),
-           max_spurious_eigenvalue = -std::numeric_limits<double>::max();
+           max_spurious_eigenvalue = std::numeric_limits<double>::lowest();
 
     for (unsigned int i = 0; i < dof_handler.n_dofs(); ++i)
       if (constraints.is_constrained(i))

--- a/tests/arpack/step-36_ar_shift.cc
+++ b/tests/arpack/step-36_ar_shift.cc
@@ -192,7 +192,7 @@ namespace Step36
 
 
     double min_spurious_eigenvalue = std::numeric_limits<double>::max(),
-           max_spurious_eigenvalue = -std::numeric_limits<double>::max();
+           max_spurious_eigenvalue = std::numeric_limits<double>::lowest();
 
     for (unsigned int i = 0; i < dof_handler.n_dofs(); ++i)
       if (constraints.is_constrained(i))

--- a/tests/arpack/step-36_ar_with_iterations.cc
+++ b/tests/arpack/step-36_ar_with_iterations.cc
@@ -198,7 +198,7 @@ namespace Step36
 
 
     double min_spurious_eigenvalue = std::numeric_limits<double>::max(),
-           max_spurious_eigenvalue = -std::numeric_limits<double>::max();
+           max_spurious_eigenvalue = std::numeric_limits<double>::lowest();
 
     for (unsigned int i = 0; i < dof_handler.n_dofs(); ++i)
       if (constraints.is_constrained(i))

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -359,7 +359,7 @@ namespace Step31
     if (timestep_number != 0)
       {
         double min_temperature = std::numeric_limits<double>::max(),
-               max_temperature = -std::numeric_limits<double>::max();
+               max_temperature = std::numeric_limits<double>::lowest();
         for (const auto &cell : temperature_dof_handler.active_cell_iterators())
           {
             fe_values.reinit(cell);
@@ -381,7 +381,7 @@ namespace Step31
     else
       {
         double min_temperature = std::numeric_limits<double>::max(),
-               max_temperature = -std::numeric_limits<double>::max();
+               max_temperature = std::numeric_limits<double>::lowest();
         for (const auto &cell : temperature_dof_handler.active_cell_iterators())
           {
             fe_values.reinit(cell);


### PR DESCRIPTION
We used `-max()` previously because `lowest()` is a C++11 feature. But the latter is canonically correct, and the former only works because floating point numbers actually store a sign bit, rather than using ones-complement to indicate the sign of a number as integers do.

References:
https://en.cppreference.com/w/cpp/types/numeric_limits/max
https://en.cppreference.com/w/cpp/types/numeric_limits/min
https://en.cppreference.com/w/cpp/types/numeric_limits/lowest

/rebuild