### PR TITLE
Simplify calls to FEEvaluation kernels

### DIFF
--- a/examples/step-76/step-76.cc
+++ b/examples/step-76/step-76.cc
@@ -790,11 +790,10 @@ namespace Euler_DG
                                                      VectorizedArrayType>::
                   template interpolate_quadrature<true, false>(
                     dim + 2,
+                    EvaluationFlags::values,
                     data.get_shape_info(),
                     buffer.data(),
                     phi_m.begin_values(),
-                    false,
-                    false,
                     face);
 
                 // Check if the face is an internal or a boundary face and
@@ -893,11 +892,10 @@ namespace Euler_DG
                                                      VectorizedArrayType>::
                   template interpolate_quadrature<false, true>(
                     dim + 2,
+                    EvaluationFlags::values,
                     data.get_shape_info(),
                     phi_m.begin_values(),
                     phi.begin_values(),
-                    false,
-                    false,
                     face);
               }
 

--- a/include/deal.II/fe/mapping_q.h
+++ b/include/deal.II/fe/mapping_q.h
@@ -507,30 +507,6 @@ public:
     mutable AlignedVector<VectorizedArrayType> scratch;
 
     /**
-     * In case the quadrature rule given represents a tensor product
-     * the values at the mapped support points are stored in this object.
-     */
-    mutable AlignedVector<VectorizedArrayType> values_dofs;
-
-    /**
-     * In case the quadrature rule given represents a tensor product
-     * the values at the quadrature points are stored in this object.
-     */
-    mutable AlignedVector<VectorizedArrayType> values_quad;
-
-    /**
-     * In case the quadrature rule given represents a tensor product
-     * the gradients at the quadrature points are stored in this object.
-     */
-    mutable AlignedVector<VectorizedArrayType> gradients_quad;
-
-    /**
-     * In case the quadrature rule given represents a tensor product
-     * the hessians at the quadrature points are stored in this object.
-     */
-    mutable AlignedVector<VectorizedArrayType> hessians_quad;
-
-    /**
      * Indicates whether the given Quadrature object is a tensor product.
      */
     bool tensor_product_quadrature;

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1136,7 +1136,7 @@ namespace internal
       temp_data.descriptor.resize(1);
       temp_data.descriptor[0].n_q_points = n_q_points;
       FEEvaluationBaseData<dim, double, false, VectorizedArrayType> eval(
-        {&data.shape_info, nullptr, &temp_data, 0, 0}, 0, false, 0);
+        {&data.shape_info, nullptr, &temp_data, 0, 0});
 
       // prepare arrays
       if (evaluation_flag != EvaluationFlags::nothing)

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1130,13 +1130,7 @@ namespace internal
           return;
         }
 
-      internal::MatrixFreeFunctions::
-        MappingInfoStorage<dim, dim, VectorizedArrayType>
-          temp_data;
-      temp_data.descriptor.resize(1);
-      temp_data.descriptor[0].n_q_points = n_q_points;
-      FEEvaluationData<dim, VectorizedArrayType, false> eval(
-        std::make_tuple(&data.shape_info, nullptr, &temp_data, 0, 0));
+      FEEvaluationData<dim, VectorizedArrayType, false> eval(data.shape_info);
 
       // prepare arrays
       if (evaluation_flag != EvaluationFlags::nothing)

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -35,7 +35,7 @@
 
 #include <deal.II/matrix_free/evaluation_flags.h>
 #include <deal.II/matrix_free/evaluation_template_factory.h>
-#include <deal.II/matrix_free/fe_evaluation_base_data.h>
+#include <deal.II/matrix_free/fe_evaluation_data.h>
 #include <deal.II/matrix_free/mapping_info_storage.h>
 #include <deal.II/matrix_free/shape_info.h>
 #include <deal.II/matrix_free/tensor_product_kernels.h>
@@ -1131,11 +1131,11 @@ namespace internal
         }
 
       internal::MatrixFreeFunctions::
-        MappingInfoStorage<dim, dim, double, VectorizedArrayType>
+        MappingInfoStorage<dim, dim, VectorizedArrayType>
           temp_data;
       temp_data.descriptor.resize(1);
       temp_data.descriptor[0].n_q_points = n_q_points;
-      FEEvaluationBaseData<dim, double, false, VectorizedArrayType> eval(
+      FEEvaluationData<dim, VectorizedArrayType, false> eval(
         {&data.shape_info, nullptr, &temp_data, 0, 0});
 
       // prepare arrays
@@ -1156,8 +1156,8 @@ namespace internal
               }
 
           // do the actual tensorized evaluation
-          internal::FEEvaluationFactory<dim, double, VectorizedArrayType>::
-            evaluate(n_comp, evaluation_flag, eval.begin_dof_values(), eval);
+          internal::FEEvaluationFactory<dim, VectorizedArrayType>::evaluate(
+            n_comp, evaluation_flag, eval.begin_dof_values(), eval);
         }
 
       // do the postprocessing

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1143,6 +1143,11 @@ namespace internal
         {
           eval.set_data_pointers(&data.scratch, n_comp);
 
+          // make sure to initialize on all lanes also when some are unused in
+          // the code below
+          for (unsigned int i = 0; i < n_shape_values * n_comp; ++i)
+            eval.begin_dof_values()[i] = VectorizedArrayType();
+
           const std::vector<unsigned int> &renumber_to_lexicographic =
             data.shape_info.lexicographic_numbering;
           for (unsigned int i = 0; i < n_shape_values; ++i)

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1136,7 +1136,7 @@ namespace internal
       temp_data.descriptor.resize(1);
       temp_data.descriptor[0].n_q_points = n_q_points;
       FEEvaluationData<dim, VectorizedArrayType, false> eval(
-        {&data.shape_info, nullptr, &temp_data, 0, 0});
+        std::make_tuple(&data.shape_info, nullptr, &temp_data, 0, 0));
 
       // prepare arrays
       if (evaluation_flag != EvaluationFlags::nothing)

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2083,7 +2083,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if (evaluation_flag == EvaluationFlags::values)
+      if (evaluation_flag & EvaluationFlags::values &&
+          !(evaluation_flag & EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2283,7 +2284,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if (integration_flag == EvaluationFlags::values)
+      if (integration_flag & EvaluationFlags::values &&
+          !(integration_flag & EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -135,7 +135,7 @@ namespace internal
 
     static Eval
     create_evaluator_tensor_product(
-      const internal::MatrixFreeFunctions::UnivariateShapeData<Number>
+      const MatrixFreeFunctions::UnivariateShapeData<Number>
         *univariate_shape_data)
     {
       if (variant == evaluate_evenodd)
@@ -1771,7 +1771,7 @@ namespace internal
         FEEvaluationData<dim, Number, false> & eval)
     {
       const auto element_type = eval.get_shape_info().element_type;
-      using ElementType       = internal::MatrixFreeFunctions::ElementType;
+      using ElementType       = MatrixFreeFunctions::ElementType;
 
       Assert(eval.get_shape_info().data.size() == 1 ||
                (eval.get_shape_info().data.size() == dim &&
@@ -1781,8 +1781,8 @@ namespace internal
       if (fe_degree >= 0 && fe_degree + 1 == n_q_points_1d &&
           element_type == ElementType::tensor_symmetric_collocation)
         {
-          internal::FEEvaluationImplCollocation<dim, fe_degree, Number>::
-            evaluate(n_components, evaluation_flag, values_dofs, eval);
+          FEEvaluationImplCollocation<dim, fe_degree, Number>::evaluate(
+            n_components, evaluation_flag, values_dofs, eval);
         }
       // '<=' on type means tensor_symmetric or tensor_symmetric_hermite, see
       // shape_info.h for more details
@@ -1790,7 +1790,7 @@ namespace internal
                use_collocation_evaluation(fe_degree, n_q_points_1d) &&
                element_type <= ElementType::tensor_symmetric)
         {
-          internal::FEEvaluationImplTransformToCollocation<
+          FEEvaluationImplTransformToCollocation<
             dim,
             fe_degree,
             n_q_points_1d,
@@ -1798,58 +1798,58 @@ namespace internal
         }
       else if (fe_degree >= 0 && element_type <= ElementType::tensor_symmetric)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_symmetric,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::evaluate(n_components,
-                                                       evaluation_flag,
-                                                       values_dofs,
-                                                       eval);
+          FEEvaluationImpl<ElementType::tensor_symmetric,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::evaluate(n_components,
+                                             evaluation_flag,
+                                             values_dofs,
+                                             eval);
         }
       else if (element_type == ElementType::tensor_symmetric_plus_dg0)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_symmetric_plus_dg0,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::evaluate(n_components,
-                                                       evaluation_flag,
-                                                       values_dofs,
-                                                       eval);
+          FEEvaluationImpl<ElementType::tensor_symmetric_plus_dg0,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::evaluate(n_components,
+                                             evaluation_flag,
+                                             values_dofs,
+                                             eval);
         }
       else if (element_type == ElementType::truncated_tensor)
         {
-          internal::FEEvaluationImpl<ElementType::truncated_tensor,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::evaluate(n_components,
-                                                       evaluation_flag,
-                                                       values_dofs,
-                                                       eval);
+          FEEvaluationImpl<ElementType::truncated_tensor,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::evaluate(n_components,
+                                             evaluation_flag,
+                                             values_dofs,
+                                             eval);
         }
       else if (element_type == ElementType::tensor_none)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_none,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::evaluate(n_components,
-                                                       evaluation_flag,
-                                                       values_dofs,
-                                                       eval);
+          FEEvaluationImpl<ElementType::tensor_none,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::evaluate(n_components,
+                                             evaluation_flag,
+                                             values_dofs,
+                                             eval);
         }
       else
         {
-          internal::FEEvaluationImpl<ElementType::tensor_general,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::evaluate(n_components,
-                                                       evaluation_flag,
-                                                       values_dofs,
-                                                       eval);
+          FEEvaluationImpl<ElementType::tensor_general,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::evaluate(n_components,
+                                             evaluation_flag,
+                                             values_dofs,
+                                             eval);
         }
 
       return false;
@@ -1885,7 +1885,7 @@ namespace internal
         const bool                             sum_into_values_array)
     {
       const auto element_type = eval.get_shape_info().element_type;
-      using ElementType       = internal::MatrixFreeFunctions::ElementType;
+      using ElementType       = MatrixFreeFunctions::ElementType;
 
       Assert(eval.get_shape_info().data.size() == 1 ||
                (eval.get_shape_info().data.size() == dim &&
@@ -1895,12 +1895,12 @@ namespace internal
       if (fe_degree >= 0 && fe_degree + 1 == n_q_points_1d &&
           element_type == ElementType::tensor_symmetric_collocation)
         {
-          internal::FEEvaluationImplCollocation<dim, fe_degree, Number>::
-            integrate(n_components,
-                      integration_flag,
-                      values_dofs,
-                      eval,
-                      sum_into_values_array);
+          FEEvaluationImplCollocation<dim, fe_degree, Number>::integrate(
+            n_components,
+            integration_flag,
+            values_dofs,
+            eval,
+            sum_into_values_array);
         }
       // '<=' on type means tensor_symmetric or tensor_symmetric_hermite, see
       // shape_info.h for more details
@@ -1908,7 +1908,7 @@ namespace internal
                use_collocation_evaluation(fe_degree, n_q_points_1d) &&
                element_type <= ElementType::tensor_symmetric)
         {
-          internal::FEEvaluationImplTransformToCollocation<
+          FEEvaluationImplTransformToCollocation<
             dim,
             fe_degree,
             n_q_points_1d,
@@ -1920,63 +1920,63 @@ namespace internal
         }
       else if (fe_degree >= 0 && element_type <= ElementType::tensor_symmetric)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_symmetric,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::integrate(n_components,
-                                                        integration_flag,
-                                                        values_dofs,
-                                                        eval,
-                                                        sum_into_values_array);
+          FEEvaluationImpl<ElementType::tensor_symmetric,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::integrate(n_components,
+                                              integration_flag,
+                                              values_dofs,
+                                              eval,
+                                              sum_into_values_array);
         }
       else if (element_type == ElementType::tensor_symmetric_plus_dg0)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_symmetric_plus_dg0,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::integrate(n_components,
-                                                        integration_flag,
-                                                        values_dofs,
-                                                        eval,
-                                                        sum_into_values_array);
+          FEEvaluationImpl<ElementType::tensor_symmetric_plus_dg0,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::integrate(n_components,
+                                              integration_flag,
+                                              values_dofs,
+                                              eval,
+                                              sum_into_values_array);
         }
       else if (element_type == ElementType::truncated_tensor)
         {
-          internal::FEEvaluationImpl<ElementType::truncated_tensor,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::integrate(n_components,
-                                                        integration_flag,
-                                                        values_dofs,
-                                                        eval,
-                                                        sum_into_values_array);
+          FEEvaluationImpl<ElementType::truncated_tensor,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::integrate(n_components,
+                                              integration_flag,
+                                              values_dofs,
+                                              eval,
+                                              sum_into_values_array);
         }
       else if (element_type == ElementType::tensor_none)
         {
-          internal::FEEvaluationImpl<ElementType::tensor_none,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::integrate(n_components,
-                                                        integration_flag,
-                                                        values_dofs,
-                                                        eval,
-                                                        sum_into_values_array);
+          FEEvaluationImpl<ElementType::tensor_none,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::integrate(n_components,
+                                              integration_flag,
+                                              values_dofs,
+                                              eval,
+                                              sum_into_values_array);
         }
       else
         {
-          internal::FEEvaluationImpl<ElementType::tensor_general,
-                                     dim,
-                                     fe_degree,
-                                     n_q_points_1d,
-                                     Number>::integrate(n_components,
-                                                        integration_flag,
-                                                        values_dofs,
-                                                        eval,
-                                                        sum_into_values_array);
+          FEEvaluationImpl<ElementType::tensor_general,
+                           dim,
+                           fe_degree,
+                           n_q_points_1d,
+                           Number>::integrate(n_components,
+                                              integration_flag,
+                                              values_dofs,
+                                              eval,
+                                              sum_into_values_array);
         }
 
       return false;
@@ -1997,19 +1997,18 @@ namespace internal
     // choice in terms of operation counts (third condition) and if we were
     // able to initialize the fields in shape_info.templates.h from the
     // polynomials (fourth condition).
-    using Eval =
-      EvaluatorTensorProduct<symmetric_evaluate ? internal::evaluate_evenodd :
-                                                  internal::evaluate_general,
-                             dim - 1,
-                             fe_degree + 1,
-                             n_q_points_1d,
-                             Number>;
+    using Eval = EvaluatorTensorProduct<symmetric_evaluate ? evaluate_evenodd :
+                                                             evaluate_general,
+                                        dim - 1,
+                                        fe_degree + 1,
+                                        n_q_points_1d,
+                                        Number>;
 
     static Eval
     create_evaluator_tensor_product(
-      const internal::MatrixFreeFunctions::UnivariateShapeData<Number> &data,
-      const unsigned int subface_index,
-      const unsigned int direction)
+      const MatrixFreeFunctions::UnivariateShapeData<Number> &data,
+      const unsigned int                                      subface_index,
+      const unsigned int                                      direction)
     {
       if (symmetric_evaluate)
         return Eval(data.shape_values_eo,
@@ -2100,12 +2099,11 @@ namespace internal
                                                             values_quad);
                       eval0.template values<1, true, false>(values_quad,
                                                             values_quad);
-                      internal::EvaluatorTensorProduct<
-                        internal::evaluate_evenodd,
-                        dim - 1,
-                        n_q_points_1d,
-                        n_q_points_1d,
-                        Number>
+                      EvaluatorTensorProduct<evaluate_evenodd,
+                                             dim - 1,
+                                             n_q_points_1d,
+                                             n_q_points_1d,
+                                             Number>
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
@@ -2305,12 +2303,11 @@ namespace internal
                   if (symmetric_evaluate &&
                       use_collocation_evaluation(fe_degree, n_q_points_1d))
                     {
-                      internal::EvaluatorTensorProduct<
-                        internal::evaluate_evenodd,
-                        dim - 1,
-                        n_q_points_1d,
-                        n_q_points_1d,
-                        Number>
+                      EvaluatorTensorProduct<evaluate_evenodd,
+                                             dim - 1,
+                                             n_q_points_1d,
+                                             n_q_points_1d,
+                                             Number>
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
@@ -2547,11 +2544,11 @@ namespace internal
     {
       if (face_direction == face_no / 2)
         {
-          internal::EvaluatorTensorProduct<internal::evaluate_general,
-                                           dim,
-                                           fe_degree + 1,
-                                           0,
-                                           Number>
+          EvaluatorTensorProduct<evaluate_general,
+                                 dim,
+                                 fe_degree + 1,
+                                 0,
+                                 Number>
             evalf(shape_data[face_no % 2],
                   AlignedVector<Number>(),
                   AlignedVector<Number>(),
@@ -2769,6 +2766,74 @@ namespace internal
                       hessians_quad[(c * hdim + d) * n_q_points + q];
                 for (unsigned int q = 0; q < n_q_points; ++q)
                   hessians_quad[(c * hdim + d) * n_q_points + q] =
+                    tmp_values[q];
+              }
+          }
+      }
+  }
+
+
+
+  template <typename Number, typename VectorizedArrayType>
+  void
+  adjust_for_face_orientation_per_lane(
+    const unsigned int                     dim,
+    const unsigned int                     n_components,
+    const unsigned int                     v,
+    const EvaluationFlags::EvaluationFlags flag,
+    const unsigned int *                   orientation,
+    const bool                             integrate,
+    const std::size_t                      n_q_points,
+    Number *                               tmp_values,
+    VectorizedArrayType *                  values_quad,
+    VectorizedArrayType *                  gradients_quad = nullptr,
+    VectorizedArrayType *                  hessians_quad  = nullptr)
+  {
+    for (unsigned int c = 0; c < n_components; ++c)
+      {
+        if (flag & EvaluationFlags::values)
+          {
+            if (integrate)
+              for (unsigned int q = 0; q < n_q_points; ++q)
+                tmp_values[q] = values_quad[c * n_q_points + orientation[q]][v];
+            else
+              for (unsigned int q = 0; q < n_q_points; ++q)
+                tmp_values[orientation[q]] = values_quad[c * n_q_points + q][v];
+            for (unsigned int q = 0; q < n_q_points; ++q)
+              values_quad[c * n_q_points + q][v] = tmp_values[q];
+          }
+        if (flag & EvaluationFlags::gradients)
+          for (unsigned int d = 0; d < dim; ++d)
+            {
+              Assert(gradients_quad != nullptr, ExcInternalError());
+              if (integrate)
+                for (unsigned int q = 0; q < n_q_points; ++q)
+                  tmp_values[q] = gradients_quad[(c * dim + d) * n_q_points +
+                                                 orientation[q]][v];
+              else
+                for (unsigned int q = 0; q < n_q_points; ++q)
+                  tmp_values[orientation[q]] =
+                    gradients_quad[(c * dim + d) * n_q_points + q][v];
+              for (unsigned int q = 0; q < n_q_points; ++q)
+                gradients_quad[(c * dim + d) * n_q_points + q][v] =
+                  tmp_values[q];
+            }
+        if (flag & EvaluationFlags::hessians)
+          {
+            Assert(hessians_quad != nullptr, ExcInternalError());
+            const unsigned int hdim = (dim * (dim + 1)) / 2;
+            for (unsigned int d = 0; d < hdim; ++d)
+              {
+                if (integrate)
+                  for (unsigned int q = 0; q < n_q_points; ++q)
+                    tmp_values[q] = hessians_quad[(c * hdim + d) * n_q_points +
+                                                  orientation[q]][v];
+                else
+                  for (unsigned int q = 0; q < n_q_points; ++q)
+                    tmp_values[orientation[q]] =
+                      hessians_quad[(c * hdim + d) * n_q_points + q][v];
+                for (unsigned int q = 0; q < n_q_points; ++q)
+                  hessians_quad[(c * hdim + d) * n_q_points + q][v] =
                     tmp_values[q];
               }
           }
@@ -3093,19 +3158,34 @@ namespace internal
     constexpr bool     integrate  = Processor::do_integrate;
     const unsigned int face_no    = eval.get_face_no();
     const auto &       dof_info   = eval.get_dof_info();
-    const unsigned int cell       = eval.get_current_cell_index();
+    const unsigned int cell       = eval.get_cell_or_face_batch_id();
     const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index =
       eval.get_dof_access_index();
+    AssertIndexRange(cell,
+                     dof_info.index_storage_variants[dof_access_index].size());
     constexpr unsigned int dofs_per_face =
       Utilities::pow(fe_degree + 1, dim - 1);
+    const unsigned int n_filled_lanes =
+      dof_info.n_vectorization_lanes_filled[dof_access_index][cell];
+
+    bool all_faces_are_same = n_filled_lanes == n_lanes;
+    if (n_face_orientations == n_lanes)
+      for (unsigned int v = 1; v < n_lanes; ++v)
+        if (eval.get_all_face_numbers()[v] != eval.get_all_face_numbers()[0] ||
+            eval.get_all_face_orientations()[v] !=
+              eval.get_all_face_orientations()[0])
+          {
+            all_faces_are_same = false;
+            break;
+          }
 
     // we know that the gradient weights for the Hermite case on the
     // right (side==1) are the negative from the value at the left
     // (side==0), so we only read out one of them.
     VectorizedArrayType grad_weight =
       shape_data
-        .shape_data_on_face[0][fe_degree + integrate ? (2 - face_no % 2) :
-                                                       (1 + face_no % 2)];
+        .shape_data_on_face[0][fe_degree + (integrate ? (2 - face_no % 2) :
+                                                        (1 + face_no % 2))];
 
     // re-orientation
     std::array<const unsigned int *, n_face_orientations> orientation = {};
@@ -3124,8 +3204,8 @@ namespace internal
           if (shape_data.nodal_at_cell_boundaries &&
               eval.get_all_face_orientations()[v] != 0)
             orientation[v] =
-              &eval
-                 .get_orientation_map()[eval.get_all_face_orientations()[v]][0];
+              &eval.get_shape_info()
+                 .face_orientations[eval.get_all_face_orientations()[v]][0];
         }
     else if (eval.get_face_orientation() != 0)
       orientation[0] =
@@ -3182,8 +3262,12 @@ namespace internal
           }
       }
 
+    const unsigned int subface_index = eval.get_subface_index();
     const auto reorientate = [&](const unsigned int v, const unsigned int i) {
-      return (dim < 3 || orientation[v] == nullptr) ? i : orientation[v][i];
+      return (dim < 3 || orientation[v] == nullptr ||
+              subface_index < GeometryInfo<dim>::max_children_per_cell) ?
+               i :
+               orientation[v][i];
     };
 
     const unsigned int *dof_indices =
@@ -3395,21 +3479,17 @@ namespace internal
           }
 
         // case 4: contiguous indices without interleaving
