### PR TITLE
Relax an assert in DoFTools::map_dofs_to_support_points

### DIFF
--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2134,7 +2134,8 @@ namespace DoFTools
              ++fe_index)
           {
             // check whether every FE in the collection has support points
-            Assert(fe_collection[fe_index].has_support_points(),
+            Assert((fe_collection[fe_index].n_dofs_per_cell() == 0) ||
+                     (fe_collection[fe_index].has_support_points()),
                    typename FiniteElement<dim>::ExcFEHasNoSupportPoints());
             q_coll_dummy.push_back(Quadrature<dim>(
               fe_collection[fe_index].get_unit_support_points()));


### PR DESCRIPTION
In `DoFTools::map_dofs_to_support_points`, we check that all the finite elements in the `FE_Collection` have support points and so this function cannot be called if you have `FE_Nothing`. This assert can be relaxed because we already skip the cells that don't have dofs when filling the map.

cc: @stvdwtt 