### PR TITLE
Use std::string::size() instead of std::string::length().

### DIFF
--- a/include/deal.II/base/hdf5.h
+++ b/include/deal.II/base/hdf5.h
@@ -1529,7 +1529,7 @@ namespace HDF5
       std::string message;
 
       auto append_to_message = [&message](const char *p) {
-        if (message.length() > 0)
+        if (message.size() > 0)
           message += ", ";
         message += p;
       };

--- a/include/deal.II/base/memory_consumption.h
+++ b/include/deal.II/base/memory_consumption.h
@@ -306,7 +306,7 @@ namespace MemoryConsumption
   inline std::size_t
   memory_consumption(const std::string &s)
   {
-    return sizeof(s) + s.length();
+    return sizeof(s) + s.size();
   }
 
 

--- a/include/deal.II/base/table_handler.h
+++ b/include/deal.II/base/table_handler.h
@@ -964,7 +964,7 @@ TableHandler::add_value(const std::string &key, const T value)
           columns[key].max_length =
             std::max(columns[key].max_length,
                      static_cast<unsigned int>(
-                       entry.get_cached_string().length()));
+                       entry.get_cached_string().size()));
         }
     }
 
@@ -974,7 +974,7 @@ TableHandler::add_value(const std::string &key, const T value)
   entry.cache_string(columns[key].scientific, columns[key].precision);
   columns[key].max_length =
     std::max(columns[key].max_length,
-             static_cast<unsigned int>(entry.get_cached_string().length()));
+             static_cast<unsigned int>(entry.get_cached_string().size()));
 }
 
 