-        else if ((n_face_orientations > 1 ||
-                  dof_info.index_storage_variants[dof_access_index][cell] ==
-                    MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
-                      contiguous))
+        else if (n_face_orientations > 1 ||
+                 dof_info.index_storage_variants[dof_access_index][cell] ==
+                   MatrixFreeFunctions::DoFInfo::IndexStorageVariants::
+                     contiguous)
           {
             Number2_ *vector_ptr = global_vector_ptr + index_offset;
 
-            const unsigned int n_filled_lanes =
-              dof_info.n_vectorization_lanes_filled[dof_access_index][cell];
+            const bool vectorization_possible =
+              all_faces_are_same && (sm_ptr == nullptr);
 
-            const bool vectorization_possible = (n_face_orientations == 1) &&
-                                                (n_filled_lanes == n_lanes) &&
-                                                (sm_ptr != nullptr);
-
-            std::array<Number2_ *, n_lanes> vector_ptrs = {};
+            std::array<Number2_ *, n_lanes> vector_ptrs;
 
             if (vectorization_possible == false)
               {
@@ -3500,12 +3580,16 @@ namespace internal
                       if (integrate == false)
                         for (unsigned int v = n_filled_lanes; v < n_lanes; ++v)
                           {
-                            temp1[i_][v]                 = 0.0;
-                            temp1[i_ + dofs_per_face][v] = 0.0;
+                            temp1[i][v]                 = 0.0;
+                            temp1[i + dofs_per_face][v] = 0.0;
                           }
                     }
                 else
                   {
+                    if (integrate == false && n_filled_lanes < n_lanes)
+                      for (unsigned int i = 0; i < dofs_per_face; ++i)
+                        temp1[i] = temp1[i + dofs_per_face] = Number();
+
                     for (unsigned int v = 0; v < n_filled_lanes; ++v)
                       for (unsigned int i = 0; i < dofs_per_face; ++i)
                         proc.hermite_grad(
@@ -3542,16 +3626,16 @@ namespace internal
                           temp1[i_][v] = 0.0;
                     }
                 else
-                  for (unsigned int i = 0; i < dofs_per_face; ++i)
-                    {
-                      for (unsigned int v = 0; v < n_filled_lanes; ++v)
+                  {
+                    if (integrate == false && n_filled_lanes < n_lanes)
+                      for (unsigned int i = 0; i < dofs_per_face; ++i)
+                        temp1[i] = Number();
+
+                    for (unsigned int v = 0; v < n_filled_lanes; ++v)
+                      for (unsigned int i = 0; i < dofs_per_face; ++i)
                         proc.value(temp1[reorientate(v, i)][v],
                                    vector_ptrs[v][index_array_nodal[v][i]]);
-
-                      if (integrate == false)
-                        for (unsigned int v = n_filled_lanes; v < n_lanes; ++v)
-                          temp1[i][v] = 0.0;
-                    }
+                  }
               }
           }
         else
@@ -3560,6 +3644,7 @@ namespace internal
             // FEFaceEvaluationImplGatherEvaluateSelector::supports()
             Assert(false, ExcInternalError());
           }
+        temp1 += 3 * dofs_per_face;
       }
   }
 
@@ -3590,10 +3675,10 @@ namespace internal
       VectorizedArrayType *scratch_data =
         temp + 3 * n_components * dofs_per_face;
 
-      Processor<fe_degree, n_q_points_1d> p;
+      Processor<fe_degree> p;
 
       if (eval.get_dof_access_index() ==
-            internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+            MatrixFreeFunctions::DoFInfo::dof_access_cell &&
           eval.get_is_interior_face() == false)
         fe_face_evaluation_process_and_io<VectorizedArrayType::size()>(
           p, n_components, evaluation_flag, src_ptr, sm_ptr, eval, temp);
@@ -3634,16 +3719,61 @@ namespace internal
                                                  scratch_data,
                                                  subface_index);
 
+      // re-orientation for cases not possible with above algorithm
+      if (subface_index < GeometryInfo<dim>::max_children_per_cell)
+        {
+          if (eval.get_dof_access_index() ==
+                MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+              eval.get_is_interior_face() == false)
+            {
+              for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+                {
+                  // the loop breaks once an invalid_unsigned_int is hit for
+                  // all cases except the exterior faces in the ECL loop (where
+                  // some faces might be at the boundaries but others not)
+                  if (eval.get_cell_ids()[v] == numbers::invalid_unsigned_int)
+                    continue;
+
+                  if (eval.get_all_face_orientations()[v] != 0)
+                    adjust_for_face_orientation_per_lane(
+                      dim,
+                      n_components,
+                      v,
+                      evaluation_flag,
+                      &eval.get_orientation_map()
+                         [eval.get_all_face_orientations()[v]][0],
+                      false,
+                      Utilities::pow(n_q_points_1d, dim - 1),
+                      &temp[0][0],
+                      eval.begin_values(),
+                      eval.begin_gradients(),
+                      eval.begin_hessians());
+                }
+            }
+          else if (eval.get_face_orientation() != 0)
+            for (unsigned int c = 0; c < n_components; ++c)
+              adjust_for_face_orientation(
+                dim,
+                n_components,
+                evaluation_flag,
+                &eval.get_orientation_map()[eval.get_face_orientation()][0],
+                false,
+                Utilities::pow(n_q_points_1d, dim - 1),
+                temp,
+                eval.begin_values(),
+                eval.begin_gradients(),
+                eval.begin_hessians());
+        }
+
       return false;
     }
 
     static bool
     supports(
       const EvaluationFlags::EvaluationFlags evaluation_flag,
-      const internal::MatrixFreeFunctions::ShapeInfo<VectorizedArrayType>
-        &                                                          shape_info,
-      const Number *                                               vector_ptr,
-      internal::MatrixFreeFunctions::DoFInfo::IndexStorageVariants storage)
+      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
+      const Number *                                             vector_ptr,
+      MatrixFreeFunctions::DoFInfo::IndexStorageVariants         storage)
     {
       const unsigned int fe_degree = shape_info.data[0].fe_degree;
       if (fe_degree < 1 || !shape_info.data[0].nodal_at_cell_boundaries ||
@@ -3663,16 +3793,15 @@ namespace internal
     }
 
   private:
-    template <int fe_degree, int n_q_points_1d>
+    template <int fe_degree>
     struct Processor
     {
-      static const bool do_integrate   = false;
-      static const int  dim_           = dim;
-      static const int  fe_degree_     = fe_degree;
-      static const int  n_q_points_1d_ = n_q_points_1d;
-      using VectorizedArrayType_       = VectorizedArrayType;
-      using Number_                    = Number;
-      using Number2_                   = const Number2;
+      static const bool do_integrate = false;
+      static const int  dim_         = dim;
+      static const int  fe_degree_   = fe_degree;
+      using VectorizedArrayType_     = VectorizedArrayType;
+      using Number_                  = Number;
+      using Number2_                 = const Number2;
 
       template <typename T0, typename T1, typename T2>
       void
@@ -3739,6 +3868,8 @@ namespace internal
     };
   };
 
+
+
   template <int dim,
             typename Number,
             typename VectorizedArrayType,
@@ -3765,6 +3896,49 @@ namespace internal
         temp + 3 * n_components * dofs_per_face;
 
       const unsigned int subface_index = eval.get_subface_index();
+
+      // re-orientation for cases not possible with the io function below
+      if (subface_index < GeometryInfo<dim>::max_children_per_cell)
+        {
+          if (eval.get_dof_access_index() ==
+                MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+              eval.get_is_interior_face() == false)
+            for (unsigned int v = 0; v < VectorizedArrayType::size(); ++v)
+              {
+                // the loop breaks once an invalid_unsigned_int is hit for
+                // all cases except the exterior faces in the ECL loop (where
+                // some faces might be at the boundaries but others not)
+                if (eval.get_cell_ids()[v] == numbers::invalid_unsigned_int)
+                  continue;
+
+                if (eval.get_all_face_orientations()[v] != 0)
+                  adjust_for_face_orientation_per_lane(
+                    dim,
+                    n_components,
+                    v,
+                    integration_flag,
+                    &eval.get_orientation_map()
+                       [eval.get_all_face_orientations()[v]][0],
+                    true,
+                    Utilities::pow(n_q_points_1d, dim - 1),
+                    &temp[0][0],
+                    eval.begin_values(),
+                    eval.begin_gradients(),
+                    eval.begin_hessians());
+              }
+          else if (eval.get_face_orientation() != 0)
+            adjust_for_face_orientation(
+              dim,
+              n_components,
+              integration_flag,
+              &eval.get_orientation_map()[eval.get_face_orientation()][0],
+              true,
+              Utilities::pow(n_q_points_1d, dim - 1),
+              temp,
+              eval.begin_values(),
+              eval.begin_gradients(),
+              eval.begin_hessians());
+        }
 
       if (fe_degree > -1 && eval.get_subface_index() >=
                               GeometryInfo<dim - 1>::max_children_per_cell)
