### PR TITLE
No more magic number Pi.

### DIFF
--- a/examples/step-11/step-11.cc
+++ b/examples/step-11/step-11.cc
@@ -22,6 +22,7 @@
 // you are probably already used to by now:
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/function.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/logstream.h>
 #include <deal.II/base/table_handler.h>
 #include <deal.II/lac/vector.h>
@@ -360,8 +361,7 @@ namespace Step11
     // Last task -- generate output:
     output_table.add_value("cells", triangulation.n_active_cells());
     output_table.add_value("|u|_1", norm);
-    output_table.add_value("error",
-                           std::fabs(norm - std::sqrt(3.14159265358 / 2)));
+    output_table.add_value("error", std::fabs(norm - std::sqrt(numbers::PI_2)));
   }
 
 

--- a/tests/base/function_parser_02.cc
+++ b/tests/base/function_parser_02.cc
@@ -21,6 +21,7 @@
 // recycle the test to use constants instead of units
 
 #include <deal.II/base/function_parser.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 
 #include <deal.II/lac/vector.h>
@@ -40,7 +41,7 @@ main()
   std::vector<std::string>      function(1);
   std::map<std::string, double> constants;
 
-  constants["PI"] = 3.141592654;
+  constants["PI"] = numbers::PI;
   constants["cm"] = 10;
   constants["m"]  = 1000;
 

--- a/tests/base/utilities_pack_unpack_03.cc
+++ b/tests/base/utilities_pack_unpack_03.cc
@@ -18,6 +18,7 @@
 // for trivially-copyable (small) types, packing is just a memcpy
 // operation
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/point.h>
 #include <deal.II/base/utilities.h>
 
@@ -80,7 +81,7 @@ test()
   deallog << "std::array:" << std::endl;
   check(std::array<int, 3>{{1, 2, 3}});
   deallog << "struct X:" << std::endl;
-  check(X{1, 2, 3.1415926});
+  check(X{1, 2, numbers::PI});
   deallog << "double:" << std::endl;
   check(1.);
 }

--- a/tests/bits/step-11.cc
+++ b/tests/bits/step-11.cc
@@ -18,6 +18,7 @@
 // a un-hp-ified version of hp/step-11
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table_handler.h>
 
@@ -173,8 +174,7 @@ LaplaceProblem<dim>::assemble_and_solve()
 
   output_table.add_value("cells", triangulation.n_active_cells());
   output_table.add_value("|u|_1", norm);
-  output_table.add_value("error",
-                         std::fabs(norm - std::sqrt(3.14159265358 / 2)));
+  output_table.add_value("error", std::fabs(norm - std::sqrt(numbers::PI_2)));
 }
 
 

--- a/tests/dofs/dof_test.cc
+++ b/tests/dofs/dof_test.cc
@@ -15,6 +15,8 @@
 
 
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/dofs/dof_accessor.h>
 #include <deal.II/dofs/dof_handler.h>
 #include <deal.II/dofs/dof_renumbering.h>
@@ -130,14 +132,14 @@ CurvedLine<dim>::get_new_point_on_line(
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * 3.141592 * middle(0));
+      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(1));
+      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * 3.141592 * middle(1));
+    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(0));
+    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
 
   return middle;
 }
@@ -164,14 +166,14 @@ CurvedLine<dim>::get_new_point_on_quad(
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * 3.141592 * middle(0));
+      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(1));
+      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * 3.141592 * middle(1));
+    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(0));
+    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
 
   return middle;
 }

--- a/tests/fe/non_primitive_1.cc
+++ b/tests/fe/non_primitive_1.cc
@@ -23,6 +23,7 @@
 // and compare again whether the matrices are the same
 
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -70,7 +71,7 @@ create_stokes_matrix_1(const DoFHandler<dim> &dof_handler,
                           quadrature,
                           update_values | update_gradients | update_JxW_values);
 
