### PR TITLE
Optimize particle generation

### DIFF
--- a/include/deal.II/particles/generators.h
+++ b/include/deal.II/particles/generators.h
@@ -112,6 +112,23 @@ namespace Particles
            .template get_default_linear_mapping<dim, spacedim>()));
 
     /**
+     * A function that generates one particle at a random location in cell @p cell and with
+     * index @p id. This version of the function above immediately inserts the generated
+     * particle into the @p particle_handler and returns a iterator to it instead of
+     * a particle object. This avoids unnecessary copies of the particle.
+     */
+    template <int dim, int spacedim = dim>
+    ParticleIterator<dim, spacedim>
+    random_particle_in_cell_insert(
+      const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+      const types::particle_index                                        id,
+      std::mt19937 &                  random_number_generator,
+      ParticleHandler<dim, spacedim> &particle_handler,
+      const Mapping<dim, spacedim> &  mapping =
+        (ReferenceCells::get_hypercube<dim>()
+           .template get_default_linear_mapping<dim, spacedim>()));
+
+    /**
      * A function that generates particles randomly in the domain with a
      * particle density
      * according to a provided probability density function @p probability_density_function.

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -289,9 +289,18 @@ namespace Particles
 
     /**
      * Insert a particle into the collection of particles given all the
-     * properties necessary for a particle. This function is used internally to
+     * properties necessary for creating a particle. This function is used to
      * efficiently generate particles without the detour through a Particle
      * object.
+     *
+     * @param[in] position Initial position of the particle in real space.
+     * @param[in] reference_position Initial position of the particle
+     * in the coordinate system of the reference cell.
+     * @param[in] particle_index Globally unique identifier for this particle.
+     * @param[in] cell The cell in which the particle is located.
+     * @param[in] properties An optional ArrayView that describes the
+     * particle properties. If given this has to be of size
+     * n_properties_per_particle().
      */
     particle_iterator
     insert_particle(

--- a/include/deal.II/particles/particle_handler.h
+++ b/include/deal.II/particles/particle_handler.h
@@ -152,6 +152,23 @@ namespace Particles
     clear_particles();
 
     /**
+     * This function can be used to preemptively reserve memory for particle
+     * data. Calling this function before inserting particles will reduce
+     * memory allocations and therefore increase the performance. Calling
+     * this function is optional; if memory is not already allocated it will
+     * be allocated automatically during the insertion. It is recommended to
+     * use this function if you know the number of particles that will be
+     * inserted, but cannot use one of the collective particle insertion
+     * functions.
+     *
+     * @param n_particles Number of particles to reserve memory for. Note that
+     * this is the total number of particles to be stored, not the number of
+     * particles to be newly inserted.
+     */
+    void
+    reserve(std::size_t n_particles);
+
+    /**
      * Update all internally cached numbers. Note that all functions that
      * modify internal data structures and act on multiple particles will
      * call this function automatically (e.g. insert_particles), while
@@ -269,6 +286,20 @@ namespace Particles
     insert_particle(
       const Particle<dim, spacedim> &particle,
       const typename Triangulation<dim, spacedim>::active_cell_iterator &cell);
+
+    /**
+     * Insert a particle into the collection of particles given all the
+     * properties necessary for a particle. This function is used internally to
+     * efficiently generate particles without the detour through a Particle
+     * object.
+     */
+    particle_iterator
+    insert_particle(
+      const Point<spacedim> &     position,
+      const Point<dim> &          reference_position,
+      const types::particle_index particle_index,
+      const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
+      const ArrayView<const double> &properties = {});
 
     /**
      * Insert a number of particles into the collection of particles.
@@ -863,20 +894,6 @@ namespace Particles
     insert_particle(
       const void *&                                                      data,
       const typename Triangulation<dim, spacedim>::active_cell_iterator &cell);
-
-    /**
-     * Insert a particle into the collection of particles given all the
-     * properties necessary for a particle. This function is used internally to
-     * efficiently generate particles without the detour through a Particle
-     * object.
-     */
-    particle_iterator
-    insert_particle(
-      const Point<spacedim> &     position,
-      const Point<dim> &          reference_position,
-      const types::particle_index particle_index,
-      const typename Triangulation<dim, spacedim>::active_cell_iterator &cell,
-      const ArrayView<const double> &properties = {});
 
     /**
      * Perform the local insertion operation into the particle container. This

--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -223,6 +223,15 @@ namespace Particles
 
   template <int dim, int spacedim>
   void
+  ParticleHandler<dim, spacedim>::reserve(std::size_t n_particles)
+  {
+    property_pool->reserve(n_particles);
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
   ParticleHandler<dim, spacedim>::reset_particle_container(
     particle_container &given_particles)
   {
@@ -668,6 +677,7 @@ namespace Particles
       typename Triangulation<dim, spacedim>::active_cell_iterator,
       Particle<dim, spacedim>> &new_particles)
   {
+    reserve(n_locally_owned_particles() + new_particles.size());
     for (const auto &cell_and_particle : new_particles)
       insert_particle(cell_and_particle.second, cell_and_particle.first);
 
@@ -684,6 +694,7 @@ namespace Particles
     Assert(triangulation != nullptr, ExcInternalError());
 
     update_cached_numbers();
+    reserve(n_locally_owned_particles() + positions.size());
 
     // Determine the starting particle index of this process, which
     // is the highest currently existing particle index plus the sum


### PR DESCRIPTION
These are some backwards compatible changes that make particle generation around 30-40% faster (in a test model in ASPECT).
Changes:
1. Possibility to reserve memory in the property pool ahead of inserting particles via the `reserve` function. This avoids reallocation and movement of the vectors that store the data. We dont have an easy way to do the same for the vectors storing the handles into the property pool, but they are smaller, and at least we can pre-allocate 4 vectors (position,reference position, id, properties) of the 5 vectors (+handle into pool).
2. Make the `ParticleHandler::insert_particle` function that does not  take a particle object `public`. This avoids creating/copying/destroying a particle object if none is needed. Adjust the generators to use this function where possible.
3. One functional change that is a strict improvement is taken over geodynamics/aspect#4348 into the `Generators::random_location_in_cell` function. Previously the function would give up creating locations in the real cell after a number of unsuccessful tries and throw an exception. Now it falls back to creating locations in the unit cell, which always succeeds. If there are badly deformed cells it is more important to find any possible location at all rather than preserve perfectly randomly distributed particles within this cell.

Possibly relevant for @kronbichler @peterrum @blaisb