### PR TITLE
Make the 'direction' argument of some GridTools functions 'unsigned'.

### DIFF
--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -2762,7 +2762,7 @@ namespace GridTools
     std::bitset<3> &                                              orientation,
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,
-    const int                                                     direction,
+    const unsigned int                                            direction,
     const Tensor<1, FaceIterator::AccessorType::space_dimension> &offset =
       Tensor<1, FaceIterator::AccessorType::space_dimension>(),
     const FullMatrix<double> &matrix = FullMatrix<double>());
@@ -2776,7 +2776,7 @@ namespace GridTools
   orthogonal_equality(
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,
-    const int                                                     direction,
+    const unsigned int                                            direction,
     const Tensor<1, FaceIterator::AccessorType::space_dimension> &offset =
       Tensor<1, FaceIterator::AccessorType::space_dimension>(),
     const FullMatrix<double> &matrix = FullMatrix<double>());
@@ -2844,7 +2844,7 @@ namespace GridTools
     const MeshType &         mesh,
     const types::boundary_id b_id1,
     const types::boundary_id b_id2,
-    const int                direction,
+    const unsigned int       direction,
     std::vector<PeriodicFacePair<typename MeshType::cell_iterator>>
       &                                         matched_pairs,
     const Tensor<1, MeshType::space_dimension> &offset =
@@ -2879,7 +2879,7 @@ namespace GridTools
   collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id,
-    const int                direction,
+    const unsigned int       direction,
     std::vector<PeriodicFacePair<typename MeshType::cell_iterator>>
       &                                                 matched_pairs,
     const dealii::Tensor<1, MeshType::space_dimension> &offset =

--- a/source/grid/grid_tools_dof_handlers.cc
+++ b/source/grid/grid_tools_dof_handlers.cc
@@ -2013,7 +2013,7 @@ namespace GridTools
     std::set<std::pair<CellIterator, unsigned int>> &pairs1,
     std::set<std::pair<typename identity<CellIterator>::type, unsigned int>>
       &                                          pairs2,
-    const int                                    direction,
+    const unsigned int                           direction,
     std::vector<PeriodicFacePair<CellIterator>> &matched_pairs,
     const dealii::Tensor<1, CellIterator::AccessorType::space_dimension>
       &                       offset,
@@ -2106,7 +2106,7 @@ namespace GridTools
   collect_periodic_faces(
     const MeshType &         mesh,
     const types::boundary_id b_id,
-    const int                direction,
+    const unsigned int       direction,
     std::vector<PeriodicFacePair<typename MeshType::cell_iterator>>
       &                                         matched_pairs,
     const Tensor<1, MeshType::space_dimension> &offset,
@@ -2188,7 +2188,7 @@ namespace GridTools
     const MeshType &         mesh,
     const types::boundary_id b_id1,
     const types::boundary_id b_id2,
-    const int                direction,
+    const unsigned int       direction,
     std::vector<PeriodicFacePair<typename MeshType::cell_iterator>>
       &                                         matched_pairs,
     const Tensor<1, MeshType::space_dimension> &offset,
@@ -2275,7 +2275,7 @@ namespace GridTools
   inline bool
   orthogonal_equality(const Point<spacedim> &    point1,
                       const Point<spacedim> &    point2,
-                      const int                  direction,
+                      const unsigned int         direction,
                       const Tensor<1, spacedim> &offset,
                       const FullMatrix<double> & matrix)
   {
@@ -2294,7 +2294,7 @@ namespace GridTools
 
     distance += offset - point2;
 
-    for (int i = 0; i < spacedim; ++i)
+    for (unsigned int i = 0; i < spacedim; ++i)
       {
         // Only compare coordinate-components != direction:
         if (i == direction)
@@ -2414,7 +2414,7 @@ namespace GridTools
     std::bitset<3> &                                              orientation,
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,
-    const int                                                     direction,
+    const unsigned int                                            direction,
     const Tensor<1, FaceIterator::AccessorType::space_dimension> &offset,
     const FullMatrix<double> &                                    matrix)
   {
@@ -2466,7 +2466,7 @@ namespace GridTools
   orthogonal_equality(
     const FaceIterator &                                          face1,
     const FaceIterator &                                          face2,
-    const int                                                     direction,
+    const unsigned int                                            direction,
     const Tensor<1, FaceIterator::AccessorType::space_dimension> &offset,
     const FullMatrix<double> &                                    matrix)
   {

--- a/source/grid/grid_tools_dof_handlers.inst.in
+++ b/source/grid/grid_tools_dof_handlers.inst.in
@@ -254,7 +254,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
         std::bitset<3> &,
         const X::active_face_iterator &,
         const X::active_face_iterator &,
-        const int,
+        const unsigned int,
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
@@ -263,7 +263,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
         std::bitset<3> &,
         const X::face_iterator &,
         const X::face_iterator &,
-        const int,
+        const unsigned int,
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
@@ -271,7 +271,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
       orthogonal_equality<X::active_face_iterator>(
         const X::active_face_iterator &,
         const X::active_face_iterator &,
-        const int,
+        const unsigned int,
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
@@ -279,7 +279,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLER;
       orthogonal_equality<X::face_iterator>(
         const X::face_iterator &,
         const X::face_iterator &,
-        const int,
+        const unsigned int,
         const Tensor<1, deal_II_space_dimension> &,
         const FullMatrix<double> &);
 
@@ -299,7 +299,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS;
         const X &,
         const types::boundary_id,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<X::cell_iterator>> &,
         const Tensor<1, X::space_dimension> &,
         const FullMatrix<double> &);
@@ -308,7 +308,7 @@ for (X : SEQUENTIAL_TRIANGULATION_AND_DOFHANDLERS;
       collect_periodic_faces<X>(
         const X &,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<X::cell_iterator>> &,
         const Tensor<1, X::space_dimension> &,
         const FullMatrix<double> &);
@@ -334,7 +334,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                                                    deal_II_space_dimension> &,
         const types::boundary_id,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<parallel::distributed::Triangulation<
           deal_II_dimension,
           deal_II_space_dimension>::cell_iterator>> &,
@@ -351,7 +351,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const parallel::distributed::Triangulation<deal_II_dimension,
                                                    deal_II_space_dimension> &,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<parallel::distributed::Triangulation<
           deal_II_dimension,
           deal_II_space_dimension>::cell_iterator>> &,
@@ -382,7 +382,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
                                               deal_II_space_dimension> &,
         const types::boundary_id,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<parallel::shared::Triangulation<
           deal_II_dimension,
           deal_II_space_dimension>::cell_iterator>> &,
@@ -399,7 +399,7 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
         const parallel::shared::Triangulation<deal_II_dimension,
                                               deal_II_space_dimension> &,
         const types::boundary_id,
-        const int,
+        const unsigned int,
         std::vector<PeriodicFacePair<parallel::shared::Triangulation<
           deal_II_dimension,
           deal_II_space_dimension>::cell_iterator>> &,


### PR DESCRIPTION
Prompted by the discussion in another PR (#12953). This is strictly speaking an incompatible change, but I think we need not worry too much about it.

/rebuild