### PR TITLE
Add assert to DataOut to force users to use block vectors for non-contiguous indexsets

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -866,6 +866,12 @@ namespace internal
                         const VectorType &               src,
                         LinearAlgebra::distributed::BlockVector<Number> &dst)
       {
+        Assert(dof_handler.locally_owned_dofs().is_contiguous(),
+               ExcMessage(
+                 "You are trying to add a non-block vector with non-contiguous "
+                 "locally-owned index sets. This is not possible. Please "
+                 "consider to use an adequate block vector!"));
+
         IndexSet locally_relevant_dofs;
         DoFTools::extract_locally_relevant_dofs(dof_handler,
                                                 locally_relevant_dofs);


### PR DESCRIPTION
references #12640