### PR TITLE
AssertDimension macro in examples

### DIFF
--- a/doc/doxygen/headers/coding_conventions.h
+++ b/doc/doxygen/headers/coding_conventions.h
@@ -308,8 +308,7 @@ we list here:
     operator+=(Vector       &lhs,
                const Vector &rhs)
     {
-      Assert (lhs.size() == rhs.size(),
-              ExcDimensionMismatch(lhs.size(), rhs.size());
+      AssertDimension (lhs.size(), rhs.size());
       for (unsigned int i=0; i<lhs.size(); ++i)
         lhs(i) += rhs(i);
       return lhs;

--- a/examples/step-12/step-12.cc
+++ b/examples/step-12/step-12.cc
@@ -97,8 +97,7 @@ namespace Step12
   {
     (void)component;
     AssertIndexRange(component, 1);
-    Assert(values.size() == points.size(),
-           ExcDimensionMismatch(values.size(), points.size()));
+    AssertDimension(values.size(), points.size());
 
     for (unsigned int i = 0; i < values.size(); ++i)
       {

--- a/examples/step-12b/step-12b.cc
+++ b/examples/step-12b/step-12b.cc
@@ -103,8 +103,7 @@ namespace Step12
   {
     (void)component;
     AssertIndexRange(component, 1);
-    Assert(values.size() == points.size(),
-           ExcDimensionMismatch(values.size(), points.size()));
+    AssertDimension(values.size(), points.size());
 
     for (unsigned int i = 0; i < values.size(); ++i)
       {

--- a/examples/step-17/step-17.cc
+++ b/examples/step-17/step-17.cc
@@ -184,7 +184,7 @@ namespace Step17
     virtual void vector_value(const Point<dim> &p,
                               Vector<double> &  values) const override
     {
-      Assert(values.size() == dim, ExcDimensionMismatch(values.size(), dim));
+      AssertDimension(values.size(), dim);
       Assert(dim >= 2, ExcInternalError());
 
       Point<dim> point_1, point_2;
@@ -209,8 +209,7 @@ namespace Step17
     {
       const unsigned int n_points = points.size();
 
-      Assert(value_list.size() == n_points,
-             ExcDimensionMismatch(value_list.size(), n_points));
+      AssertDimension(value_list.size(), n_points);
 
       for (unsigned int p = 0; p < n_points; ++p)
         RightHandSide<dim>::vector_value(points[p], value_list[p]);

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -559,7 +559,7 @@ namespace Step18
   inline void BodyForce<dim>::vector_value(const Point<dim> & /*p*/,
                                            Vector<double> &values) const
   {
-    Assert(values.size() == dim, ExcDimensionMismatch(values.size(), dim));
+    AssertDimension(values.size(), dim);
 
     const double g   = 9.81;
     const double rho = 7700;
@@ -577,8 +577,7 @@ namespace Step18
   {
     const unsigned int n_points = points.size();
 
-    Assert(value_list.size() == n_points,
-           ExcDimensionMismatch(value_list.size(), n_points));
+    AssertDimension(value_list.size(), n_points);
 
     for (unsigned int p = 0; p < n_points; ++p)
       BodyForce<dim>::vector_value(points[p], value_list[p]);
@@ -650,7 +649,7 @@ namespace Step18
   IncrementalBoundaryValues<dim>::vector_value(const Point<dim> & /*p*/,
                                                Vector<double> &values) const
   {
-    Assert(values.size() == dim, ExcDimensionMismatch(values.size(), dim));
+    AssertDimension(values.size(), dim);
 
     values    = 0;
     values(2) = -present_timestep * velocity;
@@ -665,8 +664,7 @@ namespace Step18
   {
     const unsigned int n_points = points.size();
 
-    Assert(value_list.size() == n_points,
-           ExcDimensionMismatch(value_list.size(), n_points));
+    AssertDimension(value_list.size(), n_points);
 
     for (unsigned int p = 0; p < n_points; ++p)
       IncrementalBoundaryValues<dim>::vector_value(points[p], value_list[p]);

--- a/examples/step-20/doc/results.dox
+++ b/examples/step-20/doc/results.dox
@@ -179,8 +179,7 @@ void
 KInverse<dim>::value_list (const std::vector<Point<dim> > &points,
                            std::vector<Tensor<2,dim> >    &values) const
 {
-  Assert (points.size() == values.size(),
-	  ExcDimensionMismatch (points.size(), values.size()));
+  AssertDimension (points.size(), values.size());
 
   for (unsigned int p=0; p<points.size(); ++p)
     {
@@ -256,8 +255,7 @@ void
 KInverse<dim>::value_list (const std::vector<Point<dim> > &points,
                            std::vector<Tensor<2,dim> >    &values) const
 {
-  Assert (points.size() == values.size(),
-	  ExcDimensionMismatch (points.size(), values.size()));
+  AssertDimension (points.size(), values.size());
 
   for (unsigned int p=0; p<points.size(); ++p)
     {

--- a/examples/step-20/step-20.cc
+++ b/examples/step-20/step-20.cc
@@ -195,8 +195,7 @@ namespace Step20
     void ExactSolution<dim>::vector_value(const Point<dim> &p,
                                           Vector<double> &  values) const
     {
-      Assert(values.size() == dim + 1,
-             ExcDimensionMismatch(values.size(), dim + 1));
+      AssertDimension(values.size(), dim + 1);
 
       values(0) = alpha * p[1] * p[1] / 2 + beta - alpha * p[0] * p[0] / 2;
       values(1) = alpha * p[0] * p[1];

--- a/examples/step-21/step-21.cc
+++ b/examples/step-21/step-21.cc
@@ -267,8 +267,7 @@ namespace Step21
       value_list(const std::vector<Point<dim>> &points,
                  std::vector<Tensor<2, dim>> &  values) const override
       {
-        Assert(points.size() == values.size(),
-               ExcDimensionMismatch(points.size(), values.size()));
+        AssertDimension(points.size(), values.size());
 
         for (unsigned int p = 0; p < points.size(); ++p)
           {
@@ -336,8 +335,7 @@ namespace Step21
       value_list(const std::vector<Point<dim>> &points,
                  std::vector<Tensor<2, dim>> &  values) const override
       {
-        Assert(points.size() == values.size(),
-               ExcDimensionMismatch(points.size(), values.size()));
+        AssertDimension(points.size(), values.size());
 
         for (unsigned int p = 0; p < points.size(); ++p)
           {

--- a/examples/step-29/step-29.cc
+++ b/examples/step-29/step-29.cc
@@ -102,7 +102,7 @@ namespace Step29
     virtual void vector_value(const Point<dim> & /*p*/,
                               Vector<double> &values) const override
     {
-      Assert(values.size() == 2, ExcDimensionMismatch(values.size(), 2));
+      AssertDimension(values.size(), 2);
 
       values(0) = 1;
       values(1) = 0;
@@ -112,8 +112,7 @@ namespace Step29
     vector_value_list(const std::vector<Point<dim>> &points,
                       std::vector<Vector<double>> &  value_list) const override
     {
-      Assert(value_list.size() == points.size(),
-             ExcDimensionMismatch(value_list.size(), points.size()));
+      AssertDimension(value_list.size(), points.size());
 
       for (unsigned int p = 0; p < points.size(); ++p)
         DirichletBoundaryValues<dim>::vector_value(points[p], value_list[p]);
@@ -326,9 +325,7 @@ namespace Step29
     const DataPostprocessorInputs::Vector<dim> &inputs,
     std::vector<Vector<double>> &               computed_quantities) const
   {
-    Assert(computed_quantities.size() == inputs.solution_values.size(),
-           ExcDimensionMismatch(computed_quantities.size(),
-                                inputs.solution_values.size()));
+    AssertDimension(computed_quantities.size(), inputs.solution_values.size());
 
     // The computation itself is straightforward: We iterate over each
     // entry in the output vector and compute $|u|$ from the
@@ -341,10 +338,8 @@ namespace Step29
     // something called a "norm".)
     for (unsigned int i = 0; i < computed_quantities.size(); ++i)
       {
-        Assert(computed_quantities[i].size() == 1,
-               ExcDimensionMismatch(computed_quantities[i].size(), 1));
-        Assert(inputs.solution_values[i].size() == 2,
-               ExcDimensionMismatch(inputs.solution_values[i].size(), 2));
+        AssertDimension(computed_quantities[i].size(), 1);
+        AssertDimension(inputs.solution_values[i].size(), 2);
 
         const std::complex<double> u(inputs.solution_values[i](0),
                                      inputs.solution_values[i](1));

--- a/examples/step-30/step-30.cc
+++ b/examples/step-30/step-30.cc
@@ -63,8 +63,7 @@ namespace Step30
                             const unsigned int /*component*/ = 0) const override
     {
       (void)points;
-      Assert(values.size() == points.size(),
-             ExcDimensionMismatch(values.size(), points.size()));
+      AssertDimension(values.size(), points.size());
 
       std::fill(values.begin(), values.end(), 0.);
     }
@@ -79,8 +78,7 @@ namespace Step30
                             std::vector<double> &          values,
                             const unsigned int /*component*/ = 0) const override
     {
-      Assert(values.size() == points.size(),
-             ExcDimensionMismatch(values.size(), points.size()));
+      AssertDimension(values.size(), points.size());
 
       for (unsigned int i = 0; i < values.size(); ++i)
         {
@@ -110,8 +108,7 @@ namespace Step30
     void value_list(const std::vector<Point<dim>> &points,
                     std::vector<Point<dim>> &      values) const
     {
-      Assert(values.size() == points.size(),
-             ExcDimensionMismatch(values.size(), points.size()));
+      AssertDimension(values.size(), points.size());
 
       for (unsigned int i = 0; i < points.size(); ++i)
         {

--- a/examples/step-35/step-35.cc
+++ b/examples/step-35/step-35.cc
@@ -352,8 +352,7 @@ namespace Step35
                                    const unsigned int) const
     {
       const unsigned int n_points = points.size();
-      Assert(values.size() == n_points,
-             ExcDimensionMismatch(values.size(), n_points));
+      AssertDimension(values.size(), n_points);
       for (unsigned int i = 0; i < n_points; ++i)
         values[i] = Velocity<dim>::value(points[i]);
     }
@@ -411,8 +410,7 @@ namespace Step35
       (void)component;
       AssertIndexRange(component, 1);
       const unsigned int n_points = points.size();
-      Assert(values.size() == n_points,
-             ExcDimensionMismatch(values.size(), n_points));
+      AssertDimension(values.size(), n_points);
       for (unsigned int i = 0; i < n_points; ++i)
         values[i] = Pressure<dim>::value(points[i]);
     }

--- a/examples/step-43/step-43.cc
+++ b/examples/step-43/step-43.cc
@@ -185,8 +185,7 @@ namespace Step43
     void KInverse<dim>::value_list(const std::vector<Point<dim>> &points,
                                    std::vector<Tensor<2, dim>> &  values) const
     {
-      Assert(points.size() == values.size(),
-             ExcDimensionMismatch(points.size(), values.size()));
+      AssertDimension(points.size(), values.size());
 
       for (unsigned int p = 0; p < points.size(); ++p)
         {

--- a/examples/step-58/step-58.cc
+++ b/examples/step-58/step-58.cc
@@ -477,16 +477,12 @@ namespace Step58
       const DataPostprocessorInputs::Vector<dim> &inputs,
       std::vector<Vector<double>> &               computed_quantities) const
     {
-      Assert(computed_quantities.size() == inputs.solution_values.size(),
-             ExcDimensionMismatch(computed_quantities.size(),
-                                  inputs.solution_values.size()));
+      AssertDimension(computed_quantities.size(), inputs.solution_values.size());
 
       for (unsigned int q = 0; q < computed_quantities.size(); ++q)
         {
-          Assert(computed_quantities[q].size() == 1,
-                 ExcDimensionMismatch(computed_quantities[q].size(), 1));
-          Assert(inputs.solution_values[q].size() == 2,
-                 ExcDimensionMismatch(inputs.solution_values[q].size(), 2));
+          AssertDimension(computed_quantities[q].size(), 1);
+          AssertDimension(inputs.solution_values[q].size(), 2);
 
           const std::complex<double> psi(inputs.solution_values[q](0),
                                          inputs.solution_values[q](1));
@@ -536,17 +532,13 @@ namespace Step58
       const DataPostprocessorInputs::Vector<dim> &inputs,
       std::vector<Vector<double>> &               computed_quantities) const
     {
-      Assert(computed_quantities.size() == inputs.solution_values.size(),
-             ExcDimensionMismatch(computed_quantities.size(),
-                                  inputs.solution_values.size()));
+      AssertDimension(computed_quantities.size(), inputs.solution_values.size());
 
       double max_phase = -numbers::PI;
       for (unsigned int q = 0; q < computed_quantities.size(); ++q)
         {
-          Assert(computed_quantities[q].size() == 1,
-                 ExcDimensionMismatch(computed_quantities[q].size(), 1));
-          Assert(inputs.solution_values[q].size() == 2,
-                 ExcDimensionMismatch(inputs.solution_values[q].size(), 2));
+          AssertDimension(computed_quantities[q].size(), 1);
+          AssertDimension(inputs.solution_values[q].size(), 2);
 
           max_phase =
             std::max(max_phase,

--- a/examples/step-58/step-58.cc
+++ b/examples/step-58/step-58.cc
@@ -477,7 +477,8 @@ namespace Step58
       const DataPostprocessorInputs::Vector<dim> &inputs,
       std::vector<Vector<double>> &               computed_quantities) const
     {
-      AssertDimension(computed_quantities.size(), inputs.solution_values.size());
+      AssertDimension(computed_quantities.size(),
+                      inputs.solution_values.size());
 
       for (unsigned int q = 0; q < computed_quantities.size(); ++q)
         {
@@ -532,7 +533,8 @@ namespace Step58
       const DataPostprocessorInputs::Vector<dim> &inputs,
       std::vector<Vector<double>> &               computed_quantities) const
     {
-      AssertDimension(computed_quantities.size(), inputs.solution_values.size());
+      AssertDimension(computed_quantities.size(),
+                      inputs.solution_values.size());
 
       double max_phase = -numbers::PI;
       for (unsigned int q = 0; q < computed_quantities.size(); ++q)

--- a/examples/step-61/step-61.cc
+++ b/examples/step-61/step-61.cc
@@ -141,8 +141,7 @@ namespace Step61
   void Coefficient<dim>::value_list(const std::vector<Point<dim>> &points,
                                     std::vector<Tensor<2, dim>> &  values) const
   {
-    Assert(points.size() == values.size(),
-           ExcDimensionMismatch(points.size(), values.size()));
+    AssertDimension(points.size(), values.size());
     for (unsigned int p = 0; p < points.size(); ++p)
       values[p] = unit_symmetric_tensor<dim>();
   }

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -388,8 +388,7 @@ namespace Step63
                                       std::vector<double> &          values,
                                       const unsigned int component) const
   {
-    Assert(values.size() == points.size(),
-           ExcDimensionMismatch(values.size(), points.size()));
+    AssertDimension(values.size(), points.size());
 
     for (unsigned int i = 0; i < points.size(); ++i)
       values[i] = RightHandSide<dim>::value(points[i], component);
@@ -439,8 +438,7 @@ namespace Step63
                                        std::vector<double> &          values,
                                        const unsigned int component) const
   {
-    Assert(values.size() == points.size(),
-           ExcDimensionMismatch(values.size(), points.size()));
+    AssertDimension(values.size(), points.size());
 
     for (unsigned int i = 0; i < points.size(); ++i)
       values[i] = BoundaryValues<dim>::value(points[i], component);

--- a/examples/step-8/step-8.cc
+++ b/examples/step-8/step-8.cc
@@ -138,8 +138,7 @@ namespace Step8
   void right_hand_side(const std::vector<Point<dim>> &points,
                        std::vector<Tensor<1, dim>> &  values)
   {
-    Assert(values.size() == points.size(),
-           ExcDimensionMismatch(values.size(), points.size()));
+    AssertDimension(values.size(), points.size());
     Assert(dim >= 2, ExcNotImplemented());
 
     // The rest of the function implements computing force values. We will use

--- a/examples/step-9/step-9.cc
+++ b/examples/step-9/step-9.cc
@@ -117,6 +117,10 @@ namespace Step9
     // this macro call declares and defines a class
     // <code>ExcDimensionMismatch</code> inheriting from ExceptionBase which
     // implements all necessary error output functions.
+    //
+    // @note This exception is similarly used inside the
+    // <code>AssertDimension</code> macro, which is a handy wrapper to the
+    // check the dimensions of two given objects.
   };
 
   // The following two functions implement the interface described above. The


### PR DESCRIPTION
Replace all ``Assert(... , ... , ExcDimensionMismatch())`` by ``AssertDimension( ... , ... )`` at least in the turotial steps. In particular, update the explanation in step-9.