### PR TITLE
Inline active_cell_index functions

### DIFF
--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -3863,6 +3863,42 @@ CellAccessor<dim, spacedim>::is_level_cell()
 }
 
 
+
+template <int dim, int spacedim>
+inline unsigned int
+CellAccessor<dim, spacedim>::active_cell_index() const
+{
+  Assert(this->is_active(), TriaAccessorExceptions::ExcCellNotActive());
+  return this->tria->levels[this->present_level]
+    ->active_cell_indices[this->present_index];
+}
+
+
+
+template <int dim, int spacedim>
+inline types::global_cell_index
+CellAccessor<dim, spacedim>::global_active_cell_index() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(this->is_active(),
+         ExcMessage(
+           "global_active_cell_index() can only be called on active cells!"));
+
+  return this->tria->levels[this->present_level]
+    ->global_active_cell_indices[this->present_index];
+}
+
+
+
+template <int dim, int spacedim>
+inline types::global_cell_index
+CellAccessor<dim, spacedim>::global_level_cell_index() const
+{
+  return this->tria->levels[this->present_level]
+    ->global_level_cell_indices[this->present_index];
+}
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -2124,17 +2124,6 @@ CellAccessor<dim, spacedim>::parent_index() const
 
 
 template <int dim, int spacedim>
-unsigned int
-CellAccessor<dim, spacedim>::active_cell_index() const
-{
-  Assert(this->is_active(), TriaAccessorExceptions::ExcCellNotActive());
-  return this->tria->levels[this->present_level]
-    ->active_cell_indices[this->present_index];
-}
-
-
-
-template <int dim, int spacedim>
 void
 CellAccessor<dim, spacedim>::set_active_cell_index(
   const unsigned int active_cell_index) const
@@ -2157,37 +2146,12 @@ CellAccessor<dim, spacedim>::set_global_active_cell_index(
 
 
 template <int dim, int spacedim>
-inline types::global_cell_index
-CellAccessor<dim, spacedim>::global_active_cell_index() const
-{
-  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
-  Assert(this->is_active(),
-         ExcMessage(
-           "global_active_cell_index() can only be called on active cells!"));
-
-  return this->tria->levels[this->present_level]
-    ->global_active_cell_indices[this->present_index];
-}
-
-
-
-template <int dim, int spacedim>
 void
 CellAccessor<dim, spacedim>::set_global_level_cell_index(
   const types::global_cell_index index) const
 {
   this->tria->levels[this->present_level]
     ->global_level_cell_indices[this->present_index] = index;
-}
-
-
-
-template <int dim, int spacedim>
-inline types::global_cell_index
-CellAccessor<dim, spacedim>::global_level_cell_index() const
-{
-  return this->tria->levels[this->present_level]
-    ->global_level_cell_indices[this->present_index];
 }
 
 


### PR DESCRIPTION
Make the getter functions of `active_cell_index` and friends inline; the respective `set_active_cell_index` functions are not used often, so I would keep them in the `.cc` file.