### PR TITLE
Consistently declare size_type in preconditioners derived from PreconditionRelaxation.

### DIFF
--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -498,6 +498,11 @@ class PreconditionJacobi : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
+   * Declare type for container size.
+   */
+  using size_type = typename PreconditionRelaxation<MatrixType>::size_type;
+
+  /**
    * An alias to the base class AdditionalData.
    */
   using AdditionalData =
@@ -584,6 +589,11 @@ class PreconditionSOR : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
+   * Declare type for container size.
+   */
+  using size_type = typename PreconditionRelaxation<MatrixType>::size_type;
+
+  /**
    * An alias to the base class AdditionalData.
    */
   using AdditionalData =
@@ -651,15 +661,15 @@ class PreconditionSSOR : public PreconditionRelaxation<MatrixType>
 {
 public:
   /**
+   * Declare type for container size.
+   */
+  using size_type = typename PreconditionRelaxation<MatrixType>::size_type;
+
+  /**
    * An alias to the base class AdditionalData.
    */
   using AdditionalData =
     typename PreconditionRelaxation<MatrixType>::AdditionalData;
-
-  /**
-   * Declare type for container size.
-   */
-  using size_type = typename MatrixType::size_type;
 
   /**
    * An alias to the base class.
@@ -752,7 +762,7 @@ public:
   /**
    * Declare type for container size.
    */
-  using size_type = typename MatrixType::size_type;
+  using size_type = typename PreconditionRelaxation<MatrixType>::size_type;
 
   /**
    * Parameters for PreconditionPSOR.


### PR DESCRIPTION
The base class declares a 'size_type' typedef, but only some of the derived classes
import it. Do so consistently, and do it by inheriting the type instead of
re-inventing the wheel.

Prompted by running into this `static_assert`
```
template <typename MatrixType>
template <class VectorType>
inline void
PreconditionJacobi<MatrixType>::vmult(VectorType &      dst,
                                      const VectorType &src) const
{
  static_assert(
    std::is_same<typename PreconditionJacobi<MatrixType>::size_type,
                 typename VectorType::size_type>::value,
    "PreconditionJacobi and VectorType must have the same size_type.");
```
...and having to figure out whether that type actually exists.

@juleoc02 -- FYI.

/rebuild