### PR TITLE
Move implementation for ShapeInfo to templates.h file

### DIFF
--- a/doc/news/changes/incompatibilities/20211130MartinKronbichler
+++ b/doc/news/changes/incompatibilities/20211130MartinKronbichler
@@ -1,0 +1,6 @@
+Updated: The header inclusions of several files in the `deal.II/matrix_free`
+subfolder have been cleaned up to make the library more maintainable. As a
+result, some headers are no longer implicitly included and a user code might
+need to add the respective include file.
+<br>
+(Martin Kronbichler, 2021/11/30)

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -232,7 +232,6 @@ public:
   std::array<unsigned int, VectorizedArrayType::size()>
   get_cell_or_face_ids() const;
 
-
   /**
    * Return the numbering of local degrees of freedom within the evaluation
    * routines of FEEvaluation in terms of the standard numbering on finite

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -22,13 +22,18 @@
 
 #include <deal.II/base/aligned_vector.h>
 #include <deal.II/base/exceptions.h>
-#include <deal.II/base/quadrature_lib.h>
+#include <deal.II/base/quadrature.h>
+#include <deal.II/base/table.h>
 #include <deal.II/base/vectorization.h>
-
-#include <deal.II/fe/fe.h>
 
 
 DEAL_II_NAMESPACE_OPEN
+
+
+// forward declaration
+template <int dim, int spacedim>
+class FiniteElement;
+
 
 namespace internal
 {
@@ -132,7 +137,7 @@ namespace internal
       ElementType element_type;
 
       /**
-       * Stores the shape values of the 1D finite element evaluated on all 1D
+       * Stores the shape values of the 1D finite element evaluated at all 1D
        * quadrature points. The length of
        * this array is <tt>n_dofs_1d * n_q_points_1d</tt> and quadrature
        * points are the index running fastest.
@@ -140,7 +145,7 @@ namespace internal
       AlignedVector<Number> shape_values;
 
       /**
-       * Stores the shape gradients of the 1D finite element evaluated on all
+       * Stores the shape gradients of the 1D finite element evaluated at all
        * 1D quadrature points. The length of
        * this array is <tt>n_dofs_1d * n_q_points_1d</tt> and quadrature
        * points are the index running fastest.
@@ -148,7 +153,7 @@ namespace internal
       AlignedVector<Number> shape_gradients;
 
       /**
-       * Stores the shape Hessians of the 1D finite element evaluated on all
+       * Stores the shape Hessians of the 1D finite element evaluated at all
        * 1D quadrature points. The length of
        * this array is <tt>n_dofs_1d * n_q_points_1d</tt> and quadrature
        * points are the index running fastest.
@@ -300,16 +305,16 @@ namespace internal
       bool nodal_at_cell_boundaries;
 
       /**
-       * Stores the shape values of the finite element evaluated on all
+       * Stores the shape values of the finite element evaluated at all
        * quadrature points for all faces and orientations (no tensor-product
        * structure exploited).
        */
       Table<3, Number> shape_values_face;
 
       /**
-       * Stores the shape gradients of the finite element evaluated on all
+       * Stores the shape gradients of the finite element evaluated at all
        * quadrature points for all faces, orientations, and directions
-       * (no tensor-product structure  exploited).
+       * (no tensor-product structure exploited).
        */
       Table<4, Number> shape_gradients_face;
     };
@@ -344,10 +349,10 @@ namespace internal
       /**
        * Constructor that initializes the data fields using the reinit method.
        */
-      template <int dim, int dim_q>
-      ShapeInfo(const Quadrature<dim_q> & quad,
-                const FiniteElement<dim> &fe,
-                const unsigned int        base_element = 0);
+      template <int dim, int spacedim, int dim_q>
+      ShapeInfo(const Quadrature<dim_q> &           quad,
+                const FiniteElement<dim, spacedim> &fe,
+                const unsigned int                  base_element = 0);
 
       /**
        * Initializes the data fields. Takes a one-dimensional quadrature
@@ -357,11 +362,11 @@ namespace internal
        * dimensional element by a tensor product and that the zeroth shape
        * function in zero evaluates to one.
        */
-      template <int dim, int dim_q>
+      template <int dim, int spacedim, int dim_q>
       void
