### PR TITLE
p::f::T: allow repartitioning

### DIFF
--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -19,6 +19,7 @@
 
 #include <deal.II/base/config.h>
 
+#include <deal.II/distributed/repartitioning_policy_tools.h>
 #include <deal.II/distributed/tria_base.h>
 
 #include <deal.II/grid/grid_tools.h>
@@ -38,12 +39,6 @@ namespace GridTools
 {
   template <typename CellIterator>
   struct PeriodicFacePair;
-}
-
-namespace RepartitioningPolicyTools
-{
-  template <int dim, int spacedim>
-  class Base;
 }
 #endif
 
@@ -203,7 +198,8 @@ namespace parallel
         const TriangulationDescription::Settings &     settings);
 
       /**
-       * TODO
+       * Register a partitioner, which is used within the method
+       * repartition().
        */
       void
       set_partitioner(
@@ -211,7 +207,8 @@ namespace parallel
         const TriangulationDescription::Settings &            settings);
 
       /**
-       * TODO
+       * Execute repartitioning and use the partitioner attached by the
+       * method set_partitioner();
        */
       void
       repartition();
@@ -322,7 +319,7 @@ namespace parallel
         partitioner;
 
       /**
-       * TODO
+       * Partitioner used during repartition().
        */
       SmartPointer<const RepartitioningPolicyTools::Base<dim, spacedim>>
         partitioner_distributed;

--- a/include/deal.II/distributed/fully_distributed_tria.h
+++ b/include/deal.II/distributed/fully_distributed_tria.h
@@ -39,6 +39,12 @@ namespace GridTools
   template <typename CellIterator>
   struct PeriodicFacePair;
 }
+
+namespace RepartitioningPolicyTools
+{
+  template <int dim, int spacedim>
+  class Base;
+}
 #endif
 
 namespace parallel
@@ -197,6 +203,20 @@ namespace parallel
         const TriangulationDescription::Settings &     settings);
 
       /**
+       * TODO
+       */
+      void
+      set_partitioner(
+        const RepartitioningPolicyTools::Base<dim, spacedim> &partitioner,
+        const TriangulationDescription::Settings &            settings);
+
+      /**
+       * TODO
+       */
+      void
+      repartition();
+
+      /**
        * Coarsen and refine the mesh according to refinement and coarsening
        * flags set.
        *
@@ -300,6 +320,12 @@ namespace parallel
       std::function<void(dealii::Triangulation<dim, spacedim> &,
                          const unsigned int)>
         partitioner;
+
+      /**
+       * TODO
+       */
+      SmartPointer<const RepartitioningPolicyTools::Base<dim, spacedim>>
+        partitioner_distributed;
 
       /**
        * Sorted list of pairs of coarse-cell ids and their indices.

--- a/include/deal.II/distributed/repartitioning_policy_tools.h
+++ b/include/deal.II/distributed/repartitioning_policy_tools.h
@@ -46,7 +46,7 @@ namespace RepartitioningPolicyTools
    * See the description of RepartitioningPolicyTools for more information.
    */
   template <int dim, int spacedim = dim>
