### PR TITLE
Simplify a piece of code.

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -237,13 +237,13 @@ namespace internal
                 const auto reference_cell = (*fe)[i].reference_cell();
 
                 if (reference_cell.is_hyper_cube())
-                  needs_hypercube_setup |= true;
+                  needs_hypercube_setup = true;
                 else if (reference_cell.is_simplex())
-                  needs_simplex_setup |= true;
+                  needs_simplex_setup = true;
                 else if (reference_cell == dealii::ReferenceCells::Wedge)
-                  needs_wedge_setup |= true;
+                  needs_wedge_setup = true;
                 else if (reference_cell == dealii::ReferenceCells::Pyramid)
-                  needs_pyramid_setup |= true;
+                  needs_pyramid_setup = true;
                 else
                   Assert(false, ExcNotImplemented());
               }


### PR DESCRIPTION
We initialize variables with `false` and only ever do `|= true`. This is equivalent to doing `= true` right away.

/rebuild