### PR TITLE
QIterated: varying subdivisions

### DIFF
--- a/include/deal.II/base/quadrature.h
+++ b/include/deal.II/base/quadrature.h
@@ -374,6 +374,18 @@ public:
   QIterated(const Quadrature<1> &base_quadrature, const unsigned int n_copies);
 
   /**
+   * Constructor. Iterate the given quadrature formula on the given subintervals
+   * defined by adjacent points in @p intervals in each direction. The resulting
+   * quadrature rule will have `base_quadrature.size() * (intervals.size() - 1)`
+   * quadrature points if no quadrature point of `base_quadrature` is positioned
+   * on the boundaries.
+   *
+   * @note We require that `intervals.front() == 0` and `interval.back() == 1`.
+   */
+  QIterated(const Quadrature<1> &        base_quadrature,
+            const std::vector<Point<1>> &intervals);
+
+  /**
    * Exception
    */
   DeclExceptionMsg(ExcInvalidQuadratureFormula,

--- a/source/base/quadrature.cc
+++ b/source/base/quadrature.cc
@@ -449,9 +449,32 @@ namespace internal
                       [](const Point<1> &p) { return p == Point<1>{1.}; });
         return (at_left && at_right);
       }
+
+      std::vector<Point<1>>
+      create_interval_points(const unsigned int n_copies)
+      {
+        std::vector<Point<1>> support_points(n_copies + 1);
+
+        for (unsigned int copy = 0; copy < n_copies; ++copy)
+          support_points[copy][0] =
+            static_cast<double>(copy) / static_cast<double>(n_copies);
+
+        support_points[n_copies][0] = 1.0;
+
+        return support_points;
+      }
     } // namespace
   }   // namespace QIteratedImplementation
 } // namespace internal
+
+
+
+template <>
+QIterated<0>::QIterated(const Quadrature<1> &, const std::vector<Point<1>> &)
+  : Quadrature<0>()
+{
+  Assert(false, ExcNotImplemented());
+}
 
 
 
@@ -465,15 +488,17 @@ QIterated<0>::QIterated(const Quadrature<1> &, const unsigned int)
 
 
 template <>
-QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
-                        const unsigned int   n_copies)
+QIterated<1>::QIterated(const Quadrature<1> &        base_quadrature,
+                        const std::vector<Point<1>> &intervals)
   : Quadrature<1>(
       internal::QIteratedImplementation::uses_both_endpoints(base_quadrature) ?
-        (base_quadrature.size() - 1) * n_copies + 1 :
-        base_quadrature.size() * n_copies)
+        (base_quadrature.size() - 1) * (intervals.size() - 1) + 1 :
+        base_quadrature.size() * (intervals.size() - 1))
 {
   Assert(base_quadrature.size() > 0, ExcNotInitialized());
-  Assert(n_copies > 0, ExcZero());
+  Assert(intervals.size() > 1, ExcZero());
+
+  const unsigned int n_copies = intervals.size() - 1;
 
   if (!internal::QIteratedImplementation::uses_both_endpoints(base_quadrature))
     // we don't have to skip some points in order to get a reasonable quadrature
@@ -485,10 +510,12 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
              ++q_point)
           {
             this->quadrature_points[next_point] =
-              Point<1>(base_quadrature.point(q_point)(0) / n_copies +
-                       (1.0 * copy) / n_copies);
+              Point<1>(base_quadrature.point(q_point)(0) *
+                         (intervals[copy + 1][0] - intervals[copy][0]) +
+                       intervals[copy][0]);
             this->weights[next_point] =
-              base_quadrature.weight(q_point) / n_copies;
+              base_quadrature.weight(q_point) *
+              (intervals[copy + 1][0] - intervals[copy][0]);
 
             ++next_point;
           }
