### PR TITLE
Fix unused-but-set-variable warnings

### DIFF
--- a/include/deal.II/lac/trilinos_sparse_matrix.h
+++ b/include/deal.II/lac/trilinos_sparse_matrix.h
@@ -2893,13 +2893,15 @@ namespace TrilinosWrappers
         // TODO: fix this (do not run compress here, but fail)
         if (last_action == Insert)
           {
+#      ifdef DEBUG
             int ierr;
-            ierr = matrix->GlobalAssemble(*column_space_map,
-                                          matrix->RowMap(),
-                                          false);
+            ierr =
+#      endif
+              matrix->GlobalAssemble(*column_space_map,
+                                     matrix->RowMap(),
+                                     false);
 
             Assert(ierr == 0, ExcTrilinosError(ierr));
-            (void)ierr; // removes -Wunused-but-set-variable in optimized mode
           }
 
         last_action = Add;

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1609,6 +1609,7 @@ namespace internal
             irregular_cells.back() = task_info.n_ghost_cells % n_lanes;
           }
 
+#ifdef DEBUG
         {
           unsigned int n_cells = 0;
           for (unsigned int i = 0; i < task_info.cell_partition_data.back();
@@ -1622,6 +1623,7 @@ namespace internal
             n_cells += irregular_cells[i] > 0 ? irregular_cells[i] : n_lanes;
           AssertDimension(n_cells, task_info.n_ghost_cells);
         }
+#endif
 
         task_info.cell_partition_data.push_back(
           task_info.cell_partition_data.back() + n_ghost_slots);

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -1520,7 +1520,9 @@ FE_Q_Base<dim, spacedim>::get_restriction_matrix(
                   }
               unsigned int j_indices[dim];
               internal::FE_Q_Base::zero_indices<dim>(j_indices);
+#ifdef DEBUG
               double sum_check = 0;
+#endif
               for (unsigned int j = 0; j < q_dofs_per_cell; j += dofs1d)
                 {
                   double val_extra_dim = 1.;
@@ -1540,7 +1542,9 @@ FE_Q_Base<dim, spacedim>::get_restriction_matrix(
                         my_restriction(mother_dof, child_dof) = 1.;
                       else if (std::fabs(val) > eps)
                         my_restriction(mother_dof, child_dof) = val;
+#ifdef DEBUG
                       sum_check += val;
+#endif
                     }
                   internal::FE_Q_Base::increment_indices<dim>(j_indices,
                                                               dofs1d);

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -2721,6 +2721,7 @@ namespace GridGenerator
             std::reverse(step_sizes[i].begin(), step_sizes[i].end());
           }
 
+#  ifdef DEBUG
         double x = 0;
         for (unsigned int j = 0; j < step_sizes.at(i).size(); ++j)
           x += step_sizes[i][j];
@@ -2730,6 +2731,7 @@ namespace GridGenerator
                  Utilities::int_to_string(i) +
                  " must be equal to the distance of the two given "
                  "points in this coordinate direction."));
+#  endif
       }
 
 


### PR DESCRIPTION
Note that at one place we had a fix for this warning but `nvcc` still complains. So I had to be more heavy-handed.