### PR TITLE
Use std::next instead of ++object.begin().

### DIFF
--- a/include/deal.II/base/iterator_range.h
+++ b/include/deal.II/base/iterator_range.h
@@ -114,10 +114,11 @@ class IteratorOverIterators;
  * way that if you <i>dereference</i> the result of IteratorRange::begin(),
  * you get the <code>b</code> iterator. Furthermore, you must be able to
  * increment the object returned by IteratorRange::begin() so that
- * <code>*(++begin()) == b+1</code>. In other words, IteratorRange::begin()
- * must return an iterator that when dereferenced returns an iterator of the
- * template type <code>Iterator</code>: It is an iterator over iterators in
- * the same sense as if you had a pointer into an array of pointers.
+ * <code>*(std::next(begin())) == b+1</code>. In other words,
+ * IteratorRange::begin() must return an iterator that when dereferenced returns
+ * an iterator of the template type <code>Iterator</code>: It is an iterator
+ * over iterators in the same sense as if you had a pointer into an array of
+ * pointers.
  *
  * This is implemented in the form of the IteratorRange::IteratorOverIterators
  * class.

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -331,8 +331,9 @@ BlockIndices::global_to_local(const size_type i) const
   Assert(n_blocks > 0, ExcLowerRangeType<size_type>(i, size_type(1)));
 
   // start_indices[0] == 0 so we might as well start from the next one
-  const auto it =
-    --std::upper_bound(++start_indices.begin(), start_indices.end(), i);
+  const auto it = --std::upper_bound(std::next(start_indices.begin()),
+                                     start_indices.end(),
+                                     i);
 
   return {std::distance(start_indices.begin(), it), i - *it};
 }

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -25,6 +25,7 @@
 #include <deal.II/base/utilities.h>
 
 #include <cstddef>
+#include <iterator>
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
@@ -331,9 +332,8 @@ BlockIndices::global_to_local(const size_type i) const
   Assert(n_blocks > 0, ExcLowerRangeType<size_type>(i, size_type(1)));
 
   // start_indices[0] == 0 so we might as well start from the next one
-  const auto it = --std::upper_bound(std::next(start_indices.begin()),
-                                     start_indices.end(),
-                                     i);
+  const auto it = std::prev(
+    std::upper_bound(std::next(start_indices.begin()), start_indices.end(), i));
 
   return {std::distance(start_indices.begin(), it), i - *it};
 }

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -141,9 +141,10 @@ namespace internal
                                   typename BlockVectorType::value_type>::type;
 
       /**
-       * Declare some alias which are standard for iterators and are used
+       * Declare some aliases that are standard for iterators and are used
        * by algorithms to enquire about the specifics of the iterators they
-       * work on.
+       * work on. (Example: `std::next()`, which needs to know about a local
+       * type named `difference_type`.)
        */
       using iterator_category = std::random_access_iterator_tag;
       using difference_type   = std::ptrdiff_t;

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -26,6 +26,7 @@
 #  include <deal.II/lac/exceptions.h>
 #  include <deal.II/lac/identity_matrix.h>
 
+#  include <iterator>
 #  include <memory>
 
 
@@ -308,6 +309,12 @@ namespace ChunkSparseMatrixIterators
     using value_type = const Accessor<number, Constness> &;
 
     /**
+     * A type that denotes what data types is used to express the difference
+     * between two iterators.
+     */
+    using difference_type = types::global_dof_index;
+
+    /**
      * Constructor. Create an iterator into the matrix @p matrix for the given
      * row and the index within it.
      */
@@ -400,6 +407,24 @@ namespace ChunkSparseMatrixIterators
   };
 
 } // namespace ChunkSparseMatrixIterators
+
+DEAL_II_NAMESPACE_CLOSE
+
+namespace std
+{
+  template <typename number, bool Constness>
+  struct iterator_traits<
+    dealii::ChunkSparseMatrixIterators::Iterator<number, Constness>>
+  {
+    using iterator_category = forward_iterator_tag;
+    using value_type        = typename dealii::ChunkSparseMatrixIterators::
+      Iterator<number, Constness>::value_type;
+    using difference_type = typename dealii::ChunkSparseMatrixIterators::
+      Iterator<number, Constness>::difference_type;
+  };
+} // namespace std
+
+DEAL_II_NAMESPACE_OPEN
 
 
 

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -30,6 +30,7 @@
 #    include <mpi.h>
 #  endif
 
+#  include <iterator>
 #  include <memory>
 
 
@@ -360,6 +361,10 @@ namespace SparseMatrixIterators
      */
     using value_type = const Accessor<number, Constness> &;
 
