### PR TITLE
Avoid a warning about an unused variable in BOOST.

### DIFF
--- a/bundled/boost-1.70.0/include/boost/archive/iterators/wchar_from_mb.hpp
+++ b/bundled/boost-1.70.0/include/boost/archive/iterators/wchar_from_mb.hpp
@@ -174,6 +174,7 @@ void wchar_from_mb<Base>::drain(){
         m_output.m_buffer.end(),
         next_available
     );
+    (void)r;
     BOOST_ASSERT(std::codecvt_base::ok == r);
     m_output.m_next_available = next_available;
     m_output.m_next = m_output.m_buffer.begin();


### PR DESCRIPTION
Not sure why this shows up now, but I had that in one of my builds.

/rebuild