### PR TITLE
Make sure MPI BigData objects are always destroyed.

### DIFF
--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -1466,23 +1466,22 @@ namespace parallel
       else
         {
           // Writes bigger than 2GB require some extra care:
-          MPI_Datatype bigtype =
-            Utilities::MPI::create_mpi_data_type_n_bytes(src_data_fixed.size());
           ierr =
             MPI_File_write_at(fh,
                               my_global_file_position,
                               DEAL_II_MPI_CONST_CAST(src_data_fixed.data()),
                               1,
-                              bigtype,
+                              *Utilities::MPI::create_mpi_data_type_n_bytes(
+                                src_data_fixed.size()),
                               MPI_STATUS_IGNORE);
-          AssertThrowMPI(ierr);
-          ierr = MPI_Type_free(&bigtype);
           AssertThrowMPI(ierr);
         }
 
       ierr = MPI_File_close(&fh);
       AssertThrowMPI(ierr);
     }
+
+
 
     //
     // ---------- Variable size data ----------
@@ -1568,17 +1567,15 @@ namespace parallel
         else
           {
             // Writes bigger than 2GB require some extra care:
-            MPI_Datatype bigtype = Utilities::MPI::create_mpi_data_type_n_bytes(
-              src_data_variable.size());
-            ierr = MPI_File_write_at(fh,
-                                     my_global_file_position,
-                                     DEAL_II_MPI_CONST_CAST(
-                                       src_data_variable.data()),
-                                     1,
-                                     bigtype,
-                                     MPI_STATUS_IGNORE);
-            AssertThrowMPI(ierr);
-            ierr = MPI_Type_free(&bigtype);
+            ierr =
+              MPI_File_write_at(fh,
+                                my_global_file_position,
+                                DEAL_II_MPI_CONST_CAST(
+                                  src_data_variable.data()),
+                                1,
+                                *Utilities::MPI::create_mpi_data_type_n_bytes(
+                                  src_data_variable.size()),
+                                MPI_STATUS_IGNORE);
             AssertThrowMPI(ierr);
           }
 
@@ -1681,16 +1678,13 @@ namespace parallel
       else
         {
           // Reads bigger than 2GB require some extra care:
-          MPI_Datatype bigtype = Utilities::MPI::create_mpi_data_type_n_bytes(
-            dest_data_fixed.size());
           ierr = MPI_File_read_at(fh,
                                   my_global_file_position,
                                   dest_data_fixed.data(),
                                   1,
-                                  bigtype,
+                                  *Utilities::MPI::create_mpi_data_type_n_bytes(
+                                    dest_data_fixed.size()),
                                   MPI_STATUS_IGNORE);
-          AssertThrowMPI(ierr);
-          ierr = MPI_Type_free(&bigtype);
           AssertThrowMPI(ierr);
         }
 
@@ -1772,16 +1766,14 @@ namespace parallel
         else
           {
             // Reads bigger than 2GB require some extra care:
-            MPI_Datatype bigtype = Utilities::MPI::create_mpi_data_type_n_bytes(
-              src_data_fixed.size());
-            ierr = MPI_File_read_at(fh,
-                                    my_global_file_position,
-                                    dest_data_variable.data(),
-                                    1,
-                                    bigtype,
-                                    MPI_STATUS_IGNORE);
-            AssertThrowMPI(ierr);
-            ierr = MPI_Type_free(&bigtype);
+            ierr =
+              MPI_File_read_at(fh,
+                               my_global_file_position,
+                               dest_data_variable.data(),
+                               1,
+                               *Utilities::MPI::create_mpi_data_type_n_bytes(
+                                 src_data_fixed.size()),
+                               MPI_STATUS_IGNORE);
             AssertThrowMPI(ierr);
           }
 

--- a/tests/mpi/create_mpi_datatype_01.cc
+++ b/tests/mpi/create_mpi_datatype_01.cc
@@ -29,12 +29,12 @@ using namespace dealii;
 void
 test_data_type(const std::uint64_t n_bytes)
 {
-  MPI_Datatype bigtype = Utilities::MPI::create_mpi_data_type_n_bytes(n_bytes);
+  const auto bigtype = Utilities::MPI::create_mpi_data_type_n_bytes(n_bytes);
 
   deallog << "checking size " << n_bytes << ":";
 
   int size32;
-  int ierr = MPI_Type_size(bigtype, &size32);
+  int ierr = MPI_Type_size(*bigtype, &size32);
   AssertThrowMPI(ierr);
 
   if (size32 == MPI_UNDEFINED)
@@ -45,16 +45,16 @@ test_data_type(const std::uint64_t n_bytes)
 
 #if DEAL_II_MPI_VERSION_GTE(3, 0)
   MPI_Count size64;
-  ierr = MPI_Type_size_x(bigtype, &size64);
+  ierr = MPI_Type_size_x(*bigtype, &size64);
   AssertThrowMPI(ierr);
 
   deallog << " size64=" << size64;
 #endif
 
   deallog << std::endl;
-
-  MPI_Type_free(&bigtype);
 }
+
+
 
 void
 test_send_recv(MPI_Comm comm)
@@ -66,28 +66,24 @@ test_send_recv(MPI_Comm comm)
     {
       std::vector<char> buffer(n_bytes, 'A');
       buffer[n_bytes - 1] = 'B';
-      MPI_Datatype bigtype =
+      const auto bigtype =
         Utilities::MPI::create_mpi_data_type_n_bytes(buffer.size());
       int ierr =
-        MPI_Send(buffer.data(), 1, bigtype, 1 /* dest */, 0 /* tag */, comm);
-      AssertThrowMPI(ierr);
-      ierr = MPI_Type_free(&bigtype);
+        MPI_Send(buffer.data(), 1, *bigtype, 1 /* dest */, 0 /* tag */, comm);
       AssertThrowMPI(ierr);
     }
   else if (myid == 1)
     {
       std::vector<char> buffer(n_bytes, '?');
-      MPI_Datatype      bigtype =
+      const auto        bigtype =
         Utilities::MPI::create_mpi_data_type_n_bytes(buffer.size());
       int ierr = MPI_Recv(buffer.data(),
                           1,
-                          bigtype,
+                          *bigtype,
                           0 /* src */,
                           0 /* tag */,
                           comm,
                           MPI_STATUS_IGNORE);
-      AssertThrowMPI(ierr);
-      ierr = MPI_Type_free(&bigtype);
       AssertThrowMPI(ierr);
 
       AssertThrow(buffer[0] == 'A', ExcInternalError());


### PR DESCRIPTION
This is the promised follow-up to #12964 that uses C++ features to ensure that we always call `MPI_Type_free`. As explained in #12986, the test fails for me right now, but I believe this to be unrelated to the patch.

/rebuild