-      reinit(const Quadrature<dim_q> & quad,
-             const FiniteElement<dim> &fe_dim,
-             const unsigned int        base_element = 0);
+      reinit(const Quadrature<dim_q> &           quad,
+             const FiniteElement<dim, spacedim> &fe_dim,
+             const unsigned int                  base_element = 0);
 
       /**
        * Return which kinds of elements are supported by MatrixFree.
@@ -555,22 +560,6 @@ namespace internal
 
 
     // ------------------------------------------ inline functions
-
-    template <typename Number>
-    template <int dim, int dim_q>
-    inline ShapeInfo<Number>::ShapeInfo(const Quadrature<dim_q> & quad,
-                                        const FiniteElement<dim> &fe_in,
-                                        const unsigned int base_element_number)
-      : element_type(tensor_general)
-      , n_dimensions(0)
-      , n_components(0)
-      , n_q_points(0)
-      , dofs_per_component_on_cell(0)
-      , n_q_points_face(0)
-      , dofs_per_component_on_face(0)
-    {
-      reinit(quad, fe_in, base_element_number);
-    }
 
     template <typename Number>
     inline const UnivariateShapeData<Number> &

--- a/source/matrix_free/shape_info.inst.in
+++ b/source/matrix_free/shape_info.inst.in
@@ -16,18 +16,28 @@
 
 for (deal_II_dimension : DIMENSIONS; deal_II_scalar : REAL_SCALARS)
   {
-    template void internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
-      reinit<deal_II_dimension>(
-        const Quadrature<deal_II_dimension> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
+    template internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
+      ShapeInfo(const Quadrature<deal_II_dimension> &,
+                const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+                const unsigned int);
+
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::reinit(
+      const Quadrature<deal_II_dimension> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
 
 #if deal_II_dimension > 1
-    template void internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
-      reinit<deal_II_dimension>(
-        const Quadrature<1> &,
-        const FiniteElement<deal_II_dimension, deal_II_dimension> &,
-        const unsigned int);
+    template internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::
+      ShapeInfo(const Quadrature<1> &,
+                const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+                const unsigned int);
+
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar>::reinit(
+      const Quadrature<1> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
 #endif
   }
 
@@ -45,18 +55,30 @@ for (deal_II_dimension : DIMENSIONS; deal_II_space_dimension : SPACE_DIMENSIONS)
 for (deal_II_dimension : DIMENSIONS;
      deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
   {
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
+    template internal::MatrixFreeFunctions::
+      ShapeInfo<deal_II_scalar_vectorized>::ShapeInfo(
         const Quadrature<deal_II_dimension> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
 
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar_vectorized>::reinit(
+      const Quadrature<deal_II_dimension> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
+
 #if deal_II_dimension > 1
-    template void internal::MatrixFreeFunctions::
-      ShapeInfo<deal_II_scalar_vectorized>::reinit<deal_II_dimension>(
+    template internal::MatrixFreeFunctions::
+      ShapeInfo<deal_II_scalar_vectorized>::ShapeInfo(
         const Quadrature<1> &,
         const FiniteElement<deal_II_dimension, deal_II_dimension> &,
         const unsigned int);
+
+    template void
+    internal::MatrixFreeFunctions::ShapeInfo<deal_II_scalar_vectorized>::reinit(
+      const Quadrature<1> &,
+      const FiniteElement<deal_II_dimension, deal_II_dimension> &,
+      const unsigned int);
 #endif
   }
 

--- a/tests/matrix_free/shape_info.cc
+++ b/tests/matrix_free/shape_info.cc
@@ -18,6 +18,8 @@
 // test the correctness of the detection of the elements in
 // internal::MatrixFreeFunctions::ShapeInfo
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgp.h>
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>

--- a/tests/matrix_free/shape_info_inverse.cc
+++ b/tests/matrix_free/shape_info_inverse.cc
@@ -18,6 +18,8 @@
 // test the correctness of the inverse_shape_values field of
 // internal::MatrixFreeFunctions::ShapeInfo
 
+#include <deal.II/base/quadrature_lib.h>
+
 #include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
 


### PR DESCRIPTION
This moves an implementation of `ShapeInfo` to the `.templates.h` file in order to avoid including `fe.h` in that file. This is a preparation to include only a minimal set of headers in `evaluation_template_factory` to not re-compile this heavy file more often than necessary.