### PR TITLE
Remove some duplication in MappingCartesian

### DIFF
--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -374,6 +374,18 @@ private:
     const CellSimilarity::Similarity cell_similarity,
     internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
       &output_data) const;
+
+
+  /**
+   * Compute the inverse Jacobians if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_inverse_jacobians(
+    const InternalData &             data,
+    const CellSimilarity::Similarity cell_similarity,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
 };
 
 /*@}*/

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -377,6 +377,13 @@ private:
 
 
   /**
+   * Compute the volume elements if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_volume_elements(const InternalData &data) const;
+
+  /**
    * Compute the Jacobians if the UpdateFlags of the incoming
    * InternalData object say that they should be updated.
    */

--- a/include/deal.II/fe/mapping_cartesian.h
+++ b/include/deal.II/fe/mapping_cartesian.h
@@ -377,6 +377,17 @@ private:
 
 
   /**
+   * Compute the Jacobians if the UpdateFlags of the incoming
+   * InternalData object say that they should be updated.
+   */
+  void
+  maybe_update_jacobians(
+    const InternalData &             data,
+    const CellSimilarity::Similarity cell_similarity,
+    internal::FEValuesImplementation::MappingRelatedData<dim, spacedim>
+      &output_data) const;
+
+  /**
    * Compute the inverse Jacobians if the UpdateFlags of the incoming
    * InternalData object say that they should be updated.
    */

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -387,6 +387,22 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
 
 template <int dim, int spacedim>
 void
+MappingCartesian<dim, spacedim>::maybe_update_volume_elements(
+  const InternalData &data) const
+{
+  if (data.update_each & update_volume_elements)
+    {
+      double volume = data.cell_extents[0];
+      for (unsigned int d = 1; d < dim; ++d)
+        volume *= data.cell_extents[d];
+      data.volume_element = volume;
+    }
+}
+
+
+
+template <int dim, int spacedim>
+void
 MappingCartesian<dim, spacedim>::maybe_update_jacobians(
   const InternalData &             data,
   const CellSimilarity::Similarity cell_similarity,
@@ -556,14 +572,7 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values(
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
-  if (data.update_each & update_volume_elements)
-    {
-      J = data.cell_extents[0];
-      for (unsigned int d = 1; d < dim; ++d)
-        J *= data.cell_extents[d];
-      data.volume_element = J;
-    }
-
+  maybe_update_volume_elements(data);
   maybe_update_jacobians(data, CellSimilarity::none, output_data);
   maybe_update_jacobian_derivatives(data, CellSimilarity::none, output_data);
   maybe_update_inverse_jacobians(data, CellSimilarity::none, output_data);
@@ -620,14 +629,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
-  if (data.update_each & update_volume_elements)
-    {
-      J = data.cell_extents[0];
-      for (unsigned int d = 1; d < dim; ++d)
-        J *= data.cell_extents[d];
-      data.volume_element = J;
-    }
-
+  maybe_update_volume_elements(data);
   maybe_update_jacobians(data, CellSimilarity::none, output_data);
   maybe_update_jacobian_derivatives(data, CellSimilarity::none, output_data);
   maybe_update_inverse_jacobians(data, CellSimilarity::none, output_data);


### PR DESCRIPTION
By introducing 3 helper functions and calling these from the various `fill_fe_*_values functions`. These functions are also needed to avoid more duplication in #12024.