### PR TITLE
fix docker.yml - try 3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./contrib/docker/
-          file: Dockerfile.root
+          file: ./contrib/docker/Dockerfile.root
           cache-from: type=registry,ref=dealii/dealii:master-focal
           cache-to: type=inline
           push: true


### PR DESCRIPTION
The [example](https://github.com/docker/build-push-action/blob/b1aeb1103e6b3b5648dbd6deaf0559919456ca6b/.github/workflows/example.yml#L52-L53) in the docker repository uses absolute paths, so we might do the same.

Follow-up to #13125, #13120.
