### PR TITLE
Do not store unnecessary variables.

### DIFF
--- a/include/deal.II/base/exceptions.h
+++ b/include/deal.II/base/exceptions.h
@@ -61,7 +61,7 @@ public:
   /**
    * Destructor.
    */
-  virtual ~ExceptionBase() noexcept override;
+  virtual ~ExceptionBase() noexcept override = default;
 
   /**
    * Copy operator. This operator is deleted since exception objects
@@ -142,13 +142,7 @@ protected:
   const char *exc;
 
   /**
-   * A backtrace to the position where the problem happened, if the system
-   * supports this.
-   */
-  mutable char **stacktrace;
-
-  /**
-   * The number of stacktrace frames that are stored in the previous variable.
+   * The number of stacktrace frames that are stored in the following variable.
    * Zero if the system does not support stack traces.
    */
   int n_stacktrace_frames;


### PR DESCRIPTION
We unnecessarily compute something in one place, store the result in a member variable, call a function that calls another function, and then use the information previously stored. That is unnecessary. We might as well compute the thing in the one place where we use it, and save ourselves the hassle of the member variable and its non-trivial memory management.

Found while looking at #12693 and #12694.

/rebuild