### PR TITLE
Mapping classes: Unify public/private properties

### DIFF
--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -181,8 +181,6 @@ public:
     dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
       &output_data) const;
 
-
-private:
   /**
    * @name Interface with FEValues
    * @{
@@ -235,6 +233,7 @@ private:
     std::vector<Point<dim>> quadrature_points;
   };
 
+private:
   // documentation can be found in Mapping::requires_update_flags()
   virtual UpdateFlags
   requires_update_flags(const UpdateFlags update_flags) const override;

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -152,7 +152,6 @@ public:
    * @{
    */
 
-public:
   /**
    * Storage for internal data of polynomial mappings. See
    * Mapping::InternalDataBase for an extensive description.
@@ -194,7 +193,6 @@ public:
     initialize_face(const UpdateFlags      update_flags,
                     const Quadrature<dim> &quadrature,
                     const unsigned int     n_original_q_points);
-
 
     /**
      * Compute the weights associated to the Manifold object, that
@@ -238,7 +236,6 @@ public:
      */
     Quadrature<dim> quad;
 
-
     /**
      * Values of quadrature weights for manifold quadrature
      * formulas.
@@ -258,7 +255,6 @@ public:
      * Computed once.
      */
     std::vector<std::vector<double>> cell_manifold_quadrature_weights;
-
 
     /**
      * A vector of weights for use in Manifold::get_new_point(). For
@@ -332,7 +328,7 @@ public:
     mutable SmartPointer<const Manifold<dim, spacedim>> manifold;
   };
 
-
+private:
   // documentation can be found in Mapping::requires_update_flags()
   virtual UpdateFlags
   requires_update_flags(const UpdateFlags update_flags) const override;

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -232,6 +232,31 @@ public:
    */
 
   /**
+   * As opposed to the other fill_fe_values() and fill_fe_face_values()
+   * functions that rely on pre-computed information of InternalDataBase, this
+   * function chooses the flexible evaluation path on the cell and points
+   * passed in to the current function.
+   *
+   * @param[in] cell The cell where to evaluate the mapping
+   *
+   * @param[in] unit_points The points in reference coordinates where the
+   * transformation (Jacobians, positions) should be computed.
+   *
+   * @param[in] update_flags The kind of information that should be computed.
+   *
+   * @param[out] output_data A struct containing the evaluated quantities such
+   * as the Jacobian resulting from application of the mapping on the given
+   * cell with its underlying manifolds.
+   */
+  void
+  fill_mapping_data_for_generic_points(
+    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
+    const ArrayView<const Point<dim>> &                         unit_points,
+    const UpdateFlags                                           update_flags,
+    dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+  /**
    * @name Interface with FEValues and friends
    * @{
    */
@@ -536,7 +561,7 @@ public:
     mutable AlignedVector<double> volume_elements;
   };
 
-
+protected:
   // documentation can be found in Mapping::requires_update_flags()
   virtual UpdateFlags
   requires_update_flags(const UpdateFlags update_flags) const override;
@@ -590,37 +615,10 @@ public:
     dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
       &output_data) const override;
 
-
-  /**
-   * As opposed to the other fill_fe_values() and fill_fe_face_values()
-   * functions that rely on pre-computed information of InternalDataBase, this
-   * function chooses the flexible evaluation path on the cell and points
-   * passed in to the current function.
-   *
-   * @param[in] cell The cell where to evaluate the mapping
-   *
-   * @param[in] unit_points The points in reference coordinates where the
-   * transformation (Jacobians, positions) should be computed.
-   *
-   * @param[in] update_flags The kind of information that should be computed.
-   *
-   * @param[out] output_data A struct containing the evaluated quantities such
-   * as the Jacobian resulting from application of the mapping on the given
-   * cell with its underlying manifolds.
-   */
-  void
-  fill_mapping_data_for_generic_points(
-    const typename Triangulation<dim, spacedim>::cell_iterator &cell,
-    const ArrayView<const Point<dim>> &                         unit_points,
-    const UpdateFlags                                           update_flags,
-    dealii::internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
-      &output_data) const;
-
   /**
    * @}
    */
 
-protected:
   /**
    * The degree of the polynomials used as shape functions for the mapping of
    * cells.


### PR DESCRIPTION
Spurred by the fact that `MappingCartesian` does not allow external use of its `InternalData` class, as opposed to `MappingQ` or `MappingFEField`, I decided to have a quick look at what kind of functions we expose in the mapping classes. I observed that `MappingQ` makes some members public which we don't in other classes, and similarly `MappingManifold`, whereas `MappingCartesian` was too conservative. Now, the classes should be more uniformly structured, of course with the caveat that `MappingQ` holds various protected attributes as there are other classes deriving from it.