### PR TITLE
Un-deprecate DoFHandler::set_fe.

### DIFF
--- a/doc/news/changes/minor/20210723Fehling
+++ b/doc/news/changes/minor/20210723Fehling
@@ -1,0 +1,5 @@
+New: The functions DoFHandler::set_fe() have been taken from the
+deprecation list. They register a FECollection with a DoFHandler object.
+No communication of active or future FE indices will occur.
+<br>
+(Marc Fehling, 2021/07/23)

--- a/include/deal.II/dofs/dof_handler.h
+++ b/include/deal.II/dofs/dof_handler.h
@@ -614,19 +614,13 @@ public:
    * either not been distributed yet, or are distributed using a previously set
    * element. In both cases, accessing degrees of freedom will lead to invalid
    * results. To restore consistency, call distribute_dofs().
-   *
-   * @deprecated Use distribute_dofs() instead.
    */
-  DEAL_II_DEPRECATED
   void
   set_fe(const FiniteElement<dim, spacedim> &fe);
 
   /**
    * Same as above but taking an hp::FECollection object.
-   *
-   * @deprecated Use distribute_dofs() instead.
    */
-  DEAL_II_DEPRECATED
   void
   set_fe(const hp::FECollection<dim, spacedim> &fe);
 


### PR DESCRIPTION
I suggested to simplify the DoFHandler initialization interface in #11160. Working on serialization, I realized that one of these functions is actually quite handy and would like to propose to 'un-deprecate' it.

Consider a large hp-adapted grid on which you would like to impose weighted repartitioning based on the number of dofs per cell. After loading it from the file system, we need a FECollection to know how many dofs are associated with each cell.

With the `set_fe` function, you can assign a FECollection without enumerating dofs. We always store active and future FE indices in the DoFHandler.

I changed the function that it also works for empty Triangulation objects, so no active FE indices will be exchanged.