### PR TITLE
Make sure doxygen does not format all combinations of NonMatching::coupling_*.

### DIFF
--- a/source/non_matching/coupling.cc
+++ b/source/non_matching/coupling.cc
@@ -959,8 +959,9 @@ namespace NonMatching
           }
       }
   }
-
-#include "coupling.inst"
+#ifndef DOXYGEN
+#  include "coupling.inst"
+#endif
 } // namespace NonMatching
 
 DEAL_II_NAMESPACE_CLOSE


### PR DESCRIPTION
The page  https://www.dealii.org/developer/doxygen/deal.II/namespaceNonMatching.html is unreadable. 

Make sure we don't parse all instantiations when building the documentation.