### PR TITLE
[9.3] Boost 1.78

### DIFF
--- a/cmake/configure/configure_2_boost.cmake
+++ b/cmake/configure/configure_2_boost.cmake
@@ -74,6 +74,26 @@ MACRO(FEATURE_BOOST_CONFIGURE_COMMON)
   ENDIF()
 
   ENABLE_IF_SUPPORTED(BOOST_CXX_FLAGS "-Wno-unused-local-typedefs")
+
+  # At least BOOST 1.74 has the problem that some of the BOOST headers
+  # include other BOOST headers that are deprecated, and this then leads to
+  # warnings. That's rather annoying.
+
+  # The configure function is called only once. In case an externally provided
+  # boost library is detected, BOOST_INCLUDE_DIRS contains the include paths to
+  # be used and BOOST_BUNDLED_INCLUDE_DIRS is empty. For the bundled library, it
+  # is the other way around.
+  LIST(APPEND CMAKE_REQUIRED_INCLUDES ${BOOST_INCLUDE_DIRS} ${BOOST_BUNDLED_INCLUDE_DIRS})
+
+  CHECK_CXX_COMPILER_BUG(
+    "
+    #define BOOST_CONFIG_HEADER_DEPRECATED_HPP_INCLUDED
+    #define BOOST_HEADER_DEPRECATED(a) _Pragma(\"GCC error \\\"stop compilation\\\"\");
+    #include <boost/geometry/index/rtree.hpp>
+    int main() { return 0; }
+    "
+    DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS)
+  RESET_CMAKE_REQUIRED()
 ENDMACRO()
 
 

--- a/include/deal.II/base/bounding_box_data_out.h
+++ b/include/deal.II/base/bounding_box_data_out.h
@@ -32,10 +32,10 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
 #include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
 #ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
 #  undef BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
-#include <boost/geometry/strategies/strategies.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 

--- a/include/deal.II/base/bounding_box_data_out.h
+++ b/include/deal.II/base/bounding_box_data_out.h
@@ -28,7 +28,13 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+#  define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 #include <boost/geometry/index/rtree.hpp>
+#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+#  undef BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 #include <boost/geometry/strategies/strategies.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -220,6 +220,9 @@
 /* cmake/modules/FindSYMENGINE.cmake */
 #cmakedefine DEAL_II_SYMENGINE_WITH_LLVM
 
+/* cmake/configure/configure_2_boost.cmake */
+#cmakedefine DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+
 /* cmake/configure/configure_2_trilinos.cmake */
 #cmakedefine DEAL_II_TRILINOS_CXX_SUPPORTS_SACADO_COMPLEX_RAD
 #cmakedefine DEAL_II_TRILINOS_WITH_EPETRAEXT

--- a/include/deal.II/grid/grid_tools.h
+++ b/include/deal.II/grid/grid_tools.h
@@ -51,7 +51,6 @@
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #  include <boost/archive/binary_iarchive.hpp>
 #  include <boost/archive/binary_oarchive.hpp>
-#  include <boost/geometry/index/rtree.hpp>
 #  include <boost/random/mersenne_twister.hpp>
 #  include <boost/serialization/array.hpp>
 #  include <boost/serialization/vector.hpp>

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -32,7 +32,13 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
  * can include rtree.hpp. Otherwise a compilation error within boost
  * headers is encountered.
  */
+#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+#  define BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 #include <boost/geometry/index/rtree.hpp>
+#ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
+#  undef BOOST_ALLOW_DEPRECATED_HEADERS
+#endif
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <memory>

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -26,6 +26,8 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
+#include <boost/geometry/algorithms/distance.hpp>
+
 #ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
 #  define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -26,16 +26,11 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <boost/geometry/strategies/strategies.hpp>
-/*
- * For boost 1.77 compatibility we need to include strategies.hpp before we
- * can include rtree.hpp. Otherwise a compilation error within boost
- * headers is encountered.
- */
 #ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
 #  define BOOST_ALLOW_DEPRECATED_HEADERS
 #endif
 #include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
 #ifdef DEAL_II_BOOST_HAS_BROKEN_HEADER_DEPRECATIONS
 #  undef BOOST_ALLOW_DEPRECATED_HEADERS
 #endif

--- a/include/deal.II/numerics/rtree.h
+++ b/include/deal.II/numerics/rtree.h
@@ -26,8 +26,13 @@
 #include <deal.II/boost_adaptors/segment.h>
 
 DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
-#include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
+/*
+ * For boost 1.77 compatibility we need to include strategies.hpp before we
+ * can include rtree.hpp. Otherwise a compilation error within boost
+ * headers is encountered.
+ */
+#include <boost/geometry/index/rtree.hpp>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 #include <memory>

--- a/tests/boost/rtree_01.cc
+++ b/tests/boost/rtree_01.cc
@@ -19,6 +19,7 @@
 
 #include <deal.II/boost_adaptors/point.h>
 
+#include <boost/geometry/algorithms/distance.hpp>
 #include <boost/geometry/index/rtree.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 


### PR DESCRIPTION
Port of #13165 and other relevant patches to the 9.3 branch.

At least Arch Linux has moved to oneAPI and boost > 1.76 - I will either need to package patches myself or we can do the release. I think the later is the better choice.