### PR TITLE
PETScWrappers::MPI::Vector: add new reinit()

### DIFF
--- a/include/deal.II/lac/petsc_vector.h
+++ b/include/deal.II/lac/petsc_vector.h
@@ -22,6 +22,7 @@
 #  ifdef DEAL_II_WITH_PETSC
 
 #    include <deal.II/base/index_set.h>
+#    include <deal.II/base/partitioner.h>
 #    include <deal.II/base/subscriptor.h>
 
 #    include <deal.II/lac/exceptions.h>
@@ -355,6 +356,14 @@ namespace PETScWrappers
        */
       void
       reinit(const IndexSet &local, const MPI_Comm &communicator);
+
+      /**
+       * Initialize the vector given to the parallel partitioning described in
+       * @p partitioner.
+       */
+      void
+      reinit(
+        const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner);
 
       /**
        * Return a reference to the MPI communicator object in use with this

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -254,6 +254,15 @@ namespace PETScWrappers
       create_vector(local.size(), local.n_elements());
     }
 
+    void
+    Vector::reinit(
+      const std::shared_ptr<const Utilities::MPI::Partitioner> &partitioner)
+    {
+      this->reinit(partitioner->locally_owned_range(),
+                   partitioner->ghost_indices(),
+                   partitioner->get_mpi_communicator());
+    }
+
 
     void
     Vector::create_vector(const size_type n, const size_type locally_owned_size)


### PR DESCRIPTION
similar to `L:d:V::reinit()`; to be able to easily switch vector types