### PR TITLE
Avoid generation of expensive FE objects.

### DIFF
--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -311,19 +311,17 @@ namespace internal
           if (needs_wedge_setup)
             {
               Assert(n_subdivisions == 1, ExcNotImplemented());
+
               quadrature_wedge = std::make_unique<Quadrature<dim>>(
-                FE_WedgeP<dim, spacedim>(
-                  1 /*note: vtk only supports linear wedges*/)
-                  .get_unit_support_points());
+                ReferenceCells::Wedge.get_nodal_type_quadrature<dim>());
             }
 
           if (needs_pyramid_setup)
             {
               Assert(n_subdivisions == 1, ExcNotImplemented());
+
               quadrature_pyramid = std::make_unique<Quadrature<dim>>(
-                FE_PyramidP<dim, spacedim>(
-                  1 /*note: vtk only supports linear wedges*/)
-                  .get_unit_support_points());
+                ReferenceCells::Pyramid.get_nodal_type_quadrature<dim>());
             }
 
           n_q_points =


### PR DESCRIPTION
Creating an FE object just so we can extract its support points seems like overkill. That's especially true if one only needs them for the lowest order where the support points are just the vertices of the reference cell. Query those instead.

It's finally also an occasion for me to use a `mutable` lambda function :-)

/rebuild