### PR TITLE
Enhance VectorTools::project

### DIFF
--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -91,8 +91,7 @@ namespace VectorTools
    * - @p enforce_zero_boundary is false,
    * - @p project_to_boundary_first is false,
    * - the FiniteElement is supported by the MatrixFree class,
-   * - the FiniteElement has less than five components
-   * - the degree of the FiniteElement is less than nine.
+   * - the FiniteElement has less than five components,
    * - dim==spacedim
    *
    * In this case, this function performs numerical quadrature using the given

--- a/include/deal.II/numerics/vector_tools_project.h
+++ b/include/deal.II/numerics/vector_tools_project.h
@@ -91,7 +91,7 @@ namespace VectorTools
    * - @p enforce_zero_boundary is false,
    * - @p project_to_boundary_first is false,
    * - the FiniteElement is supported by the MatrixFree class,
-   * - the FiniteElement has less than five components,
+   * - the FiniteElement has less than eleven components,
    * - dim==spacedim
    *
    * In this case, this function performs numerical quadrature using the given

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -393,6 +393,78 @@ namespace VectorTools
                                    project_to_boundary_first);
             break;
 
+          case 5:
+            project_matrix_free<5>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
+          case 6:
+            project_matrix_free<6>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
+          case 7:
+            project_matrix_free<7>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
+          case 8:
+            project_matrix_free<8>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
+          case 9:
+            project_matrix_free<9>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
+          case 10:
+            project_matrix_free<10>(mapping,
+                                   dof,
+                                   constraints,
+                                   quadrature,
+                                   function,
+                                   work_result,
+                                   enforce_zero_boundary,
+                                   q_boundary,
+                                   project_to_boundary_first);
+            break;
+
           default:
             Assert(false, ExcInternalError());
         }
@@ -780,7 +852,7 @@ namespace VectorTools
       // We have explicit instantiations only if
       // the number of components is not too high.
       if (enforce_zero_boundary || project_to_boundary_first ||
-          dof.get_fe(0).n_components() > 4)
+          dof.get_fe(0).n_components() > 10)
         use_matrix_free = false;
 
       if (use_matrix_free)

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -156,18 +156,18 @@ namespace VectorTools
      * MatrixFree implementation of project() for an arbitrary number of
      * components of the FiniteElement.
      */
-    template <int components, int dim, typename Number, int spacedim>
+    template <int components, int dim, typename number, int spacedim>
     void
     project_matrix_free(
       const Mapping<dim, spacedim> &   mapping,
       const DoFHandler<dim, spacedim> &dof,
-      const AffineConstraints<Number> &constraints,
+      const AffineConstraints<number> &constraints,
       const Quadrature<dim> &          quadrature,
       const Function<
         spacedim,
-        typename LinearAlgebra::distributed::Vector<Number>::value_type>
+        typename LinearAlgebra::distributed::Vector<number>::value_type>
         &                                         function,
-      LinearAlgebra::distributed::Vector<Number> &work_result,
+      LinearAlgebra::distributed::Vector<number> &work_result,
       const bool                                  enforce_zero_boundary,
       const Quadrature<dim - 1> &                 q_boundary,
       const bool                                  project_to_boundary_first)
@@ -196,13 +196,13 @@ namespace VectorTools
         quadrature_mf = quadrature;
 
       // set up mass matrix and right hand side
-      typename MatrixFree<dim, Number>::AdditionalData additional_data;
+      typename MatrixFree<dim, number>::AdditionalData additional_data;
       additional_data.tasks_parallel_scheme =
-        MatrixFree<dim, Number>::AdditionalData::partition_color;
+        MatrixFree<dim, number>::AdditionalData::partition_color;
       additional_data.mapping_update_flags =
         (update_values | update_JxW_values);
-      std::shared_ptr<MatrixFree<dim, Number>> matrix_free(
-        new MatrixFree<dim, Number>());
+      std::shared_ptr<MatrixFree<dim, number>> matrix_free(
+        new MatrixFree<dim, number>());
       matrix_free->reinit(
         mapping, dof, constraints, quadrature_mf, additional_data);
       using MatrixType = MatrixFreeOperators::MassOperator<
