### PR TITLE
typo in docu of fourth order unit tensor (SymmetricTensor<4, dim, Number> identity_tensor())

### DIFF
--- a/include/deal.II/base/symmetric_tensor.h
+++ b/include/deal.II/base/symmetric_tensor.h
@@ -99,7 +99,7 @@ DEAL_II_CONSTEXPR inline DEAL_II_ALWAYS_INLINE SymmetricTensor<4, dim, Number>
  * In index notation, we can write the general form
  * \f[
  *   \mathcal{I}_{ijkl} = \frac 12 \left( \delta_{ik} \delta_{jl} +
- *                                        \delta_{il} \delta_{jl} \right).
+ *                                        \delta_{il} \delta_{jk} \right).
  * \f]
  * To see why this factor of $1 / 2$ is necessary, consider computing
  * $\mathbf A= \mathbb I : \mathbf B$.


### PR DESCRIPTION
Hello,

I found a minor typo in the documentation of `SymmetricTensor<4, dim, Number> identity_tensor();` [(docu of identity_tensor)](https://dealii.org/developer/doxygen/deal.II/classSymmetricTensor.html#ab3e890348aa219805e84f7d367e098c3). In the index notation (line 101-102) the last index pair for `\mathcal{I}_{ijkl}` should be "jk" and not "jl". (compare for instance Wriggers "Nonlinear Finite Element Methods" p.79 eq. (3.270) or [Notes on Continuum Mechanics - Tensors](http://mmc.rmee.upc.edu/documents/Tensor_Analysis/tensors.pdf) eq. (1.175)) This appears to be a copy-paste error from the previous line 101 that sneaked in with #9830.

Obviously the implementation is fine, it is just this one character in the documentation that I stumble over from time to time.
Normally, such a small thing would not bother me, but this documentation is so well written and very helpful that I often look things up there instead of opening a book. Overall, a fantastic work that is very much appreciated!
I took this opportunity to try a pull request, so please let me know if anything is out of order.