### PR TITLE
Fix typename number

### DIFF
--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -570,7 +570,7 @@ namespace VectorTools
               dofs.resize(dofs_per_cell);
               cell_vector.reinit(dofs_per_cell);
 
-              const std::vector<double> &weights = fe_values.get_JxW_values();
+              const auto &weights = fe_values.get_JxW_values();
               rhs_function.vector_value_list(fe_values.get_quadrature_points(),
                                              rhs_values);
 

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -534,7 +534,7 @@ namespace VectorTools
               dofs.resize(dofs_per_cell);
               cell_vector.reinit(dofs_per_cell);
 
-              const std::vector<double> &weights = fe_values.get_JxW_values();
+              const auto &weights = fe_values.get_JxW_values();
               rhs_function.value_list(fe_values.get_quadrature_points(),
                                       rhs_values);
 

--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -534,7 +534,7 @@ namespace VectorTools
               dofs.resize(dofs_per_cell);
               cell_vector.reinit(dofs_per_cell);
 
-              const std::vector<Number> &weights = fe_values.get_JxW_values();
+              const std::vector<double> &weights = fe_values.get_JxW_values();
               rhs_function.value_list(fe_values.get_quadrature_points(),
                                       rhs_values);
 
@@ -570,7 +570,7 @@ namespace VectorTools
               dofs.resize(dofs_per_cell);
               cell_vector.reinit(dofs_per_cell);
 
-              const std::vector<Number> &weights = fe_values.get_JxW_values();
+              const std::vector<double> &weights = fe_values.get_JxW_values();
               rhs_function.vector_value_list(fe_values.get_quadrature_points(),
                                              rhs_values);
 


### PR DESCRIPTION
Fix the type of ``weigths`` in ``vector_tools_rhs.templates.h ``. According to the documentation ``fe_values.get_JxW_values()`` always returns a ``std::vector`` of  ``double``. This caused an error in #12699.