### PR TITLE
Treat internal boundaries in p:f:T

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1859,12 +1859,14 @@ TriaAccessor<structdim, dim, spacedim>::set_boundary_id(
 {
   Assert(structdim < dim, ExcImpossibleInDim(dim));
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  /*
   Assert(boundary_ind != numbers::internal_face_boundary_id,
          ExcMessage("You are trying to set the boundary_id to an invalid "
                     "value (numbers::internal_face_boundary_id is reserved)."));
   Assert(this->at_boundary(),
          ExcMessage("You are trying to set the boundary_id of an "
                     "internal object, which is not allowed!"));
+   */
 
   this->objects().boundary_or_material_id[this->present_index].boundary_id =
     boundary_ind;

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1859,14 +1859,6 @@ TriaAccessor<structdim, dim, spacedim>::set_boundary_id(
 {
   Assert(structdim < dim, ExcImpossibleInDim(dim));
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  /*
-  Assert(boundary_ind != numbers::internal_face_boundary_id,
-         ExcMessage("You are trying to set the boundary_id to an invalid "
-                    "value (numbers::internal_face_boundary_id is reserved)."));
-  Assert(this->at_boundary(),
-         ExcMessage("You are trying to set the boundary_id of an "
-                    "internal object, which is not allowed!"));
-   */
 
   this->objects().boundary_or_material_id[this->present_index].boundary_id =
     boundary_ind;
@@ -3096,11 +3088,14 @@ template <int spacedim>
 inline void
 TriaAccessor<0, 1, spacedim>::set_boundary_id(const types::boundary_id b)
 {
-  Assert(tria->vertex_to_boundary_id_map_1d->find(this->vertex_index()) !=
-           tria->vertex_to_boundary_id_map_1d->end(),
-         ExcInternalError());
+  if (tria->vertex_to_boundary_id_map_1d->find(this->vertex_index()) !=
+      tria->vertex_to_boundary_id_map_1d->end())
+    {
+      (*tria->vertex_to_boundary_id_map_1d)[this->vertex_index()] = b;
+      return;
+    }
 
-  (*tria->vertex_to_boundary_id_map_1d)[this->vertex_index()] = b;
+  Assert(b == numbers::internal_face_boundary_id, ExcInternalError());
 }
 
 

--- a/include/deal.II/grid/tria_description.h
+++ b/include/deal.II/grid/tria_description.h
@@ -339,10 +339,10 @@ namespace TriangulationDescription
       manifold_quad_ids;
 
     /**
-     * List of face number and boundary id of all non-internal faces of the
-     * cell.
+     * Boundary id of all faces of the cell.
      */
-    std::vector<std::pair<unsigned int, types::boundary_id>> boundary_ids;
+    std::array<types::boundary_id, GeometryInfo<dim>::faces_per_cell>
+      boundary_ids;
   };
 
   /**

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -4512,14 +4512,14 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
-                  // check if cell is at en EXTERIOR boundary
-                  bool flag = false;
+                  // check if cell is at an EXTERIOR boundary
+                  bool is_not_interior_boundary = false;
 
                   for (const auto &f : cell->face_iterators())
-                    flag |=
+                    is_not_interior_boundary |=
                       (f->boundary_id() != numbers::internal_face_boundary_id);
 
-                  if (flag && cell->at_boundary())
+                  if (is_not_interior_boundary && cell->at_boundary())
                     cell->set_user_flag();
 
                   create_children(triangulation,
@@ -11862,8 +11862,8 @@ Triangulation<dim, spacedim>::create_triangulation(
        level < cell_infos.size() && !cell_infos[level].empty();
        ++level)
     {
-      // a) set manifold ids here (because new vertices have to be
-      //    positioned correctly during each refinement step)
+      // a) set manifold ids and boundary ids here (because new vertices have to
+      //    be positioned correctly during each refinement step)
       {
         auto cell      = this->begin(level);
         auto cell_info = cell_infos[level].begin();
@@ -11882,25 +11882,9 @@ Triangulation<dim, spacedim>::create_triangulation(
                   cell_info->manifold_line_ids[line]);
 
             cell->set_manifold_id(cell_info->manifold_id);
-          }
-      }
 
-      {
-        auto cell      = this->begin(level);
-        auto cell_info = cell_infos[level].begin();
-        for (; cell_info != cell_infos[level].end(); ++cell_info)
-          {
-            // find cell that has the correct cell
-            while (cell_info->id != cell->id().template to_binary<dim>())
-              ++cell;
-
-            // boundary ids
-            for (auto pair : cell_info->boundary_ids)
-              {
-                // Assert(cell->at_boundary(pair.first),
-                //       ExcMessage("Cell face is not on the boundary!"));
-                cell->face(pair.first)->set_boundary_id(pair.second);
-              }
+            for (const auto face : cell->face_indices())
+              cell->face(face)->set_boundary_id(cell_info->boundary_ids[face]);
           }
       }
 
@@ -11930,29 +11914,6 @@ Triangulation<dim, spacedim>::create_triangulation(
                                 spacedim>::execute_coarsening_and_refinement();
         }
     }
-
-  //  // 3) set boundary ids
-  //  for (unsigned int level = 0;
-  //       level < cell_infos.size() && !cell_infos[level].empty();
-  //       ++level)
-  //    {
-  //      auto cell      = this->begin(level);
-  //      auto cell_info = cell_infos[level].begin();
-  //      for (; cell_info != cell_infos[level].end(); ++cell_info)
-  //        {
-  //          // find cell that has the correct cell
-  //          while (cell_info->id != cell->id().template to_binary<dim>())
-  //            ++cell;
-  //
-  //          // boundary ids
-  //          for (auto pair : cell_info->boundary_ids)
-  //            {
-  //              Assert(cell->at_boundary(pair.first),
-  //                     ExcMessage("Cell face is not on the boundary!"));
-  //              cell->face(pair.first)->set_boundary_id(pair.second);
-  //            }
-  //        }
-  //    }
 }
 
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -337,6 +337,9 @@ namespace TriangulationDescription
               if (!(cell->user_flag_set()))
                 continue;
 
+              std::cout << cell->id() << " " << cell->manifold_id()
+                        << std::endl;
+
               CellData<dim> cell_info;
 
               // save coarse-cell id
@@ -347,7 +350,8 @@ namespace TriangulationDescription
                 {
                   types::boundary_id boundary_ind =
                     cell->face(f)->boundary_id();
-                  if (boundary_ind != numbers::internal_face_boundary_id)
+                  if (true ||
+                      boundary_ind != numbers::internal_face_boundary_id)
                     cell_info.boundary_ids.emplace_back(f, boundary_ind);
                 }
 

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -347,13 +347,7 @@ namespace TriangulationDescription
 
               // save boundary_ids of each face of this cell
               for (const auto f : cell->face_indices())
-                {
-                  types::boundary_id boundary_ind =
-                    cell->face(f)->boundary_id();
-                  if (true ||
-                      boundary_ind != numbers::internal_face_boundary_id)
-                    cell_info.boundary_ids.emplace_back(f, boundary_ind);
-                }
+                cell_info.boundary_ids[f] = cell->face(f)->boundary_id();
 
               // save manifold id
               {
@@ -704,11 +698,7 @@ namespace TriangulationDescription
 
       // save boundary_ids of each face of this cell
       for (const auto f : cell->face_indices())
-        {
-          types::boundary_id boundary_ind = cell->face(f)->boundary_id();
-          if (boundary_ind != numbers::internal_face_boundary_id)
-            cell_info.boundary_ids.emplace_back(f, boundary_ind);
-        }
+        cell_info.boundary_ids[f] = cell->face(f)->boundary_id();
 
       // save manifold id
       {


### PR DESCRIPTION
Assign internal coarse-grid boundaries `numbers::internal_face_boundary_id` as boundary ids.

@richardschu could you give this a try? 

fixes #12665 (once ready)