### PR TITLE
Fix a redefined variable error in a test.

### DIFF
--- a/tests/mpi/data_out_hdf5_02.cc
+++ b/tests/mpi/data_out_hdf5_02.cc
@@ -24,11 +24,6 @@
 
 #include "../data_out/patches.h"
 
-double cell_coordinates[3][8] = {{0, 1, 0, 1, 0, 1, 0, 1},
-                                 {0, 0, 1, 1, 0, 0, 1, 1},
-                                 {0, 0, 0, 0, 1, 1, 1, 1}};
-
-
 template <int dim, int spacedim>
 void
 check()


### PR DESCRIPTION
052ab5dfbd combined some things into patches.h but didn't delete this one array.

In particular, the top of `patches.h` contains the same definition of `cell_coordinates`.