### PR TITLE
Add an assertion to GridGenerator::flatten_triangulation().

### DIFF
--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -7500,6 +7500,9 @@ namespace GridGenerator
            ExcMessage(
              "This function cannot be used on "
              "parallel::distributed::Triangulation objects as inputs."));
+    Assert(in_tria.has_hanging_nodes() == false,
+           ExcMessage("This function does not work for meshes that have "
+                      "hanging nodes."));
 
 
     const unsigned int spacedim = std::min(spacedim1, spacedim2);


### PR DESCRIPTION
Fixes #13131. Let's see what this actually breaks.

/rebuild