### PR TITLE
Extend ScratchData's public interface with getter methods to access private data

### DIFF
--- a/doc/news/changes/minor/20211231Jean-PaulPelteret
+++ b/doc/news/changes/minor/20211231Jean-PaulPelteret
@@ -1,0 +1,5 @@
+New: More "getter" functions have been added to MeshWorker::ScratchData,
+facilitating the construction of other FEValues-type objects with some of 
+the same objects as those used in a ScratchData instance.
+<br>
+(Jean-Paul Pelteret, 2021/12/31)

--- a/include/deal.II/meshworker/scratch_data.h
+++ b/include/deal.II/meshworker/scratch_data.h
@@ -533,6 +533,48 @@ namespace MeshWorker
     get_mapping() const;
 
     /**
+     * Return a reference to the selected finite element object.
+     */
+    const FiniteElement<dim, spacedim> &
+    get_fe() const;
+
+    /**
+     * Return a reference to the cell quadrature object in use.
+     */
+    const Quadrature<dim> &
+    get_cell_quadrature() const;
+
+    /**
+     * Return a reference to the face quadrature object in use.
+     */
+    const Quadrature<dim - 1> &
+    get_face_quadrature() const;
+
+    /**
+     * Return the cell update flags set.
+     */
+    UpdateFlags
+    get_cell_update_flags() const;
+
+    /**
+     * Return the neighbor cell update flags set.
+     */
+    UpdateFlags
+    get_neighbor_cell_update_flags() const;
+
+    /**
+     * Return the face update flags set.
+     */
+    UpdateFlags
+    get_face_update_flags() const;
+
+    /**
+     * Return the neighbor face update flags set.
+     */
+    UpdateFlags
+    get_neighbor_face_update_flags() const;
+
+    /**
      * @name Evaluation of finite element fields and their derivatives on the current cell
      */
     /** @{ */ // CurrentCellEvaluation

--- a/source/meshworker/scratch_data.cc
+++ b/source/meshworker/scratch_data.cc
@@ -403,6 +403,69 @@ namespace MeshWorker
     return *mapping;
   }
 
+
+
+  template <int dim, int spacedim>
+  const FiniteElement<dim, spacedim> &
+  ScratchData<dim, spacedim>::get_fe() const
+  {
+    return *fe;
+  }
+
+
+
+  template <int dim, int spacedim>
+  const Quadrature<dim> &
+  ScratchData<dim, spacedim>::get_cell_quadrature() const
+  {
+    return cell_quadrature;
+  }
+
+
+
+  template <int dim, int spacedim>
+  const Quadrature<dim - 1> &
+  ScratchData<dim, spacedim>::get_face_quadrature() const
+  {
+    return face_quadrature;
+  }
+
+
+
+  template <int dim, int spacedim>
+  UpdateFlags
+  ScratchData<dim, spacedim>::get_cell_update_flags() const
+  {
+    return cell_update_flags;
+  }
+
+
+
+  template <int dim, int spacedim>
+  UpdateFlags
+  ScratchData<dim, spacedim>::get_neighbor_cell_update_flags() const
+  {
+    return neighbor_cell_update_flags;
+  }
+
+
+
+  template <int dim, int spacedim>
+  UpdateFlags
+  ScratchData<dim, spacedim>::get_face_update_flags() const
+  {
+    return face_update_flags;
+  }
+
+
+
+  template <int dim, int spacedim>
+  UpdateFlags
+  ScratchData<dim, spacedim>::get_neighbor_face_update_flags() const
+  {
+    return neighbor_face_update_flags;
+  }
+
 } // namespace MeshWorker
 DEAL_II_NAMESPACE_CLOSE
 


### PR DESCRIPTION
This is necessary if, for instance, you want to duplicate a `ScratchData` object without using the deep copy constructor.