### PR TITLE
Do not reuse an MPI_Status object.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -253,7 +253,7 @@ namespace Utilities
                             other_rank,
                             tag_request,
                             this->comm,
-                            &status);
+                            MPI_STATUS_IGNORE);
             AssertThrowMPI(ierr);
 
             // Allocate memory for an answer message to the current request,


### PR DESCRIPTION
We use an `MPI_Status` object in this place that was declared further up in the function for a different purpose. But we don't actually care about what the function in question here returns, and so it seems wrong to re-use an innocent bystander object here (which, just to be clear, we never look at again). But we don't have to: MPI provides for a way to say "don't bother with this argument".

/rebuild