### PR TITLE
Make MassOperator's diagonals true diagonals, not lumped ones.

### DIFF
--- a/doc/news/changes/incompatibilities/20210729DavidWells
+++ b/doc/news/changes/incompatibilities/20210729DavidWells
@@ -1,0 +1,4 @@
+Changed: MatrixFreeOperators::MassOperator now computes its true diagonal (and
+not a lumped mass matrix) as its diagonal.
+<br>
+(David Wells, 2021/07/29)

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -96,7 +96,7 @@ test()
     mf;
   mf.initialize(mf_data);
   mf.compute_diagonal();
-  const LinearAlgebra::distributed::Vector<double> &diagonal =
+  const LinearAlgebra::distributed::Vector<double> &inverse_diagonal =
     mf.get_matrix_diagonal_inverse()->get_vector();
 
   LinearAlgebra::distributed::Vector<number> in, out, ref;
@@ -113,7 +113,7 @@ test()
     }
 
   in.update_ghost_values();
-  out = diagonal;
+  out = inverse_diagonal;
 
   // assemble trilinos sparse matrix with
   // (v, u) for reference
@@ -168,15 +168,13 @@ test()
   }
   sparse_matrix.compress(VectorOperation::add);
 
-  sparse_matrix.vmult(ref, in);
-
   for (unsigned int i = 0; i < ref.local_size(); ++i)
     {
-      const unsigned int glob_index = owned_set.nth_index_in_set(i);
+      const auto glob_index = owned_set.nth_index_in_set(i);
       if (constraints.is_constrained(glob_index))
         ref.local_element(i) = 1.;
       else
-        ref.local_element(i) = 1. / ref.local_element(i);
+        ref.local_element(i) = 1. / sparse_matrix(glob_index, glob_index);
     }
   ref.compress(VectorOperation::insert);
 
@@ -184,9 +182,9 @@ test()
   const double diff_norm = out.linfty_norm();
 
   deallog << "Norm of difference: " << diff_norm << std::endl;
-  deallog << "l2_norm: " << diagonal.l2_norm() << std::endl;
-  deallog << "l1_norm: " << diagonal.l1_norm() << std::endl;
-  deallog << "linfty_norm: " << diagonal.linfty_norm() << std::endl
+  deallog << "l2_norm: " << inverse_diagonal.l2_norm() << std::endl;
+  deallog << "l1_norm: " << inverse_diagonal.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << inverse_diagonal.linfty_norm() << std::endl
           << std::endl;
 }
 

--- a/tests/matrix_free/mass_operator_02.cc
+++ b/tests/matrix_free/mass_operator_02.cc
@@ -168,6 +168,7 @@ test()
   }
   sparse_matrix.compress(VectorOperation::add);
 
+  // Check the diagonal:
   for (unsigned int i = 0; i < ref.local_size(); ++i)
     {
       const auto glob_index = owned_set.nth_index_in_set(i);
@@ -179,13 +180,32 @@ test()
   ref.compress(VectorOperation::insert);
 
   out -= ref;
-  const double diff_norm = out.linfty_norm();
 
-  deallog << "Norm of difference: " << diff_norm << std::endl;
-  deallog << "l2_norm: " << inverse_diagonal.l2_norm() << std::endl;
-  deallog << "l1_norm: " << inverse_diagonal.l1_norm() << std::endl;
-  deallog << "linfty_norm: " << inverse_diagonal.linfty_norm() << std::endl
-          << std::endl;
+  deallog << "Norm of difference: " << out.linfty_norm() << std::endl;
+  deallog << "l2_norm: " << ref.l2_norm() << std::endl;
+  deallog << "l1_norm: " << ref.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << ref.linfty_norm() << std::endl << std::endl;
+
+  // Check the lumped diagonal:
+  mf.compute_lumped_diagonal();
+  out = mf.get_matrix_lumped_diagonal_inverse()->get_vector();
+  sparse_matrix.vmult(ref, in);
+  for (unsigned int i = 0; i < ref.local_size(); ++i)
+    {
+      const auto glob_index = owned_set.nth_index_in_set(i);
+      if (constraints.is_constrained(glob_index))
+        ref.local_element(i) = 1.;
+      else
+        ref.local_element(i) = 1. / ref.local_element(i);
+    }
+  ref.compress(VectorOperation::insert);
+
+  out -= ref;
+
+  deallog << "Norm of difference: " << out.linfty_norm() << std::endl;
+  deallog << "l2_norm: " << ref.l2_norm() << std::endl;
+  deallog << "l1_norm: " << ref.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << ref.linfty_norm() << std::endl << std::endl;
 }
 
 

