### PR TITLE
Avoid a warning about copying invalid data.

### DIFF
--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1428,8 +1428,11 @@ template <int rank_, int dim, typename Number>
 inline Number *
 Tensor<rank_, dim, Number>::begin_raw()
 {
+  // Recursively get at the address of the underlying objects
   return std::addressof(
-    this->operator[](this->unrolled_to_component_indices(0)));
+    (*reinterpret_cast<
+      Number(*)[(n_independent_components > 0) ? n_independent_components : 1]>(
+      values[0].begin_raw()))[0]);
 }
 
 
@@ -1438,8 +1441,11 @@ template <int rank_, int dim, typename Number>
 inline const Number *
 Tensor<rank_, dim, Number>::begin_raw() const
 {
+  // Recursively get at the address of the underlying objects
   return std::addressof(
-    this->operator[](this->unrolled_to_component_indices(0)));
+    (*reinterpret_cast<const Number(
+         *)[(n_independent_components > 0) ? n_independent_components : 1]>(
+      values[0].begin_raw()))[0]);
 }
 
 

--- a/include/deal.II/base/tensor.h
+++ b/include/deal.II/base/tensor.h
@@ -1428,11 +1428,18 @@ template <int rank_, int dim, typename Number>
 inline Number *
 Tensor<rank_, dim, Number>::begin_raw()
 {
-  // Recursively get at the address of the underlying objects
+  // Recursively get at the address of the underlying objects. Since
+  // begin_raw() in the base class only returns a pointer to the first
+  // element, GCC 8.1 loses track of the fact that this is really the
+  // first element of an array and complains when creating an
+  // ArrayView object that begin_raw() and end_raw() do not belong to
+  // the same object -- which of course they do. We work around this
+  // by ensuring that the compiler sees that the pointer we're taking
+  // is in fact to the beginning of an array.
+  using ElementsArray =
+    Number(*)[(n_independent_components > 0) ? n_independent_components : 1];
   return std::addressof(
-    (*reinterpret_cast<
-      Number(*)[(n_independent_components > 0) ? n_independent_components : 1]>(
-      values[0].begin_raw()))[0]);
+    (*reinterpret_cast<ElementsArray>(values[0].begin_raw()))[0]);
 }
 
 
@@ -1441,11 +1448,18 @@ template <int rank_, int dim, typename Number>
 inline const Number *
 Tensor<rank_, dim, Number>::begin_raw() const
 {
-  // Recursively get at the address of the underlying objects
+  // Recursively get at the address of the underlying objects. Since
+  // begin_raw() in the base class only returns a pointer to the first
+  // element, GCC 8.1 loses track of the fact that this is really the
+  // first element of an array and complains when creating an
+  // ArrayView object that begin_raw() and end_raw() do not belong to
+  // the same object -- which of course they do. We work around this
+  // by ensuring that the compiler sees that the pointer we're taking
+  // is in fact to the beginning of an array.
+  using ElementsArray = const Number(
+      *)[(n_independent_components > 0) ? n_independent_components : 1];
   return std::addressof(
-    (*reinterpret_cast<const Number(
-         *)[(n_independent_components > 0) ? n_independent_components : 1]>(
-      values[0].begin_raw()))[0]);
+    (*reinterpret_cast<ElementsArray>(values[0].begin_raw()))[0]);
 }
 
 


### PR DESCRIPTION
On one of my machines, using GCC 8.1, I get this error when compiling step-19 in release mode:
```
In file included from /scratch/local/gcc-8.1.0/include/c++/8.1.0/bits/stl_tree.h:63,
                 from /scratch/local/gcc-8.1.0/include/c++/8.1.0/map:60,
                 from /usr/include/openmpi-x86_64/openmpi/ompi/mpi/cxx/mpicxx.h:38,
                 from /usr/include/openmpi-x86_64/mpi.h:2674,
                 from include/deal.II/base/config.h:497,
                 from /home/fac/g/bangerth/p/deal.II/1/dealii/include/deal.II/base/quadrature_lib.h:20,
                 from /home/fac/g/bangerth/p/deal.II/1/dealii/examples/step-19/step-19.cc:26:
In static member function ‘static _Tp* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(const _Tp*, const _Tp*, _Tp*) [with _Tp = double; bool _IsMove = false]’,
    inlined from ‘void dealii::Particles::ParticleAccessor<dim, spacedim>::set_properties(const dealii::ArrayView<const double>&) [with int dim = 2; int spacedim = 2]’ at /scratch/local/gcc-8.1.0/include/c++/8.1.0/bits/stl_algobase.h:386:30,
    inlined from ‘void Step19::CathodeRaySimulator<dim>::move_particles() [with int dim = 2]’ at /home/fac/g/bangerth/p/deal.II/1/dealii/examples/step-19/step-19.cc:710:17:
/scratch/local/gcc-8.1.0/include/c++/8.1.0/bits/stl_algobase.h:368:23: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ offset [9, 16] from the object at ‘new_velocity’ is out of the bounds of referenced subobject ‘dealii::Tensor<0, 2, double>::value’ with type ‘double’ at offset 0 [-Warray-bounds]
      __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The problem comes from this place:
```
  template <int dim, int spacedim>
  inline void
  ParticleAccessor<dim, spacedim>::set_properties(
    const ArrayView<const double> &new_properties)
  {
    Assert(state() == IteratorState::valid, ExcInternalError());

    const ArrayView<double> property_values =
      property_pool->get_properties(get_handle());

    Assert(new_properties.size() == property_values.size(),
           ExcMessage(
             "You are trying to assign properties with an incompatible length. "
             "The particle has space to store " +
             std::to_string(property_values.size()) +
             " properties, but you are trying to assign " +
             std::to_string(new_properties.size()) +
             " properties. This is not allowed."));

    if (property_values.size() > 0)
      std::copy(new_properties.begin(),
                new_properties.end(),
                property_values.begin());
  }
```
Here, we copy a range of data starting at `new_properties.begin()` and ending at `new_properties.end()`, which ultimately calls these functions on `Tensor<1,dim>`:
```
template <int rank_, int dim, typename Number>
inline Number *
Tensor<rank_, dim, Number>::begin_raw()
{
  return std::addressof(
    this->operator[](this->unrolled_to_component_indices(0)));
}


template <int rank_, int dim, typename Number>
inline Number *
Tensor<rank_, dim, Number>::end_raw()
{
  return begin_raw() + n_independent_components;
}
```
From what I can see, the compiler loses track of the fact that in `begin_raw()`, we are taking the address of the first element of an array, rather than a single element. It then complains (see the warning message) that accessing the second element of the array in the `memmove` call is an out-of-bounds access because the pointer only points to a single `double` value (8 bytes).

This patch avoids the issue by -- somewhat laboriously -- ensuring that the compiler sees that what we are accessing is an array, and taking the address of the first element. This requires a `reinterpret_cast` instead of a `static_cast` because what we really store is an array of `Tensor<rank-1,dim,double>`, not an array of `double`s. In other word, the cast is a bit of a lie, but because `Tensor` is a pod data type at least in spirit, the harm is probably small.

I'm torn about whether that's a useful approach to the original problem, but at least it hides the warning.

/rebuild