### PR TITLE
Use narrowest possible SIMD vector for MappingQ::InternalData

### DIFF
--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -475,8 +475,18 @@ public:
     QGaussLobatto<1> line_support_points;
 
     /**
-     * A vectorized array type to reflect the necessary number of components
-     * for all interpolations to be done by this class.
+     * For the fast tensor-product path of the MappingQ class, we choose SIMD
+     * vectors that are as wide as possible to minimize the number of
+     * arithmetic operations. However, we do not want to choose it wider than
+     * necessary, e.g., we avoid something like 8-wide AVX-512 when we only
+     * compute 3 components of a 3D computation. This is because the
+     * additional lanes would not do useful work, but a few operations on very
+     * wide vectors can already lead to a lower clock frequency of processors
+     * over long time spans (thousands of clock cycles). Hence, we choose
+     * 2-wide SIMD for 1D and 2D and 4-wide SIMD for 3D. Note that we do not
+     * immediately fall back to no SIMD for 1D because all architectures that
+     * support SIMD also support 128-bit vectors (and none is reported to
+     * reduce clock frequency for 128-bit SIMD).
      */
     using VectorizedArrayType =
       VectorizedArray<double,

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -475,42 +475,50 @@ public:
     QGaussLobatto<1> line_support_points;
 
     /**
+     * A vectorized array type to reflect the necessary number of components
+     * for all interpolations to be done by this class.
+     */
+    using VectorizedArrayType =
+      VectorizedArray<double,
+                      std::min<std::size_t>(VectorizedArray<double>::size(),
+                                            (dim <= 2 ? 2 : 4))>;
+
+    /**
      * In case the quadrature rule given represents a tensor product
      * we need to store the evaluations of the 1d polynomials at
      * the 1d quadrature points. That is what this variable is for.
      */
-    internal::MatrixFreeFunctions::ShapeInfo<VectorizedArray<double>>
-      shape_info;
+    internal::MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> shape_info;
 
     /**
      * In case the quadrature rule given represents a tensor product
      * we need to store temporary data in this object.
      */
-    mutable AlignedVector<VectorizedArray<double>> scratch;
+    mutable AlignedVector<VectorizedArrayType> scratch;
 
     /**
      * In case the quadrature rule given represents a tensor product
      * the values at the mapped support points are stored in this object.
      */
-    mutable AlignedVector<VectorizedArray<double>> values_dofs;
+    mutable AlignedVector<VectorizedArrayType> values_dofs;
 
     /**
      * In case the quadrature rule given represents a tensor product
      * the values at the quadrature points are stored in this object.
      */
-    mutable AlignedVector<VectorizedArray<double>> values_quad;
+    mutable AlignedVector<VectorizedArrayType> values_quad;
 
     /**
      * In case the quadrature rule given represents a tensor product
      * the gradients at the quadrature points are stored in this object.
      */
-    mutable AlignedVector<VectorizedArray<double>> gradients_quad;
+    mutable AlignedVector<VectorizedArrayType> gradients_quad;
 
     /**
      * In case the quadrature rule given represents a tensor product
      * the hessians at the quadrature points are stored in this object.
      */
-    mutable AlignedVector<VectorizedArray<double>> hessians_quad;
+    mutable AlignedVector<VectorizedArrayType> hessians_quad;
 
     /**
      * Indicates whether the given Quadrature object is a tensor product.

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1079,9 +1079,12 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
+      using VectorizedArrayType =
+        typename dealii::MappingQ<dim,
+                                  spacedim>::InternalData::VectorizedArrayType;
       const unsigned int     n_shape_values = data.n_shape_functions;
       const unsigned int     n_q_points     = data.shape_info.n_q_points;
-      constexpr unsigned int n_lanes        = VectorizedArray<double>::size();
+      constexpr unsigned int n_lanes        = VectorizedArrayType::size();
       constexpr unsigned int n_comp         = 1 + (spacedim - 1) / n_lanes;
       constexpr unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
@@ -1148,7 +1151,7 @@ namespace internal
               }
 
           // do the actual tensorized evaluation
-          internal::FEEvaluationFactory<dim, double, VectorizedArray<double>>::
+          internal::FEEvaluationFactory<dim, double, VectorizedArrayType>::
             evaluate(n_comp,
                      evaluation_flag,
                      data.shape_info,


### PR DESCRIPTION
In the tensor-product optimized path of `MappingQ`, we would previously always use `VectorizedArray<double>`, i.e., the widest possible SIMD vector. Since modern Intel CPUs clock down for the widest vectors, we should only use as wide a vector as makes sense in terms of useful components. To achieve this, I added a typedef in the `MappingQ::InternalData` class that either chooses 2 or 4 SIMD lanes, depending on whether we are in `dim <= 2` or `dim == 3`. (In 1D, we could fall back to the scalar case, but there is no architecture we support with <128 bit vectors, so it makes little sense.)