### PR TITLE
Avoid comment from grid_in.cc showing up in doc of read_vtk.

### DIFF
--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -388,8 +388,7 @@ GridIn<dim, spacedim>::read_vtk(std::istream &in)
                     ExcMessage(
                       "While reading VTK file, failed to find CELLS section"));
 
-      /////////////////////Processing the CELL_TYPES
-      /// section////////////////////////
+      // Processing the CELL_TYPES section
 
       in >> keyword;
 


### PR DESCRIPTION
By changing the /// to // in the cc-file.

See end of https://www.dealii.org/current/doxygen/deal.II/group__simplex.html#ga058cd187cea704428ac1118410cd0fb8