### PR TITLE
Prevent excess timer output.

### DIFF
--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -326,7 +326,7 @@ namespace Step55
             (Utilities::MPI::this_mpi_process(mpi_communicator) == 0))
     , computing_timer(mpi_communicator,
                       pcout,
-                      TimerOutput::summary,
+                      TimerOutput::never,
                       TimerOutput::wall_times)
   {}
 

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -729,7 +729,7 @@ namespace step62
             (Utilities::MPI::this_mpi_process(mpi_communicator) == 0))
     , computing_timer(mpi_communicator,
                       pcout,
-                      TimerOutput::summary,
+                      TimerOutput::never,
                       TimerOutput::wall_times)
   {}
 

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -904,7 +904,7 @@ namespace Step75
             (Utilities::MPI::this_mpi_process(mpi_communicator) == 0))
     , computing_timer(mpi_communicator,
                       pcout,
-                      TimerOutput::summary,
+                      TimerOutput::never,
                       TimerOutput::wall_times)
   {
     Assert(prm.min_h_level <= prm.max_h_level,

--- a/examples/step-79/step-79.cc
+++ b/examples/step-79/step-79.cc
@@ -2435,7 +2435,6 @@ namespace SAND
            (iteration_number < max_iterations));
 
     write_as_stl();
-    timer.print_summary();
   }
 } // namespace SAND
 


### PR DESCRIPTION
Follow-up to #12636.

Not only `step-40` has duplicated timer output, but also some other examples. I either changed the `output_frequency` parameter to `never` if `print_summary()` and `reset()` are called at the end of each loop iteration, or removed the `print_summary()` call if called at the end of the program.