--- a/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -5,11 +5,21 @@ DEAL:2d::l2_norm: 1008.02
 DEAL:2d::l1_norm: 7088.00
 DEAL:2d::linfty_norm: 144.000
 DEAL:2d::
+DEAL:2d::Norm of difference: 2.84217e-14
+DEAL:2d::l2_norm: 504.352
+DEAL:2d::l1_norm: 3536.64
+DEAL:2d::linfty_norm: 92.1600
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Norm of difference: 3.41061e-13
 DEAL:2d::l2_norm: 8100.00
 DEAL:2d::l1_norm: 108964.
 DEAL:2d::linfty_norm: 900.000
+DEAL:2d::
+DEAL:2d::Norm of difference: 2.84217e-13
+DEAL:2d::l2_norm: 5051.63
+DEAL:2d::l1_norm: 68866.9
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Norm of difference: 2.27374e-13
@@ -17,9 +27,19 @@ DEAL:3d::l2_norm: 32003.0
 DEAL:3d::l1_norm: 593090.
 DEAL:3d::linfty_norm: 1728.00
 DEAL:3d::
+DEAL:3d::Norm of difference: 2.27374e-13
+DEAL:3d::l2_norm: 11325.6
+DEAL:3d::l1_norm: 207861.
+DEAL:3d::linfty_norm: 884.736
+DEAL:3d::
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Norm of difference: 2.54659e-11
 DEAL:3d::l2_norm: 729000.
 DEAL:3d::l1_norm: 3.59385e+07
 DEAL:3d::linfty_norm: 27000.0
+DEAL:3d::
+DEAL:3d::Norm of difference: 1.27329e-11
+DEAL:3d::l2_norm: 359043.
+DEAL:3d::l1_norm: 1.80487e+07
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,25 +1,25 @@
 
 DEAL:2d::Testing FE_Q<2>(1)
-DEAL:2d::Norm of difference: 4.26326e-14
-DEAL:2d::l2_norm: 504.352
-DEAL:2d::l1_norm: 3536.64
-DEAL:2d::linfty_norm: 92.1600
+DEAL:2d::Norm of difference: 0.00000
+DEAL:2d::l2_norm: 1008.02
+DEAL:2d::l1_norm: 7088.00
+DEAL:2d::linfty_norm: 144.000
 DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(2)
-DEAL:2d::Norm of difference: 4.54747e-13
-DEAL:2d::l2_norm: 5051.63
-DEAL:2d::l1_norm: 68866.9
-DEAL:2d::linfty_norm: 576.000
+DEAL:2d::Norm of difference: 3.41061e-13
+DEAL:2d::l2_norm: 8100.00
+DEAL:2d::l1_norm: 108964.
+DEAL:2d::linfty_norm: 900.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Norm of difference: 5.68434e-13
-DEAL:3d::l2_norm: 11325.6
-DEAL:3d::l1_norm: 207861.
-DEAL:3d::linfty_norm: 884.736
+DEAL:3d::Norm of difference: 2.27374e-13
+DEAL:3d::l2_norm: 32003.0
+DEAL:3d::l1_norm: 593090.
+DEAL:3d::linfty_norm: 1728.00
 DEAL:3d::
 DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Norm of difference: 2.18279e-11
