### PR TITLE
Remove an unused member variable.

### DIFF
--- a/include/deal.II/hp/q_collection.h
+++ b/include/deal.II/hp/q_collection.h
@@ -124,13 +124,6 @@ namespace hp
      * Exception
      */
     DeclException0(ExcNoQuadrature);
-
-  private:
-    /**
-     * The real container, which stores pointers to the different quadrature
-     * objects.
-     */
-    std::vector<std::shared_ptr<const Quadrature<dim>>> quadratures;
   };
 
 


### PR DESCRIPTION
Now that we have hp::Collection (see 84f55c7706) this field is no longer used.