### PR TITLE
Replace MPI_Irecv with MPI_Iprobe+MPI_Recv.

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -331,9 +331,9 @@ namespace Utilities
         std::vector<std::unique_ptr<MPI_Request>> request_requests;
 
         /**
-         * The ranks of processes from which we are still expecting answers.
+         * The number of processes from which we are still expecting answers.
          */
-        std::set<unsigned int> outstanding_answers;
+        unsigned int n_outstanding_answers;
 
         // request for barrier
         MPI_Request barrier_request;

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -317,17 +317,6 @@ namespace Utilities
         std::vector<MPI_Request> send_requests;
 
         /**
-         * Buffers for receiving answers to requests.
-         */
-        std::vector<std::vector<T2>> recv_buffers;
-
-
-        /**
-         * Requests for receiving answers to requests.
-         */
-        std::vector<MPI_Request> recv_requests;
-
-        /**
          * Buffers for sending answers to requests. We use a vector of
          * pointers because that guarantees that the buffers themselves
          * are newer moved around in memory, even if the vector is

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -330,6 +330,11 @@ namespace Utilities
          */
         std::vector<std::unique_ptr<MPI_Request>> request_requests;
 
+        /**
+         * The ranks of processes from which we are still expecting answers.
+         */
+        std::set<unsigned int> outstanding_answers;
+
         // request for barrier
         MPI_Request barrier_request;
 #endif

--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -240,7 +240,9 @@ namespace Utilities
         // immediately with a return code that indicates whether
         // it has found a message from any process with a given
         // tag.
-        while (outstanding_answers.size() > 0)
+        if (outstanding_answers.size() == 0)
+          return true;
+        else
           {
             const int tag_deliver = Utilities::MPI::internal::Tags::
               consensus_algorithm_nbx_process_deliver;
@@ -302,18 +304,18 @@ namespace Utilities
                 // Finally, remove this rank from the list of outstanding
                 // targets:
                 outstanding_answers.erase(target);
+
+                // We could do another go-around from the top of this
+                // else-branch to see whether there are actually other messages
+                // that are currently pending. But that would mean spending
+                // substantial time in receiving answers while we should also be
+                // sending answers to requests we have received from other
+                // places. So let it be enough for now. If there are outstanding
+                // answers, we will get back to this function before long and
+                // can take care of them then.
+                return (outstanding_answers.size() == 0);
               }
-
-            // Do another round of the 'while' loop above. It will either
-            // terminate because there are no outstanding answers left,
-            // or its body will return false because there are no other
-            // pending messages, or there is another pending message and
-            // we can process that too.
           }
-
-        // If we have made it here, then we have received an answer
-        // from everyone and can return true:
-        return true;
 
 #else
         return true;


### PR DESCRIPTION
This goes most of the way towards fixing #13213 for the NBX implementation of the consensus algorithm.

In the existing implementation, we post `Irecv` operations, get a request object for each, and know that we have gotten all messages when a `Testtall` on these request objects returns `true`. The problem with this approach is that we need to know the size of the message to post the `Irecv` operation, and that's why the user has to provide the message size.

But we can do that differently: We can query the existence of messages using `MPI_Probe` instead, and when we know that each `MPI_Probe` returns `true` for all anticipated messages, we can move on and actually receive these messages using a direct `MPI_Recv`. This patch does this. 

A follow-up would be to use the result of the `MPI_Probe` to query the size of the message and use that to resize the buffer before we call `MPI_Recv`, without the need for the user to know the message size up front.

/rebuild