### PR TITLE
MatrixFree: store refinement configuration once per cell

### DIFF
--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -527,6 +527,12 @@ namespace internal
       std::vector<unsigned int> dof_indices;
 
       /**
+       * Supported components of all entries of the hp::FECollection object of
+       * the given DoFHandler.
+       */
+      std::vector<std::vector<bool>> hanging_node_constraint_masks_comp;
+
+      /**
        * Masks indicating for each cell and component if the optimized
        * hanging-node constraint is applicable and if yes which type.
        */

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1236,8 +1236,7 @@ namespace internal
         hanging_nodes = std::make_unique<
           dealii::internal::MatrixFreeFunctions::HangingNodes<dim>>(tria);
         for (unsigned int no = 0; no < n_dof_handlers; ++no)
-          dof_info[no].hanging_node_constraint_masks.resize(
-            n_active_cells * dof_handler[no]->get_fe().n_components());
+          dof_info[no].hanging_node_constraint_masks.resize(n_active_cells);
       }
 
     for (unsigned int counter = 0; counter < n_active_cells; ++counter)

--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -447,13 +447,13 @@ namespace MatrixFreeTools
               locally_relevant_constrains.end());
 
             // STEP 2c: apply hanging-node constraints
-            if (dof_info.hanging_node_constraint_masks.size() > 0)
+            if (dof_info.hanging_node_constraint_masks.size() > 0 &&
+                dof_info
+                  .hanging_node_constraint_masks_comp[phi.get_active_fe_index()]
+                                                     [first_selected_component])
               {
                 const auto mask =
-                  dof_info
-                    .hanging_node_constraint_masks[(cell * n_lanes + v) *
-                                                     n_fe_components +
-                                                   first_selected_component];
+                  dof_info.hanging_node_constraint_masks[cell * n_lanes + v];
 
                 // cell has hanging nodes
                 if (mask != dealii::internal::MatrixFreeFunctions::


### PR DESCRIPTION
This PR splits up in `DoFInfo` the info related to presence of hanging nodes of a cell and if for a FE component optimized interpolation is possible. In a follow-up PR, I would like to move the first outside of `DoFInfo`, since the information could be shared by multiple `DoFInfos`. However, I am not sure what the right place is.

~depends on #12616~