### PR TITLE
Make FEEvaluationBase::apply_hanging_node_constraints protected

### DIFF
--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -1274,6 +1274,13 @@ protected:
     const std::array<VectorType *, n_components_> &vectors) const;
 
   /**
+   * Apply hanging-node constraints.
+   */
+  template <bool transpose>
+  void
+  apply_hanging_node_constraints() const;
+
+  /**
    * This field stores the values for local degrees of freedom (e.g. after
    * reading out from a vector but before applying unit cell transformations
    * or before distributing them into a result vector). The methods
@@ -1417,13 +1424,6 @@ private:
    */
   void
   set_data_pointers();
-
-  /**
-   * Apply hanging-node constraints.
-   */
-  template <bool transpose>
-  void
-  apply_hanging_node_constraints() const;
 };
 
 


### PR DESCRIPTION
This is similar to the status of `read_write_operation` and the other related functions. This change allows to test `apply_hanging_node_constraints` on its own.