### PR TITLE
Improve build system when using Kokkos

### DIFF
--- a/cmake/configure/configure_2_trilinos.cmake
+++ b/cmake/configure/configure_2_trilinos.cmake
@@ -178,6 +178,20 @@ MACRO(FEATURE_TRILINOS_FIND_EXTERNAL var)
 
     IF(DEAL_II_TRILINOS_WITH_KOKKOS)
       CHECK_SYMBOL_EXISTS(
+        "KOKKOS_ENABLE_CUDA"
+        "Kokkos_Macros.hpp"
+        DEAL_II_KOKKOS_CUDA_EXISTS
+        )
+      IF(DEAL_II_KOKKOS_CUDA_EXISTS)
+        # We need to disable SIMD vectorization for CUDA device code.
+        # Otherwise, nvcc compilers from version 9 on will emit an error message like:
+        # "[...] contains a vector, which is not supported in device code". We
+        # would like to set the variable in check_01_cpu_feature but at that point
+        # we don't know if CUDA support is enabled in Kokkos
+        SET(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
+      ENDIF()
+
+      CHECK_SYMBOL_EXISTS(
         "KOKKOS_ENABLE_CUDA_LAMBDA"
         "Kokkos_Macros.hpp"
         DEAL_II_KOKKOS_LAMBDA_EXISTS

--- a/cmake/modules/FindKOKKOS.cmake
+++ b/cmake/modules/FindKOKKOS.cmake
@@ -44,10 +44,20 @@ ELSE()
       STRING(REGEX REPLACE "\\$<\\$<LINK_LANGUAGE:CXX>:([^>]*)>" "\\1" KOKKOS_EXTRA_LD_FLAGS "${KOKKOS_EXTRA_LD_FLAGS_FULL}")
       GET_PROPERTY(KOKKOS_COMPILE_FLAGS_FULL TARGET Kokkos::kokkoscore PROPERTY INTERFACE_COMPILE_OPTIONS)
       STRING(REGEX REPLACE "\\$<\\$<COMPILE_LANGUAGE:CXX>:([^>]*)>" "\\1" KOKKOS_COMPILE_FLAGS "${KOKKOS_COMPILE_FLAGS_FULL}")
-      # In serial the flag is empty but ADD_FLAGS does not support adding an empty
-      # flag
-      IF(KOKKOS_COMPILE_FLAGS)
-        ADD_FLAGS(DEAL_II_CXX_FLAGS ${KOKKOS_COMPILE_FLAGS})
+      STRING(REGEX REPLACE ";" " " KOKKOS_COMPILE_FLAGS_STR "${KOKKOS_COMPILE_FLAGS}")
+      ADD_FLAGS(DEAL_II_CXX_FLAGS "${KOKKOS_COMPILE_FLAGS_STR}")
+
+      # We need to disable SIMD vectorization for CUDA device code.
+      # Otherwise, nvcc compilers from version 9 on will emit an error message like:
+      # "[...] contains a vector, which is not supported in device code". We
+      # would like to set the variable in check_01_cpu_feature but at that point
+      # we don't know if CUDA support is enabled in Kokkos
+      IF(Kokkos_ENABLE_CUDA)
+        SET(DEAL_II_VECTORIZATION_WIDTH_IN_BITS 0)
+        IF(DEAL_II_WITH_KOKKOS_BACKEND)
+          # Require lambda support to use Kokkos as a backend
+          KOKKOS_CHECK(OPTIONS CUDA_LAMBDA)
+        ENDIF()
       ENDIF()
 
       DEAL_II_FIND_LIBRARY(KOKKOS_CORE_LIBRARY


### PR DESCRIPTION
This PR does the following:
 - disable vectorization if Kokkos is using CUDA. CUDA and vectorization do not mix well and we already disable vectorization when using CUDA
 - fix a bug where only the first flag from Kokkos was used. The others where ignored. The side effect of the PR is that I know get hundreds of shadowing warnings. I have a fix I'll open the PR later.
 - when using Kokkos with CUDA and if `DEAL_II_WITH_KOKKOS_BACKEND` is enable, check that Kokkos was compiled with lambda support. I will use `DEAL_II_WITH_KOKKOS_BACKEND` to guard the new Kokkos code, otherwise any one using Trilinos would use the new code.