### PR TITLE
Bugfix: Invalid dofs on lines with similar FEs not correctly merged.

### DIFF
--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -1444,7 +1444,7 @@ namespace internal
                                              numbers::invalid_dof_index))
                                           line->set_dof_index(j,
                                                               primary_dof_index,
-                                                              fe_index_2);
+                                                              other_fe_index);
                                       }
                                   }
                               }


### PR DESCRIPTION
I don't know how to write a failing test for this bug, since all FEs that we consider for unification in that category of "similar FEs" have unique FEDomination relations, so the `other_fe_index` always ends up to be `fe_index_2`.

In my prototype which considers the tie-break criterion during unification, this is no longer the case, hence I ended up with invalid dofs after enumeration which revealed the bug.