### PR TITLE
Fix a bug in SD::BatchOptimizer::extract()

### DIFF
--- a/source/differentiation/sd/symengine_optimizer.cc
+++ b/source/differentiation/sd/symengine_optimizer.cc
@@ -601,7 +601,7 @@ namespace Differentiation
                   new_map_expr.get_value().__str__())
                 {
                   map_dep_expr_vec_entry[func] = e.second;
-                  return evaluate(func);
+                  return extract(func, cached_evaluation);
                 }
             }
 


### PR DESCRIPTION
We shouldn't call `SD::BatchOptimizer::evaluate()` from `SD::BatchOptimizer::extract()`, as the optimizer may not be set up to do evaluation (as can happen when one optimizer is used to perform all of the calculations, while a "worker" optimizer is set up just to do value extraction based on what the first one computed.