### PR TITLE
Fix bug in ParameterHandler::parse_input for .prm

### DIFF
--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -1951,6 +1951,15 @@ ParameterHandler::scan_line(std::string        line,
 
           // finally write the new value into the database
           entries->put(path + path_separator + "value", entry_value);
+
+          auto map_iter = entries_set_status.find(path);
+          if (map_iter != entries_set_status.end())
+            map_iter->second =
+              std::pair<bool, bool>(map_iter->second.first, true);
+          else
+            AssertThrow(false,
+                        ExcMessage("Could not find parameter " + path +
+                                   " in map entries_set_status."));
         }
       else
         {

--- a/tests/parameter_handler/parameter_handler_26.cc
+++ b/tests/parameter_handler/parameter_handler_26.cc
@@ -20,7 +20,7 @@
 #include "../tests.h"
 
 void
-success()
+success(const std::string &filename)
 {
   unsigned int dim       = 2;
   std::string  precision = "double";
@@ -42,8 +42,6 @@ success()
 
   try
     {
-      std::string source   = SOURCE_DIR;
-      std::string filename = source + "/prm/parameter_handler_26_success.json";
       prm.parse_input(filename, "", true, true);
     }
   catch (std::exception &exc)
@@ -55,7 +53,7 @@ success()
 }
 
 void
-fail()
+fail(const std::string &filename)
 {
   unsigned int dim       = 2;
   std::string  precision = "double";
@@ -74,8 +72,6 @@ fail()
 
   try
     {
-      std::string source   = SOURCE_DIR;
-      std::string filename = source + "/prm/parameter_handler_26_fail.json";
       prm.parse_input(filename, "", true, true);
     }
   catch (std::exception &exc)
@@ -91,10 +87,13 @@ main()
   initlog();
   deallog.get_file_stream().precision(3);
 
+  const std::string source = SOURCE_DIR;
   try
     {
-      success();
-      fail();
+      success(source + "/prm/parameter_handler_26_success.json");
+      fail(source + "/prm/parameter_handler_26_fail.json");
+      success(source + "/prm/parameter_handler_26_success.prm");
+      fail(source + "/prm/parameter_handler_26_fail.prm");
     }
   catch (std::exception &exc)
     {

--- a/tests/parameter_handler/parameter_handler_26.output
+++ b/tests/parameter_handler/parameter_handler_26.output
@@ -19,3 +19,23 @@ Additional information:
     correct.
 --------------------------------------------------------
 
+DEAL::
+DEAL::successful
+DEAL::
+--------------------------------------------------------
+An error occurred in file <parameter_handler.cc> in function
+    void dealii::ParameterHandler::assert_that_entries_have_been_set() const
+The violated condition was: 
+    entries_wrongly_not_set.size() == 0
+Additional information: 
+    Not all entries of the parameter handler that were declared with
+    `has_to_be_set = true` have been set. The following parameters
+    
+    General.Precision
+    General.dim
+    
+    have not been set. A possible reason might be that you did not add
+    these parameter to the input file or that their spelling is not
+    correct.
+--------------------------------------------------------
+

--- a/tests/parameter_handler/prm/parameter_handler_26_fail.prm
+++ b/tests/parameter_handler/prm/parameter_handler_26_fail.prm
@@ -1,0 +1,3 @@
+subsection General
+  set Precison = float
+end

--- a/tests/parameter_handler/prm/parameter_handler_26_success.prm
+++ b/tests/parameter_handler/prm/parameter_handler_26_success.prm
@@ -1,0 +1,3 @@
+subsection General
+  set Precision = float
+end


### PR DESCRIPTION
The `entries_set_status` was not updated when parsing from .prm files.

I am not super happy with my fix as it copies the lines from `ParameterHandler::set` into the .prm parsing logic. When parsing .xml and .json files, it seems to directly call the `set` method. This inconsistency probably lead to the bug in the first place. Maybe it would be a good idea to call `set` for the .prm case as well? I can do it in another PR if you agree.