### PR TITLE
Add a missing include file.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/memory_consumption.h>
 #include <deal.II/base/partitioner.h>
 #include <deal.II/base/thread_management.h>
+#include <deal.II/base/types.h>
 #include <deal.II/base/utilities.h>
 #include <deal.II/base/work_stream.h>
 


### PR DESCRIPTION
We use `numbers::invalid_dof_index` which if declared in `types.h`. I believe this is the cause of https://github.com/xsdk-project/xsdk-issues/issues/153 .

/rebuild