### PR TITLE
Fix bug MatrixFree::reinit

### DIFF
--- a/include/deal.II/matrix_free/matrix_free.h
+++ b/include/deal.II/matrix_free/matrix_free.h
@@ -3087,7 +3087,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handlers.push_back(dh);
 
   this->reinit(dof_handlers, constraint, quad, additional_data);
 }
@@ -3168,7 +3168,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handlers.push_back(dh);
 
   this->reinit(mapping, dof_handlers, constraint, quad, additional_data);
 }
@@ -3190,7 +3190,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::reinit(
   std::vector<const DoFHandler<dim> *> dof_handlers;
 
   for (const auto dh : dof_handler)
-    dof_handlers.push_back(dof_handler);
+    dof_handlers.push_back(dh);
 
   this->reinit(dof_handlers, constraint, quad, additional_data);
 }


### PR DESCRIPTION
I think nobody has tried to call these functions otherwise they would have hit an error at compile time.