### PR TITLE
Allow passing physical units into a VTU file.

### DIFF
--- a/doc/news/changes/major/20210709Bangerth
+++ b/doc/news/changes/major/20210709Bangerth
@@ -1,0 +1,11 @@
+New: VTU files have traditionally been used for visualization
+purposes, but more recently they have also been used for more general
+postprocessing tasks since they can easily be imported into Python,
+for example. By setting the DataOutBase::VtkFlags::physical_units
+variable and attaching such a flags object to a DataOut,
+Particles::DataOut, or MatrixOut object, one can now specify the
+physical units associated with variables that are written into VTU
+files, so that they can be parsed by scripts that do further
+postprocessing.
+<br>
+(Wolfgang Bangerth, 2021/07/09)

--- a/examples/step-19/step-19.cc
+++ b/examples/step-19/step-19.cc
@@ -903,12 +903,14 @@ namespace Step19
 
 
   // With this, the `output_results()` function becomes relatively
-  // straightforward: We use the DataOut class as we have in almost every one of
-  // the previous tutorial programs to output the solution (the "electric
-  // potential") and we use the postprocessor defined above to also output its
-  // gradient (the "electric field"). This all is then written into a file in
-  // VTU format after also associating the current time and time step number
-  // with this file.
+  // straightforward: We use the DataOut class as we have in almost
+  // every one of the previous tutorial programs to output the
+  // solution (the "electric potential") and we use the postprocessor
+  // defined above to also output its gradient (the "electric
+  // field"). This all is then written into a file in VTU format after
+  // also associating the current time and time step number with this
+  // file, and providing physical units for the two fields to be
+  // output.
   template <int dim>
   void CathodeRaySimulator<dim>::output_results() const
   {
@@ -920,8 +922,13 @@ namespace Step19
       data_out.add_data_vector(solution, electric_field);
       data_out.build_patches();
 
-      data_out.set_flags(
-        DataOutBase::VtkFlags(time.get_current_time(), time.get_step_number()));
+      DataOutBase::VtkFlags output_flags;
+      output_flags.time  = time.get_current_time();
+      output_flags.cycle = time.get_step_number();
+      output_flags.physical_units["electric_potential"] = "V";
+      output_flags.physical_units["electric_field"]     = "V/m";
+
+      data_out.set_flags(output_flags);
 
       std::ofstream output("solution-" +
                            Utilities::int_to_string(time.get_step_number(), 4) +
@@ -943,8 +950,12 @@ namespace Step19
         std::vector<DataComponentInterpretation::DataComponentInterpretation>(
           dim, DataComponentInterpretation::component_is_part_of_vector));
 
-      particle_out.set_flags(
-        DataOutBase::VtkFlags(time.get_current_time(), time.get_step_number()));
+      DataOutBase::VtkFlags output_flags;
+      output_flags.time                       = time.get_current_time();
+      output_flags.cycle                      = time.get_step_number();
+      output_flags.physical_units["velocity"] = "m/s";
+
+      particle_out.set_flags(output_flags);
 
       std::ofstream output("particles-" +
                            Utilities::int_to_string(time.get_step_number(), 4) +

--- a/examples/step-44/step-44.cc
+++ b/examples/step-44/step-44.cc
@@ -3216,7 +3216,8 @@ namespace Step44
     solution_name.emplace_back("dilatation");
 
     DataOutBase::VtkFlags output_flags;
-    output_flags.write_higher_order_cells = true;
+    output_flags.write_higher_order_cells       = true;
+    output_flags.physical_units["displacement"] = "m";
     data_out.set_flags(output_flags);
 
     data_out.attach_dof_handler(dof_handler);

--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -1170,14 +1170,39 @@ namespace DataOutBase
     bool write_higher_order_cells;
 
     /**
-     * Constructor.
+     * A map that describes for (some or all) of the output quantities what
+     * the physical units are. This field is ignored for VTK file format, but
+     * used for VTU format where it is attached to the individual scalar,
+     * vector, or tensor fields for use by visualization or other postprocessing
+     * tools. The default is to not attach any physical units to fields at all,
+     * i.e., an empty map.
+     *
+     * If the map does not contain an entry for a specific output variable, then
+     * no unit will be written into the output file. In other words, it is not
+     * an error to provide units for only some variables.
+     *
+     * step-19, step-44 and step-69 all demonstrate how to use this variable.
+     *
+     * @note While the functions that make use of this information do not care
+     *   about how physical units are specified, downstream postprocessing tools
+     *   should and do. As a consequence, these units should be specified in a
+     *   format that is understandable to these postprocessing tools. As an
+     *   example, the [unyt project](https://unyt.readthedocs.io/en/stable/)
+     *   describes a standard for describing and converting units.
+     */
+    std::map<std::string, std::string> physical_units;
+
+    /**
+     * Constructor. Initializes the member variables with names corresponding
+     * to the argument names of this function.
      */
     VtkFlags(
       const double       time  = std::numeric_limits<double>::min(),
       const unsigned int cycle = std::numeric_limits<unsigned int>::min(),
       const bool         print_date_and_time              = true,
       const ZlibCompressionLevel compression_level        = best_compression,
-      const bool                 write_higher_order_cells = false);
+      const bool                 write_higher_order_cells = false,
+      const std::map<std::string, std::string> &physical_units = {});
   };
 
 
