### PR TITLE
Identity constraints in 3D are correct.

### DIFF
--- a/tests/hp/identity_constraints_02.cc
+++ b/tests/hp/identity_constraints_02.cc
@@ -21,12 +21,14 @@
 // On each of the four lines on the interface between the Q2 and Q4 element, the
 // central dofs are identical and will be treated with constraints.
 //
-// If the dominating element in the collection of finite elements on the central
-// line does not have a central dof, the dof duplicates on the elements Q2 and
-// Q4 will not be recognized with constraints.
-// This is the reason why there is one identity constraint less in scenario 1
-// than in scenario 2 -- the dominating Q1 element has no dofs on lines.
-// This is a bug.
+// We put special emphasis on the central line.
+// - In scenario 1, the central dof of the central line will be constrained
+//   against the vertex dofs of the Q1 element. Thus, we only have 3 identity
+//   constraints in total on the remaining lines of the interface between the Q2
+//   and Q4 element.
+// - In scenario 2, the central dof of the central line belongs to the Q2
+//   element and remains unconstrained. Thus, we end up with 4 identity
+//   constraints.
 //
 // Scenario 1:    Scenario 2:
 // +----+----+    +----+----+


### PR DESCRIPTION
Fix description of test `hp/identity_constraints_02`.

@bangerth and I thought about the scenario of this particular test in context of #12626 again. While introducing the test in #12623, it didn't come to my mind that the central dof of the central line is actually itself constrained to the vertex dofs of the Q1 element, so that it will not appear as an identity constraint. That's the reason why there is one identity constraint less in scenario 1 than in scenario 2.

Actually I'm quite happy about this mistake -- that means that there is one less bug to fix :)

Only changes the documentation of the test, so no need to run the full testsuite.