### PR TITLE
CMake: set the taskflow feature default to disabled

### DIFF
--- a/cmake/configure/configure_1_taskflow.cmake
+++ b/cmake/configure/configure_1_taskflow.cmake
@@ -18,6 +18,11 @@
 # library:
 #
 
+#
+# Disallow the default detection of taskflow for the time being to avoid
+# unpleasant surprises on user side.
+#
+SET(DEAL_II_WITH_TASKFLOW OFF CACHE BOOL "")
 
 MACRO(FEATURE_TASKFLOW_FIND_EXTERNAL var)
   FIND_PACKAGE(TASKFLOW)


### PR DESCRIPTION
Let us (default) disable taskflow for the time being to avoid
unnecessary surprises on user side. For example, with taskflow and tbb
enabled both libraries will create and maintain an independent
threadpool which leads to unpleasant surprises when the number of
threads is limited or when trying to pin threads to specific cpus