### PR TITLE
Fix some errors revealed by STL debug compile

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -1291,7 +1291,8 @@ namespace parallel
         // Adjust buffer iterator to the offset of the callback
         // function so that we only have to advance its position
         // to the next cell after each iteration.
-        dest_data_it = dest_data_fixed.cbegin() + offset;
+        if (cell_relations.begin() != cell_relations.end())
+          dest_data_it = dest_data_fixed.cbegin() + offset;
       }
 
     // Iterate over all cells and unpack the transferred data.
@@ -1334,8 +1335,10 @@ namespace parallel
                 data_increment -= offset;
               }
 
-            // Advance data size iterators to the next cell.
-            dest_sizes_cell_it += sizes_fixed_cumulative.back();
+            // Advance data size iterators to the next cell, avoid iterating
+            // past the end of dest_sizes_cell_it
+            if (cell_rel_it != cell_relations.end() - 1)
+              dest_sizes_cell_it += sizes_fixed_cumulative.back();
             ++dest_sizes_it;
           }
 
@@ -1369,7 +1372,8 @@ namespace parallel
               break;
           }
 
-        dest_data_it += data_increment;
+        if (cell_rel_it != cell_relations.end() - 1)
+          dest_data_it += data_increment;
       }
   }
 

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -4266,20 +4266,16 @@ namespace GridGenerator
     // compute cells to remove
     std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>
       cells_to_remove;
-    std::copy_if(
-      rectangle.active_cell_iterators().begin(),
-      rectangle.active_cell_iterators().end(),
-      std::inserter(cells_to_remove, cells_to_remove.end()),
-      [&](
-        const typename Triangulation<dim, spacedim>::active_cell_iterator &cell)
-        -> bool {
-        for (unsigned int d = 0; d < dim; ++d)
+    for (const auto &cell : rectangle.active_cell_iterators())
+      {
+        bool remove_cell = true;
+        for (unsigned int d = 0; d < dim && remove_cell; ++d)
           if ((n_cells_to_remove[d] > 0 && cell->center()[d] >= cut_step[d]) ||
               (n_cells_to_remove[d] < 0 && cell->center()[d] <= cut_step[d]))
-            return false;
-
-        return true;
-      });
+            remove_cell = false;
+        if (remove_cell)
+          cells_to_remove.insert(cell);
+      }
 
     GridGenerator::create_triangulation_with_removed_cells(rectangle,
                                                            cells_to_remove,


### PR DESCRIPTION
I compiled deal.II with `-DGLIBCXX_DEBUG` on my machine and observed some errors. deal.II would not even compile due to `grid_generator.cc`, where some types via `rectangle.active_cell_iterators().begin()` could not be folded back to the right iterator type, not really sure if it is my particular compiler (clang-13) or a real bug. Either way, the use of the lambda function and `std::copy_if` looks much more complicated than spelling out the code explicitly anyway.

Furthermore, in `DistributedTriangulationBase<dim, spacedim>::DataTransfer::unpack_data` the problem was that we referenced past the end of several `iterator` types by adding some offsets that were not used. I worked around those by adding appropriate checks.