@@ -210,7 +210,7 @@ namespace VectorTools
         -1,
         0,
         components,
-        LinearAlgebra::distributed::Vector<Number>>;
+        LinearAlgebra::distributed::Vector<number>>;
       MatrixType mass_matrix;
       mass_matrix.initialize(matrix_free);
 
@@ -238,7 +238,7 @@ namespace VectorTools
               const auto &lumped_diagonal =
                 mass_matrix.get_matrix_lumped_diagonal_inverse()->get_vector();
               bool all_entries_positive = true;
-              for (const Number &v : lumped_diagonal)
+              for (const number &v : lumped_diagonal)
                 if (v < 0.0)
                   {
                     all_entries_positive = false;
@@ -272,7 +272,7 @@ namespace VectorTools
       else
         mass_matrix.compute_diagonal();
 
-      LinearAlgebra::distributed::Vector<Number> rhs, inhomogeneities;
+      LinearAlgebra::distributed::Vector<number> rhs, inhomogeneities;
       matrix_free->initialize_dof_vector(work_result);
       matrix_free->initialize_dof_vector(rhs);
       matrix_free->initialize_dof_vector(inhomogeneities);
@@ -285,7 +285,7 @@ namespace VectorTools
 
         // account for inhomogeneous constraints
         inhomogeneities.update_ghost_values();
-        FEEvaluation<dim, -1, 0, components, Number> phi(*matrix_free);
+        FEEvaluation<dim, -1, 0, components, number> phi(*matrix_free);
         for (unsigned int cell = 0; cell < matrix_free->n_cell_batches();
              ++cell)
           {
@@ -314,7 +314,7 @@ namespace VectorTools
 #ifdef DEBUG
       // Make sure we picked a valid preconditioner
       const auto &diagonal = preconditioner.get_vector();
-      for (const Number &v : diagonal)
+      for (const number &v : diagonal)
         Assert(v > 0.0, ExcInternalError());
 #endif
       cg.solve(mass_matrix, work_result, rhs, preconditioner);
@@ -327,18 +327,18 @@ namespace VectorTools
 
     // Helper interface for the matrix-free implementation of project().
     // Used to determine the number of components.
-    template <int dim, typename Number, int spacedim>
+    template <int dim, typename number, int spacedim>
     void
     project_matrix_free_component(
       const Mapping<dim, spacedim> &   mapping,
       const DoFHandler<dim, spacedim> &dof,
-      const AffineConstraints<Number> &constraints,
+      const AffineConstraints<number> &constraints,
       const Quadrature<dim> &          quadrature,
       const Function<
         spacedim,
-        typename LinearAlgebra::distributed::Vector<Number>::value_type>
+        typename LinearAlgebra::distributed::Vector<number>::value_type>
         &                                         function,
-      LinearAlgebra::distributed::Vector<Number> &work_result,
+      LinearAlgebra::distributed::Vector<number> &work_result,
       const bool                                  enforce_zero_boundary,
       const Quadrature<dim - 1> &                 q_boundary,
       const bool                                  project_to_boundary_first)
@@ -586,30 +586,30 @@ namespace VectorTools
         const unsigned int)> &                                  func,
       VectorType &                                              vec_result)
     {
-      using Number = typename VectorType::value_type;
+      using number = typename VectorType::value_type;
       AssertDimension(dof.get_fe(0).n_components(), 1);
       AssertDimension(vec_result.size(), dof.n_dofs());
 
       // set up mass matrix and right hand side
-      typename MatrixFree<dim, Number>::AdditionalData additional_data;
+      typename MatrixFree<dim, number>::AdditionalData additional_data;
       additional_data.tasks_parallel_scheme =
-        MatrixFree<dim, Number>::AdditionalData::partition_color;
+        MatrixFree<dim, number>::AdditionalData::partition_color;
       additional_data.mapping_update_flags =
         (update_values | update_JxW_values);
-      std::shared_ptr<MatrixFree<dim, Number>> matrix_free(
-        new MatrixFree<dim, Number>());
+      std::shared_ptr<MatrixFree<dim, number>> matrix_free(
+        new MatrixFree<dim, number>());
       matrix_free->reinit(mapping,
                           dof,
                           constraints,
                           QGauss<1>(dof.get_fe().degree + 2),
                           additional_data);
       using MatrixType = MatrixFreeOperators::
-        MassOperator<dim, -1, 0, 1, LinearAlgebra::distributed::Vector<Number>>;
+        MassOperator<dim, -1, 0, 1, LinearAlgebra::distributed::Vector<number>>;
       MatrixType mass_matrix;
       mass_matrix.initialize(matrix_free);
       mass_matrix.compute_diagonal();
 
-      using LocalVectorType = LinearAlgebra::distributed::Vector<Number>;
+      using LocalVectorType = LinearAlgebra::distributed::Vector<number>;
       LocalVectorType vec, rhs, inhomogeneities;
       matrix_free->initialize_dof_vector(vec);
       matrix_free->initialize_dof_vector(rhs);
@@ -626,7 +626,7 @@ namespace VectorTools
 
         const unsigned int dofs_per_cell = dof.get_fe().n_dofs_per_cell();
         const unsigned int n_q_points    = quadrature.size();
-        Vector<Number>     cell_rhs(dofs_per_cell);
+        Vector<number>     cell_rhs(dofs_per_cell);
         std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
         typename DoFHandler<dim, spacedim>::active_cell_iterator
           cell = dof.begin_active(),
@@ -660,7 +660,7 @@ namespace VectorTools
       // badly conditioned matrices. This behavior can be observed, e.g. for
       // FE_Q_Hierarchical for degree higher than three.
       ReductionControl control(5 * rhs.size(), 0., 1e-12, false, false);
-      SolverCG<LinearAlgebra::distributed::Vector<Number>>    cg(control);
+      SolverCG<LinearAlgebra::distributed::Vector<number>>    cg(control);
       typename PreconditionJacobi<MatrixType>::AdditionalData data(0.8);
       PreconditionJacobi<MatrixType>                          preconditioner;
       preconditioner.initialize(mass_matrix, data);
@@ -695,17 +695,17 @@ namespace VectorTools
       const DoFHandler<dim, spacedim> &dof =
         matrix_free->get_dof_handler(fe_component);
 
-      using Number = typename VectorType::value_type;
+      using number = typename VectorType::value_type;
       AssertDimension(dof.get_fe(0).n_components(), 1);
       AssertDimension(vec_result.size(), dof.n_dofs());
 
       using MatrixType = MatrixFreeOperators::
-        MassOperator<dim, -1, 0, 1, LinearAlgebra::distributed::Vector<Number>>;
+        MassOperator<dim, -1, 0, 1, LinearAlgebra::distributed::Vector<number>>;
       MatrixType mass_matrix;
       mass_matrix.initialize(matrix_free, {fe_component});
       mass_matrix.compute_diagonal();
 
-      using LocalVectorType = LinearAlgebra::distributed::Vector<Number>;
+      using LocalVectorType = LinearAlgebra::distributed::Vector<number>;
       LocalVectorType vec, rhs, inhomogeneities;
       matrix_free->initialize_dof_vector(vec, fe_component);
       matrix_free->initialize_dof_vector(rhs, fe_component);
@@ -715,7 +715,7 @@ namespace VectorTools
 
       // assemble right hand side:
       {
-        FEEvaluation<dim, -1, 0, 1, Number> fe_eval(*matrix_free, fe_component);
+        FEEvaluation<dim, -1, 0, 1, number> fe_eval(*matrix_free, fe_component);
         const unsigned int n_cells    = matrix_free->n_cell_batches();
         const unsigned int n_q_points = fe_eval.n_q_points;
 
@@ -739,7 +739,7 @@ namespace VectorTools
       // badly conditioned matrices. This behavior can be observed, e.g. for
       // FE_Q_Hierarchical for degree higher than three.
       ReductionControl control(5 * rhs.size(), 0., 1e-12, false, false);
-      SolverCG<LinearAlgebra::distributed::Vector<Number>>    cg(control);
+      SolverCG<LinearAlgebra::distributed::Vector<number>>    cg(control);
       typename PreconditionJacobi<MatrixType>::AdditionalData data(0.8);
       PreconditionJacobi<MatrixType>                          preconditioner;
       preconditioner.initialize(mass_matrix, data);

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -78,11 +78,8 @@ namespace VectorTools
       // that is actually wholly on
       // the boundary, not only by
       // one line or one vertex
-      typename DoFHandler<dim, spacedim>::active_cell_iterator
-        cell = dof_handler.begin_active(),
-        endc = dof_handler.end();
       std::vector<types::global_dof_index> face_dof_indices;
-      for (; cell != endc; ++cell)
+      for (const auto &cell : dof_handler.active_cell_iterators())
         for (auto f : GeometryInfo<dim>::face_indices())
           if (cell->at_boundary(f))
             {
@@ -698,10 +695,7 @@ namespace VectorTools
         const unsigned int n_q_points    = quadrature.size();
         Vector<number>     cell_rhs(dofs_per_cell);
         std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-        typename DoFHandler<dim, spacedim>::active_cell_iterator
-          cell = dof.begin_active(),
-          endc = dof.end();
-        for (; cell != endc; ++cell)
+        for (const auto &cell : dof.active_cell_iterators())
           if (cell->is_locally_owned())
             {
               cell_rhs = 0;

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -191,7 +191,7 @@ namespace VectorTools
       else
         // TODO: since we have currently only implemented a handful quadrature
         // rules for non-hypercube objects, we do not construct a new
-        // quadrature rule with degree + 2 here but  use the user-provided
+        // quadrature rule with degree + 2 here but use the user-provided
         // quadrature rule (which is guaranteed to be tabulated).
         quadrature_mf = quadrature;
 

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -432,11 +432,9 @@ namespace VectorTools
                                     q_boundary,
                                     project_to_boundary_first);
 
-      const IndexSet &          locally_owned_dofs = dof.locally_owned_dofs();
-      IndexSet::ElementIterator it                 = locally_owned_dofs.begin();
-      for (; it != locally_owned_dofs.end(); ++it)
-        ::dealii::internal::ElementAccess<VectorType>::set(work_result(*it),
-                                                           *it,
+      for (const auto it : dof.locally_owned_dofs())
+        ::dealii::internal::ElementAccess<VectorType>::set(work_result(it),
+                                                           it,
                                                            vec_result);
       vec_result.compress(VectorOperation::insert);
     }
@@ -568,9 +566,9 @@ namespace VectorTools
       // copy vec into vec_result. we can't use vec_result itself above, since
       // it may be of another type than Vector<double> and that wouldn't
       // necessarily go together with the matrix and other functions
-      for (unsigned int i = 0; i < vec.size(); ++i)
-        ::dealii::internal::ElementAccess<VectorType>::set(vec(i),
-                                                           i,
+      for (const auto it : dof.locally_owned_dofs())
+        ::dealii::internal::ElementAccess<VectorType>::set(vec(it),
+                                                           it,
                                                            vec_result);
     }
 
@@ -669,11 +667,9 @@ namespace VectorTools
 
       constraints.distribute(vec);
 
-      const IndexSet &          locally_owned_dofs = dof.locally_owned_dofs();
-      IndexSet::ElementIterator it                 = locally_owned_dofs.begin();
-      for (; it != locally_owned_dofs.end(); ++it)
-        ::dealii::internal::ElementAccess<VectorType>::set(vec(*it),
-                                                           *it,
+      for (const auto it : dof.locally_owned_dofs())
+        ::dealii::internal::ElementAccess<VectorType>::set(vec(it),
+                                                           it,
                                                            vec_result);
       vec_result.compress(VectorOperation::insert);
     }
@@ -748,11 +744,9 @@ namespace VectorTools
 
       constraints.distribute(vec);
 
-      const IndexSet &          locally_owned_dofs = dof.locally_owned_dofs();
-      IndexSet::ElementIterator it                 = locally_owned_dofs.begin();
-      for (; it != locally_owned_dofs.end(); ++it)
-        ::dealii::internal::ElementAccess<VectorType>::set(vec(*it),
-                                                           *it,
+      for (const auto it : dof.locally_owned_dofs())
+        ::dealii::internal::ElementAccess<VectorType>::set(vec(it),
+                                                           it,
                                                            vec_result);
       vec_result.compress(VectorOperation::insert);
     }

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -98,6 +98,8 @@ namespace VectorTools
             }
     }
 
+
+
     /**
      * Compute the boundary values to be used in the project() functions.
      */
@@ -147,6 +149,7 @@ namespace VectorTools
             mapping, dof, boundary_functions, q_boundary, boundary_values);
         }
     }
