### PR TITLE
Deprecated autopartition parameter in parallel::DistributedTriangulationBase::load()

### DIFF
--- a/doc/news/changes/incompatibilities/20210724Fehling
+++ b/doc/news/changes/incompatibilities/20210724Fehling
@@ -1,0 +1,5 @@
+Deprecated: The autopartition parameter has been removed from
+parallel::DistributedTriangulationBase::load() and all inheriting
+classes.
+<br>
+(Marc Fehling, 2021/07/24)

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -252,8 +252,16 @@ namespace parallel
        * in with notify_ready_to_unpack() after calling load().
        */
       virtual void
-      load(const std::string &filename,
-           const bool         autopartition = false) override;
+      load(const std::string &filename) override;
+
+      /**
+       * @copydoc load()
+       *
+       * @deprecated The autopartition parameter has been removed.
+       */
+      DEAL_II_DEPRECATED_EARLY
+      virtual void
+      load(const std::string &filename, const bool autopartition) override;
 
     private:
       virtual unsigned int

--- a/include/deal.II/distributed/tria.h
+++ b/include/deal.II/distributed/tria.h
@@ -604,16 +604,18 @@ namespace parallel
        * be read in with
        * DistributedTriangulationBase::DataTransfer::notify_ready_to_unpack()
        * after calling load().
-       *
-       * The @p autopartition flag tells p4est to ignore the partitioning that
-       * the triangulation had when it was saved and make it uniform upon
-       * loading. If @p autopartition is set to true, the triangulation will
-       * always be repartitioned. If set to false, it is only repartitioned if
-       * needed (i.e., if a different number of MPI processes is encountered).
        */
       virtual void
-      load(const std::string &filename,
-           const bool         autopartition = true) override;
+      load(const std::string &filename) override;
+
+      /**
+       * @copydoc load()
+       *
+       * @deprecated The autopartition parameter has been removed.
+       */
+      DEAL_II_DEPRECATED_EARLY
+      virtual void
+      load(const std::string &filename, const bool autopartition) override;
 
       /**
        * Load the refinement information from a given parallel forest. This
@@ -870,8 +872,15 @@ namespace parallel
        * compiler.
        */
       virtual void
-      load(const std::string &filename,
-           const bool         autopartition = true) override;
+      load(const std::string &filename) override;
+
+      /**
+       * This function is not implemented, but needs to be present for the
+       * compiler.
+       */
+      DEAL_II_DEPRECATED_EARLY
+      virtual void
+      load(const std::string &filename, const bool autopartition) override;
 
       /**
        * This function is not implemented, but needs to be present for the
@@ -1000,8 +1009,17 @@ namespace parallel
        * this class.
        */
       virtual void
+      load(const std::string & /*filename*/) override
+      {}
+
+      /**
+       * Dummy replacement to allow for better error messages when compiling
+       * this class.
+       */
+      DEAL_II_DEPRECATED_EARLY
+      virtual void
       load(const std::string & /*filename*/,
-           const bool /*autopartition*/ = true) override
+           const bool /*autopartition*/) override
       {}
 
       /**

--- a/include/deal.II/distributed/tria_base.h
+++ b/include/deal.II/distributed/tria_base.h
@@ -480,7 +480,16 @@ namespace parallel
      * notify_ready_to_unpack() after calling load().
      */
     virtual void
