### PR TITLE
Use extractors for local_rhs in step-22

### DIFF
--- a/doc/news/changes/minor/20211123MarcoFeder
+++ b/doc/news/changes/minor/20211123MarcoFeder
@@ -1,0 +1,3 @@
+Fixed: The step-22 tutorial now uses FEValuesExtractors also for the right-hand side
+<br>
+(Marco Feder, 2021/11/23)


### PR DESCRIPTION
Local contributions for the right-hand side are now computed using extractors, following a discussion in the mailing list. This fixes #11039

Thanks a lot @bangerth for the suggestions.