-DEAL:3d::l2_norm: 359043.
-DEAL:3d::l1_norm: 1.80487e+07
-DEAL:3d::linfty_norm: 13824.0
+DEAL:3d::Norm of difference: 2.54659e-11
+DEAL:3d::l2_norm: 729000.
+DEAL:3d::l1_norm: 3.59385e+07
+DEAL:3d::linfty_norm: 27000.0
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,25 +1,25 @@
 
 DEAL:2d::Testing FE_Q<2>(1)
-DEAL:2d::Norm of difference: 4.26326e-14
-DEAL:2d::l2_norm: 504.352
-DEAL:2d::l1_norm: 3536.64
-DEAL:2d::linfty_norm: 92.1600
+DEAL:2d::Norm of difference: 8.52651e-14
+DEAL:2d::l2_norm: 1008.02
+DEAL:2d::l1_norm: 7088.00
+DEAL:2d::linfty_norm: 144.000
 DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(2)
-DEAL:2d::Norm of difference: 4.54747e-13
-DEAL:2d::l2_norm: 5051.63
-DEAL:2d::l1_norm: 68866.9
-DEAL:2d::linfty_norm: 576.000
+DEAL:2d::Norm of difference: 7.95808e-13
+DEAL:2d::l2_norm: 8100.00
+DEAL:2d::l1_norm: 108964.
+DEAL:2d::linfty_norm: 900.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q<3>(1)
-DEAL:3d::Norm of difference: 5.68434e-13
-DEAL:3d::l2_norm: 11325.6
-DEAL:3d::l1_norm: 207861.
-DEAL:3d::linfty_norm: 884.736
+DEAL:3d::Norm of difference: 6.82121e-13
+DEAL:3d::l2_norm: 32003.0
+DEAL:3d::l1_norm: 593090.
+DEAL:3d::linfty_norm: 1728.00
 DEAL:3d::
 DEAL:3d::Testing FE_Q<3>(2)
-DEAL:3d::Norm of difference: 2.18279e-11
-DEAL:3d::l2_norm: 359043.
-DEAL:3d::l1_norm: 1.80487e+07
-DEAL:3d::linfty_norm: 13824.0
+DEAL:3d::Norm of difference: 4.00178e-11
+DEAL:3d::l2_norm: 729000.
+DEAL:3d::l1_norm: 3.59385e+07
+DEAL:3d::linfty_norm: 27000.0
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/mass_operator_02.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -5,11 +5,21 @@ DEAL:2d::l2_norm: 1008.02
 DEAL:2d::l1_norm: 7088.00
 DEAL:2d::linfty_norm: 144.000
 DEAL:2d::
+DEAL:2d::Norm of difference: 7.10543e-14
+DEAL:2d::l2_norm: 504.352
+DEAL:2d::l1_norm: 3536.64
+DEAL:2d::linfty_norm: 92.1600
+DEAL:2d::
 DEAL:2d::Testing FE_Q<2>(2)
 DEAL:2d::Norm of difference: 7.95808e-13
 DEAL:2d::l2_norm: 8100.00
 DEAL:2d::l1_norm: 108964.
 DEAL:2d::linfty_norm: 900.000
+DEAL:2d::
+DEAL:2d::Norm of difference: 7.95808e-13
+DEAL:2d::l2_norm: 5051.63
+DEAL:2d::l1_norm: 68866.9
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q<3>(1)
 DEAL:3d::Norm of difference: 6.82121e-13
@@ -17,9 +27,19 @@ DEAL:3d::l2_norm: 32003.0
 DEAL:3d::l1_norm: 593090.
 DEAL:3d::linfty_norm: 1728.00
 DEAL:3d::
+DEAL:3d::Norm of difference: 5.68434e-13
+DEAL:3d::l2_norm: 11325.6
+DEAL:3d::l1_norm: 207861.
+DEAL:3d::linfty_norm: 884.736
+DEAL:3d::
 DEAL:3d::Testing FE_Q<3>(2)
 DEAL:3d::Norm of difference: 4.00178e-11
 DEAL:3d::l2_norm: 729000.
 DEAL:3d::l1_norm: 3.59385e+07
 DEAL:3d::linfty_norm: 27000.0
