### PR TITLE
Add tolerance to subdivided_cylinder generator

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -5602,11 +5602,15 @@ namespace GridGenerator
     // above
     tria.set_all_manifold_ids_on_boundary(0);
 
+    // Tolerance is calculated using the minimal length defining
+    // the cylinder
+    const double tolerance = 1e-5 * std::min(radius, half_length);
+
     for (const auto &cell : tria.cell_iterators())
       for (unsigned int i : GeometryInfo<3>::face_indices())
         if (cell->at_boundary(i))
           {
-            if (cell->face(i)->center()(0) > half_length - 1.e-5)
+            if (cell->face(i)->center()(0) > half_length - tolerance)
               {
                 cell->face(i)->set_boundary_id(2);
                 cell->face(i)->set_manifold_id(numbers::flat_manifold_id);
@@ -5623,7 +5627,7 @@ namespace GridGenerator
                         numbers::flat_manifold_id);
                     }
               }
-            else if (cell->face(i)->center()(0) < -half_length + 1.e-5)
+            else if (cell->face(i)->center()(0) < -half_length + tolerance)
               {
                 cell->face(i)->set_boundary_id(1);
                 cell->face(i)->set_manifold_id(numbers::flat_manifold_id);


### PR DESCRIPTION
This simple PR adds a tolerance to the sudivided_cylinder GridGenerator.
I used 1e-5 * min(radius,half_length). This way, we use 1e-5 * the smallest distance defining the geometry.
For the case where these are 1, this falls back on the previous tolerance, but for smaller cylinders this is more robust I believe.

This should close #12668 