@@ -3798,10 +3972,10 @@ namespace internal
                                                   scratch_data,
                                                   subface_index);
 
-      Processor<fe_degree, n_q_points_1d> p;
+      Processor<fe_degree> p;
 
       if (eval.get_dof_access_index() ==
-            internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+            MatrixFreeFunctions::DoFInfo::dof_access_cell &&
           eval.get_is_interior_face() == false)
         fe_face_evaluation_process_and_io<VectorizedArrayType::size()>(
           p, n_components, integration_flag, dst_ptr, sm_ptr, eval, temp);
@@ -3813,16 +3987,15 @@ namespace internal
     }
 
   private:
-    template <int fe_degree, int n_q_points_1d>
+    template <int fe_degree>
     struct Processor
     {
-      static const bool do_integrate   = true;
-      static const int  dim_           = dim;
-      static const int  fe_degree_     = fe_degree;
-      static const int  n_q_points_1d_ = n_q_points_1d;
-      using VectorizedArrayType_       = VectorizedArrayType;
-      using Number_                    = Number;
-      using Number2_                   = Number2;
+      static const bool do_integrate = true;
+      static const int  dim_         = dim;
+      static const int  fe_degree_   = fe_degree;
+      using VectorizedArrayType_     = VectorizedArrayType;
+      using Number_                  = Number;
+      using Number2_                 = Number2;
 
       template <typename T0, typename T1, typename T2, typename T3, typename T4>
       void
@@ -3922,11 +4095,11 @@ namespace internal
                MatrixFreeFunctions::tensor_symmetric,
              ExcNotImplemented());
 
