### PR TITLE
Fix typo in ScratchData doc

### DIFF
--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -41,7 +41,7 @@ namespace MeshWorker
    * problems, and the evaluation of finite element fields.
    *
    * This class is a drop in ScratchData to use with the WorkStream::run()
-   * function and with the MeshWorker::mesh_loop function().
+   * function and with the MeshWorker::mesh_loop() function.
    *
    * The ScratchData class has three main goals:
    * - to create FEValues, FEFaceValues, FESubfaceValues, and FEInterfaceValues


### PR DESCRIPTION
Put the parenthesis at the right place.