+DEAL:3d::
+DEAL:3d::Norm of difference: 3.81988e-11
+DEAL:3d::l2_norm: 359043.
+DEAL:3d::l1_norm: 1.80487e+07
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -165,15 +165,13 @@ test()
   }
   sparse_matrix.compress(VectorOperation::add);
 
-  sparse_matrix.vmult(ref, in);
-
   for (unsigned int i = 0; i < ref.local_size(); ++i)
     {
-      const unsigned int glob_index = owned_set.nth_index_in_set(i);
+      const auto glob_index = owned_set.nth_index_in_set(i);
       if (constraints.is_constrained(glob_index))
         ref.local_element(i) = 1.;
       else
-        ref.local_element(i) = 1. / ref.local_element(i);
+        ref.local_element(i) = 1. / sparse_matrix(glob_index, glob_index);
     }
   ref.compress(VectorOperation::insert);
 

--- a/tests/matrix_free/mass_operator_03.cc
+++ b/tests/matrix_free/mass_operator_03.cc
@@ -93,7 +93,7 @@ test()
     mf;
   mf.initialize(mf_data);
   mf.compute_diagonal();
-  const LinearAlgebra::distributed::Vector<double> &diagonal =
+  const LinearAlgebra::distributed::Vector<double> &inverse_diagonal =
     mf.get_matrix_diagonal_inverse()->get_vector();
 
   LinearAlgebra::distributed::Vector<number> in, out, ref;
@@ -110,7 +110,7 @@ test()
     }
 
   in.update_ghost_values();
-  out = diagonal;
+  out = inverse_diagonal;
 
   // assemble trilinos sparse matrix with
   // (v, u) for reference
@@ -165,6 +165,7 @@ test()
   }
   sparse_matrix.compress(VectorOperation::add);
 
+  // Check the diagonal:
   for (unsigned int i = 0; i < ref.local_size(); ++i)
     {
       const auto glob_index = owned_set.nth_index_in_set(i);
@@ -176,13 +177,32 @@ test()
   ref.compress(VectorOperation::insert);
 
   out -= ref;
-  const double diff_norm = out.linfty_norm();
 
-  deallog << "Norm of difference: " << diff_norm << std::endl;
-  deallog << "l2_norm: " << diagonal.l2_norm() << std::endl;
-  deallog << "l1_norm: " << diagonal.l1_norm() << std::endl;
-  deallog << "linfty_norm: " << diagonal.linfty_norm() << std::endl
-          << std::endl;
+  deallog << "Norm of difference: " << out.linfty_norm() << std::endl;
+  deallog << "l2_norm: " << ref.l2_norm() << std::endl;
+  deallog << "l1_norm: " << ref.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << ref.linfty_norm() << std::endl << std::endl;
+
+  // Check the lumped diagonal:
+  mf.compute_lumped_diagonal();
+  out = mf.get_matrix_lumped_diagonal_inverse()->get_vector();
+  sparse_matrix.vmult(ref, in);
+  for (unsigned int i = 0; i < ref.local_size(); ++i)
+    {
+      const auto glob_index = owned_set.nth_index_in_set(i);
+      if (constraints.is_constrained(glob_index))
+        ref.local_element(i) = 1.;
+      else
+        ref.local_element(i) = 1. / ref.local_element(i);
+    }
+  ref.compress(VectorOperation::insert);
+
+  out -= ref;
+
+  deallog << "Norm of difference: " << out.linfty_norm() << std::endl;
+  deallog << "l2_norm: " << ref.l2_norm() << std::endl;
+  deallog << "l1_norm: " << ref.l1_norm() << std::endl;
+  deallog << "linfty_norm: " << ref.linfty_norm() << std::endl << std::endl;
 }
 
 

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -5,11 +5,21 @@ DEAL:2d::l2_norm: 2160.00
 DEAL:2d::l1_norm: 17424.0
 DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
