### PR TITLE
Improve default behaviour of CUDAWrappers::MatrixFree::reinit()

### DIFF
--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -711,10 +711,13 @@ namespace CUDAWrappers
   MatrixFree<dim, Number>::get_data(unsigned int color) const
   {
     Data data_copy;
-    data_copy.q_points        = q_points[color];
+    if (q_points.size() > 0)
+      data_copy.q_points = q_points[color];
+    if (inv_jacobian.size() > 0)
+      data_copy.inv_jacobian = inv_jacobian[color];
+    if (JxW.size() > 0)
+      data_copy.JxW = JxW[color];
     data_copy.local_to_global = local_to_global[color];
-    data_copy.inv_jacobian    = inv_jacobian[color];
-    data_copy.JxW             = JxW[color];
     data_copy.id              = my_id;
     data_copy.n_cells         = n_cells[color];
     data_copy.padding_length  = padding_length;
@@ -898,7 +901,9 @@ namespace CUDAWrappers
     if (typeid(Number) == typeid(double))
       cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
 
-    const UpdateFlags &update_flags = additional_data.mapping_update_flags;
+    UpdateFlags update_flags = additional_data.mapping_update_flags;
+    if (update_flags & update_gradients)
+      update_flags |= update_JxW_values;
 
     if (additional_data.parallelization_scheme != parallel_over_elem &&
         additional_data.parallelization_scheme != parallel_in_elem)


### PR DESCRIPTION
We got segmentation faults in a Laplace operator when only the following flags have been enabled:
```cpp
    typename CUDAWrappers::MatrixFree<dim, Number>::AdditionalData
      additional_data;
    additional_data.mapping_update_flags = update_gradients;
```
The CUDA tried to access `jxw` (correctly) even though it was explicitly requested and `q_points` although it is not needed. 

This PR 1) checks if the data is set and if not the data is not accessed and 2) changes the default behavior to to the CPU version (if `update_gradients` is enabled, enable also `jxw`).

FYI @Rombur @kronbichler 