--- a/source/base/logstream.cc
+++ b/source/base/logstream.cc
@@ -91,7 +91,7 @@ LogStream::~LogStream()
   // if there was anything left in the stream that is current to this
   // thread, make sure we flush it before it gets lost
   {
-    if (get_stream().str().length() > 0)
+    if (get_stream().str().size() > 0)
       {
         // except the situation is not quite that simple. if this object is
         // the 'deallog' object, then it is destroyed upon exit of the

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -457,15 +457,15 @@ ParameterHandler::parse_input(std::istream &     input,
 
       // If we see the line which is the same as @p last_line ,
       // terminate the parsing.
-      if (last_line.length() != 0 && input_line == last_line)
+      if (last_line.size() != 0 && input_line == last_line)
         break;
 
       // Check whether or not the current line should be joined with the next
       // line before calling scan_line.
-      if (input_line.length() != 0 &&
-          input_line.find_last_of('\\') == input_line.length() - 1)
+      if (input_line.size() != 0 &&
+          input_line.find_last_of('\\') == input_line.size() - 1)
         {
-          input_line.erase(input_line.length() - 1); // remove the last '\'
+          input_line.erase(input_line.size() - 1); // remove the last '\'
           is_concatenated = true;
 
           fully_concatenated_line += input_line;
@@ -1409,10 +1409,9 @@ ParameterHandler::recursively_print_parameters(
       for (const auto &p : current_section)
         if (is_parameter_node(p.second) == true)
           {
-            longest_name = std::max(longest_name, demangle(p.first).length());
-            longest_value =
-              std::max(longest_value,
-                       p.second.get<std::string>("value").length());
+            longest_name  = std::max(longest_name, demangle(p.first).size());
+            longest_value = std::max(longest_value,
+                                     p.second.get<std::string>("value").size());
           }
 
       // print entries one by one
@@ -1448,8 +1447,7 @@ ParameterHandler::recursively_print_parameters(
             // print name and value of this entry
             out << std::setw(overall_indent_level * 2) << ""
                 << "set " << demangle(p.first)
-                << std::setw(longest_name - demangle(p.first).length() + 1)
-                << " "
+                << std::setw(longest_name - demangle(p.first).size() + 1) << " "
                 << "= " << value;
 
             // finally print the default value, but only if it differs
@@ -1457,7 +1455,7 @@ ParameterHandler::recursively_print_parameters(
             if (!is_short &&
                 value != p.second.get<std::string>("default_value"))
               {
-                out << std::setw(longest_value - value.length() + 1) << ' '
+                out << std::setw(longest_value - value.size() + 1) << ' '
                     << "# ";
                 out << "default: "
                     << p.second.get<std::string>("default_value");
@@ -1605,7 +1603,7 @@ ParameterHandler::recursively_print_parameters(
       std::size_t longest_name = 0;
       for (const auto &p : current_section)
         if (is_parameter_node(p.second) == true)
-          longest_name = std::max(longest_name, demangle(p.first).length());
+          longest_name = std::max(longest_name, demangle(p.first).size());
 
       // print entries one by one
       for (const auto &p : current_section)
@@ -1614,8 +1612,7 @@ ParameterHandler::recursively_print_parameters(
             // print name and value
             out << std::setw(overall_indent_level * 2) << ""
                 << "set " << demangle(p.first)
-                << std::setw(longest_name - demangle(p.first).length() + 1)
-                << " "
+                << std::setw(longest_name - demangle(p.first).size() + 1) << " "
                 << " = ";
 
             // print possible values:
@@ -1640,7 +1637,7 @@ ParameterHandler::recursively_print_parameters(
 
             // if there is a documenting string, print it as well
             if (!is_short &&
-                p.second.get<std::string>("documentation").length() != 0)
+                p.second.get<std::string>("documentation").size() != 0)
               out << std::setw(overall_indent_level * 2 + longest_name + 10)
                   << ""
                   << "(" << p.second.get<std::string>("documentation") << ")"
@@ -1832,7 +1829,7 @@ ParameterHandler::scan_line(std::string        line,
   line = Utilities::trim(line);
 
   // if line is now empty: leave
-  if (line.length() == 0)
+  if (line.size() == 0)
     {
       return;
     }
@@ -1841,7 +1838,7 @@ ParameterHandler::scan_line(std::string        line,
            Utilities::match_at_string_start(line, "subsection "))
     {
       // delete this prefix
-      line.erase(0, std::string("subsection").length() + 1);
+      line.erase(0, std::string("subsection").size() + 1);
 
       const std::string subsection = Utilities::trim(line);
 

--- a/source/base/patterns.cc
+++ b/source/base/patterns.cc
@@ -548,7 +548,7 @@ namespace Patterns
     std::string tmp(sequence);
 
     // remove whitespace at beginning
-    while ((tmp.length() != 0) && (std::isspace(tmp.front()) != 0))
+    while ((tmp.size() != 0) && (std::isspace(tmp.front()) != 0))
       tmp.erase(0, 1);
 
     // check the different possibilities
@@ -561,7 +561,7 @@ namespace Patterns
       }
 
     // remove whitespace at the end
-    while ((tmp.length() != 0) && (std::isspace(tmp.back()) != 0))
+    while ((tmp.size() != 0) && (std::isspace(tmp.back()) != 0))
       tmp.erase(tmp.end() - 1);
 
     // check last choice, not finished by |
@@ -635,7 +635,7 @@ namespace Patterns
         std::string sequence(description);
 
         sequence.erase(0, std::strlen(description_init) + 1);
-        sequence.erase(sequence.length() - 2, 2);
+        sequence.erase(sequence.size() - 2, 2);
 
         return std::make_unique<Selection>(sequence);
       }
@@ -1259,7 +1259,7 @@ namespace Patterns
     std::vector<std::string> split_names;
 
     // first split the input list
-    while (tmp.length() != 0)
+    while (tmp.size() != 0)
       {
         std::string name;
         name = tmp;
@@ -1272,10 +1272,10 @@ namespace Patterns
         else
           tmp = "";
 
-        while ((name.length() != 0) && (std::isspace(name.front()) != 0))
+        while ((name.size() != 0) && (std::isspace(name.front()) != 0))
           name.erase(0, 1);
-        while ((name.length() != 0) && (std::isspace(name.back()) != 0))
-          name.erase(name.length() - 1, 1);
+        while ((name.size() != 0) && (std::isspace(name.back()) != 0))
+          name.erase(name.size() - 1, 1);
 
         split_names.push_back(name);
       }
@@ -1376,7 +1376,7 @@ namespace Patterns
         std::string sequence(description);
 
         sequence.erase(0, std::strlen(description_init) + 1);
-        sequence.erase(sequence.length() - 2, 2);
+        sequence.erase(sequence.size() - 2, 2);
 
         return std::make_unique<MultipleSelection>(sequence);
       }

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -171,7 +171,7 @@ TableHandler::Column::pad_column_below(const unsigned int size)
       entry.cache_string(scientific, precision);
       max_length =
         std::max(max_length,
-                 static_cast<unsigned int>(entry.get_cached_string().length()));
+                 static_cast<unsigned int>(entry.get_cached_string().size()));
     }
 }
 
@@ -186,7 +186,7 @@ TableHandler::Column::invalidate_cache()
       entry.cache_string(this->scientific, this->precision);
       max_length =
         std::max(max_length,
-                 static_cast<unsigned int>(entry.get_cached_string().length()));
+                 static_cast<unsigned int>(entry.get_cached_string().size()));
     }
 }
 
@@ -234,8 +234,7 @@ TableHandler::start_new_row()
         entry.cache_string(column.second.scientific, column.second.precision);
         column.second.max_length =
           std::max(column.second.max_length,
-                   static_cast<unsigned int>(
-                     entry.get_cached_string().length()));
+                   static_cast<unsigned int>(entry.get_cached_string().size()));
       }
 }
 
