### PR TITLE
Add missing compress() to VectorTools::create_right_hand_side()

### DIFF
--- a/include/deal.II/numerics/vector_tools_rhs.templates.h
+++ b/include/deal.II/numerics/vector_tools_rhs.templates.h
@@ -457,6 +457,8 @@ namespace VectorTools
                                                      rhs_vector);
             }
       }
+
+    rhs_vector.compress(VectorOperation::values::add);
   }
 
 
@@ -617,6 +619,8 @@ namespace VectorTools
                                                      rhs_vector);
             }
       }
+
+    rhs_vector.compress(VectorOperation::values::add);
   }
 
 


### PR DESCRIPTION
The functions are using `AffineConstraints::distribute_local_to_global()` so compress seems to be needed in parallel. The documentation does not state anything different!?