### PR TITLE
Load: align dealii and p4est meshes before repartitioning.

### DIFF
--- a/doc/news/changes/incompatibilities/20210723Fehling
+++ b/doc/news/changes/incompatibilities/20210723Fehling
@@ -1,0 +1,6 @@
+Changed: Custom repartitioning via Triangulation::Signals::cell_weight
+is no longer part of parallel::distributed::Triangulation::load(). If
+desired, call parallel::distributed::Triangulation::repartition()
+manually after load().
+<br>
+(Marc Fehling, 2021/07/23)

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -594,17 +594,22 @@ namespace parallel
        * You do not need to load with the same number of MPI processes that
        * you saved with. Rather, if a mesh is loaded with a different number
        * of MPI processes than used at the time of saving, the mesh is
-       * repartitioned appropriately. Cell-based data that was saved with
+       * repartitioned that the number of cells is balanced among all processes.
+       * Individual repartitioning, e.g., based on the number of dofs or
+       * particles per cell, needs to be invoked manually by calling
+       * repartition() afterwards.
+       *
+       * Cell-based data that was saved with
        * DistributedTriangulationBase::DataTransfer::register_data_attach() can
        * be read in with
        * DistributedTriangulationBase::DataTransfer::notify_ready_to_unpack()
        * after calling load().
        *
-       * If you use p4est version > 0.3.4.2 the @p autopartition flag tells
-       * p4est to ignore the partitioning that the triangulation had when it
-       * was saved and make it uniform upon loading. If @p autopartition is
-       * set to false, the triangulation is only repartitioned if needed (i.e.
-       * if a different number of MPI processes is encountered).
+       * The @p autopartition flag tells p4est to ignore the partitioning that
+       * the triangulation had when it was saved and make it uniform upon
+       * loading. If @p autopartition is set to true, the triangulation will
+       * always be repartitioned. If set to false, it is only repartitioned if
+       * needed (i.e., if a different number of MPI processes is encountered).
        */
       virtual void
       load(const std::string &filename,

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1534,8 +1534,8 @@ namespace parallel
         filename.c_str(),
         this->mpi_communicator,
         0,
-        false,
-        autopartition,
+        0,
+        static_cast<int>(autopartition),
         0,
         this,
         &connectivity);
@@ -1547,49 +1547,10 @@ namespace parallel
           // number of CPUs and so everything works without this call, but
           // this command changes the distribution for some reason, so we
           // will leave it in here.
-          if (this->signals.cell_weight.num_slots() == 0)
-            {
-              // no cell weights given -- call p4est's 'partition' without a
-              // callback for cell weights
-              dealii::internal::p4est::functions<dim>::partition(
-                parallel_forest,
-                /* prepare coarsening */ 1,
-                /* weight_callback */ nullptr);
-            }
-          else
-            {
-              // first, align both dealii and p4est meshes, which is a
-              // requirement of our internal cell weights algorithm
-              try
-                {
-                  copy_local_forest_to_triangulation();
-                }
-              catch (const typename Triangulation<dim>::DistortedCellList &)
-                {
-                  // the underlying triangulation should not be checking for
-                  // distorted cells
-                  Assert(false, ExcInternalError());
-                }
-
-              // get cell weights for a weighted repartitioning.
-              const std::vector<unsigned int> cell_weights = get_cell_weights();
-
-              PartitionWeights<dim, spacedim> partition_weights(cell_weights);
-
-              // attach (temporarily) a pointer to the cell weights through
-              // p4est's user_pointer object
-              Assert(parallel_forest->user_pointer == this, ExcInternalError());
-              parallel_forest->user_pointer = &partition_weights;
-
-              dealii::internal::p4est::functions<dim>::partition(
-                parallel_forest,
-                /* prepare coarsening */ 1,
-                /* weight_callback */
-                &PartitionWeights<dim, spacedim>::cell_weight);
-
-              // reset the user pointer to its previous state
-              parallel_forest->user_pointer = this;
-            }
+          dealii::internal::p4est::functions<dim>::partition(
+            parallel_forest,
+            /* prepare coarsening */ 1,
+            /* weight_callback */ nullptr);
         }
 
       try

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -1558,6 +1558,19 @@ namespace parallel
             }
           else
             {
+              // first, align both dealii and p4est meshes, which is a
+              // requirement of our internal cell weights algorithm
+              try
+                {
+                  copy_local_forest_to_triangulation();
+                }
+              catch (const typename Triangulation<dim>::DistortedCellList &)
+                {
+                  // the underlying triangulation should not be checking for
+                  // distorted cells
+                  Assert(false, ExcInternalError());
+                }
+
               // get cell weights for a weighted repartitioning.
               const std::vector<unsigned int> cell_weights = get_cell_weights();
 
@@ -1585,10 +1598,8 @@ namespace parallel
         }
       catch (const typename Triangulation<dim>::DistortedCellList &)
         {
-          // the underlying
-          // triangulation should not
-          // be checking for
-          // distorted cells
+          // the underlying triangulation should not be checking for distorted
+          // cells
           Assert(false, ExcInternalError());
         }
 


### PR DESCRIPTION
Deserializing a `p:d:Triangulation` fails when callbacks are connected to the `cell_weights` signal.

Our internal weighting algorithm requires that both meshes are aligned in a sense that the deal.II mesh levels must differ by at most one with the p4est mesh. Before calling `load`, the deal.II mesh only contains coarse cells.

I can provide a failing test if desired.