### PR TITLE
Optimize Utilities::MPI::broadcast for built-in types

### DIFF
--- a/doc/news/changes/minor/20211123Andreuzzi
+++ b/doc/news/changes/minor/20211123Andreuzzi
@@ -1,0 +1,4 @@
+Improved: Optimized calls to dealii::utilities::MPI::broadcast for
+built-in MPI types.
+<br>
+(Francesco Andreuzzi, 2021/11/23)

--- a/include/deal.II/base/template_constraints.h
+++ b/include/deal.II/base/template_constraints.h
@@ -466,6 +466,24 @@ struct EnableIfScalar<std::complex<T>>
 };
 
 
+/**
+ * Checks that the data type `U` is inside the given tuple of data types.
+ *
+ * @param[in] type_tuple A tuple of data types.
+ *
+ * @return `true` if `U` has been found in the tuple, `false` otherwise.
+ */
+template <typename U, typename... T>
+constexpr bool contains(std::tuple<T...> type_tuple)
+{
+  (void) type_tuple;
+  return !std::is_same<
+    std::integer_sequence<bool, false, std::is_same<U, T>::value...>,
+    std::integer_sequence<bool, std::is_same<U, T>::value..., false>>::value;
+}
+
+
+
 DEAL_II_NAMESPACE_CLOSE
 
 #endif

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1033,6 +1033,84 @@ namespace Utilities
     }
 
 
+    namespace internal
+    {
+      template <typename T>
+      std::enable_if_t<is_mpi_type<T>(), T>
+      builtin_single_broadcast(const MPI_Comm &   comm,
+                               T                  object_to_send,
+                               const unsigned int root_process)
+      {
+#ifndef DEAL_II_WITH_MPI
+        (void)comm;
+        (void)root_process;
+        return object_to_send;
+#else
+        MPI_Datatype datatype =
+          dealii::Utilities::MPI::internal::mpi_type_id(&object_to_send);
+
+        int ierr = MPI_Bcast(&object_to_send, 1, datatype, root_process, comm);
+        AssertThrowMPI(ierr);
+
+        return object_to_send;
+#endif
+      }
+
+
+      template bool
+      builtin_single_broadcast(const MPI_Comm &, bool, const unsigned int);
+      template char
+      builtin_single_broadcast(const MPI_Comm &, char, const unsigned int);
+      template signed char
+      builtin_single_broadcast(const MPI_Comm &,
+                               signed char,
+                               const unsigned int);
+      template short
+      builtin_single_broadcast(const MPI_Comm &, short, const unsigned int);
+      template int
+      builtin_single_broadcast(const MPI_Comm &, int, const unsigned int);
+      template long int
+      builtin_single_broadcast(const MPI_Comm &, long int, const unsigned int);
+      template unsigned char
+      builtin_single_broadcast(const MPI_Comm &,
+                               unsigned char,
+                               const unsigned int);
+      template unsigned short
+      builtin_single_broadcast(const MPI_Comm &,
+                               unsigned short,
+                               const unsigned int);
+      template unsigned int
+      builtin_single_broadcast(const MPI_Comm &,
+                               unsigned int,
+                               const unsigned int);
+      template unsigned long int
+      builtin_single_broadcast(const MPI_Comm &,
+                               unsigned long int,
+                               const unsigned int);
+      template unsigned long long int
+      builtin_single_broadcast(const MPI_Comm &,
+                               unsigned long long int,
+                               const unsigned int);
+      template float
+      builtin_single_broadcast(const MPI_Comm &, float, const unsigned int);
+      template double
+      builtin_single_broadcast(const MPI_Comm &, double, const unsigned int);
+      template long double
+      builtin_single_broadcast(const MPI_Comm &,
+                               long double,
+                               const unsigned int);
+      template std::complex<float>
+      builtin_single_broadcast(const MPI_Comm &,
+                               std::complex<float>,
+                               const unsigned int);
+      template std::complex<double>
+      builtin_single_broadcast(const MPI_Comm &,
+                               std::complex<double>,
+                               const unsigned int);
+
+    } // namespace internal
+
+
 
     CollectiveMutex::CollectiveMutex()
       : locked(false)

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -1057,7 +1057,7 @@ namespace Utilities
       }
 
 
-      template bool
+      template std::enable_if_t<true,bool>
       builtin_single_broadcast(const MPI_Comm &, bool, const unsigned int);
       template char
       builtin_single_broadcast(const MPI_Comm &, char, const unsigned int);

--- a/tests/mpi/broadcast_01.cc
+++ b/tests/mpi/broadcast_01.cc
@@ -17,6 +17,8 @@
 
 // Test Utilities::MPI::broadcast().
 
+#include <iomanip>
+
 #include <deal.II/base/mpi.h>
 
 #include "../tests.h"