-  const double nu = 3.14159265358e-2;
+  const double nu = 0.01 * numbers::PI;
 
   for (; cell != endc; ++cell)
     {
@@ -140,7 +141,7 @@ create_stokes_matrix_2(const DoFHandler<dim> &dof_handler,
                           quadrature,
                           update_values | update_gradients | update_JxW_values);
 
-  const double nu = 3.14159265358e-2;
+  const double nu = 0.01 * numbers::PI;
 
   for (; cell != endc; ++cell)
     {
@@ -214,7 +215,7 @@ create_stokes_matrix_3(const DoFHandler<dim> &dof_handler,
                           quadrature,
                           update_values | update_gradients | update_JxW_values);
 
-  const double nu = 3.14159265358e-2;
+  const double nu = 0.01 * numbers::PI;
 
   for (; cell != endc; ++cell)
     {

--- a/tests/fe/non_primitive_2.cc
+++ b/tests/fe/non_primitive_2.cc
@@ -21,6 +21,7 @@
 // of course, it makes absolutely no sense to work the Stokes equation
 // with a Nedelec element, but this is just to test the library, no?
 
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -73,7 +74,7 @@ create_stokes_matrix_2(const DoFHandler<dim> &dof_handler,
                           quadrature,
                           update_values | update_gradients | update_JxW_values);
 
-  const double nu = 3.14159265358e-2;
+  const double nu = 0.01 * numbers::PI;
 
   for (; cell != endc; ++cell)
     {
@@ -147,7 +148,7 @@ create_stokes_matrix_3(const DoFHandler<dim> &dof_handler,
                           quadrature,
                           update_values | update_gradients | update_JxW_values);
 
-  const double nu = 3.14159265358e-2;
+  const double nu = 0.01 * numbers::PI;
 
   for (; cell != endc; ++cell)
     {

--- a/tests/grid/grid_test.cc
+++ b/tests/grid/grid_test.cc
@@ -15,6 +15,8 @@
 
 
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/grid/grid_generator.h>
 #include <deal.II/grid/grid_out.h>
 #include <deal.II/grid/manifold_lib.h>
@@ -107,14 +109,14 @@ CurvedLine<dim>::get_new_point_on_line(
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * 3.141592 * middle(0));
+      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(1));
+      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * 3.141592 * middle(1));
+    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(0));
+    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
 
   return middle;
 }
@@ -140,14 +142,14 @@ CurvedLine<dim>::get_new_point_on_quad(
 
   if (y < x)
     if (y < 1 - x)
-      middle(1) = 0.04 * std::sin(6 * 3.141592 * middle(0));
+      middle(1) = 0.04 * std::sin(6 * numbers::PI * middle(0));
     else
-      middle(0) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(1));
+      middle(0) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(1));
 
   else if (y < 1 - x)
-    middle(0) = 0.04 * std::sin(6 * 3.141592 * middle(1));
+    middle(0) = 0.04 * std::sin(6 * numbers::PI * middle(1));
   else
-    middle(1) = 1 + 0.04 * std::sin(6 * 3.141592 * middle(0));
+    middle(1) = 1 + 0.04 * std::sin(6 * numbers::PI * middle(0));
 
   return middle;
 }

--- a/tests/hp/step-11.cc
+++ b/tests/hp/step-11.cc
@@ -19,6 +19,7 @@
 
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table_handler.h>
 
@@ -180,8 +181,7 @@ LaplaceProblem<dim>::assemble_and_solve()
 
   output_table.add_value("cells", triangulation.n_active_cells());
   output_table.add_value("|u|_1", norm);
-  output_table.add_value("error",
-                         std::fabs(norm - std::sqrt(3.14159265358 / 2)));
+  output_table.add_value("error", std::fabs(norm - std::sqrt(numbers::PI_2)));
 }
 
 

--- a/tests/lac/la_parallel_vector_add_and_dot_complex.cc
+++ b/tests/lac/la_parallel_vector_add_and_dot_complex.cc
@@ -17,6 +17,8 @@
 // check that LinearAlgebra::distributed::Vector::add_and_dot works correctly
 // for complex-valued vectors
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/la_parallel_vector.h>
 
 #include "../tests.h"
@@ -39,7 +41,8 @@ check()
         {
           v1(i) = std::complex<number>(0.1 + 0.005 * i, 1.234 + 12 * i);
           v2(i) = std::complex<number>(-5.2 + 0.18 * i, 42.4242 + 42 * i);
-          v3(i) = std::complex<number>(3.14159 + 2.7183 / (1. + i), 13.);
+          v3(i) =
+            std::complex<number>(numbers::PI + numbers::E / (1. + i), 13.);
         }
       check                             = v1;
       const std::complex<number> factor = std::complex<number>(0.01432);