@@ -430,7 +429,7 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
               const std::string &key = sel_columns[j];
               column_widths[j] =
                 std::max(column_widths[j],
-                         static_cast<unsigned int>(key.length()));
+                         static_cast<unsigned int>(key.size()));
               out << std::setw(column_widths[j]);
               out << key << " | ";
             }
@@ -529,7 +528,7 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
               }
 
               // header is longer than the column(s) under it
-              if (width < key.length())
+              if (width < key.size())
                 {
                   // make the column or the last column in this
                   // supercolumn wide enough
@@ -548,18 +547,18 @@ TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
                     {
                       if (sel_columns[i] == colname)
                         {
-                          column_widths[i] += key.length() - width;
+                          column_widths[i] += key.size() - width;
                           break;
                         }
                     }
 
-                  width = key.length();
+                  width = key.size();
                 }
 
               // now write key. try to center it somehow
-              const unsigned int front_padding = (width - key.length()) / 2,
+              const unsigned int front_padding = (width - key.size()) / 2,
                                  rear_padding =
-                                   (width - key.length()) - front_padding;
+                                   (width - key.size()) - front_padding;
               for (unsigned int i = 0; i < front_padding; ++i)
                 out << ' ';
               out << key;

--- a/source/base/timer.cc
+++ b/source/base/timer.cc
@@ -541,8 +541,7 @@ TimerOutput::print_summary() const
   // get the maximum width among all sections
   unsigned int max_width = 0;
   for (const auto &i : sections)
-    max_width =
-      std::max(max_width, static_cast<unsigned int>(i.first.length()));
+    max_width = std::max(max_width, static_cast<unsigned int>(i.first.size()));
 
   // 32 is the default width until | character
   max_width = std::max(max_width + 1, static_cast<unsigned int>(32));
