### PR TITLE
Fixed bug in SparseDirectUMFPACK #12916

### DIFF
--- a/source/lac/sparse_direct.cc
+++ b/source/lac/sparse_direct.cc
@@ -199,7 +199,7 @@ SparseDirectUMFPACK::sort_arrays(const BlockSparseMatrix<number> &matrix)
 
               std::swap(Ax[element], Ax[element + 1]);
               if (numbers::NumberTraits<number>::is_complex == true)
-                std::swap(Az[cursor], Az[cursor + 1]);
+                std::swap(Az[element], Az[element + 1]);
 
               ++element;
             }


### PR DESCRIPTION
Fixed a bug in line 202 of sources/lac/sparse_direct.cc. The indexing variable should be element and not cursor.