### PR TITLE
Refactor HangingNodes::setup_constraints()

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -387,7 +387,7 @@ namespace CUDAWrappers
 
       hanging_nodes.setup_constraints(cell,
                                       partitioner,
-                                      lexicographic_inv,
+                                      {lexicographic_inv},
                                       lexicographic_dof_indices,
                                       cell_id_view);
 

--- a/include/deal.II/matrix_free/dof_info.h
+++ b/include/deal.II/matrix_free/dof_info.h
@@ -222,9 +222,9 @@ namespace internal
       template <int dim>
       bool
       process_hanging_node_constraints(
-        const HangingNodes<dim> &        hanging_nodes,
-        const std::vector<unsigned int> &lexicographic_mapping,
-        const unsigned int               cell_number,
+        const HangingNodes<dim> &                     hanging_nodes,
+        const std::vector<std::vector<unsigned int>> &lexicographic_mapping,
+        const unsigned int                            cell_number,
         const TriaIterator<DoFCellAccessor<dim, dim, false>> &cell,
         std::vector<types::global_dof_index> &                dof_indices);
 

--- a/include/deal.II/matrix_free/dof_info.templates.h
+++ b/include/deal.II/matrix_free/dof_info.templates.h
@@ -277,9 +277,9 @@ namespace internal
     template <int dim>
     bool
     DoFInfo::process_hanging_node_constraints(
-      const HangingNodes<dim> &        hanging_nodes,
-      const std::vector<unsigned int> &lexicographic_mapping,
-      const unsigned int               cell_number,
+      const HangingNodes<dim> &                     hanging_nodes,
+      const std::vector<std::vector<unsigned int>> &lexicographic_mapping,
+      const unsigned int                            cell_number,
       const TriaIterator<DoFCellAccessor<dim, dim, false>> &cell,
       std::vector<types::global_dof_index> &                dof_indices)
     {

--- a/source/matrix_free/dof_info.cc
+++ b/source/matrix_free/dof_info.cc
@@ -1519,21 +1519,21 @@ namespace internal
     template bool
     DoFInfo::process_hanging_node_constraints<1>(
       const HangingNodes<1> &                           hanging_nodes,
-      const std::vector<unsigned int> &                 lexicographic_mapping,
+      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
       const unsigned int                                cell_number,
       const TriaIterator<DoFCellAccessor<1, 1, false>> &cell,
       std::vector<types::global_dof_index> &            dof_indices);
     template bool
     DoFInfo::process_hanging_node_constraints<2>(
       const HangingNodes<2> &                           hanging_nodes,
-      const std::vector<unsigned int> &                 lexicographic_mapping,
+      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
       const unsigned int                                cell_number,
       const TriaIterator<DoFCellAccessor<2, 2, false>> &cell,
       std::vector<types::global_dof_index> &            dof_indices);
     template bool
     DoFInfo::process_hanging_node_constraints<3>(
       const HangingNodes<3> &                           hanging_nodes,
-      const std::vector<unsigned int> &                 lexicographic_mapping,
+      const std::vector<std::vector<unsigned int>> &    lexicographic_mapping,
       const unsigned int                                cell_number,
       const TriaIterator<DoFCellAccessor<3, 3, false>> &cell,
       std::vector<types::global_dof_index> &            dof_indices);

--- a/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
+++ b/tests/matrix_free/mixed_mesh_hn_algorithm_01.cc
@@ -1,0 +1,165 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2018 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Test that the fast matrix-free hanging-node algorithm is also working on
+// adaptively refined 2D mixed meshes.
+
+#include <deal.II/base/quadrature_lib.h>
+
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/dofs/dof_tools.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+
+#include <deal.II/hp/fe_collection.h>
+#include <deal.II/hp/mapping_collection.h>
+#include <deal.II/hp/q_collection.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include "../tests.h"
+
+
+
+int
+main()
+{
+  initlog();
+
+  const unsigned int dim    = 2;
+  const unsigned int degree = 1;
+
+  Triangulation<dim> tria_0, tria_1, tria_2, tria_3, tria;
+
+  GridGenerator::subdivided_hyper_rectangle(tria_0,
+                                            {1, 1},
+                                            {0.0, 0.0},
+                                            {0.5, 0.5});
+  GridGenerator::subdivided_hyper_rectangle_with_simplices(tria_1,
+                                                           {1, 1},
+                                                           {0.5, 0.0},
+                                                           {1.0, 0.5});
+  GridGenerator::subdivided_hyper_rectangle_with_simplices(tria_2,
+                                                           {1, 1},
+                                                           {0.0, 0.5},
+                                                           {0.5, 1.0});
+  GridGenerator::subdivided_hyper_rectangle_with_simplices(tria_3,
+                                                           {1, 1},
+                                                           {0.5, 0.5},
+                                                           {1.0, 1.0});
+
+  GridGenerator::merge_triangulations({&tria_0, &tria_1, &tria_2, &tria_3},
+                                      tria);
+
+  auto cell = tria.begin();
+
+  cell->set_refine_flag();
+  cell++;
+  cell->set_refine_flag();
+  tria.execute_coarsening_and_refinement();
+
+  if (false)
+    {
+      GridOut       grid_out;
+      std::ofstream out("mesh.vtk");
+      grid_out.write_vtk(tria, out);
+    }
+
+  DoFHandler<dim> dof_handler(tria);
+
+  for (const auto &cell : dof_handler.active_cell_iterators())
+    {
+      if (cell->reference_cell() == ReferenceCells::Triangle)
+        cell->set_active_fe_index(0);
+      else if (cell->reference_cell() == ReferenceCells::Quadrilateral)
+        cell->set_active_fe_index(1);
+      else
+        Assert(false, ExcNotImplemented());
+    }
+
+  const hp::MappingCollection<2> mapping(MappingFE<2>(FE_SimplexP<2>(1)),
+                                         MappingFE<2>(FE_Q<2>(1)));
+  const hp::FECollection<2>      fe(FE_SimplexP<2>{degree}, FE_Q<2>{degree});
+  const hp::QCollection<2> quadrature_formula(QGaussSimplex<2>(degree + 1),
+                                              QGauss<2>(degree + 1));
+
+  dof_handler.distribute_dofs(fe);
+
+  AffineConstraints<double> constraints;
+  DoFTools::make_hanging_node_constraints(dof_handler, constraints);
+
+  const auto print = [](const auto &label, const auto &matrix_free) {
+    deallog << label << std::endl;
+
+    for (unsigned int c = 0;
+         c < matrix_free.get_dof_info(0).row_starts.size() - 1;
+         ++c)
+      {
+        deallog
+          << std::setw(3)
+          << (matrix_free.get_dof_info(0)
+                    .hanging_node_constraint_masks.size() == 0 ?
+                0 :
+                static_cast<unsigned int>(
+                  matrix_free.get_dof_info(0).hanging_node_constraint_masks[c]))
+          << " : ";
+
+        for (unsigned int i = matrix_free.get_dof_info(0).row_starts[c].first;
+             i < matrix_free.get_dof_info(0).row_starts[c + 1].first;
+             ++i)
+          deallog << std::setw(3) << matrix_free.get_dof_info(0).dof_indices[i]
+                  << " ";
+        deallog << std::endl;
+      }
+    deallog << std::endl;
+  };
+
+  {
+    typename MatrixFree<dim, double, VectorizedArray<double, 1>>::AdditionalData
+      additional_data;
+    additional_data.mapping_update_flags = update_gradients | update_values;
+
+    MatrixFree<dim, double, VectorizedArray<double, 1>> matrix_free;
+    matrix_free.reinit(
+      mapping, dof_handler, constraints, quadrature_formula, additional_data);
+
+    print("use_fast_hanging_node_algorithm = true", matrix_free);
+  }
+
+  {
+    typename MatrixFree<dim, double, VectorizedArray<double, 1>>::AdditionalData
+      additional_data;
+    additional_data.mapping_update_flags = update_gradients | update_values;
+    additional_data.use_fast_hanging_node_algorithm = false;
+
+    MatrixFree<dim, double, VectorizedArray<double, 1>> matrix_free;
+    matrix_free.reinit(
+      mapping, dof_handler, constraints, quadrature_formula, additional_data);
+
+    for (const auto &i :
+         matrix_free.get_dof_info(0).hanging_node_constraint_masks)
+      deallog << static_cast<unsigned int>(i) << std::endl;
+    deallog << std::endl;
+
+    print("use_fast_hanging_node_algorithm = false", matrix_free);
+  }
+}

--- a/tests/matrix_free/mixed_mesh_hn_algorithm_01.output
+++ b/tests/matrix_free/mixed_mesh_hn_algorithm_01.output
@@ -1,0 +1,32 @@
+
+DEAL::use_fast_hanging_node_algorithm = true
+DEAL::0   : 12  13  14  
+DEAL::0   : 13  2   2   1   
+DEAL::0   : 14  2   1   1   
+DEAL::0   : 13  2   1   14  
+DEAL::0   : 0   1   2   
+DEAL::0   : 3   1   4   
+DEAL::0   : 5   4   1   
+DEAL::0   : 1   0   5   
+DEAL::0   : 6   5   0   
+DEAL::0   : 7   8   9   10  
+DEAL::0   : 8   12  10  14  
+DEAL::17  : 9   10  3   1   
+DEAL::16  : 10  14  3   1   
+DEAL::
+DEAL::
+DEAL::use_fast_hanging_node_algorithm = false
+DEAL::0   : 12  13  14  
+DEAL::0   : 13  2   2   1   
+DEAL::0   : 14  2   1   1   
+DEAL::0   : 13  2   1   14  
+DEAL::0   : 0   1   2   
+DEAL::0   : 3   1   4   
+DEAL::0   : 5   4   1   
+DEAL::0   : 1   0   5   
+DEAL::0   : 6   5   0   
+DEAL::0   : 7   8   9   10  
+DEAL::0   : 8   12  10  14  
+DEAL::0   : 9   10  3   3   1   
+DEAL::0   : 10  14  3   1   1   
+DEAL::


### PR DESCRIPTION
With this PR, the algorithm is split up three steps:

https://github.com/dealii/dealii/blob/4d3c4090d6eaa12ebba0e8da6ff94113a052702b/include/deal.II/matrix_free/hanging_nodes_internal.h#L730-L755

(In follow up PRs, I would like to call the new functions at separate places to minimize redundant work).

The determination of the refinement configuration now consists of basic bit shifts of the form:

https://github.com/dealii/dealii/blob/4d3c4090d6eaa12ebba0e8da6ff94113a052702b/include/deal.II/matrix_free/hanging_nodes_internal.h#L439

https://github.com/dealii/dealii/blob/4d3c4090d6eaa12ebba0e8da6ff94113a052702b/include/deal.II/matrix_free/hanging_nodes_internal.h#L466

depends on ~#12979, #12980, #1298~