### PR TITLE
Minor changes to internal function arguments.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -192,6 +192,7 @@ namespace internal
               // any sense at all
               for (const auto &identity : *identities)
                 {
+                  (void)identity;
                   Assert(identity.first <
                            fes[fe_index_1]
                              .template n_dofs_per_object<structdim>(face_no),


### PR DESCRIPTION
Minor follow-up to #12690: Change the interface of an internal function to take FE indices, rather than FE references. I will want to change the function to call the new functionality in `hp::FECollection` next, so let's get this one out of the way already.

/rebuild