### PR TITLE
Fix a test.

### DIFF
--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -40,7 +40,23 @@ create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
       const unsigned int nsub  = p + 1;
       const unsigned int nsubp = nsub + 1;
 
-      patch.n_subdivisions = nsub;
+#ifdef DEAL_II_HAVE_CXX17
+      if constexpr (dim > 0)
+        patch.n_subdivisions = nsub;
+#else
+      if (dim > 0)
+        const_cast<unsigned int &>(patch.n_subdivisions) = nsub;
+#endif
+
+#ifdef DEAL_II_HAVE_CXX17
+      if constexpr (dim > 0)
+        patch.reference_cell = ReferenceCells::get_hypercube<dim>();
+#else
+      if (dim > 0)
+        const_cast<ReferenceCell &>(patch.reference_cell) =
+          ReferenceCells::get_hypercube<dim>();
+#endif
+
       for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
         for (unsigned int d = 0; d < spacedim; ++d)
           patch.vertices[v](d) =


### PR DESCRIPTION
Fixes #12900. 

The function where this happens has this comment:
```
// This function is a copy from tests/data_out/patches.h, included here
// to not introduce dependencies between different test targets
template <int dim, int spacedim>
void
create_patches(std::vector<DataOutBase::Patch<dim, spacedim>> &patches)
{
  ...
```
The two functions are indeed identical. I don't understand what the comment is afraid of. Should I just `#include "../data_out/patches.h"`? (As a follow-up, so that this particular issue is quickly fixed at least.)

/rebuild