### PR TITLE
Spawn tasks via the TBB again.

### DIFF
--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1015,7 +1015,8 @@ namespace Threads
           // but have to make do with a pointer to such an object.
           std::unique_ptr<std::promise<RT>> promise =
             std::make_unique<std::promise<RT>>();
-          task_data = std::make_shared<TaskData>(promise->get_future());
+          task_data =
+            std::make_shared<TaskData>(std::move(promise->get_future()));
 
           // Then start the task, using a task_group object (for just this one
           // task) that is associated with the TaskData object. Note that we
@@ -1291,7 +1292,7 @@ namespace Threads
        * Constructor. Initializes an std::future object and assumes
        * that the task so set has not finished yet.
        */
-      TaskData(std::future<RT> &&future)
+      TaskData(std::future<RT> &&future) noexcept
         : future(std::move(future))
         , task_has_finished(false)
       {}
@@ -1329,7 +1330,7 @@ namespace Threads
        * this makes sure that one cannot just abandon a task completely
        * by letting all Task objects that point to it go out of scope.
        */
-      ~TaskData()
+      ~TaskData() noexcept
       {
         // Explicitly wait for the results to be ready. This class stores
         // a std::future object, and we could just let the compiler generate

--- a/include/deal.II/base/thread_management.h
+++ b/include/deal.II/base/thread_management.h
@@ -1296,6 +1296,31 @@ namespace Threads
         , task_has_finished(false)
       {}
 
+      /**
+       * There can only be one TaskData object referencing
+       * a task. Make sure that these objects are not copied.
+       */
+      TaskData(const TaskData &) = delete;
+
+      /**
+       * There can only be one TaskData object referencing
+       * a task. Make sure that these objects are not moved.
+       */
+      TaskData(TaskData &&) = delete;
+
+      /**
+       * There can only be one TaskData object referencing
+       * a task. Make sure that these objects are not copied.
+       */
+      TaskData &
+      operator=(const TaskData &) = delete;
+
+      /**
+       * There can only be one TaskData object referencing
+       * a task. Make sure that these objects are not moved.
+       */
+      TaskData &
+      operator=(TaskData &&) = delete;
 
       /**
        * Destructor. Wait for the results to be ready. This ensures that the


### PR DESCRIPTION
In #10389, I rewrote the `Threads::Task` class to use the C++11 function `std::async` to start tasks, replacing the old way via the TBB. This seemed like a good idea at the time, given that https://en.cppreference.com/w/cpp/thread/async says this:

> The function template `async` runs the function `f` asynchronously (potentially in a separate thread which might be a part of a thread pool) and returns a `std::future` that will eventually hold the result of that function call.

The problem, as I've learned since, is that at least GCC does not actually use a thread pool for the tasks spawned by `std::async` :-( The first argument to that function can be `std::launch::async` or `std::launch::deferred`, or both. The *intent* of the standard's writers was probably that if one sets it to `std::launch::async | std::launch::deferred`, that the task is run in a thread pool, but this is not *mandated*. At least as of 2021, GCC doesn't do that: It just runs it on a new thread. If one chooses `std::launch::deferred`, it runs the task on the same thread but only once one calls `join()` on the task's `std::future` object. In the former case, this leads to oversubscription, in the latter case to undersubscription of resources.

All in all, the situation is undesirable: We really want to use a thread pool, and the only one we currently have available is the one from the TBB.

So: This patch brings back the TBB for this job. Compared to the code removed in #10389, the code here is vastly simpler because the TBB has learned to support modern C++ like lambda functions. I suspect that a very similar piece of code will also be necessary if we go with TaskFlow, so the effort is probably not wasted.

There are a couple of wrinkles I had to work around:
* Spawning tasks requires an "arena", so I had to export one from `MultithreadInfo`.
* The TBB does accept lambda functions, but not `mutable` lambda functions. This required a lengthy comment and an otherwise unnecessary pointer use.

/rebuild