@@ -496,53 +523,70 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
   else
     // skip doubly available points
     {
-      unsigned int next_point = 0;
+      const unsigned int left_index =
+        std::distance(base_quadrature.get_points().begin(),
+                      std::find_if(base_quadrature.get_points().cbegin(),
+                                   base_quadrature.get_points().cend(),
+                                   [](const Point<1> &p) {
+                                     return p == Point<1>{0.};
+                                   }));
 
-      // first find out the weights of the left and the right boundary points.
-      // note that these usually are but need not necessarily be the same
-      double       double_point_weight = 0;
-      unsigned int n_end_points        = 0;
-      for (unsigned int i = 0; i < base_quadrature.size(); ++i)
-        // add up the weight if this is an endpoint
-        if ((base_quadrature.point(i) == Point<1>(0.0)) ||
-            (base_quadrature.point(i) == Point<1>(1.0)))
-          {
-            double_point_weight += base_quadrature.weight(i);
-            ++n_end_points;
-          }
-      // scale the weight correctly
-      double_point_weight /= n_copies;
+      const unsigned int right_index =
+        std::distance(base_quadrature.get_points().begin(),
+                      std::find_if(base_quadrature.get_points().cbegin(),
+                                   base_quadrature.get_points().cend(),
+                                   [](const Point<1> &p) {
+                                     return p == Point<1>{1.};
+                                   }));
 
-      // make sure the base quadrature formula has only one quadrature point per
-      // end point
-      Assert(n_end_points == 2, ExcInvalidQuadratureFormula());
+      const unsigned double_point_offset =
+        left_index + (base_quadrature.size() - right_index);
 
-
-      for (unsigned int copy = 0; copy < n_copies; ++copy)
+      for (unsigned int copy = 0, next_point = 0; copy < n_copies; ++copy)
         for (unsigned int q_point = 0; q_point < base_quadrature.size();
              ++q_point)
           {
             // skip the left point of this copy since we have already entered it
             // the last time
             if ((copy > 0) && (base_quadrature.point(q_point) == Point<1>(0.0)))
-              continue;
+              {
+                Assert(this->quadrature_points[next_point - double_point_offset]
+                           .distance(Point<1>(
+                             base_quadrature.point(q_point)(0) *
+                               (intervals[copy + 1][0] - intervals[copy][0]) +
+                             intervals[copy][0])) < 1e-10 /*tolerance*/,
+                       ExcInternalError());
+
+                this->weights[next_point - double_point_offset] +=
+                  base_quadrature.weight(q_point) *
+                  (intervals[copy + 1][0] - intervals[copy][0]);
+
+                continue;
+              }
 
             this->quadrature_points[next_point] =
-              Point<1>(base_quadrature.point(q_point)(0) / n_copies +
-                       (1.0 * copy) / n_copies);
+              Point<1>(base_quadrature.point(q_point)(0) *
+                         (intervals[copy + 1][0] - intervals[copy][0]) +
+                       intervals[copy][0]);
 
             // if this is the rightmost point of one of the non-last copies:
             // give it the double weight
-            if ((copy != n_copies - 1) &&
-                (base_quadrature.point(q_point) == Point<1>(1.0)))
-              this->weights[next_point] = double_point_weight;
-            else
-              this->weights[next_point] =
-                base_quadrature.weight(q_point) / n_copies;
+            this->weights[next_point] =
+              base_quadrature.weight(q_point) *
+              (intervals[copy + 1][0] - intervals[copy][0]);
 
             ++next_point;
           }
     }
+
+  // make sure that there is no rounding error for 0.0 and 1.0, since there
+  // are multiple asserts in the library checking for equality without
+  // tolorances
+  for (auto &i : this->quadrature_points)
+    if (std::abs(i[0] - 0.0) < 1e-12)
+      i[0] = 0.0;
+    else if (std::abs(i[0] - 1.0) < 1e-12)
+      i[0] = 1.0;
 
 #if DEBUG
   double sum_of_weights = 0;
@@ -554,13 +598,35 @@ QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
 
 
 
