### PR TITLE
Fix compile warning by adding copy constructor to hp iterator

### DIFF
--- a/include/deal.II/hp/collection.h
+++ b/include/deal.II/hp/collection.h
@@ -48,6 +48,17 @@ namespace hp
     {}
 
     /**
+     * Copy constructor.
+     */
+    CollectionIterator(const CollectionIterator<T> &other) = default;
+
+    /**
+     * Copy assignment.
+     */
+    CollectionIterator<T> &
+    operator=(const CollectionIterator<T> &other) = default;
+
+    /**
      * Compare for equality.
      */
     bool
@@ -72,12 +83,6 @@ namespace hp
           "You are trying to compare iterators into different hp::Collection objects."));
       return this->index != other.index;
     }
-
-    /**
-     * Copy assignment.
-     */
-    CollectionIterator<T> &
-    operator=(const CollectionIterator<T> &other) = default;
 
     /**
      * Dereferencing operator: returns the value of the current index.


### PR DESCRIPTION
My compiler (clang-13) complained about
```
/home/kronbichler/deal/deal.II/include/deal.II/hp/collection.h:80:5: warning: definition of implicit 
copy constructor for 'CollectionIterator<dealii::FiniteElement<1>>' is deprecated because it has a 
user-declared copy assignment operator [-Wdeprecated-copy]
    operator=(const CollectionIterator<T> &other) = default;
```
So we better add a copy constructor as well. Alternatively, we could have relied on the implicitly generated copy assignment operator.