### PR TITLE
DoFHandlerPolicy: Fix 64 bit code path

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3686,7 +3686,7 @@ namespace internal
               DoFAccessorImplementation::Implementation::
                 DoFIndexProcessor<dim, spacedim, false>(),
               [&complete](auto &stored_index, auto &received_index) {
-                if (received_index != numbers::invalid_unsigned_int)
+                if (received_index != numbers::invalid_dof_index)
                   {
                     Assert((stored_index == (numbers::invalid_dof_index)) ||
                              (stored_index == received_index),


### PR DESCRIPTION
This fixes a bug introduced by #12576, meaning that we cannot run most 64 bit programs (609 new test failures for https://cdash.43-1.org/index.php?project=deal.II ). See e.g. the message here: https://cdash.43-1.org/test/18224525