-    load(const std::string &filename, const bool autopartition = true) = 0;
+    load(const std::string &filename) = 0;
+
+    /**
+     * @copydoc load()
+     *
+     * @deprecated The autopartition parameter has been removed.
+     */
+    DEAL_II_DEPRECATED_EARLY
+    virtual void
+    load(const std::string &filename, const bool autopartition) = 0;
 
     /**
      * Register a function that can be used to attach data of fixed size

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -558,15 +558,9 @@ namespace parallel
 
     template <int dim, int spacedim>
     void
-    Triangulation<dim, spacedim>::load(const std::string &filename,
-                                       const bool         autopartition)
+    Triangulation<dim, spacedim>::load(const std::string &filename)
     {
 #ifdef DEAL_II_WITH_MPI
-      AssertThrow(
-        autopartition == false,
-        ExcMessage(
-          "load() only works if run with the same number of MPI processes used for saving the triangulation, hence autopartition is disabled."));
-
       Assert(this->n_cells() == 0,
              ExcMessage("load() only works if the Triangulation is empty!"));
 
@@ -694,10 +688,20 @@ namespace parallel
       this->update_number_cache();
 #else
       (void)filename;
-      (void)autopartition;
 
       AssertThrow(false, ExcNeedsMPI());
 #endif
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::load(const std::string &filename,
+                                       const bool         autopartition)
+    {
+      (void)autopartition;
+      load(filename);
     }
 
 

--- a/tests/mpi/cell_data_transfer_02.with_p4est=true.mpirun=8.output
+++ b/tests/mpi/cell_data_transfer_02.with_p4est=true.mpirun=8.output
@@ -7,6 +7,8 @@ DEAL:0:2d::cellid=0_1:3 parentid=0
 DEAL:0:2d::reading
 DEAL:0:2d::cellid=0_1:0 parentid=0
 DEAL:0:2d::cellid=0_1:1 parentid=0
+DEAL:0:2d::cellid=0_1:2 parentid=0
+DEAL:0:2d::cellid=0_1:3 parentid=0
 DEAL:0:2d::OK
 DEAL:0:3d::writing
 DEAL:0:3d::cellid=0_1:0 parentid=0
@@ -30,8 +32,6 @@ DEAL:0:3d::OK
 
 DEAL:1:2d::writing
 DEAL:1:2d::reading
-DEAL:1:2d::cellid=0_1:2 parentid=0
-DEAL:1:2d::cellid=0_1:3 parentid=0
 DEAL:1:2d::OK
 DEAL:1:3d::writing
 DEAL:1:3d::cellid=1_1:0 parentid=1
@@ -62,6 +62,8 @@ DEAL:2:2d::cellid=1_1:3 parentid=1
 DEAL:2:2d::reading
 DEAL:2:2d::cellid=1_1:0 parentid=1
 DEAL:2:2d::cellid=1_1:1 parentid=1
+DEAL:2:2d::cellid=1_1:2 parentid=1
+DEAL:2:2d::cellid=1_1:3 parentid=1
 DEAL:2:2d::OK
 DEAL:2:3d::writing
 DEAL:2:3d::cellid=2_1:0 parentid=2
@@ -86,8 +88,6 @@ DEAL:2:3d::OK
 
 DEAL:3:2d::writing
 DEAL:3:2d::reading
-DEAL:3:2d::cellid=1_1:2 parentid=1
-DEAL:3:2d::cellid=1_1:3 parentid=1
 DEAL:3:2d::OK
 DEAL:3:3d::writing
 DEAL:3:3d::cellid=3_1:0 parentid=3
@@ -118,6 +118,8 @@ DEAL:4:2d::cellid=2_1:3 parentid=2
 DEAL:4:2d::reading
 DEAL:4:2d::cellid=2_1:0 parentid=2
 DEAL:4:2d::cellid=2_1:1 parentid=2
+DEAL:4:2d::cellid=2_1:2 parentid=2
+DEAL:4:2d::cellid=2_1:3 parentid=2
 DEAL:4:2d::OK
 DEAL:4:3d::writing
 DEAL:4:3d::cellid=4_1:0 parentid=4
@@ -142,8 +144,6 @@ DEAL:4:3d::OK
 
 DEAL:5:2d::writing
 DEAL:5:2d::reading
-DEAL:5:2d::cellid=2_1:2 parentid=2
-DEAL:5:2d::cellid=2_1:3 parentid=2
 DEAL:5:2d::OK
 DEAL:5:3d::writing
 DEAL:5:3d::cellid=5_1:0 parentid=5
@@ -174,6 +174,8 @@ DEAL:6:2d::cellid=3_1:3 parentid=3
 DEAL:6:2d::reading
 DEAL:6:2d::cellid=3_1:0 parentid=3
 DEAL:6:2d::cellid=3_1:1 parentid=3
+DEAL:6:2d::cellid=3_1:2 parentid=3
+DEAL:6:2d::cellid=3_1:3 parentid=3
 DEAL:6:2d::OK
 DEAL:6:3d::writing
 DEAL:6:3d::cellid=6_1:0 parentid=6
@@ -198,8 +200,6 @@ DEAL:6:3d::OK
 
 DEAL:7:2d::writing
 DEAL:7:2d::reading
-DEAL:7:2d::cellid=3_1:2 parentid=3
-DEAL:7:2d::cellid=3_1:3 parentid=3
 DEAL:7:2d::OK
 DEAL:7:3d::writing
 DEAL:7:3d::cellid=7_1:0 parentid=7

--- a/tests/mpi/hp_active_fe_indices_transfer_02.with_p4est=true.mpirun=8.output
+++ b/tests/mpi/hp_active_fe_indices_transfer_02.with_p4est=true.mpirun=8.output
@@ -7,10 +7,13 @@ DEAL:0:2d::cellid=0_1:3 fe_index=3
 DEAL:0:2d::reading
 DEAL:0:2d::cellid=0_1:0 fe_index=0
 DEAL:0:2d::cellid=0_1:1 fe_index=1
-DEAL:0:2d::cellid=0_1:2 fe_index=2 ghost
-DEAL:0:2d::cellid=0_1:3 fe_index=3 ghost
+DEAL:0:2d::cellid=0_1:2 fe_index=2
+DEAL:0:2d::cellid=0_1:3 fe_index=3
 DEAL:0:2d::cellid=1_1:0 fe_index=0 ghost
 DEAL:0:2d::cellid=1_1:2 fe_index=2 ghost
+DEAL:0:2d::cellid=2_1:0 fe_index=0 ghost
+DEAL:0:2d::cellid=2_1:1 fe_index=1 ghost
+DEAL:0:2d::cellid=3_1:0 fe_index=0 ghost
 DEAL:0:2d::OK
 DEAL:0:3d::writing
 DEAL:0:3d::cellid=0_1:0 fe_index=0
@@ -53,15 +56,6 @@ DEAL:0:3d::OK
 
 DEAL:1:2d::writing
 DEAL:1:2d::reading
-DEAL:1:2d::cellid=0_1:0 fe_index=0 ghost
-DEAL:1:2d::cellid=0_1:1 fe_index=1 ghost
-DEAL:1:2d::cellid=0_1:2 fe_index=2
-DEAL:1:2d::cellid=0_1:3 fe_index=3
-DEAL:1:2d::cellid=1_1:0 fe_index=0 ghost
-DEAL:1:2d::cellid=1_1:2 fe_index=2 ghost
-DEAL:1:2d::cellid=2_1:0 fe_index=0 ghost
-DEAL:1:2d::cellid=2_1:1 fe_index=1 ghost
-DEAL:1:2d::cellid=3_1:0 fe_index=0 ghost
 DEAL:1:2d::OK
 DEAL:1:3d::writing
 DEAL:1:3d::cellid=1_1:0 fe_index=0
@@ -113,8 +107,11 @@ DEAL:2:2d::cellid=0_1:1 fe_index=1 ghost
 DEAL:2:2d::cellid=0_1:3 fe_index=3 ghost
 DEAL:2:2d::cellid=1_1:0 fe_index=0
 DEAL:2:2d::cellid=1_1:1 fe_index=1
-DEAL:2:2d::cellid=1_1:2 fe_index=2 ghost
-DEAL:2:2d::cellid=1_1:3 fe_index=3 ghost
+DEAL:2:2d::cellid=1_1:2 fe_index=2
+DEAL:2:2d::cellid=1_1:3 fe_index=3
+DEAL:2:2d::cellid=2_1:1 fe_index=1 ghost
+DEAL:2:2d::cellid=3_1:0 fe_index=0 ghost
+DEAL:2:2d::cellid=3_1:1 fe_index=1 ghost
 DEAL:2:2d::OK
 DEAL:2:3d::writing
 DEAL:2:3d::cellid=2_1:0 fe_index=0
@@ -158,15 +155,6 @@ DEAL:2:3d::OK
 
 DEAL:3:2d::writing
 DEAL:3:2d::reading
-DEAL:3:2d::cellid=0_1:1 fe_index=1 ghost
-DEAL:3:2d::cellid=0_1:3 fe_index=3 ghost
-DEAL:3:2d::cellid=1_1:0 fe_index=0 ghost
-DEAL:3:2d::cellid=1_1:1 fe_index=1 ghost
-DEAL:3:2d::cellid=1_1:2 fe_index=2
-DEAL:3:2d::cellid=1_1:3 fe_index=3
-DEAL:3:2d::cellid=2_1:1 fe_index=1 ghost
-DEAL:3:2d::cellid=3_1:0 fe_index=0 ghost
-DEAL:3:2d::cellid=3_1:1 fe_index=1 ghost
 DEAL:3:2d::OK
 DEAL:3:3d::writing
 DEAL:3:3d::cellid=3_1:0 fe_index=0
@@ -219,8 +207,8 @@ DEAL:4:2d::cellid=0_1:3 fe_index=3 ghost
 DEAL:4:2d::cellid=1_1:2 fe_index=2 ghost
 DEAL:4:2d::cellid=2_1:0 fe_index=0
 DEAL:4:2d::cellid=2_1:1 fe_index=1
-DEAL:4:2d::cellid=2_1:2 fe_index=2 ghost
-DEAL:4:2d::cellid=2_1:3 fe_index=3 ghost
+DEAL:4:2d::cellid=2_1:2 fe_index=2
+DEAL:4:2d::cellid=2_1:3 fe_index=3
 DEAL:4:2d::cellid=3_1:0 fe_index=0 ghost
 DEAL:4:2d::cellid=3_1:2 fe_index=2 ghost
 DEAL:4:2d::OK
@@ -266,12 +254,6 @@ DEAL:4:3d::OK
 
 DEAL:5:2d::writing
 DEAL:5:2d::reading
-DEAL:5:2d::cellid=2_1:0 fe_index=0 ghost
-DEAL:5:2d::cellid=2_1:1 fe_index=1 ghost
-DEAL:5:2d::cellid=2_1:2 fe_index=2
-DEAL:5:2d::cellid=2_1:3 fe_index=3
-DEAL:5:2d::cellid=3_1:0 fe_index=0 ghost
-DEAL:5:2d::cellid=3_1:2 fe_index=2 ghost
 DEAL:5:2d::OK
 DEAL:5:3d::writing
 DEAL:5:3d::cellid=5_1:0 fe_index=0
@@ -326,8 +308,8 @@ DEAL:6:2d::cellid=2_1:1 fe_index=1 ghost
 DEAL:6:2d::cellid=2_1:3 fe_index=3 ghost
 DEAL:6:2d::cellid=3_1:0 fe_index=0
 DEAL:6:2d::cellid=3_1:1 fe_index=1
-DEAL:6:2d::cellid=3_1:2 fe_index=2 ghost
-DEAL:6:2d::cellid=3_1:3 fe_index=3 ghost
+DEAL:6:2d::cellid=3_1:2 fe_index=2
+DEAL:6:2d::cellid=3_1:3 fe_index=3
 DEAL:6:2d::OK
 DEAL:6:3d::writing
 DEAL:6:3d::cellid=6_1:0 fe_index=0
@@ -371,12 +353,6 @@ DEAL:6:3d::OK
 
 DEAL:7:2d::writing
 DEAL:7:2d::reading
-DEAL:7:2d::cellid=2_1:1 fe_index=1 ghost
-DEAL:7:2d::cellid=2_1:3 fe_index=3 ghost
-DEAL:7:2d::cellid=3_1:0 fe_index=0 ghost
-DEAL:7:2d::cellid=3_1:1 fe_index=1 ghost
-DEAL:7:2d::cellid=3_1:2 fe_index=2
-DEAL:7:2d::cellid=3_1:3 fe_index=3
 DEAL:7:2d::OK
 DEAL:7:3d::writing
 DEAL:7:3d::cellid=7_1:0 fe_index=0


### PR DESCRIPTION
~Blocked by #12596.~ (EDIT: PR has been merged)

I noticed that those tests crash for `autopartition = false` when we load a `p:d:Triangulation` with a different number of processes (`tests/mpi/p4est_save_*`). We partition the p4est mesh nevertheless when the number of processes changes regardless of the `autopartition` parameter, so I found this very confusing.

So the only case in which changing this parameter won't cause a crash is when the number of processes stays the same. Setting `autopartition = true` puts p4est in charge of partitioning, which will not necessarily prepare its partitioning for coarsening, i.e., a requirement for AMR in deal.II.

This PR gets rid of the `autopartition` parameter altogether and sets it always to `true`. We will always call the `partition` function manually afterwards to prepare the partitioning for coarsening.

---

Alternatively, we can leave `autopatition` as a parameter and only consider it when the number of processes stays the same. If set to false, partitioning from the old mesh will be used. If set to true (or the number of processes changes), we let p4est change the partitioning and right after partition again to prepare it for coarsening. I don't know how much performance one would gain from `autopartition = false`. I would be in favor to keep it simple and drop the parameter entirely.