### PR TITLE
Let find_active_cell_around_point() return mesh.end() if point is not found in BBs

### DIFF
--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -2774,6 +2774,8 @@ namespace GridTools
     std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,
               Point<dim>>
       cell_and_position;
+    cell_and_position.first = mesh.end();
+
     // To handle points at the border we keep track of points which are close to
     // the unit cell:
     std::pair<typename MeshType<dim, spacedim>::active_cell_iterator,


### PR DESCRIPTION
since the documentation states:

https://github.com/dealii/dealii/blob/b1a5775265bbca6beee27d459ba2fbb83c74dafd/include/deal.II/grid/grid_tools.h#L1315-L1317

closes #12555