### PR TITLE
step-40 disable timer summary output

### DIFF
--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -216,7 +216,7 @@ namespace Step40
             (Utilities::MPI::this_mpi_process(mpi_communicator) == 0))
     , computing_timer(mpi_communicator,
                       pcout,
-                      TimerOutput::summary,
+                      TimerOutput::never,
                       TimerOutput::wall_times)
   {}
 


### PR DESCRIPTION
In the current version an empty table is written on the terminal as the destructor of the ``TimerOutput`` object is called. However, as the summary is written explicitly after each cycle, we can remove the ``summary`` flag.