### PR TITLE
Avoid unnecessary memory allocation.

### DIFF
--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -2154,10 +2154,9 @@ TableBase<N, T>::TableBase(const TableIndices<N> &sizes,
 template <int N, typename T>
 TableBase<N, T>::TableBase(const TableBase<N, T> &src)
   : Subscriptor()
-{
-  reinit(src.table_size, true);
-  values = src.values;
-}
+  , values(src.values)
+  , table_size(src.table_size)
+{}
 
 
 

--- a/tests/base/aligned_vector_memory_02.output
+++ b/tests/base/aligned_vector_memory_02.output
@@ -2,12 +2,10 @@
 DEAL::---- Creating outer table
 DEAL::default constructor. Object number 0
 DEAL::---- Cloning outer table
-DEAL::default constructor. Object number 1
-DEAL::destructor. Object number 1
-DEAL::copy constructor from 0. Object number 2
+DEAL::copy constructor from 0. Object number 1
 DEAL::---- Destroying the clone
-DEAL::destructor. Object number 2
+DEAL::destructor. Object number 1
 DEAL::---- Destroying the source table
 DEAL::destructor. Object number 0
-DEAL::Objects created: 3
-DEAL::Objects destroyed: 3
+DEAL::Objects created: 2
+DEAL::Objects destroyed: 2


### PR DESCRIPTION
While looking around what is necessary for #13005/#12998/#12993, I also realized an inefficiency: In one place, we resize a vector, and then copy into that vector, but the copy operation releases the previously allocated memory and re-allocates it. We can avoid this.

/rebuild