### PR TITLE
Fix Y-pipe example in doc for `pipe_junction`.

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1126,9 +1126,9 @@ namespace GridGenerator
    *       <tr><td rowspan="3">Openings
    *           <td>$(-2,0,0)$
    *           <td>$1$
-   *       <tr><td>$(1,\sqrt{3},1)$
+   *       <tr><td>$(1,\sqrt{3},0)$
    *           <td>$1$
-   *       <tr><td>$(1,-\sqrt{3},1)$
+   *       <tr><td>$(1,-\sqrt{3},0)$
    *           <td>$1$
    *       <tr><td>Bifurcation
    *           <td>$(0,0,0)$


### PR DESCRIPTION
All points for the Y-pipe examples are located on the xy-plane.

I translated the points wrongly from the corresponding test.