### PR TITLE
Fix doxygen problems with `GridGenerator::pipe_junction`

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1079,9 +1079,13 @@ namespace GridGenerator
    *       <tr><td>
    *           <td>Point
    *           <td>Radius
-   *       <tr><td>Openings
-   *           <td>$(2,0,0)$<br>$(0,2,0)$<br>$(0,0,2)$
-   *           <td>$1$<br>$1$<br>$1$
+   *       <tr><td rowspan="3">Openings
+   *           <td>$(2,0,0)$
+   *           <td>$1$
+   *       <tr><td>$(0,2,0)$
+   *           <td>$1$
+   *       <tr><td>$(0,0,2)$
+   *           <td>$1$
    *       <tr><td>Bifurcation
    *           <td>$(0,0,0)$
    *           <td>$1$
@@ -1097,9 +1101,13 @@ namespace GridGenerator
    *       <tr><td>
    *           <td>Point
    *           <td>Radius
-   *       <tr><td>Openings
-   *           <td>$(-2,0,0)$<br>$(0,2,0)$<br>$(2,0,0)$
-   *           <td>$1$<br>$1$<br>$1$
+   *       <tr><td rowspan="3">Openings
+   *           <td>$(-2,0,0)$
+   *           <td>$1$
+   *       <tr><td>$(0,2,0)$
+   *           <td>$1$
+   *       <tr><td>$(2,0,0)$
+   *           <td>$1$
    *       <tr><td>Bifurcation
    *           <td>$(0,0,0)$
    *           <td>$1$
@@ -1115,9 +1123,13 @@ namespace GridGenerator
    *       <tr><td>
    *           <td>Point
    *           <td>Radius
-   *       <tr><td>Openings
-   *           <td>$(-2,0,0)$<br>$(1,\sqrt{3},1)$<br>$(1,-\sqrt{3},1)$
-   *           <td>$1$<br>$1$<br>$1$
+   *       <tr><td rowspan="3">Openings
+   *           <td>$(-2,0,0)$
+   *           <td>$1$
+   *       <tr><td>$(1,\sqrt{3},1)$
+   *           <td>$1$
+   *       <tr><td>$(1,-\sqrt{3},1)$
+   *           <td>$1$
    *       <tr><td>Bifurcation
    *           <td>$(0,0,0)$
    *           <td>$1$

--- a/source/grid/grid_generator_pipe_junction.cc
+++ b/source/grid/grid_generator_pipe_junction.cc
@@ -88,6 +88,9 @@ namespace GridGenerator
 
 
 
+  // hide the template specialization from doxygen
+#ifndef DOXYGEN
+
   template <>
   void
   pipe_junction(Triangulation<3, 3> &                           tria,
@@ -102,7 +105,7 @@ namespace GridGenerator
     constexpr unsigned int n_pipes   = 3;
     constexpr double       tolerance = 1.e-12;
 
-#ifdef DEBUG
+#  ifdef DEBUG
     // Verify user input.
     Assert(bifurcation.second > 0,
            ExcMessage("Invalid input: negative radius."));
@@ -110,7 +113,7 @@ namespace GridGenerator
            ExcMessage("Invalid input: only 3 openings allowed."));
     for (const auto &opening : openings)
       Assert(opening.second > 0, ExcMessage("Invalid input: negative radius."));
-#endif
+#  endif
 
     // Each pipe segment will be identified by the index of its opening in the
     // parameter array. To determine the next and previous entry in the array
@@ -428,6 +431,9 @@ namespace GridGenerator
               face->set_boundary_id(n_pipes);
           }
   }
+
+#endif
+
 } // namespace GridGenerator
 
 


### PR DESCRIPTION
Follow-up to #13028.

I noticed some issues with doxygen that I didn't pay attention to earlier:
1. Tables are awkwardly formatted after being parsed by MathJax (see [here](https://www.dealii.org/developer/doxygen/deal.II/namespaceGridGenerator.html#ac19553ab0b1153b242db674e4cef7988)).
2. Template specialization somehow appears separately (see [here](https://www.dealii.org/developer/doxygen/deal.II/namespaceGridGenerator.html#ab475d4cf5813f47a1a8b432fdd63035a)).