### PR TITLE
Add test for inserting particle method

### DIFF
--- a/tests/particles/insert_particle.cc
+++ b/tests/particles/insert_particle.cc
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// check that inserting particles works:
+// - in parallel when one processor is not inserting any particles
+// - and when all cells are locally owned on one processor
+
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/mapping_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_tools.h>
+
+#include <deal.II/particles/generators.h>
+#include <deal.II/particles/particle_handler.h>
+
+#include "../tests.h"
+
+template <int dim, int spacedim>
+void
+test(const unsigned int refinement)
+{
+  {
+    parallel::distributed::Triangulation<dim, spacedim> tr(MPI_COMM_WORLD);
+
+    GridGenerator::hyper_cube(tr);
+    tr.refine_global(refinement);
+    MappingQ<dim, spacedim> mapping(1);
+
+    deallog << "Refinement: " << refinement << std::endl;
+
+    deallog << "Global active cells: " << tr.n_global_active_cells()
+            << std::endl;
+    deallog << "Locally owned active cells: "
+            << tr.n_locally_owned_active_cells() << std::endl;
+
+    Particles::ParticleHandler<dim, spacedim> particle_handler(tr, mapping);
+
+    std::vector<Point<dim>> positions(1, Point<dim>());
+    if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 1)
+      positions.clear();
+
+    particle_handler.insert_particles(positions);
+
+    deallog << "Global particles: " << particle_handler.n_global_particles()
+            << std::endl;
+    deallog << "Locally owned particles: "
+            << particle_handler.n_locally_owned_particles() << std::endl;
+  }
+
+  deallog << "OK" << std::endl;
+}
+
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+  MPILogInitAll log;
+
+  deallog.push("2d/2d");
+  test<2, 2>(1);
+  deallog.pop();
+  deallog << "---" << std::endl;
+  deallog.push("2d/2d");
+  test<2, 2>(2);
+  deallog.pop();
+}

--- a/tests/particles/insert_particle.with_p4est=true.mpirun=2.output
+++ b/tests/particles/insert_particle.with_p4est=true.mpirun=2.output
@@ -1,0 +1,29 @@
+
+DEAL:0:2d/2d::Refinement: 1
+DEAL:0:2d/2d::Global active cells: 4
+DEAL:0:2d/2d::Locally owned active cells: 4
+DEAL:0:2d/2d::Global particles: 1
+DEAL:0:2d/2d::Locally owned particles: 1
+DEAL:0:2d/2d::OK
+DEAL:0:---
+DEAL:0:2d/2d::Refinement: 2
+DEAL:0:2d/2d::Global active cells: 16
+DEAL:0:2d/2d::Locally owned active cells: 8
+DEAL:0:2d/2d::Global particles: 1
+DEAL:0:2d/2d::Locally owned particles: 1
+DEAL:0:2d/2d::OK
+
+DEAL:1:2d/2d::Refinement: 1
+DEAL:1:2d/2d::Global active cells: 4
+DEAL:1:2d/2d::Locally owned active cells: 0
+DEAL:1:2d/2d::Global particles: 1
+DEAL:1:2d/2d::Locally owned particles: 0
+DEAL:1:2d/2d::OK
+DEAL:1:---
+DEAL:1:2d/2d::Refinement: 2
+DEAL:1:2d/2d::Global active cells: 16
+DEAL:1:2d/2d::Locally owned active cells: 8
+DEAL:1:2d/2d::Global particles: 1
+DEAL:1:2d/2d::Locally owned particles: 0
+DEAL:1:2d/2d::OK
+


### PR DESCRIPTION
Add a test to cover the bug fix in method `ParticleHandler::insert_particles(const std::vector<Point<spacedim>> &positions)` following #12724 and #12727.

This test is set up to run on 2 MPI ranks only: A particle is inserted on rank 0 only, while rank 1 gets no particles.