### PR TITLE
Fix a parenthesis.

### DIFF
--- a/include/deal.II/matrix_free/tools.h
+++ b/include/deal.II/matrix_free/tools.h
@@ -493,11 +493,9 @@ namespace MatrixFreeTools
 
                             for (unsigned int j = 0; j < dofs_per_component;
                                  ++j)
-                              if (1e-10 <
-                                  std::abs(values_dofs[j][0] &&
-                                           (j != i ||
-                                            1e-10 < std::abs(values_dofs[j][0] -
-                                                             1.0))))
+                              if (1e-10 < std::abs(values_dofs[j][0]) &&
+                                  (j != i ||
+                                   1e-10 < std::abs(values_dofs[j][0] - 1.0)))
                                 locally_relevant_constrains_hn.emplace_back(
                                   j, i, values_dofs[j][0]);
                           }


### PR DESCRIPTION
I see a bunch of warnings of the form
```
/Users/runner/work/dealii/dealii/include/deal.II/matrix_free/tools.h:497:35:
error: taking the absolute value of unsigned type 'bool' has no effect [-Werror,-Wabsolute-value]
854
                                  std::abs(values_dofs[j][0] &&
```
on the CI tester.