### PR TITLE
Allow to disable fast matrix-free hanging-node algorithm

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -226,7 +226,8 @@ public:
       const bool         overlap_communication_computation    = true,
       const bool         hold_all_faces_to_owned_cells        = false,
       const bool         cell_vectorization_categories_strict = false,
-      const bool         allow_ghosted_vectors_in_loops       = true)
+      const bool         allow_ghosted_vectors_in_loops       = true,
+      const bool         use_fast_hanging_node_algorithm      = true)
       : tasks_parallel_scheme(tasks_parallel_scheme)
       , tasks_block_size(tasks_block_size)
       , mapping_update_flags(mapping_update_flags)
@@ -242,6 +243,7 @@ public:
       , cell_vectorization_categories_strict(
           cell_vectorization_categories_strict)
       , allow_ghosted_vectors_in_loops(allow_ghosted_vectors_in_loops)
+      , use_fast_hanging_node_algorithm(use_fast_hanging_node_algorithm)
       , communicator_sm(MPI_COMM_SELF)
     {}
 
@@ -268,6 +270,7 @@ public:
       , cell_vectorization_categories_strict(
           other.cell_vectorization_categories_strict)
       , allow_ghosted_vectors_in_loops(other.allow_ghosted_vectors_in_loops)
+      , use_fast_hanging_node_algorithm(other.use_fast_hanging_node_algorithm)
       , communicator_sm(other.communicator_sm)
     {}
 
@@ -295,8 +298,9 @@ public:
       cell_vectorization_category   = other.cell_vectorization_category;
       cell_vectorization_categories_strict =
         other.cell_vectorization_categories_strict;
-      allow_ghosted_vectors_in_loops = other.allow_ghosted_vectors_in_loops;
-      communicator_sm                = other.communicator_sm;
+      allow_ghosted_vectors_in_loops  = other.allow_ghosted_vectors_in_loops;
+      use_fast_hanging_node_algorithm = other.use_fast_hanging_node_algorithm;
+      communicator_sm                 = other.communicator_sm;
 
       return *this;
     }
@@ -532,6 +536,11 @@ public:
      * difference is only in whether the initial non-ghosted state is restored.
      */
     bool allow_ghosted_vectors_in_loops;
+
+    /**
+     * Flag that allows to disable the fast hanging-node algorithm.
+     */
+    bool use_fast_hanging_node_algorithm;
 
     /**
      * Shared-memory MPI communicator. Default: MPI_COMM_SELF.

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -1036,7 +1036,8 @@ namespace internal
     std::vector<MatrixFreeFunctions::DoFInfo> &         dof_info,
     MatrixFreeFunctions::FaceSetup<dim> &               face_setup,
     MatrixFreeFunctions::ConstraintValues<double> &     constraint_values,
-    const bool use_vector_data_exchanger_full)
+    const bool use_vector_data_exchanger_full,
+    const bool use_fast_hanging_node_algorithm)
   {
     if (do_face_integrals)
       face_setup.initialize(dof_handler[0]->get_triangulation(),
@@ -1225,7 +1226,8 @@ namespace internal
 
                 bool cell_has_hanging_node_constraints = false;
 
-                if (dim > 1 && dofh->get_fe_collection().size() == 1)
+                if (dim > 1 && use_fast_hanging_node_algorithm &&
+                    dofh->get_fe_collection().size() == 1)
                   {
                     local_dof_indices_resolved = local_dof_indices;
 
@@ -1749,7 +1751,8 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
     dof_info,
     face_setup,
     constraint_values,
-    additional_data.communicator_sm != MPI_COMM_SELF);
+    additional_data.communicator_sm != MPI_COMM_SELF,
+    additional_data.use_fast_hanging_node_algorithm);
 
   // set constraint pool from the std::map and reorder the indices
   std::vector<const std::vector<double> *> constraints(


### PR DESCRIPTION
We can remove it later on but currently I am switching between these configurations so often that a simple way to switch without the need to recompile the library would be good.