### PR TITLE
CI: replace windows-2016 by windows-2022

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2016]
+        os: [windows-2019, windows-2022]
 
     steps:
     - uses: actions/checkout@v2
@@ -41,7 +41,6 @@ jobs:
         cd c:/project
         7z a dealii-windows.zip *
     - name: test library
-      if: matrix.os != 'windows-2016' #TODO: For windows-2016 this step does not terminate (12.12.2020)
       shell: bash
       run: |
         cmake --build build  --target test -- -m


### PR DESCRIPTION
The 2016 environment will be removed March 2022 and will have blackout
on dec 1 (today). Replace with 2022.

https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/