### PR TITLE
Correct typo (math rendering)

### DIFF
--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -871,8 +871,8 @@ namespace FEInterfaceViews
     //@{
 
     /**
-     * Return the average vector $\average{\mathbf{u}}=\frac{1}{2}(\mathbf{u_1} +
-     * \mathbf{u_2})$ on the interface for the shape
+     * Return the average vector $\average{\mathbf{u}}=\frac{1}{2}(\mathbf{u_1}
+     * + \mathbf{u_2})$ on the interface for the shape
      * function @p interface_dof_index in the quadrature point @p q_point.
      */
     value_type

--- a/include/deal.II/fe/fe_interface_values.h
+++ b/include/deal.II/fe/fe_interface_values.h
@@ -871,7 +871,7 @@ namespace FEInterfaceViews
     //@{
 
     /**
-     * Return the average vector $\average{\mathbf{u}}=\frac{1}{2}(\matbf{u_1} +
+     * Return the average vector $\average{\mathbf{u}}=\frac{1}{2}(\mathbf{u_1} +
      * \mathbf{u_2})$ on the interface for the shape
      * function @p interface_dof_index in the quadrature point @p q_point.
      */


### PR DESCRIPTION
Tiny thing but a bit annoying: remove `Undefined control sequence \matbf` error in the documentation