### PR TITLE
Intel 18 does not like assertions in nested lambdas.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -3689,9 +3689,11 @@ namespace internal
               [&complete](auto &stored_index, auto &received_index) {
                 if (received_index != numbers::invalid_dof_index)
                   {
+#    if !defined(__INTEL_COMPILER) || __INTEL_COMPILER >= 1900
                     Assert((stored_index == (numbers::invalid_dof_index)) ||
                              (stored_index == received_index),
                            ExcInternalError());
+#    endif
                     stored_index = received_index;
                   }
                 else


### PR DESCRIPTION
Fixes https://github.com/xsdk-project/xsdk-issues/issues/153. Related to #12589.

Compilation succeeds with Intel 19.1, so I've added a conditional like in other places in the library.