### PR TITLE
Guard a forward declaration.

### DIFF
--- a/include/deal.II/base/multithread_info.h
+++ b/include/deal.II/base/multithread_info.h
@@ -25,11 +25,14 @@
 
 #  include <memory>
 
+#  ifdef DEAL_II_WITH_TASKFLOW
 // forward declaration from <taskflow/taskflow.hpp>
 namespace tf
 {
   class Executor;
 }
+#  endif
+
 
 DEAL_II_NAMESPACE_OPEN
 


### PR DESCRIPTION
The declaration is only used when using TaskFlow, so guard it with the appropriate preprocessor flag. This also makes it easier to identify which code needs to be removed if we decide to remove TaskFlow again at some point, or what else to do with this.

/rebuild