### PR TITLE
Make TriaAccessor::set_*_boundary() const.

### DIFF
--- a/doc/news/changes/minor/20210821Bangerth
+++ b/doc/news/changes/minor/20210821Bangerth
@@ -1,0 +1,16 @@
+Changed: For 1d cells, the following code did not compile:
+@code
+    for (const auto &face : cell->face_iterators())
+      if (face->at_boundary())
+        {
+          face->set_boundary_id(1);
+        }
+@endcode
+That was because, unlike in the 2d and 3d case, the class that
+describes the faces of 1d cells had a `set_boundary_id()` function
+that was not marked as `const`. This has now been fixed by adding the
+`const` specification for this function, along with the one on the
+`set_all_boundary_ids()` function.
+<br>
+(Wolfgang Bangerth, Tyler Anderson, 2021/08/21)
+

--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -2707,7 +2707,7 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void
-  set_boundary_id(const types::boundary_id);
+  set_boundary_id(const types::boundary_id) const;
 
   /**
    * Set the manifold indicator of this vertex. This does nothing so far since
@@ -2730,7 +2730,7 @@ public:
    * @ref GlossBoundaryIndicator "Glossary entry on boundary indicators"
    */
   void
-  set_all_boundary_ids(const types::boundary_id);
+  set_all_boundary_ids(const types::boundary_id) const;
 
   /**
    * Set the manifold indicator of this object and all of its lower-

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3092,11 +3092,12 @@ TriaAccessor<0, 1, spacedim>::isotropic_child_index(const unsigned int)
 
 template <int spacedim>
 inline void
-TriaAccessor<0, 1, spacedim>::set_boundary_id(const types::boundary_id b)
+TriaAccessor<0, 1, spacedim>::set_boundary_id(const types::boundary_id b) const
 {
   Assert(tria->vertex_to_boundary_id_map_1d->find(this->vertex_index()) !=
            tria->vertex_to_boundary_id_map_1d->end(),
-         ExcInternalError());
+         ExcMessage("You can't set the boundary_id of a face of a cell that is "
+                    "not actually at the boundary."));
 
   (*tria->vertex_to_boundary_id_map_1d)[this->vertex_index()] = b;
 }
@@ -3114,7 +3115,8 @@ TriaAccessor<0, 1, spacedim>::set_manifold_id(const types::manifold_id b)
 
 template <int spacedim>
 inline void
-TriaAccessor<0, 1, spacedim>::set_all_boundary_ids(const types::boundary_id b)
+TriaAccessor<0, 1, spacedim>::set_all_boundary_ids(
+  const types::boundary_id b) const
 {
   set_boundary_id(b);
 }

--- a/tests/grid/accessor_set_boundary_id.cc
+++ b/tests/grid/accessor_set_boundary_id.cc
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2020 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// TriaAccessor<0,dim,spacedim>::set_boundary_id() and
+// TriaAccessor<0,dim,spacedim>::set_all_boundary_ids() were marked as
+// 'const', in contrast to the corresponding functions of faces of
+// higher-dimensional objects. This prevented us from writing loops
+// over all faces where the 'face' object was marked as 'const'.
+
+#include <deal.II/base/logstream.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/tria.h>
+#include <deal.II/grid/tria_accessor.h>
+#include <deal.II/grid/tria_iterator.h>
+
+#include "../tests.h"
+
+
+
+template <int dim, int spacedim>
+void
+test()
+{
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria);
+
+  std::map<typename Triangulation<dim, spacedim>::face_iterator, int> mymap;
+
+  for (auto &cell : tria.active_cell_iterators())
+    for (const auto &face : cell->face_iterators())
+      {
+        face->set_all_boundary_ids(2);
+        if (face->at_boundary())
+          face->set_boundary_id(1);
+      }
+  deallog << "OK" << std::endl;
+}
+
+
+int
+main()
+{
+  initlog();
+
+  test<1, 1>();
+  test<1, 2>();
+  test<2, 2>();
+  test<2, 3>();
+  test<3, 3>();
+}

--- a/tests/grid/accessor_set_boundary_id.output
+++ b/tests/grid/accessor_set_boundary_id.output
@@ -1,0 +1,6 @@
+
+DEAL::OK
+DEAL::OK
+DEAL::OK
+DEAL::OK
+DEAL::OK


### PR DESCRIPTION
For 1d cells, the following code did not compile:
```
    for (const auto &face : cell->face_iterators())
      if (face->at_boundary())
        {
          face->set_boundary_id(1);
        }
```
That was because, unlike in the 2d and 3d case, the class that describes the faces of 1d cells had a `set_boundary_id()` function
that was not marked as `const`. This has now been fixed by adding the `const` specification for this function, along with the one on the `set_all_boundary_ids()` function.

While there also improve on an error message.

@tyand96 -- FYI

/rebuild