@@ -2077,7 +2102,8 @@ namespace DataOutBase
                  unsigned int,
                  std::string,
                  DataComponentInterpretation::DataComponentInterpretation>>
-      &nonscalar_data_ranges);
+      &             nonscalar_data_ranges,
+    const VtkFlags &flags);
 
   /**
    * In ParaView it is possible to visualize time-dependent data tagged with

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5462,6 +5462,17 @@ namespace DataOutBase
   {
     AssertThrow(out, ExcIO());
 
+    // If the user provided physical units, make sure that they don't contain
+    // quote characters as this would make the VTU file invalid XML and
+    // probably lead to all sorts of difficult error messages. Other than that,
+    // trust the user that whatever they provide makes sense somehow.
+    for (const auto unit : flags.physical_units)
+      Assert(
+        unit.second.find('\"') == std::string::npos,
+        ExcMessage(
+          "A physical unit you provided, <" + unit.second +
+          ">, contained a quotation mark character. This is not allowed."));
+
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
     // times, people just forget to call build_patches when there are no
@@ -5709,14 +5720,14 @@ namespace DataOutBase
             AssertThrow((last_component + 1 - first_component <= 9),
                         ExcMessage(
                           "Can't declare a tensor with more than 9 components "
-                          "in VTK"));
+                          "in VTK/VTU format."));
           }
         else
           {
             AssertThrow((last_component + 1 - first_component <= 3),
                         ExcMessage(
                           "Can't declare a vector with more than 3 components "
-                          "in VTK"));
+                          "in VTK/VTU format."));
           }
 
         // mark these components as already written:
@@ -5890,6 +5901,17 @@ namespace DataOutBase
     const VtkFlags &flags)
   {
     AssertThrow(out, ExcIO());
+
+    // If the user provided physical units, make sure that they don't contain
+    // quote characters as this would make the VTU file invalid XML and
+    // probably lead to all sorts of difficult error messages. Other than that,
+    // trust the user that whatever they provide makes sense somehow.
+    for (const auto unit : flags.physical_units)
+      Assert(
+        unit.second.find('\"') == std::string::npos,
+        ExcMessage(
+          "A physical unit you provided, <" + unit.second +
+          ">, contained a quotation mark character. This is not allowed."));
 
     const unsigned int n_data_sets = data_names.size();
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5466,7 +5466,7 @@ namespace DataOutBase
     // quote characters as this would make the VTU file invalid XML and
     // probably lead to all sorts of difficult error messages. Other than that,
     // trust the user that whatever they provide makes sense somehow.
-    for (const auto unit : flags.physical_units)
+    for (const auto &unit : flags.physical_units)
       Assert(
         unit.second.find('\"') == std::string::npos,
         ExcMessage(
@@ -5906,7 +5906,7 @@ namespace DataOutBase
     // quote characters as this would make the VTU file invalid XML and
     // probably lead to all sorts of difficult error messages. Other than that,
     // trust the user that whatever they provide makes sense somehow.
-    for (const auto unit : flags.physical_units)
+    for (const auto &unit : flags.physical_units)
       Assert(
         unit.second.find('\"') == std::string::npos,
         ExcMessage(
@@ -5966,7 +5966,7 @@ namespace DataOutBase
         // underscores unless a vector name has been specified
         out << "    <PDataArray type=\"Float32\" Name=\"";
 
-        const std::string name = std::get<2>(nonscalar_data_range);
+        const std::string &name = std::get<2>(nonscalar_data_range);
         if (!name.empty())
           out << name;
         else

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -5467,11 +5467,14 @@ namespace DataOutBase
     // probably lead to all sorts of difficult error messages. Other than that,
     // trust the user that whatever they provide makes sense somehow.
     for (const auto &unit : flags.physical_units)
-      Assert(
-        unit.second.find('\"') == std::string::npos,
-        ExcMessage(
-          "A physical unit you provided, <" + unit.second +
-          ">, contained a quotation mark character. This is not allowed."));
+      {
+        (void)unit;
+        Assert(
+          unit.second.find('\"') == std::string::npos,
+          ExcMessage(
+            "A physical unit you provided, <" + unit.second +
+            ">, contained a quotation mark character. This is not allowed."));
+      }
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -5907,11 +5910,14 @@ namespace DataOutBase
     // probably lead to all sorts of difficult error messages. Other than that,
     // trust the user that whatever they provide makes sense somehow.
     for (const auto &unit : flags.physical_units)
-      Assert(
-        unit.second.find('\"') == std::string::npos,
-        ExcMessage(
-          "A physical unit you provided, <" + unit.second +
-          ">, contained a quotation mark character. This is not allowed."));
+      {
+        (void)unit;
+        Assert(
+          unit.second.find('\"') == std::string::npos,
+          ExcMessage(
+            "A physical unit you provided, <" + unit.second +
+            ">, contained a quotation mark character. This is not allowed."));
+      }
 
     const unsigned int n_data_sets = data_names.size();
 

--- a/tests/data_out/pvtu_physical_units_01.cc
+++ b/tests/data_out/pvtu_physical_units_01.cc
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that one can output physical units along with output
+// fields. This test is for scalar quantities and checks the
+// pvtu writer.
+
+
+#include <deal.II/base/data_out_base.h>
+
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "patches.h"
+
+// Output data on repetitions of the unit hypercube
+
+template <int dim, int spacedim>
+void
+check(DataOutBase::VtkFlags flags, std::ostream &out)
+{
+  std::vector<std::string> names(5);
+  names[0] = "x1";
+  names[1] = "x2";
+  names[2] = "x3";
+  names[3] = "x4";
+  names[4] = "i";
+
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
+  DataOutBase::write_pvtu_record(out, {"abc.vtu"}, names, vectors, flags);
+}
+
+
+template <int dim, int spacedim>
+void
+check_all(std::ostream &log)
+{
+  DataOutBase::VtkFlags flags;
+
+  // Set the units of some but not all output quantities
+  flags.physical_units["x1"] = "kg/s";
+  flags.physical_units["x3"] = "N/m";
+  flags.physical_units["i"]  = "J/K";
+
+  log << "==============================" << std::endl
+      << dim << spacedim << ".vtu" << std::endl
+      << "==============================" << std::endl;
+  check<dim, spacedim>(flags, log);
+}
+
+int
+main()
+{
+  initlog();
+
+  check_all<1, 1>(deallog.get_file_stream());
+  check_all<1, 2>(deallog.get_file_stream());
+  check_all<2, 2>(deallog.get_file_stream());
+  check_all<2, 3>(deallog.get_file_stream());
+  check_all<3, 3>(deallog.get_file_stream());
+}

--- a/tests/data_out/pvtu_physical_units_01.with_zlib=true.output
+++ b/tests/data_out/pvtu_physical_units_01.with_zlib=true.output
@@ -1,0 +1,111 @@
+
+==============================
+11.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x2" format="ascii"/>
+    <PDataArray type="Float32" Name="x3" format="ascii" units="N/m"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii" units="J/K"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+12.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x2" format="ascii"/>
+    <PDataArray type="Float32" Name="x3" format="ascii" units="N/m"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii" units="J/K"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+22.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x2" format="ascii"/>
+    <PDataArray type="Float32" Name="x3" format="ascii" units="N/m"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii" units="J/K"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+23.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x2" format="ascii"/>
+    <PDataArray type="Float32" Name="x3" format="ascii" units="N/m"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii" units="J/K"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+33.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x2" format="ascii"/>
+    <PDataArray type="Float32" Name="x3" format="ascii" units="N/m"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii" units="J/K"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>

--- a/tests/data_out/pvtu_physical_units_02.cc
+++ b/tests/data_out/pvtu_physical_units_02.cc
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that one can output physical units along with output
+// fields. This test is for vector-valued quantities and checks the
+// pvtu writer.
+
+
+#include <deal.II/base/data_out_base.h>
+
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "patches.h"
+
+// Output data on repetitions of the unit hypercube
+
+template <int dim, int spacedim>
+void
+check(DataOutBase::VtkFlags flags, std::ostream &out)
+{
+  std::vector<std::string> names(5);
+  names[0] = "x1";
+  names[1] = "x2";
+  names[2] = "x3";
+  names[3] = "x4";
+  names[4] = "i";
+  for (unsigned int i = 1; i < 1 + dim; ++i)
+    names[i] = "v";
+
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors{{1,
+             1 + dim - 1,
+             "v",
+             DataComponentInterpretation::component_is_part_of_vector}};
+  DataOutBase::write_pvtu_record(out, {"abc.vtu"}, names, vectors, flags);
+}
+
+
+template <int dim, int spacedim>
+void
+check_all(std::ostream &log)
+{
+  DataOutBase::VtkFlags flags;
+
+  // Set the units of some but not all output quantities
+  flags.physical_units["x1"] = "kg/s";
+  flags.physical_units["v"]  = "m/s";
+
+  log << "==============================" << std::endl
+      << dim << spacedim << ".vtu" << std::endl
+      << "==============================" << std::endl;
+  check<dim, spacedim>(flags, log);
+}
+
+int
+main()
+{
+  std::stringstream ss;
+  check_all<1, 1>(ss);
+  check_all<1, 2>(ss);
+  check_all<2, 2>(ss);
+  check_all<2, 3>(ss);
+  check_all<3, 3>(ss);
+
+  std::ofstream logfile("output");
+  filter_out_xml_key(ss, "DataArray", logfile);
+}

--- a/tests/data_out/pvtu_physical_units_02.cc
+++ b/tests/data_out/pvtu_physical_units_02.cc
@@ -43,15 +43,17 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   for (unsigned int i = 1; i < 1 + dim; ++i)
     names[i] = "v";
 
-  std::vector<
+  using Descriptor =
     std::tuple<unsigned int,
                unsigned int,
                std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-    vectors{{1,
-             1 + dim - 1,
-             "v",
-             DataComponentInterpretation::component_is_part_of_vector}};
+               DataComponentInterpretation::DataComponentInterpretation>;
+  std::vector<Descriptor> vectors(
+    1,
+    Descriptor{1,
+               1 + dim - 1,
+               "v",
+               DataComponentInterpretation::component_is_part_of_vector});
   DataOutBase::write_pvtu_record(out, {"abc.vtu"}, names, vectors, flags);
 }
 

--- a/tests/data_out/pvtu_physical_units_02.with_zlib=true.output
+++ b/tests/data_out/pvtu_physical_units_02.with_zlib=true.output
@@ -1,0 +1,106 @@
+==============================
+11.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="v" NumberOfComponents="3" format="ascii" units="m/s"/>
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x3" format="ascii"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+12.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="v" NumberOfComponents="3" format="ascii" units="m/s"/>
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x3" format="ascii"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+22.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="v" NumberOfComponents="3" format="ascii" units="m/s"/>
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+23.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="v" NumberOfComponents="3" format="ascii" units="m/s"/>
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="x4" format="ascii"/>
+    <PDataArray type="Float32" Name="i" format="ascii"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>
+==============================
+33.vtu
+==============================
+<?xml version="1.0"?>
+<!--
+#This file was generated 
+-->
+<VTKFile type="PUnstructuredGrid" version="0.1" byte_order="LittleEndian">
+  <PUnstructuredGrid GhostLevel="0">
+    <PPointData Scalars="scalars">
+    <PDataArray type="Float32" Name="v" NumberOfComponents="3" format="ascii" units="m/s"/>
+    <PDataArray type="Float32" Name="x1" format="ascii" units="kg/s"/>
+    <PDataArray type="Float32" Name="i" format="ascii"/>
+    </PPointData>
+    <PPoints>
+      <PDataArray type="Float32" NumberOfComponents="3"/>
+    </PPoints>
+    <Piece Source="abc.vtu"/>
+  </PUnstructuredGrid>
+</VTKFile>

--- a/tests/data_out/vtu_physical_units_01.cc
+++ b/tests/data_out/vtu_physical_units_01.cc
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that one can output physical units along with output fields
+
+
+#include <deal.II/base/data_out_base.h>
+
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "patches.h"
+
+// Output data on repetitions of the unit hypercube
+
+template <int dim, int spacedim>
+void
+check(DataOutBase::VtkFlags flags, std::ostream &out)
+{
+  const unsigned int np = 4;
+
+  std::vector<DataOutBase::Patch<dim, spacedim>> patches(np);
+
+  create_patches(patches);
+
+  std::vector<std::string> names(5);
+  names[0] = "x1";
+  names[1] = "x2";
+  names[2] = "x3";
+  names[3] = "x4";
+  names[4] = "i";
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors;
+  DataOutBase::write_vtu(patches, names, vectors, flags, out);
+}
+
+
+template <int dim, int spacedim>
+void
+check_all(std::ostream &log)
+{
+  DataOutBase::VtkFlags flags;
+
+  // Set the units of some but not all output quantities
+  flags.physical_units["x1"] = "kg/s";
+  flags.physical_units["x3"] = "N/m";
+  flags.physical_units["i"]  = "J/K";
+
+  log << "==============================" << std::endl
+      << dim << spacedim << ".vtu" << std::endl
+      << "==============================" << std::endl;
+  check<dim, spacedim>(flags, log);
+}
+
+int
+main()
+{
+  std::stringstream ss;
+  check_all<1, 1>(ss);
+  check_all<1, 2>(ss);
+  check_all<2, 2>(ss);
+  check_all<2, 3>(ss);
+  check_all<3, 3>(ss);
+
+  std::ofstream logfile("output");
+  filter_out_xml_key(ss, "DataArray", logfile);
+}

--- a/tests/data_out/vtu_physical_units_01.with_zlib=true.output
+++ b/tests/data_out/vtu_physical_units_01.with_zlib=true.output
@@ -1,0 +1,195 @@
+==============================
+11.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="14" NumberOfCells="10" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x2" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary" units="N/m">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary" units="J/K">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+12.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="14" NumberOfCells="10" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x2" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary" units="N/m">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary" units="J/K">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+22.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="54" NumberOfCells="30" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x2" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary" units="N/m">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary" units="J/K">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+23.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="54" NumberOfCells="30" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x2" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary" units="N/m">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary" units="J/K">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+33.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="224" NumberOfCells="100" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x2" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary" units="N/m">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary" units="J/K">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>

--- a/tests/data_out/vtu_physical_units_02.cc
+++ b/tests/data_out/vtu_physical_units_02.cc
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2006 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check that one can output physical units along with output
+// fields. This test is for vector-valued quantities
+
+
+#include <deal.II/base/data_out_base.h>
+
+#include <string>
+#include <vector>
+
+#include "../tests.h"
+
+#include "patches.h"
+
+// Output data on repetitions of the unit hypercube
+
+template <int dim, int spacedim>
+void
+check(DataOutBase::VtkFlags flags, std::ostream &out)
+{
+  const unsigned int np = 4;
+
+  std::vector<DataOutBase::Patch<dim, spacedim>> patches(np);
+
+  create_patches(patches);
+
+  std::vector<std::string> names(5);
+  names[0] = "x1";
+  names[1] = "x2";
+  names[2] = "x3";
+  names[3] = "x4";
+  names[4] = "i";
+  for (unsigned int i = 1; i < 1 + dim; ++i)
+    names[i] = "v";
+
+  std::vector<
+    std::tuple<unsigned int,
+               unsigned int,
+               std::string,
+               DataComponentInterpretation::DataComponentInterpretation>>
+    vectors{{1,
+             1 + dim - 1,
+             "v",
+             DataComponentInterpretation::component_is_part_of_vector}};
+  DataOutBase::write_vtu(patches, names, vectors, flags, out);
+}
+
+
+template <int dim, int spacedim>
+void
+check_all(std::ostream &log)
+{
+  DataOutBase::VtkFlags flags;
+
+  // Set the units of some but not all output quantities
+  flags.physical_units["x1"] = "kg/s";
+  flags.physical_units["v"]  = "m/s";
+
+  log << "==============================" << std::endl
+      << dim << spacedim << ".vtu" << std::endl
+      << "==============================" << std::endl;
+  check<dim, spacedim>(flags, log);
+}
+
+int
+main()
+{
+  std::stringstream ss;
+  check_all<1, 1>(ss);
+  check_all<1, 2>(ss);
+  check_all<2, 2>(ss);
+  check_all<2, 3>(ss);
+  check_all<3, 3>(ss);
+
+  std::ofstream logfile("output");
+  filter_out_xml_key(ss, "DataArray", logfile);
+}

--- a/tests/data_out/vtu_physical_units_02.cc
+++ b/tests/data_out/vtu_physical_units_02.cc
@@ -48,15 +48,17 @@ check(DataOutBase::VtkFlags flags, std::ostream &out)
   for (unsigned int i = 1; i < 1 + dim; ++i)
     names[i] = "v";
 
-  std::vector<
+  using Descriptor =
     std::tuple<unsigned int,
                unsigned int,
                std::string,
-               DataComponentInterpretation::DataComponentInterpretation>>
-    vectors{{1,
-             1 + dim - 1,
-             "v",
-             DataComponentInterpretation::component_is_part_of_vector}};
+               DataComponentInterpretation::DataComponentInterpretation>;
+  std::vector<Descriptor> vectors(
+    1,
+    Descriptor{1,
+               1 + dim - 1,
+               "v",
+               DataComponentInterpretation::component_is_part_of_vector});
   DataOutBase::write_vtu(patches, names, vectors, flags, out);
 }
 

--- a/tests/data_out/vtu_physical_units_02.with_zlib=true.output
+++ b/tests/data_out/vtu_physical_units_02.with_zlib=true.output
@@ -1,0 +1,187 @@
+==============================
+11.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="14" NumberOfCells="10" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="v" NumberOfComponents="3" format="binary" units="m/s">
+</DataArray>
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+12.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="14" NumberOfCells="10" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="v" NumberOfComponents="3" format="binary" units="m/s">
+</DataArray>
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x3" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+22.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="54" NumberOfCells="30" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="v" NumberOfComponents="3" format="binary" units="m/s">
+</DataArray>
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+23.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="54" NumberOfCells="30" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="v" NumberOfComponents="3" format="binary" units="m/s">
+</DataArray>
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="x4" format="binary">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>
+==============================
+33.vtu
+==============================
+<?xml version="1.0" ?> 
+<!-- 
+# vtk DataFile Version 3.0
+#This file was generated 
+-->
+<VTKFile type="UnstructuredGrid" version="0.1" compressor="vtkZLibDataCompressor" byte_order="LittleEndian">
+<UnstructuredGrid>
+<Piece NumberOfPoints="224" NumberOfCells="100" >
+  <Points>
+    <DataArray type="Float32" NumberOfComponents="3" format="binary">
+</DataArray>
+  </Points>
+
+  <Cells>
+    <DataArray type="Int32" Name="connectivity" format="binary">
+</DataArray>
+    <DataArray type="Int32" Name="offsets" format="binary">
+</DataArray>
+    <DataArray type="UInt8" Name="types" format="binary">
+</DataArray>
+  </Cells>
+  <PointData Scalars="scalars">
+    <DataArray type="Float32" Name="v" NumberOfComponents="3" format="binary" units="m/s">
+</DataArray>
+    <DataArray type="Float32" Name="x1" format="binary" units="kg/s">
+</DataArray>
+    <DataArray type="Float32" Name="i" format="binary">
+</DataArray>
+  </PointData>
+ </Piece>
+ </UnstructuredGrid>
+</VTKFile>


### PR DESCRIPTION
VTU files have traditionally been used for visualization
purposes, but more recently they have also been used for more general
postprocessing tasks since they can easily be imported into Python,
for example. By setting the DataOutBase::VtkFlags::physical_units
variables and attaching such a flags object to a DataOut,
Particles::DataOut, or MatrixOut object, one can now specify the
physical units associated with variables that are written into VTU
files, so that they can be parsed by scripts that do further
postprocessing.

/rebuild