### PR TITLE
Skip a bunch of work for tests that we don't actually want.

### DIFF
--- a/cmake/macros/macro_deal_ii_pickup_tests.cmake
+++ b/cmake/macros/macro_deal_ii_pickup_tests.cmake
@@ -256,6 +256,7 @@ MACRO(DEAL_II_PICKUP_TESTS)
           # given test
           #
           SET(_skip_test TRUE)
+          CONTINUE() # drop out of "FOREACH(_match ${_matches})"
         ENDIF()
       ENDIF()
 
@@ -275,11 +276,8 @@ Comparison operator \"=\" expected for boolean match.\n"
         IF( (${_variable} AND NOT ${_boolean}) OR
             (NOT ${_variable} AND ${_boolean}) )
           SET(_skip_test TRUE)
+          CONTINUE() # drop out of "FOREACH(_match ${_matches})"
         ENDIF()
-      ENDIF()
-
-      IF(_skip_test)
-        CONTINUE()   # next test
       ENDIF()
 
       #
@@ -298,10 +296,15 @@ Comparison operator \"=\" expected for boolean match.\n"
               "${DEAL_II_${_feature}_VERSION}" VERSION_LESS "${_version}" ) OR
             ( "${_operator}" STREQUAL ".leq." AND
               "${DEAL_II_${_feature}_VERSION}" VERSION_GREATER "${_version}" ) )
-          CONTINUE()   # next test
+          SET(_skip_test TRUE)
+          CONTINUE() # drop out of "FOREACH(_match ${_matches})"
         ENDIF()
       ENDIF()
     ENDFOREACH()
+
+    IF(_skip_test)
+      CONTINUE() # next test
+    ENDIF()
 
     #
     # We've made it all the way to here, which means that we actually


### PR DESCRIPTION
When setting `TEST_PICKUP_REGEX`, the path through the macro that is used to construct the list of tests iterates over all tests, checks the regex, checks a bunch of other things, and at the very end decides whether we actually want that test. That is a lot of work if a test doesn't match the regex -- what we should really be doing in that case is a quick exit: just check the next test.

This patch implements that: Instead of setting a flag about whether the test should be defined or not and then keep going with more work, we just call cmake's `CONTINUE` and skip to the next test.

There are two problems:
* `CONTINUE` requires cmake 3.2, but we currently only require 3.1. That might be an acceptable thing to require these days.
* This patch doesn't actually work and instead produces a lot of CMake warnings of the kind
```
CMake Error at /home/fac/g/bangerth/p/deal.II/1/build-strange/share/deal.II/macros/macro_deal_ii_add_test.cmake:351 (ADD_TEST):
  ADD_TEST given test NAME "multigrid/transfer_04b.mpirun=2.release" which
  already exists in this directory.
Call Stack (most recent call first):
  /home/fac/g/bangerth/p/deal.II/1/build-strange/share/deal.II/macros/macro_deal_ii_pickup_tests.cmake:311 (DEAL_II_ADD_TEST)
  CMakeLists.txt:4 (DEAL_II_PICKUP_TESTS)
```
I fail to see where that is from -- some other eyes might be quite useful. I thought I'd post the patch anyway to get the idea out there.

@tamiko?