### PR TITLE
Unify spelling 2.

### DIFF
--- a/examples/doxygen/step_3_mixed.cc
+++ b/examples/doxygen/step_3_mixed.cc
@@ -84,7 +84,7 @@
  * cell via the method hp::FEValues::get_present_fe_values().
  *
  * For hp::FEValues, to be able to select the right finite element/quadrature
- * rule/ mapping object set, it queries the active_fe_index of the given cell
+ * rule/mapping object set, it queries the active FE index of the given cell
  * during hp::FEValues::reinit(). The indices have to be set - as shown below -
  * before calling DoFHandler::distribute_dofs() by the user.
  *
@@ -241,7 +241,7 @@ void Step3::make_grid()
 // @sect4{Step3::setup_system}
 //
 // In contrast to step-3 and step-3simplex, we need here a preprocessing step
-// that assigns an active_fe_index to each cell consistently according to the
+// that assigns an active FE index to each cell consistently according to the
 // indices in the collections and the cell type.
 void Step3::setup_system()
 {

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -296,7 +296,7 @@ namespace internal
         Assert(ptr != dof_handler.hp_object_fe_indices[structdim].begin() +
                         dof_handler.hp_object_fe_ptr[structdim][obj_index + 1],
                ExcMessage(
-                 "You are requesting an active_fe_index that is not assigned "
+                 "You are requesting an active FE index that is not assigned "
                  "to any of the cells connected to this entity."));
 
         const unsigned int fe_index_ =

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -1473,20 +1473,20 @@ public:
     const unsigned int                           dof_handler_index = 0) const;
 
   /**
-   * In the hp-adaptive case, return number of active_fe_indices.
+   * In the hp-adaptive case, return number of active FE indices.
    */
   unsigned int
   n_active_fe_indices() const;
 
   /**
-   * In the hp-adaptive case, return the active_fe_index of a cell range.
+   * In the hp-adaptive case, return the active FE index of a cell range.
    */
   unsigned int
   get_cell_active_fe_index(
     const std::pair<unsigned int, unsigned int> range) const;
 
   /**
-   * In the hp-adaptive case, return the active_fe_index of a face range.
+   * In the hp-adaptive case, return the active FE index of a face range.
    */
   unsigned int
   get_face_active_fe_index(const std::pair<unsigned int, unsigned int> range,

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -504,7 +504,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
 
 
   // subdivide cell, face and boundary face partitioner data, s.t., all
-  // ranges have the same active_fe_indices
+  // ranges have the same active FE indices
   if (task_info.scheme != internal::MatrixFreeFunctions::TaskInfo::
                             TasksParallelScheme::partition_color)
     {
@@ -754,8 +754,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
       if (dof_handler.size() > 1)
         {
           // check if all DoHandlers are in the same hp-mode; and if hp-
-          // capabilities are enabled: check if active_fe_indices of all
-          // DoFHandler are the same.
+          // capabilities are enabled: check if active FE indices of all
+          // DoFHandlers are the same.
           for (unsigned int i = 1; i < dof_handler.size(); ++i)
             {
               Assert(dof_handler[0]->has_hp_capabilities() ==

--- a/include/deal.II/numerics/solution_transfer.h
+++ b/include/deal.II/numerics/solution_transfer.h
@@ -298,7 +298,7 @@ DEAL_II_NAMESPACE_OPEN
  * DoFHandler, should be considered on cells that are not active (i.e., that
  * have children). This is because degrees of freedom are only allocated for
  * active cells and, in fact, it is not allowed to set an active FE index on
- * non- active cells using DoFAccessor::set_active_fe_index().
+ * non-active cells using DoFAccessor::set_active_fe_index().
  *
  * It is, thus, not entirely natural what should happen if, for example, a few
  * cells are coarsened away. This class then implements the following

--- a/source/non_matching/mesh_classifier.cc
+++ b/source/non_matching/mesh_classifier.cc
@@ -90,7 +90,7 @@ namespace NonMatching
         get_fe_collection() const override;
 
         /**
-         * Return the active_fe_index of the DoFCellAccessor associated with the
+         * Return the active FE index of the DoFCellAccessor associated with the
          * DoFHandler and the the incoming cell in the triangulation.
          */
         unsigned int


### PR DESCRIPTION
Follow-up to #12683.

Fixes minor spelling issues and removes underscores from `active_fe_index` terms as discussed in #11216.