### PR TITLE
Update predict_error doc entry

### DIFF
--- a/include/deal.II/hp/refinement.h
+++ b/include/deal.II/hp/refinement.h
@@ -543,7 +543,6 @@ namespace hp
      * // perform adaptation
      * CellDataTransfer<dim, spacedim, Vector<float>> cell_data_transfer(
      *   triangulation,
-     *   false,
      *   &AdaptationStrategies::Refinement::l2_norm<dim, spacedim, float>,
      *   &AdaptationStrategies::Coarsening::l2_norm<dim, spacedim, float>);
      * cell_data_transfer.prepare_coarsening_and_refinement();


### PR DESCRIPTION
I see no contructor of ``CellDataTransfer`` with four arguments in serial? I see, the additional argument might be necessary for the p:d case, but this code snippet seems to be for serial, right?