### PR TITLE
Fix a bug in `ParticleHandler::insert_particles(const std::vector<Point<spacedim>> &positions)`

### DIFF
--- a/doc/news/changes/minor/20210831SebastianFuchs
+++ b/doc/news/changes/minor/20210831SebastianFuchs
@@ -1,0 +1,4 @@
+Fixed: ParticleHandler::insert_particles() runs into a deadlock in parallel
+when a processor is not inserting any particles. This is now fixed.
+<br>
+(Sebastian Fuchs, 2021/08/31)

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -590,9 +590,6 @@ namespace Particles
 
     (void)missing_points;
 
-    if (cells.size() == 0)
-      return;
-
     for (unsigned int i = 0; i < cells.size(); ++i)
       for (unsigned int p = 0; p < local_positions[i].size(); ++p)
         insert_particle(positions[index_map[i][p]],


### PR DESCRIPTION
Fix a bug in `ParticleHandler::insert_particles(const std::vector<Point<spacedim>> &positions)` as described in #12724.

closes #12724