### PR TITLE
TBB: Use void* instead of void*&

### DIFF
--- a/include/deal.II/base/work_stream.h
+++ b/include/deal.II/base/work_stream.h
@@ -488,7 +488,7 @@ namespace WorkStream
          * Work on an item.
          */
         void *
-        operator()(void *&item) const
+        operator()(void *item) const
         {
           // first unpack the current item
           using ItemType =
@@ -632,7 +632,7 @@ namespace WorkStream
          * Work on a single item.
          */
         void *
-        operator()(void *&item) const
+        operator()(void *item) const
         {
           // first unpack the current item
           using ItemType =


### PR DESCRIPTION
TBB version 2020.3 requires a plain void* for the two operators instead
of void*&. Also tested with bundled TBB

In reference to #13031