@@ -68,6 +70,59 @@ check(const std::vector<int> &int_vector, const std::string &string)
   deallog << std::endl;
 }
 
+void
+check(int int_value)
+{
+  const auto my_proc = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  int buffer;
+  if (my_proc == 0)
+    {
+      buffer = int_value;
+    }
+
+  const auto result = Utilities::MPI::broadcast(MPI_COMM_WORLD, buffer);
+
+  deallog << result << " ";
+  deallog << std::endl;
+}
+
+
+void
+check(double double_value)
+{
+  const auto my_proc = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  double buffer;
+  if (my_proc == 0)
+    {
+      buffer = double_value;
+    }
+
+  const auto result = Utilities::MPI::broadcast(MPI_COMM_WORLD, buffer);
+
+  deallog << std::setprecision(4) << result << " ";
+  deallog << std::endl;
+}
+
+
+void
+check(std::complex<double> complex_value)
+{
+  const auto my_proc = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+
+  std::complex<double> buffer;
+  if (my_proc == 0)
+    {
+      buffer = complex_value;
+    }
+
+  const auto result = Utilities::MPI::broadcast(MPI_COMM_WORLD, buffer);
+
+  deallog << std::setprecision(2) << result << " ";
+  deallog << std::endl;
+}
+
 
 int
 main(int argc, char *argv[])
@@ -80,4 +135,16 @@ main(int argc, char *argv[])
 
   // broadcast test
   check({-1, 0, 1}, "i love democracy");
+
+  // broadcast test
+  check(23);
+
+  // broadcast test
+  double d = 14.32;
+  check(d);
+
+  // broadcast test
+  using namespace std::complex_literals;
+  std::complex<double> z (1., 2.);
+  check(z);
 }

--- a/tests/mpi/broadcast_01.cc
+++ b/tests/mpi/broadcast_01.cc
@@ -144,7 +144,6 @@ main(int argc, char *argv[])
   check(d);
 
   // broadcast test
-  using namespace std::complex_literals;
   std::complex<double> z (1., 2.);
   check(z);
 }

--- a/tests/mpi/broadcast_01.mpirun=1.output
+++ b/tests/mpi/broadcast_01.mpirun=1.output
@@ -1,3 +1,6 @@
 
 DEAL:0::1 2 3 test
 DEAL:0::-1 0 1 i love democracy
+DEAL:0::23
+DEAL:0::14.32
+DEAL:0::(1.0,2.0)

--- a/tests/mpi/broadcast_01.mpirun=5.output
+++ b/tests/mpi/broadcast_01.mpirun=5.output
@@ -1,19 +1,34 @@
 
 DEAL:0::1 2 3 test
 DEAL:0::-1 0 1 i love democracy
+DEAL:0::23
+DEAL:0::14.32
+DEAL:0::(1.0,2.0)
 
 DEAL:1::1 2 3 test
 DEAL:1::-1 0 1 i love democracy
+DEAL:1::23
+DEAL:1::14.32
+DEAL:1::(1.0,2.0)
 
 
 DEAL:2::1 2 3 test
 DEAL:2::-1 0 1 i love democracy
+DEAL:2::23
+DEAL:2::14.32
+DEAL:2::(1.0,2.0)
 
 
 DEAL:3::1 2 3 test
 DEAL:3::-1 0 1 i love democracy
+DEAL:3::23
+DEAL:3::14.32
+DEAL:3::(1.0,2.0)
 
 
 DEAL:4::1 2 3 test
 DEAL:4::-1 0 1 i love democracy
+DEAL:4::23
+DEAL:4::14.32
+DEAL:4::(1.0,2.0)
 


### PR DESCRIPTION
In this PR I tried to fix #11955 by providing overloaded versions of `broadcast` for built-in types (those for which `mpy_type_id` is available). I'm not sure this is the optimal way to do that though.

My changes start from L1542, it looks like the formatter changed some things in the file.

I tried to compile with the instructions provided in the README, but unfortunately I'm getting the following error as a result of `make`:

```
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, bool const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, char const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, signed char const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, short const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, int const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, long const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, unsigned char const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, unsigned short const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, unsigned int const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, unsigned long const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, unsigned long long const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, float const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, double const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, long double const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, std::complex<float> const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
/usr/bin/ld.gold: error: sundials/CMakeFiles/obj_sundials_release.dir/ida.cc.o: multiple definition of 'dealii::Utilities::MPI::broadcast(int const&, std::complex<double> const&, unsigned int)'
/usr/bin/ld.gold: numerics/CMakeFiles/obj_numerics_release.dir/data_out.cc.o: previous definition here
collect2: error: ld returned 1 exit status
```

This error is replicated for each file which includes `mpi.h`. Unfortunately at the moment I'm not able to figure out where this error comes from since it looks like the include guard is right at the beginning of the file.