--- a/tests/lac/la_vector_add_and_dot.cc
+++ b/tests/lac/la_vector_add_and_dot.cc
@@ -16,6 +16,8 @@
 
 // check that LinearAlgebra::Vector::add_and_dot works correctly
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/la_vector.h>
 
 #include "../tests.h"
@@ -36,7 +38,7 @@ check()
         {
           v1[i] = 0.1 + 0.005 * i;
           v2[i] = -5.2 + 0.18 * i;
-          v3[i] = 3.14159 + 2.7183 / (1. + i);
+          v3[i] = numbers::PI + numbers::E / (1. + i);
         }
       check               = v1;
       const number factor = 0.01432;

--- a/tests/lac/la_vector_add_and_dot_complex.cc
+++ b/tests/lac/la_vector_add_and_dot_complex.cc
@@ -17,6 +17,8 @@
 // check that LinearAlgebra::Vector::add_and_dot works correctly for
 // complex-valued vectors
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/la_vector.h>
 
 #include "../tests.h"
@@ -36,7 +38,8 @@ check()
         {
           v1(i) = std::complex<number>(0.1 + 0.005 * i, 1.234 + 12 * i);
           v2(i) = std::complex<number>(-5.2 + 0.18 * i, 42.4242 + 42 * i);
-          v3(i) = std::complex<number>(3.14159 + 2.7183 / (1. + i), 13.);
+          v3(i) =
+            std::complex<number>(numbers::PI + numbers::E / (1. + i), 13.);
         }
       check                             = v1;
       const std::complex<number> factor = std::complex<number>(0.01432);

--- a/tests/lac/la_vector_norms.cc
+++ b/tests/lac/la_vector_norms.cc
@@ -18,6 +18,8 @@
 // (check the summation algorithm), including an accuracy test (should not
 // lose more than 1 decimal also for 200000 vector entries)
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/la_vector.h>
 
 #include "../tests.h"
@@ -45,7 +47,7 @@ check_norms()
                   ExcInternalError());
 
       // test accuracy of summation
-      const long double value = 3.14159265358979323846;
+      constexpr long double value = numbers::PI;
       for (unsigned int i = 0; i < size; ++i)
         vec[i] = (number)value;
       const number l1_norma = vec.l1_norm();
@@ -83,7 +85,7 @@ check_complex_norms()
       AssertThrow(std::abs(l1_norm - sum) < acc * sum, ExcInternalError());
 
       // test accuracy of summation
-      const std::complex<long double> value(3.14159265358979323846, 0.1);
+      constexpr std::complex<long double> value(numbers::PI, 0.1);
       for (unsigned int i = 0; i < size; ++i)
         vec[i] = std::complex<number>(value);
       const number l1_norma = vec.l1_norm();

--- a/tests/lac/vector_add_and_dot.cc
+++ b/tests/lac/vector_add_and_dot.cc
@@ -16,6 +16,8 @@
 
 // check that Vector::add_and_dot works correctly
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
@@ -34,7 +36,7 @@ check()
         {
           v1(i) = 0.1 + 0.005 * i;
           v2(i) = -5.2 + 0.18 * i;
-          v3(i) = 3.14159 + 2.7183 / (1. + i);
+          v3(i) = numbers::PI + numbers::E / (1. + i);
         }
       check               = v1;
       const number factor = 0.01432;

--- a/tests/lac/vector_add_and_dot_complex.cc
+++ b/tests/lac/vector_add_and_dot_complex.cc
@@ -17,6 +17,8 @@
 // check that Vector::add_and_dot works correctly for complex-valued
 // vectors
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
@@ -35,7 +37,8 @@ check()
         {
           v1(i) = std::complex<number>(0.1 + 0.005 * i, 1.234 + 12 * i);
           v2(i) = std::complex<number>(-5.2 + 0.18 * i, 42.4242 + 42 * i);
-          v3(i) = std::complex<number>(3.14159 + 2.7183 / (1. + i), 13.);
+          v3(i) =
+            std::complex<number>(numbers::PI + numbers::E / (1. + i), 13.);
         }
       check                             = v1;
       const std::complex<number> factor = std::complex<number>(0.01432);

