### PR TITLE
Minor cleanups in thread_management.h.

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -33,7 +33,6 @@
 #  include <memory>
 #  include <mutex>
 #  include <thread>
-#  include <tuple>
 #  include <utility>
 #  include <vector>
 
@@ -919,10 +918,8 @@ namespace Threads
     void
     join_all() const
     {
-      for (typename std::list<Thread<RT>>::const_iterator t = threads.begin();
-           t != threads.end();
-           ++t)
-        t->join();
+      for (auto &t : threads)
+        t.join();
     }
 
   private:


### PR DESCRIPTION
Had to look something up there. It turns out that we need the entire long list of `#include` files, except for `<tuple>`.

/rebuild