### PR TITLE
Add FiniteElement::supports_mass_lumping().

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -1180,6 +1180,18 @@ public:
   bool
   isotropic_restriction_is_implemented() const;
 
+  /**
+   * Boolean indicating whether or not the finite element supports <em>mass
+   * lumping</em>: i.e., whether or not the approximate mass matrix we get when
+   * combining this element and a nodal quadrature scheme can be used as an
+   * acceptably accurate replacement for the mass matrix itself. For example:
+   * FE_Q can be generally used with mass lumping while FE_SimplexP can only be
+   * used with mass lumping with linear elements.
+   *
+   * The default implementation returns false.
+   */
+  virtual bool
+  supports_mass_lumping() const;
 
   /**
    * Access the #restriction_is_additive_flags field. See the discussion about

--- a/include/deal.II/fe/fe_q_base.h
+++ b/include/deal.II/fe/fe_q_base.h
@@ -158,6 +158,12 @@ public:
       RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
+   * These elements support mass lumping, so this function always returns true.
+   */
+  virtual bool
+  supports_mass_lumping() const override;
+
+  /**
    * Given an index in the natural ordering of indices on a face, return the
    * index of the same degree of freedom on the cell.
    *

--- a/include/deal.II/fe/fe_simplex_p.h
+++ b/include/deal.II/fe/fe_simplex_p.h
@@ -75,6 +75,12 @@ public:
       RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
+   * FE_SimplexP and FE_SimplexDGP only support mass lumping for degrees 0 and 1.
+   */
+  virtual bool
+  supports_mass_lumping() const override;
+
+  /**
    * @copydoc dealii::FiniteElement::get_face_interpolation_matrix()
    */
   void

--- a/include/deal.II/fe/fe_simplex_p_bubbles.h
+++ b/include/deal.II/fe/fe_simplex_p_bubbles.h
@@ -97,6 +97,13 @@ public:
   virtual std::string
   get_name() const override;
 
+  /**
+   * By construction this element supports mass lumping for all degrees so this
+   * function always returns true.
+   */
+  virtual bool
+  supports_mass_lumping() const override;
+
 protected:
   /**
    * Degree of the approximation (i.e., the constructor argument).

--- a/include/deal.II/fe/fe_system.h
+++ b/include/deal.II/fe/fe_system.h
@@ -863,6 +863,12 @@ public:
       RefinementCase<dim>::isotropic_refinement) const override;
 
   /**
+   * Return whether or not all base elements support mass lumping.
+   */
+  virtual bool
+  supports_mass_lumping() const override;
+
+  /**
    * Given an index in the natural ordering of indices on a face, return the
    * index of the same degree of freedom on the cell.
    *

--- a/source/fe/fe.cc
+++ b/source/fe/fe.cc
@@ -853,6 +853,15 @@ FiniteElement<dim, spacedim>::constraints_are_implemented(
 
 template <int dim, int spacedim>
 bool
+FiniteElement<dim, spacedim>::supports_mass_lumping() const
+{
+  return false;
+}
+
+
+
+template <int dim, int spacedim>
+bool
 FiniteElement<dim, spacedim>::hp_constraints_are_implemented() const
 {
   return false;

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1435,6 +1435,15 @@ FE_Q_Base<dim, spacedim>::get_prolongation_matrix(
 
 
 template <int dim, int spacedim>
+bool
+FE_Q_Base<dim, spacedim>::supports_mass_lumping() const
+{
+  return true;
+}
+
+
+
+template <int dim, int spacedim>
 const FullMatrix<double> &
 FE_Q_Base<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,

--- a/source/fe/fe_simplex_p.cc
+++ b/source/fe/fe_simplex_p.cc
@@ -580,6 +580,15 @@ FE_SimplexPoly<dim, spacedim>::get_subface_interpolation_matrix(
 
 template <int dim, int spacedim>
 bool
+FE_SimplexPoly<dim, spacedim>::supports_mass_lumping() const
+{
+  return this->degree == 0 || this->degree == 1;
+}
+
+
+
+template <int dim, int spacedim>
+bool
 FE_SimplexPoly<dim, spacedim>::hp_constraints_are_implemented() const
 {
   return true;

--- a/source/fe/fe_simplex_p_bubbles.cc
+++ b/source/fe/fe_simplex_p_bubbles.cc
@@ -270,6 +270,15 @@ FE_SimplexP_Bubbles<dim, spacedim>::clone() const
   return std::make_unique<FE_SimplexP_Bubbles<dim, spacedim>>(*this);
 }
 
+
+
+template <int dim, int spacedim>
+bool
+FE_SimplexP_Bubbles<dim, spacedim>::supports_mass_lumping() const
+{
+  return true;
+}
+
 // explicit instantiations
 #include "fe_simplex_p_bubbles.inst"
 

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -690,6 +690,17 @@ FESystem<dim, spacedim>::get_interpolation_matrix(
 
 
 template <int dim, int spacedim>
+bool
+FESytem<dim, spacedim>::supports_mass_lumping() const
+{
+  return std::all_of(
+    base_elements.begin(), base_elements.end(),
+    [](const auto &pair) {return pair.first->supports_mass_lumping();});
+}
+
+
+
+template <int dim, int spacedim>
 const FullMatrix<double> &
 FESystem<dim, spacedim>::get_restriction_matrix(
   const unsigned int         child,


### PR DESCRIPTION
A spin-off from #12612.

We need a way to programmatically determine whether or not we can use mass lumping with an element. For example, FE_Q can always be used with mass lumping but FE_SimplexP only works with degrees 0 and 1. Since this adds another method to `FiniteElement` I'd like to leave this open for awhile for people to comment.

I want to check a few things before we merge:
- [ ] do other elements we implement support mass lumping? This is primarily a concern for higher-order elements since the diagonal is an acceptable approximation of the mass matrix at lower degrees.
- [ ] does FE_Q work with mass lumping when we have very distorted grids?