### PR TITLE
Add a hash to SymEngine expression wrapper

### DIFF
--- a/doc/news/changes/minor/20211226Jean-PaulPelteret
+++ b/doc/news/changes/minor/20211226Jean-PaulPelteret
@@ -1,0 +1,8 @@
+New: A symbolic expression can now be hashed using the
+SD::Expression::compute_hash() function. The (cached) hash can then be retrieved
+using the SD::Expression::get_hash() function. In some circumstances this can
+aid comparing expressions without resorting to the more costly comparator
+provided by SymEngine.
+
+<br>
+(Jean-Paul Pelteret, 2021/12/26)

--- a/include/deal.II/differentiation/sd/symengine_number_types.h
+++ b/include/deal.II/differentiation/sd/symengine_number_types.h
@@ -56,6 +56,7 @@
 #  include <symengine/derivative.h>
 
 #  include <algorithm>
+#  include <functional>
 #  include <memory>
 #  include <sstream>
 #  include <type_traits>
@@ -428,6 +429,27 @@ namespace Differentiation
        */
       std::ostream &
       print(std::ostream &stream) const;
+
+      /**
+       * Computes the hash for the @p expression that this object represents.
+       */
+      void
+      compute_hash();
+
+      /**
+       * Returns @p true if the @p hash for this object has been calculated.
+       */
+      bool
+      is_hashed() const;
+
+      /**
+       * Returns the @p hash for this @p expression.
+       *
+       * This function can only be called if compute_hash() has been called on
+       * @p this expression.
+       */
+      SymEngine::hash_t
+      get_hash() const;
 
       /**
        * Save the value stored by this object to the @p stream.
@@ -869,6 +891,26 @@ namespace Differentiation
        * represent.
        */
       SymEngine::Expression expression;
+
+      /**
+       * A cached value of the hash of the SymEngine class instance.
+       * This can be used to rapidly compare two expressions for equality.
+       * By default, this is not computed and will only be initialized when
+       * compute_hash() is called. This value persists when the object is
+       * copied or serialized/deserialized.
+       */
+      SymEngine::hash_t hash;
+
+      /**
+       * A flag to indicate if this object has been hashed or not.
+       */
+      bool hash_computed;
+
+      /**
+       * Resets the @p hash to an uninitialized state.
+       */
+      void
+      reset_hash();
     };
 
     /**
@@ -1256,6 +1298,8 @@ namespace Differentiation
       sstream << *this;
       const std::string expr = sstream.str();
       ar &              expr;
+      ar &              hash;
+      ar &              hash_computed;
     }
 
 
@@ -1265,6 +1309,8 @@ namespace Differentiation
     {
       std::string expr;
       ar &        expr;
+      ar &        hash;
+      ar &        hash_computed;
       parse(expr);
     }
 


### PR DESCRIPTION
I'll be using this in a follow up PR, where I'll provide some tests. (The calculation of the hash itself should be treated as an "internal detail" of SymEngine, so we cannot expect that the value is deterministic.)