### PR TITLE
cmake: check_compiler_setup: move linker flags to correct CMAKE_REQUIRED variable

### DIFF
--- a/cmake/macros/macro_check_compiler_setup.cmake
+++ b/cmake/macros/macro_check_compiler_setup.cmake
@@ -67,8 +67,8 @@ MACRO(CHECK_COMPILER_SETUP _compiler_flags_unstr _linker_flags_unstr _var)
     )
   SET(CACHED_${_var}_ARGN "${ARGN}" CACHE INTERNAL "" FORCE)
 
-  SET(CMAKE_REQUIRED_FLAGS ${_compiler_flags})
-  SET(CMAKE_REQUIRED_LIBRARIES ${_linker_flags} ${ARGN})
+  SET(CMAKE_REQUIRED_FLAGS "${_compiler_flags} ${_linker_flags}")
+  SET(CMAKE_REQUIRED_LIBRARIES ${ARGN})
 
   CHECK_CXX_SOURCE_COMPILES("int main(){ return 0; }" ${_var})
   RESET_CMAKE_REQUIRED()


### PR DESCRIPTION
See https://cmake.org/cmake/help/latest/module/CheckCXXSourceCompiles.html.

`CMAKE_REQUIRED_LIBRARIES` takes a semicolon-separated list of arguments that we provide via `ARGN`. All flags should be part of `CMAKE_REQUIRED_FLAGS`.

This PR moves the linker flags into the proper variable.

FYI -- @masterleinad @tamiko 