### PR TITLE
Use pre-compiled code for CellwiseInverseMassMatrix

### DIFF
--- a/doc/news/changes/minor/20211129MartinKronbichler
+++ b/doc/news/changes/minor/20211129MartinKronbichler
@@ -1,0 +1,6 @@
+Fixed: MatrixFreeOperators::CellwiseInverseMassMatrix with template argument
+`-1` for the polynomial degree now chooses the pre-compiled code with fast
+tensor-product algorithms if available, rather than a slower general-purpose
+code.
+<br>
+(Martin Kronbichler, 2021/11/29)

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -172,7 +172,6 @@ namespace internal
   {
     static void
     apply(const unsigned int n_components,
-          const unsigned int fe_degree,
           const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
             &                        fe_eval,
           const VectorizedArrayType *in_array,
@@ -189,8 +188,6 @@ namespace internal
     static void
     transform_from_q_points_to_basis(
       const unsigned int n_components,
-      const unsigned int fe_degree,
-      const unsigned int n_q_points_1d,
       const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
         &                        fe_eval,
       const VectorizedArrayType *in_array,

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -330,12 +330,12 @@ namespace internal
   void
   CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::apply(
     const unsigned int n_components,
-    const unsigned int fe_degree,
     const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
       &                        fe_eval,
     const VectorizedArrayType *in_array,
     VectorizedArrayType *      out_array)
   {
+    const unsigned int fe_degree = fe_eval.get_shape_info().data[0].fe_degree;
     instantiation_helper_run<
       1,
       CellwiseInverseMassMatrixImplBasic<dim, VectorizedArrayType>>(
@@ -373,13 +373,14 @@ namespace internal
   CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
     transform_from_q_points_to_basis(
       const unsigned int n_components,
-      const unsigned int fe_degree,
-      const unsigned int n_q_points_1d,
       const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
         &                        fe_eval,
       const VectorizedArrayType *in_array,
       VectorizedArrayType *      out_array)
   {
+    const unsigned int fe_degree = fe_eval.get_shape_info().data[0].fe_degree;
+    const unsigned int n_q_points_1d =
+      fe_eval.get_shape_info().data[0].n_q_points_1d;
     instantiation_helper_run<
       1,
       CellwiseInverseMassMatrixImplTransformFromQPoints<dim,

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1063,8 +1063,12 @@ namespace MatrixFreeOperators
     VectorizedArrayType>::apply(const VectorizedArrayType *in_array,
                                 VectorizedArrayType *      out_array) const
   {
-    internal::CellwiseInverseMassMatrixImplBasic<dim, VectorizedArrayType>::
-      template run<fe_degree>(n_components, fe_eval, in_array, out_array);
+    if (fe_degree > -1)
+      internal::CellwiseInverseMassMatrixImplBasic<dim, VectorizedArrayType>::
+        template run<fe_degree>(n_components, fe_eval, in_array, out_array);
+    else
+      internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
+        apply(n_components, fe_eval, in_array, out_array);
   }
 
 
@@ -1085,13 +1089,25 @@ namespace MatrixFreeOperators
           const VectorizedArrayType *               in_array,
           VectorizedArrayType *                     out_array) const
   {
-    internal::CellwiseInverseMassMatrixImplFlexible<dim, VectorizedArrayType>::
-      template run<fe_degree>(
-        n_actual_components,
-        fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
-        inverse_coefficients,
-        in_array,
-        out_array);
+    const unsigned int given_degree =
+      fe_eval.get_shape_info().data[0].fe_degree;
+    if (fe_degree > -1)
+      internal::CellwiseInverseMassMatrixImplFlexible<dim,
+                                                      VectorizedArrayType>::
+        template run<fe_degree>(
+          n_actual_components,
+          fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
+          inverse_coefficients,
+          in_array,
+          out_array);
+    else
+      internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
+        apply(n_actual_components,
+              given_degree,
+              fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
+              inverse_coefficients,
+              in_array,
+              out_array);
   }
 
 
@@ -1124,8 +1140,6 @@ namespace MatrixFreeOperators
     else
       internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
         transform_from_q_points_to_basis(n_actual_components,
-                                         fe_degree,
-                                         n_q_points_1d,
                                          fe_eval,
                                          in_array,
                                          out_array);


### PR DESCRIPTION
By looking at a profiler output I realized that `CellwiseInverseMassMatrix` would not use the optimized pre-compiled version of the code with compile-time loop bounds, but rather the slower path with run-time loop bounds. It turned out that we forgot to add the respective call to the templated/precompiled code in `CellwiseInverseMassMatrix`. While there, I also simplified the calls slightly as the fe degree can be read in a more central place.