### PR TITLE
Make Patch<0,spacedim>::reference_cell const.

### DIFF
--- a/include/deal.II/base/data_out_base.h
+++ b/include/deal.II/base/data_out_base.h
@@ -472,9 +472,11 @@ namespace DataOutBase
     bool points_are_available;
 
     /**
-     * Reference-cell type of the underlying cell of this patch.
+     * Reference-cell type of the underlying cell of this patch. Since for
+     * zero-dimensional objects, a patch can only refer to a vertex, this
+     * field is always equal to ReferenceCells::Vertex and can not be changed.
      */
-    ReferenceCell reference_cell;
+    static const ReferenceCell reference_cell;
 
     /**
      * Default constructor. Sets #points_are_available

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -2067,10 +2067,13 @@ namespace DataOutBase
   unsigned int Patch<0, spacedim>::n_subdivisions = 1;
 
   template <int spacedim>
+  const ReferenceCell Patch<0, spacedim>::reference_cell =
+    ReferenceCells::Vertex;
+
+  template <int spacedim>
   Patch<0, spacedim>::Patch()
     : patch_index(no_neighbor)
     , points_are_available(false)
-    , reference_cell(ReferenceCells::get_hypercube<0>())
   {
     Assert(spacedim <= 3, ExcNotImplemented());
   }


### PR DESCRIPTION
Similar to #12874, just for the `reference_cell` variable. Except this time, the variable wasn't even `static`, which it might as well be because the variable can only have one possible value for point objects (`patch_dim==0`).

/rebuild