### PR TITLE
Convert loops in some tests to reference-cell-independent form.

### DIFF
--- a/tests/grid/grid_in.cc
+++ b/tests/grid/grid_in.cc
@@ -89,7 +89,7 @@ test2()
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << hash << std::endl;
 }

--- a/tests/grid/grid_in_3d.cc
+++ b/tests/grid/grid_in_3d.cc
@@ -59,7 +59,7 @@ test(const char *filename)
   for (Triangulation<dim>::active_cell_iterator c = tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_3d_02.cc
+++ b/tests/grid/grid_in_3d_02.cc
@@ -62,7 +62,7 @@ test(const char *filename)
   for (Triangulation<dim>::active_cell_iterator c = tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 

--- a/tests/grid/grid_in_abaqus_01.cc
+++ b/tests/grid/grid_in_abaqus_01.cc
@@ -44,7 +44,7 @@ abaqus_grid(const char *name)
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_abaqus_02.cc
+++ b/tests/grid/grid_in_abaqus_02.cc
@@ -50,7 +50,7 @@ abaqus_grid(const std::string path_and_name,
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 

--- a/tests/grid/grid_in_gmsh_01.cc
+++ b/tests/grid/grid_in_gmsh_01.cc
@@ -44,7 +44,7 @@ gmsh_grid(const char *name)
          tria.begin_active();
        c != tria.end();
        ++c, ++index)
-    for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+    for (const unsigned int i : c->vertex_indices())
       hash += (index * i * c->vertex_index(i)) % (tria.n_active_cells() + 1);
   deallog << "  hash=" << hash << std::endl;
 }

--- a/tests/grid/grid_in_gmsh_01_v4.cc
+++ b/tests/grid/grid_in_gmsh_01_v4.cc
@@ -61,7 +61,7 @@ gmsh_grid(const char *name_v2, const char *name_v4)
     {
       AssertThrow(cell_v2->material_id() == cell_v4->material_id(),
                   ExcInternalError());
-      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+      for (const unsigned int i : cell_v2->vertex_indices())
         {
           AssertThrow((cell_v2->vertex(i) - cell_v4->vertex(i)).norm() < 1.e-10,
                       ExcInternalError());

--- a/tests/grid/grid_in_gmsh_01_v41.cc
+++ b/tests/grid/grid_in_gmsh_01_v41.cc
@@ -61,7 +61,7 @@ gmsh_grid(const char *name_v2, const char *name_v41)
     {
       AssertThrow(cell_v2->material_id() == cell_v41->material_id(),
                   ExcInternalError());
-      for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
+      for (const unsigned int i : cell_v2->vertex_indices())
         {
           AssertThrow((cell_v2->vertex(i) - cell_v41->vertex(i)).norm() <
                         1.e-10,


### PR DESCRIPTION
Makes writing follow-up tests that read tet meshes easier.

/rebuild