### PR TITLE
Add some explicit casts to IndexSet.

### DIFF
--- a/include/deal.II/base/index_set.h
+++ b/include/deal.II/base/index_set.h
@@ -1723,7 +1723,7 @@ IndexSet::add_indices(const ForwardIterator &begin, const ForwardIterator &end)
       size_type       end_index   = begin_index + 1;
       ForwardIterator q           = p;
       ++q;
-      while ((q != end) && (*q == end_index))
+      while ((q != end) && (static_cast<size_type>(*q) == end_index))
         {
           ++end_index;
           ++q;
@@ -1736,7 +1736,7 @@ IndexSet::add_indices(const ForwardIterator &begin, const ForwardIterator &end)
       // than the end index of the one just identified, then we will have at
       // least one pair of ranges that are not sorted, and consequently the
       // whole collection of ranges is not sorted.
-      if (p != end && *p < end_index)
+      if (p != end && static_cast<size_type>(*p) < end_index)
         ranges_are_sorted = false;
     }
 


### PR DESCRIPTION
I tried adding an array PetscInts to an index set and got a sign conversion warning.