### PR TITLE
OneAPI compatibility: enable oneAPI configuration in CMake, changelog

### DIFF
--- a/cmake/configure/configure_1_tbb.cmake
+++ b/cmake/configure/configure_1_tbb.cmake
@@ -27,17 +27,6 @@ MACRO(FEATURE_TBB_FIND_EXTERNAL var)
 
   SET(DEAL_II_TBB_WITH_ONEAPI ${TBB_WITH_ONEAPI})
 
-  IF(TBB_WITH_ONEAPI)
-    MESSAGE(STATUS
-      "deal.II is not fully ported to the new TBB oneAPI interface, disabling external TBB"
-      )
-    SET(TBB_ADDITIONAL_ERROR_STRING
-      "deal.II is not fully ported to the new TBB oneAPI interface.\n"
-      "Disabling external TBB for now...\n\n"
-      )
-    SET(${var} FALSE)
-  ENDIF()
-
   #
   # TBB currently uses the version numbering scheme
   #

--- a/doc/news/changes/minor/20220106BangerthMaier
+++ b/doc/news/changes/minor/20220106BangerthMaier
@@ -1,4 +1,7 @@
 Fixed: deal.II has been updated to support the new OneAPI api interface
-introduced by the Intel Threading Building Blocks Library.
+introduced by the Intel Threading Building Blocks Library. Note that the
+threading support of the matrix-free backend will be disabled in this case:
+For now, the MatrixFree::AdditionalData::tasks_parallel_scheme control has
+no effect and simply defaults to the serial loop.
 <br>
 (Wolfgang Bangerth, Matthias Maier, 2022/01/06)

--- a/doc/news/changes/minor/20220106BangerthMaier
+++ b/doc/news/changes/minor/20220106BangerthMaier
@@ -1,0 +1,4 @@
+Fixed: deal.II has been updated to support the new OneAPI api interface
+introduced by the Intel Threading Building Blocks Library.
+<br>
+(Wolfgang Bangerth, Matthias Maier, 2022/01/06)

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -68,9 +68,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 //
 // Matthias Maier, Martin Kronbichler, 2021
 //
-#ifdef DEAL_II_TBB_WITH_ONEAPI
-#  undef DEAL_II_WITH_TBB
-#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -460,7 +457,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::internal_reinit(
 
         // initialize the basic multithreading information that needs to be
         // passed to the DoFInfo structure
-#ifdef DEAL_II_WITH_TBB
+#if defined(DEAL_II_WITH_TBB) && !defined(DEAL_II_TBB_WITH_ONEAPI)
       if (additional_data.tasks_parallel_scheme != AdditionalData::none &&
           MultithreadInfo::n_threads() > 1)
         {
@@ -922,7 +919,7 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_dof_handlers(
 
 namespace internal
 {
-#ifdef DEAL_II_WITH_TBB
+#if defined(DEAL_II_WITH_TBB) && !defined(DEAL_II_TBB_WITH_ONEAPI)
 
 #  ifdef DEAL_II_TBB_WITH_ONEAPI
   struct unsigned_int_pair_hash
@@ -1595,7 +1592,7 @@ namespace internal
         connectivity.reinit(task_info.n_active_cells, task_info.n_active_cells);
         if (do_face_integrals)
           {
-#ifdef DEAL_II_WITH_TBB
+#if defined(DEAL_II_WITH_TBB) && !defined(DEAL_II_TBB_WITH_ONEAPI)
             // step 1: build map between the index in the matrix-free context
             // and the one in the triangulation
             tbb::concurrent_unordered_map<std::pair<unsigned int, unsigned int>,
@@ -2286,9 +2283,5 @@ MatrixFree<dim, Number, VectorizedArrayType>::print(std::ostream &out) const
 
 
 DEAL_II_NAMESPACE_CLOSE
-
-#ifdef DEAL_II_TBB_WITH_ONEAPI
-#  define DEAL_II_WITH_TBB
-#endif
 
 #endif

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -53,6 +53,24 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <fstream>
 
+//
+// TBB with oneAPI API has deprecated and removed the
+// <code>tbb::tasks</code> backend. With this it is no longer possible to
+// compile the following code that builds a directed acyclic graph (DAG) of
+// (thread parallel) tasks without a major porting effort. It turned out
+// that such a dynamic handling of dependencies and structures is not as
+// competitive as initially assumed. Consequently, this part of the matrix
+// free infrastructure has seen less attention than the rest over the last
+// years and is (presumably) not used that often.
+//
+// In case of detected oneAPI backend we simply disable threading in the
+// matrix free backend for now.
+//
+// Matthias Maier, Martin Kronbichler, 2021
+//
+#ifdef DEAL_II_TBB_WITH_ONEAPI
+#  undef DEAL_II_WITH_TBB
+#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -2268,5 +2286,9 @@ MatrixFree<dim, Number, VectorizedArrayType>::print(std::ostream &out) const
 
 
 DEAL_II_NAMESPACE_CLOSE
+
+#ifdef DEAL_II_TBB_WITH_ONEAPI
+#  define DEAL_II_WITH_TBB
+#endif
 
 #endif

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -36,6 +36,25 @@
 #include <iostream>
 #include <set>
 
+//
+// TBB with oneAPI API has deprecated and removed the
+// <code>tbb::tasks</code> backend. With this it is no longer possible to
+// compile the following code that builds a directed acyclic graph (DAG) of
+// (thread parallel) tasks without a major porting effort. It turned out
+// that such a dynamic handling of dependencies and structures is not as
+// competitive as initially assumed. Consequently, this part of the matrix
+// free infrastructure has seen less attention than the rest over the last
+// years and is (presumably) not used that often.
+//
+// In case of detected oneAPI backend we simply disable threading in the
+// matrix free backend for now.
+//
+// Matthias Maier, Martin Kronbichler, 2021
+//
+#ifdef DEAL_II_TBB_WITH_ONEAPI
+#  undef DEAL_II_WITH_TBB
+#endif
+
 DEAL_II_NAMESPACE_OPEN
 
 

--- a/source/matrix_free/task_info.cc
+++ b/source/matrix_free/task_info.cc
@@ -51,9 +51,6 @@
 //
 // Matthias Maier, Martin Kronbichler, 2021
 //
-#ifdef DEAL_II_TBB_WITH_ONEAPI
-#  undef DEAL_II_WITH_TBB
-#endif
 
 DEAL_II_NAMESPACE_OPEN
 
@@ -64,7 +61,7 @@ namespace internal
 {
   namespace MatrixFreeFunctions
   {
-#ifdef DEAL_II_WITH_TBB
+#if defined(DEAL_II_WITH_TBB) && !defined(DEAL_II_TBB_WITH_ONEAPI)
 
     // This defines the TBB data structures that are needed to schedule the
     // partition-partition variant
@@ -362,7 +359,7 @@ namespace internal
 
       funct.vector_update_ghosts_start();
 
-#ifdef DEAL_II_WITH_TBB
+#if defined(DEAL_II_WITH_TBB) && !defined(DEAL_II_TBB_WITH_ONEAPI)
 
       if (scheme != none)
         {


### PR DESCRIPTION
I suggest we simply disable threading support in the matrix free backend for now if we use oneAPI. This would allow us to move forward in the least disruptive way.

https://github.com/dealii/dealii/issues/9901

Closes: https://github.com/dealii/dealii/issues/11561