### PR TITLE
Boost 1.77 compatibility: change order of includes

### DIFF
--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -26,8 +26,13 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+/*
+ * For boost 1.77 compatibility we need to include strategies.hpp before we
+ * can include rtree.hpp. Otherwise a compilation error within boost
+ * headers is encountered.
+ */
+#include <boost/geometry/index/rtree.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <memory>


### PR DESCRIPTION
Otherwise, including both header files in reverse order leads to a
compilation failure:

```
In file included from /usr/include/boost/geometry/index/detail/rtree/rstar/choose_next_node.hpp:25,
                 from /usr/include/boost/geometry/index/detail/rtree/rstar/rstar.hpp:15,
                 from /usr/include/boost/geometry/index/rtree.hpp:80,
                 from ../include/deal.II/numerics/rtree.h:29,
                 from ../include/deal.II/grid/grid_tools.h:49,
                 from ../include/deal.II/numerics/vector_tools_point_gradient.templates.h:22,
                 from ../source/numerics/vector_tools_point_gradient.cc:17:
/usr/include/boost/geometry/index/detail/algorithms/intersection_content.hpp: In function ‘bool boost::geometry::index::detail::disjoint_box_box(const Box&, const Box&, const boost::geometry::default_strategy&)’:
/usr/include/boost/geometry/index/detail/algorithms/intersection_content.hpp:35:32: error: ‘boost::geometry::strategy::disjoint’ has not been declared
   35 |     typedef typename strategy::disjoint::services::default_strategy<Box, Box>::type strategy_type;
      |                                ^~~~~~~~
/usr/include/boost/geometry/index/detail/algorithms/intersection_content.hpp:35:68: error: expected unqualified-id before ‘<’ token
   35 |     typedef typename strategy::disjoint::services::default_strategy<Box, Box>::type strategy_type;
      |                                                                    ^
/usr/include/boost/geometry/index/detail/algorithms/intersection_content.hpp:36:83: error: class template argument deduction failed:
   36 |     return geometry::detail::disjoint::disjoint_box_box(box1, box2, strategy_type());
```