### PR TITLE
Adjust assert in Physics::VectorRelations.

### DIFF
--- a/include/deal.II/physics/vector_relations.h
+++ b/include/deal.II/physics/vector_relations.h
@@ -121,8 +121,8 @@ Physics::VectorRelations::signed_angle(const Tensor<1, spacedim, Number> &a,
 
   Assert(std::abs(axis.norm() - 1.) < 1.e-12,
          ExcMessage("The axial vector is not a unit vector."));
-  Assert(std::abs(axis * a) < 1.e-12 * b.norm() &&
-           std::abs(axis * b) < 1.e-12 * a.norm(),
+  Assert(std::abs(axis * a) < 1.e-12 * a.norm() &&
+           std::abs(axis * b) < 1.e-12 * b.norm(),
          ExcMessage("The vectors are not perpendicular to the axial vector."));
 
   const Number dot = a * b;


### PR DESCRIPTION
@bangerth -- We talked about this today. For checking orthogonality, we should multiply with the norms of the vectors with which we calculate the dot product. The axis vector has length 1 (checked above), so we can omit that part.