### PR TITLE
Fix shadowing warning

### DIFF
--- a/include/deal.II/base/array_view.h
+++ b/include/deal.II/base/array_view.h
@@ -394,10 +394,10 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView()
 
 template <typename ElementType, typename MemorySpaceType>
 inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
-  value_type *      starting_element,
-  const std::size_t n_elements)
-  : starting_element(starting_element)
-  , n_elements(n_elements)
+  value_type *      starting_element_,
+  const std::size_t n_elements_)
+  : starting_element(starting_element_)
+  , n_elements(n_elements_)
 {
   Assert(
     n_elements == 0 ||
@@ -411,10 +411,10 @@ inline ArrayView<ElementType, MemorySpaceType>::ArrayView(
 
 template <typename ElementType, typename MemorySpaceType>
 inline void
-ArrayView<ElementType, MemorySpaceType>::reinit(value_type *starting_element,
-                                                const std::size_t n_elements)
+ArrayView<ElementType, MemorySpaceType>::reinit(value_type *      start_element,
+                                                const std::size_t n_elems)
 {
-  *this = ArrayView(starting_element, n_elements);
+  *this = ArrayView(start_element, n_elems);
 }
 
 

--- a/include/deal.II/base/bounding_box.h
+++ b/include/deal.II/base/bounding_box.h
@@ -406,7 +406,7 @@ namespace internal
 template <int spacedim, typename Number>
 inline BoundingBox<spacedim, Number>::BoundingBox(
   const std::pair<Point<spacedim, Number>, Point<spacedim, Number>>
-    &boundary_points)
+    &boundary_pts)
 {
   // We check the Bounding Box is not degenerate
   for (unsigned int i = 0; i < spacedim; ++i)
@@ -414,7 +414,7 @@ inline BoundingBox<spacedim, Number>::BoundingBox(
            ExcMessage("Bounding Box can't be created: the points' "
                       "order should be bottom left, top right!"));
 
-  this->boundary_points = boundary_points;
+  this->boundary_points = boundary_pts;
 }
 
 

--- a/include/deal.II/base/geometry_info.h
+++ b/include/deal.II/base/geometry_info.h
@@ -2684,8 +2684,8 @@ GeometryInfo<3>::d_linear_shape_function_gradient(const Point<3> &   xi,
 /* -------------- inline functions ------------- */
 
 
-inline GeometryPrimitive::GeometryPrimitive(const Object object)
-  : object(object)
+inline GeometryPrimitive::GeometryPrimitive(const Object object_)
+  : object(object_)
 {}
 
 

--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1029,9 +1029,9 @@ complete_index_set(const IndexSet::size_type N)
 
 inline IndexSet::IntervalAccessor::IntervalAccessor(
   const IndexSet *          idxset,
-  const IndexSet::size_type range_idx)
+  const IndexSet::size_type range_idx_)
   : index_set(idxset)
-  , range_idx(range_idx)
+  , range_idx(range_idx_)
 {
   Assert(range_idx < idxset->n_intervals(),
          ExcInternalError("Invalid range index"));
@@ -1270,10 +1270,10 @@ IndexSet::IntervalIterator::operator-(
 
 inline IndexSet::ElementIterator::ElementIterator(
   const IndexSet *          idxset,
-  const IndexSet::size_type range_idx,
+  const IndexSet::size_type range_idx_,
   const IndexSet::size_type index)
   : index_set(idxset)
-  , range_idx(range_idx)
+  , range_idx(range_idx_)
   , idx(index)
 {
   Assert(range_idx < index_set->ranges.size(),

--- a/include/deal.II/base/linear_index_iterator.h
+++ b/include/deal.II/base/linear_index_iterator.h
@@ -502,8 +502,8 @@ LinearIndexIterator<DerivedIterator, AccessorType>::operator>(
 
 template <class DerivedIterator, class AccessorType>
 inline LinearIndexIterator<DerivedIterator, AccessorType>::LinearIndexIterator(
-  const AccessorType accessor)
-  : accessor(accessor)
+  const AccessorType accessor_)
+  : accessor(accessor_)
 {}
 
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -348,9 +348,9 @@ namespace Utilities
         /**
          * Constructor. Blocks until it can acquire the lock.
          */
-        explicit ScopedLock(CollectiveMutex &mutex, const MPI_Comm &comm)
-          : mutex(mutex)
-          , comm(comm)
+        explicit ScopedLock(CollectiveMutex &mutex_, const MPI_Comm &comm_)
+          : mutex(mutex_)
+          , comm(comm_)
         {
           mutex.lock(comm);
         }

--- a/include/deal.II/base/parallel.h
+++ b/include/deal.II/base/parallel.h
@@ -82,8 +82,8 @@ namespace parallel
       /**
        * Constructor. Take and package the given function object.
        */
-      Body(const F &f)
-        : f(f)
+      Body(const F &f_)
+        : f(f_)
       {}
 
       template <typename Range>
@@ -555,13 +555,13 @@ namespace parallel
        * std::plus<int>().
        */
       template <typename Reductor>
-      ReductionOnSubranges(const Function & f,
-                           const Reductor & reductor,
-                           const ResultType neutral_element = ResultType())
-        : result(neutral_element)
-        , f(f)
-        , neutral_element(neutral_element)
-        , reductor(reductor)
+      ReductionOnSubranges(const Function & f_,
+                           const Reductor & reductor_,
+                           const ResultType neutral_element_ = ResultType())
+        : result(neutral_element_)
+        , f(f_)
+        , neutral_element(neutral_element_)
+        , reductor(reductor_)
       {}
 
       /**

--- a/include/deal.II/base/patterns.h
+++ b/include/deal.II/base/patterns.h
@@ -1413,16 +1413,16 @@ namespace Patterns
 namespace Patterns
 {
   template <class... PatternTypes>
-  Tuple::Tuple(const char *separator, const PatternTypes &...ps)
+  Tuple::Tuple(const char *separator_, const PatternTypes &...ps)
     : // forward to the version with std::string argument
-    Tuple(std::string(separator), ps...)
+    Tuple(std::string(separator_), ps...)
   {}
 
 
 
   template <class... PatternTypes>
-  Tuple::Tuple(const std::string &separator, const PatternTypes &...ps)
-    : separator(separator)
+  Tuple::Tuple(const std::string &separator_, const PatternTypes &...ps)
+    : separator(separator_)
   {
     static_assert(is_base_of_all<PatternBase, PatternTypes...>::value,
                   "Not all of the input arguments of this function "
@@ -1872,8 +1872,8 @@ namespace Patterns
         std::string s;
         if (vec.size() > 0)
           s = vec[0];
-        for (unsigned int i = 1; i < vec.size(); ++i)
-          s += p->get_separator() + " " + vec[i];
+        for (unsigned int j = 1; j < vec.size(); ++j)
+          s += p->get_separator() + " " + vec[j];
 
         AssertThrow(p->match(s), ExcNoMatch(s, p->description()));
         return s;

--- a/include/deal.II/base/polynomials_pyramid.h
+++ b/include/deal.II/base/polynomials_pyramid.h
@@ -131,8 +131,8 @@ ScalarLagrangePolynomialPyramid<dim>::compute_derivative(
   Assert(order == 1, ExcNotImplemented());
   const auto grad = compute_grad(i, p);
 
-  for (unsigned int i = 0; i < dim; ++i)
-    der[i] = grad[i];
+  for (unsigned int d = 0; d < dim; ++d)
+    der[d] = grad[d];
 
   return der;
 }

--- a/include/deal.II/base/polynomials_wedge.h
+++ b/include/deal.II/base/polynomials_wedge.h
@@ -154,8 +154,8 @@ ScalarLagrangePolynomialWedge<dim>::compute_derivative(
   AssertDimension(order, 1);
   const auto grad = compute_grad(i, p);
 
-  for (unsigned int i = 0; i < dim; ++i)
-    der[i] = grad[i];
+  for (unsigned int d = 0; d < dim; ++d)
+    der[d] = grad[d];
 
   return der;
 }

--- a/include/deal.II/base/qprojector.h
+++ b/include/deal.II/base/qprojector.h
@@ -546,8 +546,8 @@ public:
 
 template <int dim>
 inline QProjector<dim>::DataSetDescriptor::DataSetDescriptor(
-  const unsigned int dataset_offset)
-  : dataset_offset(dataset_offset)
+  const unsigned int dataset_offset_)
+  : dataset_offset(dataset_offset_)
 {}
 
 

--- a/include/deal.II/base/smartpointer.h
+++ b/include/deal.II/base/smartpointer.h
@@ -224,8 +224,8 @@ inline SmartPointer<T, P>::SmartPointer()
 
 
 template <typename T, typename P>
-inline SmartPointer<T, P>::SmartPointer(T *t)
-  : t(t)
+inline SmartPointer<T, P>::SmartPointer(T *t_)
+  : t(t_)
   , id(typeid(P).name())
   , pointed_to_object_is_alive(false)
 {
@@ -236,9 +236,9 @@ inline SmartPointer<T, P>::SmartPointer(T *t)
 
 
 template <typename T, typename P>
-inline SmartPointer<T, P>::SmartPointer(T *t, const std::string &id)
-  : t(t)
-  , id(id)
+inline SmartPointer<T, P>::SmartPointer(T *t_, const std::string &id_)
+  : t(t_)
+  , id(id_)
   , pointed_to_object_is_alive(false)
 {
   if (t != nullptr)

--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -1104,10 +1104,10 @@ namespace internal
     template <int rank_, int dim, bool constness, int P, typename Number>
     constexpr DEAL_II_ALWAYS_INLINE
     Accessor<rank_, dim, constness, P, Number>::Accessor(
-      tensor_type &              tensor,
-      const TableIndices<rank_> &previous_indices)
-      : tensor(tensor)
-      , previous_indices(previous_indices)
+      tensor_type &              tensor_,
+      const TableIndices<rank_> &previous_indices_)
+      : tensor(tensor_)
+      , previous_indices(previous_indices_)
     {}
 
 
@@ -1139,10 +1139,10 @@ namespace internal
     template <int rank_, int dim, bool constness, typename Number>
     constexpr DEAL_II_ALWAYS_INLINE
     Accessor<rank_, dim, constness, 1, Number>::Accessor(
-      tensor_type &              tensor,
-      const TableIndices<rank_> &previous_indices)
-      : tensor(tensor)
-      , previous_indices(previous_indices)
+      tensor_type &              tensor_,
+      const TableIndices<rank_> &previous_indices_)
+      : tensor(tensor_)
+      , previous_indices(previous_indices_)
     {}
 
 

--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -2200,10 +2200,10 @@ namespace internal
   namespace TableBaseAccessors
   {
     template <int N, typename T, bool C, unsigned int P>
-    inline Accessor<N, T, C, P>::Accessor(const TableType &table,
-                                          const iterator   data)
-      : table(table)
-      , data(data)
+    inline Accessor<N, T, C, P>::Accessor(const TableType &table_,
+                                          const iterator   data_)
+      : table(table_)
+      , data(data_)
     {}
 
 
@@ -2243,10 +2243,10 @@ namespace internal
 
 
     template <int N, typename T, bool C>
-    inline Accessor<N, T, C, 1>::Accessor(const TableType &table,
-                                          const iterator   data)
-      : table(table)
-      , data(data)
+    inline Accessor<N, T, C, 1>::Accessor(const TableType &table_,
+                                          const iterator   data_)
+      : table(table_)
+      , data(data_)
     {}
 
 

--- a/include/deal.II/base/tensor_product_polynomials_bubbles.h
+++ b/include/deal.II/base/tensor_product_polynomials_bubbles.h
@@ -341,11 +341,11 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
             {
               derivative_1[d] = 1.;
               // compute grad(4*\prod_{i=1}^d (x_i(1-x_i)))(p)
-              for (unsigned j = 0; j < dim; ++j)
+              for (unsigned int j = 0; j < dim; ++j)
                 derivative_1[d] *=
                   (d == j ? 4 * (1 - 2 * p(j)) : 4 * p(j) * (1 - p(j)));
               // and multiply with (2*x_i-1)^{r-1}
-              for (unsigned int i = 0; i < q_degree - 1; ++i)
+              for (unsigned int j = 0; j < q_degree - 1; ++j)
                 derivative_1[d] *= 2 * p(comp) - 1;
             }
 
@@ -357,7 +357,7 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
                 value *= 4 * p(j) * (1 - p(j));
               // and multiply with grad(2*x_i-1)^{r-1}
               double tmp = value * 2 * (q_degree - 1);
-              for (unsigned int i = 0; i < q_degree - 2; ++i)
+              for (unsigned int j = 0; j < q_degree - 2; ++j)
                 tmp *= 2 * p(comp) - 1;
               derivative_1[comp] += tmp;
             }
@@ -379,26 +379,26 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
               }
 
             double tmp = 1.;
-            for (unsigned int i = 0; i < q_degree - 1; ++i)
+            for (unsigned int j = 0; j < q_degree - 1; ++j)
               tmp *= 2 * p(comp) - 1;
             v[dim][0] = tmp;
 
             if (q_degree >= 2)
               {
-                double tmp = 2 * (q_degree - 1);
-                for (unsigned int i = 0; i < q_degree - 2; ++i)
-                  tmp *= 2 * p(comp) - 1;
-                v[dim][1] = tmp;
+                double tmp_v = 2 * (q_degree - 1);
+                for (unsigned int j = 0; j < q_degree - 2; ++j)
+                  tmp_v *= 2 * p(comp) - 1;
+                v[dim][1] = tmp_v;
               }
             else
               v[dim][1] = 0.;
 
             if (q_degree >= 3)
               {
-                double tmp = 4 * (q_degree - 2) * (q_degree - 1);
-                for (unsigned int i = 0; i < q_degree - 3; ++i)
-                  tmp *= 2 * p(comp) - 1;
-                v[dim][2] = tmp;
+                double tmp_v = 4 * (q_degree - 2) * (q_degree - 1);
+                for (unsigned int j = 0; j < q_degree - 3; ++j)
+                  tmp_v *= 2 * p(comp) - 1;
+                v[dim][2] = tmp_v;
               }
             else
               v[dim][2] = 0.;
@@ -412,15 +412,15 @@ TensorProductPolynomialsBubbles<dim>::compute_derivative(
                 grad_grad_1[d1][d2] = v[dim][0];
                 for (unsigned int x = 0; x < dim; ++x)
                   {
-                    unsigned int derivative = 0;
+                    unsigned int derivative_idx = 0;
                     if (d1 == x || d2 == x)
                       {
                         if (d1 == d2)
-                          derivative = 2;
+                          derivative_idx = 2;
                         else
-                          derivative = 1;
+                          derivative_idx = 1;
                       }
-                    grad_grad_1[d1][d2] *= v[x][derivative];
+                    grad_grad_1[d1][d2] *= v[x][derivative_idx];
                   }
               }
 

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1198,8 +1198,8 @@ namespace Threads
        * Constructor. Initializes an std::future object and assumes
        * that the task so set has not finished yet.
        */
-      TaskData(std::future<RT> &&future)
-        : future(std::move(future))
+      TaskData(std::future<RT> &&future_)
+        : future(std::move(future_))
         , task_has_finished(false)
       {}
 

--- a/include/deal.II/base/vectorization.h
+++ b/include/deal.II/base/vectorization.h
@@ -103,9 +103,9 @@ public:
    * @param data The actual VectorizedArray.
    * @param lane A pointer to the current lane.
    */
-  VectorizedArrayIterator(T &data, const std::size_t lane)
-    : data(&data)
-    , lane(lane)
+  VectorizedArrayIterator(T &data_, const std::size_t lane_)
+    : data(&data_)
+    , lane(lane_)
   {}
 
   /**

--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -319,14 +319,14 @@ namespace WorkStream
         IteratorRangeToItemStream(const Iterator &   begin,
                                   const Iterator &   end,
                                   const unsigned int buffer_size,
-                                  const unsigned int chunk_size,
-                                  const ScratchData &sample_scratch_data,
+                                  const unsigned int chunk_size_,
+                                  const ScratchData &sample_scratch_data_,
                                   const CopyData &   sample_copy_data)
           : tbb::filter(/*is_serial=*/true)
           , remaining_iterator_range(begin, end)
           , item_buffer(buffer_size)
-          , sample_scratch_data(sample_scratch_data)
-          , chunk_size(chunk_size)
+          , sample_scratch_data(sample_scratch_data_)
+          , chunk_size(chunk_size_)
         {
           // initialize the elements of the ring buffer
           for (unsigned int element = 0; element < item_buffer.size();
@@ -478,11 +478,11 @@ namespace WorkStream
          */
         TBBWorker(
           const std::function<void(const Iterator &, ScratchData &, CopyData &)>
-            &  worker,
-          bool copier_exist = true)
+            &  worker_,
+          bool copier_exist_ = true)
           : tbb::filter(/* is_serial= */ false)
-          , worker(worker)
-          , copier_exist(copier_exist)
+          , worker(worker_)
+          , copier_exist(copier_exist_)
         {}
 
 
@@ -625,9 +625,9 @@ namespace WorkStream
          * copying from the additional data object to the global matrix or
          * similar.
          */
-        TBBCopier(const std::function<void(const CopyData &)> &copier)
+        TBBCopier(const std::function<void(const CopyData &)> &copier_)
           : tbb::filter(/*is_serial=*/true)
-          , copier(copier)
+          , copier(copier_)
         {}
 
 
@@ -881,14 +881,14 @@ namespace WorkStream
          */
         WorkerAndCopier(
           const std::function<void(const Iterator &, ScratchData &, CopyData &)>
-            &                                          worker,
-          const std::function<void(const CopyData &)> &copier,
-          const ScratchData &                          sample_scratch_data,
-          const CopyData &                             sample_copy_data)
-          : worker(worker)
-          , copier(copier)
-          , sample_scratch_data(sample_scratch_data)
-          , sample_copy_data(sample_copy_data)
+            &                                          worker_,
+          const std::function<void(const CopyData &)> &copier_,
+          const ScratchData &                          sample_scratch_data_,
+          const CopyData &                             sample_copy_data_)
+          : worker(worker_)
+          , copier(copier_)
+          , sample_scratch_data(sample_scratch_data_)
+          , sample_copy_data(sample_copy_data_)
         {}
 
 

--- a/include/deal.II/dofs/dof_accessor.templates.h
+++ b/include/deal.II/dofs/dof_accessor.templates.h
@@ -51,16 +51,16 @@ inline DoFAccessor<structdim, dim, spacedim, level_dof_access>::DoFAccessor()
 
 template <int structdim, int dim, int spacedim, bool level_dof_access>
 inline DoFAccessor<structdim, dim, spacedim, level_dof_access>::DoFAccessor(
-  const Triangulation<dim, spacedim> *tria,
+  const Triangulation<dim, spacedim> *tria_,
   const int                           level,
   const int                           index,
-  const DoFHandler<dim, spacedim> *   dof_handler)
+  const DoFHandler<dim, spacedim> *   dof_handler_)
   : dealii::internal::DoFAccessorImplementation::
-      Inheritance<structdim, dim, spacedim>::BaseClass(tria, level, index)
-  , dof_handler(const_cast<DoFHandler<dim, spacedim> *>(dof_handler))
+      Inheritance<structdim, dim, spacedim>::BaseClass(tria_, level, index)
+  , dof_handler(const_cast<DoFHandler<dim, spacedim> *>(dof_handler_))
 {
   Assert(
-    tria == nullptr || &dof_handler->get_triangulation() == tria,
+    tria_ == nullptr || &dof_handler->get_triangulation() == tria_,
     ExcMessage(
       "You can't create a DoF accessor in which the DoFHandler object "
       "uses a different triangulation than the one you pass as argument."));
@@ -1141,10 +1141,10 @@ namespace internal
         /**
          * Constructor.
          */
-        MGDoFIndexGetter(const FiniteElement<dim, spacedim> &fe,
-                         const unsigned int                  level)
-          : fe(fe)
-          , level(level)
+        MGDoFIndexGetter(const FiniteElement<dim, spacedim> &fe_,
+                         const unsigned int                  level_)
+          : fe(fe_)
+          , level(level_)
         {}
 
         /**
@@ -1223,10 +1223,10 @@ namespace internal
         /**
          * Constructor.
          */
-        MGDoFIndexSetter(const FiniteElement<dim, spacedim> &fe,
-                         const unsigned int                  level)
-          : fe(fe)
-          , level(level)
+        MGDoFIndexSetter(const FiniteElement<dim, spacedim> &fe_,
+                         const unsigned int                  level_)
+          : fe(fe_)
+          , level(level_)
         {}
 
         /**
@@ -1824,22 +1824,22 @@ inline DoFAccessor<0, 1, spacedim, level_dof_access>::DoFAccessor()
 
 template <int spacedim, bool level_dof_access>
 inline DoFAccessor<0, 1, spacedim, level_dof_access>::DoFAccessor(
-  const Triangulation<1, spacedim> *                      tria,
-  const typename TriaAccessor<0, 1, spacedim>::VertexKind vertex_kind,
+  const Triangulation<1, spacedim> *                      tria_,
+  const typename TriaAccessor<0, 1, spacedim>::VertexKind vertex_kind_,
   const unsigned int                                      vertex_index,
-  const DoFHandler<1, spacedim> *                         dof_handler)
-  : BaseClass(tria, vertex_kind, vertex_index)
-  , dof_handler(const_cast<DoFHandler<1, spacedim> *>(dof_handler))
+  const DoFHandler<1, spacedim> *                         dof_handler_)
+  : BaseClass(tria_, vertex_kind_, vertex_index)
+  , dof_handler(const_cast<DoFHandler<1, spacedim> *>(dof_handler_))
 {}
 
 
 
 template <int spacedim, bool level_dof_access>
 inline DoFAccessor<0, 1, spacedim, level_dof_access>::DoFAccessor(
-  const Triangulation<1, spacedim> *tria,
+  const Triangulation<1, spacedim> *triangulation,
   const int                         level,
   const int                         index,
-  const DoFHandler<1, spacedim> *   dof_handler)
+  const DoFHandler<1, spacedim> *   dof_handler_)
   // This is the constructor signature for "ordinary" (non-vertex)
   // accessors and we shouldn't be calling it altogether. But it is also
   // the constructor that the default-constructor of TriaRawIterator
@@ -1849,14 +1849,14 @@ inline DoFAccessor<0, 1, spacedim, level_dof_access>::DoFAccessor(
   // other constructor of this class, and then asserting the condition
   // on level and index.
   : DoFAccessor<0, 1, spacedim, level_dof_access>(
-      tria,
+      triangulation,
       TriaAccessor<0, 1, spacedim>::interior_vertex,
       0U,
-      dof_handler)
+      dof_handler_)
 {
   (void)level;
   (void)index;
-  Assert((tria == nullptr) && (level == -2) && (index == -2) &&
+  Assert((triangulation == nullptr) && (level == -2) && (index == -2) &&
            (dof_handler == nullptr),
          ExcMessage(
            "This constructor can not be called for face iterators in 1d, "
@@ -2406,12 +2406,12 @@ namespace internal
 
 template <int dimension_, int space_dimension_, bool level_dof_access>
 inline DoFCellAccessor<dimension_, space_dimension_, level_dof_access>::
-  DoFCellAccessor(const Triangulation<dimension_, space_dimension_> *tria,
+  DoFCellAccessor(const Triangulation<dimension_, space_dimension_> *tria_,
                   const int                                          level,
                   const int                                          index,
                   const AccessorData *                               local_data)
   : DoFAccessor<dimension_, dimension_, space_dimension_, level_dof_access>(
-      tria,
+      tria_,
       level,
       index,
       local_data)

--- a/include/deal.II/dofs/dof_renumbering.h
+++ b/include/deal.II/dofs/dof_renumbering.h
@@ -352,8 +352,8 @@ namespace DoFRenumbering
     /**
      * Constructor.
      */
-    CompareDownstream(const Tensor<1, dim> &dir)
-      : dir(dir)
+    CompareDownstream(const Tensor<1, dim> &d)
+      : dir(d)
     {}
     /**
      * Return true if c1 less c2.
@@ -386,8 +386,8 @@ namespace DoFRenumbering
     /**
      * Constructor.
      */
-    ComparePointwiseDownstream(const Tensor<1, dim> &dir)
-      : dir(dir)
+    ComparePointwiseDownstream(const Tensor<1, dim> &d)
+      : dir(d)
     {}
     /**
      * Return true if c1 less c2.

--- a/include/deal.II/fe/block_mask.h
+++ b/include/deal.II/fe/block_mask.h
@@ -238,8 +238,8 @@ operator<<(std::ostream &out, const BlockMask &mask);
 #ifndef DOXYGEN
 // -------------------- inline functions ---------------------
 
-inline BlockMask::BlockMask(const std::vector<bool> &block_mask)
-  : block_mask(block_mask)
+inline BlockMask::BlockMask(const std::vector<bool> &block_mask_)
+  : block_mask(block_mask_)
 {}
 
 

--- a/include/deal.II/fe/component_mask.h
+++ b/include/deal.II/fe/component_mask.h
@@ -259,8 +259,8 @@ operator<<(std::ostream &out, const ComponentMask &mask);
 #ifndef DOXYGEN
 // -------------------- inline functions ---------------------
 
-inline ComponentMask::ComponentMask(const std::vector<bool> &component_mask)
-  : component_mask(component_mask)
+inline ComponentMask::ComponentMask(const std::vector<bool> &component_mask_)
+  : component_mask(component_mask_)
 {}
 
 

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -35,14 +35,14 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 FE_Poly<dim, spacedim>::FE_Poly(
-  const ScalarPolynomialsBase<dim> &poly_space,
+  const ScalarPolynomialsBase<dim> &poly_space_,
   const FiniteElementData<dim> &    fe_data,
-  const std::vector<bool> &         restriction_is_additive_flags,
-  const std::vector<ComponentMask> &nonzero_components)
+  const std::vector<bool> &         restriction_is_additive_flags_,
+  const std::vector<ComponentMask> &nonzero_components_)
   : FiniteElement<dim, spacedim>(fe_data,
-                                 restriction_is_additive_flags,
-                                 nonzero_components)
-  , poly_space(poly_space.clone())
+                                 restriction_is_additive_flags_,
+                                 nonzero_components_)
+  , poly_space(poly_space_.clone())
 {}
 
 

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -30,14 +30,14 @@ DEAL_II_NAMESPACE_OPEN
 
 template <class PolynomialType, int dim, int spacedim>
 FE_PolyFace<PolynomialType, dim, spacedim>::FE_PolyFace(
-  const PolynomialType &        poly_space,
+  const PolynomialType &        poly_space_,
   const FiniteElementData<dim> &fe_data,
-  const std::vector<bool> &     restriction_is_additive_flags)
+  const std::vector<bool> &     restriction_is_additive_flags_)
   : FiniteElement<dim, spacedim>(
       fe_data,
-      restriction_is_additive_flags,
+      restriction_is_additive_flags_,
       std::vector<ComponentMask>(1, ComponentMask(1, true)))
-  , poly_space(poly_space)
+  , poly_space(poly_space_)
 {
   AssertDimension(dim, PolynomialType::dimension + 1);
 }

--- a/include/deal.II/fe/fe_tools.templates.h
+++ b/include/deal.II/fe/fe_tools.templates.h
@@ -2111,16 +2111,14 @@ namespace FETools
       [&reference_cell, &mapping, &fe, &q_fine, n, nd, nq](
         const unsigned int               ref_case,
         const FullMatrix<double> &       inverse_mass_matrix,
-        std::vector<FullMatrix<double>> &matrices) {
+        std::vector<FullMatrix<double>> &mat) {
         const unsigned int nc =
           GeometryInfo<dim>::n_children(RefinementCase<dim>(ref_case));
 
         for (unsigned int i = 0; i < nc; ++i)
           {
-            Assert(matrices[i].n() == n,
-                   ExcDimensionMismatch(matrices[i].n(), n));
-            Assert(matrices[i].m() == n,
-                   ExcDimensionMismatch(matrices[i].m(), n));
+            Assert(mat[i].n() == n, ExcDimensionMismatch(mat[i].n(), n));
+            Assert(mat[i].m() == n, ExcDimensionMismatch(mat[i].m(), n));
           }
 
         // create a respective refinement on the triangulation
@@ -2143,7 +2141,7 @@ namespace FETools
 
         for (unsigned int cell_number = 0; cell_number < nc; ++cell_number)
           {
-            FullMatrix<double> &this_matrix = matrices[cell_number];
+            FullMatrix<double> &this_matrix = mat[cell_number];
 
             // Compute right hand side, which is a fine level basis
             // function tested with the coarse level functions.

--- a/include/deal.II/fe/fe_values_extractors.h
+++ b/include/deal.II/fe/fe_values_extractors.h
@@ -282,8 +282,8 @@ namespace FEValuesExtractors
 
 
 
-  inline Scalar::Scalar(const unsigned int component)
-    : component(component)
+  inline Scalar::Scalar(const unsigned int component_)
+    : component(component_)
   {}
 
 
@@ -293,8 +293,8 @@ namespace FEValuesExtractors
   {}
 
 
-  inline Vector::Vector(const unsigned int first_vector_component)
-    : first_vector_component(first_vector_component)
+  inline Vector::Vector(const unsigned int first_vector_component_)
+    : first_vector_component(first_vector_component_)
   {}
 
 
@@ -306,8 +306,8 @@ namespace FEValuesExtractors
 
   template <int rank>
   inline SymmetricTensor<rank>::SymmetricTensor(
-    const unsigned int first_tensor_component)
-    : first_tensor_component(first_tensor_component)
+    const unsigned int first_tensor_component_)
+    : first_tensor_component(first_tensor_component_)
   {}
 
 
@@ -318,8 +318,8 @@ namespace FEValuesExtractors
 
 
   template <int rank>
-  inline Tensor<rank>::Tensor(const unsigned int first_tensor_component)
-    : first_tensor_component(first_tensor_component)
+  inline Tensor<rank>::Tensor(const unsigned int first_tensor_component_)
+    : first_tensor_component(first_tensor_component_)
   {}
 } // namespace FEValuesExtractors
 

--- a/include/deal.II/fe/mapping_manifold.h
+++ b/include/deal.II/fe/mapping_manifold.h
@@ -398,28 +398,28 @@ private:
 template <int dim, int spacedim>
 inline void
 MappingManifold<dim, spacedim>::InternalData::store_vertices(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell) const
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell_) const
 {
   vertices.resize(GeometryInfo<dim>::vertices_per_cell);
   for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
-    vertices[i] = cell->vertex(i);
-  this->cell = cell;
+    vertices[i] = cell_->vertex(i);
+  this->cell = cell_;
 }
 
 
 template <int dim, int spacedim>
 inline void
 MappingManifold<dim, spacedim>::InternalData::
-  compute_manifold_quadrature_weights(const Quadrature<dim> &quad)
+  compute_manifold_quadrature_weights(const Quadrature<dim> &quad_)
 {
   cell_manifold_quadrature_weights.resize(
-    quad.size(), std::vector<double>(GeometryInfo<dim>::vertices_per_cell));
-  for (unsigned int q = 0; q < quad.size(); ++q)
+    quad_.size(), std::vector<double>(GeometryInfo<dim>::vertices_per_cell));
+  for (unsigned int q = 0; q < quad_.size(); ++q)
     {
       for (const unsigned int i : GeometryInfo<dim>::vertex_indices())
         {
           cell_manifold_quadrature_weights[q][i] =
-            GeometryInfo<dim>::d_linear_shape_function(quad.point(q), i);
+            GeometryInfo<dim>::d_linear_shape_function(quad_.point(q), i);
         }
     }
 }

--- a/include/deal.II/grid/filtered_iterator.h
+++ b/include/deal.II/grid/filtered_iterator.h
@@ -1122,8 +1122,8 @@ FilteredIterator<BaseIterator>::operator--(int)
 template <typename BaseIterator>
 template <typename Predicate>
 inline FilteredIterator<BaseIterator>::PredicateTemplate<
-  Predicate>::PredicateTemplate(const Predicate &predicate)
-  : predicate(predicate)
+  Predicate>::PredicateTemplate(const Predicate &predicate_)
+  : predicate(predicate_)
 {}
 
 
@@ -1182,8 +1182,8 @@ namespace IteratorFilters
 
 
   // ---------------- IteratorFilters::LevelEqualTo ---------
-  inline LevelEqualTo::LevelEqualTo(const unsigned int level)
-    : level(level)
+  inline LevelEqualTo::LevelEqualTo(const unsigned int level_)
+    : level(level_)
   {}
 
 
@@ -1199,8 +1199,8 @@ namespace IteratorFilters
 
   // ---------------- IteratorFilters::SubdomainEqualTo ---------
   inline SubdomainEqualTo::SubdomainEqualTo(
-    const types::subdomain_id subdomain_id)
-    : subdomain_id(subdomain_id)
+    const types::subdomain_id subdomain_id_)
+    : subdomain_id(subdomain_id_)
   {}
 
 
@@ -1238,18 +1238,18 @@ namespace IteratorFilters
   // ---------------- IteratorFilters::MaterialIdEqualTo ---------
   inline MaterialIdEqualTo::MaterialIdEqualTo(
     const types::material_id material_id,
-    const bool               only_locally_owned)
+    const bool               only_locally_owned_)
     : material_ids{material_id}
-    , only_locally_owned(only_locally_owned)
+    , only_locally_owned(only_locally_owned_)
   {}
 
 
 
   inline MaterialIdEqualTo::MaterialIdEqualTo(
-    const std::set<types::material_id> &material_ids,
-    const bool                          only_locally_owned)
-    : material_ids(material_ids)
-    , only_locally_owned(only_locally_owned)
+    const std::set<types::material_id> &material_ids_,
+    const bool                          only_locally_owned_)
+    : material_ids(material_ids_)
+    , only_locally_owned(only_locally_owned_)
   {}
 
 
@@ -1269,18 +1269,18 @@ namespace IteratorFilters
   // ---------------- IteratorFilters::ActiveFEIndexEqualTo ---------
   inline ActiveFEIndexEqualTo::ActiveFEIndexEqualTo(
     const unsigned int active_fe_index,
-    const bool         only_locally_owned)
+    const bool         only_locally_owned_)
     : active_fe_indices{active_fe_index}
-    , only_locally_owned(only_locally_owned)
+    , only_locally_owned(only_locally_owned_)
   {}
 
 
 
   inline ActiveFEIndexEqualTo::ActiveFEIndexEqualTo(
-    const std::set<unsigned int> &active_fe_indices,
-    const bool                    only_locally_owned)
-    : active_fe_indices(active_fe_indices)
-    , only_locally_owned(only_locally_owned)
+    const std::set<unsigned int> &active_fe_indices_,
+    const bool                    only_locally_owned_)
+    : active_fe_indices(active_fe_indices_)
+    , only_locally_owned(only_locally_owned_)
   {}
 
 

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -3519,10 +3519,7 @@ namespace GridTools
     // that we get to all vertices in
     // the triangulation by only
     // visiting the active cells.
-    typename Triangulation<dim, spacedim>::active_cell_iterator
-      cell = triangulation.begin_active(),
-      endc = triangulation.end();
-    for (; cell != endc; ++cell)
+    for (const auto &cell : triangulation.active_cell_iterators())
       for (const unsigned int v : cell->vertex_indices())
         if (treated_vertices[cell->vertex_index(v)] == false)
           {
@@ -3536,10 +3533,7 @@ namespace GridTools
     // now fix any vertices on hanging nodes so that we don't create any holes
     if (dim == 2)
       {
-        typename Triangulation<dim, spacedim>::active_cell_iterator
-          cell = triangulation.begin_active(),
-          endc = triangulation.end();
-        for (; cell != endc; ++cell)
+        for (const auto &cell : triangulation.active_cell_iterators())
           for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->has_children() &&
                 !cell->face(face)->at_boundary())
@@ -3556,10 +3550,7 @@ namespace GridTools
       }
     else if (dim == 3)
       {
-        typename Triangulation<dim, spacedim>::active_cell_iterator
-          cell = triangulation.begin_active(),
-          endc = triangulation.end();
-        for (; cell != endc; ++cell)
+        for (const auto &cell : triangulation.active_cell_iterators())
           for (const unsigned int face : cell->face_indices())
             if (cell->face(face)->has_children() &&
                 !cell->face(face)->at_boundary())

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -614,8 +614,8 @@ std::istream &
 operator>>(std::istream &in, ReferenceCell &reference_cell);
 
 
-inline constexpr ReferenceCell::ReferenceCell(const std::uint8_t kind)
-  : kind(kind)
+inline constexpr ReferenceCell::ReferenceCell(const std::uint8_t kind_)
+  : kind(kind_)
 {}
 
 
@@ -1976,12 +1976,12 @@ namespace internal
     /**
      * Constructor.
      */
-    NoPermutation(const dealii::ReferenceCell &entity_type,
-                  const std::array<T, N> &     vertices_0,
-                  const std::array<T, N> &     vertices_1)
-      : entity_type(entity_type)
-      , vertices_0(vertices_0)
-      , vertices_1(vertices_1)
+    NoPermutation(const dealii::ReferenceCell &entity_type_,
+                  const std::array<T, N> &     vertices_0_,
+                  const std::array<T, N> &     vertices_1_)
+      : entity_type(entity_type_)
+      , vertices_0(vertices_0_)
+      , vertices_1(vertices_1_)
     {}
 
     /**

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -125,13 +125,13 @@ namespace internal
 
 template <int structdim, int dim, int spacedim>
 inline TriaAccessorBase<structdim, dim, spacedim>::TriaAccessorBase(
-  const Triangulation<dim, spacedim> *tria,
+  const Triangulation<dim, spacedim> *tria_,
   const int                           level,
   const int                           index,
   const AccessorData *)
   : present_level((structdim == dim) ? level : 0)
   , present_index(index)
-  , tria(tria)
+  , tria(tria_)
 {
   // non-cells have no level, so a 0
   // should have been passed, or a -1
@@ -2289,9 +2289,9 @@ TriaAccessor<structdim, dim, spacedim>::face_indices() const
 
 template <int dim, int spacedim>
 inline TriaAccessor<0, dim, spacedim>::TriaAccessor(
-  const Triangulation<dim, spacedim> *tria,
+  const Triangulation<dim, spacedim> *tria_,
   const unsigned int                  vertex_index)
-  : tria(tria)
+  : tria(tria_)
   , global_vertex_index(vertex_index)
 {}
 
@@ -2299,11 +2299,11 @@ inline TriaAccessor<0, dim, spacedim>::TriaAccessor(
 
 template <int dim, int spacedim>
 inline TriaAccessor<0, dim, spacedim>::TriaAccessor(
-  const Triangulation<dim, spacedim> *tria,
+  const Triangulation<dim, spacedim> *tria_,
   const int /*level*/,
   const int index,
   const AccessorData *)
-  : tria(tria)
+  : tria(tria_)
   , global_vertex_index(index)
 {}
 
@@ -2697,11 +2697,11 @@ TriaAccessor<0, dim, spacedim>::used() const
 
 template <int spacedim>
 inline TriaAccessor<0, 1, spacedim>::TriaAccessor(
-  const Triangulation<1, spacedim> *tria,
-  const VertexKind                  vertex_kind,
+  const Triangulation<1, spacedim> *tria_,
+  const VertexKind                  vertex_kind_,
   const unsigned int                vertex_index)
-  : tria(tria)
-  , vertex_kind(vertex_kind)
+  : tria(tria_)
+  , vertex_kind(vertex_kind_)
   , global_vertex_index(vertex_index)
 {}
 
@@ -2709,11 +2709,11 @@ inline TriaAccessor<0, 1, spacedim>::TriaAccessor(
 
 template <int spacedim>
 inline TriaAccessor<0, 1, spacedim>::TriaAccessor(
-  const Triangulation<1, spacedim> *tria,
+  const Triangulation<1, spacedim> *tria_,
   const int                         level,
   const int                         index,
   const AccessorData *)
-  : tria(tria)
+  : tria(tria_)
   , vertex_kind(interior_vertex)
   , global_vertex_index(numbers::invalid_unsigned_int)
 {

--- a/include/deal.II/grid/tria_levels.h
+++ b/include/deal.II/grid/tria_levels.h
@@ -60,8 +60,8 @@ namespace internal
        *
        * @param dim Dimension of the Triangulation.
        */
-      TriaLevel(const unsigned int dim)
-        : dim(dim)
+      TriaLevel(const unsigned int dim_)
+        : dim(dim_)
         , cells(dim)
       {}
 

--- a/include/deal.II/grid/tria_objects.h
+++ b/include/deal.II/grid/tria_objects.h
@@ -479,8 +479,8 @@ namespace internal
     {}
 
 
-    inline TriaObjects::TriaObjects(const unsigned int structdim)
-      : structdim(structdim)
+    inline TriaObjects::TriaObjects(const unsigned int structdim_)
+      : structdim(structdim_)
       , next_free_single(numbers::invalid_unsigned_int)
       , next_free_pair(numbers::invalid_unsigned_int)
       , reverse_order_next_free_single(false)

--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -41,10 +41,10 @@ namespace hp
      * @param data The actual data of hp::Collection.
      * @param index The current index.
      */
-    CollectionIterator(const std::vector<std::shared_ptr<const T>> &data,
-                       const std::size_t                            index)
-      : data(&data)
-      , index(index)
+    CollectionIterator(const std::vector<std::shared_ptr<const T>> &data_,
+                       const std::size_t                            index_)
+      : data(&data_)
+      , index(index_)
     {}
 
     /**

--- a/include/deal.II/lac/affine_constraints.h
+++ b/include/deal.II/lac/affine_constraints.h
@@ -2560,12 +2560,12 @@ AffineConstraints<number>::add_entries_local_to_global(
 
 template <typename number>
 inline AffineConstraints<number>::ConstraintLine::ConstraintLine(
-  const size_type &                                                  index,
-  const typename AffineConstraints<number>::ConstraintLine::Entries &entries,
-  const number &inhomogeneity)
-  : index(index)
-  , entries(entries)
-  , inhomogeneity(inhomogeneity)
+  const size_type &                                                  index_,
+  const typename AffineConstraints<number>::ConstraintLine::Entries &entries_,
+  const number &inhomogeneity_)
+  : index(index_)
+  , entries(entries_)
+  , inhomogeneity(inhomogeneity_)
 {}
 
 

--- a/include/deal.II/lac/block_indices.h
+++ b/include/deal.II/lac/block_indices.h
@@ -286,9 +286,9 @@ inline BlockIndices::BlockIndices()
 
 
 
-inline BlockIndices::BlockIndices(const unsigned int n_blocks,
+inline BlockIndices::BlockIndices(const unsigned int n_blocks_,
                                   const size_type    block_size)
-  : n_blocks(n_blocks)
+  : n_blocks(n_blocks_)
   , start_indices(n_blocks + 1)
 {
   for (size_type i = 0; i <= n_blocks; ++i)

--- a/include/deal.II/lac/block_matrix_base.h
+++ b/include/deal.II/lac/block_matrix_base.h
@@ -1110,10 +1110,10 @@ namespace BlockMatrixIterators
 
   template <class BlockMatrixType>
   inline Accessor<BlockMatrixType, true>::Accessor(
-    const BlockMatrixType *matrix,
+    const BlockMatrixType *matrix_,
     const size_type        row,
     const size_type        col)
-    : matrix(matrix)
+    : matrix(matrix_)
     , base_iterator(matrix->block(0, 0).begin())
   {
     (void)col;
@@ -1310,10 +1310,10 @@ namespace BlockMatrixIterators
 
 
   template <class BlockMatrixType>
-  inline Accessor<BlockMatrixType, false>::Accessor(BlockMatrixType *matrix,
+  inline Accessor<BlockMatrixType, false>::Accessor(BlockMatrixType *matrix_,
                                                     const size_type  row,
                                                     const size_type  col)
-    : matrix(matrix)
+    : matrix(matrix_)
     , base_iterator(matrix->block(0, 0).begin())
   {
     (void)col;

--- a/include/deal.II/lac/block_sparse_matrix_ez.h
+++ b/include/deal.II/lac/block_sparse_matrix_ez.h
@@ -474,12 +474,12 @@ BlockSparseMatrixEZ<number>::print_statistics(StreamType &out, bool full)
         if (full)
           {
             used_by_line_total.resize(used_by_line.size());
-            for (size_type i = 0; i < used_by_line.size(); ++i)
-              if (used_by_line[i] != 0)
+            for (size_type k = 0; k < used_by_line.size(); ++k)
+              if (used_by_line[k] != 0)
                 {
-                  out << "row-entries\t" << i << "\trows\t" << used_by_line[i]
+                  out << "row-entries\t" << k << "\trows\t" << used_by_line[k]
                       << std::endl;
-                  used_by_line_total[i] += used_by_line[i];
+                  used_by_line_total[k] += used_by_line[k];
                 }
           }
       }

--- a/include/deal.II/lac/block_vector.h
+++ b/include/deal.II/lac/block_vector.h
@@ -394,9 +394,9 @@ BlockVector<Number>::BlockVector(const std::vector<size_type> &block_sizes,
   InputIterator start = first;
   for (size_type b = 0; b < block_sizes.size(); ++b)
     {
-      InputIterator end = start;
-      std::advance(end, static_cast<signed int>(block_sizes[b]));
-      std::copy(start, end, this->block(b).begin());
+      InputIterator finish = start;
+      std::advance(finish, static_cast<signed int>(block_sizes[b]));
+      std::copy(start, finish, this->block(b).begin());
       start = end;
     };
   Assert(start == end, ExcIteratorRangeDoesNotMatchVectorSize());

--- a/include/deal.II/lac/block_vector_base.h
+++ b/include/deal.II/lac/block_vector_base.h
@@ -1014,18 +1014,18 @@ namespace internal
 
     template <class BlockVectorType, bool Constness>
     inline Iterator<BlockVectorType, Constness>::Iterator(
-      BlockVector &   parent,
-      const size_type global_index,
-      const size_type current_block,
-      const size_type index_within_block,
-      const size_type next_break_forward,
-      const size_type next_break_backward)
-      : parent(&parent)
-      , global_index(global_index)
-      , current_block(current_block)
-      , index_within_block(index_within_block)
-      , next_break_forward(next_break_forward)
-      , next_break_backward(next_break_backward)
+      BlockVector &   parent_,
+      const size_type global_index_,
+      const size_type current_block_,
+      const size_type index_within_block_,
+      const size_type next_break_forward_,
+      const size_type next_break_backward_)
+      : parent(&parent_)
+      , global_index(global_index_)
+      , current_block(current_block_)
+      , index_within_block(index_within_block_)
+      , next_break_forward(next_break_forward_)
+      , next_break_backward(next_break_backward_)
     {}
 
 
@@ -1321,10 +1321,11 @@ namespace internal
 
 
     template <class BlockVectorType, bool Constness>
-    Iterator<BlockVectorType, Constness>::Iterator(BlockVector &   parent,
-                                                   const size_type global_index)
-      : parent(&parent)
-      , global_index(global_index)
+    Iterator<BlockVectorType, Constness>::Iterator(
+      BlockVector &   parent_,
+      const size_type global_index_)
+      : parent(&parent_)
+      , global_index(global_index_)
     {
       // find which block we are
       // in. for this, take into
@@ -1332,25 +1333,25 @@ namespace internal
       // times that people want to
       // initialize iterators
       // past-the-end
-      if (global_index < parent.size())
+      if (global_index < parent->size())
         {
           const std::pair<size_type, size_type> indices =
-            parent.block_indices.global_to_local(global_index);
+            parent->block_indices.global_to_local(global_index);
           current_block      = indices.first;
           index_within_block = indices.second;
 
           next_break_backward =
-            parent.block_indices.local_to_global(current_block, 0);
+            parent->block_indices.local_to_global(current_block, 0);
           next_break_forward =
-            (parent.block_indices.local_to_global(current_block, 0) +
-             parent.block_indices.block_size(current_block) - 1);
+            (parent->block_indices.local_to_global(current_block, 0) +
+             parent->block_indices.block_size(current_block) - 1);
         }
       else
         // past the end. only have one
         // value for this
         {
-          this->global_index  = parent.size();
-          current_block       = parent.n_blocks();
+          this->global_index  = parent->size();
+          current_block       = parent->n_blocks();
           index_within_block  = 0;
           next_break_backward = global_index;
           next_break_forward  = numbers::invalid_size_type;

--- a/include/deal.II/lac/chunk_sparse_matrix.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.h
@@ -1686,19 +1686,19 @@ ChunkSparseMatrix<number>::copy_from(const ForwardIterator begin,
 namespace ChunkSparseMatrixIterators
 {
   template <typename number>
-  inline Accessor<number, true>::Accessor(const MatrixType * matrix,
+  inline Accessor<number, true>::Accessor(const MatrixType * matrix_,
                                           const unsigned int row)
-    : ChunkSparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern(),
+    : ChunkSparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern(),
                                               row)
-    , matrix(matrix)
+    , matrix(matrix_)
   {}
 
 
 
   template <typename number>
-  inline Accessor<number, true>::Accessor(const MatrixType *matrix)
-    : ChunkSparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern())
-    , matrix(matrix)
+  inline Accessor<number, true>::Accessor(const MatrixType *matrix_)
+    : ChunkSparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern())
+    , matrix(matrix_)
   {}
 
 
@@ -1734,9 +1734,10 @@ namespace ChunkSparseMatrixIterators
 
 
   template <typename number>
-  inline Accessor<number, false>::Reference::Reference(const Accessor *accessor,
-                                                       const bool)
-    : accessor(accessor)
+  inline Accessor<number, false>::Reference::Reference(
+    const Accessor *accessor_,
+    const bool)
+    : accessor(accessor_)
   {}
 
 
@@ -1823,19 +1824,19 @@ namespace ChunkSparseMatrixIterators
 
 
   template <typename number>
-  inline Accessor<number, false>::Accessor(MatrixType *       matrix,
+  inline Accessor<number, false>::Accessor(MatrixType *       matrix_,
                                            const unsigned int row)
-    : ChunkSparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern(),
+    : ChunkSparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern(),
                                               row)
-    , matrix(matrix)
+    , matrix(matrix_)
   {}
 
 
 
   template <typename number>
-  inline Accessor<number, false>::Accessor(MatrixType *matrix)
-    : ChunkSparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern())
-    , matrix(matrix)
+  inline Accessor<number, false>::Accessor(MatrixType *matrix_)
+    : ChunkSparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern())
+    , matrix(matrix_)
   {}
 
 

--- a/include/deal.II/lac/chunk_sparsity_pattern.h
+++ b/include/deal.II/lac/chunk_sparsity_pattern.h
@@ -865,9 +865,9 @@ private:
 
 namespace ChunkSparsityPatternIterators
 {
-  inline Accessor::Accessor(const ChunkSparsityPattern *sparsity_pattern,
+  inline Accessor::Accessor(const ChunkSparsityPattern *sparsity_pattern_,
                             const size_type             row)
-    : sparsity_pattern(sparsity_pattern)
+    : sparsity_pattern(sparsity_pattern_)
     , reduced_accessor(row == sparsity_pattern->n_rows() ?
                          *sparsity_pattern->sparsity_pattern.end() :
                          *sparsity_pattern->sparsity_pattern.begin(
@@ -880,8 +880,8 @@ namespace ChunkSparsityPatternIterators
 
 
 
-  inline Accessor::Accessor(const ChunkSparsityPattern *sparsity_pattern)
-    : sparsity_pattern(sparsity_pattern)
+  inline Accessor::Accessor(const ChunkSparsityPattern *sparsity_pattern_)
+    : sparsity_pattern(sparsity_pattern_)
     , reduced_accessor(*sparsity_pattern->sparsity_pattern.end())
     , chunk_row(0)
     , chunk_col(0)
@@ -1174,7 +1174,7 @@ ChunkSparsityPattern::copy_from(const size_type       n_rows,
                                 const size_type       n_cols,
                                 const ForwardIterator begin,
                                 const ForwardIterator end,
-                                const size_type       chunk_size)
+                                const size_type       chunk_size_)
 {
   Assert(static_cast<size_type>(std::distance(begin, end)) == n_rows,
          ExcIteratorRange(std::distance(begin, end), n_rows));
@@ -1189,7 +1189,7 @@ ChunkSparsityPattern::copy_from(const size_type       n_rows,
   for (ForwardIterator i = begin; i != end; ++i)
     row_lengths.push_back(std::distance(i->begin(), i->end()) +
                           (is_square ? 1 : 0));
-  reinit(n_rows, n_cols, row_lengths, chunk_size);
+  reinit(n_rows, n_cols, row_lengths, chunk_size_);
 
   // now enter all the elements into the matrix
   size_type row = 0;

--- a/include/deal.II/lac/dynamic_sparsity_pattern.h
+++ b/include/deal.II/lac/dynamic_sparsity_pattern.h
@@ -742,10 +742,10 @@ private:
 
 namespace DynamicSparsityPatternIterators
 {
-  inline Accessor::Accessor(const DynamicSparsityPattern *sparsity_pattern,
+  inline Accessor::Accessor(const DynamicSparsityPattern *sparsity_pattern_,
                             const size_type               row,
                             const unsigned int            index_within_row)
-    : sparsity_pattern(sparsity_pattern)
+    : sparsity_pattern(sparsity_pattern_)
     , current_row(row)
     , current_entry(
         ((sparsity_pattern->rowset.size() == 0) ?
@@ -778,8 +778,8 @@ namespace DynamicSparsityPatternIterators
   }
 
 
-  inline Accessor::Accessor(const DynamicSparsityPattern *sparsity_pattern)
-    : sparsity_pattern(sparsity_pattern)
+  inline Accessor::Accessor(const DynamicSparsityPattern *sparsity_pattern_)
+    : sparsity_pattern(sparsity_pattern_)
     , current_row(numbers::invalid_size_type)
     , current_entry()
     , end_of_row()

--- a/include/deal.II/lac/precondition.h
+++ b/include/deal.II/lac/precondition.h
@@ -1384,8 +1384,8 @@ PreconditionIdentity::n() const
 //---------------------------------------------------------------------------
 
 inline PreconditionRichardson::AdditionalData::AdditionalData(
-  const double relaxation)
-  : relaxation(relaxation)
+  const double relaxation_)
+  : relaxation(relaxation_)
 {}
 
 
@@ -1819,12 +1819,13 @@ PreconditionPSOR<MatrixType>::Tvmult(VectorType &      dst,
 
 template <typename MatrixType>
 PreconditionPSOR<MatrixType>::AdditionalData::AdditionalData(
-  const std::vector<size_type> &permutation,
-  const std::vector<size_type> &inverse_permutation,
-  const typename PreconditionRelaxation<MatrixType>::AdditionalData &parameters)
-  : permutation(permutation)
-  , inverse_permutation(inverse_permutation)
-  , parameters(parameters)
+  const std::vector<size_type> &permutation_,
+  const std::vector<size_type> &inverse_permutation_,
+  const typename PreconditionRelaxation<MatrixType>::AdditionalData
+    &parameters_)
+  : permutation(permutation_)
+  , inverse_permutation(inverse_permutation_)
+  , parameters(parameters_)
 {}
 
 
@@ -1854,8 +1855,8 @@ PreconditionUseMatrix<MatrixType, VectorType>::vmult(
 
 template <typename MatrixType>
 inline PreconditionRelaxation<MatrixType>::AdditionalData::AdditionalData(
-  const double relaxation)
-  : relaxation(relaxation)
+  const double relaxation_)
+  : relaxation(relaxation_)
 {}
 
 
@@ -1918,22 +1919,22 @@ namespace internal
     template <typename Number>
     struct VectorUpdater
     {
-      VectorUpdater(const Number *     rhs,
-                    const Number *     matrix_diagonal_inverse,
-                    const unsigned int iteration_index,
-                    const Number       factor1,
-                    const Number       factor2,
-                    Number *           solution_old,
-                    Number *           tmp_vector,
-                    Number *           solution)
-        : rhs(rhs)
-        , matrix_diagonal_inverse(matrix_diagonal_inverse)
-        , iteration_index(iteration_index)
-        , factor1(factor1)
-        , factor2(factor2)
-        , solution_old(solution_old)
-        , tmp_vector(tmp_vector)
-        , solution(solution)
+      VectorUpdater(const Number *     rhs_,
+                    const Number *     matrix_diagonal_inverse_,
+                    const unsigned int iteration_index_,
+                    const Number       factor1_,
+                    const Number       factor2_,
+                    Number *           solution_old_,
+                    Number *           tmp_vector_,
+                    Number *           solution_)
+        : rhs(rhs_)
+        , matrix_diagonal_inverse(matrix_diagonal_inverse_)
+        , iteration_index(iteration_index_)
+        , factor1(factor1_)
+        , factor2(factor2_)
+        , solution_old(solution_old_)
+        , tmp_vector(tmp_vector_)
+        , solution(solution_)
       {}
 
       void
@@ -1943,14 +1944,14 @@ namespace internal
         // (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63945), we create
         // copies of the variables factor1 and factor2 and do not check based on
         // factor1.
-        const Number factor1        = this->factor1;
+        const Number factor1_       = this->factor1;
         const Number factor1_plus_1 = 1. + this->factor1;
-        const Number factor2        = this->factor2;
+        const Number factor2_       = this->factor2;
         if (iteration_index == 0)
           {
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (std::size_t i = begin; i < end; ++i)
-              solution[i] = factor2 * matrix_diagonal_inverse[i] * rhs[i];
+              solution[i] = factor2_ * matrix_diagonal_inverse[i] * rhs[i];
           }
         else if (iteration_index == 1)
           {
@@ -1959,9 +1960,9 @@ namespace internal
             for (std::size_t i = begin; i < end; ++i)
               // for efficiency reason, write back to temp_vector that is
               // already read (avoid read-for-ownership)
-              tmp_vector[i] =
-                factor1_plus_1 * solution[i] +
-                factor2 * matrix_diagonal_inverse[i] * (rhs[i] - tmp_vector[i]);
+              tmp_vector[i] = factor1_plus_1 * solution[i] +
+                              factor2_ * matrix_diagonal_inverse[i] *
+                                (rhs[i] - tmp_vector[i]);
           }
         else
           {
@@ -1969,9 +1970,10 @@ namespace internal
             //           + f_2 * P^{-1} * (b-A*x^{n})
             DEAL_II_OPENMP_SIMD_PRAGMA
             for (std::size_t i = begin; i < end; ++i)
-              solution_old[i] =
-                factor1_plus_1 * solution[i] - factor1 * solution_old[i] +
-                factor2 * matrix_diagonal_inverse[i] * (rhs[i] - tmp_vector[i]);
+              solution_old[i] = factor1_plus_1 * solution[i] -
+                                factor1_ * solution_old[i] +
+                                factor2_ * matrix_diagonal_inverse[i] *
+                                  (rhs[i] - tmp_vector[i]);
           }
       }
 
@@ -1988,9 +1990,9 @@ namespace internal
     template <typename Number>
     struct VectorUpdatesRange : public ::dealii::parallel::ParallelForInteger
     {
-      VectorUpdatesRange(const VectorUpdater<Number> &updater,
+      VectorUpdatesRange(const VectorUpdater<Number> &updater_,
                          const std::size_t            size)
-        : updater(updater)
+        : updater(updater_)
       {
         if (size < internal::VectorImplementation::minimum_parallel_grain_size)
           VectorUpdatesRange::apply_to_subrange(0, size);
@@ -2387,16 +2389,16 @@ namespace internal
 
 template <typename MatrixType, class VectorType, typename PreconditionerType>
 inline PreconditionChebyshev<MatrixType, VectorType, PreconditionerType>::
-  AdditionalData::AdditionalData(const unsigned int degree,
-                                 const double       smoothing_range,
-                                 const unsigned int eig_cg_n_iterations,
-                                 const double       eig_cg_residual,
-                                 const double       max_eigenvalue)
-  : degree(degree)
-  , smoothing_range(smoothing_range)
-  , eig_cg_n_iterations(eig_cg_n_iterations)
-  , eig_cg_residual(eig_cg_residual)
-  , max_eigenvalue(max_eigenvalue)
+  AdditionalData::AdditionalData(const unsigned int degree_,
+                                 const double       smoothing_range_,
+                                 const unsigned int eig_cg_n_iterations_,
+                                 const double       eig_cg_residual_,
+                                 const double       max_eigenvalue_)
+  : degree(degree_)
+  , smoothing_range(smoothing_range_)
+  , eig_cg_n_iterations(eig_cg_n_iterations_)
+  , eig_cg_residual(eig_cg_residual_)
+  , max_eigenvalue(max_eigenvalue_)
 {}
 
 

--- a/include/deal.II/lac/read_write_vector.h
+++ b/include/deal.II/lac/read_write_vector.h
@@ -1004,10 +1004,10 @@ namespace LinearAlgebra
   template <typename Number2>
   inline void
   ReadWriteVector<Number>::add(const std::vector<size_type> &indices,
-                               const std::vector<Number2> &  values)
+                               const std::vector<Number2> &  val)
   {
-    AssertDimension(indices.size(), values.size());
-    add(indices.size(), indices.data(), values.data());
+    AssertDimension(indices.size(), val.size());
+    add(indices.size(), indices.data(), val.data());
   }
 
 
@@ -1016,7 +1016,7 @@ namespace LinearAlgebra
   template <typename Number2>
   inline void
   ReadWriteVector<Number>::add(const std::vector<size_type> &  indices,
-                               const ReadWriteVector<Number2> &values)
+                               const ReadWriteVector<Number2> &val)
   {
     const size_type size = indices.size();
     for (size_type i = 0; i < size; ++i)
@@ -1025,7 +1025,7 @@ namespace LinearAlgebra
           numbers::is_finite(values[i]),
           ExcMessage(
             "The given value is not finite but either infinite or Not A Number (NaN)"));
-        this->operator()(indices[i]) += values[indices[i]];
+        this->operator()(indices[i]) += val[indices[i]];
       }
   }
 
@@ -1053,10 +1053,10 @@ namespace LinearAlgebra
   template <typename Number>
   template <typename Functor>
   inline ReadWriteVector<Number>::FunctorTemplate<Functor>::FunctorTemplate(
-    ReadWriteVector<Number> &parent,
-    const Functor &          functor)
-    : parent(parent)
-    , functor(functor)
+    ReadWriteVector<Number> &parent_,
+    const Functor &          functor_)
+    : parent(parent_)
+    , functor(functor_)
   {}
 
 

--- a/include/deal.II/lac/solver_control.h
+++ b/include/deal.II/lac/solver_control.h
@@ -94,9 +94,9 @@ public:
   class NoConvergence : public dealii::ExceptionBase
   {
   public:
-    NoConvergence(const unsigned int last_step, const double last_residual)
-      : last_step(last_step)
-      , last_residual(last_residual)
+    NoConvergence(const unsigned int last_step_, const double last_residual_)
+      : last_step(last_step_)
+      , last_residual(last_residual_)
     {}
 
     virtual ~NoConvergence() noexcept override = default;

--- a/include/deal.II/lac/sparse_matrix.h
+++ b/include/deal.II/lac/sparse_matrix.h
@@ -2143,19 +2143,19 @@ SparseMatrix<number>::copy_from(const ForwardIterator begin,
 namespace SparseMatrixIterators
 {
   template <typename number>
-  inline Accessor<number, true>::Accessor(const MatrixType *matrix,
+  inline Accessor<number, true>::Accessor(const MatrixType *matrix_,
                                           const std::size_t index_within_matrix)
-    : SparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern(),
+    : SparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern(),
                                          index_within_matrix)
-    , matrix(matrix)
+    , matrix(matrix_)
   {}
 
 
 
   template <typename number>
-  inline Accessor<number, true>::Accessor(const MatrixType *matrix)
-    : SparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern())
-    , matrix(matrix)
+  inline Accessor<number, true>::Accessor(const MatrixType *matrix_)
+    : SparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern())
+    , matrix(matrix_)
   {}
 
 
@@ -2189,9 +2189,10 @@ namespace SparseMatrixIterators
 
 
   template <typename number>
-  inline Accessor<number, false>::Reference::Reference(const Accessor *accessor,
-                                                       const bool)
-    : accessor(accessor)
+  inline Accessor<number, false>::Reference::Reference(
+    const Accessor *accessor_,
+    const bool)
+    : accessor(accessor_)
   {}
 
 
@@ -2266,18 +2267,19 @@ namespace SparseMatrixIterators
 
 
   template <typename number>
-  inline Accessor<number, false>::Accessor(MatrixType *      matrix,
+  inline Accessor<number, false>::Accessor(MatrixType *      matrix_,
                                            const std::size_t index)
-    : SparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern(), index)
-    , matrix(matrix)
+    : SparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern(),
+                                         index)
+    , matrix(matrix_)
   {}
 
 
 
   template <typename number>
-  inline Accessor<number, false>::Accessor(MatrixType *matrix)
-    : SparsityPatternIterators::Accessor(&matrix->get_sparsity_pattern())
-    , matrix(matrix)
+  inline Accessor<number, false>::Accessor(MatrixType *matrix_)
+    : SparsityPatternIterators::Accessor(&matrix_->get_sparsity_pattern())
+    , matrix(matrix_)
   {}
 
 

--- a/include/deal.II/lac/sparse_matrix_ez.h
+++ b/include/deal.II/lac/sparse_matrix_ez.h
@@ -913,10 +913,10 @@ private:
 /*---------------------- Inline functions -----------------------------------*/
 
 template <typename number>
-inline SparseMatrixEZ<number>::Entry::Entry(const size_type column,
-                                            const number &  value)
-  : column(column)
-  , value(value)
+inline SparseMatrixEZ<number>::Entry::Entry(const size_type column_,
+                                            const number &  value_)
+  : column(column_)
+  , value(value_)
 {}
 
 
@@ -929,8 +929,8 @@ inline SparseMatrixEZ<number>::Entry::Entry()
 
 
 template <typename number>
-inline SparseMatrixEZ<number>::RowInfo::RowInfo(const size_type start)
-  : start(start)
+inline SparseMatrixEZ<number>::RowInfo::RowInfo(const size_type start_)
+  : start(start_)
   , length(0)
   , diagonal(invalid_diagonal)
 {}
@@ -939,10 +939,10 @@ inline SparseMatrixEZ<number>::RowInfo::RowInfo(const size_type start)
 //---------------------------------------------------------------------------
 template <typename number>
 inline SparseMatrixEZ<number>::const_iterator::Accessor::Accessor(
-  const SparseMatrixEZ<number> *matrix,
+  const SparseMatrixEZ<number> *matrix_,
   const size_type               r,
   const unsigned short          i)
-  : matrix(matrix)
+  : matrix(matrix_)
   , a_row(r)
   , a_index(i)
 {}

--- a/include/deal.II/lac/sparse_vanka.templates.h
+++ b/include/deal.II/lac/sparse_vanka.templates.h
@@ -382,8 +382,8 @@ SparseVanka<number>::memory_consumption() const
 
 template <typename number>
 SparseVanka<number>::AdditionalData::AdditionalData(
-  const std::vector<bool> &selected)
-  : selected(selected)
+  const std::vector<bool> &selected_)
+  : selected(selected_)
 {}
 
 
@@ -404,10 +404,10 @@ template <typename number>
 SparseBlockVanka<number>::SparseBlockVanka(
   const SparseMatrix<number> &M,
   const std::vector<bool> &   selected,
-  const unsigned int          n_blocks,
+  const unsigned int          n_blocks_,
   const BlockingStrategy      blocking_strategy)
   : SparseVanka<number>(M, selected)
-  , n_blocks(n_blocks)
+  , n_blocks(n_blocks_)
   , dof_masks(n_blocks, std::vector<bool>(M.m(), false))
 {
   compute_dof_masks(M, selected, blocking_strategy);

--- a/include/deal.II/lac/sparsity_pattern.h
+++ b/include/deal.II/lac/sparsity_pattern.h
@@ -1461,8 +1461,8 @@ namespace SparsityPatternIterators
   {}
 
 
-  inline Iterator::Iterator(const Accessor &accessor)
-    : LinearIndexIterator<Iterator, Accessor>(accessor)
+  inline Iterator::Iterator(const Accessor &accessor_)
+    : LinearIndexIterator<Iterator, Accessor>(accessor_)
   {}
 
 
@@ -1735,7 +1735,7 @@ SparsityPattern::copy_from(const size_type       n_rows,
     typename std::iterator_traits<ForwardIterator>::value_type::const_iterator;
   for (ForwardIterator i = begin; i != end; ++i, ++row)
     {
-      size_type *          cols = &colnums[rowstart[row]] + (is_square ? 1 : 0);
+      size_type *columns = &colnums[rowstart[row]] + (is_square ? 1 : 0);
       const inner_iterator end_of_row = i->end();
       for (inner_iterator j = i->begin(); j != end_of_row; ++j)
         {
@@ -1744,7 +1744,7 @@ SparsityPattern::copy_from(const size_type       n_rows,
           AssertIndexRange(col, n_cols);
 
           if ((col != row) || !is_square)
-            *cols++ = col;
+            *columns++ = col;
         }
     }
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1216,10 +1216,10 @@ template <typename Number>
 template <typename OtherNumber>
 inline void
 Vector<Number>::extract_subvector_to(const std::vector<size_type> &indices,
-                                     std::vector<OtherNumber> &    values) const
+                                     std::vector<OtherNumber> &    val) const
 {
   for (size_type i = 0; i < indices.size(); ++i)
-    values[i] = operator()(indices[i]);
+    val[i] = operator()(indices[i]);
 }
 
 
@@ -1258,11 +1258,11 @@ template <typename Number>
 template <typename OtherNumber>
 inline void
 Vector<Number>::add(const std::vector<size_type> &  indices,
-                    const std::vector<OtherNumber> &values)
+                    const std::vector<OtherNumber> &val)
 {
-  Assert(indices.size() == values.size(),
-         ExcDimensionMismatch(indices.size(), values.size()));
-  add(indices.size(), indices.data(), values.data());
+  Assert(indices.size() == val.size(),
+         ExcDimensionMismatch(indices.size(), val.size()));
+  add(indices.size(), indices.data(), val.data());
 }
 
 
@@ -1271,11 +1271,11 @@ template <typename Number>
 template <typename OtherNumber>
 inline void
 Vector<Number>::add(const std::vector<size_type> &indices,
-                    const Vector<OtherNumber> &   values)
+                    const Vector<OtherNumber> &   val)
 {
-  Assert(indices.size() == values.size(),
-         ExcDimensionMismatch(indices.size(), values.size()));
-  add(indices.size(), indices.data(), values.values.begin());
+  Assert(indices.size() == val.size(),
+         ExcDimensionMismatch(indices.size(), val.size()));
+  add(indices.size(), indices.data(), val.values.begin());
 }
 
 
@@ -1285,7 +1285,7 @@ template <typename OtherNumber>
 inline void
 Vector<Number>::add(const size_type    n_indices,
                     const size_type *  indices,
-                    const OtherNumber *values)
+                    const OtherNumber *val)
 {
   for (size_type i = 0; i < n_indices; ++i)
     {
@@ -1295,7 +1295,7 @@ Vector<Number>::add(const size_type    n_indices,
         ExcMessage(
           "The given value is not finite but either infinite or Not A Number (NaN)"));
 
-      this->values[indices[i]] += values[i];
+      this->values[indices[i]] += val[i];
     }
 }
 

--- a/include/deal.II/lac/vector_operations_internal.h
+++ b/include/deal.II/lac/vector_operations_internal.h
@@ -200,9 +200,9 @@ namespace internal
     template <typename Number>
     struct Vector_set
     {
-      Vector_set(const Number value, Number *const dst)
-        : value(value)
-        , dst(dst)
+      Vector_set(const Number value_, Number *const dst_)
+        : value(value_)
+        , dst(dst_)
       {
         Assert(dst != nullptr, ExcInternalError());
       }
@@ -426,9 +426,9 @@ namespace internal
     template <typename Number>
     struct Vectorization_add_v
     {
-      Vectorization_add_v(Number *const val, const Number *const v_val)
-        : val(val)
-        , v_val(v_val)
+      Vectorization_add_v(Number *const val_, const Number *const v_val_)
+        : val(val_)
+        , v_val(v_val_)
       {}
 
       void
@@ -454,16 +454,16 @@ namespace internal
     template <typename Number>
     struct Vectorization_add_avpbw
     {
-      Vectorization_add_avpbw(Number *const       val,
-                              const Number *const v_val,
-                              const Number *const w_val,
-                              const Number        a,
-                              const Number        b)
-        : val(val)
-        , v_val(v_val)
-        , w_val(w_val)
-        , a(a)
-        , b(b)
+      Vectorization_add_avpbw(Number *const       val_,
+                              const Number *const v_val_,
+                              const Number *const w_val_,
+                              const Number        a_,
+                              const Number        b_)
+        : val(val_)
+        , v_val(v_val_)
+        , w_val(w_val_)
+        , a(a_)
+        , b(b_)
       {}
 
       void
@@ -492,12 +492,12 @@ namespace internal
     template <typename Number>
     struct Vectorization_sadd_xv
     {
-      Vectorization_sadd_xv(Number *const       val,
-                            const Number *const v_val,
-                            const Number        x)
-        : val(val)
-        , v_val(v_val)
-        , x(x)
+      Vectorization_sadd_xv(Number *const       val_,
+                            const Number *const v_val_,
+                            const Number        x_)
+        : val(val_)
+        , v_val(v_val_)
+        , x(x_)
       {}
 
       void
@@ -524,18 +524,18 @@ namespace internal
     template <typename Number>
     struct Vectorization_sadd_xavbw
     {
-      Vectorization_sadd_xavbw(Number *      val,
-                               const Number *v_val,
-                               const Number *w_val,
-                               Number        x,
-                               Number        a,
-                               Number        b)
-        : val(val)
-        , v_val(v_val)
-        , w_val(w_val)
-        , x(x)
-        , a(a)
-        , b(b)
+      Vectorization_sadd_xavbw(Number *      val_,
+                               const Number *v_val_,
+                               const Number *w_val_,
+                               Number        x_,
+                               Number        a_,
+                               Number        b_)
+        : val(val_)
+        , v_val(v_val_)
+        , w_val(w_val_)
+        , x(x_)
+        , a(a_)
+        , b(b_)
       {}
 
       void
@@ -565,9 +565,9 @@ namespace internal
     template <typename Number>
     struct Vectorization_scale
     {
-      Vectorization_scale(Number *const val, const Number *const v_val)
-        : val(val)
-        , v_val(v_val)
+      Vectorization_scale(Number *const val_, const Number *const v_val_)
+        : val(val_)
+        , v_val(v_val_)
       {}
 
       void
@@ -593,12 +593,12 @@ namespace internal
     template <typename Number>
     struct Vectorization_equ_au
     {
-      Vectorization_equ_au(Number *const       val,
-                           const Number *const u_val,
-                           const Number        a)
-        : val(val)
-        , u_val(u_val)
-        , a(a)
+      Vectorization_equ_au(Number *const       val_,
+                           const Number *const u_val_,
+                           const Number        a_)
+        : val(val_)
+        , u_val(u_val_)
+        , a(a_)
       {}
 
       void
@@ -625,16 +625,16 @@ namespace internal
     template <typename Number>
     struct Vectorization_equ_aubv
     {
-      Vectorization_equ_aubv(Number *const       val,
-                             const Number *const u_val,
-                             const Number *const v_val,
-                             const Number        a,
-                             const Number        b)
-        : val(val)
-        , u_val(u_val)
-        , v_val(v_val)
-        , a(a)
-        , b(b)
+      Vectorization_equ_aubv(Number *const       val_,
+                             const Number *const u_val_,
+                             const Number *const v_val_,
+                             const Number        a_,
+                             const Number        b_)
+        : val(val_)
+        , u_val(u_val_)
+        , v_val(v_val_)
+        , a(a_)
+        , b(b_)
       {}
 
       void
@@ -663,20 +663,20 @@ namespace internal
     template <typename Number>
     struct Vectorization_equ_aubvcw
     {
-      Vectorization_equ_aubvcw(Number *      val,
-                               const Number *u_val,
-                               const Number *v_val,
-                               const Number *w_val,
-                               const Number  a,
-                               const Number  b,
-                               const Number  c)
-        : val(val)
-        , u_val(u_val)
-        , v_val(v_val)
-        , w_val(w_val)
-        , a(a)
-        , b(b)
-        , c(c)
+      Vectorization_equ_aubvcw(Number *      val_,
+                               const Number *u_val_,
+                               const Number *v_val_,
+                               const Number *w_val_,
+                               const Number  a_,
+                               const Number  b_,
+                               const Number  c_)
+        : val(val_)
+        , u_val(u_val_)
+        , v_val(v_val_)
+        , w_val(w_val_)
+        , a(a_)
+        , b(b_)
+        , c(c_)
       {}
 
       void
@@ -707,10 +707,12 @@ namespace internal
     template <typename Number>
     struct Vectorization_ratio
     {
-      Vectorization_ratio(Number *val, const Number *a_val, const Number *b_val)
-        : val(val)
-        , a_val(a_val)
-        , b_val(b_val)
+      Vectorization_ratio(Number *      val_,
+                          const Number *a_val_,
+                          const Number *b_val_)
+        : val(val_)
+        , a_val(a_val_)
+        , b_val(b_val_)
       {}
 
       void
@@ -747,9 +749,9 @@ namespace internal
       static constexpr bool vectorizes = std::is_same<Number, Number2>::value &&
                                          (VectorizedArray<Number>::size() > 1);
 
-      Dot(const Number *const X, const Number2 *const Y)
-        : X(X)
-        , Y(Y)
+      Dot(const Number *const X_, const Number2 *const Y_)
+        : X(X_)
+        , Y(Y_)
       {}
 
       Number
@@ -787,8 +789,8 @@ namespace internal
     {
       static const bool vectorizes = VectorizedArray<Number>::size() > 1;
 
-      Norm2(const Number *const X)
-        : X(X)
+      Norm2(const Number *const X_)
+        : X(X_)
       {}
 
       RealType
@@ -813,8 +815,8 @@ namespace internal
     {
       static const bool vectorizes = VectorizedArray<Number>::size() > 1;
 
-      Norm1(const Number *X)
-        : X(X)
+      Norm1(const Number *X_)
+        : X(X_)
       {}
 
       RealType
@@ -839,9 +841,9 @@ namespace internal
     {
       static const bool vectorizes = VectorizedArray<Number>::size() > 1;
 
-      NormP(const Number *X, RealType p)
-        : X(X)
-        , p(p)
+      NormP(const Number *X_, RealType p_)
+        : X(X_)
+        , p(p_)
       {}
 
       RealType
@@ -867,8 +869,8 @@ namespace internal
     {
       static const bool vectorizes = VectorizedArray<Number>::size() > 1;
 
-      MeanValue(const Number *X)
-        : X(X)
+      MeanValue(const Number *X_)
+        : X(X_)
       {}
 
       Number
@@ -893,14 +895,14 @@ namespace internal
     {
       static const bool vectorizes = VectorizedArray<Number>::size() > 1;
 
-      AddAndDot(Number *const       X,
-                const Number *const V,
-                const Number *const W,
-                const Number        a)
-        : X(X)
-        , V(V)
-        , W(W)
-        , a(a)
+      AddAndDot(Number *const       X_,
+                const Number *const V_,
+                const Number *const W_,
+                const Number        a_)
+        : X(X_)
+        , V(V_)
+        , W(W_)
+        , a(a_)
       {}
 
       Number
@@ -1264,12 +1266,12 @@ namespace internal
     {
       static const unsigned int threshold_array_allocate = 512;
 
-      TBBReduceFunctor(const Operation &op,
-                       const size_type  start,
-                       const size_type  end)
-        : op(op)
-        , start(start)
-        , end(end)
+      TBBReduceFunctor(const Operation &op_,
+                       const size_type  start_,
+                       const size_type  end_)
+        : op(op_)
+        , start(start_)
+        , end(end_)
       {
         const size_type vec_size = end - start;
         // set chunk size for sub-tasks

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -4139,49 +4139,49 @@ namespace internal
       using Number2_                  = const Number2;
 
       Processor(
-        const unsigned int                          n_components,
-        const bool                                  integrate,
-        const Number2 *                             global_vector_ptr,
-        const std::vector<ArrayView<const Number>> *sm_ptr,
-        const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-        const MatrixFreeFunctions::DoFInfo &                       dof_info,
-        VectorizedArrayType *                                      values_quad,
-        VectorizedArrayType *gradients_quad,
-        VectorizedArrayType *hessians_quad,
-        VectorizedArrayType *scratch_data,
-        const bool           do_values,
-        const bool           do_gradients,
-        const bool           do_hessians,
-        const unsigned int   active_fe_index,
-        const unsigned int   first_selected_component,
-        const std::array<unsigned int, VectorizedArrayType::size()> cells,
-        const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-        const unsigned int                                 subface_index,
-        const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
+        const unsigned int                          n_components_,
+        const bool                                  integrate_,
+        const Number2 *                             global_vector_ptr_,
+        const std::vector<ArrayView<const Number>> *sm_ptr_,
+        const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data_,
+        const MatrixFreeFunctions::DoFInfo &                       dof_info_,
+        VectorizedArrayType *                                      values_quad_,
+        VectorizedArrayType *gradients_quad_,
+        VectorizedArrayType *hessians_quad_,
+        VectorizedArrayType *scratch_data_,
+        const bool           do_values_,
+        const bool           do_gradients_,
+        const bool           do_hessians_,
+        const unsigned int   active_fe_index_,
+        const unsigned int   first_selected_component_,
+        const std::array<unsigned int, VectorizedArrayType::size()> cells_,
+        const std::array<unsigned int, VectorizedArrayType::size()> face_nos_,
+        const unsigned int                                 subface_index_,
+        const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index_,
         const std::array<unsigned int, VectorizedArrayType::size()>
-                                      face_orientations,
-        const Table<2, unsigned int> &orientation_map)
-        : n_components(n_components)
-        , integrate(integrate)
-        , global_vector_ptr(global_vector_ptr)
-        , sm_ptr(sm_ptr)
-        , data(data)
-        , dof_info(dof_info)
-        , values_quad(values_quad)
-        , gradients_quad(gradients_quad)
-        , hessians_quad(hessians_quad)
-        , scratch_data(scratch_data)
-        , do_values(do_values)
-        , do_gradients(do_gradients)
-        , do_hessians(do_hessians)
-        , active_fe_index(active_fe_index)
-        , first_selected_component(first_selected_component)
-        , cells(cells)
-        , face_nos(face_nos)
-        , subface_index(subface_index)
-        , dof_access_index(dof_access_index)
-        , face_orientations(face_orientations)
-        , orientation_map(orientation_map)
+                                      face_orientations_,
+        const Table<2, unsigned int> &orientation_map_)
+        : n_components(n_components_)
+        , integrate(integrate_)
+        , global_vector_ptr(global_vector_ptr_)
+        , sm_ptr(sm_ptr_)
+        , data(data_)
+        , dof_info(dof_info_)
+        , values_quad(values_quad_)
+        , gradients_quad(gradients_quad_)
+        , hessians_quad(hessians_quad_)
+        , scratch_data(scratch_data_)
+        , do_values(do_values_)
+        , do_gradients(do_gradients_)
+        , do_hessians(do_hessians_)
+        , active_fe_index(active_fe_index_)
+        , first_selected_component(first_selected_component_)
+        , cells(cells_)
+        , face_nos(face_nos_)
+        , subface_index(subface_index_)
+        , dof_access_index(dof_access_index_)
+        , face_orientations(face_orientations_)
+        , orientation_map(orientation_map_)
       {}
 
       template <typename T0, typename T1, typename T2>
@@ -4433,51 +4433,51 @@ namespace internal
 
 
       Processor(
-        VectorizedArrayType *                       values_array,
-        const unsigned int                          n_components,
-        const bool                                  integrate,
-        Number2 *                                   global_vector_ptr,
-        const std::vector<ArrayView<const Number>> *sm_ptr,
-        const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-        const MatrixFreeFunctions::DoFInfo &                       dof_info,
-        VectorizedArrayType *                                      values_quad,
-        VectorizedArrayType *gradients_quad,
-        VectorizedArrayType *hessians_quad,
-        VectorizedArrayType *scratch_data,
-        const bool           do_values,
-        const bool           do_gradients,
-        const bool           do_hessians,
-        const unsigned int   active_fe_index,
-        const unsigned int   first_selected_component,
-        const std::array<unsigned int, VectorizedArrayType::size()> cells,
-        const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-        const unsigned int                                 subface_index,
-        const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
+        VectorizedArrayType *                       values_array_,
+        const unsigned int                          n_components_,
+        const bool                                  integrate_,
+        Number2 *                                   global_vector_ptr_,
+        const std::vector<ArrayView<const Number>> *sm_ptr_,
+        const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data_,
+        const MatrixFreeFunctions::DoFInfo &                       dof_info_,
+        VectorizedArrayType *                                      values_quad_,
+        VectorizedArrayType *gradients_quad_,
+        VectorizedArrayType *hessians_quad_,
+        VectorizedArrayType *scratch_data_,
+        const bool           do_values_,
+        const bool           do_gradients_,
+        const bool           do_hessians_,
+        const unsigned int   active_fe_index_,
+        const unsigned int   first_selected_component_,
+        const std::array<unsigned int, VectorizedArrayType::size()> cells_,
+        const std::array<unsigned int, VectorizedArrayType::size()> face_nos_,
+        const unsigned int                                 subface_index_,
+        const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index_,
         const std::array<unsigned int, VectorizedArrayType::size()>
-                                      face_orientations,
-        const Table<2, unsigned int> &orientation_map)
-        : values_array(values_array)
-        , n_components(n_components)
-        , integrate(integrate)
-        , global_vector_ptr(global_vector_ptr)
-        , sm_ptr(sm_ptr)
-        , data(data)
-        , dof_info(dof_info)
-        , values_quad(values_quad)
-        , gradients_quad(gradients_quad)
-        , hessians_quad(hessians_quad)
-        , scratch_data(scratch_data)
-        , do_values(do_values)
-        , do_gradients(do_gradients)
-        , do_hessians(do_hessians)
-        , active_fe_index(active_fe_index)
-        , first_selected_component(first_selected_component)
-        , cells(cells)
-        , face_nos(face_nos)
-        , subface_index(subface_index)
-        , dof_access_index(dof_access_index)
-        , face_orientations(face_orientations)
-        , orientation_map(orientation_map)
+                                      face_orientations_,
+        const Table<2, unsigned int> &orientation_map_)
+        : values_array(values_array_)
+        , n_components(n_components_)
+        , integrate(integrate_)
+        , global_vector_ptr(global_vector_ptr_)
+        , sm_ptr(sm_ptr_)
+        , data(data_)
+        , dof_info(dof_info_)
+        , values_quad(values_quad_)
+        , gradients_quad(gradients_quad_)
+        , hessians_quad(hessians_quad_)
+        , scratch_data(scratch_data_)
+        , do_values(do_values_)
+        , do_gradients(do_gradients_)
+        , do_hessians(do_hessians_)
+        , active_fe_index(active_fe_index_)
+        , first_selected_component(first_selected_component_)
+        , cells(cells_)
+        , face_nos(face_nos_)
+        , subface_index(subface_index_)
+        , dof_access_index(dof_access_index_)
+        , face_orientations(face_orientations_)
+        , orientation_map(orientation_map_)
       {}
 
       template <typename T0, typename T1, typename T2, typename T3, typename T4>

--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -212,38 +212,40 @@ public:
      * Constructor for AdditionalData.
      */
     AdditionalData(
-      const TasksParallelScheme tasks_parallel_scheme = partition_partition,
-      const unsigned int        tasks_block_size      = 0,
-      const UpdateFlags         mapping_update_flags  = update_gradients |
-                                               update_JxW_values,
-      const UpdateFlags  mapping_update_flags_boundary_faces = update_default,
-      const UpdateFlags  mapping_update_flags_inner_faces    = update_default,
-      const UpdateFlags  mapping_update_flags_faces_by_cells = update_default,
-      const unsigned int mg_level            = numbers::invalid_unsigned_int,
-      const bool         store_plain_indices = true,
-      const bool         initialize_indices  = true,
-      const bool         initialize_mapping  = true,
-      const bool         overlap_communication_computation    = true,
-      const bool         hold_all_faces_to_owned_cells        = false,
-      const bool         cell_vectorization_categories_strict = false,
-      const bool         allow_ghosted_vectors_in_loops       = true,
-      const bool         use_fast_hanging_node_algorithm      = true)
-      : tasks_parallel_scheme(tasks_parallel_scheme)
-      , tasks_block_size(tasks_block_size)
-      , mapping_update_flags(mapping_update_flags)
-      , mapping_update_flags_boundary_faces(mapping_update_flags_boundary_faces)
-      , mapping_update_flags_inner_faces(mapping_update_flags_inner_faces)
-      , mapping_update_flags_faces_by_cells(mapping_update_flags_faces_by_cells)
-      , mg_level(mg_level)
-      , store_plain_indices(store_plain_indices)
-      , initialize_indices(initialize_indices)
-      , initialize_mapping(initialize_mapping)
-      , overlap_communication_computation(overlap_communication_computation)
-      , hold_all_faces_to_owned_cells(hold_all_faces_to_owned_cells)
+      const TasksParallelScheme tasks_parallel_scheme_ = partition_partition,
+      const unsigned int        tasks_block_size_      = 0,
+      const UpdateFlags         mapping_update_flags_  = update_gradients |
+                                                update_JxW_values,
+      const UpdateFlags  mapping_update_flags_boundary_faces_ = update_default,
+      const UpdateFlags  mapping_update_flags_inner_faces_    = update_default,
+      const UpdateFlags  mapping_update_flags_faces_by_cells_ = update_default,
+      const unsigned int mg_level_            = numbers::invalid_unsigned_int,
+      const bool         store_plain_indices_ = true,
+      const bool         initialize_indices_  = true,
+      const bool         initialize_mapping_  = true,
+      const bool         overlap_communication_computation_    = true,
+      const bool         hold_all_faces_to_owned_cells_        = false,
+      const bool         cell_vectorization_categories_strict_ = false,
+      const bool         allow_ghosted_vectors_in_loops_       = true,
+      const bool         use_fast_hanging_node_algorithm_      = true)
+      : tasks_parallel_scheme(tasks_parallel_scheme_)
+      , tasks_block_size(tasks_block_size_)
+      , mapping_update_flags(mapping_update_flags_)
+      , mapping_update_flags_boundary_faces(
+          mapping_update_flags_boundary_faces_)
+      , mapping_update_flags_inner_faces(mapping_update_flags_inner_faces_)
+      , mapping_update_flags_faces_by_cells(
+          mapping_update_flags_faces_by_cells_)
+      , mg_level(mg_level_)
+      , store_plain_indices(store_plain_indices_)
+      , initialize_indices(initialize_indices_)
+      , initialize_mapping(initialize_mapping_)
+      , overlap_communication_computation(overlap_communication_computation_)
+      , hold_all_faces_to_owned_cells(hold_all_faces_to_owned_cells_)
       , cell_vectorization_categories_strict(
-          cell_vectorization_categories_strict)
-      , allow_ghosted_vectors_in_loops(allow_ghosted_vectors_in_loops)
-      , use_fast_hanging_node_algorithm(use_fast_hanging_node_algorithm)
+          cell_vectorization_categories_strict_)
+      , allow_ghosted_vectors_in_loops(allow_ghosted_vectors_in_loops_)
+      , use_fast_hanging_node_algorithm(use_fast_hanging_node_algorithm_)
       , communicator_sm(MPI_COMM_SELF)
     {}
 
@@ -2942,24 +2944,24 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   const typename MatrixFree<dim, Number, VectorizedArrayType>::AdditionalData
     &additional_data)
 {
-  std::vector<const DoFHandler<dim, dim> *>       dof_handlers;
+  std::vector<const DoFHandler<dim, dim> *>       dof_handler_vec;
   std::vector<const AffineConstraints<number2> *> constraints;
   std::vector<QuadratureType>                     quads;
 
-  dof_handlers.push_back(&dof_handler);
+  dof_handler_vec.push_back(&dof_handler);
   constraints.push_back(&constraints_in);
   quads.push_back(quad);
 
   std::vector<IndexSet> locally_owned_sets =
     internal::MatrixFreeImplementation::extract_locally_owned_index_sets(
-      dof_handlers, additional_data.mg_level);
+      dof_handler_vec, additional_data.mg_level);
 
   std::vector<hp::QCollection<dim>> quad_hp;
   quad_hp.emplace_back(quad);
 
   internal_reinit(std::make_shared<hp::MappingCollection<dim>>(
                     StaticMappingQ1<dim>::mapping),
-                  dof_handlers,
+                  dof_handler_vec,
                   constraints,
                   locally_owned_sets,
                   quad_hp,
@@ -2979,21 +2981,21 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   const typename MatrixFree<dim, Number, VectorizedArrayType>::AdditionalData
     &additional_data)
 {
-  std::vector<const DoFHandler<dim, dim> *>       dof_handlers;
+  std::vector<const DoFHandler<dim, dim> *>       dof_handler_vec;
   std::vector<const AffineConstraints<number2> *> constraints;
 
-  dof_handlers.push_back(&dof_handler);
+  dof_handler_vec.push_back(&dof_handler);
   constraints.push_back(&constraints_in);
 
   std::vector<IndexSet> locally_owned_sets =
     internal::MatrixFreeImplementation::extract_locally_owned_index_sets(
-      dof_handlers, additional_data.mg_level);
+      dof_handler_vec, additional_data.mg_level);
 
   std::vector<hp::QCollection<dim>> quad_hp;
   quad_hp.emplace_back(quad);
 
   internal_reinit(std::make_shared<hp::MappingCollection<dim>>(mapping),
-                  dof_handlers,
+                  dof_handler_vec,
                   constraints,
                   locally_owned_sets,
                   quad_hp,
@@ -3046,12 +3048,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   static_assert(dim == DoFHandlerType::dimension,
                 "Dimension dim not equal to DoFHandlerType::dimension.");
 
-  std::vector<const DoFHandler<dim> *> dof_handlers;
+  std::vector<const DoFHandler<dim> *> dof_handler_vec;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dh);
+    dof_handler_vec.push_back(dh);
 
-  this->reinit(mapping, dof_handlers, constraint, quad, additional_data);
+  this->reinit(mapping, dof_handler_vec, constraint, quad, additional_data);
 }
 
 
@@ -3095,12 +3097,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   static_assert(dim == DoFHandlerType::dimension,
                 "Dimension dim not equal to DoFHandlerType::dimension.");
 
-  std::vector<const DoFHandler<dim> *> dof_handlers;
+  std::vector<const DoFHandler<dim> *> dof_handler_vec;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handler_vec.push_back(dh);
 
-  this->reinit(dof_handlers, constraint, quad, additional_data);
+  this->reinit(dof_handler_vec, constraint, quad, additional_data);
 }
 
 
@@ -3176,12 +3178,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   static_assert(dim == DoFHandlerType::dimension,
                 "Dimension dim not equal to DoFHandlerType::dimension.");
 
-  std::vector<const DoFHandler<dim> *> dof_handlers;
+  std::vector<const DoFHandler<dim> *> dof_handler_vec;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handler_vec.push_back(dh);
 
-  this->reinit(mapping, dof_handlers, constraint, quad, additional_data);
+  this->reinit(mapping, dof_handler_vec, constraint, quad, additional_data);
 }
 
 
@@ -3198,12 +3200,12 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   static_assert(dim == DoFHandlerType::dimension,
                 "Dimension dim not equal to DoFHandlerType::dimension.");
 
-  std::vector<const DoFHandler<dim> *> dof_handlers;
+  std::vector<const DoFHandler<dim> *> dof_handler_vec;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handler_vec.push_back(dh);
 
-  this->reinit(dof_handlers, constraint, quad, additional_data);
+  this->reinit(dof_handler_vec, constraint, quad, additional_data);
 }
 
 
@@ -3240,16 +3242,16 @@ namespace internal
      * number of components.
      */
     VectorDataExchange(
-      const dealii::MatrixFree<dim, Number, VectorizedArrayType> &matrix_free,
+      const dealii::MatrixFree<dim, Number, VectorizedArrayType> &matrix_free_,
       const typename dealii::MatrixFree<dim, Number, VectorizedArrayType>::
-        DataAccessOnFaces vector_face_access,
+        DataAccessOnFaces vector_face_access_,
       const unsigned int  n_components)
-      : matrix_free(matrix_free)
+      : matrix_free(matrix_free_)
       , vector_face_access(
           matrix_free.get_task_info().face_partition_data.empty() ?
             dealii::MatrixFree<dim, Number, VectorizedArrayType>::
               DataAccessOnFaces::unspecified :
-            vector_face_access)
+            vector_face_access_)
       , ghosts_were_set(false)
 #  ifdef DEAL_II_WITH_MPI
       , tmp_data(n_components)
@@ -4595,30 +4597,30 @@ namespace internal
         function_type;
 
     // constructor, binds all the arguments to this class
-    MFWorker(const MF &                           matrix_free,
-             const InVector &                     src,
-             OutVector &                          dst,
-             const bool                           zero_dst_vector_setting,
-             const Container &                    container,
-             function_type                        cell_function,
-             function_type                        face_function,
-             function_type                        boundary_function,
+    MFWorker(const MF &                           matrix_free_,
+             const InVector &                     src_,
+             OutVector &                          dst_,
+             const bool                           zero_dst_vector_setting_,
+             const Container &                    container_,
+             function_type                        cell_function_,
+             function_type                        face_function_,
+             function_type                        boundary_function_,
              const typename MF::DataAccessOnFaces src_vector_face_access =
                MF::DataAccessOnFaces::none,
              const typename MF::DataAccessOnFaces dst_vector_face_access =
                MF::DataAccessOnFaces::none,
              const std::function<void(const unsigned int, const unsigned int)>
-               &operation_before_loop = {},
+               &operation_before_loop_ = {},
              const std::function<void(const unsigned int, const unsigned int)>
-               &                operation_after_loop       = {},
-             const unsigned int dof_handler_index_pre_post = 0)
-      : matrix_free(matrix_free)
-      , container(const_cast<Container &>(container))
-      , cell_function(cell_function)
-      , face_function(face_function)
-      , boundary_function(boundary_function)
-      , src(src)
-      , dst(dst)
+               &                operation_after_loop_       = {},
+             const unsigned int dof_handler_index_pre_post_ = 0)
+      : matrix_free(matrix_free_)
+      , container(const_cast<Container &>(container_))
+      , cell_function(cell_function_)
+      , face_function(face_function_)
+      , boundary_function(boundary_function_)
+      , src(src_)
+      , dst(dst_)
       , src_data_exchanger(matrix_free,
                            src_vector_face_access,
                            n_components(src))
@@ -4626,11 +4628,11 @@ namespace internal
                            dst_vector_face_access,
                            n_components(dst))
       , src_and_dst_are_same(PointerComparison::equal(&src, &dst))
-      , zero_dst_vector_setting(zero_dst_vector_setting &&
+      , zero_dst_vector_setting(zero_dst_vector_setting_ &&
                                 !src_and_dst_are_same)
-      , operation_before_loop(operation_before_loop)
-      , operation_after_loop(operation_after_loop)
-      , dof_handler_index_pre_post(dof_handler_index_pre_post)
+      , operation_before_loop(operation_before_loop_)
+      , operation_after_loop(operation_after_loop_)
+      , dof_handler_index_pre_post(dof_handler_index_pre_post_)
     {}
 
     // Runs the cell work. If no function is given, nothing is done
@@ -4842,12 +4844,12 @@ namespace internal
                          const InVector &,
                          const std::pair<unsigned int, unsigned int> &)>;
 
-    MFClassWrapper(const function_type cell,
-                   const function_type face,
-                   const function_type boundary)
-      : cell(cell)
-      , face(face)
-      , boundary(boundary)
+    MFClassWrapper(const function_type cell_,
+                   const function_type face_,
+                   const function_type boundary_)
+      : cell(cell_)
+      , face(face_)
+      , boundary(boundary_)
     {}
 
     void

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1011,8 +1011,8 @@ namespace MatrixFreeOperators
                              n_components,
                              Number,
                              false,
-                             VectorizedArrayType> &fe_eval)
-    : fe_eval(fe_eval)
+                             VectorizedArrayType> &fe_eval_)
+    : fe_eval(fe_eval_)
   {}
 
 
@@ -2041,7 +2041,7 @@ namespace MatrixFreeOperators
       const MatrixFree<
         dim,
         typename Base<dim, VectorType, VectorizedArrayType>::value_type,
-        VectorizedArrayType> &                     data,
+        VectorizedArrayType> &                     data_,
       VectorType &                                 dst,
       const VectorType &                           src,
       const std::pair<unsigned int, unsigned int> &cell_range) const
@@ -2054,7 +2054,7 @@ namespace MatrixFreeOperators
                  n_components,
                  Number,
                  VectorizedArrayType>
-      phi(data, this->selected_rows[0]);
+      phi(data_, this->selected_rows[0]);
     for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
       {
         phi.reinit(cell);

--- a/include/deal.II/matrix_free/tensor_product_kernels.h
+++ b/include/deal.II/matrix_free/tensor_product_kernels.h
@@ -167,29 +167,29 @@ namespace internal
     /**
      * Constructor, taking the data from ShapeInfo
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values,
-                           const AlignedVector<Number2> &shape_gradients,
-                           const AlignedVector<Number2> &shape_hessians,
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_,
+                           const AlignedVector<Number2> &shape_gradients_,
+                           const AlignedVector<Number2> &shape_hessians_,
                            const unsigned int            dummy1 = 0,
                            const unsigned int            dummy2 = 0)
-      : shape_values(shape_values.begin())
-      , shape_gradients(shape_gradients.begin())
-      , shape_hessians(shape_hessians.begin())
+      : shape_values(shape_values_.begin())
+      , shape_gradients(shape_gradients_.begin())
+      , shape_hessians(shape_hessians_.begin())
     {
       // We can enter this function either for the apply() path that has
       // n_rows * n_columns entries or for the apply_face() path that only has
       // n_rows * 3 entries in the array. Since we cannot decide about the use
       // we must allow for both here.
-      Assert(shape_values.size() == 0 ||
-               shape_values.size() == n_rows * n_columns ||
-               shape_values.size() == 3 * n_rows,
-             ExcDimensionMismatch(shape_values.size(), n_rows * n_columns));
-      Assert(shape_gradients.size() == 0 ||
-               shape_gradients.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_gradients.size(), n_rows * n_columns));
-      Assert(shape_hessians.size() == 0 ||
-               shape_hessians.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_hessians.size(), n_rows * n_columns));
+      Assert(shape_values_.size() == 0 ||
+               shape_values_.size() == n_rows * n_columns ||
+               shape_values_.size() == 3 * n_rows,
+             ExcDimensionMismatch(shape_values_.size(), n_rows * n_columns));
+      Assert(shape_gradients_.size() == 0 ||
+               shape_gradients_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_gradients_.size(), n_rows * n_columns));
+      Assert(shape_hessians_.size() == 0 ||
+               shape_hessians_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_hessians_.size(), n_rows * n_columns));
       (void)dummy1;
       (void)dummy2;
     }
@@ -441,7 +441,7 @@ namespace internal
     AssertIndexRange(face_direction, dim);
     constexpr int stride     = Utilities::pow(n_rows, face_direction);
     constexpr int out_stride = Utilities::pow(n_rows, dim - 1);
-    const Number *DEAL_II_RESTRICT shape_values = this->shape_values;
+    const Number *DEAL_II_RESTRICT shape_val = this->shape_values;
 
     for (int i2 = 0; i2 < n_blocks2; ++i2)
       {
@@ -449,19 +449,19 @@ namespace internal
           {
             if (contract_onto_face == true)
               {
-                Number res0 = shape_values[0] * in[0];
+                Number res0 = shape_val[0] * in[0];
                 Number res1, res2;
                 if (max_derivative > 0)
-                  res1 = shape_values[n_rows] * in[0];
+                  res1 = shape_val[n_rows] * in[0];
                 if (max_derivative > 1)
-                  res2 = shape_values[2 * n_rows] * in[0];
+                  res2 = shape_val[2 * n_rows] * in[0];
                 for (int ind = 1; ind < n_rows; ++ind)
                   {
-                    res0 += shape_values[ind] * in[stride * ind];
+                    res0 += shape_val[ind] * in[stride * ind];
                     if (max_derivative > 0)
-                      res1 += shape_values[ind + n_rows] * in[stride * ind];
+                      res1 += shape_val[ind + n_rows] * in[stride * ind];
                     if (max_derivative > 1)
-                      res2 += shape_values[ind + 2 * n_rows] * in[stride * ind];
+                      res2 += shape_val[ind + 2 * n_rows] * in[stride * ind];
                   }
                 if (add == false)
                   {
@@ -485,15 +485,15 @@ namespace internal
                 for (int col = 0; col < n_rows; ++col)
                   {
                     if (add == false)
-                      out[col * stride] = shape_values[col] * in[0];
+                      out[col * stride] = shape_val[col] * in[0];
                     else
-                      out[col * stride] += shape_values[col] * in[0];
+                      out[col * stride] += shape_val[col] * in[0];
                     if (max_derivative > 0)
                       out[col * stride] +=
-                        shape_values[col + n_rows] * in[out_stride];
+                        shape_val[col + n_rows] * in[out_stride];
                     if (max_derivative > 1)
                       out[col * stride] +=
-                        shape_values[col + 2 * n_rows] * in[2 * out_stride];
+                        shape_val[col + 2 * n_rows] * in[2 * out_stride];
                   }
               }
 
@@ -598,46 +598,46 @@ namespace internal
     /**
      * Constructor, taking the data from ShapeInfo
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values,
-                           const AlignedVector<Number2> &shape_gradients,
-                           const AlignedVector<Number2> &shape_hessians,
-                           const unsigned int            n_rows,
-                           const unsigned int            n_columns)
-      : shape_values(shape_values.begin())
-      , shape_gradients(shape_gradients.begin())
-      , shape_hessians(shape_hessians.begin())
-      , n_rows(n_rows)
-      , n_columns(n_columns)
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_,
+                           const AlignedVector<Number2> &shape_gradients_,
+                           const AlignedVector<Number2> &shape_hessians_,
+                           const unsigned int            n_rows_,
+                           const unsigned int            n_columns_)
+      : shape_values(shape_values_.begin())
+      , shape_gradients(shape_gradients_.begin())
+      , shape_hessians(shape_hessians_.begin())
+      , n_rows(n_rows_)
+      , n_columns(n_columns_)
     {
       // We can enter this function either for the apply() path that has
       // n_rows * n_columns entries or for the apply_face() path that only has
       // n_rows * 3 entries in the array. Since we cannot decide about the use
       // we must allow for both here.
-      Assert(shape_values.size() == 0 ||
-               shape_values.size() == n_rows * n_columns ||
-               shape_values.size() == n_rows * 3,
-             ExcDimensionMismatch(shape_values.size(), n_rows * n_columns));
-      Assert(shape_gradients.size() == 0 ||
-               shape_gradients.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_gradients.size(), n_rows * n_columns));
-      Assert(shape_hessians.size() == 0 ||
-               shape_hessians.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_hessians.size(), n_rows * n_columns));
+      Assert(shape_values_.size() == 0 ||
+               shape_values_.size() == n_rows * n_columns ||
+               shape_values_.size() == n_rows * 3,
+             ExcDimensionMismatch(shape_values_.size(), n_rows * n_columns));
+      Assert(shape_gradients_.size() == 0 ||
+               shape_gradients_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_gradients_.size(), n_rows * n_columns));
+      Assert(shape_hessians_.size() == 0 ||
+               shape_hessians_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_hessians_.size(), n_rows * n_columns));
     }
 
     /**
      * Constructor, taking the data from ShapeInfo
      */
-    EvaluatorTensorProduct(const Number2 *    shape_values,
-                           const Number2 *    shape_gradients,
-                           const Number2 *    shape_hessians,
-                           const unsigned int n_rows,
-                           const unsigned int n_columns)
-      : shape_values(shape_values)
-      , shape_gradients(shape_gradients)
-      , shape_hessians(shape_hessians)
-      , n_rows(n_rows)
-      , n_columns(n_columns)
+    EvaluatorTensorProduct(const Number2 *    shape_values_,
+                           const Number2 *    shape_gradients_,
+                           const Number2 *    shape_hessians_,
+                           const unsigned int n_rows_,
+                           const unsigned int n_columns_)
+      : shape_values(shape_values_)
+      , shape_gradients(shape_gradients_)
+      , shape_hessians(shape_hessians_)
+      , n_rows(n_rows_)
+      , n_columns(n_columns_)
     {}
 
     template <int direction, bool contract_over_rows, bool add>
@@ -1028,24 +1028,24 @@ namespace internal
     /**
      * Constructor, taking the data from ShapeInfo
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values,
-                           const AlignedVector<Number2> &shape_gradients,
-                           const AlignedVector<Number2> &shape_hessians,
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_,
+                           const AlignedVector<Number2> &shape_gradients_,
+                           const AlignedVector<Number2> &shape_hessians_,
                            const unsigned int            dummy1 = 0,
                            const unsigned int            dummy2 = 0)
-      : shape_values(shape_values.begin())
-      , shape_gradients(shape_gradients.begin())
-      , shape_hessians(shape_hessians.begin())
+      : shape_values(shape_values_.begin())
+      , shape_gradients(shape_gradients_.begin())
+      , shape_hessians(shape_hessians_.begin())
     {
-      Assert(shape_values.size() == 0 ||
-               shape_values.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_values.size(), n_rows * n_columns));
-      Assert(shape_gradients.size() == 0 ||
-               shape_gradients.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_gradients.size(), n_rows * n_columns));
-      Assert(shape_hessians.size() == 0 ||
-               shape_hessians.size() == n_rows * n_columns,
-             ExcDimensionMismatch(shape_hessians.size(), n_rows * n_columns));
+      Assert(shape_values_.size() == 0 ||
+               shape_values_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_values_.size(), n_rows * n_columns));
+      Assert(shape_gradients_.size() == 0 ||
+               shape_gradients_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_gradients_.size(), n_rows * n_columns));
+      Assert(shape_hessians_.size() == 0 ||
+               shape_hessians_.size() == n_rows * n_columns,
+             ExcDimensionMismatch(shape_hessians_.size(), n_rows * n_columns));
       (void)dummy1;
       (void)dummy2;
     }
@@ -1620,35 +1620,36 @@ namespace internal
      * Constructor, taking the data from ShapeInfo (using the even-odd
      * variants stored there)
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values)
-      : shape_values(shape_values.begin())
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_)
+      : shape_values(shape_values_.begin())
       , shape_gradients(nullptr)
       , shape_hessians(nullptr)
     {
-      AssertDimension(shape_values.size(), n_rows * ((n_columns + 1) / 2));
+      AssertDimension(shape_values_.size(), n_rows * ((n_columns + 1) / 2));
     }
 
     /**
      * Constructor, taking the data from ShapeInfo (using the even-odd
      * variants stored there)
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values,
-                           const AlignedVector<Number2> &shape_gradients,
-                           const AlignedVector<Number2> &shape_hessians,
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_,
+                           const AlignedVector<Number2> &shape_gradients_,
+                           const AlignedVector<Number2> &shape_hessians_,
                            const unsigned int            dummy1 = 0,
                            const unsigned int            dummy2 = 0)
-      : shape_values(shape_values.begin())
-      , shape_gradients(shape_gradients.begin())
-      , shape_hessians(shape_hessians.begin())
+      : shape_values(shape_values_.begin())
+      , shape_gradients(shape_gradients_.begin())
+      , shape_hessians(shape_hessians_.begin())
     {
       // In this function, we allow for dummy pointers if some of values,
       // gradients or hessians should not be computed
-      if (!shape_values.empty())
-        AssertDimension(shape_values.size(), n_rows * ((n_columns + 1) / 2));
-      if (!shape_gradients.empty())
-        AssertDimension(shape_gradients.size(), n_rows * ((n_columns + 1) / 2));
-      if (!shape_hessians.empty())
-        AssertDimension(shape_hessians.size(), n_rows * ((n_columns + 1) / 2));
+      if (!shape_values_.empty())
+        AssertDimension(shape_values_.size(), n_rows * ((n_columns + 1) / 2));
+      if (!shape_gradients_.empty())
+        AssertDimension(shape_gradients_.size(),
+                        n_rows * ((n_columns + 1) / 2));
+      if (!shape_hessians_.empty())
+        AssertDimension(shape_hessians_.size(), n_rows * ((n_columns + 1) / 2));
       (void)dummy1;
       (void)dummy2;
     }
@@ -2009,8 +2010,8 @@ namespace internal
      * Constructor, taking the data from ShapeInfo (using the even-odd
      * variants stored there)
      */
-    EvaluatorTensorProduct(const AlignedVector<Number> &shape_values)
-      : shape_values(shape_values.begin())
+    EvaluatorTensorProduct(const AlignedVector<Number> &shape_values_)
+      : shape_values(shape_values_.begin())
       , shape_gradients(nullptr)
       , shape_hessians(nullptr)
     {}
@@ -2019,14 +2020,14 @@ namespace internal
      * Constructor, taking the data from ShapeInfo (using the even-odd
      * variants stored there)
      */
-    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values,
-                           const AlignedVector<Number2> &shape_gradients,
-                           const AlignedVector<Number2> &shape_hessians,
+    EvaluatorTensorProduct(const AlignedVector<Number2> &shape_values_,
+                           const AlignedVector<Number2> &shape_gradients_,
+                           const AlignedVector<Number2> &shape_hessians_,
                            const unsigned int            dummy1 = 0,
                            const unsigned int            dummy2 = 0)
-      : shape_values(shape_values.begin())
-      , shape_gradients(shape_gradients.begin())
-      , shape_hessians(shape_hessians.begin())
+      : shape_values(shape_values_.begin())
+      , shape_gradients(shape_gradients_.begin())
+      , shape_hessians(shape_hessians_.begin())
     {
       (void)dummy1;
       (void)dummy2;

--- a/include/deal.II/numerics/cell_data_transfer.templates.h
+++ b/include/deal.II/numerics/cell_data_transfer.templates.h
@@ -51,21 +51,21 @@ namespace internal
 
 template <int dim, int spacedim, typename VectorType>
 CellDataTransfer<dim, spacedim, VectorType>::CellDataTransfer(
-  const Triangulation<dim, spacedim> &               triangulation,
+  const Triangulation<dim, spacedim> &               tria,
   const std::function<std::vector<value_type>(
     const typename Triangulation<dim, spacedim>::cell_iterator &parent,
-    const value_type parent_value)>                  refinement_strategy,
+    const value_type parent_value)>                  refinement_strategy_,
   const std::function<value_type(
     const typename Triangulation<dim, spacedim>::cell_iterator &parent,
-    const std::vector<value_type> &children_values)> coarsening_strategy)
-  : triangulation(&triangulation, typeid(*this).name())
-  , refinement_strategy(refinement_strategy)
-  , coarsening_strategy(coarsening_strategy)
+    const std::vector<value_type> &children_values)> coarsening_strategy_)
+  : triangulation(&tria, typeid(*this).name())
+  , refinement_strategy(refinement_strategy_)
+  , coarsening_strategy(coarsening_strategy_)
   , n_active_cells_pre(numbers::invalid_unsigned_int)
 {
   Assert(
     (dynamic_cast<const parallel::distributed::Triangulation<dim, spacedim> *>(
-       &triangulation) == nullptr),
+       &tria) == nullptr),
     ExcMessage("You are calling the CellDataTransfer class "
                "with a parallel::distributed::Triangulation. "
                "You probably want to use the "

--- a/include/deal.II/numerics/data_out_dof_data.templates.h
+++ b/include/deal.II/numerics/data_out_dof_data.templates.h
@@ -67,22 +67,22 @@ namespace internal
   {
     template <int dim, int spacedim>
     ParallelDataBase<dim, spacedim>::ParallelDataBase(
-      const unsigned int                    n_datasets,
-      const unsigned int                    n_subdivisions,
+      const unsigned int                    n_datasets_,
+      const unsigned int                    n_subdivisions_,
       const std::vector<unsigned int> &     n_postprocessor_outputs,
       const dealii::Mapping<dim, spacedim> &mapping,
       const std::vector<
         std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>>
-        &               finite_elements,
-      const UpdateFlags update_flags,
+        &               finite_elements_,
+      const UpdateFlags update_flags_,
       const bool        use_face_values)
       : ParallelDataBase<dim, spacedim>(
-          n_datasets,
-          n_subdivisions,
+          n_datasets_,
+          n_subdivisions_,
           n_postprocessor_outputs,
           dealii::hp::MappingCollection<dim, spacedim>(mapping),
-          finite_elements,
-          update_flags,
+          finite_elements_,
+          update_flags_,
           use_face_values)
     {}
 
@@ -472,21 +472,21 @@ namespace internal
 
     template <int dim, int spacedim>
     ParallelDataBase<dim, spacedim>::ParallelDataBase(
-      const unsigned int               n_datasets,
-      const unsigned int               n_subdivisions,
+      const unsigned int               n_datasets_,
+      const unsigned int               n_subdivisions_,
       const std::vector<unsigned int> &n_postprocessor_outputs,
       const dealii::hp::MappingCollection<dim, spacedim> &mapping,
       const std::vector<
         std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>>
-        &               finite_elements,
-      const UpdateFlags update_flags,
+        &               finite_elements_,
+      const UpdateFlags update_flags_,
       const bool        use_face_values)
-      : n_datasets(n_datasets)
-      , n_subdivisions(n_subdivisions)
+      : n_datasets(n_datasets_)
+      , n_subdivisions(n_subdivisions_)
       , postprocessed_values(n_postprocessor_outputs.size())
       , mapping_collection(mapping)
-      , finite_elements(finite_elements)
-      , update_flags(update_flags)
+      , finite_elements(finite_elements_)
+      , update_flags(update_flags_)
     {
       const unsigned int n_q_points =
         setup_parallel_data_base_internal(n_subdivisions,
@@ -803,12 +803,12 @@ namespace internal
       const std::vector<std::string> & names_in,
       const std::vector<
         DataComponentInterpretation::DataComponentInterpretation>
-        &data_component_interpretation)
+        &data_component_interpretation_)
       : dof_handler(
           dofs,
           typeid(dealii::DataOut_DoFData<dim, dim, spacedim, spacedim>).name())
       , names(names_in)
-      , data_component_interpretation(data_component_interpretation)
+      , data_component_interpretation(data_component_interpretation_)
       , postprocessor(nullptr, typeid(*this).name())
       , n_output_variables(names.size())
     {
@@ -1175,12 +1175,14 @@ namespace internal
     DataEntry<dim, spacedim, ScalarType>::DataEntry(
       const DoFHandler<dim, spacedim> *dofs,
       const VectorType *               data,
-      const std::vector<std::string> & names,
+      const std::vector<std::string> & names_,
       const std::vector<
         DataComponentInterpretation::DataComponentInterpretation>
-        &                  data_component_interpretation,
+        &                  data_component_interpretation_,
       const DataVectorType actual_type)
-      : DataEntryBase<dim, spacedim>(dofs, names, data_component_interpretation)
+      : DataEntryBase<dim, spacedim>(dofs,
+                                     names_,
+                                     data_component_interpretation_)
     {
       if (actual_type == DataVectorType::type_dof_data)
         create_dof_vector(*dofs, *data, vector);
@@ -1533,15 +1535,15 @@ namespace internal
     {
     public:
       MGDataEntry(const DoFHandler<dim, spacedim> *dofs,
-                  const MGLevelObject<VectorType> *vectors,
-                  const std::vector<std::string> & names,
+                  const MGLevelObject<VectorType> *vectors_,
+                  const std::vector<std::string> & names_,
                   const std::vector<
                     DataComponentInterpretation::DataComponentInterpretation>
-                    &data_component_interpretation)
+                    &data_component_interpretation_)
         : DataEntryBase<dim, spacedim>(dofs,
-                                       names,
-                                       data_component_interpretation)
-        , vectors(vectors)
+                                       names_,
+                                       data_component_interpretation_)
+        , vectors(vectors_)
       {}
 
       virtual double

--- a/include/deal.II/numerics/dof_output_operator.templates.h
+++ b/include/deal.II/numerics/dof_output_operator.templates.h
@@ -27,10 +27,10 @@ namespace Algorithms
 {
   template <typename VectorType, int dim, int spacedim>
   DoFOutputOperator<VectorType, dim, spacedim>::DoFOutputOperator(
-    const std::string &filename_base,
-    const unsigned int digits)
-    : filename_base(filename_base)
-    , digits(digits)
+    const std::string &filename_base_,
+    const unsigned int digits_)
+    : filename_base(filename_base_)
+    , digits(digits_)
   {
     out.set_default_format(DataOutBase::gnuplot);
   }

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -207,18 +207,18 @@ namespace internal
   template <class FE>
   ParallelData<dim, spacedim, number>::ParallelData(
     const FE &                                          fe,
-    const dealii::hp::QCollection<dim - 1> &            face_quadratures,
+    const dealii::hp::QCollection<dim - 1> &            face_quadratures_,
     const dealii::hp::MappingCollection<dim, spacedim> &mapping,
     const bool                                          need_quadrature_points,
     const unsigned int                                  n_solution_vectors,
-    const types::subdomain_id                           subdomain_id,
-    const types::material_id                            material_id,
+    const types::subdomain_id                           subdomain_id_,
+    const types::material_id                            material_id_,
     const std::map<types::boundary_id, const Function<spacedim, number> *>
-      *                       neumann_bc,
-    const ComponentMask &     component_mask,
-    const Function<spacedim> *coefficients)
+      *                       neumann_bc_,
+    const ComponentMask &     component_mask_,
+    const Function<spacedim> *coefficients_)
     : finite_element(fe)
-    , face_quadratures(face_quadratures)
+    , face_quadratures(face_quadratures_)
     , fe_face_values_cell(mapping,
                           finite_element,
                           face_quadratures,
@@ -253,11 +253,11 @@ namespace internal
     , coefficient_values(face_quadratures.max_n_quadrature_points(),
                          dealii::Vector<double>(fe.n_components()))
     , JxW_values(face_quadratures.max_n_quadrature_points())
-    , subdomain_id(subdomain_id)
-    , material_id(material_id)
-    , neumann_bc(neumann_bc)
-    , component_mask(component_mask)
-    , coefficients(coefficients)
+    , subdomain_id(subdomain_id_)
+    , material_id(material_id_)
+    , neumann_bc(neumann_bc_)
+    , component_mask(component_mask_)
+    , coefficients(coefficients_)
   {}
 
 
@@ -1245,11 +1245,11 @@ KellyErrorEstimator<dim, spacedim>::estimate(
     [&solutions, strategy](
       const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
       internal::ParallelData<dim, spacedim, typename InputVector::value_type>
-        &                            parallel_data,
+        &                            par_data,
       std::map<typename DoFHandler<dim, spacedim>::face_iterator,
                std::vector<double>> &local_face_integrals) {
       internal::estimate_one_cell(
-        cell, parallel_data, local_face_integrals, solutions, strategy);
+        cell, par_data, local_face_integrals, solutions, strategy);
     },
     [&face_integrals](
       const std::map<typename DoFHandler<dim, spacedim>::face_iterator,

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -74,9 +74,9 @@ namespace MatrixCreator
       struct Scratch
       {
         Scratch(const ::dealii::hp::FECollection<dim, spacedim> &fe,
-                const UpdateFlags                                update_flags,
-                const Function<spacedim, number> *               coefficient,
-                const Function<spacedim, number> *               rhs_function,
+                const UpdateFlags                                update_flags_,
+                const Function<spacedim, number> *               coefficient_,
+                const Function<spacedim, number> *               rhs_function_,
                 const ::dealii::hp::QCollection<dim> &           quadrature,
                 const ::dealii::hp::MappingCollection<dim, spacedim> &mapping)
           : fe_collection(fe)
@@ -85,7 +85,7 @@ namespace MatrixCreator
           , x_fe_values(mapping_collection,
                         fe_collection,
                         quadrature_collection,
-                        update_flags)
+                        update_flags_)
           , coefficient_values(quadrature_collection.max_n_quadrature_points())
           , coefficient_vector_values(
               quadrature_collection.max_n_quadrature_points(),
@@ -94,9 +94,9 @@ namespace MatrixCreator
           , rhs_vector_values(quadrature_collection.max_n_quadrature_points(),
                               dealii::Vector<number>(
                                 fe_collection.n_components()))
-          , coefficient(coefficient)
-          , rhs_function(rhs_function)
-          , update_flags(update_flags)
+          , coefficient(coefficient_)
+          , rhs_function(rhs_function_)
+          , update_flags(update_flags_)
         {}
 
         Scratch(const Scratch &data)
@@ -1385,10 +1385,10 @@ namespace MatrixCreator
         typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
         MatrixCreator::internal::AssemblerBoundary::Scratch const &scratch_data,
         MatrixCreator::internal::AssemblerBoundary::
-          CopyData<dim, spacedim, number> &copy_data) {
+          CopyData<dim, spacedim, number> &cpy_data) {
         internal::create_boundary_mass_matrix_1(cell,
                                                 scratch_data,
-                                                copy_data,
+                                                cpy_data,
                                                 mapping,
                                                 fe,
                                                 q,
@@ -1398,8 +1398,8 @@ namespace MatrixCreator
       },
       [&boundary_functions, &dof_to_boundary_mapping, &matrix, &rhs_vector](
         MatrixCreator::internal::AssemblerBoundary::
-          CopyData<dim, spacedim, number> const &copy_data) {
-        internal::copy_boundary_mass_matrix_1(copy_data,
+          CopyData<dim, spacedim, number> const &cpy_data) {
+        internal::copy_boundary_mass_matrix_1(cpy_data,
                                               boundary_functions,
                                               dof_to_boundary_mapping,
                                               matrix,
@@ -1861,10 +1861,10 @@ namespace MatrixCreator
         typename DoFHandler<dim, spacedim>::active_cell_iterator const &cell,
         MatrixCreator::internal::AssemblerBoundary::Scratch const &scratch_data,
         MatrixCreator::internal::AssemblerBoundary ::
-          CopyData<dim, spacedim, number> &copy_data) {
+          CopyData<dim, spacedim, number> &cpy_data) {
         internal::create_hp_boundary_mass_matrix_1(cell,
                                                    scratch_data,
-                                                   copy_data,
+                                                   cpy_data,
                                                    mapping,
                                                    fe_collection,
                                                    q,
@@ -1874,8 +1874,8 @@ namespace MatrixCreator
       },
       [&boundary_functions, &dof_to_boundary_mapping, &matrix, &rhs_vector](
         MatrixCreator::internal::AssemblerBoundary ::
-          CopyData<dim, spacedim, number> const &copy_data) {
-        internal::copy_hp_boundary_mass_matrix_1(copy_data,
+          CopyData<dim, spacedim, number> const &cpy_data) {
+        internal::copy_hp_boundary_mass_matrix_1(cpy_data,
                                                  boundary_functions,
                                                  dof_to_boundary_mapping,
                                                  matrix,

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -486,13 +486,13 @@ template <typename Value,
           typename Allocators>
 ExtractLevelVisitor<Value, Options, Translator, Box, Allocators>::
   ExtractLevelVisitor(
-    const Translator & translator,
-    const unsigned int target_level,
-    std::vector<BoundingBox<boost::geometry::dimension<Box>::value>> &boxes)
-  : translator(translator)
+    const Translator & translator_,
+    const unsigned int target_level_,
+    std::vector<BoundingBox<boost::geometry::dimension<Box>::value>> &boxes_)
+  : translator(translator_)
   , level(0)
-  , target_level(target_level)
-  , boxes(boxes)
+  , target_level(target_level_)
+  , boxes(boxes_)
 {}
 
 

--- a/include/deal.II/numerics/vector_tools_boundary.templates.h
+++ b/include/deal.II/numerics/vector_tools_boundary.templates.h
@@ -227,7 +227,7 @@ namespace VectorTools
 
           for (auto const &cell : dof.active_cell_iterators())
             if (!cell->is_artificial())
-              for (const unsigned int face_no : cell->face_indices())
+              for (const unsigned int face_index : cell->face_indices())
                 {
                   const FiniteElement<dim, spacedim> &fe = cell->get_fe();
 
@@ -259,7 +259,7 @@ namespace VectorTools
                     }
 
                   const typename DoFHandler<dim, spacedim>::face_iterator face =
-                    cell->face(face_no);
+                    cell->face(face_index);
                   const types::boundary_id boundary_component =
                     face->boundary_id();
 
@@ -268,16 +268,16 @@ namespace VectorTools
                   // element in use here has DoFs on the face at all
                   if ((function_map.find(boundary_component) !=
                        function_map.end()) &&
-                      (cell->get_fe().n_dofs_per_face(face_no) > 0))
+                      (cell->get_fe().n_dofs_per_face(face_index) > 0))
                     {
                       // face is of the right component
-                      x_fe_values.reinit(cell, face_no);
+                      x_fe_values.reinit(cell, face_index);
                       const dealii::FEFaceValues<dim, spacedim> &fe_values =
                         x_fe_values.get_present_fe_values();
 
                       // get indices, physical location and boundary values of
                       // dofs on this face
-                      face_dofs.resize(fe.n_dofs_per_face(face_no));
+                      face_dofs.resize(fe.n_dofs_per_face(face_index));
                       face->get_dof_indices(face_dofs, cell->active_fe_index());
                       const std::vector<Point<spacedim>> &dof_locations =
                         fe_values.get_quadrature_points();
@@ -287,13 +287,13 @@ namespace VectorTools
                           // resize array. avoid construction of a memory
                           // allocating temporary if possible
                           if (dof_values_system.size() <
-                              fe.n_dofs_per_face(face_no))
+                              fe.n_dofs_per_face(face_index))
                             dof_values_system.resize(
-                              fe.n_dofs_per_face(face_no),
+                              fe.n_dofs_per_face(face_index),
                               Vector<number>(fe.n_components()));
                           else
                             dof_values_system.resize(
-                              fe.n_dofs_per_face(face_no));
+                              fe.n_dofs_per_face(face_index));
 
                           function_map.find(boundary_component)
                             ->second->vector_value_list(dof_locations,
@@ -308,7 +308,8 @@ namespace VectorTools
                               unsigned int component;
                               if (fe.is_primitive())
                                 component =
-                                  fe.face_system_to_component_index(i, face_no)
+                                  fe.face_system_to_component_index(i,
+                                                                    face_index)
                                     .first;
                               else
                                 {
@@ -371,7 +372,8 @@ namespace VectorTools
                         // FE has only one component, so save some computations
                         {
                           // get only the one component that this function has
-                          dof_values_scalar.resize(fe.n_dofs_per_face(face_no));
+                          dof_values_scalar.resize(
+                            fe.n_dofs_per_face(face_index));
                           function_map.find(boundary_component)
                             ->second->value_list(dof_locations,
                                                  dof_values_scalar,
@@ -1505,15 +1507,16 @@ namespace VectorTools
               edge_matrix_inv.vmult(edge_solution, edge_rhs);
 
               // Store computed DoFs
-              for (unsigned int associated_edge_dof_index = 0;
-                   associated_edge_dof_index < associated_edge_dofs;
-                   ++associated_edge_dof_index)
+              for (unsigned int associated_edge_dof_idx = 0;
+                   associated_edge_dof_idx < associated_edge_dofs;
+                   ++associated_edge_dof_idx)
                 {
-                  dof_values[associated_edge_dof_to_face_dof
-                               [associated_edge_dof_index]] =
-                    edge_solution(associated_edge_dof_index);
-                  dofs_processed[associated_edge_dof_to_face_dof
-                                   [associated_edge_dof_index]] = true;
+                  dof_values
+                    [associated_edge_dof_to_face_dof[associated_edge_dof_idx]] =
+                      edge_solution(associated_edge_dof_idx);
+                  dofs_processed
+                    [associated_edge_dof_to_face_dof[associated_edge_dof_idx]] =
+                      true;
                 }
               break;
             }

--- a/include/deal.II/numerics/vector_tools_constraints.templates.h
+++ b/include/deal.II/numerics/vector_tools_constraints.templates.h
@@ -23,6 +23,8 @@
 
 #include <deal.II/numerics/vector_tools_constraints.h>
 
+#include <limits>
+
 DEAL_II_NAMESPACE_OPEN
 
 namespace VectorTools
@@ -493,7 +495,7 @@ namespace VectorTools
     // TODO: the implementation makes the assumption that all faces have the
     // same number of dofs
     AssertDimension(dof_handler.get_fe().n_unique_faces(), 1);
-    const unsigned int face_no = 0;
+    const unsigned int face_number = 0;
 
     // now also create a quadrature collection for the faces of a cell. fill
     // it with a quadrature formula with the support points on faces for each
@@ -502,10 +504,10 @@ namespace VectorTools
     for (unsigned int i = 0; i < fe_collection.size(); ++i)
       {
         const std::vector<Point<dim - 1>> &unit_support_points =
-          fe_collection[i].get_unit_face_support_points(face_no);
+          fe_collection[i].get_unit_face_support_points(face_number);
 
         Assert(unit_support_points.size() ==
-                 fe_collection[i].n_dofs_per_face(face_no),
+                 fe_collection[i].n_dofs_per_face(face_number),
                ExcInternalError());
 
         face_quadrature_collection.push_back(
@@ -1086,7 +1088,7 @@ namespace VectorTools
     // TODO: the implementation makes the assumption that all faces have the
     // same number of dofs
     AssertDimension(dof_handler.get_fe().n_unique_faces(), 1);
-    const unsigned int face_no = 0;
+    const unsigned int face_number = 0;
 
     // now also create a quadrature collection for the faces of a cell. fill
     // it with a quadrature formula with the support points on faces for each
@@ -1095,10 +1097,10 @@ namespace VectorTools
     for (unsigned int i = 0; i < fe_collection.size(); ++i)
       {
         const std::vector<Point<dim - 1>> &unit_support_points =
-          fe_collection[i].get_unit_face_support_points(face_no);
+          fe_collection[i].get_unit_face_support_points(face_number);
 
         Assert(unit_support_points.size() ==
-                 fe_collection[i].n_dofs_per_face(face_no),
+                 fe_collection[i].n_dofs_per_face(face_number),
                ExcInternalError());
 
         face_quadrature_collection.push_back(
@@ -1226,7 +1228,8 @@ namespace VectorTools
             // constraint indices will get the normal that contain the other
             // indices.
             Tensor<1, dim> normal;
-            unsigned       constrained_index = -1;
+            unsigned int   constrained_index =
+              std::numeric_limits<unsigned int>::max();
             for (unsigned int d = 0; d < dim; ++d)
               if (is_constrained[d])
                 {

--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -353,13 +353,14 @@ namespace VectorTools
             }
         };
 
-        std::vector<value_type> evaluation_point_results;
+        std::vector<value_type> evaluation_pt_results;
         std::vector<value_type> buffer;
 
-        cache.template evaluate_and_process<value_type>(
-          evaluation_point_results, buffer, evaluation_function);
+        cache.template evaluate_and_process<value_type>(evaluation_pt_results,
+                                                        buffer,
+                                                        evaluation_function);
 
-        return evaluation_point_results;
+        return evaluation_pt_results;
       }();
 
       if (cache.is_map_unique())

--- a/source/dofs/dof_handler.cc
+++ b/source/dofs/dof_handler.cc
@@ -2123,10 +2123,11 @@ DoFHandler<dim, spacedim>::DoFHandler()
 
 
 template <int dim, int spacedim>
-DoFHandler<dim, spacedim>::DoFHandler(const Triangulation<dim, spacedim> &tria)
+DoFHandler<dim, spacedim>::DoFHandler(
+  const Triangulation<dim, spacedim> &triangulation)
   : DoFHandler()
 {
-  reinit(tria);
+  reinit(triangulation);
 }
 
 
@@ -2159,20 +2160,22 @@ DoFHandler<dim, spacedim>::~DoFHandler()
 
 template <int dim, int spacedim>
 void
-DoFHandler<dim, spacedim>::initialize(const Triangulation<dim, spacedim> &tria,
-                                      const FiniteElement<dim, spacedim> &fe)
+DoFHandler<dim, spacedim>::initialize(
+  const Triangulation<dim, spacedim> &triangulation,
+  const FiniteElement<dim, spacedim> &fe)
 {
-  this->initialize(tria, hp::FECollection<dim, spacedim>(fe));
+  this->initialize(triangulation, hp::FECollection<dim, spacedim>(fe));
 }
 
 
 
 template <int dim, int spacedim>
 void
-DoFHandler<dim, spacedim>::initialize(const Triangulation<dim, spacedim> &tria,
-                                      const hp::FECollection<dim, spacedim> &fe)
+DoFHandler<dim, spacedim>::initialize(
+  const Triangulation<dim, spacedim> &   triangulation,
+  const hp::FECollection<dim, spacedim> &fe)
 {
-  this->reinit(tria);
+  this->reinit(triangulation);
   this->distribute_dofs(fe);
 }
 
@@ -2180,7 +2183,8 @@ DoFHandler<dim, spacedim>::initialize(const Triangulation<dim, spacedim> &tria,
 
 template <int dim, int spacedim>
 void
-DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
+DoFHandler<dim, spacedim>::reinit(
+  const Triangulation<dim, spacedim> &triangulation)
 {
   //
   // call destructor
@@ -2205,7 +2209,7 @@ DoFHandler<dim, spacedim>::reinit(const Triangulation<dim, spacedim> &tria)
   // call constructor
   //
   // establish connection to new triangulation
-  this->tria = &tria;
+  this->tria = &triangulation;
   this->setup_policy();
 
   // start in hp-mode and let distribute_dofs toggle it if necessary

--- a/source/dofs/dof_handler_policy.cc
+++ b/source/dofs/dof_handler_policy.cc
@@ -2851,8 +2851,8 @@ namespace internal
 
       template <int dim, int spacedim>
       Sequential<dim, spacedim>::Sequential(
-        DoFHandler<dim, spacedim> &dof_handler)
-        : dof_handler(&dof_handler)
+        DoFHandler<dim, spacedim> &dof_handler_)
+        : dof_handler(&dof_handler_)
       {}
 
 
@@ -2956,8 +2956,8 @@ namespace internal
 
       template <int dim, int spacedim>
       ParallelShared<dim, spacedim>::ParallelShared(
-        DoFHandler<dim, spacedim> &dof_handler)
-        : dof_handler(&dof_handler)
+        DoFHandler<dim, spacedim> &dof_handler_)
+        : dof_handler(&dof_handler_)
       {}
 
 
@@ -3820,8 +3820,8 @@ namespace internal
 
       template <int dim, int spacedim>
       ParallelDistributed<dim, spacedim>::ParallelDistributed(
-        DoFHandler<dim, spacedim> &dof_handler)
-        : dof_handler(&dof_handler)
+        DoFHandler<dim, spacedim> &dof_handler_)
+        : dof_handler(&dof_handler_)
       {}
 
 

--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -1594,22 +1594,23 @@ namespace DoFRenumbering
   compute_cell_wise(
     std::vector<types::global_dof_index> &new_indices,
     std::vector<types::global_dof_index> &reverse,
-    const DoFHandler<dim, spacedim> &     dof,
+    const DoFHandler<dim, spacedim> &     dof_handler,
     const typename std::vector<
       typename DoFHandler<dim, spacedim>::active_cell_iterator> &cells)
   {
     if (const parallel::TriangulationBase<dim, spacedim> *p =
           dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
-            &dof.get_triangulation()))
+            &dof_handler.get_triangulation()))
       {
         AssertDimension(cells.size(), p->n_locally_owned_active_cells());
       }
     else
       {
-        AssertDimension(cells.size(), dof.get_triangulation().n_active_cells());
+        AssertDimension(cells.size(),
+                        dof_handler.get_triangulation().n_active_cells());
       }
 
-    const auto n_owned_dofs = dof.n_locally_owned_dofs();
+    const auto n_owned_dofs = dof_handler.n_locally_owned_dofs();
 
     // Actually, we compute the inverse of the reordering vector, called reverse
     // here. Later, its inverse is computed into new_indices, which is the
@@ -1623,7 +1624,7 @@ namespace DoFRenumbering
     std::vector<bool>                    already_sorted(n_owned_dofs, false);
     std::vector<types::global_dof_index> cell_dofs;
 
-    const auto &owned_dofs = dof.locally_owned_dofs();
+    const auto &owned_dofs = dof_handler.locally_owned_dofs();
 
     unsigned int index = 0;
 
@@ -1963,9 +1964,9 @@ namespace DoFRenumbering
       /**
        * Constructor.
        */
-      ClockCells(const Point<dim> &center, bool counter)
-        : center(center)
-        , counter(counter)
+      ClockCells(const Point<dim> &center_, bool counter_)
+        : center(center_)
+        , counter(counter_)
       {}
 
       /**

--- a/source/dofs/number_cache.cc
+++ b/source/dofs/number_cache.cc
@@ -34,8 +34,8 @@ namespace internal
 
 
 
-    NumberCache::NumberCache(const types::global_dof_index n_global_dofs)
-      : n_global_dofs(n_global_dofs)
+    NumberCache::NumberCache(const types::global_dof_index n_global_dofs_)
+      : n_global_dofs(n_global_dofs_)
       , n_locally_owned_dofs(n_global_dofs)
       , locally_owned_dofs(complete_index_set(n_global_dofs))
       , n_locally_owned_dofs_per_processor(1, n_global_dofs)
@@ -45,9 +45,9 @@ namespace internal
 
 
     NumberCache::NumberCache(
-      const std::vector<IndexSet> &locally_owned_dofs_per_processor,
+      const std::vector<IndexSet> &locally_owned_dofs_per_processor_,
       const unsigned int           my_rank)
-      : locally_owned_dofs_per_processor(locally_owned_dofs_per_processor)
+      : locally_owned_dofs_per_processor(locally_owned_dofs_per_processor_)
     {
       const unsigned int n_procs = locally_owned_dofs_per_processor.size();
 

--- a/source/fe/fe_bernstein.cc
+++ b/source/fe/fe_bernstein.cc
@@ -35,12 +35,12 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-FE_Bernstein<dim, spacedim>::FE_Bernstein(const unsigned int degree)
-  : FE_Q_Base<dim, spacedim>(this->renumber_bases(degree),
+FE_Bernstein<dim, spacedim>::FE_Bernstein(const unsigned int degree_)
+  : FE_Q_Base<dim, spacedim>(this->renumber_bases(degree_),
                              FiniteElementData<dim>(this->get_dpo_vector(
-                                                      degree),
+                                                      degree_),
                                                     1,
-                                                    degree,
+                                                    degree_,
                                                     FiniteElementData<dim>::H1),
                              std::vector<bool>(1, false))
 {}

--- a/source/fe/fe_dgq.cc
+++ b/source/fe/fe_dgq.cc
@@ -63,28 +63,28 @@ namespace internal
 
 
 template <int dim, int spacedim>
-FE_DGQ<dim, spacedim>::FE_DGQ(const unsigned int degree)
+FE_DGQ<dim, spacedim>::FE_DGQ(const unsigned int degree_)
   : FE_Poly<dim, spacedim>(
       TensorProductPolynomials<dim>(
         Polynomials::generate_complete_Lagrange_basis(
-          internal::FE_DGQ::get_QGaussLobatto_points(degree))),
-      FiniteElementData<dim>(get_dpo_vector(degree),
+          internal::FE_DGQ::get_QGaussLobatto_points(degree_))),
+      FiniteElementData<dim>(get_dpo_vector(degree_),
                              1,
-                             degree,
+                             degree_,
                              FiniteElementData<dim>::L2),
       std::vector<bool>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+        FiniteElementData<dim>(get_dpo_vector(degree_), 1, degree_)
           .n_dofs_per_cell(),
         true),
       std::vector<ComponentMask>(
-        FiniteElementData<dim>(get_dpo_vector(degree), 1, degree)
+        FiniteElementData<dim>(get_dpo_vector(degree_), 1, degree_)
           .n_dofs_per_cell(),
         std::vector<bool>(1, true)))
 {
   // Compute support points, which are the tensor product of the Lagrange
   // interpolation points in the constructor.
   this->unit_support_points =
-    Quadrature<dim>(internal::FE_DGQ::get_QGaussLobatto_points(degree))
+    Quadrature<dim>(internal::FE_DGQ::get_QGaussLobatto_points(degree_))
       .get_points();
 
   // do not initialize embedding and restriction here. these matrices are
@@ -1033,9 +1033,9 @@ FE_DGQLegendre<dim, spacedim>::clone() const
 // ---------------------------------- FE_DGQHermite --------------------------
 
 template <int dim, int spacedim>
-FE_DGQHermite<dim, spacedim>::FE_DGQHermite(const unsigned int degree)
+FE_DGQHermite<dim, spacedim>::FE_DGQHermite(const unsigned int degree_)
   : FE_DGQ<dim, spacedim>(
-      Polynomials::HermiteLikeInterpolation::generate_complete_basis(degree))
+      Polynomials::HermiteLikeInterpolation::generate_complete_basis(degree_))
 {}
 
 

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -48,14 +48,14 @@ namespace internal
 } // namespace internal
 
 template <int dim, int spacedim>
-FE_FaceQ<dim, spacedim>::FE_FaceQ(const unsigned int degree)
+FE_FaceQ<dim, spacedim>::FE_FaceQ(const unsigned int degree_)
   : FE_PolyFace<TensorProductPolynomials<dim - 1>, dim, spacedim>(
       TensorProductPolynomials<dim - 1>(
         Polynomials::generate_complete_Lagrange_basis(
-          internal::FE_FaceQImplementation::get_QGaussLobatto_points(degree))),
-      FiniteElementData<dim>(get_dpo_vector(degree),
+          internal::FE_FaceQImplementation::get_QGaussLobatto_points(degree_))),
+      FiniteElementData<dim>(get_dpo_vector(degree_),
                              1,
-                             degree,
+                             degree_,
                              FiniteElementData<dim>::L2),
       std::vector<bool>(1, true))
 {
@@ -70,7 +70,8 @@ FE_FaceQ<dim, spacedim>::FE_FaceQ(const unsigned int degree)
   else
     {
       std::vector<Point<1>> points =
-        internal::FE_FaceQImplementation::get_QGaussLobatto_points(degree);
+        internal::FE_FaceQImplementation::get_QGaussLobatto_points(
+          this->degree);
 
       unsigned int k = 0;
       for (unsigned int iz = 0; iz <= ((codim > 2) ? this->degree : 0); ++iz)
@@ -104,7 +105,8 @@ FE_FaceQ<dim, spacedim>::FE_FaceQ(const unsigned int degree)
               // faces in y-direction are oriented differently
               unsigned int renumber = i;
               if (dim == 3 && d == 1)
-                renumber = i / (degree + 1) + (degree + 1) * (i % (degree + 1));
+                renumber = i / (this->degree + 1) +
+                           (this->degree + 1) * (i % (this->degree + 1));
               this->unit_support_points[n_face_dofs * 2 * d + i][e] =
                 this->unit_face_support_points[0][renumber][c];
               this->unit_support_points[n_face_dofs * (2 * d + 1) + i][e] =
@@ -513,11 +515,11 @@ FE_FaceQ<dim, spacedim>::convert_generalized_support_point_values_to_dof_values(
 // ----------------------------- FE_FaceQ<1,spacedim> ------------------------
 
 template <int spacedim>
-FE_FaceQ<1, spacedim>::FE_FaceQ(const unsigned int degree)
+FE_FaceQ<1, spacedim>::FE_FaceQ(const unsigned int degree_)
   : FiniteElement<1, spacedim>(
-      FiniteElementData<1>(get_dpo_vector(degree),
+      FiniteElementData<1>(get_dpo_vector(degree_),
                            1,
-                           degree,
+                           degree_,
                            FiniteElementData<1>::L2),
       std::vector<bool>(1, true),
       std::vector<ComponentMask>(1, ComponentMask(1, true)))
@@ -760,13 +762,13 @@ FE_FaceQ<1, spacedim>::fill_fe_subface_values(
 // --------------------------------------- FE_FaceP --------------------------
 
 template <int dim, int spacedim>
-FE_FaceP<dim, spacedim>::FE_FaceP(const unsigned int degree)
+FE_FaceP<dim, spacedim>::FE_FaceP(const unsigned int degree_)
   : FE_PolyFace<PolynomialSpace<dim - 1>, dim, spacedim>(
       PolynomialSpace<dim - 1>(
-        Polynomials::Legendre::generate_complete_basis(degree)),
-      FiniteElementData<dim>(get_dpo_vector(degree),
+        Polynomials::Legendre::generate_complete_basis(degree_)),
+      FiniteElementData<dim>(get_dpo_vector(degree_),
                              1,
-                             degree,
+                             degree_,
                              FiniteElementData<dim>::L2),
       std::vector<bool>(1, true))
 {}
@@ -1009,8 +1011,8 @@ FE_FaceP<dim, spacedim>::get_constant_modes() const
 
 
 template <int spacedim>
-FE_FaceP<1, spacedim>::FE_FaceP(const unsigned int degree)
-  : FE_FaceQ<1, spacedim>(degree)
+FE_FaceP<1, spacedim>::FE_FaceP(const unsigned int degree_)
+  : FE_FaceQ<1, spacedim>(degree_)
 {}
 
 

--- a/source/fe/fe_q_base.cc
+++ b/source/fe/fe_q_base.cc
@@ -414,16 +414,16 @@ struct FE_Q_Base<xdim, xspacedim>::Implementation
 
 template <int dim, int spacedim>
 FE_Q_Base<dim, spacedim>::FE_Q_Base(
-  const ScalarPolynomialsBase<dim> &poly_space,
+  const ScalarPolynomialsBase<dim> &poly_space_,
   const FiniteElementData<dim> &    fe_data,
-  const std::vector<bool> &         restriction_is_additive_flags)
+  const std::vector<bool> &         restriction_is_additive_flags_)
   : FE_Poly<dim, spacedim>(
-      poly_space,
+      poly_space_,
       fe_data,
-      restriction_is_additive_flags,
+      restriction_is_additive_flags_,
       std::vector<ComponentMask>(1, std::vector<bool>(1, true)))
   , q_degree(dynamic_cast<const TensorProductPolynomialsBubbles<dim> *>(
-               &poly_space) != nullptr ?
+               &poly_space_) != nullptr ?
                this->degree - 1 :
                this->degree)
 {}

--- a/source/fe/fe_q_bubbles.cc
+++ b/source/fe/fe_q_bubbles.cc
@@ -186,22 +186,22 @@ namespace internal
 
 
 template <int dim, int spacedim>
-FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const unsigned int q_degree)
+FE_Q_Bubbles<dim, spacedim>::FE_Q_Bubbles(const unsigned int q_degree_)
   : FE_Q_Base<dim, spacedim>(TensorProductPolynomialsBubbles<dim>(
                                Polynomials::generate_complete_Lagrange_basis(
-                                 QGaussLobatto<1>(q_degree + 1).get_points())),
-                             FiniteElementData<dim>(get_dpo_vector(q_degree),
+                                 QGaussLobatto<1>(q_degree_ + 1).get_points())),
+                             FiniteElementData<dim>(get_dpo_vector(q_degree_),
                                                     1,
-                                                    q_degree + 1,
+                                                    q_degree_ + 1,
                                                     FiniteElementData<dim>::H1),
-                             get_riaf_vector(q_degree))
-  , n_bubbles((q_degree <= 1) ? 1 : dim)
+                             get_riaf_vector(q_degree_))
+  , n_bubbles((q_degree_ <= 1) ? 1 : dim)
 {
-  Assert(q_degree > 0,
+  Assert(q_degree_ > 0,
          ExcMessage("This element can only be used for polynomial degrees "
                     "greater than zero"));
 
-  this->initialize(QGaussLobatto<1>(q_degree + 1).get_points());
+  this->initialize(QGaussLobatto<1>(q_degree_ + 1).get_points());
 
   // adjust unit support point for discontinuous node
   Point<dim> point;
@@ -275,24 +275,23 @@ FE_Q_Bubbles<dim, spacedim>::get_name() const
   bool                           type     = true;
   const unsigned int             n_points = this->degree;
   std::vector<double>            points(n_points);
-  const unsigned int             dofs_per_cell = this->n_dofs_per_cell();
-  const std::vector<Point<dim>> &unit_support_points =
-    this->unit_support_points;
-  unsigned int index = 0;
+  const unsigned int             dofs_per_cell    = this->n_dofs_per_cell();
+  const std::vector<Point<dim>> &unit_support_pts = this->unit_support_points;
+  unsigned int                   index            = 0;
 
   // Decode the support points in one coordinate direction.
   for (unsigned int j = 0; j < dofs_per_cell; ++j)
     {
-      if ((dim > 1) ? (unit_support_points[j](1) == 0 &&
-                       ((dim > 2) ? unit_support_points[j](2) == 0 : true)) :
+      if ((dim > 1) ? (unit_support_pts[j](1) == 0 &&
+                       ((dim > 2) ? unit_support_pts[j](2) == 0 : true)) :
                       true)
         {
           if (index == 0)
-            points[index] = unit_support_points[j](0);
+            points[index] = unit_support_pts[j](0);
           else if (index == 1)
-            points[n_points - 1] = unit_support_points[j](0);
+            points[n_points - 1] = unit_support_pts[j](0);
           else
-            points[index - 1] = unit_support_points[j](0);
+            points[index - 1] = unit_support_pts[j](0);
 
           index++;
         }

--- a/source/fe/fe_q_dg0.cc
+++ b/source/fe/fe_q_dg0.cc
@@ -32,21 +32,21 @@ DEAL_II_NAMESPACE_OPEN
 
 
 template <int dim, int spacedim>
-FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const unsigned int degree)
+FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const unsigned int degree_)
   : FE_Q_Base<dim, spacedim>(TensorProductPolynomialsConst<dim>(
                                Polynomials::generate_complete_Lagrange_basis(
-                                 QGaussLobatto<1>(degree + 1).get_points())),
-                             FiniteElementData<dim>(get_dpo_vector(degree),
+                                 QGaussLobatto<1>(degree_ + 1).get_points())),
+                             FiniteElementData<dim>(get_dpo_vector(degree_),
                                                     1,
-                                                    degree,
+                                                    degree_,
                                                     FiniteElementData<dim>::L2),
-                             get_riaf_vector(degree))
+                             get_riaf_vector(degree_))
 {
-  Assert(degree > 0,
+  Assert(degree_ > 0,
          ExcMessage("This element can only be used for polynomial degrees "
                     "greater than zero"));
 
-  this->initialize(QGaussLobatto<1>(degree + 1).get_points());
+  this->initialize(QGaussLobatto<1>(degree_ + 1).get_points());
 
   // adjust unit support point for discontinuous node
   Point<dim> point;
@@ -69,10 +69,7 @@ FE_Q_DG0<dim, spacedim>::FE_Q_DG0(const Quadrature<1> &points)
                              FiniteElementData<dim>::L2),
       get_riaf_vector(points.size() - 1))
 {
-  const int degree = points.size() - 1;
-  (void)degree;
-
-  Assert(degree > 0,
+  Assert(points.size() - 1 > 0,
          ExcMessage("This element can only be used for polynomial degrees "
                     "at least zero"));
 
@@ -100,24 +97,23 @@ FE_Q_DG0<dim, spacedim>::get_name() const
   bool                           type     = true;
   const unsigned int             n_points = this->degree + 1;
   std::vector<double>            points(n_points);
-  const unsigned int             dofs_per_cell = this->n_dofs_per_cell();
-  const std::vector<Point<dim>> &unit_support_points =
-    this->unit_support_points;
-  unsigned int index = 0;
+  const unsigned int             n_dofs_per_cell  = this->n_dofs_per_cell();
+  const std::vector<Point<dim>> &unit_support_pts = this->unit_support_points;
+  unsigned int                   index            = 0;
 
   // Decode the support points in one coordinate direction.
-  for (unsigned int j = 0; j < dofs_per_cell; ++j)
+  for (unsigned int j = 0; j < n_dofs_per_cell; ++j)
     {
-      if ((dim > 1) ? (unit_support_points[j](1) == 0 &&
-                       ((dim > 2) ? unit_support_points[j](2) == 0 : true)) :
+      if ((dim > 1) ? (unit_support_pts[j](1) == 0 &&
+                       ((dim > 2) ? unit_support_pts[j](2) == 0 : true)) :
                       true)
         {
           if (index == 0)
-            points[index] = unit_support_points[j](0);
+            points[index] = unit_support_pts[j](0);
           else if (index == 1)
-            points[n_points - 1] = unit_support_points[j](0);
+            points[n_points - 1] = unit_support_pts[j](0);
           else
-            points[index - 1] = unit_support_points[j](0);
+            points[index - 1] = unit_support_pts[j](0);
 
           index++;
         }

--- a/source/fe/fe_rannacher_turek.cc
+++ b/source/fe/fe_rannacher_turek.cc
@@ -30,8 +30,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim>
 FE_RannacherTurek<dim>::FE_RannacherTurek(
-  const unsigned int order,
-  const unsigned int n_face_support_points)
+  const unsigned int order_,
+  const unsigned int n_face_support_points_)
   : FE_Poly<dim>(PolynomialsRannacherTurek<dim>(),
                  FiniteElementData<dim>(this->get_dpo_vector(),
                                         1,
@@ -39,8 +39,8 @@ FE_RannacherTurek<dim>::FE_RannacherTurek(
                                         FiniteElementData<dim>::L2),
                  std::vector<bool>(4, false), // restriction not implemented
                  std::vector<ComponentMask>(4, std::vector<bool>(1, true)))
-  , order(order)
-  , n_face_support_points(n_face_support_points)
+  , order(order_)
+  , n_face_support_points(n_face_support_points_)
 {
   Assert(dim == 2, ExcNotImplemented());
   Assert(order == 0, ExcNotImplemented());

--- a/source/fe/fe_raviart_thomas.cc
+++ b/source/fe/fe_raviart_thomas.cc
@@ -604,11 +604,11 @@ FE_RaviartThomas<dim>::get_constant_modes() const
   for (unsigned int d = 0; d < dim; ++d)
     for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
       constant_modes(d, i) = true;
-  std::vector<unsigned int> components;
+  std::vector<unsigned int> comp;
   for (unsigned int d = 0; d < dim; ++d)
-    components.push_back(d);
+    comp.push_back(d);
   return std::pair<Table<2, bool>, std::vector<unsigned int>>(constant_modes,
-                                                              components);
+                                                              comp);
 }
 
 

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -142,10 +142,10 @@ namespace internal
 namespace FEValuesViews
 {
   template <int dim, int spacedim>
-  Scalar<dim, spacedim>::Scalar(const FEValuesBase<dim, spacedim> &fe_values,
-                                const unsigned int                 component)
-    : fe_values(&fe_values)
-    , component(component)
+  Scalar<dim, spacedim>::Scalar(const FEValuesBase<dim, spacedim> &fe_values_,
+                                const unsigned int                 component_)
+    : fe_values(&fe_values_)
+    , component(component_)
     , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
@@ -187,10 +187,10 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  Vector<dim, spacedim>::Vector(const FEValuesBase<dim, spacedim> &fe_values,
-                                const unsigned int first_vector_component)
-    : fe_values(&fe_values)
-    , first_vector_component(first_vector_component)
+  Vector<dim, spacedim>::Vector(const FEValuesBase<dim, spacedim> &fe_values_,
+                                const unsigned int first_vector_component_)
+    : fe_values(&fe_values_)
+    , first_vector_component(first_vector_component_)
     , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
@@ -266,10 +266,10 @@ namespace FEValuesViews
 
   template <int dim, int spacedim>
   SymmetricTensor<2, dim, spacedim>::SymmetricTensor(
-    const FEValuesBase<dim, spacedim> &fe_values,
-    const unsigned int                 first_tensor_component)
-    : fe_values(&fe_values)
-    , first_tensor_component(first_tensor_component)
+    const FEValuesBase<dim, spacedim> &fe_values_,
+    const unsigned int                 first_tensor_component_)
+    : fe_values(&fe_values_)
+    , first_tensor_component(first_tensor_component_)
     , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
@@ -355,10 +355,11 @@ namespace FEValuesViews
 
 
   template <int dim, int spacedim>
-  Tensor<2, dim, spacedim>::Tensor(const FEValuesBase<dim, spacedim> &fe_values,
-                                   const unsigned int first_tensor_component)
-    : fe_values(&fe_values)
-    , first_tensor_component(first_tensor_component)
+  Tensor<2, dim, spacedim>::Tensor(
+    const FEValuesBase<dim, spacedim> &fe_values_,
+    const unsigned int                 first_tensor_component_)
+    : fe_values(&fe_values_)
+    , first_tensor_component(first_tensor_component_)
     , shape_function_data(this->fe_values->fe->n_dofs_per_cell())
   {
     const FiniteElement<dim, spacedim> &fe = *this->fe_values->fe;
@@ -2605,9 +2606,9 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer()
 template <int dim, int spacedim>
 template <bool lda>
 FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
-  const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell)
+  const TriaIterator<DoFCellAccessor<dim, spacedim, lda>> &cell_)
   : initialized(true)
-  , cell(cell)
+  , cell(cell_)
   , dof_handler(&cell->get_dof_handler())
   , level_dof_access(lda)
 {}
@@ -2616,9 +2617,9 @@ FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
 
 template <int dim, int spacedim>
 FEValuesBase<dim, spacedim>::CellIteratorContainer::CellIteratorContainer(
-  const typename Triangulation<dim, spacedim>::cell_iterator &cell)
+  const typename Triangulation<dim, spacedim>::cell_iterator &cell_)
   : initialized(true)
-  , cell(cell)
+  , cell(cell_)
   , dof_handler(nullptr)
   , level_dof_access(false)
 {}
@@ -2874,15 +2875,15 @@ namespace internal
 template <int dim, int spacedim>
 FEValuesBase<dim, spacedim>::FEValuesBase(
   const unsigned int                  n_q_points,
-  const unsigned int                  dofs_per_cell,
+  const unsigned int                  dofs_per_cell_,
   const UpdateFlags                   flags,
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe)
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_)
   : n_quadrature_points(n_q_points)
   , max_n_quadrature_points(n_q_points)
-  , dofs_per_cell(dofs_per_cell)
-  , mapping(&mapping, typeid(*this).name())
-  , fe(&fe, typeid(*this).name())
+  , dofs_per_cell(dofs_per_cell_)
+  , mapping(&mapping_, typeid(*this).name())
+  , fe(&fe_, typeid(*this).name())
   , cell_similarity(CellSimilarity::Similarity::none)
   , fe_values_views_cache(*this)
 {
@@ -4017,7 +4018,7 @@ FEValuesBase<dim, spacedim>::memory_consumption() const
 template <int dim, int spacedim>
 UpdateFlags
 FEValuesBase<dim, spacedim>::compute_update_flags(
-  const UpdateFlags update_flags) const
+  const UpdateFlags update_flags_) const
 {
   // first find out which objects need to be recomputed on each
   // cell we visit. this we have to ask the finite element and mapping.
@@ -4025,7 +4026,7 @@ FEValuesBase<dim, spacedim>::compute_update_flags(
   //
   // there is no need to iterate since mappings will never require
   // the finite element to compute something for them
-  UpdateFlags flags = update_flags | fe->requires_update_flags(update_flags);
+  UpdateFlags flags = update_flags_ | fe->requires_update_flags(update_flags_);
   flags |= mapping->requires_update_flags(flags);
 
   return flags;
@@ -4174,28 +4175,28 @@ const unsigned int FEValues<dim, spacedim>::integral_dimension;
 
 
 template <int dim, int spacedim>
-FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping,
-                                  const FiniteElement<dim, spacedim> &fe,
+FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping_,
+                                  const FiniteElement<dim, spacedim> &fe_,
                                   const Quadrature<dim> &             q,
-                                  const UpdateFlags update_flags)
+                                  const UpdateFlags update_flags_)
   : FEValuesBase<dim, spacedim>(q.size(),
-                                fe.n_dofs_per_cell(),
+                                fe_.n_dofs_per_cell(),
                                 update_default,
-                                mapping,
-                                fe)
+                                mapping_,
+                                fe_)
   , quadrature(q)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
-FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping,
-                                  const FiniteElement<dim, spacedim> &fe,
+FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping_,
+                                  const FiniteElement<dim, spacedim> &fe_,
                                   const hp::QCollection<dim> &        q,
-                                  const UpdateFlags update_flags)
-  : FEValues(mapping, fe, q[0], update_flags)
+                                  const UpdateFlags update_flags_)
+  : FEValues(mapping_, fe_, q[0], update_flags_)
 {
   AssertDimension(q.size(), 1);
 }
@@ -4203,27 +4204,27 @@ FEValues<dim, spacedim>::FEValues(const Mapping<dim, spacedim> &      mapping,
 
 
 template <int dim, int spacedim>
-FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
+FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe_,
                                   const Quadrature<dim> &             q,
-                                  const UpdateFlags update_flags)
+                                  const UpdateFlags update_flags_)
   : FEValuesBase<dim, spacedim>(
       q.size(),
-      fe.n_dofs_per_cell(),
+      fe_.n_dofs_per_cell(),
       update_default,
-      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
-      fe)
+      fe_.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
+      fe_)
   , quadrature(q)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
-FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
+FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe_,
                                   const hp::QCollection<dim> &        q,
-                                  const UpdateFlags update_flags)
-  : FEValues(fe, q[0], update_flags)
+                                  const UpdateFlags update_flags_)
+  : FEValues(fe_, q[0], update_flags_)
 {
   AssertDimension(q.size(), 1);
 }
@@ -4232,19 +4233,19 @@ FEValues<dim, spacedim>::FEValues(const FiniteElement<dim, spacedim> &fe,
 
 template <int dim, int spacedim>
 void
-FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
+FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags_)
 {
   // You can compute normal vectors to the cells only in the
   // codimension one case.
   if (dim != spacedim - 1)
-    Assert((update_flags & update_normal_vectors) == false,
+    Assert((update_flags_ & update_normal_vectors) == false,
            ExcMessage("You can only pass the 'update_normal_vectors' "
                       "flag to FEFaceValues or FESubfaceValues objects, "
                       "but not to an FEValues object unless the "
                       "triangulation it refers to is embedded in a higher "
                       "dimensional space."));
 
-  const UpdateFlags flags = this->compute_update_flags(update_flags);
+  const UpdateFlags flags = this->compute_update_flags(update_flags_);
 
   // initialize the base classes
   if (flags & update_mapping)
@@ -4391,37 +4392,37 @@ FEValues<dim, spacedim>::memory_consumption() const
 
 template <int dim, int spacedim>
 FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
-  const unsigned int                  dofs_per_cell,
-  const UpdateFlags                   flags,
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const Quadrature<dim - 1> &         quadrature)
-  : FEFaceValuesBase<dim, spacedim>(dofs_per_cell,
-                                    flags,
-                                    mapping,
-                                    fe,
-                                    hp::QCollection<dim - 1>(quadrature))
+  const unsigned int                  dofs_per_cell_,
+  const UpdateFlags                   flags_,
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const Quadrature<dim - 1> &         quadrature_)
+  : FEFaceValuesBase<dim, spacedim>(dofs_per_cell_,
+                                    flags_,
+                                    mapping_,
+                                    fe_,
+                                    hp::QCollection<dim - 1>(quadrature_))
 {}
 
 
 
 template <int dim, int spacedim>
 FEFaceValuesBase<dim, spacedim>::FEFaceValuesBase(
-  const unsigned int dofs_per_cell,
+  const unsigned int dofs_per_cell_,
   const UpdateFlags,
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const hp::QCollection<dim - 1> &    quadrature)
-  : FEValuesBase<dim, spacedim>(quadrature.max_n_quadrature_points(),
-                                dofs_per_cell,
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const hp::QCollection<dim - 1> &    quadrature_)
+  : FEValuesBase<dim, spacedim>(quadrature_.max_n_quadrature_points(),
+                                dofs_per_cell_,
                                 update_default,
-                                mapping,
-                                fe)
+                                mapping_,
+                                fe_)
   , present_face_index(numbers::invalid_unsigned_int)
-  , quadrature(quadrature)
+  , quadrature(quadrature_)
 {
   Assert(quadrature.size() == 1 ||
-           quadrature.size() == fe.reference_cell().n_faces(),
+           quadrature.size() == fe_.reference_cell().n_faces(),
          ExcInternalError());
 }
 
@@ -4462,69 +4463,69 @@ const unsigned int FEFaceValues<dim, spacedim>::integral_dimension;
 
 template <int dim, int spacedim>
 FEFaceValues<dim, spacedim>::FEFaceValues(
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const Quadrature<dim - 1> &         quadrature,
-  const UpdateFlags                   update_flags)
-  : FEFaceValues<dim, spacedim>(mapping,
-                                fe,
-                                hp::QCollection<dim - 1>(quadrature),
-                                update_flags)
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const Quadrature<dim - 1> &         quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FEFaceValues<dim, spacedim>(mapping_,
+                                fe_,
+                                hp::QCollection<dim - 1>(quadrature_),
+                                update_flags_)
 {}
 
 
 
 template <int dim, int spacedim>
 FEFaceValues<dim, spacedim>::FEFaceValues(
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const hp::QCollection<dim - 1> &    quadrature,
-  const UpdateFlags                   update_flags)
-  : FEFaceValuesBase<dim, spacedim>(fe.n_dofs_per_cell(),
-                                    update_flags,
-                                    mapping,
-                                    fe,
-                                    quadrature)
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const hp::QCollection<dim - 1> &    quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FEFaceValuesBase<dim, spacedim>(fe_.n_dofs_per_cell(),
+                                    update_flags_,
+                                    mapping_,
+                                    fe_,
+                                    quadrature_)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
 FEFaceValues<dim, spacedim>::FEFaceValues(
-  const FiniteElement<dim, spacedim> &fe,
-  const Quadrature<dim - 1> &         quadrature,
-  const UpdateFlags                   update_flags)
-  : FEFaceValues<dim, spacedim>(fe,
-                                hp::QCollection<dim - 1>(quadrature),
-                                update_flags)
+  const FiniteElement<dim, spacedim> &fe_,
+  const Quadrature<dim - 1> &         quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FEFaceValues<dim, spacedim>(fe_,
+                                hp::QCollection<dim - 1>(quadrature_),
+                                update_flags_)
 {}
 
 
 
 template <int dim, int spacedim>
 FEFaceValues<dim, spacedim>::FEFaceValues(
-  const FiniteElement<dim, spacedim> &fe,
-  const hp::QCollection<dim - 1> &    quadrature,
-  const UpdateFlags                   update_flags)
+  const FiniteElement<dim, spacedim> &fe_,
+  const hp::QCollection<dim - 1> &    quadrature_,
+  const UpdateFlags                   update_flags_)
   : FEFaceValuesBase<dim, spacedim>(
-      fe.n_dofs_per_cell(),
-      update_flags,
-      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
-      fe,
-      quadrature)
+      fe_.n_dofs_per_cell(),
+      update_flags_,
+      fe_.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
+      fe_,
+      quadrature_)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
 void
-FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
+FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags_)
 {
-  const UpdateFlags flags = this->compute_update_flags(update_flags);
+  const UpdateFlags flags = this->compute_update_flags(update_flags_);
 
   // initialize the base classes
   if (flags & update_mapping)
@@ -4701,68 +4702,68 @@ const unsigned int FESubfaceValues<dim, spacedim>::integral_dimension;
 
 template <int dim, int spacedim>
 FESubfaceValues<dim, spacedim>::FESubfaceValues(
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const Quadrature<dim - 1> &         quadrature,
-  const UpdateFlags                   update_flags)
-  : FEFaceValuesBase<dim, spacedim>(fe.n_dofs_per_cell(),
-                                    update_flags,
-                                    mapping,
-                                    fe,
-                                    quadrature)
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const Quadrature<dim - 1> &         quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FEFaceValuesBase<dim, spacedim>(fe_.n_dofs_per_cell(),
+                                    update_flags_,
+                                    mapping_,
+                                    fe_,
+                                    quadrature_)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
 FESubfaceValues<dim, spacedim>::FESubfaceValues(
-  const Mapping<dim, spacedim> &      mapping,
-  const FiniteElement<dim, spacedim> &fe,
-  const hp::QCollection<dim - 1> &    quadrature,
-  const UpdateFlags                   update_flags)
-  : FESubfaceValues(mapping, fe, quadrature[0], update_flags)
+  const Mapping<dim, spacedim> &      mapping_,
+  const FiniteElement<dim, spacedim> &fe_,
+  const hp::QCollection<dim - 1> &    quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FESubfaceValues(mapping_, fe_, quadrature_[0], update_flags_)
 {
-  AssertDimension(quadrature.size(), 1);
+  AssertDimension(quadrature_.size(), 1);
 }
 
 
 
 template <int dim, int spacedim>
 FESubfaceValues<dim, spacedim>::FESubfaceValues(
-  const FiniteElement<dim, spacedim> &fe,
-  const Quadrature<dim - 1> &         quadrature,
-  const UpdateFlags                   update_flags)
+  const FiniteElement<dim, spacedim> &fe_,
+  const Quadrature<dim - 1> &         quadrature_,
+  const UpdateFlags                   update_flags_)
   : FEFaceValuesBase<dim, spacedim>(
-      fe.n_dofs_per_cell(),
-      update_flags,
-      fe.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
-      fe,
-      quadrature)
+      fe_.n_dofs_per_cell(),
+      update_flags_,
+      fe_.reference_cell().template get_default_linear_mapping<dim, spacedim>(),
+      fe_,
+      quadrature_)
 {
-  initialize(update_flags);
+  initialize(update_flags_);
 }
 
 
 
 template <int dim, int spacedim>
 FESubfaceValues<dim, spacedim>::FESubfaceValues(
-  const FiniteElement<dim, spacedim> &fe,
-  const hp::QCollection<dim - 1> &    quadrature,
-  const UpdateFlags                   update_flags)
-  : FESubfaceValues(fe, quadrature[0], update_flags)
+  const FiniteElement<dim, spacedim> &fe_,
+  const hp::QCollection<dim - 1> &    quadrature_,
+  const UpdateFlags                   update_flags_)
+  : FESubfaceValues(fe_, quadrature_[0], update_flags_)
 {
-  AssertDimension(quadrature.size(), 1);
+  AssertDimension(quadrature_.size(), 1);
 }
 
 
 
 template <int dim, int spacedim>
 void
-FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
+FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags_)
 {
-  const UpdateFlags flags = this->compute_update_flags(update_flags);
+  const UpdateFlags flags = this->compute_update_flags(update_flags_);
 
   // initialize the base classes
   if (flags & update_mapping)

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -50,8 +50,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 MappingFE<dim, spacedim>::InternalData::InternalData(
-  const FiniteElement<dim, spacedim> &fe)
-  : fe(fe)
+  const FiniteElement<dim, spacedim> &fe_)
+  : fe(fe_)
   , polynomial_degree(fe.tensor_degree())
   , n_shape_functions(fe.n_dofs_per_cell())
 {}
@@ -187,46 +187,46 @@ MappingFE<dim, spacedim>::InternalData::compute_shape_function_values(
 
   const auto &tensor_pols = fe_poly->get_poly_space();
 
-  const unsigned int n_shape_functions = fe.n_dofs_per_cell();
-  const unsigned int n_points          = unit_points.size();
+  const unsigned int n_shape_func = fe.n_dofs_per_cell();
+  const unsigned int n_points     = unit_points.size();
 
   std::vector<double>         values;
   std::vector<Tensor<1, dim>> grads;
   if (shape_values.size() != 0)
     {
-      Assert(shape_values.size() == n_shape_functions * n_points,
+      Assert(shape_values.size() == n_shape_func * n_points,
              ExcInternalError());
-      values.resize(n_shape_functions);
+      values.resize(n_shape_func);
     }
   if (shape_derivatives.size() != 0)
     {
-      Assert(shape_derivatives.size() == n_shape_functions * n_points,
+      Assert(shape_derivatives.size() == n_shape_func * n_points,
              ExcInternalError());
-      grads.resize(n_shape_functions);
+      grads.resize(n_shape_func);
     }
 
   std::vector<Tensor<2, dim>> grad2;
   if (shape_second_derivatives.size() != 0)
     {
-      Assert(shape_second_derivatives.size() == n_shape_functions * n_points,
+      Assert(shape_second_derivatives.size() == n_shape_func * n_points,
              ExcInternalError());
-      grad2.resize(n_shape_functions);
+      grad2.resize(n_shape_func);
     }
 
   std::vector<Tensor<3, dim>> grad3;
   if (shape_third_derivatives.size() != 0)
     {
-      Assert(shape_third_derivatives.size() == n_shape_functions * n_points,
+      Assert(shape_third_derivatives.size() == n_shape_func * n_points,
              ExcInternalError());
-      grad3.resize(n_shape_functions);
+      grad3.resize(n_shape_func);
     }
 
   std::vector<Tensor<4, dim>> grad4;
   if (shape_fourth_derivatives.size() != 0)
     {
-      Assert(shape_fourth_derivatives.size() == n_shape_functions * n_points,
+      Assert(shape_fourth_derivatives.size() == n_shape_func * n_points,
              ExcInternalError());
-      grad4.resize(n_shape_functions);
+      grad4.resize(n_shape_func);
     }
 
 
@@ -240,23 +240,23 @@ MappingFE<dim, spacedim>::InternalData::compute_shape_function_values(
           unit_points[point], values, grads, grad2, grad3, grad4);
 
         if (shape_values.size() != 0)
-          for (unsigned int i = 0; i < n_shape_functions; ++i)
+          for (unsigned int i = 0; i < n_shape_func; ++i)
             shape(point, i) = values[i];
 
         if (shape_derivatives.size() != 0)
-          for (unsigned int i = 0; i < n_shape_functions; ++i)
+          for (unsigned int i = 0; i < n_shape_func; ++i)
             derivative(point, i) = grads[i];
 
         if (shape_second_derivatives.size() != 0)
-          for (unsigned int i = 0; i < n_shape_functions; ++i)
+          for (unsigned int i = 0; i < n_shape_func; ++i)
             second_derivative(point, i) = grad2[i];
 
         if (shape_third_derivatives.size() != 0)
-          for (unsigned int i = 0; i < n_shape_functions; ++i)
+          for (unsigned int i = 0; i < n_shape_func; ++i)
             third_derivative(point, i) = grad3[i];
 
         if (shape_fourth_derivatives.size() != 0)
-          for (unsigned int i = 0; i < n_shape_functions; ++i)
+          for (unsigned int i = 0; i < n_shape_func; ++i)
             fourth_derivative(point, i) = grad4[i];
       }
 }
@@ -843,20 +843,20 @@ namespace internal
 
 
 template <int dim, int spacedim>
-MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe)
-  : fe(fe.clone())
-  , polynomial_degree(fe.tensor_degree())
+MappingFE<dim, spacedim>::MappingFE(const FiniteElement<dim, spacedim> &fe_)
+  : fe(fe_.clone())
+  , polynomial_degree(fe->tensor_degree())
 {
   Assert(polynomial_degree >= 1,
          ExcMessage("It only makes sense to create polynomial mappings "
                     "with a polynomial degree greater or equal to one."));
-  Assert(fe.n_components() == 1, ExcNotImplemented());
+  Assert(fe->n_components() == 1, ExcNotImplemented());
 
-  Assert(fe.has_support_points(), ExcNotImplemented());
+  Assert(fe->has_support_points(), ExcNotImplemented());
 
-  const auto &mapping_support_points = fe.get_unit_support_points();
+  const auto &mapping_support_points = fe->get_unit_support_points();
 
-  const auto reference_cell = fe.reference_cell();
+  const auto reference_cell = fe->reference_cell();
 
   const unsigned int n_points          = mapping_support_points.size();
   const unsigned int n_shape_functions = reference_cell.n_vertices();

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -438,8 +438,8 @@ namespace internal
 
             if (update_flags & update_covariant_transformation)
               {
-                const unsigned int n_q_points = data.contravariant.size();
-                for (unsigned int point = 0; point < n_q_points; ++point)
+                const unsigned int n_q_pts = data.contravariant.size();
+                for (unsigned int point = 0; point < n_q_pts; ++point)
                   {
                     data.covariant[point] =
                       (data.contravariant[point]).covariant_form();
@@ -448,8 +448,8 @@ namespace internal
 
             if (update_flags & update_volume_elements)
               {
-                const unsigned int n_q_points = data.contravariant.size();
-                for (unsigned int point = 0; point < n_q_points; ++point)
+                const unsigned int n_q_pts = data.contravariant.size();
+                for (unsigned int point = 0; point < n_q_pts; ++point)
                   data.volume_elements[point] =
                     data.contravariant[point].determinant();
               }

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -50,8 +50,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 MappingQ<dim, spacedim>::InternalData::InternalData(
-  const unsigned int polynomial_degree)
-  : polynomial_degree(polynomial_degree)
+  const unsigned int polynomial_degree_)
+  : polynomial_degree(polynomial_degree_)
   , n_shape_functions(Utilities::fixed_power<dim>(polynomial_degree + 1))
   , line_support_points(QGaussLobatto<1>(polynomial_degree + 1))
   , tensor_product_quadrature(false)
@@ -1572,9 +1572,6 @@ MappingQ<3, 3>::add_quad_support_points(
   std::vector<Point<3>> &                   a) const
 {
   const unsigned int faces_per_cell = GeometryInfo<3>::faces_per_cell;
-
-  // used if face quad at boundary or entirely in the interior of the domain
-  std::vector<Point<3>> tmp_points;
 
   // loop over all faces and collect points on them
   for (unsigned int face_no = 0; face_no < faces_per_cell; ++face_no)

--- a/source/fe/mapping_q1_eulerian.cc
+++ b/source/fe/mapping_q1_eulerian.cc
@@ -40,11 +40,11 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, class VectorType, int spacedim>
 MappingQ1Eulerian<dim, VectorType, spacedim>::MappingQ1Eulerian(
-  const DoFHandler<dim, spacedim> &shiftmap_dof_handler,
-  const VectorType &               euler_transform_vectors)
+  const DoFHandler<dim, spacedim> &shiftmap_dof_handler_,
+  const VectorType &               euler_transform_vectors_)
   : MappingQ<dim, spacedim>(1)
-  , euler_transform_vectors(&euler_transform_vectors)
-  , shiftmap_dof_handler(&shiftmap_dof_handler)
+  , euler_transform_vectors(&euler_transform_vectors_)
+  , shiftmap_dof_handler(&shiftmap_dof_handler_)
 {}
 
 

--- a/source/fe/mapping_q_cache.cc
+++ b/source/fe/mapping_q_cache.cc
@@ -38,8 +38,8 @@ DEAL_II_NAMESPACE_OPEN
 
 template <int dim, int spacedim>
 MappingQCache<dim, spacedim>::MappingQCache(
-  const unsigned int polynomial_degree)
-  : MappingQ<dim, spacedim>(polynomial_degree)
+  const unsigned int polynomial_degree_)
+  : MappingQ<dim, spacedim>(polynomial_degree_)
   , uses_level_info(false)
 {}
 

--- a/source/fe/mapping_q_eulerian.cc
+++ b/source/fe/mapping_q_eulerian.cc
@@ -48,15 +48,15 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, class VectorType, int spacedim>
 MappingQEulerian<dim, VectorType, spacedim>::MappingQEulerian(
   const unsigned int               degree,
-  const DoFHandler<dim, spacedim> &euler_dof_handler,
-  const VectorType &               euler_vector,
-  const unsigned int               level)
+  const DoFHandler<dim, spacedim> &euler_dof_handler_,
+  const VectorType &               euler_vector_,
+  const unsigned int               level_)
   : MappingQ<dim, spacedim>(degree)
-  , euler_vector(&euler_vector)
-  , euler_dof_handler(&euler_dof_handler)
-  , level(level)
+  , euler_vector(&euler_vector_)
+  , euler_dof_handler(&euler_dof_handler_)
+  , level(level_)
   , support_quadrature(degree)
-  , fe_values(euler_dof_handler.get_fe(),
+  , fe_values(euler_dof_handler_.get_fe(),
               support_quadrature,
               update_values | update_quadrature_points)
 {}

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -48,11 +48,11 @@ ChunkSparsityPattern::ChunkSparsityPattern(const ChunkSparsityPattern &s)
 ChunkSparsityPattern::ChunkSparsityPattern(const size_type m,
                                            const size_type n,
                                            const size_type max_per_row,
-                                           const size_type chunk_size)
+                                           const size_type chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
-  reinit(m, n, max_per_row, chunk_size);
+  reinit(m, n, max_per_row, chunk_size_);
 }
 
 
@@ -61,20 +61,20 @@ ChunkSparsityPattern::ChunkSparsityPattern(
   const size_type               m,
   const size_type               n,
   const std::vector<size_type> &row_lengths,
-  const size_type               chunk_size)
+  const size_type               chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
-  reinit(m, n, row_lengths, chunk_size);
+  reinit(m, n, row_lengths, chunk_size_);
 }
 
 
 
 ChunkSparsityPattern::ChunkSparsityPattern(const size_type n,
                                            const size_type max_per_row,
-                                           const size_type chunk_size)
+                                           const size_type chunk_size_)
 {
-  reinit(n, n, max_per_row, chunk_size);
+  reinit(n, n, max_per_row, chunk_size_);
 }
 
 
@@ -82,11 +82,11 @@ ChunkSparsityPattern::ChunkSparsityPattern(const size_type n,
 ChunkSparsityPattern::ChunkSparsityPattern(
   const size_type               m,
   const std::vector<size_type> &row_lengths,
-  const size_type               chunk_size)
+  const size_type               chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
-  reinit(m, m, row_lengths, chunk_size);
+  reinit(m, m, row_lengths, chunk_size_);
 }
 
 
@@ -116,13 +116,13 @@ void
 ChunkSparsityPattern::reinit(const size_type m,
                              const size_type n,
                              const size_type max_per_row,
-                             const size_type chunk_size)
+                             const size_type chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
   // simply map this function to the other @p{reinit} function
   const std::vector<size_type> row_lengths(m, max_per_row);
-  reinit(m, n, row_lengths, chunk_size);
+  reinit(m, n, row_lengths, chunk_size_);
 }
 
 
@@ -131,15 +131,15 @@ void
 ChunkSparsityPattern::reinit(const size_type                   m,
                              const size_type                   n,
                              const ArrayView<const size_type> &row_lengths,
-                             const size_type                   chunk_size)
+                             const size_type                   chunk_size_)
 {
   Assert(row_lengths.size() == m, ExcInvalidNumber(m));
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
   rows = m;
   cols = n;
 
-  this->chunk_size = chunk_size;
+  this->chunk_size = chunk_size_;
 
   // pass down to the necessary information to the underlying object. we need
   // to calculate how many chunks we need: we need to round up (m/chunk_size)
@@ -181,10 +181,10 @@ ChunkSparsityPattern::compress()
 template <typename SparsityPatternType>
 void
 ChunkSparsityPattern::copy_from(const SparsityPatternType &dsp,
-                                const size_type            chunk_size)
+                                const size_type            chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
-  this->chunk_size = chunk_size;
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
+  this->chunk_size = chunk_size_;
   rows             = dsp.n_rows();
   cols             = dsp.n_cols();
 
@@ -260,11 +260,11 @@ void
 ChunkSparsityPattern::reinit(const size_type               m,
                              const size_type               n,
                              const std::vector<size_type> &row_lengths,
-                             const size_type               chunk_size)
+                             const size_type               chunk_size_)
 {
-  Assert(chunk_size > 0, ExcInvalidNumber(chunk_size));
+  Assert(chunk_size_ > 0, ExcInvalidNumber(chunk_size_));
 
-  reinit(m, n, make_array_view(row_lengths), chunk_size);
+  reinit(m, n, make_array_view(row_lengths), chunk_size_);
 }
 
 

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -42,23 +42,23 @@ namespace internal
   {
     template <int dim, int spacedim>
     ParallelData<dim, spacedim>::ParallelData(
-      const unsigned int               n_datasets,
-      const unsigned int               n_subdivisions,
-      const std::vector<unsigned int> &n_postprocessor_outputs,
-      const dealii::hp::MappingCollection<dim, spacedim> &mapping,
+      const unsigned int               n_datasets_,
+      const unsigned int               n_subdivisions_,
+      const std::vector<unsigned int> &n_postprocessor_outputs_,
+      const dealii::hp::MappingCollection<dim, spacedim> &mapping_,
       const std::vector<
         std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>>
-        &                                           finite_elements,
-      const UpdateFlags                             update_flags,
-      const std::vector<std::vector<unsigned int>> &cell_to_patch_index_map)
-      : ParallelDataBase<dim, spacedim>(n_datasets,
-                                        n_subdivisions,
-                                        n_postprocessor_outputs,
-                                        mapping,
-                                        finite_elements,
-                                        update_flags,
+        &                                           finite_elements_,
+      const UpdateFlags                             update_flags_,
+      const std::vector<std::vector<unsigned int>> &cell_to_patch_index_map_)
+      : ParallelDataBase<dim, spacedim>(n_datasets_,
+                                        n_subdivisions_,
+                                        n_postprocessor_outputs_,
+                                        mapping_,
+                                        finite_elements_,
+                                        update_flags_,
                                         false)
-      , cell_to_patch_index_map(&cell_to_patch_index_map)
+      , cell_to_patch_index_map(&cell_to_patch_index_map_)
     {}
   } // namespace DataOutImplementation
 } // namespace internal
@@ -1290,13 +1290,13 @@ DataOut<dim, spacedim>::set_cell_selection(
   const FilteredIterator<cell_iterator> &filtered_iterator)
 {
   const auto first_cell =
-    [filtered_iterator](const Triangulation<dim, spacedim> &triangulation) {
+    [filtered_iterator](const Triangulation<dim, spacedim> &tria) {
       // Create a copy of the filtered iterator so that we can
       // call a non-const function -- though we are really only
       // interested in the return value of that function, not the
       // state of the object
       FilteredIterator<cell_iterator> x = filtered_iterator;
-      return x.set_to_next_positive(triangulation.begin());
+      return x.set_to_next_positive(tria.begin());
     };
 
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -42,21 +42,21 @@ namespace internal
   {
     template <int dim, int spacedim>
     ParallelData<dim, spacedim>::ParallelData(
-      const unsigned int               n_datasets,
-      const unsigned int               n_subdivisions,
-      const std::vector<unsigned int> &n_postprocessor_outputs,
-      const Mapping<dim, spacedim> &   mapping,
+      const unsigned int               n_datasets_,
+      const unsigned int               n_subdivisions_,
+      const std::vector<unsigned int> &n_postprocessor_outputs_,
+      const Mapping<dim, spacedim> &   mapping_,
       const std::vector<
         std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>>
-        &               finite_elements,
-      const UpdateFlags update_flags)
+        &               finite_elements_,
+      const UpdateFlags update_flags_)
       : internal::DataOutImplementation::ParallelDataBase<dim, spacedim>(
-          n_datasets,
-          n_subdivisions,
-          n_postprocessor_outputs,
-          mapping,
-          finite_elements,
-          update_flags,
+          n_datasets_,
+          n_subdivisions_,
+          n_postprocessor_outputs_,
+          mapping_,
+          finite_elements_,
+          update_flags_,
           true)
     {}
 

--- a/source/numerics/data_out_resample.cc
+++ b/source/numerics/data_out_resample.cc
@@ -33,9 +33,9 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int patch_dim, int spacedim>
 DataOutResample<dim, patch_dim, spacedim>::DataOutResample(
   const Triangulation<patch_dim, spacedim> &patch_tria,
-  const Mapping<patch_dim, spacedim> &      patch_mapping)
+  const Mapping<patch_dim, spacedim> &      patch_mapping_)
   : patch_dof_handler(patch_tria)
-  , patch_mapping(&patch_mapping)
+  , patch_mapping(&patch_mapping_)
 {}
 
 
@@ -43,10 +43,10 @@ DataOutResample<dim, patch_dim, spacedim>::DataOutResample(
 template <int dim, int patch_dim, int spacedim>
 void
 DataOutResample<dim, patch_dim, spacedim>::update_mapping(
-  const Mapping<dim, spacedim> &mapping,
+  const Mapping<dim, spacedim> &mapping_,
   const unsigned int            n_subdivisions)
 {
-  this->mapping = &mapping;
+  this->mapping = &mapping_;
   this->point_to_local_vector_indices.clear();
 
   FE_Q_iso_Q1<patch_dim, spacedim> fe(
@@ -109,11 +109,11 @@ DataOutResample<dim, patch_dim, spacedim>::update_mapping(
 template <int dim, int patch_dim, int spacedim>
 void
 DataOutResample<dim, patch_dim, spacedim>::build_patches(
-  const Mapping<dim, spacedim> &                                mapping,
+  const Mapping<dim, spacedim> &                                mapping_,
   const unsigned int                                            n_subdivisions,
   const typename DataOut<patch_dim, spacedim>::CurvedCellRegion curved_region)
 {
-  this->update_mapping(mapping, n_subdivisions);
+  this->update_mapping(mapping_, n_subdivisions);
   this->build_patches(curved_region);
 }
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -55,24 +55,24 @@ namespace internal
   {
     template <int dim, int spacedim>
     ParallelData<dim, spacedim>::ParallelData(
-      const unsigned int               n_datasets,
-      const unsigned int               n_subdivisions,
-      const unsigned int               n_patches_per_circle,
+      const unsigned int               n_datasets_,
+      const unsigned int               n_subdivisions_,
+      const unsigned int               n_patches_per_circle_,
       const std::vector<unsigned int> &n_postprocessor_outputs,
       const Mapping<dim, spacedim> &   mapping,
       const std::vector<
         std::shared_ptr<dealii::hp::FECollection<dim, spacedim>>>
-        &               finite_elements,
-      const UpdateFlags update_flags)
+        &               finite_elements_,
+      const UpdateFlags update_flags_)
       : internal::DataOutImplementation::ParallelDataBase<dim, spacedim>(
-          n_datasets,
-          n_subdivisions,
+          n_datasets_,
+          n_subdivisions_,
           n_postprocessor_outputs,
           mapping,
-          finite_elements,
-          update_flags,
+          finite_elements_,
+          update_flags_,
           false)
-      , n_patches_per_circle(n_patches_per_circle)
+      , n_patches_per_circle(n_patches_per_circle_)
     {}
 
 
@@ -542,10 +542,10 @@ DataOutRotation<dim, spacedim>::build_patches(
       this->build_one_patch(cell, data, my_patches);
     },
     [this](const std::vector<DataOutBase::Patch<patch_dim, patch_spacedim>>
-             &new_patches) {
+             &new_patches_) {
       internal::DataOutRotationImplementation::append_patch_to_list<dim,
                                                                     spacedim>(
-        new_patches, this->patches);
+        new_patches_, this->patches);
     },
     thread_data,
     new_patches);

--- a/source/numerics/data_postprocessor.cc
+++ b/source/numerics/data_postprocessor.cc
@@ -58,10 +58,10 @@ DataPostprocessor<dim>::get_data_component_interpretation() const
 
 template <int dim>
 DataPostprocessorScalar<dim>::DataPostprocessorScalar(
-  const std::string &name,
-  const UpdateFlags  update_flags)
-  : name(name)
-  , update_flags(update_flags)
+  const std::string &name_,
+  const UpdateFlags  update_flags_)
+  : name(name_)
+  , update_flags(update_flags_)
 {}
 
 
@@ -97,10 +97,10 @@ DataPostprocessorScalar<dim>::get_needed_update_flags() const
 
 template <int dim>
 DataPostprocessorVector<dim>::DataPostprocessorVector(
-  const std::string &name,
-  const UpdateFlags  update_flags)
-  : name(name)
-  , update_flags(update_flags)
+  const std::string &name_,
+  const UpdateFlags  update_flags_)
+  : name(name_)
+  , update_flags(update_flags_)
 {}
 
 
@@ -136,10 +136,10 @@ DataPostprocessorVector<dim>::get_needed_update_flags() const
 
 template <int dim>
 DataPostprocessorTensor<dim>::DataPostprocessorTensor(
-  const std::string &name,
-  const UpdateFlags  update_flags)
-  : name(name)
-  , update_flags(update_flags)
+  const std::string &name_,
+  const UpdateFlags  update_flags_)
+  : name(name_)
+  , update_flags(update_flags_)
 {}
 
 

--- a/source/numerics/histogram.cc
+++ b/source/numerics/histogram.cc
@@ -35,9 +35,9 @@ Histogram::logarithmic_less(const number n1, const number n2)
 
 
 
-Histogram::Interval::Interval(const double left_point, const double right_point)
-  : left_point(left_point)
-  , right_point(right_point)
+Histogram::Interval::Interval(const double left_pt, const double right_pt)
+  : left_point(left_pt)
+  , right_point(right_pt)
   , content(0)
 {}
 

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -77,9 +77,9 @@ PointValueHistory<dim>::PointValueHistory(
 
 template <int dim>
 PointValueHistory<dim>::PointValueHistory(
-  const DoFHandler<dim> &dof_handler,
+  const DoFHandler<dim> &dof_handler_,
   const unsigned int     n_independent_variables)
-  : dof_handler(&dof_handler)
+  : dof_handler(&dof_handler_)
   , n_indep(n_independent_variables)
 {
   closed                = false;
@@ -95,7 +95,7 @@ PointValueHistory<dim>::PointValueHistory(
     std::vector<std::vector<double>>(n_indep, std::vector<double>(0));
   indep_names = std::vector<std::string>();
 
-  tria_listener = dof_handler.get_triangulation().signals.any_change.connect(
+  tria_listener = dof_handler->get_triangulation().signals.any_change.connect(
     [this]() { this->tria_change_listener(); });
 }
 

--- a/source/numerics/time_dependent.cc
+++ b/source/numerics/time_dependent.cc
@@ -32,10 +32,11 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-TimeDependent::TimeSteppingData::TimeSteppingData(const unsigned int look_ahead,
-                                                  const unsigned int look_back)
-  : look_ahead(look_ahead)
-  , look_back(look_back)
+TimeDependent::TimeSteppingData::TimeSteppingData(
+  const unsigned int look_ahead_,
+  const unsigned int look_back_)
+  : look_ahead(look_ahead_)
+  , look_back(look_back_)
 {}
 
 
@@ -265,12 +266,12 @@ TimeDependent::memory_consumption() const
 /* --------------------------------------------------------------------- */
 
 
-TimeStepBase::TimeStepBase(const double time)
+TimeStepBase::TimeStepBase(const double time_)
   : previous_timestep(nullptr)
   , next_timestep(nullptr)
   , sweep_no(numbers::invalid_unsigned_int)
   , timestep_no(numbers::invalid_unsigned_int)
-  , time(time)
+  , time(time_)
   , next_action(numbers::invalid_unsigned_int)
 {}
 
@@ -435,15 +436,15 @@ TimeStepBase_Tria<dim>::TimeStepBase_Tria()
 #ifndef DOXYGEN
 template <int dim>
 TimeStepBase_Tria<dim>::TimeStepBase_Tria(
-  const double              time,
-  const Triangulation<dim> &coarse_grid,
-  const Flags &             flags,
-  const RefinementFlags &   refinement_flags)
-  : TimeStepBase(time)
+  const double              time_,
+  const Triangulation<dim> &coarse_grid_,
+  const Flags &             flags_,
+  const RefinementFlags &   refinement_flags_)
+  : TimeStepBase(time_)
   , tria(nullptr, typeid(*this).name())
-  , coarse_grid(&coarse_grid, typeid(*this).name())
-  , flags(flags)
-  , refinement_flags(refinement_flags)
+  , coarse_grid(&coarse_grid_, typeid(*this).name())
+  , flags(flags_)
+  , refinement_flags(refinement_flags_)
 {}
 #endif
 
@@ -1171,18 +1172,13 @@ TimeStepBase_Tria_Flags::Flags<dim>::Flags()
 
 template <int dim>
 TimeStepBase_Tria_Flags::Flags<dim>::Flags(
-  const bool         delete_and_rebuild_tria,
-  const unsigned int wakeup_level_to_build_grid,
-  const unsigned int sleep_level_to_delete_grid)
-  : delete_and_rebuild_tria(delete_and_rebuild_tria)
-  , wakeup_level_to_build_grid(wakeup_level_to_build_grid)
-  , sleep_level_to_delete_grid(sleep_level_to_delete_grid)
-{
-  //   Assert (!delete_and_rebuild_tria || (wakeup_level_to_build_grid>=1),
-  //        ExcInvalidParameter(wakeup_level_to_build_grid));
-  //   Assert (!delete_and_rebuild_tria || (sleep_level_to_delete_grid>=1),
-  //        ExcInvalidParameter(sleep_level_to_delete_grid));
-}
+  const bool         delete_and_rebuild_tria_,
+  const unsigned int wakeup_level_to_build_grid_,
+  const unsigned int sleep_level_to_delete_grid_)
+  : delete_and_rebuild_tria(delete_and_rebuild_tria_)
+  , wakeup_level_to_build_grid(wakeup_level_to_build_grid_)
+  , sleep_level_to_delete_grid(sleep_level_to_delete_grid_)
+{}
 
 
 template <int dim>
@@ -1197,26 +1193,26 @@ typename TimeStepBase_Tria_Flags::RefinementFlags<dim>::CorrectionRelaxations
 
 template <int dim>
 TimeStepBase_Tria_Flags::RefinementFlags<dim>::RefinementFlags(
-  const unsigned int           max_refinement_level,
-  const unsigned int           first_sweep_with_correction,
-  const unsigned int           min_cells_for_correction,
-  const double                 cell_number_corridor_top,
-  const double                 cell_number_corridor_bottom,
-  const CorrectionRelaxations &correction_relaxations,
-  const unsigned int           cell_number_correction_steps,
-  const bool                   mirror_flags_to_previous_grid,
-  const bool                   adapt_grids)
-  : max_refinement_level(max_refinement_level)
-  , first_sweep_with_correction(first_sweep_with_correction)
-  , min_cells_for_correction(min_cells_for_correction)
-  , cell_number_corridor_top(cell_number_corridor_top)
-  , cell_number_corridor_bottom(cell_number_corridor_bottom)
-  , correction_relaxations(correction_relaxations.size() != 0 ?
-                             correction_relaxations :
+  const unsigned int           max_refinement_level_,
+  const unsigned int           first_sweep_with_correction_,
+  const unsigned int           min_cells_for_correction_,
+  const double                 cell_number_corridor_top_,
+  const double                 cell_number_corridor_bottom_,
+  const CorrectionRelaxations &correction_relaxations_,
+  const unsigned int           cell_number_correction_steps_,
+  const bool                   mirror_flags_to_previous_grid_,
+  const bool                   adapt_grids_)
+  : max_refinement_level(max_refinement_level_)
+  , first_sweep_with_correction(first_sweep_with_correction_)
+  , min_cells_for_correction(min_cells_for_correction_)
+  , cell_number_corridor_top(cell_number_corridor_top_)
+  , cell_number_corridor_bottom(cell_number_corridor_bottom_)
+  , correction_relaxations(correction_relaxations_.size() != 0 ?
+                             correction_relaxations_ :
                              default_correction_relaxations)
-  , cell_number_correction_steps(cell_number_correction_steps)
-  , mirror_flags_to_previous_grid(mirror_flags_to_previous_grid)
-  , adapt_grids(adapt_grids)
+  , cell_number_correction_steps(cell_number_correction_steps_)
+  , mirror_flags_to_previous_grid(mirror_flags_to_previous_grid_)
+  , adapt_grids(adapt_grids_)
 {
   Assert(cell_number_corridor_top >= 0,
          ExcInvalidValue(cell_number_corridor_top));


### PR DESCRIPTION
With https://github.com/dealii/dealii/pull/12940, we correctly import Kokkos flags including `-Wshadow`. We have a lot of these warnings and this PR fixes some of them. The majority of the shadowing happens in constructors with code like
```C++
foo::foo(int bar)
: 
bar(bar)
{}
```
but I also found a few places where we declare and recompute the same variable several times. Given the extremely large number of warnings I didn't try to be clever when changing the name of the variable. If the shadowing happens in the constructor, I added an `_` in the name of the variable. If the shadowing happens in another function then I tried to find a good name for the new variable.