--- a/tests/lac/vector_norms.cc
+++ b/tests/lac/vector_norms.cc
@@ -18,6 +18,8 @@
 // (check the summation algorithm), including an accuracy test (should not
 // lose more than 1 decimal also for 200000 vector entries)
 
+#include <deal.II/base/numbers.h>
+
 #include <deal.II/lac/vector.h>
 
 #include "../tests.h"
@@ -45,9 +47,9 @@ check_norms()
                   ExcInternalError());
 
       // test accuracy of summation
-      const long double value = 3.14159265358979323846;
-      vec                     = (number)value;
-      const number l1_norma   = vec.l1_norm();
+      constexpr long double value = numbers::PI;
+      vec                         = (number)value;
+      const number l1_norma       = vec.l1_norm();
       AssertThrow(std::abs(l1_norma - value * size) < acc * size * value,
                   ExcInternalError());
       const number l2_norma = vec.l2_norm();
@@ -90,7 +92,7 @@ check_complex_norms()
       AssertThrow(std::abs(l1_norm - sum) < acc * sum, ExcInternalError());
 
       // test accuracy of summation
-      const std::complex<long double> value(3.14159265358979323846, 0.1);
+      constexpr std::complex<long double> value(numbers::PI, 0.1);
       vec                   = std::complex<number>(value);
       const number l1_norma = vec.l1_norm();
       AssertThrow(std::abs(l1_norma - std::abs(value) * size) <

--- a/tests/lac/vector_operations_parallel_for_start_end.cc
+++ b/tests/lac/vector_operations_parallel_for_start_end.cc
@@ -17,6 +17,7 @@
 // check that internal::VectorOperations::parallel_for works for start-end
 
 #include <deal.II/base/index_set.h>
+#include <deal.II/base/numbers.h>
 
 #include <deal.II/lac/vector_operations_internal.h>
 
@@ -42,7 +43,7 @@ check()
                                         64,
                                         sizeof(Number) * size);
 
-      const Number                                   s = 3.1415;
+      const Number                                   s = numbers::PI;
       internal::VectorOperations::Vector_set<Number> setter(s, val);
 
       // now break the size in chunks

--- a/tests/meshworker/step-11-mesh_loop.cc
+++ b/tests/meshworker/step-11-mesh_loop.cc
@@ -18,6 +18,7 @@
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/logstream.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table_handler.h>
 
@@ -348,8 +349,7 @@ namespace Step11
     // Last task -- generate output:
     output_table.add_value("cells", triangulation.n_active_cells());
     output_table.add_value("|u|_1", norm);
-    output_table.add_value("error",
-                           std::fabs(norm - std::sqrt(3.14159265358 / 2)));
+    output_table.add_value("error", std::fabs(norm - std::sqrt(numbers::PI_2)));
   }
 
 

--- a/tests/quick_tests/step.cc
+++ b/tests/quick_tests/step.cc
@@ -19,6 +19,7 @@
 
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/numbers.h>
 #include <deal.II/base/quadrature_lib.h>
 #include <deal.II/base/table_handler.h>
 
@@ -177,10 +178,9 @@ LaplaceProblem<dim>::assemble_and_solve()
 
   output_table.add_value("cells", triangulation.n_active_cells());
   output_table.add_value("|u|_1", norm);
-  output_table.add_value("error",
-                         std::fabs(norm - std::sqrt(3.14159265358 / 2)));
+  output_table.add_value("error", std::fabs(norm - std::sqrt(numbers::PI_2)));
 
-  last_error = std::fabs(norm - std::sqrt(3.14159265358 / 2));
+  last_error = std::fabs(norm - std::sqrt(numbers::PI_2));
 }
 
 


### PR DESCRIPTION
As observed in #12816. Lots of tests (even step-11) use magic numbers rather than their deal.II equivalent.

This test fixes changes most of their occurrences. There are still some left that would alter the test output. I left them out for this PR (maybe fix them in a later PR?)