+    /**
+     * A type that denotes what data types is used to express the difference
+     * between two iterators.
+     */
     using difference_type = size_type;
 
     /**
@@ -461,6 +466,25 @@ namespace SparseMatrixIterators
   };
 
 } // namespace SparseMatrixIterators
+
+DEAL_II_NAMESPACE_CLOSE
+
+namespace std
+{
+  template <typename number, bool Constness>
+  struct iterator_traits<
+    dealii::SparseMatrixIterators::Iterator<number, Constness>>
+  {
+    using iterator_category = forward_iterator_tag;
+    using value_type =
+      typename dealii::SparseMatrixIterators::Iterator<number,
+                                                       Constness>::value_type;
+    using difference_type = typename dealii::SparseMatrixIterators::
+      Iterator<number, Constness>::difference_type;
+  };
+} // namespace std
+
+DEAL_II_NAMESPACE_OPEN
 
 /**
  * @}

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -360,6 +360,8 @@ namespace SparseMatrixIterators
      */
     using value_type = const Accessor<number, Constness> &;
 
+    using difference_type = size_type;
+
     /**
      * Constructor. Create an iterator into the matrix @p matrix for the given
      * index in the complete matrix (counting from the zeroth entry).

--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -44,6 +44,7 @@
 #    include <mpi.h>
 
 #    include <cmath>
+#    include <iterator>
 #    include <memory>
 #    include <type_traits>
 #    include <vector>
@@ -209,6 +210,8 @@ namespace TrilinosWrappers
       value();
     };
 
+
+
     /**
      * The specialization for a const Accessor.
      */
@@ -355,6 +358,18 @@ namespace TrilinosWrappers
       using size_type = dealii::types::global_dof_index;
 
       /**
+       * A type that denotes what data types is used to express the difference
+       * between two iterators.
+       */
+      using difference_type = dealii::types::global_dof_index;
+
+      /**
+       * An alias for the type you get when you dereference an iterator of the
+       * current kind.
+       */
+      using value_type = TrilinosScalar;
+
+      /**
        * Typedef for the matrix type (including constness) we are to operate
        * on.
        */
@@ -443,8 +458,31 @@ namespace TrilinosWrappers
     };
 
   } // namespace SparseMatrixIterators