+DEAL:2d::Norm of difference: 2.84217e-14
+DEAL:2d::l2_norm: 960.000
+DEAL:2d::l1_norm: 7744.00
+DEAL:2d::linfty_norm: 256.000
+DEAL:2d::
 DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
 DEAL:2d::Norm of difference: 2.27374e-13
 DEAL:2d::l2_norm: 3960.00
 DEAL:2d::l1_norm: 63504.0
 DEAL:2d::linfty_norm: 576.000
+DEAL:2d::
+DEAL:2d::Norm of difference: 4.27463e-11
+DEAL:2d::l2_norm: 37440.0
+DEAL:2d::l1_norm: 553536.
+DEAL:2d::linfty_norm: 3600.00
 DEAL:2d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
 DEAL:3d::Norm of difference: 3.63798e-12
@@ -17,9 +27,19 @@ DEAL:3d::l2_norm: 100388.
 DEAL:3d::l1_norm: 2.29997e+06
 DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::
+DEAL:3d::Norm of difference: 9.09495e-13
+DEAL:3d::l2_norm: 29744.5
+DEAL:3d::l1_norm: 681472.
+DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
 DEAL:3d::Norm of difference: 1.63709e-11
 DEAL:3d::l2_norm: 249197.
 DEAL:3d::l1_norm: 1.60030e+07
 DEAL:3d::linfty_norm: 13824.0
+DEAL:3d::
+DEAL:3d::Norm of difference: 1.40572e-08
+DEAL:3d::l2_norm: 7.24442e+06
+DEAL:3d::l1_norm: 4.11831e+08
+DEAL:3d::linfty_norm: 216000.
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=1.output
@@ -1,25 +1,25 @@
 
 DEAL:2d::Testing FE_Q_Hierarchical<2>(1)
 DEAL:2d::Norm of difference: 1.13687e-13
-DEAL:2d::l2_norm: 960.000
-DEAL:2d::l1_norm: 7744.00
-DEAL:2d::linfty_norm: 256.000
+DEAL:2d::l2_norm: 2160.00
+DEAL:2d::l1_norm: 17424.0
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
-DEAL:2d::Norm of difference: 3.22871e-11
-DEAL:2d::l2_norm: 37440.0
-DEAL:2d::l1_norm: 553536.
-DEAL:2d::linfty_norm: 3600.00
+DEAL:2d::Norm of difference: 2.27374e-13
+DEAL:2d::l2_norm: 3960.00
+DEAL:2d::l1_norm: 63504.0
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
-DEAL:3d::Norm of difference: 1.81899e-12
-DEAL:3d::l2_norm: 29744.5
-DEAL:3d::l1_norm: 681472.
-DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::Norm of difference: 3.63798e-12
+DEAL:3d::l2_norm: 100388.
+DEAL:3d::l1_norm: 2.29997e+06
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
-DEAL:3d::Norm of difference: 1.39116e-08
-DEAL:3d::l2_norm: 7.24442e+06
-DEAL:3d::l1_norm: 4.11831e+08
-DEAL:3d::linfty_norm: 216000.
+DEAL:3d::Norm of difference: 1.63709e-11
+DEAL:3d::l2_norm: 249197.
+DEAL:3d::l1_norm: 1.60030e+07
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -5,11 +5,21 @@ DEAL:2d::l2_norm: 2160.00
 DEAL:2d::l1_norm: 17424.0
 DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
+DEAL:2d::Norm of difference: 1.13687e-13
+DEAL:2d::l2_norm: 960.000
+DEAL:2d::l1_norm: 7744.00
+DEAL:2d::linfty_norm: 256.000
+DEAL:2d::
 DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
 DEAL:2d::Norm of difference: 5.68434e-13
 DEAL:2d::l2_norm: 3960.00
 DEAL:2d::l1_norm: 63504.0
 DEAL:2d::linfty_norm: 576.000
