### PR TITLE
Start from zero vector for MG coarse solver

### DIFF
--- a/include/deal.II/multigrid/mg_coarse.h
+++ b/include/deal.II/multigrid/mg_coarse.h
@@ -281,7 +281,7 @@ MGCoarseGridApplySmoother<VectorType>::operator()(const unsigned int level,
                                                   VectorType &       dst,
                                                   const VectorType & src) const
 {
-  coarse_smooth->smooth(level, dst, src);
+  coarse_smooth->apply(level, dst, src);
 }
 
 /* ------------------ Functions for MGCoarseGridIterativeSolver ------------ */
@@ -425,6 +425,7 @@ void
   Assert(matrix != nullptr, ExcNotInitialized());
   Assert(preconditioner != nullptr, ExcNotInitialized());
 
+  dst = 0;
   internal::MGCoarseGridIterativeSolver::solve(
     *solver, *matrix, *preconditioner, dst, src);
 }

--- a/tests/matrix_free/parallel_multigrid_interleave.with_p4est=true.with_lapack=true.mpirun=2.output
+++ b/tests/matrix_free/parallel_multigrid_interleave.with_p4est=true.with_lapack=true.mpirun=2.output
@@ -3,7 +3,7 @@ DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 81
 DEAL:cg::Starting value 7.00000
 DEAL:cg::Convergence step 3 value 1.44113e-07
-DEAL::Number of calls to special vmult for Operator of size 4: 15
+DEAL::Number of calls to special vmult for Operator of size 4: 12
 DEAL::Number of calls to special vmult for Operator of size 9: 27
 DEAL::Number of calls to special vmult for Operator of size 25: 27
 DEAL::Number of calls to special vmult for Operator of size 81: 27
@@ -11,7 +11,7 @@ DEAL::Testing FE_Q<2>(1)
 DEAL::Number of degrees of freedom: 289
 DEAL:cg::Starting value 15.0000
 DEAL:cg::Convergence step 3 value 1.49408e-06
-DEAL::Number of calls to special vmult for Operator of size 4: 15
+DEAL::Number of calls to special vmult for Operator of size 4: 12
 DEAL::Number of calls to special vmult for Operator of size 9: 27
 DEAL::Number of calls to special vmult for Operator of size 25: 27
 DEAL::Number of calls to special vmult for Operator of size 81: 27
@@ -19,16 +19,16 @@ DEAL::Number of calls to special vmult for Operator of size 289: 27
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 625
 DEAL:cg::Starting value 23.0000
-DEAL:cg::Convergence step 4 value 6.30917e-08
-DEAL::Number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 4 value 6.30996e-08
+DEAL::Number of calls to special vmult for Operator of size 16: 16
 DEAL::Number of calls to special vmult for Operator of size 49: 36
 DEAL::Number of calls to special vmult for Operator of size 169: 36
 DEAL::Number of calls to special vmult for Operator of size 625: 36
 DEAL::Testing FE_Q<2>(3)
 DEAL::Number of degrees of freedom: 2401
 DEAL:cg::Starting value 47.0000
-DEAL:cg::Convergence step 4 value 1.99839e-07
-DEAL::Number of calls to special vmult for Operator of size 16: 20
+DEAL:cg::Convergence step 4 value 1.99754e-07
+DEAL::Number of calls to special vmult for Operator of size 16: 16
 DEAL::Number of calls to special vmult for Operator of size 49: 36
 DEAL::Number of calls to special vmult for Operator of size 169: 36
 DEAL::Number of calls to special vmult for Operator of size 625: 36
@@ -37,14 +37,14 @@ DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 125
 DEAL:cg::Starting value 5.19615
 DEAL:cg::Convergence step 3 value 5.16655e-09
-DEAL::Number of calls to special vmult for Operator of size 8: 15
+DEAL::Number of calls to special vmult for Operator of size 8: 12
 DEAL::Number of calls to special vmult for Operator of size 27: 27
 DEAL::Number of calls to special vmult for Operator of size 125: 27
 DEAL::Testing FE_Q<3>(1)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 18.5203
 DEAL:cg::Convergence step 3 value 1.01773e-06
-DEAL::Number of calls to special vmult for Operator of size 8: 15
+DEAL::Number of calls to special vmult for Operator of size 8: 12
 DEAL::Number of calls to special vmult for Operator of size 27: 27
 DEAL::Number of calls to special vmult for Operator of size 125: 27
 DEAL::Number of calls to special vmult for Operator of size 729: 27
@@ -52,14 +52,14 @@ DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 729
 DEAL:cg::Starting value 18.5203
 DEAL:cg::Convergence step 4 value 5.65213e-09
-DEAL::Number of calls to special vmult for Operator of size 27: 20
+DEAL::Number of calls to special vmult for Operator of size 27: 16
 DEAL::Number of calls to special vmult for Operator of size 125: 36
 DEAL::Number of calls to special vmult for Operator of size 729: 36
 DEAL::Testing FE_Q<3>(2)
 DEAL::Number of degrees of freedom: 4913
 DEAL:cg::Starting value 58.0948
-DEAL:cg::Convergence step 4 value 3.37720e-08
-DEAL::Number of calls to special vmult for Operator of size 27: 20
+DEAL:cg::Convergence step 4 value 3.37746e-08
+DEAL::Number of calls to special vmult for Operator of size 27: 16
 DEAL::Number of calls to special vmult for Operator of size 125: 36
 DEAL::Number of calls to special vmult for Operator of size 729: 36
 DEAL::Number of calls to special vmult for Operator of size 4913: 36


### PR DESCRIPTION
I observed that our multigrid classes start iterating from the old content of a vector, by calling `smooth` rather than `apply` in the case the coarse grid is a smoother. As we can typically expect a much smaller result than in the previous call, or at least a completely different solution as we are in a different V-cycle with a fresh content, it makes more sense to start from zero.

Note that I only ran a subset of tests up to now, so we might need to watch the CI for possible fall-outs.