### PR TITLE
add Assert to MGTransfer*

### DIFF
--- a/source/multigrid/mg_transfer_matrix_free.cc
+++ b/source/multigrid/mg_transfer_matrix_free.cc
@@ -99,6 +99,12 @@ MGTransferMatrixFree<dim, Number>::build(
   const std::vector<std::shared_ptr<const Utilities::MPI::Partitioner>>
     &external_partitioners)
 {
+  Assert(dof_handler.has_level_dofs(),
+         ExcMessage(
+           "The underlying DoFHandler object did not call "
+           "distribute_mg_dofs(). This is a prerequisite for multigrid "
+           "transfers."));
+
   this->fill_and_communicate_copy_indices(dof_handler);
 
   vector_partitioners.resize(0,

--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -152,6 +152,12 @@ void
 MGTransferPrebuilt<VectorType>::build(
   const DoFHandler<dim, spacedim> &dof_handler)
 {
+  Assert(dof_handler.has_level_dofs(),
+         ExcMessage(
+           "The underlying DoFHandler object did not call "
+           "distribute_mg_dofs(). This is a prerequisite for multigrid "
+           "transfers."));
+
   const unsigned int n_levels =
     dof_handler.get_triangulation().n_global_levels();
   const unsigned int dofs_per_cell = dof_handler.get_fe().n_dofs_per_cell();


### PR DESCRIPTION
The error message when you forget to call distribute_mg_dofs() is not
helpful. Instead, add an Assert.