### PR TITLE
OneAPI compatibility: fix most of the API incompatibilities

### DIFF
--- a/source/base/multithread_info.cc
+++ b/source/base/multithread_info.cc
@@ -22,7 +22,7 @@
 
 #ifdef DEAL_II_WITH_TBB
 #  ifdef DEAL_II_TBB_WITH_ONEAPI
-#    include <tbb/task_arena.h>
+#    include <tbb/global_control.h>
 #  else
 #    include <tbb/task_scheduler_init.h>
 #  endif
@@ -96,11 +96,16 @@ MultithreadInfo::set_thread_limit(const unsigned int max_threads)
     n_max_threads = n_cores();
 
 #ifdef DEAL_II_WITH_TBB
+#  ifdef DEAL_II_TBB_WITH_ONEAPI
+  tbb::global_control(tbb::global_control::max_allowed_parallelism,
+                      n_max_threads);
+#  else
   // Initialize the scheduler and destroy the old one before doing so
   static tbb::task_scheduler_init dummy(tbb::task_scheduler_init::deferred);
   if (dummy.is_active())
     dummy.terminate();
   dummy.initialize(n_max_threads);
+#  endif
 #endif
 
 #ifdef DEAL_II_WITH_TASKFLOW

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -28,7 +28,9 @@
 #  include <tbb/blocked_range.h>
 #  include <tbb/parallel_for.h>
 #  include <tbb/task.h>
-#  include <tbb/task_scheduler_init.h>
+#  ifndef DEAL_II_TBB_WITH_ONEAPI
+#    include <tbb/task_scheduler_init.h>
+#  endif
 #endif
 
 #include <iostream>


### PR DESCRIPTION
This PR now addresses most of the remaining OneAPI incompatibilities. Meaning, everything compiles with the exception of `source/matrix_free/task_info.cc` that uses `tbb::task` and needs some major porting.

Let's review this PR first and merge it. I will make two follow-up PRs: one for the remaining fix, and another one enabling OpenAPI and adding a configuration to the CI.

Bug #11561