### PR TITLE
Work around a (wrong) warning about an unused variable.

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -152,18 +152,18 @@ namespace internal
       const internal::MatrixFreeFunctions::UnivariateShapeData<Number>
         *univariate_shape_data)
     {
-      const bool request_even_odd = variant == evaluate_evenodd;
-
-      Eval eval(request_even_odd ? univariate_shape_data->shape_values_eo :
-                                   univariate_shape_data->shape_values,
-                request_even_odd ? univariate_shape_data->shape_gradients_eo :
-                                   univariate_shape_data->shape_gradients,
-                request_even_odd ? univariate_shape_data->shape_hessians_eo :
-                                   univariate_shape_data->shape_hessians,
-                univariate_shape_data->fe_degree + 1,
-                univariate_shape_data->n_q_points_1d);
-
-      return eval;
+      if (variant == evaluate_evenodd)
+        return Eval(univariate_shape_data->shape_values_eo,
+                    univariate_shape_data->shape_gradients_eo,
+                    univariate_shape_data->shape_hessians_eo,
+                    univariate_shape_data->fe_degree + 1,
+                    univariate_shape_data->n_q_points_1d);
+      else
+        return Eval(univariate_shape_data->shape_values,
+                    univariate_shape_data->shape_gradients,
+                    univariate_shape_data->shape_hessians,
+                    univariate_shape_data->fe_degree + 1,
+                    univariate_shape_data->n_q_points_1d);
     }
   };
 


### PR DESCRIPTION
My compiler gives me this (incorrect) warning:
```
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_kernels.h: In instantiation of ‘static dealii::internal::FEEvaluationImpl<type, dim, fe_degree, n_q_points_1d, Number>::Eval dealii::internal::FEEvaluationImpl<type, dim, fe_degree, n_q_points_1d, Number>::create_evaluator_tensor_product(const dealii::internal::MatrixFreeFunctions::UnivariateShapeData<Number>*) [with dealii::internal::MatrixFreeFunctions::ElementType type = (dealii::internal::MatrixFreeFunctions::ElementType)3; int dim = 3; int fe_degree = 6; int n_q_points_1d = 10; Number = dealii::VectorizedArray<double, 2>; dealii::internal::FEEvaluationImpl<type, dim, fe_degree, n_q_points_1d, Number>::Eval = dealii::internal::EvaluatorTensorProduct<(dealii::internal::EvaluatorVariant)0, 3, 7, 10, dealii::VectorizedArray<double, 2>, dealii::VectorizedArray<double, 2> >]’:
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_kernels.h:233:49:   required from ‘static void dealii::internal::FEEvaluationImpl<type, dim, fe_degree, n_q_points_1d, Number>::evaluate(unsigned int, dealii::EvaluationFlags::EvaluationFlags, const dealii::internal::MatrixFreeFunctions::ShapeInfo<Number>&, const Number*, Number*, Number*, Number*, Number*) [with dealii::internal::MatrixFreeFunctions::ElementType type = (dealii::internal::MatrixFreeFunctions::ElementType)3; int dim = 3; int fe_degree = 6; int n_q_points_1d = 10; Number = dealii::VectorizedArray<double, 2>]’
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_kernels.h:1899:30:   required from ‘static bool dealii::internal::FEEvaluationImplEvaluateSelector<dim, Number>::run(unsigned int, dealii::EvaluationFlags::EvaluationFlags, const dealii::internal::MatrixFreeFunctions::ShapeInfo<Number>&, Number*, Number*, Number*, Number*, Number*) [with int fe_degree = 6; int n_q_points_1d = 10; int dim = 3; Number = dealii::VectorizedArray<double, 2>]’
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_template_factory_internal.h:55:23:   recursively required from ‘bool dealii::internal::instantiation_helper_run(unsigned int, unsigned int, Args& ...) [with int degree = 2; EvaluatorType = dealii::internal::FEEvaluationImplEvaluateSelector<3, dealii::VectorizedArray<double, 2> >; Args = {const unsigned int, const dealii::EvaluationFlags::EvaluationFlags, const dealii::internal::MatrixFreeFunctions::ShapeInfo<dealii::VectorizedArray<double, 2> >, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*}]’
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_template_factory_internal.h:55:23:   required from ‘bool dealii::internal::instantiation_helper_run(unsigned int, unsigned int, Args& ...) [with int degree = 1; EvaluatorType = dealii::internal::FEEvaluationImplEvaluateSelector<3, dealii::VectorizedArray<double, 2> >; Args = {const unsigned int, const dealii::EvaluationFlags::EvaluationFlags, const dealii::internal::MatrixFreeFunctions::ShapeInfo<dealii::VectorizedArray<double, 2> >, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*, dealii::VectorizedArray<double, 2>*}]’
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_template_factory.templates.h:59:66:   required from ‘static void dealii::internal::FEEvaluationFactory<dim, Number, VectorizedArrayType>::evaluate(unsigned int, dealii::EvaluationFlags::EvaluationFlags, const dealii::internal::MatrixFreeFunctions::ShapeInfo<Number>&, VectorizedArrayType*, VectorizedArrayType*, VectorizedArrayType*, VectorizedArrayType*, VectorizedArrayType*) [with int dim = 3; Number = double; VectorizedArrayType = dealii::VectorizedArray<double, 2>]’
source/matrix_free/evaluation_template_factory.inst:190:35:   required from here
/raid/bangerth/p/deal.II/1/dealii/include/deal.II/matrix_free/evaluation_kernels.h:155:22: warning: variable ‘request_even_odd’ set but not used [-Wunused-but-set-variable]
```
That's of course bogus, but I have not found a way around it other than just inlining the variable's value into the following expression.

/rebuild