+template <>
+QIterated<1>::QIterated(const Quadrature<1> &base_quadrature,
+                        const unsigned int   n_copies)
+  : QIterated<1>(base_quadrature,
+                 internal::QIteratedImplementation::create_interval_points(
+                   n_copies))
+{
+  Assert(base_quadrature.size() > 0, ExcNotInitialized());
+  Assert(n_copies > 0, ExcZero());
+}
+
+
+
 // construct higher dimensional quadrature formula by tensor product
 // of lower dimensional iterated quadrature formulae
 template <int dim>
+QIterated<dim>::QIterated(const Quadrature<1> &        base_quadrature,
+                          const std::vector<Point<1>> &intervals)
+  : Quadrature<dim>(QIterated<dim - 1>(base_quadrature, intervals),
+                    QIterated<1>(base_quadrature, intervals))
+{}
+
+
+
+template <int dim>
 QIterated<dim>::QIterated(const Quadrature<1> &base_quadrature,
-                          const unsigned int   N)
-  : Quadrature<dim>(QIterated<dim - 1>(base_quadrature, N),
-                    QIterated<1>(base_quadrature, N))
+                          const unsigned int   n_copies)
+  : Quadrature<dim>(QIterated<dim - 1>(base_quadrature, n_copies),
+                    QIterated<1>(base_quadrature, n_copies))
 {}
 
 

--- a/tests/base/quadrature_qiterated_01.cc
+++ b/tests/base/quadrature_qiterated_01.cc
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2020 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test QIterated for varying subdivisions.
+
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include "../tests.h"
+
+using namespace dealii;
+
+template <int dim>
+void
+test(const Quadrature<1> &q_outer, const Quadrature<1> &q_inner)
+{
+  QIterated<dim> quad(q_inner, q_outer.get_points());
+
+  for (unsigned int q = 0; q < quad.size(); ++q)
+    {
+      deallog << quad.point(q) << " ";
+      deallog << quad.weight(q) << " ";
+      deallog << std::endl;
+    }
+  deallog << std::endl;
+}
+
+template <int dim>
+void
+test()
+{
+  for (unsigned int i = 2; i <= 4; ++i)
+    for (unsigned int j = 1; j <= 3; ++j)
+      {
+        deallog.push("QGaussLobatto<1>(" + std::to_string(i) +
+                     ") + QGauss<1>(" + std::to_string(j) + ")");
+        test<dim>(QGaussLobatto<1>(i), QGauss<1>(j));
+        deallog.pop();
+      }
+
+  for (unsigned int i = 2; i <= 4; ++i)
+    for (unsigned int j = 2; j <= 3; ++j)
+      {
+        deallog.push("QGaussLobatto<1>(" + std::to_string(i) +
+                     ") + QGaussLobatto<1>(" + std::to_string(j) + ")");
+        test<dim>(QGaussLobatto<1>(i), QGaussLobatto<1>(j));
+        deallog.pop();
+      }
+}
+
+int
+main()
+{
+  initlog();
+
+  test<1>();
+  test<2>();
+}

