### PR TITLE
Faster and simpler search for lost particles

### DIFF
--- a/source/particles/particle_handler.cc
+++ b/source/particles/particle_handler.cc
@@ -1312,8 +1312,12 @@ namespace Particles
 
       // Reuse these vectors below, but only with a single element.
       // Avoid resizing for every particle.
-      reference_locations.resize(1);
-      real_locations.resize(1);
+      Point<dim>      invalid_reference_point;
+      Point<spacedim> invalid_point;
+      invalid_reference_point[0] = std::numeric_limits<double>::infinity();
+      invalid_point[0]           = std::numeric_limits<double>::infinity();
+      reference_locations.resize(1, invalid_reference_point);
+      real_locations.resize(1, invalid_point);
 
       // Find the cells that the particles moved to.
       for (auto &out_particle : particles_out_of_cell)
@@ -1409,19 +1413,20 @@ namespace Particles
                         reference_locations[0]))
                     {
                       current_cell = cell;
+                      found_cell   = true;
                       break;
                     }
                 }
+            }
 
-              if (current_cell.state() != IteratorState::valid)
-                {
-                  // We can find no cell for this particle. It has left the
-                  // domain due to an integration error or an open boundary.
-                  // Signal the loss and move on.
-                  signals.particle_lost(out_particle,
-                                        out_particle->get_surrounding_cell());
-                  continue;
-                }
+          if (!found_cell)
+            {
+              // We can find no cell for this particle. It has left the
+              // domain due to an integration error or an open boundary.
+              // Signal the loss and move on.
+              signals.particle_lost(out_particle,
+                                    out_particle->get_surrounding_cell());
+              continue;
             }
 
           // If we are here, we found a cell and reference position for this


### PR DESCRIPTION
The current version of the `find_active_cell_around_point` function falls back to searching through all cells if the point is outside the domain. This is not what we would want for particles as it can happen quite often that particles move outside the domain (e.g. flow through one of the boundaries). I had models with 10,000 particles, where searching all cells for 2 particles that left the domain took longer than sorting all other particles. This PR restores the original algorithm of the particle sort by taking only the part from `find_active_cell_around_point` that was used before (i.e. search the rtree of vertices for the closest vertex, then check all cells that contain this vertex if the position is inside).

The PR also contains one further optimization by using `mapping->transform_points_real_to_unit_cell` instead of `mapping->transform_real_to_unit_cell`. The algorithm the functions use is the same (because we call it for single points not groups of points), but `transform_points_real_to_unit_cell` does not throw an exception when a point is outside the cell, and at least for `MappingQ<2>(4)` throwing and catching the exception is about as expensive as the rest of the algorithm. For other mappings or spatial dimensions the change shouldnt matter.