### PR TITLE
Bug in gmsh api writer.

### DIFF
--- a/tests/gmsh/gmsh_api_05.cc
+++ b/tests/gmsh/gmsh_api_05.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Create hyper cube, 0bcs, write, read, and write again with gmsh
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+  const unsigned int dim      = 2;
+  const unsigned int spacedim = 2;
+
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1, false);
+
+  GridOut go;
+  go.write_msh(tria, "output.msh");
+
+  Triangulation<dim, spacedim> tria2;
+  GridIn<dim, spacedim>        gi(tria2);
+  gi.read_msh("output.msh");
+
+  go.write_msh(tria2, "output2.msh");
+
+  deallog << "Original mesh: " << std::endl;
+  cat_file("output.msh");
+  deallog << "Regenerated mesh: " << std::endl;
+  cat_file("output2.msh");
+}

--- a/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output
+++ b/tests/gmsh/gmsh_api_05.with_gmsh_with_api=on.output
@@ -1,0 +1,52 @@
+
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$Entities
+0 0 1 0
+1 0 0 0 1 1 0 1 1 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+1 1 1 1
+2 1 3 1
+1 1 2 4 3 
+$EndElements

--- a/tests/gmsh/gmsh_api_06.cc
+++ b/tests/gmsh/gmsh_api_06.cc
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// Create hyper cube, 0bcs, write, read, and write again with gmsh
+
+#include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
+#include <deal.II/grid/grid_out.h>
+#include <deal.II/grid/tria.h>
+
+#include "../tests.h"
+
+int
+main()
+{
+  initlog();
+  const unsigned int dim      = 2;
+  const unsigned int spacedim = 2;
+
+  Triangulation<dim, spacedim> tria;
+  GridGenerator::hyper_cube(tria, 0, 1, true);
+
+  GridOut go;
+  go.write_msh(tria, "output.msh");
+
+  Triangulation<dim, spacedim> tria2;
+  GridIn<dim, spacedim>        gi(tria2);
+  gi.read_msh("output.msh");
+
+  go.write_msh(tria2, "output2.msh");
+
+  deallog << "Original mesh: " << std::endl;
+  cat_file("output.msh");
+  deallog << "Regenerated mesh: " << std::endl;
+  cat_file("output2.msh");
+}

--- a/tests/gmsh/gmsh_api_06.with_gmsh_with_api=on.output
+++ b/tests/gmsh/gmsh_api_06.with_gmsh_with_api=on.output
@@ -1,0 +1,82 @@
+
+DEAL::Original mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+3
+1 1 "BoundaryID:1"
+1 2 "BoundaryID:2"
+1 3 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 3 1 0
+2 1 0 0 1 1 0 1 1 0 
+3 0 0 0 1 0 0 1 2 0 
+4 0 1 0 1 1 0 1 3 0 
+1 0 0 0 1 1 0 1 4 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+4 4 1 4
+1 2 1 1
+2 2 4 
+1 3 1 1
+3 1 2 
+1 4 1 1
+4 3 4 
+2 1 3 1
+1 1 2 4 3 
+$EndElements
+
+DEAL::Regenerated mesh: 
+$MeshFormat
+4.1 0 8
+$EndMeshFormat
+$PhysicalNames
+3
+1 1 "BoundaryID:1"
+1 2 "BoundaryID:2"
+1 3 "BoundaryID:3"
+$EndPhysicalNames
+$Entities
+0 3 1 0
+2 1 0 0 1 1 0 1 1 0 
+3 0 0 0 1 0 0 1 2 0 
+4 0 1 0 1 1 0 1 3 0 
+1 0 0 0 1 1 0 1 4 0 
+$EndEntities
+$Nodes
+1 4 1 4
+2 1 0 4
+1
+2
+3
+4
+0 0 0
+1 0 0
+0 1 0
+1 1 0
+$EndNodes
+$Elements
+4 4 1 4
+1 2 1 1
+2 2 4 
+1 3 1 1
+3 1 2 
+1 4 1 1
+4 3 4 
+2 1 3 1
+1 1 2 4 3 
+$EndElements


### PR DESCRIPTION
I've added two tests that do the following things:

- create a hyper_cube triangulation
- write it using gmsh api
- read it back using gmsh api
- write it again using gmsh api
- copy the two meshes to the output file (they should be identical, up to maybe different node numberings in different versions of gmsh, but not for this simple case)

If only the default boundary id (0) is used, everything is ok (test gmsh_api_05). If I colorize the grid, then the gmsh api writer `GridOut::write_msh(tria, string)` fails to write nodes information (gmsh_api_06).

In the second case, I get as msh file the following:

~~~
$MeshFormat
4.1 0 8
$EndMeshFormat
$PhysicalNames
3
1 1 "BoundaryID:1"
1 2 "BoundaryID:2"
1 3 "BoundaryID:3"
$EndPhysicalNames
$Entities
0 3 1 0
2 1 0 0 1 1 0 1 1 0 
3 0 0 0 1 0 0 1 2 0 
4 0 1 0 1 1 0 1 3 0 
1 0 0 0 1 1 0 1 4 0 
$EndEntities
$Elements
4 4 1 4
1 2 1 1
2 2 4 
1 3 1 1
3 1 2 
1 4 1 1
4 3 4 
2 1 3 1
1 1 2 4 3 
$EndElements
~~~ 

Everything is fine, except there is no `$Nodes` section. I created the output of `gmsh_api_06` by hand.

I have not worked on a fix yet, but when the fix is ready, the second test should pass. 