--- a/tests/base/quadrature_qiterated_01.output
+++ b/tests/base/quadrature_qiterated_01.output
@@ -1,0 +1,399 @@
+
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(1)::0.500000 1.00000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.211325 0.500000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.788675 0.500000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.112702 0.277778 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.500000 0.444444 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.887298 0.277778 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.250000 0.500000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.750000 0.500000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.105662 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.394338 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.605662 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.894338 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.138889 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.222222 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.138889 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.138889 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.222222 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.138889 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.138197 0.276393 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.500000 0.447214 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.861803 0.276393 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.223607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.223607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.0767759 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.122841 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.0767759 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.124226 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.198762 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.124226 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.0767759 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.122841 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.0767759 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::0.00000 0.500000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::1.00000 0.500000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.00000 0.166667 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.500000 0.666667 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::1.00000 0.166667 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.00000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.500000 0.500000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::1.00000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 0.0833333 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 0.333333 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 0.166667 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 0.333333 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 0.0833333 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.00000 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.276393 0.361803 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.723607 0.361803 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::1.00000 0.138197 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.0460655 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.184262 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.120601 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.298142 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.120601 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.184262 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.0460655 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(1)::0.500000 0.500000 1.00000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.211325 0.211325 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.788675 0.211325 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.211325 0.788675 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::0.788675 0.788675 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.112702 0.112702 0.0771605 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.500000 0.112702 0.123457 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.887298 0.112702 0.0771605 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.112702 0.500000 0.123457 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.500000 0.500000 0.197531 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.887298 0.500000 0.123457 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.112702 0.887298 0.0771605 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.500000 0.887298 0.123457 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::0.887298 0.887298 0.0771605 
+DEAL:QGaussLobatto<1>(2) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.250000 0.250000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.750000 0.250000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.250000 0.750000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::0.750000 0.750000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.105662 0.105662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.394338 0.105662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.605662 0.105662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.894338 0.105662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.105662 0.394338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.394338 0.394338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.605662 0.394338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.894338 0.394338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.105662 0.605662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.394338 0.605662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.605662 0.605662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.894338 0.605662 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.105662 0.894338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.394338 0.894338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.605662 0.894338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::0.894338 0.894338 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.0563508 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.0563508 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.0563508 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.0563508 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.0563508 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.0563508 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.250000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.250000 0.0493827 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.250000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.250000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.250000 0.0493827 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.250000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.443649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.443649 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.443649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.443649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.443649 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.443649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.556351 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.556351 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.556351 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.556351 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.556351 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.556351 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.750000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.750000 0.0493827 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.750000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.750000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.750000 0.0493827 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.750000 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.0563508 0.943649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.250000 0.943649 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.443649 0.943649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.556351 0.943649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.750000 0.943649 0.0308642 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::0.943649 0.943649 0.0192901 
+DEAL:QGaussLobatto<1>(3) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.138197 0.138197 0.0763932 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.500000 0.138197 0.123607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.861803 0.138197 0.0763932 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.138197 0.500000 0.123607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.500000 0.500000 0.200000 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.861803 0.500000 0.123607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.138197 0.861803 0.0763932 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.500000 0.861803 0.123607 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::0.861803 0.861803 0.0763932 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(1)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.0584088 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.0584088 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.0584088 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.0584088 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.0584088 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.0584088 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.217984 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.217984 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.217984 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.217984 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.217984 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.217984 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.370901 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.370901 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.370901 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.370901 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.370901 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.370901 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.629099 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.629099 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.629099 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.629099 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.629099 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.629099 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.782016 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.782016 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.782016 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.782016 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.782016 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.782016 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.0584088 0.941591 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.217984 0.941591 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.370901 0.941591 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.629099 0.941591 0.0309017 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.782016 0.941591 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::0.941591 0.941591 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(2)::
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.0311500 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.0311500 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.0311500 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.0311500 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.0311500 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.0311500 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.0311500 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.0311500 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.0311500 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.138197 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.138197 0.0150900 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.138197 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.138197 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.138197 0.0244162 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.138197 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.138197 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.138197 0.0150900 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.138197 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.245243 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.245243 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.245243 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.245243 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.245243 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.245243 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.245243 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.245243 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.245243 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.326795 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.326795 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.326795 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.326795 0.0154321 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.326795 0.0246914 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.326795 0.0154321 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.326795 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.326795 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.326795 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.500000 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.500000 0.0244162 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.500000 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.500000 0.0246914 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.500000 0.0395062 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.500000 0.0246914 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.500000 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.500000 0.0244162 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.500000 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.673205 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.673205 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.673205 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.673205 0.0154321 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.673205 0.0246914 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.673205 0.0154321 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.673205 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.673205 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.673205 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.754757 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.754757 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.754757 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.754757 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.754757 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.754757 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.754757 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.754757 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.754757 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.861803 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.861803 0.0150900 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.861803 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.861803 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.861803 0.0244162 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.861803 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.861803 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.861803 0.0150900 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.861803 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.0311500 0.968850 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.138197 0.968850 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.245243 0.968850 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.326795 0.968850 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.500000 0.968850 0.0152601 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.673205 0.968850 0.00953756 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.754757 0.968850 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.861803 0.968850 0.00943126 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::0.968850 0.968850 0.00589454 
+DEAL:QGaussLobatto<1>(4) + QGauss<1>(3)::
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::0.00000 0.00000 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::1.00000 0.00000 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::0.00000 1.00000 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::1.00000 1.00000 0.250000 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.00000 0.00000 0.0277778 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.500000 0.00000 0.111111 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::1.00000 0.00000 0.0277778 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.00000 0.500000 0.111111 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.500000 0.500000 0.444444 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::1.00000 0.500000 0.111111 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.00000 1.00000 0.0277778 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::0.500000 1.00000 0.111111 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::1.00000 1.00000 0.0277778 
+DEAL:QGaussLobatto<1>(2) + QGaussLobatto<1>(3)::
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.00000 0.00000 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.500000 0.00000 0.125000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::1.00000 0.00000 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.00000 0.500000 0.125000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.500000 0.500000 0.250000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::1.00000 0.500000 0.125000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.00000 1.00000 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::0.500000 1.00000 0.125000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::1.00000 1.00000 0.0625000 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 0.00000 0.00694444 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 0.00000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 0.00000 0.0138889 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 0.00000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 0.00000 0.00694444 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 0.250000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 0.250000 0.111111 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 0.250000 0.0555556 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 0.250000 0.111111 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 0.250000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 0.500000 0.0138889 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 0.500000 0.0555556 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 0.500000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 0.500000 0.0555556 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 0.500000 0.0138889 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 0.750000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 0.750000 0.111111 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 0.750000 0.0555556 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 0.750000 0.111111 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 0.750000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.00000 1.00000 0.00694444 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.250000 1.00000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.500000 1.00000 0.0138889 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::0.750000 1.00000 0.0277778 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::1.00000 1.00000 0.00694444 
+DEAL:QGaussLobatto<1>(3) + QGaussLobatto<1>(3)::
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.00000 0.00000 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.276393 0.00000 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.723607 0.00000 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::1.00000 0.00000 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.00000 0.276393 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.276393 0.276393 0.130902 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.723607 0.276393 0.130902 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::1.00000 0.276393 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.00000 0.723607 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.276393 0.723607 0.130902 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.723607 0.723607 0.130902 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::1.00000 0.723607 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.00000 1.00000 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.276393 1.00000 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::0.723607 1.00000 0.0500000 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::1.00000 1.00000 0.0190983 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(2)::
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.00000 0.00212203 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.00000 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.00000 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.00000 0.0137341 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.00000 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.00000 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.00000 0.00212203 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.138197 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.138197 0.0339525 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.138197 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.138197 0.0549364 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.138197 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.138197 0.0339525 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.138197 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.276393 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.276393 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.276393 0.0145446 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.276393 0.0359563 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.276393 0.0145446 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.276393 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.276393 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.500000 0.0137341 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.500000 0.0549364 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.500000 0.0359563 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.500000 0.0888889 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.500000 0.0359563 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.500000 0.0549364 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.500000 0.0137341 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.723607 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.723607 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.723607 0.0145446 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.723607 0.0359563 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.723607 0.0145446 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.723607 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.723607 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 0.861803 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 0.861803 0.0339525 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 0.861803 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 0.861803 0.0549364 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 0.861803 0.0222222 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 0.861803 0.0339525 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 0.861803 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.00000 1.00000 0.00212203 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.138197 1.00000 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.276393 1.00000 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.500000 1.00000 0.0137341 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.723607 1.00000 0.00555556 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::0.861803 1.00000 0.00848813 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::1.00000 1.00000 0.00212203 
+DEAL:QGaussLobatto<1>(4) + QGaussLobatto<1>(3)::


### PR DESCRIPTION
The aim is:
```cpp
const unsigned int n_subdivisions = 5;
const unsigned int n_q_points = 2;
    
QGaussLobatto<1> q_outer(n_subdivisions);
QGauss<1>        q_inner(n_q_points);
    
QIterated<dim> q(q_inner, q_outer.get_points());
```

This is the appropriate quadrature rule to `FE_Q_iso_Q1` with varying subdivisions (see #12838).