### PR TITLE
Make sure that copying exceptions doesn't imply dropping the backtrace.

### DIFF
--- a/doc/news/changes/minor/20210819Bangerthb
+++ b/doc/news/changes/minor/20210819Bangerthb
@@ -1,0 +1,6 @@
+Fixed: Exceptions thrown via `AssertThrow` did not have a stacktrace
+attached to them, unlike exceptions thrown with `Assert`. This is now
+fixed.
+<br>
+(Wolfgang Bangerth, Paras Kumar, 2021/08/20)
+

--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -155,7 +155,7 @@ protected:
 
 #ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
   /**
-   * array of pointers that contains the raw stack trace
+   * Array of pointers that contains the raw stack trace.
    */
   void *raw_stacktrace[25];
 #endif

--- a/source/base/exceptions.cc
+++ b/source/base/exceptions.cc
@@ -59,17 +59,23 @@ namespace deal_II_exceptions
     bool allow_abort_on_exception = true;
   } // namespace internals
 
+
+
   void
   set_additional_assert_output(const std::string &p)
   {
     internals::get_additional_assert_output() = p;
   }
 
+
+
   void
   suppress_stacktrace_in_exceptions()
   {
     internals::show_stacktrace = false;
   }
+
+
 
   void
   disable_abort_on_exception()
@@ -104,13 +110,17 @@ ExceptionBase::ExceptionBase(const ExceptionBase &exc)
   , cond(exc.cond)
   , exc(exc.exc)
   , stacktrace(nullptr)
-  , // don't copy stacktrace to avoid double de-allocation problem
-  n_stacktrace_frames(0)
+  , n_stacktrace_frames(exc.n_stacktrace_frames)
   , what_str("") // don't copy the error message, it gets generated dynamically
                  // by what()
 {
 #ifdef DEAL_II_HAVE_GLIBC_STACKTRACE
-  std::fill(std::begin(raw_stacktrace), std::end(raw_stacktrace), nullptr);
+  // Copy the raw_stacktrace pointers. We don't own them, they just point to the
+  // addresses of symbols in the executable's/library's symbol tables -- and as
+  // a consequence, it is safe to copy these pointers
+  std::copy(std::begin(exc.raw_stacktrace),
+            std::end(exc.raw_stacktrace),
+            std::begin(raw_stacktrace));
 #endif
 }
 
@@ -147,6 +157,8 @@ ExceptionBase::set_fields(const char *f,
 #endif
 }
 
+
+
 const char *
 ExceptionBase::what() const noexcept
 {
@@ -168,6 +180,7 @@ ExceptionBase::what() const noexcept
 
   return what_str.c_str();
 }
+
 
 
 const char *


### PR DESCRIPTION
Fixes #12693. The problem was that we (on purpose) did not copy data that can safely be copied.

In the test suite, we suppress stacktrace output and I could not find a way to make that happen. Nor would that be easily comparable between compilers and versions. But I did verify that the patch works on Paras Kumar's testcase.

/rebuild