### PR TITLE
Add a bunch of dummy functions for TriaAccessor<0,1,spacedim>.

### DIFF
--- a/include/deal.II/grid/tria_accessor.h
+++ b/include/deal.II/grid/tria_accessor.h
@@ -2570,11 +2570,206 @@ public:
    * Return the manifold indicator of this object.
    *
    * @see
-   * @ref GlossManifoldIndicator "Glossary entry on manifold indicators"
+   * @ref GlossManifoldIndicator "Glossary entry on manifold indicators".
    */
   types::manifold_id
   manifold_id() const;
 
+
+  /**
+   * @name User data
+   */
+  /**
+   * @{
+   */
+  /**
+   * Read the user flag. See
+   * @ref GlossUserFlags
+   * for more information.
+   */
+  bool
+  user_flag_set() const;
+
+  /**
+   * Set the user flag. See
+   * @ref GlossUserFlags
+   * for more information.
+   */
+  void
+  set_user_flag() const;
+
+  /**
+   * Clear the user flag. See
+   * @ref GlossUserFlags
+   * for more information.
+   */
+  void
+  clear_user_flag() const;
+
+  /**
+   * Set the user flag for this and all descendants. See
+   * @ref GlossUserFlags
+   * for more information.
+   */
+  void
+  recursively_set_user_flag() const;
+
+  /**
+   * Clear the user flag for this and all descendants. See
+   * @ref GlossUserFlags
+   * for more information.
+   */
+  void
+  recursively_clear_user_flag() const;
+
+  /**
+   * Reset the user data to zero, independent if pointer or index. See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  clear_user_data() const;
+
+  /**
+   * Set the user pointer to @p p.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  set_user_pointer(void *p) const;
+
+  /**
+   * Reset the user pointer to a @p nullptr pointer. See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  clear_user_pointer() const;
+
+  /**
+   * Access the value of the user pointer. It is in the responsibility of the
+   * user to make sure that the pointer points to something useful. You should
+   * use the new style cast operator to maintain a minimum of type safety,
+   * e.g.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between. <tt>A
+   * *a=static_cast<A*>(cell->user_pointer());</tt>.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void *
+  user_pointer() const;
+
+  /**
+   * Set the user pointer of this object and all its children to the given
+   * value. This is useful for example if all cells of a certain subdomain, or
+   * all faces of a certain part of the boundary should have user pointers
+   * pointing to objects describing this part of the domain or boundary.
+   *
+   * Note that the user pointer is not inherited under mesh refinement, so
+   * after mesh refinement there might be cells or faces that don't have user
+   * pointers pointing to the describing object. In this case, simply loop
+   * over all the elements of the coarsest level that has this information,
+   * and use this function to recursively set the user pointer of all finer
+   * levels of the triangulation.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  recursively_set_user_pointer(void *p) const;
+
+  /**
+   * Clear the user pointer of this object and all of its descendants. The
+   * same holds as said for the recursively_set_user_pointer() function. See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  recursively_clear_user_pointer() const;
+
+  /**
+   * Set the user index to @p p.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between. See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  set_user_index(const unsigned int p) const;
+
+  /**
+   * Reset the user index to 0. See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  clear_user_index() const;
+
+  /**
+   * Access the value of the user index.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  unsigned int
+  user_index() const;
+
+  /**
+   * Set the user index of this object and all its children.
+   *
+   * Note that the user index is not inherited under mesh refinement, so after
+   * mesh refinement there might be cells or faces that don't have the
+   * expected user indices. In this case, simply loop over all the elements of
+   * the coarsest level that has this information, and use this function to
+   * recursively set the user index of all finer levels of the triangulation.
+   *
+   * @note User pointers and user indices are mutually exclusive. Therefore,
+   * you can only use one of them, unless you call
+   * Triangulation::clear_user_data() in between.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  recursively_set_user_index(const unsigned int p) const;
+
+  /**
+   * Clear the user index of this object and all of its descendants. The same
+   * holds as said for the recursively_set_user_index() function.
+   *
+   * See
+   * @ref GlossUserData
+   * for more information.
+   */
+  void
+  recursively_clear_user_index() const;
+  /**
+   * @}
+   */
 
   /**
    * @name Orientation of sub-objects

--- a/include/deal.II/grid/tria_accessor.templates.h
+++ b/include/deal.II/grid/tria_accessor.templates.h
@@ -1753,7 +1753,8 @@ TriaAccessor<structdim, dim, spacedim>::recursively_clear_user_pointer() const
 
 template <int structdim, int dim, int spacedim>
 void
-TriaAccessor<structdim, dim, spacedim>::set_user_index(unsigned int p) const
+TriaAccessor<structdim, dim, spacedim>::set_user_index(
+  const unsigned int p) const
 {
   Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
   this->objects().user_index(this->present_index) = p;
@@ -1784,7 +1785,7 @@ TriaAccessor<structdim, dim, spacedim>::user_index() const
 template <int structdim, int dim, int spacedim>
 void
 TriaAccessor<structdim, dim, spacedim>::recursively_set_user_index(
-  unsigned int p) const
+  const unsigned int p) const
 {
   set_user_index(p);
 

--- a/source/grid/tria_accessor.cc
+++ b/source/grid/tria_accessor.cc
@@ -1798,6 +1798,190 @@ TriaAccessor<structdim, dim, spacedim>::center(
 }
 
 
+/*---------------- Functions: TriaAccessor<0,1,spacedim> -------------------*/
+
+
+template <int spacedim>
+bool
+TriaAccessor<0, 1, spacedim>::user_flag_set() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+  return true;
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::set_user_flag() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::clear_user_flag() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_set_user_flag() const
+{
+  set_user_flag();
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_set_user_flag();
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_clear_user_flag() const
+{
+  clear_user_flag();
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_clear_user_flag();
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::clear_user_data() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::set_user_pointer(void *) const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::clear_user_pointer() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void *
+TriaAccessor<0, 1, spacedim>::user_pointer() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+  return nullptr;
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_set_user_pointer(void *p) const
+{
+  set_user_pointer(p);
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_set_user_pointer(p);
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_clear_user_pointer() const
+{
+  clear_user_pointer();
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_clear_user_pointer();
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::set_user_index(const unsigned int) const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::clear_user_index() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+}
+
+
+
+template <int spacedim>
+unsigned int
+TriaAccessor<0, 1, spacedim>::user_index() const
+{
+  Assert(this->used(), TriaAccessorExceptions::ExcCellNotUsed());
+  Assert(false, ExcNotImplemented());
+  return 0;
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_set_user_index(unsigned int p) const
+{
+  set_user_index(p);
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_set_user_index(p);
+}
+
+
+
+template <int spacedim>
+void
+TriaAccessor<0, 1, spacedim>::recursively_clear_user_index() const
+{
+  clear_user_index();
+
+  if (this->has_children())
+    for (unsigned int c = 0; c < this->n_children(); ++c)
+      this->child(c)->recursively_clear_user_index();
+}
+
+
+
 /*------------------------ Functions: CellAccessor<1> -----------------------*/
 
 


### PR DESCRIPTION
To fix #13126 , I needed a bunch of functions in `TriaAccessor<0,1,spacedim>` to at least exist, though they will not be called. This patch adds them, but does not provide functional implementations (which doesn't matter, because as I mentioned, we don't actually call these functions).

/rebuild