### PR TITLE
Fix a check for zero entries in the lumped mass matrix.

### DIFF
--- a/include/deal.II/matrix_free/operators.h
+++ b/include/deal.II/matrix_free/operators.h
@@ -1960,7 +1960,7 @@ namespace MatrixFreeOperators
     // entries here.
     for (size_type i = 0; i < locally_owned_size; ++i)
       {
-        if (inverse_lumped_diagonal_vector.local_element(i) == Number(0.))
+        if (lumped_diagonal_vector.local_element(i) == Number(0.))
           inverse_lumped_diagonal_vector.local_element(i) = Number(1.);
         else
           inverse_lumped_diagonal_vector.local_element(i) =


### PR DESCRIPTION
This is unrelated to #13179 but I noticed it while examining one of the failing tests (threading with oneAPI causes vectors to apparently be set to all zeros, which creates a floating point exception).

It doesn't make sense to check the values of `inverse_lumped_diagonal` here - that's what we are computing. The check should be on the values of the lumped mass matrix.