+} // namespace TrilinosWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+namespace std
+{
+  template <bool Constness>
+  struct iterator_traits<
+    dealii::TrilinosWrappers::SparseMatrixIterators::Iterator<Constness>>
+  {
+    using iterator_category = forward_iterator_tag;
+    using value_type =
+      typename dealii::TrilinosWrappers::SparseMatrixIterators::Iterator<
+        Constness>::value_type;
+    using difference_type =
+      typename dealii::TrilinosWrappers::SparseMatrixIterators::Iterator<
+        Constness>::difference_type;
+  };
+} // namespace std
+
+DEAL_II_NAMESPACE_OPEN
 
 
+namespace TrilinosWrappers
+{
   /**
    * This class implements a wrapper to use the Trilinos distributed sparse
    * matrix class Epetra_FECrsMatrix. This is precisely the kind of matrix we

--- a/tests/bits/chunk_sparse_matrix_iterator_11.cc
+++ b/tests/bits/chunk_sparse_matrix_iterator_11.cc
@@ -39,7 +39,7 @@ test(const unsigned int chunk_size)
   // attach a sparse matrix to it
   ChunkSparseMatrix<double> A(sparsity);
 
-  ChunkSparseMatrix<double>::iterator k = A.begin(), j = ++A.begin();
+  ChunkSparseMatrix<double>::iterator k = A.begin(), j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/bits/chunk_sparse_matrix_iterator_11.cc
+++ b/tests/bits/chunk_sparse_matrix_iterator_11.cc
@@ -20,6 +20,8 @@
 
 #include <deal.II/lac/chunk_sparse_matrix.h>
 
+#include <iterator>
+
 #include "../tests.h"
 
 

--- a/tests/bits/chunk_sparse_matrix_iterator_12.cc
+++ b/tests/bits/chunk_sparse_matrix_iterator_12.cc
@@ -38,7 +38,8 @@ test(const unsigned int chunk_size)
   // attach a sparse matrix to it
   ChunkSparseMatrix<double> A(sparsity);
 
-  ChunkSparseMatrix<double>::const_iterator k = A.begin(), j = ++A.begin();
+  ChunkSparseMatrix<double>::const_iterator k = A.begin(),
+                                            j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/bits/chunk_sparse_matrix_iterator_12.cc
+++ b/tests/bits/chunk_sparse_matrix_iterator_12.cc
@@ -19,6 +19,8 @@
 
 #include <deal.II/lac/chunk_sparse_matrix.h>
 
+#include <iterator>
+
 #include "../tests.h"
 
 

--- a/tests/bits/periodicity_01.cc
+++ b/tests/bits/periodicity_01.cc
@@ -55,9 +55,10 @@ test()
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<double> cm;
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm);
 
   deallog << "dim " << std::to_string(dim) << ":" << std::endl;
   cm.print(deallog.get_file_stream());

--- a/tests/bits/periodicity_02.cc
+++ b/tests/bits/periodicity_02.cc
@@ -59,9 +59,10 @@ test()
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<double> cm;
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm);
   cm.print(deallog.get_file_stream());
 }
 

--- a/tests/bits/periodicity_03.cc
+++ b/tests/bits/periodicity_03.cc
@@ -61,9 +61,10 @@ test()
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<double> cm;
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm);
   cm.print(deallog.get_file_stream());
 }
 

--- a/tests/bits/periodicity_04.cc
+++ b/tests/bits/periodicity_04.cc
@@ -68,10 +68,11 @@ test()
   std::vector<bool> mask(2, true);
   mask[1] = false;
   AffineConstraints<double> cm;
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm,
-                                         mask);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm,
+    mask);
   cm.print(deallog.get_file_stream());
 }
 

--- a/tests/bits/periodicity_08.cc
+++ b/tests/bits/periodicity_08.cc
@@ -55,9 +55,10 @@ test()
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<std::complex<double>> cm;
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm);
   cm.print(deallog.get_file_stream());
 }
 

--- a/tests/bits/periodicity_09.cc
+++ b/tests/bits/periodicity_09.cc
@@ -68,16 +68,17 @@ test()
   deallog << dim << " 1/periodicity_factor: " << 1. / periodicity_factor
           << std::endl;
 
-  DoFTools::make_periodicity_constraints(dof_handler.begin(0)->face(0),
-                                         (++dof_handler.begin(0))->face(1),
-                                         cm,
-                                         ComponentMask(),
-                                         true,
-                                         false,
-                                         false,
-                                         FullMatrix<double>(),
-                                         std::vector<unsigned int>(),
-                                         periodicity_factor);
+  DoFTools::make_periodicity_constraints(
+    dof_handler.begin(0)->face(0),
+    (std::next(dof_handler.begin(0)))->face(1),
+    cm,
+    ComponentMask(),
+    true,
+    false,
+    false,
+    FullMatrix<double>(),
+    std::vector<unsigned int>(),
+    periodicity_factor);
   cm.print(deallog.get_file_stream());
 }
 

--- a/tests/bits/sparse_matrix_iterator_11.cc
+++ b/tests/bits/sparse_matrix_iterator_11.cc
@@ -37,7 +37,7 @@ test()
   // attach a sparse matrix to it
   SparseMatrix<double> A(sparsity);
 
-  SparseMatrix<double>::iterator k = A.begin(), j = ++A.begin();
+  SparseMatrix<double>::iterator k = A.begin(), j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/bits/sparse_matrix_iterator_11.cc
+++ b/tests/bits/sparse_matrix_iterator_11.cc
@@ -20,6 +20,8 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 
+#include <iterator>
+
 #include "../tests.h"
 
 

--- a/tests/bits/sparse_matrix_iterator_12.cc
+++ b/tests/bits/sparse_matrix_iterator_12.cc
@@ -37,7 +37,7 @@ test()
   // attach a sparse matrix to it
   SparseMatrix<double> A(sparsity);
 
-  SparseMatrix<double>::const_iterator k = A.begin(), j = ++A.begin();
+  SparseMatrix<double>::const_iterator k = A.begin(), j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/bits/sparse_matrix_iterator_12.cc
+++ b/tests/bits/sparse_matrix_iterator_12.cc
@@ -20,6 +20,8 @@
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 
+#include <iterator>
+
 #include "../tests.h"
 
 

--- a/tests/distributed_grids/tria_settings_01.cc
+++ b/tests/distributed_grids/tria_settings_01.cc
@@ -43,7 +43,7 @@ testit(parallel::distributed::Triangulation<dim> &tr)
   GridGenerator::hyper_cube(tr);
   tr.refine_global(1);
 
-  (++tr.begin_active())->set_refine_flag();
+  (std::next(tr.begin_active()))->set_refine_flag();
   tr.execute_coarsening_and_refinement();
 
   tr.begin_active()->set_refine_flag();

--- a/tests/dofs/dof_tools_01a.cc
+++ b/tests/dofs/dof_tools_01a.cc
@@ -57,7 +57,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_01a_constraints_false.cc
+++ b/tests/dofs/dof_tools_01a_constraints_false.cc
@@ -63,7 +63,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_01a_constraints_true.cc
+++ b/tests/dofs/dof_tools_01a_constraints_true.cc
@@ -63,7 +63,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_01a_subdomain.cc
+++ b/tests/dofs/dof_tools_01a_subdomain.cc
@@ -63,7 +63,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_02a.cc
+++ b/tests/dofs/dof_tools_02a.cc
@@ -67,7 +67,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_02a_constraints_false.cc
+++ b/tests/dofs/dof_tools_02a_constraints_false.cc
@@ -73,7 +73,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_02a_constraints_true.cc
+++ b/tests/dofs/dof_tools_02a_constraints_true.cc
@@ -73,7 +73,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_02a_subdomain.cc
+++ b/tests/dofs/dof_tools_02a_subdomain.cc
@@ -74,7 +74,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_15a.cc
+++ b/tests/dofs/dof_tools_15a.cc
@@ -66,7 +66,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_16a.cc
+++ b/tests/dofs/dof_tools_16a.cc
@@ -72,7 +72,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_17a.cc
+++ b/tests/dofs/dof_tools_17a.cc
@@ -57,7 +57,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_18a.cc
+++ b/tests/dofs/dof_tools_18a.cc
@@ -78,7 +78,8 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }

--- a/tests/dofs/dof_tools_18a_1d.cc
+++ b/tests/dofs/dof_tools_18a_1d.cc
@@ -83,8 +83,9 @@ check_this(const DoFHandler<dim> &dof_handler)
   unsigned int hash = 0;
   for (unsigned int l = 0; l < sp.n_rows(); ++l)
     hash +=
-      l * (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
-           (sp.row_length(l) > 1 ? ++sp.begin(l) : sp.begin(l))->column());
+      l *
+      (sp.row_length(l) + (sp.begin(l) - sp.begin()) +
+       (sp.row_length(l) > 1 ? std::next(sp.begin(l)) : sp.begin(l))->column());
   deallog << hash << std::endl;
 }
 

--- a/tests/dofs/dof_tools_21_b_x.cc
+++ b/tests/dofs/dof_tools_21_b_x.cc
@@ -179,7 +179,7 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 
   // Look for the two outermost faces:
   typename DoFHandler<dim, spacedim>::face_iterator face_1 =
-    (++dof_handler.begin(0))->face(2);
+    (std::next(dof_handler.begin(0)))->face(2);
   typename DoFHandler<dim, spacedim>::face_iterator face_2 =
     dof_handler.begin(0)->face(2);
 

--- a/tests/dofs/dof_tools_21_b_x_q3.cc
+++ b/tests/dofs/dof_tools_21_b_x_q3.cc
@@ -213,7 +213,7 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 
   // Look for the two outermost faces:
   typename DoFHandler<dim, spacedim>::face_iterator face_1 =
-    (++dof_handler.begin(0))->face(2);
+    (std::next(dof_handler.begin(0)))->face(2);
   typename DoFHandler<dim, spacedim>::face_iterator face_2 =
     dof_handler.begin(0)->face(2);
 

--- a/tests/dofs/dof_tools_21_b_y.cc
+++ b/tests/dofs/dof_tools_21_b_y.cc
@@ -179,7 +179,7 @@ print_matching(DoFHandler<dim, spacedim> &dof_handler)
 
   // Look for the two outermost faces:
   typename DoFHandler<dim, spacedim>::face_iterator face_1 =
-    (++dof_handler.begin(0))->face(2);
+    (std::next(dof_handler.begin(0)))->face(2);
   typename DoFHandler<dim, spacedim>::face_iterator face_2 =
     dof_handler.begin(0)->face(2);
 

--- a/tests/dofs/n_boundary_dofs_03.cc
+++ b/tests/dofs/n_boundary_dofs_03.cc
@@ -60,8 +60,8 @@ test()
   // assign boundary ids
   triangulation.begin()->face(0)->set_boundary_id(12);
   triangulation.begin()->face(1)->set_boundary_id(13);
-  (++triangulation.begin())->face(0)->set_boundary_id(14);
-  (++triangulation.begin())->face(1)->set_boundary_id(15);
+  std::next(triangulation.begin())->face(0)->set_boundary_id(14);
+  std::next(triangulation.begin())->face(1)->set_boundary_id(15);
 
 
   FESystem<1, spacedim> fe(FE_Q<1, spacedim>(1), 1, FE_DGQ<1, spacedim>(1), 1);

--- a/tests/dofs/sparsity_pattern_02.cc
+++ b/tests/dofs/sparsity_pattern_02.cc
@@ -67,7 +67,7 @@ check()
   triangulation_2.refine_global(1);
   (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
-  (++triangulation_2.begin_active(2))->set_refine_flag();
+  (std::next(triangulation_2.begin_active(2)))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   if (dim == 1)
     triangulation_2.refine_global(2);

--- a/tests/dofs/sparsity_pattern_02.cc
+++ b/tests/dofs/sparsity_pattern_02.cc
@@ -65,7 +65,7 @@ check()
   else
     GridGenerator::hyper_cube(triangulation_2, -1, 1);
   triangulation_2.refine_global(1);
-  (++triangulation_2.begin_active())->set_refine_flag();
+  (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   (++triangulation_2.begin_active(2))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();

--- a/tests/dofs/sparsity_pattern_03.cc
+++ b/tests/dofs/sparsity_pattern_03.cc
@@ -70,7 +70,7 @@ check()
   triangulation_2.refine_global(1);
   (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
-  (++triangulation_2.begin_active(2))->set_refine_flag();
+  (std::next(triangulation_2.begin_active(2)))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   if (dim == 1)
     triangulation_2.refine_global(2);

--- a/tests/dofs/sparsity_pattern_03.cc
+++ b/tests/dofs/sparsity_pattern_03.cc
@@ -68,7 +68,7 @@ check()
   else
     GridGenerator::hyper_cube(triangulation_2, -1, 1);
   triangulation_2.refine_global(1);
-  (++triangulation_2.begin_active())->set_refine_flag();
+  (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   (++triangulation_2.begin_active(2))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();

--- a/tests/dofs/sparsity_pattern_04.cc
+++ b/tests/dofs/sparsity_pattern_04.cc
@@ -69,7 +69,7 @@ check()
   else
     GridGenerator::hyper_cube(triangulation_2, -1, 1);
   triangulation_2.refine_global(1);
-  (++triangulation_2.begin_active())->set_refine_flag();
+  (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   (++triangulation_2.begin_active(2))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();

--- a/tests/dofs/sparsity_pattern_04.cc
+++ b/tests/dofs/sparsity_pattern_04.cc
@@ -71,7 +71,7 @@ check()
   triangulation_2.refine_global(1);
   (std::next(triangulation_2.begin_active()))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
-  (++triangulation_2.begin_active(2))->set_refine_flag();
+  (std::next(triangulation_2.begin_active(2)))->set_refine_flag();
   triangulation_2.execute_coarsening_and_refinement();
   if (dim == 1)
     triangulation_2.refine_global(2);

--- a/tests/fe/nedelec_crash_hp.cc
+++ b/tests/fe/nedelec_crash_hp.cc
@@ -68,7 +68,7 @@ test()
                                             Point<dim>(),
                                             (dim == 3 ? Point<dim>(2, 1, 1) :
                                                         Point<dim>(2, 1)));
-  (++triangulation.begin_active())->set_refine_flag();
+  (std::next(triangulation.begin_active()))->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
 
   hp::FECollection<dim> fe;

--- a/tests/fe/nedelec_face_interpolation.cc
+++ b/tests/fe/nedelec_face_interpolation.cc
@@ -52,7 +52,7 @@ test(unsigned p1, unsigned p2)
                                             Point<dim>(),
                                             (dim == 3 ? Point<dim>(2, 1, 1) :
                                                         Point<dim>(2, 1)));
-  (++triangulation.begin_active())->set_refine_flag();
+  (std::next(triangulation.begin_active()))->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
 
   hp::FECollection<dim> fe;

--- a/tests/full_matrix/full_matrix_iterator_01.cc
+++ b/tests/full_matrix/full_matrix_iterator_01.cc
@@ -29,7 +29,7 @@ test()
   FullMatrix<double> A(3, 3);
 
   // test prefix operator
-  const IteratorType k = A.begin(), j = ++A.begin();
+  const IteratorType k = A.begin(), j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/grid/grid_generator_07.cc
+++ b/tests/grid/grid_generator_07.cc
@@ -42,7 +42,7 @@ test(std::ostream &out)
   // makes a bunch of vertices unused
   std::set<typename Triangulation<dim>::active_cell_iterator> cells_to_remove;
   for (typename Triangulation<dim>::active_cell_iterator cell =
-         ++triangulation.begin_active();
+         std::next(triangulation.begin_active());
        cell != triangulation.end();
        ++cell)
     cells_to_remove.insert(cell);

--- a/tests/grid/mesh_3d_12.cc
+++ b/tests/grid/mesh_3d_12.cc
@@ -73,7 +73,7 @@ check_this(Triangulation<3> &tria)
 void
 check(Triangulation<3> &tria)
 {
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   deallog << "Initial check" << std::endl;

--- a/tests/grid/mesh_3d_13.cc
+++ b/tests/grid/mesh_3d_13.cc
@@ -83,7 +83,7 @@ check_this(Triangulation<3> &tria)
 void
 check(Triangulation<3> &tria)
 {
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   deallog << "Initial check" << std::endl;

--- a/tests/grid/mesh_3d_14.cc
+++ b/tests/grid/mesh_3d_14.cc
@@ -103,7 +103,7 @@ check_this(Triangulation<3> &tria)
 void
 check(Triangulation<3> &tria)
 {
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   deallog << "Initial check" << std::endl;

--- a/tests/grid/mesh_3d_15.cc
+++ b/tests/grid/mesh_3d_15.cc
@@ -96,7 +96,7 @@ check_this(Triangulation<3> &tria)
 void
 check(Triangulation<3> &tria)
 {
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   deallog << "Initial check" << std::endl;

--- a/tests/grid/mesh_3d_17.cc
+++ b/tests/grid/mesh_3d_17.cc
@@ -44,7 +44,7 @@ check(Triangulation<3> &tria)
 
   deallog << "Coarse cell 1 vertices:" << std::endl;
   for (unsigned int i = 0; i < 8; ++i)
-    deallog << ' ' << (++tria.begin_active())->vertex_index(i);
+    deallog << ' ' << (std::next(tria.begin_active()))->vertex_index(i);
   deallog << std::endl;
 
 

--- a/tests/grid/mesh_3d_2.cc
+++ b/tests/grid/mesh_3d_2.cc
@@ -66,6 +66,6 @@ main()
   // we know that from the second
   // cell, the common face must have
   // wrong orientation. check this
-  Assert((++coarse_grid.begin_active())->face_orientation(5) == false,
+  Assert((std::next(coarse_grid.begin_active()))->face_orientation(5) == false,
          ExcInternalError());
 }

--- a/tests/grid/mesh_3d_21.cc
+++ b/tests/grid/mesh_3d_21.cc
@@ -104,7 +104,7 @@ check_this(Triangulation<3> &tria)
 void
 check(Triangulation<3> &tria)
 {
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   deallog << "Initial check" << std::endl;

--- a/tests/grid/mesh_3d_3.cc
+++ b/tests/grid/mesh_3d_3.cc
@@ -42,7 +42,7 @@ main()
   create_two_cubes(coarse_grid);
 
   const Triangulation<3>::active_cell_iterator cells[2] = {
-    coarse_grid.begin_active(), ++coarse_grid.begin_active()};
+    coarse_grid.begin_active(), std::next(coarse_grid.begin_active())};
 
   // output all vertices
   for (unsigned int c = 0; c < 2; ++c)

--- a/tests/grid/n_faces_01.cc
+++ b/tests/grid/n_faces_01.cc
@@ -34,7 +34,7 @@ test()
   GridGenerator::hyper_cube(tria);
   tria.refine_global(2);
   tria.begin_active()->set_coarsen_flag();
-  (++(tria.begin_active()))->set_coarsen_flag();
+  (std::next((tria.begin_active())))->set_coarsen_flag();
   tria.execute_coarsening_and_refinement();
 
   std::map<typename Triangulation<dim, spacedim>::face_iterator, unsigned int>

--- a/tests/grid/union_triangulation.cc
+++ b/tests/grid/union_triangulation.cc
@@ -47,7 +47,7 @@ test()
   // similar for second grid, but
   // different cell
   tria_2.refine_global(1);
-  (++tria_2.begin_active())->set_refine_flag();
+  (std::next(tria_2.begin_active()))->set_refine_flag();
   tria_2.execute_coarsening_and_refinement();
 
   GridGenerator::create_union_triangulation(tria_1, tria_2, tria_3);

--- a/tests/hp/crash_07.cc
+++ b/tests/hp/crash_07.cc
@@ -104,7 +104,7 @@ main()
        cell != dof_handler.end();
        ++cell, ++cell_no)
     cell->set_active_fe_index(0);
-  (++dof_handler.begin_active())->set_active_fe_index(1);
+  (std::next(dof_handler.begin_active()))->set_active_fe_index(1);
   dof_handler.distribute_dofs(fe);
 
   deallog << "n_dofs=" << dof_handler.n_dofs() << std::endl;

--- a/tests/hp/crash_12.cc
+++ b/tests/hp/crash_12.cc
@@ -73,7 +73,7 @@ test()
                                             Point<dim>(),
                                             (dim == 3 ? Point<dim>(2, 1, 1) :
                                                         Point<dim>(2, 1)));
-  (++triangulation.begin_active())->set_refine_flag();
+  (std::next(triangulation.begin_active()))->set_refine_flag();
   triangulation.execute_coarsening_and_refinement();
 
   hp::FECollection<dim> fe;

--- a/tests/hp/error_prediction_02.cc
+++ b/tests/hp/error_prediction_02.cc
@@ -46,7 +46,7 @@ test()
   TestGrids::hyper_line(tria, 4);
 
   tria.begin_active()->set_refine_flag();
-  (++tria.begin_active())->set_refine_flag();
+  (std::next(tria.begin_active()))->set_refine_flag();
   tria.execute_coarsening_and_refinement();
 
   hp::FECollection<dim> fes;

--- a/tests/hp/face_domination_01.cc
+++ b/tests/hp/face_domination_01.cc
@@ -80,7 +80,7 @@ main()
   dof_handler.distribute_dofs(fe_collection);
 
   print_dofs(dof_handler.begin_active());
-  print_dofs(++dof_handler.begin_active());
+  print_dofs(std::next(dof_handler.begin_active()));
 
   AffineConstraints<double> constraints;
   constraints.clear();

--- a/tests/hp/face_domination_02.cc
+++ b/tests/hp/face_domination_02.cc
@@ -82,7 +82,7 @@ main()
   dof_handler.distribute_dofs(fe_collection);
 
   print_dofs(dof_handler.begin_active());
-  print_dofs(++dof_handler.begin_active());
+  print_dofs(std::next(dof_handler.begin_active()));
 
   AffineConstraints<double> constraints;
   constraints.clear();

--- a/tests/hp/face_domination_04.cc
+++ b/tests/hp/face_domination_04.cc
@@ -89,7 +89,7 @@ main()
 
       deallog << "RTNodal of degree " << i << std::endl;
       print_dofs(dof_handler.begin_active());
-      print_dofs(++dof_handler.begin_active());
+      print_dofs(std::next(dof_handler.begin_active()));
 
       AffineConstraints<double> constraints;
       constraints.clear();

--- a/tests/hp/fe_nothing_dominates.h
+++ b/tests/hp/fe_nothing_dominates.h
@@ -60,7 +60,7 @@ project(const hp::FECollection<dim> &fe_collection,
   TestGrids::hyper_line(tria, 2);
 
   DoFHandler<dim> dofh(tria);
-  (++(dofh.begin_active()))->set_active_fe_index(1);
+  (std::next((dofh.begin_active())))->set_active_fe_index(1);
   dofh.distribute_dofs(fe_collection);
 
   // make constraints

--- a/tests/hp/hp_constraints_common.h
+++ b/tests/hp/hp_constraints_common.h
@@ -304,10 +304,10 @@ test_with_2d_deformed_refined_mesh(const hp::FECollection<dim> &fe)
             triangulation.begin_active()->set_refine_flag();
             break;
           case 1:
-            (++(triangulation.begin_active()))->set_refine_flag();
+            (std::next((triangulation.begin_active())))->set_refine_flag();
             break;
           case 2:
-            (++(++(triangulation.begin_active())))->set_refine_flag();
+            (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
             Assert(false, ExcNotImplemented());
@@ -349,7 +349,7 @@ test_interpolation_base(const hp::FECollection<dim> &    fe,
 
   if (do_refine)
     {
-      (++triangulation.begin_active())->set_refine_flag();
+      (std::next(triangulation.begin_active()))->set_refine_flag();
       triangulation.execute_coarsening_and_refinement();
     }
 

--- a/tests/hp/hp_constraints_common_no_support.h
+++ b/tests/hp/hp_constraints_common_no_support.h
@@ -305,10 +305,10 @@ test_with_2d_deformed_refined_mesh(const hp::FECollection<dim> &fe)
             triangulation.begin_active()->set_refine_flag();
             break;
           case 1:
-            (++(triangulation.begin_active()))->set_refine_flag();
+            (std::next((triangulation.begin_active())))->set_refine_flag();
             break;
           case 2:
-            (++(++(triangulation.begin_active())))->set_refine_flag();
+            (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
             Assert(false, ExcNotImplemented());
@@ -350,7 +350,7 @@ test_interpolation_base(const hp::FECollection<dim> &    fe,
 
   if (do_refine)
     {
-      (++triangulation.begin_active())->set_refine_flag();
+      (std::next(triangulation.begin_active()))->set_refine_flag();
       triangulation.execute_coarsening_and_refinement();
     }
 

--- a/tests/hp/hp_fe_values_copy.cc
+++ b/tests/hp/hp_fe_values_copy.cc
@@ -73,7 +73,7 @@ test()
   hp_fe_values1.reinit(cell1);
 
   // Now make a copy of the object and initialize it for the second cell
-  const auto        cell2 = ++dof_handler.begin_active();
+  const auto        cell2 = std::next(dof_handler.begin_active());
   hp::FEValues<dim> hp_fe_values2(hp_fe_values1);
   hp_fe_values2.reinit(cell2);
 

--- a/tests/hp/n_boundary_dofs_03.cc
+++ b/tests/hp/n_boundary_dofs_03.cc
@@ -62,8 +62,8 @@ test()
   // assign boundary ids
   triangulation.begin()->face(0)->set_boundary_id(12);
   triangulation.begin()->face(1)->set_boundary_id(13);
-  (++triangulation.begin())->face(0)->set_boundary_id(14);
-  (++triangulation.begin())->face(1)->set_boundary_id(15);
+  std::next(triangulation.begin())->face(0)->set_boundary_id(14);
+  std::next(triangulation.begin())->face(1)->set_boundary_id(15);
 
 
   hp::FECollection<1, spacedim> fe;

--- a/tests/integrators/laplacian_02.cc
+++ b/tests/integrators/laplacian_02.cc
@@ -104,7 +104,8 @@ test_face(const FiniteElement<dim> &fe, bool diff = false)
   std::vector<types::global_dof_index> indices2(fe.dofs_per_cell);
 
   typename DoFHandler<dim>::active_cell_iterator cell1 = dof.begin_active();
-  typename DoFHandler<dim>::active_cell_iterator cell2 = ++dof.begin_active();
+  typename DoFHandler<dim>::active_cell_iterator cell2 =
+    std::next(dof.begin_active());
 
   cell1->get_dof_indices(indices1);
   cell2->get_dof_indices(indices2);

--- a/tests/lac/constraints.cc
+++ b/tests/lac/constraints.cc
@@ -231,11 +231,11 @@ make_tria(Triangulation<3> &tria, int step)
 
               case 7:
                 tria.begin_active()->set_refine_flag();
-                (++tria.begin_active())->set_refine_flag();
+                (std::next(tria.begin_active()))->set_refine_flag();
                 break;
               case 8:
                 tria.begin_active()->set_refine_flag();
-                (++(++(++tria.begin_active())))->set_refine_flag();
+                (std::next((++(++tria.begin_active()))))->set_refine_flag();
                 break;
             };
 

--- a/tests/manifold/transfinite_manifold_11.cc
+++ b/tests/manifold/transfinite_manifold_11.cc
@@ -101,7 +101,7 @@ main()
 
   {
     triangulation.set_all_manifold_ids(3);
-    const auto center_cell  = ++triangulation.begin_active();
+    const auto center_cell  = std::next(triangulation.begin_active());
     const auto lower_radial = center_cell->face(2);
     const auto upper_radial = center_cell->face(3);
     lower_radial->set_manifold_id(1);

--- a/tests/mpi/codim_01.cc
+++ b/tests/mpi/codim_01.cc
@@ -69,7 +69,7 @@ test(std::ostream & /*out*/)
   tr.refine_global();
 
   tr.begin_active()->set_refine_flag();