@@ -856,8 +855,7 @@ TimerOutput::print_wall_time_statistics(const MPI_Comm &mpi_comm,
   // get the maximum width among all sections
   unsigned int max_width = 0;
   for (const auto &i : sections)
-    max_width =
-      std::max(max_width, static_cast<unsigned int>(i.first.length()));
+    max_width = std::max(max_width, static_cast<unsigned int>(i.first.size()));
 
   // 17 is the default width until | character
   max_width = std::max(max_width + 1, static_cast<unsigned int>(17));

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -709,8 +709,8 @@ namespace Utilities
 
     // as discussed in the documentation, eat whitespace from the end
     // of the string
-    while (tmp.length() != 0 && tmp[tmp.length() - 1] == ' ')
-      tmp.erase(tmp.length() - 1, 1);
+    while (tmp.size() != 0 && tmp[tmp.size() - 1] == ' ')
+      tmp.erase(tmp.size() - 1, 1);
 
     // split the input list until it is empty. since in every iteration
     // 'tmp' is what's left of the string after the next delimiter,
@@ -719,7 +719,7 @@ namespace Utilities
     // there was space after the last delimiter. this matches what's
     // discussed in the documentation
     std::vector<std::string> split_list;
-    while (tmp.length() != 0)
+    while (tmp.size() != 0)
       {
         std::string name;
         name = tmp;
@@ -733,10 +733,10 @@ namespace Utilities
           tmp = "";
 
         // strip spaces from this element's front and end
-        while ((name.length() != 0) && (name[0] == ' '))
+        while ((name.size() != 0) && (name[0] == ' '))
           name.erase(0, 1);
-        while (name.length() != 0 && name[name.length() - 1] == ' ')
-          name.erase(name.length() - 1, 1);
+        while (name.size() != 0 && name[name.size() - 1] == ' ')
+          name.erase(name.size() - 1, 1);
 
         split_list.push_back(name);
       }
@@ -763,24 +763,23 @@ namespace Utilities
     std::vector<std::string> lines;
 
     // remove trailing spaces
-    while ((text.length() != 0) && (text[text.length() - 1] == delimiter))
-      text.erase(text.length() - 1, 1);
+    while ((text.size() != 0) && (text[text.size() - 1] == delimiter))
+      text.erase(text.size() - 1, 1);
 
     // then split the text into lines
-    while (text.length() != 0)
+    while (text.size() != 0)
       {
         // in each iteration, first remove
         // leading spaces
-        while ((text.length() != 0) && (text[0] == delimiter))
+        while ((text.size() != 0) && (text[0] == delimiter))
           text.erase(0, 1);
 
         std::size_t pos_newline = text.find_first_of('\n', 0);
         if (pos_newline != std::string::npos && pos_newline <= width)
           {
             std::string line(text, 0, pos_newline);
-            while ((line.length() != 0) &&
-                   (line[line.length() - 1] == delimiter))
-              line.erase(line.length() - 1, 1);
+            while ((line.size() != 0) && (line[line.size() - 1] == delimiter))
+              line.erase(line.size() - 1, 1);
             lines.push_back(line);
             text.erase(0, pos_newline + 1);
             continue;
@@ -789,12 +788,11 @@ namespace Utilities
         // if we can fit everything into one
         // line, then do so. otherwise, we have
         // to keep breaking
-        if (text.length() < width)
+        if (text.size() < width)
           {
             // remove trailing spaces
-            while ((text.length() != 0) &&
-                   (text[text.length() - 1] == delimiter))
-              text.erase(text.length() - 1, 1);
+            while ((text.size() != 0) && (text[text.size() - 1] == delimiter))
+              text.erase(text.size() - 1, 1);
             lines.push_back(text);
             text = "";
           }
@@ -803,7 +801,7 @@ namespace Utilities
             // starting at position width, find the
             // location of the previous space, so
             // that we can break around there
-            int location = std::min<int>(width, text.length() - 1);
+            int location = std::min<int>(width, text.size() - 1);
             for (; location > 0; --location)
               if (text[location] == delimiter)
                 break;
@@ -811,8 +809,8 @@ namespace Utilities
             // if there are no spaces, then try if
             // there are spaces coming up
             if (location == 0)
-              for (location = std::min<int>(width, text.length() - 1);
-                   location < static_cast<int>(text.length());
+              for (location = std::min<int>(width, text.size() - 1);
+                   location < static_cast<int>(text.size());
                    ++location)
                 if (text[location] == delimiter)
                   break;
@@ -821,9 +819,8 @@ namespace Utilities
             // location and put it into a single
             // line, and remove it from 'text'
             std::string line(text, 0, location);
-            while ((line.length() != 0) &&
-                   (line[line.length() - 1] == delimiter))
-              line.erase(line.length() - 1, 1);
+            while ((line.size() != 0) && (line[line.size() - 1] == delimiter))
+              line.erase(line.size() - 1, 1);
             lines.push_back(line);
             text.erase(0, location);
           }

--- a/source/grid/grid_generator.cc
+++ b/source/grid/grid_generator.cc
@@ -619,7 +619,7 @@ namespace GridGenerator
                            const unsigned int number_points,
                            const bool         is_upper)
         {
-          Assert(serialnumber.length() == 4,
+          Assert(serialnumber.size() == 4,
                  ExcMessage("This NACA-serial number is not implemented!"));
 
           return naca_create_points_4_digits(serialnumber,

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -3945,7 +3945,7 @@ GridIn<dim, spacedim>::skip_empty_lines(std::istream &in)
           }) != line.end())
         {
           in.putback('\n');
-          for (int i = line.length() - 1; i >= 0; --i)
+          for (int i = line.size() - 1; i >= 0; --i)
             in.putback(line[i]);
           return;
         }
@@ -4146,7 +4146,7 @@ GridIn<dim, spacedim>::read(const std::string &filename, Format format)
     {
       const std::string::size_type slashpos = name.find_last_of('/');
       const std::string::size_type dotpos   = name.find_last_of('.');
-      if (dotpos < name.length() &&
+      if (dotpos < name.size() &&
           (dotpos > slashpos || slashpos == std::string::npos))
         {
           std::string ext = name.substr(dotpos + 1);


### PR DESCRIPTION
`std::string` has a member function `length()` that does exactly the same as the `size()` member function. Because all other STL containers have `size()`, I thought it useful to replace all occurrences of `length()` by `size()` simply to avoid the ambiguity.

/rebuild