+DEAL:2d::
+DEAL:2d::Norm of difference: 4.27463e-11
+DEAL:2d::l2_norm: 37440.0
+DEAL:2d::l1_norm: 553536.
+DEAL:2d::linfty_norm: 3600.00
 DEAL:2d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
 DEAL:3d::Norm of difference: 5.45697e-12
@@ -17,9 +27,19 @@ DEAL:3d::l2_norm: 100388.
 DEAL:3d::l1_norm: 2.29997e+06
 DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::
+DEAL:3d::Norm of difference: 1.36424e-12
+DEAL:3d::l2_norm: 29744.5
+DEAL:3d::l1_norm: 681472.
+DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
 DEAL:3d::Norm of difference: 3.63798e-11
 DEAL:3d::l2_norm: 249197.
 DEAL:3d::l1_norm: 1.60030e+07
 DEAL:3d::linfty_norm: 13824.0
+DEAL:3d::
+DEAL:3d::Norm of difference: 1.40572e-08
+DEAL:3d::l2_norm: 7.24442e+06
+DEAL:3d::l1_norm: 4.11831e+08
+DEAL:3d::linfty_norm: 216000.
 DEAL:3d::

--- a/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
+++ b/tests/matrix_free/mass_operator_03.with_trilinos=true.with_mpi=true.with_p4est=true.mpirun=4.output
@@ -1,25 +1,25 @@
 
 DEAL:2d::Testing FE_Q_Hierarchical<2>(1)
-DEAL:2d::Norm of difference: 1.13687e-13
-DEAL:2d::l2_norm: 960.000
-DEAL:2d::l1_norm: 7744.00
-DEAL:2d::linfty_norm: 256.000
+DEAL:2d::Norm of difference: 3.41061e-13
+DEAL:2d::l2_norm: 2160.00
+DEAL:2d::l1_norm: 17424.0
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:2d::Testing FE_Q_Hierarchical<2>(2)
-DEAL:2d::Norm of difference: 3.22871e-11
-DEAL:2d::l2_norm: 37440.0
-DEAL:2d::l1_norm: 553536.
-DEAL:2d::linfty_norm: 3600.00
+DEAL:2d::Norm of difference: 5.68434e-13
+DEAL:2d::l2_norm: 3960.00
+DEAL:2d::l1_norm: 63504.0
+DEAL:2d::linfty_norm: 576.000
 DEAL:2d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(1)
-DEAL:3d::Norm of difference: 1.81899e-12
-DEAL:3d::l2_norm: 29744.5
-DEAL:3d::l1_norm: 681472.
-DEAL:3d::linfty_norm: 4096.00
+DEAL:3d::Norm of difference: 5.45697e-12
+DEAL:3d::l2_norm: 100388.
+DEAL:3d::l1_norm: 2.29997e+06
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::
 DEAL:3d::Testing FE_Q_Hierarchical<3>(2)
-DEAL:3d::Norm of difference: 1.39116e-08
-DEAL:3d::l2_norm: 7.24442e+06
-DEAL:3d::l1_norm: 4.11831e+08
-DEAL:3d::linfty_norm: 216000.
+DEAL:3d::Norm of difference: 3.63798e-11
+DEAL:3d::l2_norm: 249197.
+DEAL:3d::l1_norm: 1.60030e+07
+DEAL:3d::linfty_norm: 13824.0
 DEAL:3d::


### PR DESCRIPTION
Fixes #12604.

The previous implementation used row sums (i.e., mass lumping) instead of computing the diagonal. This should be changed for two reasons:
1. It's not really the diagonal (and it's inconsistent with LaplaceOperator).
2. Lumped mass matrices are only positive for either low-order elements (where the basis functions are all positive) or very well-behaved elements (like FE_Q). In particular, the values on the diagonal are either zero or negative for TET10 if we use lumping, which isn't going to work.

We should do some more testing to confirm that this doesn't make projections slower.