-  (++(tr.begin_active()))->set_refine_flag();
+  (std::next((tr.begin_active())))->set_refine_flag();
 
   tr.execute_coarsening_and_refinement();
 

--- a/tests/mpi/hp_unify_dof_indices_01.cc
+++ b/tests/mpi/hp_unify_dof_indices_01.cc
@@ -61,8 +61,8 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   if (dof_handler.begin_active()->is_locally_owned())
     dof_handler.begin_active()->set_active_fe_index(0);
-  if ((++dof_handler.begin_active())->is_locally_owned())
-    (++dof_handler.begin_active())->set_active_fe_index(1);
+  if ((std::next(dof_handler.begin_active()))->is_locally_owned())
+    (std::next(dof_handler.begin_active()))->set_active_fe_index(1);
   dof_handler.distribute_dofs(fe);
 
   log_dof_diagnostics(dof_handler);

--- a/tests/mpi/hp_unify_dof_indices_07.cc
+++ b/tests/mpi/hp_unify_dof_indices_07.cc
@@ -67,8 +67,8 @@ test()
   DoFHandler<dim> dof_handler(triangulation);
   if (dof_handler.begin_active()->is_locally_owned())
     dof_handler.begin_active()->set_active_fe_index(0);
-  if ((++dof_handler.begin_active())->is_locally_owned())
-    (++dof_handler.begin_active())->set_active_fe_index(1);
+  if ((std::next(dof_handler.begin_active()))->is_locally_owned())
+    (std::next(dof_handler.begin_active()))->set_active_fe_index(1);
   dof_handler.distribute_dofs(fe);
 
   AffineConstraints<double> constraints;