-      internal::EvaluatorTensorProduct<internal::evaluate_evenodd,
-                                       dim,
-                                       fe_degree + 1,
-                                       fe_degree + 1,
-                                       Number>
+      EvaluatorTensorProduct<evaluate_evenodd,
+                             dim,
+                             fe_degree + 1,
+                             fe_degree + 1,
+                             Number>
         evaluator(
           AlignedVector<Number>(),
           AlignedVector<Number>(),
@@ -3976,13 +4149,12 @@ namespace internal
 
       Assert(dim >= 1 || dim <= 3, ExcNotImplemented());
 
-      internal::
-        EvaluatorTensorProduct<internal::evaluate_general, dim, 0, 0, Number>
-          evaluator(fe_eval.get_shape_info().data.front().inverse_shape_values,
-                    AlignedVector<Number>(),
-                    AlignedVector<Number>(),
-                    fe_eval.get_shape_info().data.front().fe_degree + 1,
-                    fe_eval.get_shape_info().data.front().fe_degree + 1);
+      EvaluatorTensorProduct<evaluate_general, dim, 0, 0, Number> evaluator(
+        fe_eval.get_shape_info().data.front().inverse_shape_values,
+        AlignedVector<Number>(),
+        AlignedVector<Number>(),
+        fe_eval.get_shape_info().data.front().fe_degree + 1,
+        fe_eval.get_shape_info().data.front().fe_degree + 1);
 
       for (unsigned int d = 0; d < n_components; ++d)
         {
@@ -4045,11 +4217,11 @@ namespace internal
 
       Assert(dim >= 1 || dim <= 3, ExcNotImplemented());
 
-      internal::EvaluatorTensorProduct<internal::evaluate_evenodd,
-                                       dim,
-                                       fe_degree + 1,
-                                       fe_degree + 1,
-                                       Number>
+      EvaluatorTensorProduct<evaluate_evenodd,
+                             dim,
+                             fe_degree + 1,
+                             fe_degree + 1,
+                             Number>
         evaluator(AlignedVector<Number>(),
                   AlignedVector<Number>(),
                   inverse_shape);
@@ -4137,12 +4309,11 @@ namespace internal
                                        Utilities::pow(fe_degree + 1, dim) :
                                        fe_eval.get_shape_info().n_q_points;
 
-      internal::EvaluatorTensorProduct<do_inplace ? internal::evaluate_evenodd :
-                                                    internal::evaluate_general,
-                                       dim,
-                                       fe_degree + 1,
-                                       n_q_points_1d,
-                                       Number>
+      EvaluatorTensorProduct<do_inplace ? evaluate_evenodd : evaluate_general,
+                             dim,
+                             fe_degree + 1,
+                             n_q_points_1d,
+                             Number>
         evaluator(AlignedVector<Number>(),
                   AlignedVector<Number>(),
                   inverse_shape,

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2553,7 +2553,7 @@ namespace internal
 
   private:
     template <bool do_evaluate, bool add_into_output, int face_direction = 0>
-    static void
+    static DEAL_II_ALWAYS_INLINE void
     interpolate_generic(const unsigned int                     n_components,
                         const Number *                         input,
                         Number *                               output,
@@ -3136,6 +3136,20 @@ namespace internal
 
     // re-orientation
     std::array<const unsigned int *, n_face_orientations> orientation = {};
+
+#  ifdef DEBUG
+      // currently on structured meshes are supported -> face numbers and
+      // orientations have to be the same for all filled lanes
+      for (unsigned int v = 1; v < n_lanes; ++v)
+        {
+          if (this->all_face_numbers[v] != static_cast<std::uint8_t>(-1))
+            AssertDimension(this->all_face_numbers[0],
+                            this->all_face_numbers[v]);
+          if (this->all_face_orientations[v] != static_cast<std::uint8_t>(-1))
+            AssertDimension(this->all_face_orientations[0],
+                            this->all_face_orientations[v]);
+        }
+#  endif
 
     if (n_face_orientations == 1)
       orientation[0] =

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -3265,7 +3265,7 @@ namespace internal
     const unsigned int subface_index = eval.get_subface_index();
     const auto reorientate = [&](const unsigned int v, const unsigned int i) {
       return (dim < 3 || orientation[v] == nullptr ||
-              subface_index < Utilities::pow(2, dim)) ?
+              subface_index < Utilities::pow(2U, dim)) ?
                i :
                orientation[v][i];
     };
@@ -3493,6 +3493,7 @@ namespace internal
 
             if (vectorization_possible == false)
               {
+                vector_ptrs = {};
                 if (n_face_orientations == 1)
                   {
                     for (unsigned int v = 0; v < n_filled_lanes; ++v)

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -3265,7 +3265,7 @@ namespace internal
     const unsigned int subface_index = eval.get_subface_index();
     const auto reorientate = [&](const unsigned int v, const unsigned int i) {
       return (dim < 3 || orientation[v] == nullptr ||
-              subface_index < GeometryInfo<dim>::max_children_per_cell) ?
+              subface_index < Utilities::pow(2, dim)) ?
                i :
                orientation[v][i];
     };

--- a/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
+++ b/include/deal.II/matrix_free/evaluation_kernels_hanging_nodes.h
@@ -35,11 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 #endif
 
 
-// forward declaration
-template <int, typename, bool, typename>
-class FEEvaluationBaseData;
-
-
 
 namespace internal
 {

--- a/include/deal.II/matrix_free/evaluation_selector.h
+++ b/include/deal.II/matrix_free/evaluation_selector.h
@@ -35,9 +35,6 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 struct SelectEvaluator
 {
-  using ScalarNumber =
-    typename internal::VectorizedArrayTrait<Number>::value_type;
-
   /**
    * Chooses an appropriate evaluation strategy for the evaluate function, i.e.
    * this calls internal::FEEvaluationImpl::evaluate(),
@@ -49,7 +46,7 @@ struct SelectEvaluator
   evaluate(const unsigned int                     n_components,
            const EvaluationFlags::EvaluationFlags evaluation_flag,
            const Number *                         values_dofs,
-           FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval);
+           FEEvaluationData<dim, Number, false> & eval);
 
   /**
    * Chooses an appropriate evaluation strategy for the integrate function, i.e.
@@ -62,7 +59,7 @@ struct SelectEvaluator
   integrate(const unsigned int                     n_components,
             const EvaluationFlags::EvaluationFlags integration_flag,
             Number *                               values_dofs,
-            FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval,
+            FEEvaluationData<dim, Number, false> & eval,
             const bool sum_into_values_array = false);
 };
 
@@ -72,10 +69,10 @@ struct SelectEvaluator
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 inline void
 SelectEvaluator<dim, fe_degree, n_q_points_1d, Number>::evaluate(
-  const unsigned int                                      n_components,
-  const EvaluationFlags::EvaluationFlags                  evaluation_flag,
-  const Number *                                          values_dofs,
-  FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval)
+  const unsigned int                     n_components,
+  const EvaluationFlags::EvaluationFlags evaluation_flag,
+  const Number *                         values_dofs,
+  FEEvaluationData<dim, Number, false> & eval)
 {
   Assert(fe_degree >= 0 && n_q_points_1d > 0, ExcInternalError());
 
@@ -89,11 +86,11 @@ SelectEvaluator<dim, fe_degree, n_q_points_1d, Number>::evaluate(
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 inline void
 SelectEvaluator<dim, fe_degree, n_q_points_1d, Number>::integrate(
-  const unsigned int                                      n_components,
-  const EvaluationFlags::EvaluationFlags                  integration_flag,
-  Number *                                                values_dofs,
-  FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval,
-  const bool                                              sum_into_values_array)
+  const unsigned int                     n_components,
+  const EvaluationFlags::EvaluationFlags integration_flag,
+  Number *                               values_dofs,
+  FEEvaluationData<dim, Number, false> & eval,
+  const bool                             sum_into_values_array)
 {
   Assert(fe_degree >= 0 && n_q_points_1d > 0, ExcInternalError());
 

--- a/include/deal.II/matrix_free/evaluation_selector.h
+++ b/include/deal.II/matrix_free/evaluation_selector.h
@@ -35,6 +35,9 @@ DEAL_II_NAMESPACE_OPEN
 template <int dim, int fe_degree, int n_q_points_1d, typename Number>
 struct SelectEvaluator
 {
+  using ScalarNumber =
+    typename internal::VectorizedArrayTrait<Number>::value_type;
+
   /**
    * Chooses an appropriate evaluation strategy for the evaluate function, i.e.
    * this calls internal::FEEvaluationImpl::evaluate(),
@@ -45,12 +48,8 @@ struct SelectEvaluator
   static void
   evaluate(const unsigned int                     n_components,
            const EvaluationFlags::EvaluationFlags evaluation_flag,
-           const internal::MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-           Number *values_dofs_actual,
-           Number *values_quad,
-           Number *gradients_quad,
-           Number *hessians_quad,
-           Number *scratch_data);
+           const Number *                         values_dofs,
+           FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval);
 
   /**
    * Chooses an appropriate evaluation strategy for the integrate function, i.e.
@@ -62,12 +61,8 @@ struct SelectEvaluator
   static void
   integrate(const unsigned int                     n_components,
             const EvaluationFlags::EvaluationFlags integration_flag,
-            const internal::MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-            Number *   values_dofs_actual,
-            Number *   values_quad,
-            Number *   gradients_quad,
-            Number *   hessians_quad,
-            Number *   scratch_data,
+            Number *                               values_dofs,
+            FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval,
             const bool sum_into_values_array = false);
 };
 
@@ -79,24 +74,14 @@ inline void
 SelectEvaluator<dim, fe_degree, n_q_points_1d, Number>::evaluate(
   const unsigned int                                      n_components,
   const EvaluationFlags::EvaluationFlags                  evaluation_flag,
-  const internal::MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-  Number *                                                values_dofs_actual,
-  Number *                                                values_quad,
-  Number *                                                gradients_quad,
-  Number *                                                hessians_quad,
-  Number *                                                scratch_data)
+  const Number *                                          values_dofs,
+  FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval)
 {
   Assert(fe_degree >= 0 && n_q_points_1d > 0, ExcInternalError());
 
-  internal::FEEvaluationImplEvaluateSelector<dim, Number>::
-    template run<fe_degree, n_q_points_1d>(n_components,
-                                           evaluation_flag,
-                                           shape_info,
-                                           values_dofs_actual,
-                                           values_quad,
-                                           gradients_quad,
-                                           hessians_quad,
-                                           scratch_data);
+  internal::FEEvaluationImplEvaluateSelector<dim, Number>::template run<
+    fe_degree,
+    n_q_points_1d>(n_components, evaluation_flag, values_dofs, eval);
 }
 
 
@@ -106,26 +91,15 @@ inline void
 SelectEvaluator<dim, fe_degree, n_q_points_1d, Number>::integrate(
   const unsigned int                                      n_components,
   const EvaluationFlags::EvaluationFlags                  integration_flag,
-  const internal::MatrixFreeFunctions::ShapeInfo<Number> &shape_info,
-  Number *                                                values_dofs_actual,
-  Number *                                                values_quad,
-  Number *                                                gradients_quad,
-  Number *                                                hessians_quad,
-  Number *                                                scratch_data,
+  Number *                                                values_dofs,
+  FEEvaluationBaseData<dim, ScalarNumber, false, Number> &eval,
   const bool                                              sum_into_values_array)
 {
   Assert(fe_degree >= 0 && n_q_points_1d > 0, ExcInternalError());
 
   internal::FEEvaluationImplIntegrateSelector<dim, Number>::
-    template run<fe_degree, n_q_points_1d>(n_components,
-                                           integration_flag,
-                                           shape_info,
-                                           values_dofs_actual,
-                                           values_quad,
-                                           gradients_quad,
-                                           hessians_quad,
-                                           scratch_data,
-                                           sum_into_values_array);
+    template run<fe_degree, n_q_points_1d>(
+      n_components, integration_flag, values_dofs, eval, sum_into_values_array);
 }
 #endif // DOXYGEN
 

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -35,33 +35,23 @@ class FEEvaluationBaseData;
 
 namespace internal
 {
-  template <int dim,
-            typename Number,
-            typename VectorizedArrayType = VectorizedArray<Number>>
+  template <int dim, typename Number, typename VectorizedArrayType>
   struct FEEvaluationFactory
   {
     static void
     evaluate(
       const unsigned int                     n_components,
       const EvaluationFlags::EvaluationFlags evaluation_flag,
-      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
-      VectorizedArrayType *values_dofs_actual,
-      VectorizedArrayType *values_quad,
-      VectorizedArrayType *gradients_quad,
-      VectorizedArrayType *hessians_quad,
-      VectorizedArrayType *scratch_data);
+      const VectorizedArrayType *            values_dofs,
+      FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval);
 
     static void
     integrate(
       const unsigned int                     n_components,
       const EvaluationFlags::EvaluationFlags integration_flag,
-      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
-      VectorizedArrayType *values_dofs_actual,
-      VectorizedArrayType *values_quad,
-      VectorizedArrayType *gradients_quad,
-      VectorizedArrayType *hessians_quad,
-      VectorizedArrayType *scratch_data,
-      const bool           sum_into_values_array);
+      VectorizedArrayType *                  values_dofs,
+      FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval,
+      const bool sum_into_values_array);
 
     static bool
     fast_evaluation_supported(const unsigned int given_degree,
@@ -76,87 +66,34 @@ namespace internal
   struct FEFaceEvaluationFactory
   {
     static void
-    evaluate(const unsigned int n_components,
-             const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-             const VectorizedArrayType *   values_array,
-             VectorizedArrayType *         values_quad,
-             VectorizedArrayType *         gradients_quad,
-             VectorizedArrayType *         hessians_quad,
-             VectorizedArrayType *         scratch_data,
-             const bool                    evaluate_values,
-             const bool                    evaluate_gradients,
-             const bool                    evaluate_hessians,
-             const unsigned int            face_no,
-             const unsigned int            subface_index,
-             const unsigned int            face_orientation,
-             const Table<2, unsigned int> &orientation_map);
+    evaluate(
+      const unsigned int                     n_components,
+      const EvaluationFlags::EvaluationFlags evaluation_flag,
+      const VectorizedArrayType *            values_dofs,
+      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
 
     static void
-    integrate(const unsigned int n_components,
-              const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-              VectorizedArrayType *         values_array,
-              VectorizedArrayType *         values_quad,
-              VectorizedArrayType *         gradients_quad,
-              VectorizedArrayType *         hessians_quad,
-              VectorizedArrayType *         scratch_data,
-              const bool                    integrate_values,
-              const bool                    integrate_gradients,
-              const bool                    integrate_hessians,
-              const unsigned int            face_no,
-              const unsigned int            subface_index,
-              const unsigned int            face_orientation,
-              const Table<2, unsigned int> &orientation_map);
+    integrate(
+      const unsigned int                     n_components,
+      const EvaluationFlags::EvaluationFlags integration_flag,
+      VectorizedArrayType *                  values_dofs,
+      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
 
-    static bool
+    static void
     gather_evaluate(
       const unsigned int                          n_components,
-      const std::size_t                           n_face_orientations,
+      const EvaluationFlags::EvaluationFlags      evaluation_flag,
       const Number *                              src_ptr,
       const std::vector<ArrayView<const Number>> *sm_ptr,
-      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-      const MatrixFreeFunctions::DoFInfo &                       dof_info,
-      VectorizedArrayType *                                      values_quad,
-      VectorizedArrayType *                                      gradients_quad,
-      VectorizedArrayType *                                      hessians_quad,
-      VectorizedArrayType *                                      scratch_data,
-      const bool         evaluate_values,
-      const bool         evaluate_gradients,
-      const bool         evaluate_hessians,
-      const unsigned int active_fe_index,
-      const unsigned int first_selected_component,
-      const std::array<unsigned int, VectorizedArrayType::size()> cells,
-      const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-      const unsigned int                                          subface_index,
-      const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
-      const std::array<unsigned int, VectorizedArrayType::size()>
-                                    face_orientations,
-      const Table<2, unsigned int> &orientation_map);
+      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
 
-    static bool
+    static void
     integrate_scatter(
       const unsigned int                          n_components,
-      const std::size_t                           n_face_orientations,
+      const EvaluationFlags::EvaluationFlags      integration_flag,
       Number *                                    dst_ptr,
       const std::vector<ArrayView<const Number>> *sm_ptr,
-      const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-      const MatrixFreeFunctions::DoFInfo &                       dof_info,
-      VectorizedArrayType *                                      values_array,
-      VectorizedArrayType *                                      values_quad,
-      VectorizedArrayType *                                      gradients_quad,
-      VectorizedArrayType *                                      hessians_quad,
-      VectorizedArrayType *                                      scratch_data,
-      const bool         integrate_values,
-      const bool         integrate_gradients,
-      const bool         integrate_hessians,
-      const unsigned int active_fe_index,
-      const unsigned int first_selected_component,
-      const std::array<unsigned int, VectorizedArrayType::size()> cells,
-      const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-      const unsigned int                                          subface_index,
-      const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
-      const std::array<unsigned int, VectorizedArrayType::size()>
-                                    face_orientations,
-      const Table<2, unsigned int> &orientation_map);
+      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
 
     static bool
     fast_evaluation_supported(const unsigned int given_degree,

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -42,13 +42,13 @@ namespace internal
     evaluate(const unsigned int                     n_components,
              const EvaluationFlags::EvaluationFlags evaluation_flag,
              const Number *                         values_dofs,
-             FEEvaluationData<dim, Number, false> & eval);
+             FEEvaluationData<dim, Number, false> & fe_eval);
 
     static void
     integrate(const unsigned int                     n_components,
               const EvaluationFlags::EvaluationFlags integration_flag,
               Number *                               values_dofs,
-              FEEvaluationData<dim, Number, false> & eval,
+              FEEvaluationData<dim, Number, false> & fe_eval,
               const bool                             sum_into_values_array);
 
     static bool
@@ -65,13 +65,13 @@ namespace internal
     evaluate(const unsigned int                     n_components,
              const EvaluationFlags::EvaluationFlags evaluation_flag,
              const Number *                         values_dofs,
-             FEEvaluationData<dim, Number, true> &  eval);
+             FEEvaluationData<dim, Number, true> &  fe_eval);
 
     static void
     integrate(const unsigned int                     n_components,
               const EvaluationFlags::EvaluationFlags integration_flag,
               Number *                               values_dofs,
-              FEEvaluationData<dim, Number, true> &  eval);
+              FEEvaluationData<dim, Number, true> &  fe_eval);
   };
 
 
@@ -84,14 +84,14 @@ namespace internal
              const EvaluationFlags::EvaluationFlags            evaluation_flag,
              const Number *                                    src_ptr,
              const std::vector<ArrayView<const Number>> *      sm_ptr,
-             FEEvaluationData<dim, VectorizedArrayType, true> &eval);
+             FEEvaluationData<dim, VectorizedArrayType, true> &fe_eval);
 
     static void
     integrate(const unsigned int                          n_components,
               const EvaluationFlags::EvaluationFlags      integration_flag,
               Number *                                    dst_ptr,
               const std::vector<ArrayView<const Number>> *sm_ptr,
-              FEEvaluationData<dim, VectorizedArrayType, true> &eval);
+              FEEvaluationData<dim, VectorizedArrayType, true> &fe_eval);
   };
 
 
@@ -101,7 +101,7 @@ namespace internal
   {
     static void
     apply(const unsigned int                          n_components,
-          const FEEvaluationData<dim, Number, false> &fe_eval,
+          const FEEvaluationData<dim, Number, false> &fe_fe_eval,
           const Number *                              in_array,
           Number *                                    out_array);
 
@@ -116,7 +116,7 @@ namespace internal
     static void
     transform_from_q_points_to_basis(
       const unsigned int                          n_components,
-      const FEEvaluationData<dim, Number, false> &fe_eval,
+      const FEEvaluationData<dim, Number, false> &fe_fe_eval,
       const Number *                              in_array,
       Number *                                    out_array);
   };

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -72,11 +72,9 @@ namespace internal
               const EvaluationFlags::EvaluationFlags integration_flag,
               Number *                               values_dofs,
               FEEvaluationData<dim, Number, true> &  eval);
-
-    static bool
-    fast_evaluation_supported(const unsigned int given_degree,
-                              const unsigned int n_q_points_1d);
   };
+
+
 
   template <int dim, typename Number, typename VectorizedArrayType>
   struct FEFaceEvaluationGatherFactory

--- a/include/deal.II/matrix_free/evaluation_template_factory.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.h
@@ -29,29 +29,27 @@
 DEAL_II_NAMESPACE_OPEN
 
 
-template <int, typename, bool, typename>
-class FEEvaluationBaseData;
+template <int, typename, bool>
+class FEEvaluationData;
 
 
 namespace internal
 {
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   struct FEEvaluationFactory
   {
     static void
-    evaluate(
-      const unsigned int                     n_components,
-      const EvaluationFlags::EvaluationFlags evaluation_flag,
-      const VectorizedArrayType *            values_dofs,
-      FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval);
+    evaluate(const unsigned int                     n_components,
+             const EvaluationFlags::EvaluationFlags evaluation_flag,
+             const Number *                         values_dofs,
+             FEEvaluationData<dim, Number, false> & eval);
 
     static void
-    integrate(
-      const unsigned int                     n_components,
-      const EvaluationFlags::EvaluationFlags integration_flag,
-      VectorizedArrayType *                  values_dofs,
-      FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval,
-      const bool sum_into_values_array);
+    integrate(const unsigned int                     n_components,
+              const EvaluationFlags::EvaluationFlags integration_flag,
+              Number *                               values_dofs,
+              FEEvaluationData<dim, Number, false> & eval,
+              const bool                             sum_into_values_array);
 
     static bool
     fast_evaluation_supported(const unsigned int given_degree,
@@ -60,75 +58,69 @@ namespace internal
 
 
 
-  template <int dim,
-            typename Number,
-            typename VectorizedArrayType = VectorizedArray<Number>>
+  template <int dim, typename Number>
   struct FEFaceEvaluationFactory
   {
     static void
-    evaluate(
-      const unsigned int                     n_components,
-      const EvaluationFlags::EvaluationFlags evaluation_flag,
-      const VectorizedArrayType *            values_dofs,
-      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
+    evaluate(const unsigned int                     n_components,
+             const EvaluationFlags::EvaluationFlags evaluation_flag,
+             const Number *                         values_dofs,
+             FEEvaluationData<dim, Number, true> &  eval);
 
     static void
-    integrate(
-      const unsigned int                     n_components,
-      const EvaluationFlags::EvaluationFlags integration_flag,
-      VectorizedArrayType *                  values_dofs,
-      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
-
-    static void
-    gather_evaluate(
-      const unsigned int                          n_components,
-      const EvaluationFlags::EvaluationFlags      evaluation_flag,
-      const Number *                              src_ptr,
-      const std::vector<ArrayView<const Number>> *sm_ptr,
-      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
-
-    static void
-    integrate_scatter(
-      const unsigned int                          n_components,
-      const EvaluationFlags::EvaluationFlags      integration_flag,
-      Number *                                    dst_ptr,
-      const std::vector<ArrayView<const Number>> *sm_ptr,
-      FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval);
+    integrate(const unsigned int                     n_components,
+              const EvaluationFlags::EvaluationFlags integration_flag,
+              Number *                               values_dofs,
+              FEEvaluationData<dim, Number, true> &  eval);
 
     static bool
     fast_evaluation_supported(const unsigned int given_degree,
                               const unsigned int n_q_points_1d);
   };
 
+  template <int dim, typename Number, typename VectorizedArrayType>
+  struct FEFaceEvaluationGatherFactory
+  {
+    static void
+    evaluate(const unsigned int                                n_components,
+             const EvaluationFlags::EvaluationFlags            evaluation_flag,
+             const Number *                                    src_ptr,
+             const std::vector<ArrayView<const Number>> *      sm_ptr,
+             FEEvaluationData<dim, VectorizedArrayType, true> &eval);
+
+    static void
+    integrate(const unsigned int                          n_components,
+              const EvaluationFlags::EvaluationFlags      integration_flag,
+              Number *                                    dst_ptr,
+              const std::vector<ArrayView<const Number>> *sm_ptr,
+              FEEvaluationData<dim, VectorizedArrayType, true> &eval);
+  };
 
 
-  template <int dim,
-            typename Number,
-            typename VectorizedArrayType = VectorizedArray<Number>>
+
+  template <int dim, typename Number>
   struct CellwiseInverseMassFactory
   {
     static void
-    apply(const unsigned int n_components,
-          const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
-            &                        fe_eval,
-          const VectorizedArrayType *in_array,
-          VectorizedArrayType *      out_array);
+    apply(const unsigned int                          n_components,
+          const FEEvaluationData<dim, Number, false> &fe_eval,
+          const Number *                              in_array,
+          Number *                                    out_array);
 
     static void
-    apply(const unsigned int                        n_components,
-          const unsigned int                        fe_degree,
-          const AlignedVector<VectorizedArrayType> &inverse_shape,
-          const AlignedVector<VectorizedArrayType> &inverse_coefficients,
-          const VectorizedArrayType *               in_array,
-          VectorizedArrayType *                     out_array);
+    apply(const unsigned int           n_components,
+          const unsigned int           fe_degree,
+          const AlignedVector<Number> &inverse_shape,
+          const AlignedVector<Number> &inverse_coefficients,
+          const Number *               in_array,
+          Number *                     out_array);
 
     static void
     transform_from_q_points_to_basis(
-      const unsigned int n_components,
-      const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
-        &                        fe_eval,
-      const VectorizedArrayType *in_array,
-      VectorizedArrayType *      out_array);
+      const unsigned int                          n_components,
+      const FEEvaluationData<dim, Number, false> &fe_eval,
+      const Number *                              in_array,
+      Number *                                    out_array);
   };
 
   template <int dim,

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -185,18 +185,6 @@ namespace internal
 
 
   template <int dim, typename Number>
-  bool
-  FEFaceEvaluationFactory<dim, Number>::fast_evaluation_supported(
-    const unsigned int given_degree,
-    const unsigned int n_q_points_1d)
-  {
-    return instantiation_helper_run<1, FastEvaluationSupported>(given_degree,
-                                                                n_q_points_1d);
-  }
-
-
-
-  template <int dim, typename Number>
   void
   CellwiseInverseMassFactory<dim, Number>::apply(
     const unsigned int                          n_components,

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -47,15 +47,15 @@ namespace internal
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags evaluation_flag,
     const Number *                         values_dofs,
-    FEEvaluationData<dim, Number, false> & eval)
+    FEEvaluationData<dim, Number, false> & fe_eval)
   {
     instantiation_helper_run<1, FEEvaluationImplEvaluateSelector<dim, Number>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       evaluation_flag,
       values_dofs,
-      eval);
+      fe_eval);
   }
 
 
@@ -66,16 +66,16 @@ namespace internal
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags integration_flag,
     Number *                               values_dofs,
-    FEEvaluationData<dim, Number, false> & eval,
+    FEEvaluationData<dim, Number, false> & fe_eval,
     const bool                             sum_into_values_array)
   {
     instantiation_helper_run<1, FEEvaluationImplIntegrateSelector<dim, Number>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       integration_flag,
       values_dofs,
-      eval,
+      fe_eval,
       sum_into_values_array);
   }
 
@@ -99,16 +99,16 @@ namespace internal
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags evaluation_flag,
     const Number *                         values_dofs,
-    FEEvaluationData<dim, Number, true> &  eval)
+    FEEvaluationData<dim, Number, true> &  fe_eval)
   {
     instantiation_helper_run<1,
                              FEFaceEvaluationImplEvaluateSelector<dim, Number>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       evaluation_flag,
       values_dofs,
-      eval);
+      fe_eval);
   }
 
 
@@ -119,17 +119,17 @@ namespace internal
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags integration_flag,
     Number *                               values_dofs,
-    FEEvaluationData<dim, Number, true> &  eval)
+    FEEvaluationData<dim, Number, true> &  fe_eval)
   {
     instantiation_helper_run<
       1,
       FEFaceEvaluationImplIntegrateSelector<dim, Number>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       integration_flag,
       values_dofs,
-      eval);
+      fe_eval);
   }
 
 
@@ -141,20 +141,20 @@ namespace internal
     const EvaluationFlags::EvaluationFlags            evaluation_flag,
     const Number *                                    src_ptr,
     const std::vector<ArrayView<const Number>> *      sm_ptr,
-    FEEvaluationData<dim, VectorizedArrayType, true> &eval)
+    FEEvaluationData<dim, VectorizedArrayType, true> &fe_eval)
   {
     instantiation_helper_run<
       1,
       FEFaceEvaluationImplGatherEvaluateSelector<dim,
                                                  Number,
                                                  VectorizedArrayType>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       evaluation_flag,
       src_ptr,
       sm_ptr,
-      eval);
+      fe_eval);
   }
 
 
@@ -166,20 +166,20 @@ namespace internal
     const EvaluationFlags::EvaluationFlags            integration_flag,
     Number *                                          dst_ptr,
     const std::vector<ArrayView<const Number>> *      sm_ptr,
-    FEEvaluationData<dim, VectorizedArrayType, true> &eval)
+    FEEvaluationData<dim, VectorizedArrayType, true> &fe_eval)
   {
     instantiation_helper_run<
       1,
       FEFaceEvaluationImplIntegrateScatterSelector<dim,
                                                    Number,
                                                    VectorizedArrayType>>(
-      eval.get_shape_info().data[0].fe_degree,
-      eval.get_shape_info().data[0].n_q_points_1d,
+      fe_eval.get_shape_info().data[0].fe_degree,
+      fe_eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       integration_flag,
       dst_ptr,
       sm_ptr,
-      eval);
+      fe_eval);
   }
 
 

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -41,17 +41,15 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  FEEvaluationFactory<dim, Number, VectorizedArrayType>::evaluate(
+  FEEvaluationFactory<dim, Number>::evaluate(
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags evaluation_flag,
-    const VectorizedArrayType *            values_dofs,
-    FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval)
+    const Number *                         values_dofs,
+    FEEvaluationData<dim, Number, false> & eval)
   {
-    instantiation_helper_run<
-      1,
-      FEEvaluationImplEvaluateSelector<dim, VectorizedArrayType>>(
+    instantiation_helper_run<1, FEEvaluationImplEvaluateSelector<dim, Number>>(
       eval.get_shape_info().data[0].fe_degree,
       eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
@@ -62,18 +60,16 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  FEEvaluationFactory<dim, Number, VectorizedArrayType>::integrate(
+  FEEvaluationFactory<dim, Number>::integrate(
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags integration_flag,
-    VectorizedArrayType *                  values_dofs,
-    FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval,
-    const bool sum_into_values_array)
+    Number *                               values_dofs,
+    FEEvaluationData<dim, Number, false> & eval,
+    const bool                             sum_into_values_array)
   {
-    instantiation_helper_run<
-      1,
-      FEEvaluationImplIntegrateSelector<dim, VectorizedArrayType>>(
+    instantiation_helper_run<1, FEEvaluationImplIntegrateSelector<dim, Number>>(
       eval.get_shape_info().data[0].fe_degree,
       eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
@@ -85,11 +81,11 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   bool
-  FEEvaluationFactory<dim, Number, VectorizedArrayType>::
-    fast_evaluation_supported(const unsigned int given_degree,
-                              const unsigned int n_q_points_1d)
+  FEEvaluationFactory<dim, Number>::fast_evaluation_supported(
+    const unsigned int given_degree,
+    const unsigned int n_q_points_1d)
   {
     return instantiation_helper_run<1, FastEvaluationSupported>(given_degree,
                                                                 n_q_points_1d);
@@ -97,17 +93,16 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::evaluate(
+  FEFaceEvaluationFactory<dim, Number>::evaluate(
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags evaluation_flag,
-    const VectorizedArrayType *            values_dofs,
-    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
+    const Number *                         values_dofs,
+    FEEvaluationData<dim, Number, true> &  eval)
   {
-    instantiation_helper_run<
-      1,
-      FEFaceEvaluationImplEvaluateSelector<dim, VectorizedArrayType>>(
+    instantiation_helper_run<1,
+                             FEFaceEvaluationImplEvaluateSelector<dim, Number>>(
       eval.get_shape_info().data[0].fe_degree,
       eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
@@ -118,17 +113,17 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::integrate(
+  FEFaceEvaluationFactory<dim, Number>::integrate(
     const unsigned int                     n_components,
     const EvaluationFlags::EvaluationFlags integration_flag,
-    VectorizedArrayType *                  values_dofs,
-    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
+    Number *                               values_dofs,
+    FEEvaluationData<dim, Number, true> &  eval)
   {
     instantiation_helper_run<
       1,
-      FEFaceEvaluationImplIntegrateSelector<dim, VectorizedArrayType>>(
+      FEFaceEvaluationImplIntegrateSelector<dim, Number>>(
       eval.get_shape_info().data[0].fe_degree,
       eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
@@ -141,12 +136,12 @@ namespace internal
 
   template <int dim, typename Number, typename VectorizedArrayType>
   void
-  FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::gather_evaluate(
-    const unsigned int                          n_components,
-    const EvaluationFlags::EvaluationFlags      evaluation_flag,
-    const Number *                              src_ptr,
-    const std::vector<ArrayView<const Number>> *sm_ptr,
-    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
+  FEFaceEvaluationGatherFactory<dim, Number, VectorizedArrayType>::evaluate(
+    const unsigned int                                n_components,
+    const EvaluationFlags::EvaluationFlags            evaluation_flag,
+    const Number *                                    src_ptr,
+    const std::vector<ArrayView<const Number>> *      sm_ptr,
+    FEEvaluationData<dim, VectorizedArrayType, true> &eval)
   {
     instantiation_helper_run<
       1,
@@ -166,12 +161,12 @@ namespace internal
 
   template <int dim, typename Number, typename VectorizedArrayType>
   void
-  FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::integrate_scatter(
-    const unsigned int                          n_components,
-    const EvaluationFlags::EvaluationFlags      integration_flag,
-    Number *                                    dst_ptr,
-    const std::vector<ArrayView<const Number>> *sm_ptr,
-    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
+  FEFaceEvaluationGatherFactory<dim, Number, VectorizedArrayType>::integrate(
+    const unsigned int                                n_components,
+    const EvaluationFlags::EvaluationFlags            integration_flag,
+    Number *                                          dst_ptr,
+    const std::vector<ArrayView<const Number>> *      sm_ptr,
+    FEEvaluationData<dim, VectorizedArrayType, true> &eval)
   {
     instantiation_helper_run<
       1,
@@ -189,11 +184,11 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   bool
-  FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::
-    fast_evaluation_supported(const unsigned int given_degree,
-                              const unsigned int n_q_points_1d)
+  FEFaceEvaluationFactory<dim, Number>::fast_evaluation_supported(
+    const unsigned int given_degree,
+    const unsigned int n_q_points_1d)
   {
     return instantiation_helper_run<1, FastEvaluationSupported>(given_degree,
                                                                 n_q_points_1d);
@@ -201,65 +196,59 @@ namespace internal
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::apply(
-    const unsigned int n_components,
-    const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
-      &                        fe_eval,
-    const VectorizedArrayType *in_array,
-    VectorizedArrayType *      out_array)
+  CellwiseInverseMassFactory<dim, Number>::apply(
+    const unsigned int                          n_components,
+    const FEEvaluationData<dim, Number, false> &fe_eval,
+    const Number *                              in_array,
+    Number *                                    out_array)
   {
     const unsigned int fe_degree = fe_eval.get_shape_info().data[0].fe_degree;
-    instantiation_helper_run<
-      1,
-      CellwiseInverseMassMatrixImplBasic<dim, VectorizedArrayType>>(
+    instantiation_helper_run<1,
+                             CellwiseInverseMassMatrixImplBasic<dim, Number>>(
       fe_degree, fe_degree + 1, n_components, fe_eval, in_array, out_array);
   }
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::apply(
-    const unsigned int                        n_components,
-    const unsigned int                        fe_degree,
-    const AlignedVector<VectorizedArrayType> &inverse_shape,
-    const AlignedVector<VectorizedArrayType> &inverse_coefficients,
-    const VectorizedArrayType *               in_array,
-    VectorizedArrayType *                     out_array)
+  CellwiseInverseMassFactory<dim, Number>::apply(
+    const unsigned int           n_components,
+    const unsigned int           fe_degree,
+    const AlignedVector<Number> &inverse_shape,
+    const AlignedVector<Number> &inverse_coefficients,
+    const Number *               in_array,
+    Number *                     out_array)
   {
     instantiation_helper_run<
       1,
-      CellwiseInverseMassMatrixImplFlexible<dim, VectorizedArrayType>>(
-      fe_degree,
-      fe_degree + 1,
-      n_components,
-      inverse_shape,
-      inverse_coefficients,
-      in_array,
-      out_array);
+      CellwiseInverseMassMatrixImplFlexible<dim, Number>>(fe_degree,
+                                                          fe_degree + 1,
+                                                          n_components,
+                                                          inverse_shape,
+                                                          inverse_coefficients,
+                                                          in_array,
+                                                          out_array);
   }
 
 
 
-  template <int dim, typename Number, typename VectorizedArrayType>
+  template <int dim, typename Number>
   void
-  CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
-    transform_from_q_points_to_basis(
-      const unsigned int n_components,
-      const FEEvaluationBaseData<dim, Number, false, VectorizedArrayType>
-        &                        fe_eval,
-      const VectorizedArrayType *in_array,
-      VectorizedArrayType *      out_array)
+  CellwiseInverseMassFactory<dim, Number>::transform_from_q_points_to_basis(
+    const unsigned int                          n_components,
+    const FEEvaluationData<dim, Number, false> &fe_eval,
+    const Number *                              in_array,
+    Number *                                    out_array)
   {
     const unsigned int fe_degree = fe_eval.get_shape_info().data[0].fe_degree;
     const unsigned int n_q_points_1d =
       fe_eval.get_shape_info().data[0].n_q_points_1d;
     instantiation_helper_run<
       1,
-      CellwiseInverseMassMatrixImplTransformFromQPoints<dim,
-                                                        VectorizedArrayType>>(
+      CellwiseInverseMassMatrixImplTransformFromQPoints<dim, Number>>(
       fe_degree, n_q_points_1d, n_components, fe_eval, in_array, out_array);
   }
 

--- a/include/deal.II/matrix_free/evaluation_template_factory.templates.h
+++ b/include/deal.II/matrix_free/evaluation_template_factory.templates.h
@@ -44,28 +44,20 @@ namespace internal
   template <int dim, typename Number, typename VectorizedArrayType>
   void
   FEEvaluationFactory<dim, Number, VectorizedArrayType>::evaluate(
-    const unsigned int                                         n_components,
-    const EvaluationFlags::EvaluationFlags                     evaluation_flag,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
-    VectorizedArrayType *values_dofs_actual,
-    VectorizedArrayType *values_quad,
-    VectorizedArrayType *gradients_quad,
-    VectorizedArrayType *hessians_quad,
-    VectorizedArrayType *scratch_data)
+    const unsigned int                     n_components,
+    const EvaluationFlags::EvaluationFlags evaluation_flag,
+    const VectorizedArrayType *            values_dofs,
+    FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval)
   {
     instantiation_helper_run<
       1,
       FEEvaluationImplEvaluateSelector<dim, VectorizedArrayType>>(
-      shape_info.data[0].fe_degree,
-      shape_info.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       evaluation_flag,
-      shape_info,
-      values_dofs_actual,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data);
+      values_dofs,
+      eval);
   }
 
 
@@ -73,29 +65,21 @@ namespace internal
   template <int dim, typename Number, typename VectorizedArrayType>
   void
   FEEvaluationFactory<dim, Number, VectorizedArrayType>::integrate(
-    const unsigned int                                         n_components,
-    const EvaluationFlags::EvaluationFlags                     integration_flag,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &shape_info,
-    VectorizedArrayType *values_dofs_actual,
-    VectorizedArrayType *values_quad,
-    VectorizedArrayType *gradients_quad,
-    VectorizedArrayType *hessians_quad,
-    VectorizedArrayType *scratch_data,
-    const bool           sum_into_values_array)
+    const unsigned int                     n_components,
+    const EvaluationFlags::EvaluationFlags integration_flag,
+    VectorizedArrayType *                  values_dofs,
+    FEEvaluationBaseData<dim, Number, false, VectorizedArrayType> &eval,
+    const bool sum_into_values_array)
   {
     instantiation_helper_run<
       1,
       FEEvaluationImplIntegrateSelector<dim, VectorizedArrayType>>(
-      shape_info.data[0].fe_degree,
-      shape_info.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
       integration_flag,
-      shape_info,
-      values_dofs_actual,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data,
+      values_dofs,
+      eval,
       sum_into_values_array);
   }
 
@@ -116,40 +100,20 @@ namespace internal
   template <int dim, typename Number, typename VectorizedArrayType>
   void
   FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::evaluate(
-    const unsigned int                                         n_components,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-    const VectorizedArrayType *                                values_array,
-    VectorizedArrayType *                                      values_quad,
-    VectorizedArrayType *                                      gradients_quad,
-    VectorizedArrayType *                                      hessians_quad,
-    VectorizedArrayType *                                      scratch_data,
-    const bool                                                 evaluate_values,
-    const bool                    evaluate_gradients,
-    const bool                    evaluate_hessians,
-    const unsigned int            face_no,
-    const unsigned int            subface_index,
-    const unsigned int            face_orientation,
-    const Table<2, unsigned int> &orientation_map)
+    const unsigned int                     n_components,
+    const EvaluationFlags::EvaluationFlags evaluation_flag,
+    const VectorizedArrayType *            values_dofs,
+    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
   {
     instantiation_helper_run<
       1,
       FEFaceEvaluationImplEvaluateSelector<dim, VectorizedArrayType>>(
-      data.data[0].fe_degree,
-      data.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
-      data,
-      values_array,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data,
-      evaluate_values,
-      evaluate_gradients,
-      evaluate_hessians,
-      face_no,
-      subface_index,
-      face_orientation,
-      orientation_map);
+      evaluation_flag,
+      values_dofs,
+      eval);
   }
 
 
@@ -157,158 +121,70 @@ namespace internal
   template <int dim, typename Number, typename VectorizedArrayType>
   void
   FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::integrate(
-    const unsigned int                                         n_components,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-    VectorizedArrayType *                                      values_array,
-    VectorizedArrayType *                                      values_quad,
-    VectorizedArrayType *                                      gradients_quad,
-    VectorizedArrayType *                                      hessians_quad,
-    VectorizedArrayType *                                      scratch_data,
-    const bool                                                 integrate_values,
-    const bool                    integrate_gradients,
-    const bool                    integrate_hessians,
-    const unsigned int            face_no,
-    const unsigned int            subface_index,
-    const unsigned int            face_orientation,
-    const Table<2, unsigned int> &orientation_map)
+    const unsigned int                     n_components,
+    const EvaluationFlags::EvaluationFlags integration_flag,
+    VectorizedArrayType *                  values_dofs,
+    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
   {
     instantiation_helper_run<
       1,
       FEFaceEvaluationImplIntegrateSelector<dim, VectorizedArrayType>>(
-      data.data[0].fe_degree,
-      data.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
-      data,
-      values_array,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data,
-      integrate_values,
-      integrate_gradients,
-      integrate_hessians,
-      face_no,
-      subface_index,
-      face_orientation,
-      orientation_map);
+      integration_flag,
+      values_dofs,
+      eval);
   }
 
 
 
   template <int dim, typename Number, typename VectorizedArrayType>
-  bool
+  void
   FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::gather_evaluate(
     const unsigned int                          n_components,
-    const std::size_t                           n_face_orientations,
+    const EvaluationFlags::EvaluationFlags      evaluation_flag,
     const Number *                              src_ptr,
     const std::vector<ArrayView<const Number>> *sm_ptr,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-    const MatrixFreeFunctions::DoFInfo &                       dof_info,
-    VectorizedArrayType *                                      values_quad,
-    VectorizedArrayType *                                      gradients_quad,
-    VectorizedArrayType *                                      hessians_quad,
-    VectorizedArrayType *                                      scratch_data,
-    const bool                                                 evaluate_values,
-    const bool         evaluate_gradients,
-    const bool         evaluate_hessians,
-    const unsigned int active_fe_index,
-    const unsigned int first_selected_component,
-    const std::array<unsigned int, VectorizedArrayType::size()> cells,
-    const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-    const unsigned int                                          subface_index,
-    const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
-    const std::array<unsigned int, VectorizedArrayType::size()>
-                                  face_orientations,
-    const Table<2, unsigned int> &orientation_map)
+    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
   {
-    return instantiation_helper_run<
+    instantiation_helper_run<
       1,
       FEFaceEvaluationImplGatherEvaluateSelector<dim,
                                                  Number,
                                                  VectorizedArrayType>>(
-      data.data[0].fe_degree,
-      data.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
-      n_face_orientations,
+      evaluation_flag,
       src_ptr,
       sm_ptr,
-      data,
-      dof_info,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data,
-      evaluate_values,
-      evaluate_gradients,
-      evaluate_hessians,
-      active_fe_index,
-      first_selected_component,
-      cells,
-      face_nos,
-      subface_index,
-      dof_access_index,
-      face_orientations,
-      orientation_map);
+      eval);
   }
 
 
 
   template <int dim, typename Number, typename VectorizedArrayType>
-  bool
+  void
   FEFaceEvaluationFactory<dim, Number, VectorizedArrayType>::integrate_scatter(
     const unsigned int                          n_components,
-    const std::size_t                           n_face_orientations,
+    const EvaluationFlags::EvaluationFlags      integration_flag,
     Number *                                    dst_ptr,
     const std::vector<ArrayView<const Number>> *sm_ptr,
-    const MatrixFreeFunctions::ShapeInfo<VectorizedArrayType> &data,
-    const MatrixFreeFunctions::DoFInfo &                       dof_info,
-    VectorizedArrayType *                                      values_array,
-    VectorizedArrayType *                                      values_quad,
-    VectorizedArrayType *                                      gradients_quad,
-    VectorizedArrayType *                                      hessians_quad,
-    VectorizedArrayType *                                      scratch_data,
-    const bool                                                 integrate_values,
-    const bool         integrate_gradients,
-    const bool         integrate_hessians,
-    const unsigned int active_fe_index,
-    const unsigned int first_selected_component,
-    const std::array<unsigned int, VectorizedArrayType::size()> cells,
-    const std::array<unsigned int, VectorizedArrayType::size()> face_nos,
-    const unsigned int                                          subface_index,
-    const MatrixFreeFunctions::DoFInfo::DoFAccessIndex dof_access_index,
-    const std::array<unsigned int, VectorizedArrayType::size()>
-                                  face_orientations,
-    const Table<2, unsigned int> &orientation_map)
+    FEEvaluationBaseData<dim, Number, true, VectorizedArrayType> &eval)
   {
-    return instantiation_helper_run<
+    instantiation_helper_run<
       1,
       FEFaceEvaluationImplIntegrateScatterSelector<dim,
                                                    Number,
                                                    VectorizedArrayType>>(
-      data.data[0].fe_degree,
-      data.data[0].n_q_points_1d,
+      eval.get_shape_info().data[0].fe_degree,
+      eval.get_shape_info().data[0].n_q_points_1d,
       n_components,
-      n_face_orientations,
+      integration_flag,
       dst_ptr,
       sm_ptr,
-      data,
-      dof_info,
-      values_array,
-      values_quad,
-      gradients_quad,
-      hessians_quad,
-      scratch_data,
-      integrate_values,
-      integrate_gradients,
-      integrate_hessians,
-      active_fe_index,
-      first_selected_component,
-      cells,
-      face_nos,
-      subface_index,
-      dof_access_index,
-      face_orientations,
-      orientation_map);
+      eval);
   }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7153,7 +7153,7 @@ namespace internal
     const VectorType &                     input_vector,
     const EvaluationFlags::EvaluationFlags evaluation_flag)
   {
-    const unsigned int cell     = phi.get_current_cell_index();
+    const unsigned int cell     = phi.get_cell_or_face_batch_id();
     const auto &       dof_info = phi.get_dof_info();
     using VectorizedArrayType =
       typename std::remove_reference<decltype(*phi.begin_dof_values())>::type;
@@ -7230,7 +7230,7 @@ namespace internal
     VectorType &                           destination,
     const EvaluationFlags::EvaluationFlags evaluation_flag)
   {
-    const unsigned int cell     = phi.get_current_cell_index();
+    const unsigned int cell     = phi.get_cell_or_face_batch_id();
     const auto &       dof_info = phi.get_dof_info();
     using VectorizedArrayType =
       typename std::remove_reference<decltype(*phi.begin_dof_values())>::type;

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7719,8 +7719,8 @@ FEFaceEvaluation<dim,
           if (face_index == numbers::invalid_unsigned_int)
             {
               this->cell_ids[i]              = numbers::invalid_unsigned_int;
-              this->all_face_numbers[i]      = numbers::invalid_unsigned_int;
-              this->all_face_orientations[i] = numbers::invalid_unsigned_int;
+              this->all_face_numbers[i]      = static_cast<std::uint8_t>(-1);
+              this->all_face_orientations[i] = static_cast<std::uint8_t>(-1);
               continue; // invalid face ID: no neighbor on boundary
             }
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7141,7 +7141,7 @@ namespace internal
    */
   template <typename Number,
             typename VectorType,
-            typename T,
+            typename EvaluatorType,
             typename std::enable_if<
               internal::has_begin<VectorType>::value &&
                 std::is_same<decltype(std::declval<VectorType>().begin()),
@@ -7149,7 +7149,7 @@ namespace internal
               VectorType>::type * = nullptr>
   bool
   try_gather_evaluate_inplace(
-    T &                                    phi,
+    EvaluatorType &                        phi,
     const VectorType &                     input_vector,
     const EvaluationFlags::EvaluationFlags evaluation_flag)
   {
@@ -7199,14 +7199,14 @@ namespace internal
    */
   template <typename Number,
             typename VectorType,
-            typename T,
+            typename EvaluatorType,
             typename std::enable_if<
               !internal::has_begin<VectorType>::value ||
                 !std::is_same<decltype(std::declval<VectorType>().begin()),
                               Number *>::value,
               VectorType>::type * = nullptr>
   bool
-  try_gather_evaluate_inplace(T &,
+  try_gather_evaluate_inplace(EvaluatorType &,
                               const VectorType &,
                               const EvaluationFlags::EvaluationFlags)
   {
@@ -7218,7 +7218,7 @@ namespace internal
    */
   template <typename Number,
             typename VectorType,
-            typename T,
+            typename EvaluatorType,
             typename std::enable_if<
               internal::has_begin<VectorType>::value &&
                 std::is_same<decltype(std::declval<VectorType>().begin()),
@@ -7226,7 +7226,7 @@ namespace internal
               VectorType>::type * = nullptr>
   bool
   try_integrate_scatter_inplace(
-    T &                                    phi,
+    EvaluatorType &                        phi,
     VectorType &                           destination,
     const EvaluationFlags::EvaluationFlags evaluation_flag)
   {
@@ -7276,14 +7276,14 @@ namespace internal
    */
   template <typename Number,
             typename VectorType,
-            typename T,
+            typename EvaluatorType,
             typename std::enable_if<
               !internal::has_begin<VectorType>::value ||
                 !std::is_same<decltype(std::declval<VectorType>().begin()),
                               Number *>::value,
               VectorType>::type * = nullptr>
   bool
-  try_integrate_scatter_inplace(T,
+  try_integrate_scatter_inplace(EvaluatorType &,
                                 VectorType &,
                                 const EvaluationFlags::EvaluationFlags)
   {

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7752,7 +7752,7 @@ FEFaceEvaluation<dim,
           if (is_interior_face != orientation_interior_face)
             {
               constexpr std::array<std::uint8_t, 8> table{
-                {0, 1, 0, 3, 6, 5, 4, 7}};
+                {0, 1, 2, 3, 6, 5, 4, 7}};
               face_orientation = table[face_orientation];
             }
           this->all_face_orientations[i] = face_orientation;

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -482,14 +482,40 @@ public:
    * associated with.
    */
   const std::array<unsigned int, n_lanes> &
-  get_cell_ids() const;
+  get_cell_ids() const
+  {
+    // implemented inline to avoid compilation problems on Windows
+    Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
+    return cell_ids;
+  }
+
+  /**
+   * Return the id of the cell/face batch this FEEvaluation/FEFaceEvaluation is
+   * associated with.
+   */
+  unsigned int
+  get_cell_or_face_batch_id() const
+  {
+    // implemented inline to avoid compilation problems on Windows
+    Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
+    return cell;
+  }
 
   /**
    * Return the id of the cells/faces this FEEvaluation/FEFaceEvaluation is
    * associated with.
    */
   const std::array<unsigned int, n_lanes> &
-  get_cell_or_face_ids() const;
+  get_cell_or_face_ids() const
+  {
+    // implemented inline to avoid compilation problems on Windows
+    Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
+    if (!is_face || dof_access_index ==
+                      internal::MatrixFreeFunctions::DoFInfo::dof_access_cell)
+      return cell_ids;
+    else
+      return cell_or_face_ids;
+  }
 
   /**
    * Return the (non-vectorized) number of faces within cells in case of ECL
@@ -504,7 +530,20 @@ public:
    * internal use.
    */
   const std::array<std::uint8_t, n_lanes> &
-  get_all_face_numbers() const;
+  get_all_face_numbers() const
+  {
+    // implemented inline to avoid compilation problems on Windows
+    Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
+    Assert(is_face &&
+             dof_access_index ==
+               internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+             is_interior_face == false,
+           ExcMessage(
+             "All face numbers can only be queried for ECL at exterior "
+             "faces. Use get_face_no() in other cases."));
+
+    return all_face_numbers;
+  }
 
   /**
    * Store the orientation of the neighbor's faces with respect to the current
@@ -515,7 +554,20 @@ public:
    * `is_interior_face == false`.
    */
   const std::array<std::uint8_t, n_lanes> &
-  get_all_face_orientations() const;
+  get_all_face_orientations() const
+  {
+    // implemented inline to avoid compilation problems on Windows
+    Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
+    Assert(is_face &&
+             dof_access_index ==
+               internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
+             is_interior_face == false,
+           ExcMessage(
+             "All face numbers can only be queried for ECL at exterior "
+             "faces. Use get_face_no() in other cases."));
+
+    return all_face_orientations;
+  }
 
   //@}
 
@@ -1369,68 +1421,6 @@ inline bool
 FEEvaluationData<dim, Number, is_face>::get_is_interior_face() const
 {
   return is_interior_face;
-}
-
-
-
-template <int dim, typename Number, bool is_face>
-inline const std::array<unsigned int,
-                        FEEvaluationData<dim, Number, is_face>::n_lanes> &
-FEEvaluationData<dim, Number, is_face>::get_cell_ids() const
-{
-  Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
-  return cell_ids;
-}
-
-
-
-template <int dim, typename Number, bool is_face>
-inline const std::array<unsigned int,
-                        FEEvaluationData<dim, Number, is_face>::n_lanes> &
-FEEvaluationData<dim, Number, is_face>::get_cell_or_face_ids() const
-{
-  Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
-  if (!is_face || dof_access_index ==
-                    internal::MatrixFreeFunctions::DoFInfo::dof_access_cell)
-    return cell_ids;
-  else
-    return cell_or_face_ids;
-}
-
-
-
-template <int dim, typename Number, bool is_face>
-inline const std::array<std::uint8_t,
-                        FEEvaluationData<dim, Number, is_face>::n_lanes> &
-FEEvaluationData<dim, Number, is_face>::get_all_face_numbers() const
-{
-  Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
-  Assert(is_face &&
-           dof_access_index ==
-             internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
-           is_interior_face == false,
-         ExcMessage("All face numbers can only be queried for ECL at exterior "
-                    "faces. Use get_face_no() in other cases."));
-
-  return all_face_numbers;
-}
-
-
-
-template <int dim, typename Number, bool is_face>
-inline const std::array<std::uint8_t,
-                        FEEvaluationData<dim, Number, is_face>::n_lanes> &
-FEEvaluationData<dim, Number, is_face>::get_all_face_orientations() const
-{
-  Assert(cell != numbers::invalid_unsigned_int, ExcNotInitialized());
-  Assert(is_face &&
-           dof_access_index ==
-             internal::MatrixFreeFunctions::DoFInfo::dof_access_cell &&
-           is_interior_face == false,
-         ExcMessage("All face numbers can only be queried for ECL at exterior "
-                    "faces. Use get_face_no() in other cases."));
-
-  return all_face_orientations;
 }
 
 

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -133,7 +133,7 @@ public:
    * use, select one of the derived classes FEEvaluation or FEFaceEvaluation
    * with their respective arguments.
    */
-  FEEvaluationData(const ShapeInfoType &info,
+  FEEvaluationData(const ShapeInfoType &shape_info,
                    const bool           is_interior_face = true);
 
   /**
@@ -577,7 +577,7 @@ protected:
    * initialization. Used in derived classes when this class is initialized
    * from a MatrixFree object.
    */
-  FEEvaluationData(const InitializationData &info,
+  FEEvaluationData(const InitializationData &initialization_data,
                    const bool                is_interior_face,
                    const unsigned int        quad_no,
                    const unsigned int        first_selected_component);

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -936,7 +936,9 @@ inline FEEvaluationData<dim, Number, is_face>::FEEvaluationData(
   , active_fe_index(initialization_data.active_fe_index)
   , active_quad_index(initialization_data.active_quad_index)
   , descriptor(initialization_data.descriptor)
-  , n_quadrature_points(is_face ? data->n_q_points_face : data->n_q_points)
+  , n_quadrature_points(descriptor == nullptr ?
+                          (is_face ? data->n_q_points_face : data->n_q_points) :
+                          descriptor->n_q_points)
   , jacobian(nullptr)
   , J_value(nullptr)
   , normal_vectors(nullptr)
@@ -963,11 +965,7 @@ inline FEEvaluationData<dim, Number, is_face>::FEEvaluationData(
   , face_orientation(0)
   , subface_index(0)
   , cell_type(internal::MatrixFreeFunctions::general)
-{
-  // TODO: This currently fails for simplex/matrix_free_face_integral_01
-  // if (descriptor != nullptr)
-  // AssertDimension(n_quadrature_points, descriptor->n_q_points);
-}
+{}
 
 
 

--- a/include/deal.II/matrix_free/fe_evaluation_data.h
+++ b/include/deal.II/matrix_free/fe_evaluation_data.h
@@ -904,6 +904,17 @@ protected:
 };
 
 
+/**
+ * This class is equivalent to FEEvaluationData and exists merely for backward
+ * compatibility.
+ */
+template <int dim,
+          typename Number,
+          bool is_face,
+          typename VectorizedArrayType = VectorizedArray<Number>>
+using FEEvaluationBaseData =
+  FEEvaluationData<dim, VectorizedArrayType, is_face>;
+
 
 /*----------------------- Inline functions ----------------------------------*/
 

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -45,10 +45,10 @@ namespace internal
      * deal.II information in a form that FEEvaluation and friends can use for
      * vectorized access. Since no vectorization over cells is available with
      * the DoFHandler/Triangulation cell iterators, the interface to
-     * FEEvaluation's vectorization model is to use @p
-     * VectorizedArray::n_array_element copies of the same element. This
-     * interface is thus primarily useful for evaluating several operators on
-     * the same cell, e.g., when assembling cell matrices.
+     * FEEvaluation's vectorization model is to use VectorizedArray::size()
+     * copies of the same element. This interface is thus primarily useful for
+     * evaluating several operators on the same cell, e.g., when assembling
+     * cell matrices.
      *
      * As opposed to the Mapping classes in deal.II, this class does not
      * actually provide a boundary description that can be used to evaluate
@@ -56,13 +56,9 @@ namespace internal
      * given deal.II mapping (as passed to the constructor of this class) in a
      * form accessible to FEEvaluation.
      */
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     class MappingDataOnTheFly
     {
-      static_assert(
-        std::is_same<Number, typename VectorizedArrayType::value_type>::value,
-        "Type of Number and of VectorizedArrayType do not match.");
-
     public:
       /**
        * Constructor, similar to FEValues. Since this class only evaluates the
@@ -116,7 +112,7 @@ namespace internal
        * MappingInfo. This ensures compatibility with the precomputed data
        * fields in the MappingInfo class.
        */
-      const MappingInfoStorage<dim, dim, Number, VectorizedArrayType> &
+      const MappingInfoStorage<dim, dim, Number> &
       get_data_storage() const;
 
       /**
@@ -152,24 +148,22 @@ namespace internal
        * The storage part created for a single cell and held in analogy to
        * MappingInfo.
        */
-      MappingInfoStorage<dim, dim, Number, VectorizedArrayType>
-        mapping_info_storage;
+      MappingInfoStorage<dim, dim, Number> mapping_info_storage;
     };
 
 
     /*-------------------------- Inline functions ---------------------------*/
 
-    template <int dim, typename Number, typename VectorizedArrayType>
-    inline MappingDataOnTheFly<dim, Number, VectorizedArrayType>::
-      MappingDataOnTheFly(const Mapping<dim> & mapping,
-                          const Quadrature<1> &quadrature,
-                          const UpdateFlags    update_flags)
-      : fe_values(
-          mapping,
-          fe_dummy,
-          Quadrature<dim>(quadrature),
-          MappingInfo<dim, Number, VectorizedArrayType>::compute_update_flags(
-            update_flags))
+    template <int dim, typename Number>
+    inline MappingDataOnTheFly<dim, Number>::MappingDataOnTheFly(
+      const Mapping<dim> & mapping,
+      const Quadrature<1> &quadrature,
+      const UpdateFlags    update_flags)
+      : fe_values(mapping,
+                  fe_dummy,
+                  Quadrature<dim>(quadrature),
+                  MappingInfoStorage<dim, dim, Number>::compute_update_flags(
+                    update_flags))
       , quadrature_1d(quadrature)
     {
       mapping_info_storage.descriptor.resize(1);
@@ -196,10 +190,10 @@ namespace internal
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
-    inline MappingDataOnTheFly<dim, Number, VectorizedArrayType>::
-      MappingDataOnTheFly(const Quadrature<1> &quadrature,
-                          const UpdateFlags    update_flags)
+    template <int dim, typename Number>
+    inline MappingDataOnTheFly<dim, Number>::MappingDataOnTheFly(
+      const Quadrature<1> &quadrature,
+      const UpdateFlags    update_flags)
       : MappingDataOnTheFly(::dealii::StaticMappingQ1<dim, dim>::mapping,
                             quadrature,
                             update_flags)
@@ -207,9 +201,9 @@ namespace internal
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     inline void
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::reinit(
+    MappingDataOnTheFly<dim, Number>::reinit(
       typename dealii::Triangulation<dim>::cell_iterator cell)
     {
       if (present_cell == cell)
@@ -246,10 +240,9 @@ namespace internal
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     inline bool
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::is_initialized()
-      const
+    MappingDataOnTheFly<dim, Number>::is_initialized() const
     {
       return present_cell !=
              typename dealii::Triangulation<dim>::cell_iterator();
@@ -257,38 +250,36 @@ namespace internal
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     inline typename dealii::Triangulation<dim>::cell_iterator
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_cell() const
+    MappingDataOnTheFly<dim, Number>::get_cell() const
     {
       return fe_values.get_cell();
     }
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     inline const dealii::FEValues<dim> &
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_fe_values() const
+    MappingDataOnTheFly<dim, Number>::get_fe_values() const
     {
       return fe_values;
     }
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
-    inline const MappingInfoStorage<dim, dim, Number, VectorizedArrayType> &
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_data_storage()
-      const
+    template <int dim, typename Number>
+    inline const MappingInfoStorage<dim, dim, Number> &
+    MappingDataOnTheFly<dim, Number>::get_data_storage() const
     {
       return mapping_info_storage;
     }
 
 
 
-    template <int dim, typename Number, typename VectorizedArrayType>
+    template <int dim, typename Number>
     inline const Quadrature<1> &
-    MappingDataOnTheFly<dim, Number, VectorizedArrayType>::get_quadrature()
-      const
+    MappingDataOnTheFly<dim, Number>::get_quadrature() const
     {
       return quadrature_1d;
     }

--- a/include/deal.II/matrix_free/mapping_info.h
+++ b/include/deal.II/matrix_free/mapping_info.h
@@ -160,20 +160,19 @@ namespace internal
       /**
        * The data cache for the cells.
        */
-      std::vector<MappingInfoStorage<dim, dim, Number, VectorizedArrayType>>
-        cell_data;
+      std::vector<MappingInfoStorage<dim, dim, VectorizedArrayType>> cell_data;
 
       /**
        * The data cache for the faces.
        */
-      std::vector<MappingInfoStorage<dim - 1, dim, Number, VectorizedArrayType>>
+      std::vector<MappingInfoStorage<dim - 1, dim, VectorizedArrayType>>
         face_data;
 
       /**
        * The data cache for the face-associated-with-cell topology, following
        * the @p cell_type variable for the cell types.
        */
-      std::vector<MappingInfoStorage<dim - 1, dim, Number, VectorizedArrayType>>
+      std::vector<MappingInfoStorage<dim - 1, dim, VectorizedArrayType>>
         face_data_by_cells;
 
       /**
@@ -253,16 +252,6 @@ namespace internal
         const dealii::Triangulation<dim> &                        tria,
         const std::vector<std::pair<unsigned int, unsigned int>> &cells,
         const dealii::hp::MappingCollection<dim> &                mapping);
-
-      /**
-       * Helper function to determine which update flags must be set in the
-       * internal functions to initialize all data as requested by the user.
-       */
-      static UpdateFlags
-      compute_update_flags(
-        const UpdateFlags                                update_flags,
-        const std::vector<dealii::hp::QCollection<dim>> &quad =
-          std::vector<dealii::hp::QCollection<dim>>());
     };
 
 
@@ -277,7 +266,7 @@ namespace internal
     template <int dim, typename Number, typename VectorizedArrayType>
     struct MappingInfoCellsOrFaces<dim, Number, false, VectorizedArrayType>
     {
-      static const MappingInfoStorage<dim, dim, Number, VectorizedArrayType> &
+      static const MappingInfoStorage<dim, dim, VectorizedArrayType> &
       get(const MappingInfo<dim, Number, VectorizedArrayType> &mapping_info,
           const unsigned int                                   quad_no)
       {
@@ -289,10 +278,9 @@ namespace internal
     template <int dim, typename Number, typename VectorizedArrayType>
     struct MappingInfoCellsOrFaces<dim, Number, true, VectorizedArrayType>
     {
-      static const MappingInfoStorage<dim - 1, dim, Number, VectorizedArrayType>
-        &
-        get(const MappingInfo<dim, Number, VectorizedArrayType> &mapping_info,
-            const unsigned int                                   quad_no)
+      static const MappingInfoStorage<dim - 1, dim, VectorizedArrayType> &
+      get(const MappingInfo<dim, Number, VectorizedArrayType> &mapping_info,
+          const unsigned int                                   quad_no)
       {
         AssertIndexRange(quad_no, mapping_info.face_data.size());
         return mapping_info.face_data[quad_no];

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2056,7 +2056,7 @@ namespace internal
             {
               internal::MatrixFreeFunctions::FaceToCellTopology<
                 VectorizedDouble::size()>
-                face_double;
+                face_double = {};
               face_double.interior_face_no = faces[face].interior_face_no;
               face_double.exterior_face_no = faces[face].exterior_face_no;
               face_double.face_orientation = faces[face].face_orientation;

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2131,13 +2131,13 @@ namespace internal
                     {
                       for (unsigned int e = 0; e < dim; ++e)
                         jac_grad[d][e][e] =
-                          eval.begin_gradients()[q + (d * hess_dim + e) *
-                                                       n_q_points];
+                          eval.begin_hessians()[q + (d * hess_dim + e) *
+                                                      n_q_points];
                       for (unsigned int c = dim, e = 0; e < dim; ++e)
                         for (unsigned int f = e + 1; f < dim; ++f, ++c)
                           jac_grad[d][e][f] = jac_grad[d][f][e] =
-                            eval.begin_gradients()[q + (d * hess_dim + c) *
-                                                         n_q_points];
+                            eval.begin_hessians()[q + (d * hess_dim + c) *
+                                                        n_q_points];
                       const auto inv_jac_grad =
                         process_jacobian_gradient(inv_transp_jac_permut,
                                                   inv_transp_jac,

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -1179,7 +1179,7 @@ namespace internal
         MappingInfoStorage<dim, dim, double, VectorizedDouble> temp_data;
         temp_data.copy_descriptor(my_data);
         FEEvaluationBaseData<dim, double, false, VectorizedDouble> eval(
-          {&shape_info, nullptr, &temp_data, 0, 0}, 0, false, 0);
+          {&shape_info, nullptr, &temp_data, 0, 0});
 
         AlignedVector<VectorizedDouble> evaluation_data;
         eval.set_data_pointers(&evaluation_data, dim);
@@ -2091,9 +2091,9 @@ namespace internal
         MappingInfoStorage<dim - 1, dim, double, VectorizedDouble> temp_data;
         temp_data.copy_descriptor(my_data);
         FEEvaluationBaseData<dim, double, true, VectorizedDouble> eval_int(
-          {&shape_info, nullptr, &temp_data, 0, 0}, 0, true, 0);
+          {&shape_info, nullptr, &temp_data, 0, 0}, true);
         FEEvaluationBaseData<dim, double, true, VectorizedDouble> eval_ext(
-          {&shape_info, nullptr, &temp_data, 0, 0}, 0, false, 0);
+          {&shape_info, nullptr, &temp_data, 0, 0}, false);
 
         AlignedVector<VectorizedDouble> evaluation_data, evaluation_data_ext;
         eval_int.set_data_pointers(&evaluation_data, dim);

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -305,6 +305,17 @@ namespace internal
       quad_index_from_n_q_points(const unsigned int n_q_points) const;
 
       /**
+       * Get the descriptor from another instance of QuadratureDescriptor,
+       * clearing all other data fields.
+       */
+      template <typename Number2, typename VectorizedArrayType2>
+      void
+      copy_descriptor(const MappingInfoStorage<structdim,
+                                               spacedim,
+                                               Number2,
+                                               VectorizedArrayType2> &other);
+
+      /**
        * Prints a detailed summary of memory consumption in the different
        * structures of this class to the given output stream.
        */

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -300,7 +300,7 @@ namespace internal
       static UpdateFlags
       compute_update_flags(
         const UpdateFlags                                     update_flags,
-        const std::vector<dealii::hp::QCollection<spacedim>> &quad =
+        const std::vector<dealii::hp::QCollection<spacedim>> &quads =
           std::vector<dealii::hp::QCollection<spacedim>>());
 
       /**

--- a/include/deal.II/matrix_free/mapping_info_storage.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.h
@@ -131,15 +131,13 @@ namespace internal
          */
         template <int dim_q>
         void
-        initialize(const Quadrature<dim_q> &quadrature,
-                   const UpdateFlags update_flags_inner_faces = update_default);
+        initialize(const Quadrature<dim_q> &quadrature);
 
         /**
          * Set up the lengths in the various members of this struct.
          */
         void
-        initialize(const Quadrature<1> &quadrature_1d,
-                   const UpdateFlags update_flags_inner_faces = update_default);
+        initialize(const Quadrature<1> &quadrature_1d);
 
         /**
          * Returns the memory consumption in bytes.
@@ -176,14 +174,6 @@ namespace internal
          * when it is used in a vectorized context).
          */
         AlignedVector<ScalarNumber> quadrature_weights;
-
-        /**
-         * For quadrature on faces, the evaluation of basis functions is not
-         * in the correct order if a face is not in the standard orientation
-         * to a given element. This data structure is used to re-order the
-         * data evaluated on quadrature points to represent the correct order.
-         */
-        dealii::Table<2, unsigned int> face_orientations;
       };
 
       /**
@@ -302,15 +292,6 @@ namespace internal
        */
       unsigned int
       quad_index_from_n_q_points(const unsigned int n_q_points) const;
-
-      /**
-       * Get the descriptor from another instance of QuadratureDescriptor,
-       * clearing all other data fields.
-       */
-      template <typename Number2>
-      void
-      copy_descriptor(
-        const MappingInfoStorage<structdim, spacedim, Number2> &other);
 
       /**
        * Helper function to determine which update flags must be set in the

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -182,6 +182,47 @@ namespace internal
               int spacedim,
               typename Number,
               typename VectorizedArrayType>
+    template <typename Number2, typename VectorizedArrayType2>
+    void
+    MappingInfoStorage<structdim, spacedim, Number, VectorizedArrayType>::
+      copy_descriptor(const MappingInfoStorage<structdim,
+                                               spacedim,
+                                               Number2,
+                                               VectorizedArrayType2> &other)
+    {
+      clear_data_fields();
+      descriptor.clear();
+      descriptor.resize(other.descriptor.size());
+      for (unsigned int i = 0; i < descriptor.size(); ++i)
+        {
+          descriptor[i].n_q_points    = other.descriptor[i].n_q_points;
+          descriptor[i].quadrature_1d = other.descriptor[i].quadrature_1d;
+          descriptor[i].quadrature    = other.descriptor[i].quadrature;
+          for (unsigned int d = 0; d < structdim; ++d)
+            {
+              descriptor[i].tensor_quadrature_weights[d].resize(
+                other.descriptor[i].tensor_quadrature_weights[d].size());
+              std::copy(
+                other.descriptor[i].tensor_quadrature_weights[d].begin(),
+                other.descriptor[i].tensor_quadrature_weights[d].end(),
+                descriptor[i].tensor_quadrature_weights[d].begin());
+            }
+          descriptor[i].quadrature_weights.resize(
+            other.descriptor[i].quadrature_weights.size());
+          std::copy(other.descriptor[i].quadrature_weights.begin(),
+                    other.descriptor[i].quadrature_weights.end(),
+                    descriptor[i].quadrature_weights.begin());
+          descriptor[i].face_orientations =
+            other.descriptor[i].face_orientations;
+        }
+    }
+
+
+
+    template <int structdim,
+              int spacedim,
+              typename Number,
+              typename VectorizedArrayType>
     std::size_t
     MappingInfoStorage<structdim, spacedim, Number, VectorizedArrayType>::
       memory_consumption() const

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -124,7 +124,7 @@ namespace internal
     UpdateFlags
     MappingInfoStorage<structdim, spacedim, Number>::compute_update_flags(
       const UpdateFlags                                     update_flags,
-      const std::vector<dealii::hp::QCollection<spacedim>> &quad)
+      const std::vector<dealii::hp::QCollection<spacedim>> &quads)
     {
       // this class is build around the evaluation of jacobians, so compute
       // them in any case. The Jacobians will be inverted manually. Since we
@@ -145,19 +145,19 @@ namespace internal
       // one quadrature point on the first component, but more points on later
       // components, we need to have Jacobian gradients anyway in order to
       // determine whether the Jacobian is constant throughout a cell
-      if (quad.empty() == false)
+      if (quads.empty() == false)
         {
           bool formula_with_one_point = false;
-          for (unsigned int i = 0; i < quad[0].size(); ++i)
-            if (quad[0][i].size() == 1)
+          for (unsigned int i = 0; i < quads[0].size(); ++i)
+            if (quads[0][i].size() == 1)
               {
                 formula_with_one_point = true;
                 break;
               }
           if (formula_with_one_point == true)
-            for (unsigned int comp = 1; comp < quad.size(); ++comp)
-              for (unsigned int i = 0; i < quad[comp].size(); ++i)
-                if (quad[comp][i].size() > 1)
+            for (unsigned int comp = 1; comp < quads.size(); ++comp)
+              for (unsigned int i = 0; i < quads[comp].size(); ++i)
+                if (quads[comp][i].size() > 1)
                   {
                     new_flags |= update_jacobian_grads;
                   }

--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1067,8 +1067,8 @@ namespace MatrixFreeOperators
       internal::CellwiseInverseMassMatrixImplBasic<dim, VectorizedArrayType>::
         template run<fe_degree>(n_components, fe_eval, in_array, out_array);
     else
-      internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
-        apply(n_components, fe_eval, in_array, out_array);
+      internal::CellwiseInverseMassFactory<dim, VectorizedArrayType>::apply(
+        n_components, fe_eval, in_array, out_array);
   }
 
 
@@ -1101,13 +1101,13 @@ namespace MatrixFreeOperators
           in_array,
           out_array);
     else
-      internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
-        apply(n_actual_components,
-              given_degree,
-              fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
-              inverse_coefficients,
-              in_array,
-              out_array);
+      internal::CellwiseInverseMassFactory<dim, VectorizedArrayType>::apply(
+        n_actual_components,
+        given_degree,
+        fe_eval.get_shape_info().data.front().inverse_shape_values_eo,
+        inverse_coefficients,
+        in_array,
+        out_array);
   }
 
 
@@ -1138,7 +1138,7 @@ namespace MatrixFreeOperators
                                                           in_array,
                                                           out_array);
     else
-      internal::CellwiseInverseMassFactory<dim, Number, VectorizedArrayType>::
+      internal::CellwiseInverseMassFactory<dim, VectorizedArrayType>::
         transform_from_q_points_to_basis(n_actual_components,
                                          fe_eval,
                                          in_array,

--- a/include/deal.II/matrix_free/shape_info.h
+++ b/include/deal.II/matrix_free/shape_info.h
@@ -530,12 +530,20 @@ namespace internal
       dealii::Table<2, unsigned int> face_to_cell_index_hermite;
 
       /**
-       * For degrees on faces, the basis functions are not
+       * For unknowns located on faces, the basis functions are not
        * in the correct order if a face is not in the standard orientation
        * to a given element. This data structure is used to re-order the
        * basis functions to represent the correct order.
        */
-      dealii::Table<2, unsigned int> face_orientations;
+      dealii::Table<2, unsigned int> face_orientations_dofs;
+
+      /**
+       * For interpretation of values at quadrature points, the order of
+       * points is not correct if a face is not in the standard orientation to
+       * a given element. This data structure is used to re-order the
+       * quadrature points to represent the correct order.
+       */
+      dealii::Table<2, unsigned int> face_orientations_quad;
 
     private:
       /**

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -854,40 +854,46 @@ namespace internal
           // (similar to MappingInfoStorage::QuadratureDescriptor::initialize)
           if (dim == 3)
             {
-              const unsigned int n = fe_degree + 1;
-              face_orientations.reinit(8, n * n);
-              for (unsigned int j = 0, i = 0; j < n; ++j)
-                for (unsigned int k = 0; k < n; ++k, ++i)
-                  {
-                    // face_orientation=true,  face_flip=false,
-                    // face_rotation=false
-                    face_orientations[0][i] = i;
-                    // face_orientation=false, face_flip=false,
-                    // face_rotation=false
-                    face_orientations[1][i] = j + k * n;
-                    // face_orientation=true,  face_flip=true,
-                    // face_rotation=false
-                    face_orientations[2][i] = (n - 1 - k) + (n - 1 - j) * n;
-                    // face_orientation=false, face_flip=true,
-                    // face_rotation=false
-                    face_orientations[3][i] = (n - 1 - j) + (n - 1 - k) * n;
-                    // face_orientation=true,  face_flip=false,
-                    // face_rotation=true
-                    face_orientations[4][i] = j + (n - 1 - k) * n;
-                    // face_orientation=false, face_flip=false,
-                    // face_rotation=true
-                    face_orientations[5][i] = k + (n - 1 - j) * n;
-                    // face_orientation=true,  face_flip=true,
-                    // face_rotation=true
-                    face_orientations[6][i] = (n - 1 - j) + k * n;
-                    // face_orientation=false, face_flip=true,
-                    // face_rotation=true
-                    face_orientations[7][i] = (n - 1 - k) + j * n;
-                  }
+              auto compute_orientations =
+                [](const unsigned int      n,
+                   Table<2, unsigned int> &face_orientations) {
+                  face_orientations.reinit(8, n * n);
+                  for (unsigned int j = 0, i = 0; j < n; ++j)
+                    for (unsigned int k = 0; k < n; ++k, ++i)
+                      {
+                        // face_orientation=true,  face_flip=false,
+                        // face_rotation=false
+                        face_orientations[0][i] = i;
+                        // face_orientation=false, face_flip=false,
+                        // face_rotation=false
+                        face_orientations[1][i] = j + k * n;
+                        // face_orientation=true,  face_flip=true,
+                        // face_rotation=false
+                        face_orientations[2][i] = (n - 1 - k) + (n - 1 - j) * n;
+                        // face_orientation=false, face_flip=true,
+                        // face_rotation=false
+                        face_orientations[3][i] = (n - 1 - j) + (n - 1 - k) * n;
+                        // face_orientation=true,  face_flip=false,
+                        // face_rotation=true
+                        face_orientations[4][i] = j + (n - 1 - k) * n;
+                        // face_orientation=false, face_flip=false,
+                        // face_rotation=true
+                        face_orientations[5][i] = k + (n - 1 - j) * n;
+                        // face_orientation=true,  face_flip=true,
+                        // face_rotation=true
+                        face_orientations[6][i] = (n - 1 - j) + k * n;
+                        // face_orientation=false, face_flip=true,
+                        // face_rotation=true
+                        face_orientations[7][i] = (n - 1 - k) + j * n;
+                      }
+                };
+              compute_orientations(fe_degree + 1, face_orientations_dofs);
+              compute_orientations(n_q_points_1d, face_orientations_quad);
             }
           else
             {
-              face_orientations.reinit(1, 1);
+              face_orientations_dofs.reinit(1, 1);
+              face_orientations_quad.reinit(1, 1);
             }
         }
 

--- a/include/deal.II/matrix_free/shape_info.templates.h
+++ b/include/deal.II/matrix_free/shape_info.templates.h
@@ -854,7 +854,7 @@ namespace internal
           // (similar to MappingInfoStorage::QuadratureDescriptor::initialize)
           if (dim == 3)
             {
-              auto compute_orientations =
+              const auto compute_orientations =
                 [](const unsigned int      n,
                    Table<2, unsigned int> &face_orientations) {
                   face_orientations.reinit(8, n * n);

--- a/source/matrix_free/evaluation_template_factory.inst.in
+++ b/source/matrix_free/evaluation_template_factory.inst.in
@@ -17,19 +17,18 @@
 for (deal_II_dimension : DIMENSIONS;
      deal_II_scalar_vectorized : REAL_SCALARS_VECTORIZED)
   {
-    template struct dealii::internal::FEEvaluationFactory<
-      deal_II_dimension,
-      deal_II_scalar_vectorized::value_type,
-      deal_II_scalar_vectorized>;
+    template struct dealii::internal::
+      FEEvaluationFactory<deal_II_dimension, deal_II_scalar_vectorized>;
 
-    template struct dealii::internal::FEFaceEvaluationFactory<
+    template struct dealii::internal::
+      FEFaceEvaluationFactory<deal_II_dimension, deal_II_scalar_vectorized>;
+
+    template struct dealii::internal::FEFaceEvaluationGatherFactory<
       deal_II_dimension,
       deal_II_scalar_vectorized::value_type,
       deal_II_scalar_vectorized>;
 
     // inverse mass
-    template struct dealii::internal::CellwiseInverseMassFactory<
-      deal_II_dimension,
-      deal_II_scalar_vectorized::value_type,
-      deal_II_scalar_vectorized>;
+    template struct dealii::internal::
+      CellwiseInverseMassFactory<deal_II_dimension, deal_II_scalar_vectorized>;
   }

--- a/source/matrix_free/mapping_info.inst.in
+++ b/source/matrix_free/mapping_info.inst.in
@@ -25,14 +25,12 @@ for (deal_II_dimension : DIMENSIONS;
     template struct internal::MatrixFreeFunctions::MappingInfoStorage<
       deal_II_dimension,
       deal_II_dimension,
-      deal_II_scalar_vectorized::value_type,
       deal_II_scalar_vectorized>;
 
 #if deal_II_dimension > 1
     template struct internal::MatrixFreeFunctions::MappingInfoStorage<
       deal_II_dimension - 1,
       deal_II_dimension,
-      deal_II_scalar_vectorized::value_type,
       deal_II_scalar_vectorized>;
 #endif
 

--- a/tests/matrix_free/faces_value_optimization.cc
+++ b/tests/matrix_free/faces_value_optimization.cc
@@ -87,13 +87,13 @@ private:
         for (unsigned int q = 0; q < ref.n_q_points; ++q)
           {
             VectorizedArray<number> diff =
-              (ref.get_value(q) - check.get_value(q));
+              ref.get_value(q) - check.get_value(q);
             for (unsigned int v = 0; v < VectorizedArray<number>::size(); ++v)
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {
-                    deallog << "Error detected on face" << face << ", v=" << v
-                            << "!" << std::endl;
+                    deallog << "Error detected on interior face " << face
+                            << ", v=" << v << ", q=" << q << "!" << std::endl;
                     deallog << "ref: ";
                     for (unsigned int i = 0; i < ref.dofs_per_cell; ++i)
                       deallog << ref.get_dof_value(i)[v] << " ";
@@ -140,14 +140,14 @@ private:
               {
                 if (std::abs(diff[v]) > 1e-12)
                   {
-                    deallog << "Error detected on face" << face << ", v=" << v
-                            << "!" << std::endl;
+                    deallog << "Error detected on exterior face " << face
+                            << ", v=" << v << ", q=" << q << "!" << std::endl;
                     deallog << "ref: ";
                     for (unsigned int i = 0; i < ref.dofs_per_cell; ++i)
                       deallog << refr.get_dof_value(i)[v] << " ";
                     deallog << std::endl;
-                    deallog << "done: " << check.get_value(q)[v]
-                            << " instead of " << ref.get_value(q)[v]
+                    deallog << "done: " << checkr.get_value(q)[v]
+                            << " instead of " << refr.get_value(q)[v]
                             << std::endl;
 
                     deallog
@@ -246,7 +246,7 @@ main()
 {
   initlog();
 
-  deallog << std::setprecision(3);
+  deallog << std::setprecision(14);
 
   {
     deallog.push("2d");

--- a/tests/matrix_free/hanging_node_kernels_01.cc
+++ b/tests/matrix_free/hanging_node_kernels_01.cc
@@ -47,14 +47,11 @@ namespace dealii
       template <int fe_degree, int n_q_points_1d>
       static bool
       run(
-        const FEEvaluationBaseData<dim,
-                                   typename Number::value_type,
-                                   is_face,
-                                   Number> &fe_eval,
-        const bool                          transpose,
+        const FEEvaluationData<dim, Number, is_face> &fe_eval,
+        const bool                                    transpose,
         const std::array<dealii::internal::MatrixFreeFunctions::ConstraintKinds,
-                         Number::size()> &  c_mask,
-        Number *                            values)
+                         Number::size()> &            c_mask,
+        Number *                                      values)
       {
         Assert(is_face == false, ExcInternalError());
 
@@ -106,13 +103,10 @@ namespace dealii
       template <int fe_degree_, unsigned int direction, bool transpose>
       static void
       run_2D(
-        const FEEvaluationBaseData<dim,
-                                   typename Number::value_type,
-                                   is_face,
-                                   Number> &fe_eval,
+        const FEEvaluationData<dim, Number, is_face> &fe_eval,
         const std::array<dealii::internal::MatrixFreeFunctions::ConstraintKinds,
-                         Number::size()> &  constraint_mask,
-        Number *                            values)
+                         Number::size()> &            constraint_mask,
+        Number *                                      values)
       {
         const auto &constraint_weights = fe_eval.get_shape_info()
                                            .data.front()
@@ -247,13 +241,10 @@ namespace dealii
       template <int fe_degree_, unsigned int direction, bool transpose>
       static void
       run_3D(
-        const FEEvaluationBaseData<dim,
-                                   typename Number::value_type,
-                                   is_face,
-                                   Number> &fe_eval,
+        const FEEvaluationData<dim, Number, is_face> &fe_eval,
         const std::array<dealii::internal::MatrixFreeFunctions::ConstraintKinds,
-                         Number::size()> &  constraint_mask,
-        Number *                            values)
+                         Number::size()> &            constraint_mask,
+        Number *                                      values)
       {
         const auto &constraint_weights = fe_eval.get_shape_info()
                                            .data.front()

--- a/tests/matrix_free/interpolate_quadrature_01.cc
+++ b/tests/matrix_free/interpolate_quadrature_01.cc
@@ -120,13 +120,11 @@ test(const unsigned int n_refinements = 1)
                                                    VectorizedArrayType>::
                 template interpolate_quadrature<true, false>(
                   1,
+                  EvaluationFlags::values,
                   matrix_free.get_shape_info(),
                   phi.begin_values(),
                   temp.data(),
-                  false,
-                  false,
                   face);
-
 
               for (unsigned int q = 0; q < phi_m.n_q_points; ++q)
                 {


### PR DESCRIPTION
This PR aims at cleaning up the internal interfaces for the call in `FEEvaluation` and derived classes. The current functionality turned out hard to maintain because we had to pass in additional arguments every time we wanted to extend functionality, such as recently by #12593. It is also somewhat slow because we recursively call this function in the template instantiation mechanism, and every time a function call is made the compiler has to push all those variables to the stack and back. (I realized this when looking at a solver at the CFD application ExaDG https://github.com/exadg/exadg/blob/master/applications/incompressible_navier_stokes/taylor_green_vortex/application.h , so I decided we either clean things up now or suffer more in the future.) 

As a solution, the code now passes in an `FEEvaluationBaseData` argument to the evaluation routines, from which all data can be deduced. While this increases code size in debug mode by adding more function calls to some getters, it reduces code size in release mode somewhat. More importantly, it helps to get nicer code with less `push/pop` instructions.

The code is currently not complete, as it does not implement the optimized face extraction function https://github.com/dealii/dealii/blob/c1d536f5b02c6898ae9d33569bc750a28c71cb78/include/deal.II/matrix_free/evaluation_kernels.h#L3322-L3325 but the code should already be correct (apart from some minor things I'm currently working on) as I simply switch back to the slow path that reads too much data.

FYI @bergbauer @nfehn 