### PR TITLE
Add clear() to the Table class

### DIFF
--- a/doc/news/changes/minor/20210721JiaqiZhang
+++ b/doc/news/changes/minor/20210721JiaqiZhang
@@ -1,0 +1,4 @@
+New: The new function TableBase::clear() allows to 
+empty a Table object.
+<br>
+(Jiaqi Zhang, 2021/07/21)

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -544,6 +544,12 @@ public:
          const bool             omit_default_initialization = false);
 
   /**
+   * Set all dimensions to zero.
+   */
+  void
+  clear();
+
+  /**
    * Size of the table in direction <tt>i</tt>.
    */
   size_type
@@ -2417,6 +2423,16 @@ TableBase<N, T>::reinit(const TableIndices<N> &new_sizes,
     }
   else
     values.resize_fast(new_size);
+}
+
+
+
+template <int N, typename T>
+inline void
+TableBase<N, T>::clear()
+{
+  values.resize(0);
+  table_size = TableIndices<N>();
 }
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -2431,7 +2431,7 @@ template <int N, typename T>
 inline void
 TableBase<N, T>::clear()
 {
-  values.resize(0);
+  values.clear();
   table_size = TableIndices<N>();
 }
 

--- a/tests/base/table_05.cc
+++ b/tests/base/table_05.cc
@@ -31,6 +31,9 @@ test()
   dealii::Table<dim, int> unrolled;
   unrolled.reinit(new_size);
 
+  unrolled.clear();
+  Assert(unrolled.empty() == true, ExcInternalError());
+
   deallog << "OK" << std::endl;
 }
 

--- a/tests/base/table_07.cc
+++ b/tests/base/table_07.cc
@@ -54,5 +54,8 @@ main()
   dealii::Table<2, T> table2;
   table2 = std::move(table); // should not create new objects
 
+  table.clear();
+  Assert(table.empty() == true, ExcInternalError());
+
   deallog << "OK" << std::endl;
 }


### PR DESCRIPTION
A straightforward way to clear a Table object. 