### PR TITLE
Evaluation kernels: Make sure to pick vectorized gather function

### DIFF
--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -2628,7 +2628,7 @@ namespace internal
 
   // internal helper function for reading data; specialized version where we
   // can use a dedicated load function
-  template <typename Number, unsigned int width>
+  template <typename Number, std::size_t width>
   void
   do_vectorized_read(const Number *src_ptr, VectorizedArray<Number, width> &dst)
   {
@@ -2652,7 +2652,7 @@ namespace internal
 
   // internal helper function for reading data; specialized version where we
   // can use a dedicated gather function
-  template <typename Number, unsigned int width>
+  template <typename Number, std::size_t width>
   void
   do_vectorized_gather(const Number *                  src_ptr,
                        const unsigned int *            indices,
@@ -2676,7 +2676,7 @@ namespace internal
 
   // internal helper function for reading data; specialized version where we
   // can use a dedicated load function
-  template <typename Number, unsigned int width>
+  template <typename Number, std::size_t width>
   void
   do_vectorized_add(const VectorizedArray<Number, width> src, Number *dst_ptr)
   {
@@ -2702,7 +2702,7 @@ namespace internal
 
   // internal helper function for reading data; specialized version where we
   // can use a dedicated gather function
-  template <typename Number, unsigned int width>
+  template <typename Number, std::size_t width>
   void
   do_vectorized_scatter_add(const VectorizedArray<Number, width> src,
                             const unsigned int *                 indices,

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2049,9 +2049,7 @@ namespace internal
         for (unsigned int face = begin_face; face < end_face; ++face)
           for (unsigned vv = 0; vv < n_lanes; vv += n_lanes_d)
             {
-              internal::MatrixFreeFunctions::FaceToCellTopology<
-                VectorizedDouble::size()>
-                face_double                = {};
+              FaceToCellTopology<VectorizedDouble::size()> face_double = {};
               face_double.interior_face_no = faces[face].interior_face_no;
               face_double.exterior_face_no = faces[face].exterior_face_no;
               face_double.face_orientation = faces[face].face_orientation;


### PR DESCRIPTION
While working in #13056, I observed that we pick the wrong specialization for the various `do_vectorized_xxx` functions, hence missing a call to `gather` instructions (if available). The reason was that we imply a `VectorizedArray<typename, unsigned int>` type, but it actually is `VectorizedArray<typename, std::size_t>`.