### PR TITLE
HangingNodes: ignore artificial neighbors

### DIFF
--- a/include/deal.II/matrix_free/hanging_nodes_internal.h
+++ b/include/deal.II/matrix_free/hanging_nodes_internal.h
@@ -374,6 +374,9 @@ namespace internal
                   {
                     const auto &neighbor = cell->neighbor(face);
 
+                    if (neighbor->is_artificial())
+                      continue;
+
                     // Neighbor is coarser than us, i.e., face is constrained
                     if (neighbor->level() < cell->level())
                       {
@@ -613,6 +616,10 @@ namespace internal
                           {
                             // If one of them is coarser than us
                             const auto neighbor_cell = edge_neighbor.first;
+
+                            if (neighbor_cell->is_artificial())
+                              continue;
+
                             if (neighbor_cell->level() < cell->level())
                               {
                                 const unsigned int local_line_neighbor =


### PR DESCRIPTION
For some reason, `cell_it` might be both locally owned and ghost cells in (probably because faces are requested in the continuous FE case):

https://github.com/dealii/dealii/blob/497f915867ef1d71d33df7f618c317af0452be75/include/deal.II/matrix_free/matrix_free.templates.h#L1226-L1237

The consequence, is that the code tries to set up the hanging-node constraints also for ghost cells and looks for neighbors of these, which might be artificial (and the corresponding DoFs are invalid). I would suggest to ignore these artificial neighbors. Alternatively, one could completely exclude ghost cells form calling `process_hanging_node_constraints()`.

as reported by @mschreter 