### PR TITLE
Simplify code by using cell->is_locally_owned() and friends

### DIFF
--- a/source/multigrid/mg_transfer_prebuilt.cc
+++ b/source/multigrid/mg_transfer_prebuilt.cc
@@ -215,17 +215,11 @@ MGTransferPrebuilt<VectorType>::build(
       DoFTools::extract_locally_relevant_level_dofs(dof_handler,
                                                     level + 1,
                                                     level_p1_relevant_dofs);
-      DynamicSparsityPattern                  dsp(this->sizes[level + 1],
+      DynamicSparsityPattern dsp(this->sizes[level + 1],
                                  this->sizes[level],
                                  level_p1_relevant_dofs);
-      typename DoFHandler<dim>::cell_iterator cell,
-        endc = dof_handler.end(level);
-      for (cell = dof_handler.begin(level); cell != endc; ++cell)
-        if (cell->has_children() &&
-            (dof_handler.get_triangulation().locally_owned_subdomain() ==
-               numbers::invalid_subdomain_id ||
-             cell->level_subdomain_id() ==
-               dof_handler.get_triangulation().locally_owned_subdomain()))
+      for (const auto &cell : dof_handler.cell_iterators_on_level(level))
+        if (cell->has_children() && cell->is_locally_owned_on_level())
           {
             cell->get_mg_dof_indices(dof_indices_parent);
 
@@ -301,12 +295,8 @@ MGTransferPrebuilt<VectorType>::build(
       FullMatrix<typename VectorType::value_type> prolongation;
 
       // now actually build the matrices
-      for (cell = dof_handler.begin(level); cell != endc; ++cell)
-        if (cell->has_children() &&
-            (dof_handler.get_triangulation().locally_owned_subdomain() ==
-               numbers::invalid_subdomain_id ||
-             cell->level_subdomain_id() ==
-               dof_handler.get_triangulation().locally_owned_subdomain()))
+      for (const auto &cell : dof_handler.cell_iterators_on_level(level))
+        if (cell->has_children() && cell->is_locally_owned_on_level())
           {
             cell->get_mg_dof_indices(dof_indices_parent);
 


### PR DESCRIPTION
As far as I understand our code, statements like
```c++
          dof.get_triangulation().locally_owned_subdomain() ==
            numbers::invalid_subdomain_id ||
          cell->level_subdomain_id() ==
            dof.get_triangulation().locally_owned_subdomain()
```
is exactly what we do in `cell->is_locally_owned_on_level()`, see https://github.com/dealii/dealii/blob/43097604b36886447378a4d52a1c3c0c2b1bef2b/include/deal.II/grid/tria_accessor.templates.h#L3733-L3739 so use that shorter code. While there, I also observed that some code in `MatrixFree` used similar logic in a manual way, but we don't support any other than the partitioning implied by the `Triangulation` class anyway.