### PR TITLE
Add docker image with root user.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,3 +38,4 @@ jobs:
           cache-to: type=inline
           push: true
           tags: dealii/dealii:master-focal-root
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,3 +28,13 @@ jobs:
           cache-to: type=inline
           push: true
           tags: dealii/dealii:master-focal
+
+      - name: Build and push Docker image of master with root user
+        uses: docker/build-push-action@v2
+        with:
+          context: ./contrib/docker/
+          file: {context}/Dockerfile.root
+          cache-from: type=registry,ref=dealii/dealii:master-focal
+          cache-to: type=inline
+          push: true
+          tags: dealii/dealii:master-focal-root

--- a/contrib/docker/Dockerfile.root
+++ b/contrib/docker/Dockerfile.root
@@ -1,0 +1,5 @@
+FROM dealii/dealii:master-focal
+
+LABEL maintainer="luca.heltai@gmail.com"
+
+USER root

--- a/doc/news/changes/minor/20211224LucaHeltai
+++ b/doc/news/changes/minor/20211224LucaHeltai
@@ -1,0 +1,3 @@
+New: Build also a docker image with root user, to be used in github actions directly.
+<br>
+(Luca Heltai, 2021/12/24)


### PR DESCRIPTION
This allows one to use our docker image directly in github actions:

```
name: Run on dealii/dealii:master-focal-root
on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]

jobs:
  continuous-integration:
    runs-on: ubuntu-latest
    container: dealii/dealii:master-focal-root
    steps:          
      - name: Checkout code
        uses: actions/checkout@v2
      - name: Build and run tests
         run: |
            mkdir build
            cd build
            cmake -GNinja .. 
            ninja 
            ninja test
```