### PR TITLE
Fix compilation with boost 1.78.

### DIFF
--- a/cmake/configure/configure_2_boost.cmake
+++ b/cmake/configure/configure_2_boost.cmake
@@ -146,25 +146,6 @@ MACRO(FEATURE_BOOST_FIND_EXTERNAL var)
   IF(BOOST_FOUND)
     SET(${var} TRUE)
 
-    #
-    # Set BOOST_DIR to something meaningful if empty
-    #
-    IF("${BOOST_DIR}" STREQUAL "")
-      SET(BOOST_DIR "<system location>")
-    ENDIF()
-
-    IF(BOOST_VERSION VERSION_EQUAL 1.77)
-      MESSAGE(STATUS "Could not find a sufficient Boost installation: "
-        "deal.II is not compatible with Boost version 1.77."
-        )
-      SET(BOOST_ADDITIONAL_ERROR_STRING
-        ${BOOST_ADDITIONAL_ERROR_STRING}
-        "The Boost installation (found at \"${BOOST_DIR}\")\n"
-        "with version ${BOOST_VERSION} is not compatible with deal.II.\n\n"
-        )
-      SET(${var} FALSE)
-    ENDIF()
-
     IF(DEAL_II_WITH_ZLIB)
       #
       # Test that Boost.Iostreams is usable.

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -26,6 +26,8 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/geometry/algorithms/distance.hpp>
+
 #ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
 #  define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif

--- a/tests/boost/rtree_01.cc
+++ b/tests/boost/rtree_01.cc
@@ -19,6 +19,7 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
+#include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 


### PR DESCRIPTION
Fixes #13037 - I can now compile the library with 1.78 on my desktop.

I bisected (fortunately Boost.Geometry a header-only library so adding the include directory sufficed) and
https://github.com/boostorg/geometry/commit/6eb9e238bcb37e26dc31d16acf826784a2ba30f4 is where this problem starts for us. See also https://github.com/boostorg/geometry/issues/792 - the easiest fix for all such issues is to just include the project header `boost/geometry/geometry.hpp`.

In this particular case, if you look at the commit which causes `grid_tools.cc` fails to compile, its because we were relying on some implicit includes. In particular, we need the distance header to find the distance between points and boxes.