-  class Base
+  class Base : public Subscriptor
   {
   public:
     /**

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -335,6 +335,10 @@ namespace parallel
           this->partitioner_distributed->partition(*this),
           this->settings);
 
+      this->clear();
+      this->coarse_cell_id_to_coarse_cell_index_vector.clear();
+      this->coarse_cell_index_to_coarse_cell_id_vector.clear();
+
       this->create_triangulation(construction_data);
 
       this->signals.post_distributed_repartition();

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -18,6 +18,7 @@
 #include <deal.II/base/mpi.h>
 
 #include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/repartitioning_policy_tools.h>
 
 #include <deal.II/grid/grid_tools.h>
 
@@ -306,6 +307,37 @@ namespace parallel
     {
       this->partitioner = partitioner;
       this->settings    = settings;
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::set_partitioner(
+      const RepartitioningPolicyTools::Base<dim, spacedim> &partitioner,
+      const TriangulationDescription::Settings &            settings)
+    {
+      this->partitioner_distributed = &partitioner;
+      this->settings                = settings;
+    }
+
+
+
+    template <int dim, int spacedim>
+    void
+    Triangulation<dim, spacedim>::repartition()
+    {
+      this->signals.pre_distributed_repartition();
+
+      const auto construction_data = TriangulationDescription::Utilities::
+        create_description_from_triangulation(
+          *this,
+          this->partitioner_distributed->partition(*this),
+          this->settings);
+
+      this->create_triangulation(construction_data);
+
+      this->signals.post_distributed_repartition();
     }
 
 

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -327,20 +327,25 @@ namespace parallel
     void
     Triangulation<dim, spacedim>::repartition()
     {
+      // signal that repartitioning has started
       this->signals.pre_distributed_repartition();
 
+      // create construction_data with the help of the partitioner
       const auto construction_data = TriangulationDescription::Utilities::
         create_description_from_triangulation(
           *this,
           this->partitioner_distributed->partition(*this),
           this->settings);
 
+      // clear old content
       this->clear();
       this->coarse_cell_id_to_coarse_cell_index_vector.clear();
       this->coarse_cell_index_to_coarse_cell_id_vector.clear();
 
+      // use construction_data to set up new triangulation
       this->create_triangulation(construction_data);
 
+      // signal that repartitioning has completed
       this->signals.post_distributed_repartition();
     }
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -11871,11 +11871,8 @@ Triangulation<dim, spacedim>::create_triangulation(
 
           // boundary ids
           for (auto pair : cell_info->boundary_ids)
-            {
-              Assert(cell->at_boundary(pair.first),
-                     ExcMessage("Cell face is not on the boundary!"));
+            if (cell->face(pair.first)->at_boundary())
               cell->face(pair.first)->set_boundary_id(pair.second);
-            }
         }
     }
 }

--- a/source/grid/tria_description.cc
+++ b/source/grid/tria_description.cc
@@ -17,6 +17,7 @@
 #include <deal.II/base/mpi.h>
 #include <deal.II/base/mpi_consensus_algorithms.h>
 
+#include <deal.II/distributed/fully_distributed_tria.h>
 #include <deal.II/distributed/tria.h>
 
 #include <deal.II/dofs/dof_accessor.h>
@@ -109,7 +110,8 @@ namespace TriangulationDescription
         collect(
           const std::vector<unsigned int> &                  relevant_processes,
           const std::vector<DescriptionTemp<dim, spacedim>> &description_temp,
-          const MPI_Comm &                                   comm)
+          const MPI_Comm &                                   comm,
+          const bool vertices_have_unique_ids)
         {
           dealii::Utilities::MPI::ConsensusAlgorithms::AnonymousProcess<char,
                                                                         char>
@@ -135,7 +137,8 @@ namespace TriangulationDescription
                   std::vector<char> &) {
                 this->merge(
                   dealii::Utilities::unpack<DescriptionTemp<dim, spacedim>>(
-                    recv_buffer, false));
+                    recv_buffer, false),
+                  vertices_have_unique_ids);
               });
 
           dealii::Utilities::MPI::ConsensusAlgorithms::Selector<char, char>(
@@ -149,17 +152,66 @@ namespace TriangulationDescription
          * This done by the reduce() function.
          */
         void
-        merge(const DescriptionTemp<dim, spacedim> &other)
+        merge(const DescriptionTemp<dim, spacedim> &other,
+              const bool                            vertices_have_unique_ids)
         {
           this->cell_infos.resize(
             std::max(other.cell_infos.size(), this->cell_infos.size()));
 
-          this->coarse_cells.insert(this->coarse_cells.end(),
-                                    other.coarse_cells.begin(),
-                                    other.coarse_cells.end());
-          this->coarse_cell_vertices.insert(this->coarse_cell_vertices.end(),
-                                            other.coarse_cell_vertices.begin(),
-                                            other.coarse_cell_vertices.end());
+          if (vertices_have_unique_ids == false)
+            {
+              const auto comp = [](const auto &a, const auto &b) {
+                const double tolerance = 1e-10;
+
+                if (a.distance(b) < tolerance)
+                  return false;
+
+                for (unsigned int i = 0; i < spacedim; ++i)
+                  if (std::abs(a[i] - b[i]) > tolerance)
+                    return a[i] < b[i];
+
+                return false;
+              };
+
+              std::map<Point<spacedim>, unsigned int, decltype(comp)> map(comp);
+              std::map<unsigned int, unsigned int>                    map_i;
+
+              for (unsigned int i = 0; i < this->coarse_cell_vertices.size();
+                   ++i)
+                map[coarse_cell_vertices[i].second] = i;
+
+              unsigned int counter = coarse_cell_vertices.size();
+
+              for (const auto p : other.coarse_cell_vertices)
+                if (map.find(p.second) == map.end())
+                  {
+                    this->coarse_cell_vertices.emplace_back(counter, p.second);
+                    map[p.second] = map_i[p.first] = counter++;
+                  }
+                else
+                  map_i[p.first] = map[p.second];
+
+              for (auto cell : other.coarse_cells)
+                {
+                  for (auto &v : cell.vertices)
+                    v = map_i[v];
+                }
+
+              this->coarse_cells.insert(this->coarse_cells.end(),
+                                        other.coarse_cells.begin(),
+                                        other.coarse_cells.end());
+            }
+          else
+            {
+              this->coarse_cells.insert(this->coarse_cells.end(),
+                                        other.coarse_cells.begin(),
+                                        other.coarse_cells.end());
+              this->coarse_cell_vertices.insert(
+                this->coarse_cell_vertices.end(),
+                other.coarse_cell_vertices.begin(),
+                other.coarse_cell_vertices.end());
+            }
+
           this->coarse_cell_index_to_coarse_cell_id.insert(
             this->coarse_cell_index_to_coarse_cell_id.end(),
             other.coarse_cell_index_to_coarse_cell_id.begin(),
@@ -1025,9 +1077,13 @@ namespace TriangulationDescription
       // collect description from all processes that used to own locally-owned
       // active cells of this process in a single description
       DescriptionTemp<dim, spacedim> description_merged;
-      description_merged.collect(relevant_processes,
-                                 descriptions_per_rank,
-                                 partition.get_mpi_communicator());
+      description_merged.collect(
+        relevant_processes,
+        descriptions_per_rank,
+        partition.get_mpi_communicator(),
+        dynamic_cast<
+          const parallel::fullydistributed::Triangulation<dim, spacedim> *>(
+          &tria) != nullptr);
 
       // remove redundant entries
       description_merged.reduce();

--- a/tests/fullydistributed_grids/repartitioning_08.cc
+++ b/tests/fullydistributed_grids/repartitioning_08.cc
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Test
+// TriangulationDescription::Utilities::create_description_from_triangulation()
+// with repartitioning capabilities.
+
+#include <deal.II/base/mpi_consensus_algorithms.h>
+
+#include <deal.II/distributed/fully_distributed_tria.h>
+#include <deal.II/distributed/repartitioning_policy_tools.h>
+#include <deal.II/distributed/tria.h>
+
+#include <deal.II/fe/fe_q.h>
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/grid_tools.h>
+#include <deal.II/grid/tria_description.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/data_out.h>
+
+#include "./tests.h"
+
+using namespace dealii;
+
+
+template <int dim, int spacedim = dim>
+class MyPolicy : public RepartitioningPolicyTools::Base<dim, spacedim>
+{
+public:
+  MyPolicy(const MPI_Comm &comm, const unsigned int direction)
+    : comm(comm)
+    , direction(direction)
+  {}
+
+  virtual LinearAlgebra::distributed::Vector<double>
+  partition(const Triangulation<dim, spacedim> &tria_in) const override
+  {
+    const auto tria =
+      dynamic_cast<const parallel::TriangulationBase<dim, spacedim> *>(
+        &tria_in);
+
+    Assert(tria, ExcNotImplemented());
+
+    LinearAlgebra::distributed::Vector<double> partition(
+      tria->global_active_cell_index_partitioner().lock());
+
+    const unsigned int n_partitions = Utilities::MPI::n_mpi_processes(comm);
+
+    for (const auto &cell :
+         tria_in.active_cell_iterators() | IteratorFilters::LocallyOwnedCell())
+      partition[cell->global_active_cell_index()] =
+        std::floor(cell->center()[direction] * n_partitions);
+
+    partition.update_ghost_values();
+
+    return partition;
+  }
+
+private:
+  const MPI_Comm &   comm;
+  const unsigned int direction;
+};
+
+
+template <int dim>
+void
+test(const MPI_Comm comm)
+{
+  parallel::distributed::Triangulation<dim> tria(
+    comm,
+    Triangulation<dim>::none,
+    parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy);
+  GridGenerator::subdivided_hyper_cube(tria, 4);
+  tria.refine_global(2);
+
+  MyPolicy<dim> policy_0(comm, 0);
+  MyPolicy<dim> policy_1(comm, 1);
+
+  const auto partition_0 = policy_0.partition(tria);
+
+  const auto settings =
+    TriangulationDescription::Settings::construct_multigrid_hierarchy;
+
+  // repartition triangulation so that it has strided partitioning
+  const auto construction_data =
+    TriangulationDescription::Utilities::create_description_from_triangulation(
+      tria, partition_0, settings);
+
+  parallel::fullydistributed::Triangulation<dim> tria_pft(comm);
+  tria_pft.create_triangulation(construction_data);
+
+  {
+    FE_Q<dim>       fe(2);
+    DoFHandler<dim> dof_handler(tria_pft);
+    dof_handler.distribute_dofs(fe);
+    dof_handler.distribute_mg_dofs();
+
+    // print statistics
+    print_statistics(tria_pft);
+    print_statistics(dof_handler);
+  }
+
+  GridOut go;
+  go.write_mesh_per_processor_as_vtu(tria_pft, "mesh_old");
+
+  tria_pft.set_partitioner(policy_1, settings);
+
+  tria_pft.repartition();
+
+  go.write_mesh_per_processor_as_vtu(tria_pft, "mesh_new");
+
+  {
+    FE_Q<dim>       fe(2);
+    DoFHandler<dim> dof_handler(tria_pft);
+    dof_handler.distribute_dofs(fe);
+    dof_handler.distribute_mg_dofs();
+
+    // print statistics
+    print_statistics(tria_pft);
+    print_statistics(dof_handler);
+  }
+}
+
+
+
+int
+main(int argc, char **argv)
+{
+  Utilities::MPI::MPI_InitFinalize mpi(argc, argv, 1);
+  MPILogInitAll                    all;
+
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  test<2>(comm);
+  deallog.pop();
+}

--- a/tests/fullydistributed_grids/repartitioning_08.with_p4est=true.mpirun=4.output
+++ b/tests/fullydistributed_grids/repartitioning_08.with_p4est=true.mpirun=4.output
@@ -1,0 +1,63 @@
+
+DEAL:0::n_levels:                  3
+DEAL:0::n_cells:                   136
+DEAL:0::n_active_cells:            104
+DEAL:0::
+DEAL:0::n_dofs:                             1089
+DEAL:0::n_locally_owned_dofs:               297
+DEAL:0::
+DEAL:0::n_levels:                  3
+DEAL:0::n_cells:                   136
+DEAL:0::n_active_cells:            104
+DEAL:0::
+DEAL:0::n_dofs:                             1089
+DEAL:0::n_locally_owned_dofs:               297
+DEAL:0::
+
+DEAL:1::n_levels:                  3
+DEAL:1::n_cells:                   188
+DEAL:1::n_active_cells:            144
+DEAL:1::
+DEAL:1::n_dofs:                             1089
+DEAL:1::n_locally_owned_dofs:               264
+DEAL:1::
+DEAL:1::n_levels:                  3
+DEAL:1::n_cells:                   188
+DEAL:1::n_active_cells:            144
+DEAL:1::
+DEAL:1::n_dofs:                             1089
+DEAL:1::n_locally_owned_dofs:               264
+DEAL:1::
+
+
+DEAL:2::n_levels:                  3
+DEAL:2::n_cells:                   188
+DEAL:2::n_active_cells:            144
+DEAL:2::
+DEAL:2::n_dofs:                             1089
+DEAL:2::n_locally_owned_dofs:               264
+DEAL:2::
+DEAL:2::n_levels:                  3
+DEAL:2::n_cells:                   188
+DEAL:2::n_active_cells:            144
+DEAL:2::
+DEAL:2::n_dofs:                             1089
+DEAL:2::n_locally_owned_dofs:               264
+DEAL:2::
+
+
+DEAL:3::n_levels:                  3
+DEAL:3::n_cells:                   136
+DEAL:3::n_active_cells:            104
+DEAL:3::
+DEAL:3::n_dofs:                             1089
+DEAL:3::n_locally_owned_dofs:               264
+DEAL:3::
+DEAL:3::n_levels:                  3
+DEAL:3::n_cells:                   136
+DEAL:3::n_active_cells:            104
+DEAL:3::
+DEAL:3::n_dofs:                             1089
+DEAL:3::n_locally_owned_dofs:               264
+DEAL:3::
+


### PR DESCRIPTION
This PR allows to reparation p::f::T with the help of `RepartitioningPolicyTools`.

To allow AMR for p::f::T, one needs to revive https://github.com/dealii/dealii/pull/8834. Also a `RepartitioningPolicyTools` class that wraps `Parmetis` would be nice! Anyone interested in doing that?

FYI @elauksap @drwells 