### PR TITLE
CMake: use portable "rm" in quick_tests

### DIFF
--- a/tests/quick_tests/CMakeLists.txt
+++ b/tests/quick_tests/CMakeLists.txt
@@ -66,11 +66,11 @@ MACRO(make_quicktest test_basename build_name mpi_run)
 
   # this is a hack to make sure the -OK file is deleted
   # even if compilation fails.
-  ADD_CUSTOM_TARGET(kill-${_target}-OK
-        COMMAND rm -f ${_target}-OK
+  ADD_CUSTOM_TARGET(reset-${_target}-OK
+    COMMAND ${CMAKE_COMMAND} -E remove -f ${_target}-OK
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
-  ADD_DEPENDENCIES(${_target} kill-${_target}-OK)
+  ADD_DEPENDENCIES(${_target} reset-${_target}-OK)
 
   ADD_TEST(NAME ${_target}
     COMMAND ${CMAKE_COMMAND} -DTRGT=${_target}.run -DTEST=${_target}


### PR DESCRIPTION
Closes: https://github.com/dealii/dealii/issues/13122