--- a/tests/numerics/project_common.h
+++ b/tests/numerics/project_common.h
@@ -328,10 +328,10 @@ test_with_2d_deformed_refined_mesh(const FiniteElement<dim> &fe,
             triangulation.begin_active()->set_refine_flag();
             break;
           case 1:
-            (++(triangulation.begin_active()))->set_refine_flag();
+            (std::next((triangulation.begin_active())))->set_refine_flag();
             break;
           case 2:
-            (++(++(triangulation.begin_active())))->set_refine_flag();
+            (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
             Assert(false, ExcNotImplemented());

--- a/tests/numerics/project_parallel_common.h
+++ b/tests/numerics/project_parallel_common.h
@@ -341,10 +341,10 @@ test_with_2d_deformed_refined_mesh(const FiniteElement<dim> &fe,
             triangulation.begin_active()->set_refine_flag();
             break;
           case 1:
-            (++(triangulation.begin_active()))->set_refine_flag();
+            (std::next((triangulation.begin_active())))->set_refine_flag();
             break;
           case 2:
-            (++(++(triangulation.begin_active())))->set_refine_flag();
+            (std::next((++(triangulation.begin_active()))))->set_refine_flag();
             break;
           default:
             Assert(false, ExcNotImplemented());

--- a/tests/serialization/hp_dof_handler_01.cc
+++ b/tests/serialization/hp_dof_handler_01.cc
@@ -193,8 +193,8 @@ test()
   dof_1.begin_active()->set_future_fe_index(0);
   dof_2.begin_active()->set_future_fe_index(0);
 
-  (++dof_1.begin_active())->set_future_fe_index(1);
-  (++dof_2.begin_active())->set_future_fe_index(1);
+  (std::next(dof_1.begin_active()))->set_future_fe_index(1);
+  (std::next(dof_2.begin_active()))->set_future_fe_index(1);
 
   // right now, both hp::DoFHandlers are the same. Renumber one of them
   DoFRenumbering::random(dof_1);

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_11.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_11.cc
@@ -38,7 +38,8 @@ test()
   // attach a sparse matrix to it
   TrilinosWrappers::SparseMatrix A(sparsity);
 
-  TrilinosWrappers::SparseMatrix::iterator k = A.begin(), j = ++A.begin();
+  TrilinosWrappers::SparseMatrix::iterator k = A.begin(),
+                                           j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());

--- a/tests/trilinos/trilinos_sparse_matrix_iterator_12.cc
+++ b/tests/trilinos/trilinos_sparse_matrix_iterator_12.cc
@@ -38,7 +38,8 @@ test()
   // attach a sparse matrix to it
   TrilinosWrappers::SparseMatrix A(sparsity);
 
-  TrilinosWrappers::SparseMatrix::const_iterator k = A.begin(), j = ++A.begin();
+  TrilinosWrappers::SparseMatrix::const_iterator k = A.begin(),
+                                                 j = std::next(A.begin());
 
   AssertThrow(k < j, ExcInternalError());
   AssertThrow(j > k, ExcInternalError());


### PR DESCRIPTION
I didn't know about `std::next` until @drwells pointed it out in #12692. In the description at https://en.cppreference.com/w/cpp/iterator/next, there is a sentence that caught my eye:

> Although the expression ++c.begin() often compiles, it is not guaranteed to do so: c.begin() is an rvalue expression, and there is no LegacyInputIterator requirement that specifies that increment of an rvalue is guaranteed to work. In particular, when iterators are implemented as pointers or its operator++ is lvalue-ref-qualified, ++c.begin() does not compile, while std::next(c.begin()) does.

I also often find it sort of awkward to read `++triangulation.begin()` because the operation `++` is at the opposite end of the expression from where I get to see what the object is that is being operated on (namely, `.begin()`). `std::next` doesn't fit this, but I still find it easier to read.

/rebuild