+
 
 
     /*
@@ -508,6 +511,8 @@ namespace VectorTools
       vec_result.compress(VectorOperation::insert);
     }
 
+
+
     /**
      * Return whether the boundary values try to constrain a degree of freedom
      * that is already constrained to something else
@@ -640,6 +645,8 @@ namespace VectorTools
                                                            it,
                                                            vec_result);
     }
+
+
 
     template <int dim, typename VectorType, int spacedim>
     void
@@ -817,6 +824,8 @@ namespace VectorTools
       vec_result.compress(VectorOperation::insert);
     }
 
+
+
     /**
      * Specialization of project() for the case dim==spacedim.
      * Check if we can use the MatrixFree implementation or need
@@ -875,7 +884,10 @@ namespace VectorTools
                      project_to_boundary_first);
         }
     }
+  
   } // namespace internal
+
+
 
   template <int dim, typename VectorType, int spacedim>
   void
@@ -1043,6 +1055,7 @@ namespace VectorTools
   }
 
 
+
   template <int dim, typename VectorType, int spacedim>
   void
   project(const DoFHandler<dim, spacedim> &                         dof,
@@ -1064,6 +1077,7 @@ namespace VectorTools
             q_boundary,
             project_to_boundary_first);
   }
+
 } // namespace VectorTools
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/numerics/vector_tools_project.templates.h
+++ b/include/deal.II/numerics/vector_tools_project.templates.h
@@ -180,11 +180,8 @@ namespace VectorTools
 
       AssertDimension(dof.get_fe_collection().size(), 1);
 
-      Assert(dof.get_fe(0).n_components() == function.n_components,
-             ExcDimensionMismatch(dof.get_fe(0).n_components(),
-                                  function.n_components));
-      Assert(dof.get_fe(0).n_components() == components,
-             ExcDimensionMismatch(components, dof.get_fe(0).n_components()));
+      AssertDimension(dof.get_fe(0).n_components(), function.n_components);
+      AssertDimension(dof.get_fe(0).n_components(), components);
 
       Quadrature<dim> quadrature_mf;
 
@@ -421,8 +418,7 @@ namespace VectorTools
       const Quadrature<dim - 1> &q_boundary,
       const bool                 project_to_boundary_first)
     {
-      Assert(vec_result.size() == dof.n_dofs(),
-             ExcDimensionMismatch(vec_result.size(), dof.n_dofs()));
+      AssertDimension(vec_result.size(), dof.n_dofs());
 
       LinearAlgebra::distributed::Vector<typename VectorType::value_type>
         work_result;
@@ -493,11 +489,8 @@ namespace VectorTools
       const bool              project_to_boundary_first)
     {
       using number = typename VectorType::value_type;
-      Assert(dof.get_fe(0).n_components() == function.n_components,
-             ExcDimensionMismatch(dof.get_fe(0).n_components(),
-                                  function.n_components));
-      Assert(vec_result.size() == dof.n_dofs(),
-             ExcDimensionMismatch(vec_result.size(), dof.n_dofs()));
+      AssertDimension(dof.get_fe(0).n_components(), function.n_components);
+      AssertDimension(vec_result.size(), dof.n_dofs());
 
       // make up boundary values
       std::map<types::global_dof_index, number> boundary_values;
@@ -594,10 +587,8 @@ namespace VectorTools
       VectorType &                                              vec_result)
     {
       using Number = typename VectorType::value_type;
-      Assert(dof.get_fe(0).n_components() == 1,
-             ExcDimensionMismatch(dof.get_fe(0).n_components(), 1));
-      Assert(vec_result.size() == dof.n_dofs(),
-             ExcDimensionMismatch(vec_result.size(), dof.n_dofs()));
+      AssertDimension(dof.get_fe(0).n_components(), 1);
+      AssertDimension(vec_result.size(), dof.n_dofs());
 
       // set up mass matrix and right hand side
       typename MatrixFree<dim, Number>::AdditionalData additional_data;
@@ -705,10 +696,8 @@ namespace VectorTools
         matrix_free->get_dof_handler(fe_component);
 
       using Number = typename VectorType::value_type;
-      Assert(dof.get_fe(0).n_components() == 1,
-             ExcDimensionMismatch(dof.get_fe(0).n_components(), 1));
-      Assert(vec_result.size() == dof.n_dofs(),
-             ExcDimensionMismatch(vec_result.size(), dof.n_dofs()));
+      AssertDimension(dof.get_fe(0).n_components(), 1);
+      AssertDimension(vec_result.size(), dof.n_dofs());
 
       using MatrixType = MatrixFreeOperators::
         MassOperator<dim, -1, 0, 1, LinearAlgebra::distributed::Vector<Number>>;

--- a/source/numerics/vector_tools_rhs.inst.in
+++ b/source/numerics/vector_tools_rhs.inst.in
@@ -120,3 +120,26 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 #endif
     \}
   }
+
+// Additional insts for the parallel+hp project function.
+for (S : REAL_SCALARS; deal_II_dimension : DIMENSIONS;
+     deal_II_space_dimension : SPACE_DIMENSIONS)
+  {
+    namespace VectorTools
+    \{
+
+#if deal_II_dimension == deal_II_space_dimension
+      template void
+      create_right_hand_side<deal_II_dimension,
+                             deal_II_space_dimension,
+                             LinearAlgebra::distributed::Vector<S>>(
+        const hp::MappingCollection<deal_II_dimension> &,
+        const DoFHandler<deal_II_dimension> &,
+        const hp::QCollection<deal_II_dimension> &,
+        const Function<deal_II_space_dimension,
+                       LinearAlgebra::distributed::Vector<S>::value_type> &,
+        LinearAlgebra::distributed::Vector<S> &,
+        const AffineConstraints<S> &);
+#endif
+    \}
+  }


### PR DESCRIPTION
Since there is now matrix-free+hp support, the ``VectorTools::project`` functions might be updated in order to increase the capabilities. As I use a similar function to project the gradients of a given finite element function I tried to revise the current implementation of ``VectorTools::project``. In the following a short list of changes:
- Since we pass in ``VectorTools::internal::project_matrix_free()`` the finite element degree as ``-1`` to the ``MatrixFreeOperators::MassOperator`` the documentation, which says 'the degree of FiniteElement is less than nine', can be removed.
- Personally I consider multi-physical problems, where I get immediately more than four components. Thus I increased the number of supported components to ten and updated the documentation accordingly.
- Use range-based loops for the loop over all cells or all locally_owned_elements
- Adapt the matrix-free functions to handle the hp case as well

I have also some questions:
- In the function ``VectorTools::internal::project`` we check if we could use the matrix-free implementation by asking `` is_supported()`` and ``n_base_elements()==1``. Looking into ``deal.II/matrix_free/shape_info.templates.h`` I assume that the lines
```
const FiniteElement<dim, spacedim> *fe_ptr = &(fe.base_element(base));
if (fe_ptr->n_components() != 1)
  return false;
```
just ask
```
dof.get_fe(0).n_base_elements() == 1
```
Am I wrong?
- Is there a more elegant way to copy the passed quadrature to ``hp::QCollection<dim> quadrature_mf`` in ``project_matrix_free()``?
- I am coupling different domains with different physics like it is proposed in step-46. Hence I use the hp capabilities together with the ``FE_Nothing`` element. As I see it correctly in ``deal.II/matrix_free/shape_info.templates.h``, this element is not supported and thus the ``project`` function would switch to the generic matrix-based implementation. However, then it is not possible to use a ``p::d::Tria``? Wouldn't this be a desirable feature?
- In the current state there is no implementation for the parallel generic matrix-based case? So if we use a p::d::Tria and more than four components an error is thrown?

And some possible remaining TODOs:
- Maybe some tests would be help full
- Changelog entry