### PR TITLE
Add contains functions to check that flags contain a specific flag

### DIFF
--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -372,8 +372,7 @@ protected:
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (data_ptr->update_each & update_gradients ||
-        data_ptr->update_each & update_hessians)
+    if (contains(data_ptr->update_each, update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -308,7 +308,7 @@ protected:
     // quadrature points summed over *all* faces or subfaces, whereas
     // the number of output slots equals the number of quadrature
     // points on only *one* face)
-    if ((update_flags & update_values) &&
+    if (contains(update_flags, update_values) &&
         !((output_data.shape_values.n_rows() > 0) &&
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -325,8 +325,8 @@ protected:
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if ((update_flags & (update_values | update_gradients | update_hessians |
-                         update_3rd_derivatives)) != 0u)
+    if (contains(update_flags, (update_values | update_gradients | update_hessians |
+                         update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -288,7 +288,7 @@ protected:
       contains(update_flags, update_hessians) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
       contains(update_flags, update_3rd_derivatives) ? this->n_dofs_per_cell() :
-                                                      0);
+                                                       0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -325,8 +325,9 @@ protected:
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if (contains(update_flags, (update_values | update_gradients | update_hessians |
-                         update_3rd_derivatives)))
+    if (contains(update_flags,
+                 (update_values | update_gradients | update_hessians |
+                  update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -281,13 +281,13 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      (update_flags & update_values) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_values) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      (update_flags & update_gradients) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_gradients) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<2, dim>> grad_grads(
-      (update_flags & update_hessians) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_hessians) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      (update_flags & update_3rd_derivatives) != 0u ? this->n_dofs_per_cell() :
+      contains(update_flags, update_3rd_derivatives) ? this->n_dofs_per_cell() :
                                                       0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
@@ -313,13 +313,13 @@ protected:
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_gradients) != 0u)
+    if (contains(update_flags, update_gradients))
       data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_hessians) != 0u)
+    if (contains(update_flags, update_hessians))
       data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_3rd_derivatives) != 0u)
+    if (contains(update_flags, update_3rd_derivatives))
       data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
@@ -343,7 +343,7 @@ protected:
           // faces and subfaces, but we later on copy only a portion of it
           // into the output object; in that case, copy the data from all
           // faces into the scratch object
-          if ((update_flags & update_values) != 0u)
+          if (contains(update_flags, update_values))
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
@@ -357,15 +357,15 @@ protected:
           // for everything else, derivatives need to be transformed,
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
-          if ((update_flags & update_gradients) != 0u)
+          if (contains(update_flags, update_gradients))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
-          if ((update_flags & update_hessians) != 0u)
+          if (contains(update_flags, update_hessians))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
-          if ((update_flags & update_3rd_derivatives) != 0u)
+          if (contains(update_flags, update_3rd_derivatives))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -193,19 +193,19 @@ FE_Poly<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values;
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation |
            update_gradients | update_jacobian_pushed_forward_grads;
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     out |= update_3rd_derivatives | update_covariant_transformation |
            update_hessians | update_gradients |
            update_jacobian_pushed_forward_grads |
            update_jacobian_pushed_forward_2nd_derivatives;
-  if ((flags & update_normal_vectors) != 0u)
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -381,12 +381,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < n_q_points; ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, n_q_points),
@@ -394,7 +394,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -407,7 +407,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         correct_hessians(output_data, mapping_data, n_q_points);
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -473,12 +473,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
@@ -486,7 +486,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -499,7 +499,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -239,7 +239,7 @@ higher_derivatives_need_correcting(
 {
   // If higher derivatives weren't requested we don't need to correct them.
   const bool update_higher_derivatives =
-    (update_flags & update_hessians) || (update_flags & update_3rd_derivatives);
+    contains(update_flags, update_hessians | update_3rd_derivatives);
   if (!update_higher_derivatives)
     return false;
 
@@ -293,7 +293,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
-  if (((flags & update_gradients) != 0u) &&
+  if (contains(flags, update_gradients) &&
       (cell_similarity != CellSimilarity::translation))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
@@ -301,7 +301,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
                         mapping_internal,
                         make_array_view(output_data.shape_gradients, k));
 
-  if (((flags & update_hessians) != 0u) &&
+  if (contains(flags, update_hessians) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -314,7 +314,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (((flags & update_3rd_derivatives) != 0u) &&
+  if (contains(flags, update_3rd_derivatives) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if(contains(data.update_each, update_values))
+    if (contains(data.update_each, update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (data.update_each & update_values)
+    if(contains(data.update_each, update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),
@@ -156,8 +156,7 @@ protected:
       }
     // No derivatives of this element
     // are implemented.
-    if (data.update_each & update_gradients ||
-        data.update_each & update_hessians)
+    if (contains(data.update_each, update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -62,12 +62,14 @@ FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
   // FIXME
-  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
-  if(contains(flags, update_gradients))
+  UpdateFlags out =
+    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
+                             static_cast<unsigned int>(update_values));
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if(contains(flags, update_normal_vectors))
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -134,7 +136,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if(contains(fe_data.update_each, update_values))
+  if (contains(fe_data.update_each, update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -231,7 +233,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if(contains(fe_data.update_each, update_values))
+  if (contains(fe_data.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -61,12 +61,13 @@ UpdateFlags
 FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
-  UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  // FIXME
+  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
+  if(contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if(contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if(contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -133,7 +134,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if (fe_data.update_each & update_values)
+  if(contains(fe_data.update_each, update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -230,7 +231,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if (fe_data.update_each & update_values)
+  if(contains(fe_data.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)
@@ -241,8 +242,8 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
             fe_data.shape_values[k][i + offset];
     }
 
-  Assert(!(fe_data.update_each & update_gradients), ExcNotImplemented());
-  Assert(!(fe_data.update_each & update_hessians), ExcNotImplemented());
+  Assert(!contains(fe_data.update_each, update_gradients), ExcNotImplemented());
+  Assert(!contains(fe_data.update_each, update_hessians), ExcNotImplemented());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -325,7 +325,7 @@ protected:
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;
 
-    if ((update_flags & update_values) != 0u)
+    if (contains(update_flags, update_values))
       {
         values.resize(this->n_dofs_per_cell());
         data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -333,7 +333,7 @@ protected:
           data.transformed_shape_values.resize(n_q_points);
       }
 
-    if ((update_flags & update_gradients) != 0u)
+    if (contains(update_flags, update_gradients))
       {
         grads.resize(this->n_dofs_per_cell());
         data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -343,7 +343,7 @@ protected:
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
-    if ((update_flags & update_hessians) != 0u)
+    if (contains(update_flags, update_hessians))
       {
         grad_grads.resize(this->n_dofs_per_cell());
         data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -369,7 +369,7 @@ protected:
                                third_derivatives,
                                fourth_derivatives);
 
-          if ((update_flags & update_values) != 0u)
+          if (contains(update_flags, update_values))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -384,7 +384,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_gradients) != 0u)
+          if (contains(update_flags, update_gradients))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -399,7 +399,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_hessians) != 0u)
+          if (contains(update_flags, update_hessians))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,8 +301,7 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if ((update_flags & (update_values | update_gradients | update_hessians)) !=
-        0u)
+    if (contains(update_flags, (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really
@@ -359,7 +358,7 @@ protected:
     // node values N_i holds
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
-    if ((update_flags & (update_values | update_gradients)) != 0u)
+    if (contains(update_flags, (update_values | update_gradients)))
       for (unsigned int k = 0; k < n_q_points; ++k)
         {
           poly_space->evaluate(quadrature.point(k),

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,7 +301,8 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if (contains(update_flags, (update_values | update_gradients | update_hessians)))
+    if (contains(update_flags,
+                 (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -296,8 +296,9 @@ operator<<(StreamType &s, const UpdateFlags u)
 inline UpdateFlags
 operator|(const UpdateFlags f1, const UpdateFlags f2)
 {
-  return static_cast<UpdateFlags>(static_cast<unsigned int>(f1) |
-                                  static_cast<unsigned int>(f2));
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) |
+                                  static_cast<enum_type>(f2));
 }
 
 
@@ -326,10 +327,17 @@ operator|=(UpdateFlags &f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline UpdateFlags
-operator&(const UpdateFlags f1, const UpdateFlags f2)
+operator&(const UpdateFlags f1, const UpdateFlags f2) = delete;
+/*{
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) &
+                                  static_cast<enum_type>(f2));
+}*/
+
+bool contains(const UpdateFlags flags, const UpdateFlags mask)
 {
-  return static_cast<UpdateFlags>(static_cast<unsigned int>(f1) &
-                                  static_cast<unsigned int>(f2));
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
 }
 
 
@@ -340,11 +348,11 @@ operator&(const UpdateFlags f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline UpdateFlags &
-operator&=(UpdateFlags &f1, const UpdateFlags f2)
-{
+operator&=(UpdateFlags &f1, const UpdateFlags f2) = delete;
+/*{
   f1 = f1 & f2;
   return f1;
-}
+}*/
 
 
 

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -334,10 +334,11 @@ operator&(const UpdateFlags f1, const UpdateFlags f2) = delete;
                                   static_cast<enum_type>(f2));
 }*/
 
-bool contains(const UpdateFlags flags, const UpdateFlags mask)
+inline bool
+contains(const UpdateFlags flags, const UpdateFlags mask)
 {
   using enum_type = std::underlying_type_t<UpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
 }
 
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -5572,7 +5572,7 @@ FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5608,7 +5608,7 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5636,7 +5636,7 @@ FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5672,7 +5672,7 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5699,7 +5699,7 @@ FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5735,7 +5735,7 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5762,7 +5762,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5798,7 +5798,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5850,7 +5850,7 @@ template <int dim, int spacedim>
 inline const std::vector<Point<spacedim>> &
 FEValuesBase<dim, spacedim>::get_quadrature_points() const
 {
-  Assert(this->update_flags & update_quadrature_points,
+  Assert(contains(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.quadrature_points;
@@ -5862,7 +5862,7 @@ template <int dim, int spacedim>
 inline const std::vector<double> &
 FEValuesBase<dim, spacedim>::get_JxW_values() const
 {
-  Assert(this->update_flags & update_JxW_values,
+  Assert(contains(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.JxW_values;
@@ -5874,7 +5874,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobians() const
 {
-  Assert(this->update_flags & update_jacobians,
+  Assert(contains(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobians;
@@ -5886,7 +5886,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<2, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_grads() const
 {
-  Assert(this->update_flags & update_jacobian_grads,
+  Assert(contains(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_grads;
@@ -5899,7 +5899,7 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_grad(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_grads,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads[i];
@@ -5911,7 +5911,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<3, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_grads() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_grads,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads;
@@ -5923,7 +5923,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<3, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_2nd_derivative(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives[i];
@@ -5935,7 +5935,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<3, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_2nd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives;
@@ -5948,7 +5948,7 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5961,7 +5961,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5974,7 +5974,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<4, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_3rd_derivative(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives[i];
@@ -5986,7 +5986,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<4, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_3rd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives;
@@ -5999,7 +5999,7 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6012,7 +6012,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6025,7 +6025,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, spacedim, dim>> &
 FEValuesBase<dim, spacedim>::get_inverse_jacobians() const
 {
-  Assert(this->update_flags & update_inverse_jacobians,
+  Assert(contains(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.inverse_jacobians;
@@ -6079,7 +6079,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 FEValuesBase<dim, spacedim>::quadrature_point(const unsigned int i) const
 {
-  Assert(this->update_flags & update_quadrature_points,
+  Assert(contains(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   AssertIndexRange(i, this->mapping_output.quadrature_points.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6093,7 +6093,7 @@ template <int dim, int spacedim>
 inline double
 FEValuesBase<dim, spacedim>::JxW(const unsigned int i) const
 {
-  Assert(this->update_flags & update_JxW_values,
+  Assert(contains(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   AssertIndexRange(i, this->mapping_output.JxW_values.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6107,7 +6107,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobians,
+  Assert(contains(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   AssertIndexRange(i, this->mapping_output.jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6121,7 +6121,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<2, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_grad(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_grads,
+  Assert(contains(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   AssertIndexRange(i, this->mapping_output.jacobian_grads.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6135,7 +6135,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, spacedim, dim> &
 FEValuesBase<dim, spacedim>::inverse_jacobian(const unsigned int i) const
 {
-  Assert(this->update_flags & update_inverse_jacobians,
+  Assert(contains(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   AssertIndexRange(i, this->mapping_output.inverse_jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6149,7 +6149,7 @@ template <int dim, int spacedim>
 inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::normal_vector(const unsigned int i) const
 {
-  Assert(this->update_flags & update_normal_vectors,
+  Assert(contains(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
   AssertIndexRange(i, this->mapping_output.normal_vectors.size());
@@ -6233,7 +6233,7 @@ inline const Tensor<1, spacedim> &
 FEFaceValuesBase<dim, spacedim>::boundary_form(const unsigned int i) const
 {
   AssertIndexRange(i, this->mapping_output.boundary_forms.size());
-  Assert(this->update_flags & update_boundary_forms,
+  Assert(contains(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4675,7 +4675,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4698,7 +4698,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -4720,7 +4720,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -4743,7 +4743,7 @@ namespace FEValuesViews
                                const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -4781,7 +4781,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4821,7 +4821,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4858,7 +4858,7 @@ namespace FEValuesViews
     // this function works like in the case above
 
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     // same as for the scalar case except that we have one more index
@@ -5030,7 +5030,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -5070,7 +5070,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -5177,7 +5177,7 @@ namespace FEValuesViews
                                             const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5212,7 +5212,7 @@ namespace FEValuesViews
                                            const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5257,7 +5257,7 @@ namespace FEValuesViews
     const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5335,7 +5335,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5385,7 +5385,7 @@ namespace FEValuesViews
                                        const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5441,7 +5441,7 @@ namespace FEValuesViews
                                      const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4653,7 +4653,7 @@ namespace FEValuesViews
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(
-      fe_values->update_flags & update_values,
+      contains(fe_values->update_flags, update_values),
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
         "update_values"))));
 
@@ -5948,7 +5948,8 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5961,7 +5962,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5999,7 +6001,8 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6012,7 +6015,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1091,14 +1091,15 @@ namespace internal
       constexpr unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
       EvaluationFlags::EvaluationFlags evaluation_flag =
-        (update_flags & update_quadrature_points ? EvaluationFlags::values :
-                                                   EvaluationFlags::nothing) |
+        (contains(update_flags, update_quadrature_points) ?
+           EvaluationFlags::values :
+           EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (update_flags & update_contravariant_transformation) ?
+             (contains(update_flags, update_contravariant_transformation)) ?
            EvaluationFlags::gradients :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (update_flags & update_jacobian_grads) ?
+             (contains(update_flags, update_jacobian_grads)) ?
            EvaluationFlags::hessians :
            EvaluationFlags::nothing);
 
@@ -1195,13 +1196,13 @@ namespace internal
                                              j][in_comp];
                   }
         }
-      if (update_flags & update_covariant_transformation)
+      if (contains(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.covariant[point] =
               (data.contravariant[point]).covariant_form();
 
-      if (update_flags & update_volume_elements)
+      if (contains(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.volume_elements[point] =
@@ -1262,7 +1263,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         for (unsigned int point = 0; point < quadrature_points.size(); ++point)
           {
             const double *  shape = &data.shape(point + data_set, 0);
@@ -1294,7 +1295,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags & update_contravariant_transformation)
+      if (contains(update_flags, update_contravariant_transformation))
         // if the current cell is just a
         // translation of the previous one, no
         // need to recompute jacobians...
@@ -1335,7 +1336,7 @@ namespace internal
               }
           }
 
-      if (update_flags & update_covariant_transformation)
+      if (contains(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1346,7 +1347,7 @@ namespace internal
               }
           }
 
-      if (update_flags & update_volume_elements)
+      if (contains(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1373,7 +1374,7 @@ namespace internal
       std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_grads)
+      if (contains(update_flags, update_jacobian_grads))
         {
           const unsigned int n_q_points = jacobian_grads.size();
 
@@ -1420,7 +1421,7 @@ namespace internal
       std::vector<Tensor<3, spacedim>> &jacobian_pushed_forward_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_grads)
+      if (contains(update_flags, update_jacobian_pushed_forward_grads))
         {
           const unsigned int n_q_points = jacobian_pushed_forward_grads.size();
 
@@ -1494,7 +1495,7 @@ namespace internal
       std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_2nd_derivatives)
+      if (contains(update_flags, update_jacobian_2nd_derivatives))
         {
           const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -1550,7 +1551,8 @@ namespace internal
       std::vector<Tensor<4, spacedim>> &jacobian_pushed_forward_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_2nd_derivatives)
+      if (contains(update_flags,
+                   update_jacobian_pushed_forward_2nd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_2nd_derivatives.size();
@@ -1651,7 +1653,7 @@ namespace internal
       std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_3rd_derivatives)
+      if (contains(update_flags, update_jacobian_3rd_derivatives))
         {
           const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1710,7 +1712,8 @@ namespace internal
       std::vector<Tensor<5, spacedim>> &jacobian_pushed_forward_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_3rd_derivatives)
+      if (contains(update_flags,
+                   update_jacobian_pushed_forward_3rd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_3rd_derivatives.size();
@@ -1843,15 +1846,16 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags &
-          (update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_JxW_values | update_inverse_jacobians))
+      if (contains(update_flags,
+                   (update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_JxW_values |
+                    update_inverse_jacobians)))
         {
-          if (update_flags & update_boundary_forms)
+          if (contains(update_flags, update_boundary_forms))
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             AssertDimension(output_data.normal_vectors.size(), n_q_points);
-          if (update_flags & update_JxW_values)
+          if (contains(update_flags, update_JxW_values))
             AssertDimension(output_data.JxW_values.size(), n_q_points);
 
           Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1884,7 +1888,7 @@ namespace internal
                 make_array_view(data.aux[d].begin(), data.aux[d].end()));
             }
 
-          if (update_flags & update_boundary_forms)
+          if (contains(update_flags, update_boundary_forms))
             {
               // if dim==spacedim, we can use the unit tangentials to compute
               // the boundary form by simply taking the cross product
@@ -1954,7 +1958,7 @@ namespace internal
                 }
             }
 
-          if (update_flags & update_JxW_values)
+          if (contains(update_flags, update_JxW_values))
             for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
               {
                 output_data.JxW_values[i] =
@@ -1968,17 +1972,17 @@ namespace internal
                   }
               }
 
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
               output_data.normal_vectors[i] =
                 Point<spacedim>(output_data.boundary_forms[i] /
                                 output_data.boundary_forms[i].norm());
 
-          if (update_flags & update_jacobians)
+          if (contains(update_flags, update_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.jacobians[point] = data.contravariant[point];
 
-          if (update_flags & update_inverse_jacobians)
+          if (contains(update_flags, update_inverse_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.inverse_jacobians[point] =
                 data.covariant[point].transpose();
@@ -2087,7 +2091,8 @@ namespace internal
         {
           case mapping_contravariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2100,10 +2105,11 @@ namespace internal
 
           case mapping_piola:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -2123,7 +2129,8 @@ namespace internal
           // rather than DerivativeForm
           case mapping_covariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2165,10 +2172,12 @@ namespace internal
         {
           case mapping_contravariant_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2187,7 +2196,8 @@ namespace internal
 
           case mapping_covariant_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2206,13 +2216,15 @@ namespace internal
 
           case mapping_piola_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2263,10 +2275,12 @@ namespace internal
         {
           case mapping_contravariant_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2307,7 +2321,8 @@ namespace internal
 
           case mapping_covariant_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2349,13 +2364,15 @@ namespace internal
 
           case mapping_piola_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
 
@@ -2430,7 +2447,8 @@ namespace internal
         {
           case mapping_covariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -169,11 +169,11 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags
-  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
-  {
+  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2) = delete;
+/*  {
     return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
                                          static_cast<unsigned int>(f2));
-  }
+  }*/
 
 
   /**
@@ -183,11 +183,17 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags &
-  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2)
-  {
+  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2) = delete;
+/*  {
     f1 = f1 & f2;
     return f1;
-  }
+  }*/
+
+bool contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
+{
+  using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
+}
 
 } // namespace GridTools
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -170,10 +170,10 @@ namespace GridTools
    */
   inline CacheUpdateFlags
   operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2) = delete;
-/*  {
-    return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
-                                         static_cast<unsigned int>(f2));
-  }*/
+  /*  {
+      return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
+                                           static_cast<unsigned int>(f2));
+    }*/
 
 
   /**
@@ -184,16 +184,17 @@ namespace GridTools
    */
   inline CacheUpdateFlags &
   operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2) = delete;
-/*  {
-    f1 = f1 & f2;
-    return f1;
-  }*/
+  /*  {
+      f1 = f1 & f2;
+      return f1;
+    }*/
 
-bool contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
-{
-  using enum_type = std::underlying_type_t<CacheUpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
-}
+  inline bool
+  contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
+  {
+    using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+    return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
+  }
 
 } // namespace GridTools
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -835,13 +835,13 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::reinit(
         update_flags | update_flags_mapping);
       fe_values->reinit(cell);
       mapping_data.initialize(unit_points.size(), update_flags_mapping);
-      if ((update_flags_mapping & update_jacobians) != 0)
+      if (contains(update_flags_mapping, update_jacobians))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.jacobians[q] = fe_values->jacobian(q);
-      if ((update_flags_mapping & update_inverse_jacobians) != 0)
+      if (contains(update_flags_mapping, update_inverse_jacobians))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.inverse_jacobians[q] = fe_values->inverse_jacobian(q);
-      if ((update_flags_mapping & update_quadrature_points) != 0)
+      if (contains(update_flags_mapping, update_quadrature_points))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.quadrature_points[q] = fe_values->quadrature_point(q);
     }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -913,12 +913,13 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
                   val_and_grad.first, j, values[i + j]);
           if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
             {
-              Assert(update_flags & update_gradients ||
-                       update_flags & update_inverse_jacobians,
+              Assert(contains(update_flags,
+                              update_gradients | update_inverse_jacobians),
                      ExcNotInitialized());
               for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
                 {
-                  Assert(update_flags_mapping & update_inverse_jacobians,
+                  Assert(contains(update_flags_mapping,
+                                  update_inverse_jacobians),
                          ExcNotInitialized());
                   internal::FEPointEvaluation::EvaluatorTypeTraits<
                     dim,
@@ -1055,7 +1056,7 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::integrate(
           if ((integration_flags & EvaluationFlags::gradients) != 0u)
             for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
               {
-                Assert(update_flags_mapping & update_inverse_jacobians,
+                Assert(contains(update_flags_mapping, update_inverse_jacobians),
                        ExcNotInitialized());
                 gradients[i + j] =
                   static_cast<typename internal::FEPointEvaluation::
@@ -1224,7 +1225,7 @@ inline DerivativeForm<1, dim, spacedim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::jacobian(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_jacobians, ExcNotInitialized());
+  Assert(contains(update_flags_mapping, update_jacobians), ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.jacobians.size());
   return mapping_data.jacobians[point_index];
 }
@@ -1236,7 +1237,7 @@ inline DerivativeForm<1, spacedim, dim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::inverse_jacobian(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_inverse_jacobians ||
+  Assert(contains(update_flags_mapping, update_inverse_jacobians) ||
            update_flags_mapping & update_gradients,
          ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.inverse_jacobians.size());
@@ -1250,7 +1251,8 @@ inline Point<spacedim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::real_point(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_quadrature_points, ExcNotInitialized());
+  Assert(contains(update_flags_mapping, update_quadrature_points),
+         ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.quadrature_points.size());
   return mapping_data.quadrature_points[point_index];
 }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -800,12 +800,12 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::FEPointEvaluation(
     }
 
   // translate update flags
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     update_flags_mapping |= update_jacobians;
-  if (((update_flags & update_gradients) != 0u) ||
-      ((update_flags & update_inverse_jacobians) != 0u))
+  if ((contains(update_flags, update_gradients)) ||
+      (contains(update_flags, update_inverse_jacobians)))
     update_flags_mapping |= update_inverse_jacobians;
-  if ((update_flags & update_quadrature_points) != 0u)
+  if (contains(update_flags, update_quadrature_points))
     update_flags_mapping |= update_quadrature_points;
 }
 
@@ -846,9 +846,9 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::reinit(
           mapping_data.quadrature_points[q] = fe_values->quadrature_point(q);
     }
 
-  if ((update_flags & update_values) != 0)
+  if (contains(update_flags, update_values))
     values.resize(unit_points.size(), numbers::signaling_nan<value_type>());
-  if ((update_flags & update_gradients) != 0)
+  if (contains(update_flags, update_gradients))
     gradients.resize(unit_points.size(),
                      numbers::signaling_nan<gradient_type>());
 }

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -171,7 +171,7 @@ namespace internal
       mapping_info_storage.data_index_offsets.resize(1);
       mapping_info_storage.JxW_values.resize(fe_values.n_quadrature_points);
       mapping_info_storage.jacobians[0].resize(fe_values.n_quadrature_points);
-      if ((update_flags & update_quadrature_points) != 0u)
+      if (contains(update_flags, update_quadrature_points))
         {
           mapping_info_storage.quadrature_point_offsets.resize(1, 0);
           mapping_info_storage.quadrature_points.resize(

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2889,7 +2889,7 @@ namespace internal
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
             cell_type.size() * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_quadrature_points) != 0)
+          if (contains(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
@@ -2911,7 +2911,7 @@ namespace internal
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
-                if ((update_flags & update_quadrature_points) != 0u)
+                if (contains(update_flags, update_quadrature_points))
                   face_data_by_cells[my_q].quadrature_point_offsets
                     [i * GeometryInfo<dim>::faces_per_cell + face] =
                     (i * GeometryInfo<dim>::faces_per_cell + face) *
@@ -2923,22 +2923,22 @@ namespace internal
             storage_length * GeometryInfo<dim>::faces_per_cell);
           face_data_by_cells[my_q].jacobians[1].resize_fast(
             storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_normal_vectors) != 0u)
+          if (contains(update_flags, update_normal_vectors))
             face_data_by_cells[my_q].normal_vectors.resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if ((contains(update_flags, update_normal_vectors)) &&
+              (contains(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if ((contains(update_flags, update_normal_vectors)) &&
+              (contains(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_jacobian_grads) != 0u)
+          if (contains(update_flags, update_jacobian_grads))
             face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
 
-          if ((update_flags & update_quadrature_points) != 0u)
+          if (contains(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_points.resize_fast(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
@@ -3012,10 +3012,10 @@ namespace internal
                   // copy data for affine data type
                   if (cell_type[cell] <= affine)
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (contains(update_flags, update_JxW_values))
                         face_data_by_cells[my_q].JxW_values[offset][v] =
                           fe_val.JxW(0) / fe_val.get_quadrature().weight(0);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (contains(update_flags, update_jacobians))
                         {
                           DerivativeForm<1, dim, dim> inv_jac =
                             fe_val.jacobian(0).covariant_form();
@@ -3029,7 +3029,7 @@ namespace internal
                                   inv_jac[d][ee];
                               }
                         }
-                      if (is_local && ((update_flags & update_jacobians) != 0u))
+                      if (is_local && (contains(update_flags, update_jacobians)))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3046,11 +3046,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (contains(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (contains(update_flags, update_normal_vectors))
                         for (unsigned int d = 0; d < dim; ++d)
                           face_data_by_cells[my_q]
                             .normal_vectors[offset][d][v] =
@@ -3059,12 +3059,12 @@ namespace internal
                   // copy data for general data type
                   else
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (contains(update_flags, update_JxW_values))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           face_data_by_cells[my_q].JxW_values[offset + q][v] =
                             fe_val.JxW(q);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (contains(update_flags, update_jacobians))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3081,11 +3081,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (contains(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (contains(update_flags, update_normal_vectors))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           for (unsigned int d = 0; d < dim; ++d)
@@ -3093,7 +3093,7 @@ namespace internal
                               .normal_vectors[offset + q][d][v] =
                               fe_val.normal_vector(q)[d];
                     }
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                          ++q)
                       for (unsigned int d = 0; d < dim; ++d)
@@ -3102,8 +3102,8 @@ namespace internal
                              [cell * GeometryInfo<dim>::faces_per_cell + face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if ((contains(update_flags, update_normal_vectors)) &&
+                  (contains(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);
@@ -3112,8 +3112,8 @@ namespace internal
                     .normals_times_jacobians[0][offset + q] =
                     face_data_by_cells[my_q].normal_vectors[offset + q] *
                     face_data_by_cells[my_q].jacobians[0][offset + q];
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if ((contains(update_flags, update_normal_vectors)) &&
+                  (contains(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -134,11 +134,11 @@ namespace internal
       // for Hessian information, need inverse Jacobians and the derivative of
       // Jacobians (these two together will give use the gradients of the
       // inverse Jacobians, which is what we need)
-      if ((update_flags & update_hessians) != 0u ||
-          (update_flags & update_jacobian_grads) != 0u)
+      if (contains(update_flags, update_hessians) ||
+          contains(update_flags, update_jacobian_grads))
         new_flags |= update_jacobian_grads;
 
-      if ((update_flags & update_quadrature_points) != 0u)
+      if (contains(update_flags, update_quadrature_points))
         new_flags |= update_quadrature_points;
 
       // there is one more thing: if we have a quadrature formula with only

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -786,13 +786,13 @@ namespace MeshWorker
                                             const BlockInfo *block_info)
   {
     initialize_update_flags();
-    initialize_gauss_quadrature(((cell_flags & update_values) != 0) ?
+    initialize_gauss_quadrature((contains(cell_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((boundary_flags & update_values) != 0) ?
+                                (contains(boundary_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((face_flags & update_values) != 0) ?
+                                (contains(face_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
                                 false);

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -175,7 +175,7 @@ namespace VectorTools
         }
 
 
-      if (update_flags & update_values)
+      if (contains(update_flags, update_values))
         {
           // first compute the exact solution (vectors) at the quadrature
           // points. try to do this as efficient as possible by avoiding a
@@ -209,7 +209,7 @@ namespace VectorTools
         }
 
       // Do the same for gradients, if required
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         {
           // try to be a little clever to avoid recursive virtual function
           // calls when calling gradient_list for functions that are really
@@ -236,7 +236,7 @@ namespace VectorTools
           // tangential gradients in the finite element function, not the full
           // gradient. This is taken care of, by subtracting the normal
           // component of the gradient from the exact function.
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             for (unsigned int k = 0; k < n_components; ++k)
               for (const auto q : fe_values.quadrature_point_indices())
                 {
@@ -292,7 +292,7 @@ namespace VectorTools
               }
 
             // Compute the root only if no derivative values are added later
-            if (!(update_flags & update_gradients))
+            if (!(contains(update_flags, update_gradients)))
               diff = std::pow(diff, 1. / exponent);
             break;
 
@@ -524,9 +524,9 @@ namespace VectorTools
             const unsigned int n_q_points = fe_values.n_quadrature_points;
             data.resize_vectors(n_q_points, n_components);
 
-            if (update_flags & update_values)
+            if (contains(update_flags, update_values))
               fe_values.get_function_values(fe_function, data.function_values);
-            if (update_flags & update_gradients)
+            if (contains(update_flags, update_gradients))
               fe_values.get_function_gradients(fe_function,
                                                data.function_grads);
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -322,12 +322,17 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
@@ -378,16 +383,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains(fe_internal.update_each , (update_values | update_gradients)))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -435,12 +445,17 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -262,7 +262,7 @@ FE_DGPNonparametric<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = flags;
 
-  if ((flags & (update_values | update_gradients | update_hessians)) != 0u)
+  if (contains(flags, (update_values | update_gradients | update_hessians)))
     out |= update_quadrature_points;
 
   return out;
@@ -317,21 +317,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -341,15 +341,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -373,21 +373,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each , (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -397,15 +397,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -430,21 +430,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -454,15 +454,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if(contains(flags, update_values))
+          if (contains(flags, update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if(contains(flags, update_gradients))
+          if (contains(flags, update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if(contains(flags, update_hessians))
+          if (contains(flags, update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if(contains(base_flags, update_values))
+                  if (contains(base_flags, update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if(contains(base_flags, update_gradients))
+                  if (contains(base_flags, update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if(contains(base_flags, update_hessians))
+                  if (contains(base_flags, update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if(contains(flags, update_hessians))
+          if (contains(flags, update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if(contains(flags, update_gradients))
+          if (contains(flags, update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if(contains(flags, update_values))
+          if (contains(flags, update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if(contains(flags, update_gradients))
+  if (contains(flags, update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if(contains(flags, update_values))
+  if (contains(flags, update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if (flags & update_values)
+          if(contains(flags, update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if (flags & update_gradients)
+          if(contains(flags, update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if (flags & update_hessians)
+          if(contains(flags, update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if (base_flags & update_values)
+                  if(contains(base_flags, update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if (base_flags & update_gradients)
+                  if(contains(base_flags, update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if (base_flags & update_hessians)
+                  if(contains(base_flags, update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if (flags & update_hessians)
+          if(contains(flags, update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (flags & update_gradients)
+          if(contains(flags, update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (flags & update_values)
+          if(contains(flags, update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if (flags & update_hessians)
+  if(contains(flags, update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if (flags & update_gradients)
+  if(contains(flags, update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if (flags & update_values)
+  if(contains(flags, update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -305,15 +305,15 @@ FE_Enriched<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
   if (is_enriched)
     {
       // if we ask for values or gradients, then we would need quadrature points
-      if ((flags & (update_values | update_gradients)) != 0u)
+      if (contains(flags, (update_values | update_gradients)))
         out |= update_quadrature_points;
 
       // if need gradients, add update_values due to product rule
-      if ((out & update_gradients) != 0u)
+      if (contains(out, update_gradients))
         out |= update_values;
     }
 
-  Assert(!(flags & update_3rd_derivatives), ExcNotImplemented());
+  Assert(!contains(flags, update_3rd_derivatives), ExcNotImplemented());
 
   return out;
 }

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -677,12 +677,14 @@ UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   // FIXME
-  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
-  if(contains(flags, update_gradients))
+  UpdateFlags out =
+    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
+                             static_cast<unsigned int>(update_values));
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if(contains(flags, update_normal_vectors))
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -727,7 +729,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if(contains(fe_internal.update_each, update_values))
+  if (contains(fe_internal.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -676,12 +676,13 @@ template <int spacedim>
 UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
-  UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  // FIXME
+  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
+  if(contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if(contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if(contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -726,7 +727,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if (fe_internal.update_each & update_values)
+  if(contains(fe_internal.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -401,7 +401,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             cell_type2_offset + degree * degree;
           const unsigned int cell_type3_offset2 = cell_type3_offset1 + degree;
 
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // compute all points we must evaluate the 1d polynomials at:
               std::vector<Point<dim>> cell_points(n_q_points);
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    (flags & update_gradients) != 0u ? 3 : 2);
+                    contains(flags, update_gradients)? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -799,7 +799,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
 
               // for cell-based shape functions:
               // these don't depend on the cell, so can precompute all here:
-              if ((flags & (update_values | update_gradients)) != 0u)
+              if (contains(flags, (update_values | update_gradients)))
                 {
                   // Cell-based shape functions:
                   //
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    (flags & update_gradients) != 0u ? 3 : 2);
+                    contains(flags, update_gradients)? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -1129,11 +1129,11 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
@@ -1155,7 +1155,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
     {
       case 2:
         {
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                (flags & update_gradients) != 0u ? 3 : 2);
+                contains(flags, update_gradients)? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1340,7 +1340,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       case 3:
         {
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                (flags & update_gradients) != 0u ? 3 : 2);
+                contains(flags, update_gradients)? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1562,15 +1562,15 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
     {
       const UpdateFlags flags(fe_data.update_each);
 
-      if ((flags & (update_values | update_gradients)) != 0u)
+      if (contains(flags, (update_values | update_gradients)))
         {
           const unsigned int n_q_points = quadrature.size();
 
-          Assert(!(flags & update_values) ||
+          Assert(!contains(flags, update_values) ||
                    fe_data.shape_values.size() == this->n_dofs_per_cell(),
                  ExcDimensionMismatch(fe_data.shape_values.size(),
                                       this->n_dofs_per_cell()));
-          Assert(!(flags & update_values) ||
+          Assert(!contains(flags, update_values) ||
                    fe_data.shape_values[0].size() == n_q_points,
                  ExcDimensionMismatch(fe_data.shape_values[0].size(),
                                       n_q_points));
@@ -1688,7 +1688,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length((flags & update_gradients) != 0u ? 3 :
+          const unsigned int poly_length(contains(flags, update_gradients)? 3 :
                                                                             2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
@@ -1942,11 +1942,11 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,20 +165,20 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 vertices_per_cell, std::vector<double>(dim)));
 
   // Resize shape function arrays according to update flags:
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
   // Not implementing second derivatives yet:
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       Assert(false, ExcNotImplemented());
     }
@@ -446,7 +446,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                         cell_points[q][1], polyy[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (contains(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -483,7 +483,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                           data.shape_values[dof_index3_2][q][1] = polyx[j][0];
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (contains(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -882,7 +882,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                             cell_points[q][2], polyz[i]);
                         }
                       // Now use these to compute the shape functions:
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -965,7 +965,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1267,7 +1267,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                           IntegratedLegendrePolynomials[i + 1].value(
                             edge_sigma_values[m][q], poly[i - 1]);
                         }
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1292,7 +1292,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1454,7 +1454,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 edge_sigma_values[m][q], poly[i]);
                             }
                         }
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1478,7 +1478,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1753,7 +1753,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                         face_eta_values[m][q], polyeta[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (contains(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1805,7 +1805,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (contains(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1902,7 +1902,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
         }
-      if ((flags & update_hessians) != 0u)
+      if (contains(flags, update_hessians))
         {
           Assert(false, ExcNotImplemented());
         }
@@ -1950,7 +1950,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -1976,7 +1976,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
             }
         }
     }
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2083,7 +2083,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
                                              cell->face_rotation(face_no),
                                              n_q_points);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2112,7 +2112,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
             }
         }
     }
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2188,15 +2188,15 @@ FE_NedelecSZ<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values | update_covariant_transformation;
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_values |
            update_jacobian_pushed_forward_grads |
            update_covariant_transformation;
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     //     Assert (false, ExcNotImplemented());
     out |= update_hessians | update_values | update_gradients |
            update_jacobian_pushed_forward_grads |

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients)? 3 : 2);
+                    contains(flags, update_gradients) ? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients)? 3 : 2);
+                    contains(flags, update_gradients) ? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients)? 3 : 2);
+                contains(flags, update_gradients) ? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients)? 3 : 2);
+                contains(flags, update_gradients) ? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1688,8 +1688,8 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length(contains(flags, update_gradients)? 3 :
-                                                                            2);
+          const unsigned int poly_length(contains(flags, update_gradients) ? 3 :
+                                                                             2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
           std::vector<std::vector<double>> polyeta(

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -51,13 +51,13 @@ FE_P1NC::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values | update_quadrature_points;
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients;
-  if ((flags & update_normal_vectors) != 0u)
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     out |= update_hessians;
 
   return out;
@@ -227,14 +227,14 @@ FE_P1NC::fill_fe_values(
   ndarray<double, 4, 3> coeffs = get_linear_shape_coefficients(cell);
 
   // compute on the cell
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -268,7 +268,7 @@ FE_P1NC::fill_fe_face_values(
                                    quadrature[0],
                                    face_no);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
@@ -281,7 +281,7 @@ FE_P1NC::fill_fe_face_values(
              coeffs[k][1] * quadrature_point(1) + coeffs[k][2]);
         }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
     this->reference_cell(), quadrature, face_no, sub_no);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -327,7 +327,7 @@ FE_P1NC::fill_fe_subface_values(
           }
       }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -148,7 +148,7 @@ FE_P1NC::get_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -174,7 +174,7 @@ FE_P1NC::get_face_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -198,7 +198,7 @@ FE_P1NC::get_subface_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -2425,14 +2425,14 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
         {
           case mapping_none:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives;
@@ -2441,16 +2441,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_raviart_thomas:
           case mapping_piola:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values | update_piola |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2462,16 +2462,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           case mapping_contravariant:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2483,15 +2483,15 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_nedelec:
           case mapping_covariant:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_covariant_transformation;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -454,11 +454,11 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(fe_data.update_each & update_values) ||
+  Assert(!contains(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[0] == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size()[0],
                               this->n_dofs_per_cell()));
-  Assert(!(fe_data.update_each & update_values) ||
+  Assert(!contains(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[1] == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values.size()[1], n_q_points));
 
@@ -513,7 +513,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -550,7 +550,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // the previous one; or, even if it is a translation, if we use
       // mappings other than the standard mappings that require us to
       // recompute values and derivatives because of possible sign changes
-      if (fe_data.update_each & update_values &&
+      if (contains(fe_data.update_each, update_values) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -621,7 +621,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update gradients. apply the same logic as above
-      if (fe_data.update_each & update_gradients &&
+      if (contains(fe_data.update_each, update_gradients) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -764,7 +764,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update hessians. apply the same logic as above
-      if (fe_data.update_each & update_hessians &&
+      if (contains(fe_data.update_each, update_hessians) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1038,7 +1038,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives &&
+      if (contains(fe_data.update_each, update_3rd_derivatives) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1143,7 +1143,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1174,7 +1174,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1260,7 +1260,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (fe_data.update_each & update_gradients)
+      if (contains(fe_data.update_each, update_gradients))
         {
           switch (mapping_kind)
             {
@@ -1428,7 +1428,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (fe_data.update_each & update_hessians)
+      if (contains(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -1727,7 +1727,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives)
+      if (contains(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -1829,7 +1829,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1860,7 +1860,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1949,7 +1949,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (fe_data.update_each & update_gradients)
+      if (contains(fe_data.update_each, update_gradients))
         {
           const ArrayView<Tensor<2, spacedim>> transformed_shape_grads =
             make_array_view(fe_data.transformed_shape_grads,
@@ -2103,7 +2103,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (fe_data.update_each & update_hessians)
+      if (contains(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -2401,7 +2401,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives)
+      if (contains(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,8 +1225,8 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (flags & (update_values | update_gradients | update_hessians |
-               update_3rd_derivatives))
+  if (contains(flags,(update_values | update_gradients | update_hessians |
+               update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1368,7 +1368,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if (base_flags & update_values)
+              if(contains(base_flags, update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1376,7 +1376,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if (base_flags & update_gradients)
+              if(contains(base_flags, update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1384,7 +1384,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if (base_flags & update_hessians)
+              if(contains(base_flags, update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1392,7 +1392,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if (base_flags & update_3rd_derivatives)
+              if(contains(base_flags, update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,8 +1225,9 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (contains(flags,(update_values | update_gradients | update_hessians |
-               update_3rd_derivatives)))
+  if (contains(flags,
+               (update_values | update_gradients | update_hessians |
+                update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1368,7 +1369,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if(contains(base_flags, update_values))
+              if (contains(base_flags, update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1376,7 +1377,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if(contains(base_flags, update_gradients))
+              if (contains(base_flags, update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1384,7 +1385,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if(contains(base_flags, update_hessians))
+              if (contains(base_flags, update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1392,7 +1393,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if(contains(base_flags, update_3rd_derivatives))
+              if (contains(base_flags, update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2705,55 +2705,55 @@ namespace internal
       const unsigned int n_quadrature_points,
       const UpdateFlags  flags)
     {
-      if ((flags & update_quadrature_points) != 0u)
+      if (contains(flags, update_quadrature_points))
         this->quadrature_points.resize(
           n_quadrature_points,
           Point<spacedim>(numbers::signaling_nan<Tensor<1, spacedim>>()));
 
-      if ((flags & update_JxW_values) != 0u)
+      if (contains(flags, update_JxW_values))
         this->JxW_values.resize(n_quadrature_points,
                                 numbers::signaling_nan<double>());
 
-      if ((flags & update_jacobians) != 0u)
+      if (contains(flags, update_jacobians))
         this->jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, dim, spacedim>>());
 
-      if ((flags & update_jacobian_grads) != 0u)
+      if (contains(flags, update_jacobian_grads))
         this->jacobian_grads.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<2, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_grads) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_grads))
         this->jacobian_pushed_forward_grads.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<3, spacedim>>());
 
-      if ((flags & update_jacobian_2nd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_2nd_derivatives))
         this->jacobian_2nd_derivatives.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<3, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_2nd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_2nd_derivatives))
         this->jacobian_pushed_forward_2nd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<4, spacedim>>());
 
-      if ((flags & update_jacobian_3rd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_3rd_derivatives))
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
-      if ((flags & update_jacobian_pushed_forward_3rd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_3rd_derivatives))
         this->jacobian_pushed_forward_3rd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<5, spacedim>>());
 
-      if ((flags & update_inverse_jacobians) != 0u)
+      if (contains(flags, update_inverse_jacobians))
         this->inverse_jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, spacedim, dim>>());
 
-      if ((flags & update_boundary_forms) != 0u)
+      if (contains(flags, update_boundary_forms))
         this->boundary_forms.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
 
-      if ((flags & update_normal_vectors) != 0u)
+      if (contains(flags, update_normal_vectors))
         this->normal_vectors.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
     }
@@ -2806,14 +2806,14 @@ namespace internal
 
       // with the number of rows now known, initialize those fields
       // that we will need to their correct size
-      if ((flags & update_values) != 0u)
+      if (contains(flags, update_values))
         {
           this->shape_values.reinit(n_nonzero_shape_components,
                                     n_quadrature_points);
           this->shape_values.fill(numbers::signaling_nan<double>());
         }
 
-      if ((flags & update_gradients) != 0u)
+      if (contains(flags, update_gradients))
         {
           this->shape_gradients.reinit(n_nonzero_shape_components,
                                        n_quadrature_points);
@@ -2821,7 +2821,7 @@ namespace internal
             numbers::signaling_nan<Tensor<1, spacedim>>());
         }
 
-      if ((flags & update_hessians) != 0u)
+      if (contains(flags, update_hessians))
         {
           this->shape_hessians.reinit(n_nonzero_shape_components,
                                       n_quadrature_points);
@@ -2829,7 +2829,7 @@ namespace internal
             numbers::signaling_nan<Tensor<2, spacedim>>());
         }
 
-      if ((flags & update_3rd_derivatives) != 0u)
+      if (contains(flags, update_3rd_derivatives))
         {
           this->shape_3rd_derivatives.reinit(n_nonzero_shape_components,
                                              n_quadrature_points);
@@ -4235,7 +4235,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4255,7 +4255,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data = Threads::new_task(
       [&]() { return this->mapping->get_data(flags, quadrature); });
 
@@ -4263,7 +4263,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4515,7 +4515,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4550,7 +4550,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data = Threads::new_task(mapping_get_face_data,
                                          *this->mapping,
                                          flags,
@@ -4560,7 +4560,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4753,7 +4753,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4774,7 +4774,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data =
       Threads::new_task(&Mapping<dim, spacedim>::get_subface_data,
                         *this->mapping,
@@ -4785,7 +4785,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1549,7 +1549,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1580,7 +1580,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1604,7 +1604,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1634,7 +1634,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1658,7 +1658,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1688,7 +1688,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1712,7 +1712,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1742,7 +1742,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1767,7 +1767,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1798,7 +1798,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1822,7 +1822,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1852,7 +1852,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1876,7 +1876,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1906,7 +1906,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1931,7 +1931,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1962,7 +1962,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1986,7 +1986,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2017,7 +2017,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2041,7 +2041,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2071,7 +2071,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2095,7 +2095,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2125,7 +2125,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2149,7 +2149,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2184,7 +2184,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2212,7 +2212,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2243,7 +2243,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2267,7 +2267,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2297,7 +2297,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2321,7 +2321,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2353,7 +2353,7 @@ namespace FEValuesViews
       std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2377,7 +2377,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2407,7 +2407,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2431,7 +2431,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2462,7 +2462,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2486,7 +2486,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2517,7 +2517,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -3358,7 +3358,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> &values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3383,7 +3383,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> & values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3408,7 +3408,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
 
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3438,7 +3438,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
@@ -3466,7 +3466,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   // Size of indices must be a multiple of dofs_per_cell such that an integer
@@ -3498,7 +3498,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3524,7 +3524,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3549,7 +3549,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
     &gradients) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3582,7 +3582,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3610,7 +3610,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3635,7 +3635,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3661,7 +3661,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3691,7 +3691,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3719,7 +3719,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> &laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3744,7 +3744,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> & laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3768,7 +3768,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 {
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3798,7 +3798,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3828,7 +3828,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   using Number = typename InputVector::value_type;
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3856,7 +3856,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3882,7 +3882,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
     &third_derivatives) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3909,7 +3909,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3939,7 +3939,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3972,7 +3972,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEValuesBase<dim, spacedim>::get_normal_vectors() const
 {
-  Assert(this->update_flags & update_normal_vectors,
+  Assert(contains(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
 
@@ -4225,7 +4225,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   // You can compute normal vectors to the cells only in the
   // codimension one case.
   if (dim != spacedim - 1)
-    Assert((update_flags & update_normal_vectors) == false,
+    Assert(contains(update_flags, update_normal_vectors) == false,
            ExcMessage("You can only pass the 'update_normal_vectors' "
                       "flag to FEFaceValues or FESubfaceValues objects, "
                       "but not to an FEValues object unless the "
@@ -4339,7 +4339,7 @@ FEValues<dim, spacedim>::do_reinit()
   // specific to the mapping. also let it inspect the
   // cell similarity flag and, if necessary, update
   // it
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->cell_similarity =
         this->get_mapping().fill_fe_values(this->present_cell,
@@ -4419,7 +4419,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEFaceValuesBase<dim, spacedim>::get_boundary_forms() const
 {
-  Assert(this->update_flags & update_boundary_forms,
+  Assert(contains(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
   return this->mapping_output.boundary_forms;
@@ -4651,7 +4651,7 @@ FEFaceValues<dim, spacedim>::do_reinit(const unsigned int face_no)
     this->present_cell;
   this->present_face_index = cell->face_index(face_no);
 
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_face_values(this->present_cell,
                                               face_no,
@@ -4975,7 +4975,7 @@ FESubfaceValues<dim, spacedim>::do_reinit(const unsigned int face_no,
     }
 
   // now ask the mapping and the finite element to do the actual work
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_subface_values(this->present_cell,
                                                  face_no,

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -360,7 +360,8 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains(data.update_each,
+                   update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
@@ -374,7 +375,8 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(data.update_each,
+                   update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -729,7 +731,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -740,7 +743,8 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -790,7 +794,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -817,7 +822,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -831,7 +837,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -848,7 +855,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -900,7 +908,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -927,7 +936,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -941,7 +951,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -958,7 +969,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -997,7 +1009,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1039,7 +1052,8 @@ MappingCartesian<dim, spacedim>::transform(
           Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1079,7 +1093,8 @@ MappingCartesian<dim, spacedim>::transform(
           Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,7 +98,7 @@ MappingCartesian<dim, spacedim>::requires_update_flags(
   // since they can be computed from the normal vectors without much
   // further ado
   UpdateFlags out = in;
-  if ((out & update_boundary_forms) != 0u)
+  if (contains(out, update_boundary_forms))
     out |= update_normal_vectors;
 
   return out;
@@ -220,7 +220,7 @@ MappingCartesian<dim, spacedim>::maybe_update_cell_quadrature_points(
   const InternalData &                                        data,
   std::vector<Point<dim>> &quadrature_points) const
 {
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::cell();
 
@@ -240,7 +240,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
 {
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
         ReferenceCells::get_hypercube<dim>(),
@@ -273,7 +273,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
       AssertIndexRange(sub_no, cell->face(face_no)->n_children());
     }
 
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
         ReferenceCells::get_hypercube<dim>(),
@@ -322,7 +322,7 @@ MappingCartesian<dim, spacedim>::maybe_update_normal_vectors(
   std::vector<Tensor<1, dim>> &normal_vectors) const
 {
   // compute normal vectors. All normals on a face have the same value.
-  if (data.update_each & update_normal_vectors)
+  if (contains(data.update_each, update_normal_vectors))
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
       std::fill(normal_vectors.begin(),
@@ -343,38 +343,38 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
 {
   if (cell_similarity != CellSimilarity::translation)
     {
-      if (data.update_each & update_jacobian_grads)
+      if (contains(data.update_each, update_jacobian_grads))
         for (unsigned int i = 0; i < output_data.jacobian_grads.size(); ++i)
           output_data.jacobian_grads[i] = DerivativeForm<2, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_grads)
+      if (contains(data.update_each, update_jacobian_pushed_forward_grads))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_grads.size();
              ++i)
           output_data.jacobian_pushed_forward_grads[i] = Tensor<3, spacedim>();
 
-      if (data.update_each & update_jacobian_2nd_derivatives)
+      if (contains(data.update_each, update_jacobian_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_2nd_derivatives.size();
              ++i)
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_2nd_derivatives)
+      if (contains(data.update_each, update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
           output_data.jacobian_pushed_forward_2nd_derivatives[i] =
             Tensor<4, spacedim>();
 
-      if (data.update_each & update_jacobian_3rd_derivatives)
+      if (contains(data.update_each, update_jacobian_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_3rd_derivatives.size();
              ++i)
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_3rd_derivatives)
+      if (contains(data.update_each, update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -390,7 +390,7 @@ void
 MappingCartesian<dim, spacedim>::maybe_update_volume_elements(
   const InternalData &data) const
 {
-  if (data.update_each & update_volume_elements)
+  if (contains(data.update_each, update_volume_elements))
     {
       double volume = data.cell_extents[0];
       for (unsigned int d = 1; d < dim; ++d)
@@ -411,7 +411,7 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobians(
 {
   // "compute" Jacobian at the quadrature points, which are all the
   // same
-  if (data.update_each & update_jacobians)
+  if (contains(data.update_each, update_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.jacobians.size(); ++i)
         {
@@ -433,7 +433,7 @@ MappingCartesian<dim, spacedim>::maybe_update_inverse_jacobians(
 {
   // "compute" inverse Jacobian at the quadrature points, which are
   // all the same
-  if (data.update_each & update_inverse_jacobians)
+  if (contains(data.update_each, update_inverse_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.inverse_jacobians.size(); ++i)
         {
@@ -470,14 +470,14 @@ MappingCartesian<dim, spacedim>::fill_fe_values(
 
   // compute Jacobian determinant. all values are equal and are the
   // product of the local lengths in each coordinate direction
-  if (data.update_each & (update_JxW_values | update_volume_elements))
+  if (contains(data.update_each, (update_JxW_values | update_volume_elements)))
     if (cell_similarity != CellSimilarity::translation)
       {
         double J = data.cell_extents[0];
         for (unsigned int d = 1; d < dim; ++d)
           J *= data.cell_extents[d];
         data.volume_element = J;
-        if (data.update_each & update_JxW_values)
+        if (contains(data.update_each, update_JxW_values))
           for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
             output_data.JxW_values[i] = J * quadrature.weight(i);
       }
@@ -504,9 +504,9 @@ MappingCartesian<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(update_flags & update_inverse_jacobians ||
-           update_flags & update_jacobians ||
-           update_flags & update_quadrature_points,
+  Assert(contains(update_flags, update_inverse_jacobians) ||
+           contains(update_flags, update_jacobians) ||
+           contains(update_flags, update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -564,11 +564,11 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       output_data.JxW_values[i] = J * quadrature[0].weight(i);
 
-  if (data.update_each & update_boundary_forms)
+  if (contains(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -611,7 +611,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     {
       // Here, cell->face(face_no)->n_children() would be the right
       // choice, but unfortunately the current function is also called
@@ -625,7 +625,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
         output_data.JxW_values[i] = J * quadrature.weight(i) / n_subfaces;
     }
 
-  if (data.update_each & update_boundary_forms)
+  if (contains(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -661,7 +661,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
                                       data,
                                       output_data.quadrature_points);
 
-  if (data.update_each & update_normal_vectors)
+  if (contains(data.update_each, update_normal_vectors))
     for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
       {
         // The normals are n = J^{-T} * \hat{n} before normalizing.
@@ -675,7 +675,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         output_data.normal_vectors[i] = normal;
       }
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       {
         const Tensor<1, dim> &ref_space_normal = quadrature.normal_vector(i);
@@ -717,7 +717,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -729,7 +729,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -740,10 +740,10 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -777,7 +777,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -790,7 +790,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -803,7 +803,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -817,7 +817,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -831,10 +831,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -848,10 +848,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -887,7 +887,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -900,7 +900,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -913,7 +913,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -927,7 +927,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -941,10 +941,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -958,10 +958,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -997,7 +997,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1036,10 +1036,10 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_contravariant_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1057,7 +1057,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1076,13 +1076,13 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -91,40 +91,44 @@ MappingFE<dim, spacedim>::InternalData::initialize(
 
   const unsigned int n_q_points = q.size();
 
-  if (this->update_each & update_covariant_transformation)
+  if (contains(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (this->update_each & update_contravariant_transformation)
+  if (contains(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (this->update_each & update_volume_elements)
+  if (contains(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (this->update_each & update_quadrature_points)
+  if (contains(this->update_each, update_quadrature_points))
     shape_values.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each &
-      (update_covariant_transformation | update_contravariant_transformation |
-       update_JxW_values | update_boundary_forms | update_normal_vectors |
-       update_jacobians | update_jacobian_grads | update_inverse_jacobians |
-       update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
-       update_jacobian_pushed_forward_2nd_derivatives |
-       update_jacobian_3rd_derivatives |
-       update_jacobian_pushed_forward_3rd_derivatives))
+  if (contains(
+        this->update_each,
+        (update_covariant_transformation | update_contravariant_transformation |
+         update_JxW_values | update_boundary_forms | update_normal_vectors |
+         update_jacobians | update_jacobian_grads | update_inverse_jacobians |
+         update_jacobian_pushed_forward_grads |
+         update_jacobian_2nd_derivatives |
+         update_jacobian_pushed_forward_2nd_derivatives |
+         update_jacobian_3rd_derivatives |
+         update_jacobian_pushed_forward_3rd_derivatives)))
     shape_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each &
-      (update_jacobian_grads | update_jacobian_pushed_forward_grads))
+  if (contains(this->update_each,
+               (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
     shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each & (update_jacobian_2nd_derivatives |
-                           update_jacobian_pushed_forward_2nd_derivatives))
+  if (contains(this->update_each,
+               (update_jacobian_2nd_derivatives |
+                update_jacobian_pushed_forward_2nd_derivatives)))
     shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each & (update_jacobian_3rd_derivatives |
-                           update_jacobian_pushed_forward_3rd_derivatives))
+  if (contains(this->update_each,
+               (update_jacobian_3rd_derivatives |
+                update_jacobian_pushed_forward_3rd_derivatives)))
     shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
   // now also fill the various fields with their correct values
@@ -145,9 +149,10 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 {
   initialize(update_flags, q, n_original_q_points);
 
-  if (this->update_each &
-      (update_boundary_forms | update_normal_vectors | update_jacobians |
-       update_JxW_values | update_inverse_jacobians))
+  if (contains(this->update_each,
+               (update_boundary_forms | update_normal_vectors |
+                update_jacobians | update_JxW_values |
+                update_inverse_jacobians)))
     {
       aux.resize(dim - 1,
                  std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -284,7 +289,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags & update_quadrature_points)
+        if (contains(update_flags, update_quadrature_points))
           for (unsigned int point = 0; point < n_q_points; ++point)
             {
               const double *  shape = &data.shape(point + data_set, 0);
@@ -317,7 +322,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags & update_contravariant_transformation)
+        if (contains(update_flags, update_contravariant_transformation))
           // if the current cell is just a
           // translation of the previous one, no
           // need to recompute jacobians...
@@ -357,7 +362,7 @@ namespace internal
                 }
             }
 
-        if (update_flags & update_covariant_transformation)
+        if (contains(update_flags, update_covariant_transformation))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -367,7 +372,7 @@ namespace internal
                 }
             }
 
-        if (update_flags & update_volume_elements)
+        if (contains(update_flags, update_volume_elements))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -392,7 +397,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_grads)
+        if (contains(update_flags, update_jacobian_grads))
           {
             AssertIndexRange(n_q_points, jacobian_grads.size() + 1);
 
@@ -439,7 +444,7 @@ namespace internal
         const unsigned int                n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_grads)
+        if (contains(update_flags, update_jacobian_pushed_forward_grads))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_grads.size() + 1);
@@ -513,7 +518,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_2nd_derivatives)
+        if (contains(update_flags, update_jacobian_2nd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_2nd_derivatives.size() + 1);
 
@@ -569,7 +574,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_2nd_derivatives)
+        if (contains(update_flags,
+                     update_jacobian_pushed_forward_2nd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_2nd_derivatives.size() +
@@ -672,7 +678,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_3rd_derivatives)
+        if (contains(update_flags, update_jacobian_3rd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_3rd_derivatives.size() + 1);
 
@@ -731,7 +737,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_3rd_derivatives)
+        if (contains(update_flags,
+                     update_jacobian_pushed_forward_3rd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_3rd_derivatives.size() +
@@ -1022,18 +1029,20 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (containes(out,(update_JxW_values | update_normal_vectors)))
+      if (contains(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out, (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)))
+      if (contains(out,
+                   (update_covariant_transformation | update_JxW_values |
+                    update_jacobians | update_jacobian_grads |
+                    update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
       if (contains(out,
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)))
+                   (update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1211,11 +1220,11 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!(contains(update_flags, update_normal_vectors)) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1356,17 +1365,18 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags &
-            (update_boundary_forms | update_normal_vectors | update_jacobians |
-             update_JxW_values | update_inverse_jacobians))
+        if (contains(update_flags,
+                     (update_boundary_forms | update_normal_vectors |
+                      update_jacobians | update_JxW_values |
+                      update_inverse_jacobians)))
           {
-            if (update_flags & update_boundary_forms)
+            if (contains(update_flags, update_boundary_forms))
               AssertIndexRange(n_q_points,
                                output_data.boundary_forms.size() + 1);
-            if (update_flags & update_normal_vectors)
+            if (contains(update_flags, update_normal_vectors))
               AssertIndexRange(n_q_points,
                                output_data.normal_vectors.size() + 1);
-            if (update_flags & update_JxW_values)
+            if (contains(update_flags, update_JxW_values))
               AssertIndexRange(n_q_points, output_data.JxW_values.size() + 1);
 
             Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1395,7 +1405,7 @@ namespace internal
                   make_array_view(data.aux[d]));
               }
 
-            if (update_flags & update_boundary_forms)
+            if (contains(update_flags, update_boundary_forms))
               {
                 // if dim==spacedim, we can use the unit tangentials to
                 // compute the boundary form by simply taking the cross
@@ -1466,7 +1476,7 @@ namespace internal
                   }
               }
 
-            if (update_flags & update_JxW_values)
+            if (contains(update_flags, update_JxW_values))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 {
                   output_data.JxW_values[i] =
@@ -1486,17 +1496,17 @@ namespace internal
                     }
                 }
 
-            if (update_flags & update_normal_vectors)
+            if (contains(update_flags, update_normal_vectors))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 output_data.normal_vectors[i] =
                   Point<spacedim>(output_data.boundary_forms[i] /
                                   output_data.boundary_forms[i].norm());
 
-            if (update_flags & update_jacobians)
+            if (contains(update_flags, update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (update_flags & update_inverse_jacobians)
+            if (contains(update_flags, update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1716,7 +1726,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1730,7 +1741,8 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -1755,7 +1767,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1799,7 +1812,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1843,7 +1857,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -1902,7 +1917,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1991,7 +2007,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -2068,7 +2085,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2168,7 +2186,8 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1263,12 +1263,12 @@ MappingFE<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1301,7 +1301,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1310,7 +1310,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1022,18 +1022,18 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (containes(out,(update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
+      if (contains(out, (update_covariant_transformation | update_JxW_values |
                   update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+                  update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if ((out &
+      if (contains(out,
            (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
             update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+            update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1042,12 +1042,12 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (contains(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (contains(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1716,7 +1716,7 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1730,11 +1730,11 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1755,7 +1755,7 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1795,11 +1795,11 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1819,7 +1819,7 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1839,15 +1839,15 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1898,11 +1898,11 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1944,7 +1944,7 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1987,15 +1987,15 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -2068,7 +2068,7 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2168,7 +2168,7 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1574,7 +1574,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (contains(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim - dim == 1,
                          ExcMessage("There is no cell normal in codim 2."));
@@ -1603,7 +1603,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1611,7 +1611,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -543,7 +543,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (contains(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim == dim + 1,
                          ExcMessage(
@@ -575,7 +575,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -583,7 +583,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -1099,12 +1099,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1137,7 +1137,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1146,7 +1146,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1364,7 +1364,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
 
           output_data.JxW_values[point] = weights[point] * det * normal.norm();
 
-          if ((update_flags & update_normal_vectors) != 0u)
+          if (contains(update_flags, update_normal_vectors))
             {
               normal /= normal.norm();
               output_data.normal_vectors[point] = normal;
@@ -1373,7 +1373,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1381,7 +1381,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1438,18 +1438,18 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (contains(update_flags, update_quadrature_points))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               output_data.quadrature_points[i + j][d] = result.first[d][j];
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (contains(update_flags, update_jacobians))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               for (unsigned int e = 0; e < dim; ++e)
                 output_data.jacobians[i + j][d][e] = result.second[e][d][j];
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (contains(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac(
               result.second);
@@ -1471,16 +1471,16 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (contains(update_flags, update_quadrature_points))
           output_data.quadrature_points[i] = result.first;
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (contains(update_flags, update_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac = result.second;
             output_data.jacobians[i]             = jac.transpose();
           }
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (contains(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac(result.second);
             DerivativeForm<1, spacedim, dim> inv_jac = jac.covariant_form();

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -94,19 +94,20 @@ MappingQ<dim, spacedim>::InternalData::initialize(
   const unsigned int n_q_points = q.size();
 
   const bool needs_higher_order_terms =
-    this->update_each &
-    (update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
-     update_jacobian_pushed_forward_2nd_derivatives |
-     update_jacobian_3rd_derivatives |
-     update_jacobian_pushed_forward_3rd_derivatives);
+    contains(this->update_each,
+             (update_jacobian_pushed_forward_grads |
+              update_jacobian_2nd_derivatives |
+              update_jacobian_pushed_forward_2nd_derivatives |
+              update_jacobian_3rd_derivatives |
+              update_jacobian_pushed_forward_3rd_derivatives));
 
-  if (this->update_each & update_covariant_transformation)
+  if (contains(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (this->update_each & update_contravariant_transformation)
+  if (contains(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (this->update_each & update_volume_elements)
+  if (contains(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   tensor_product_quadrature = q.is_tensor_product();
@@ -176,31 +177,35 @@ MappingQ<dim, spacedim>::InternalData::initialize(
     {
       // see if we need the (transformation) shape function values
       // and/or gradients and resize the necessary arrays
-      if (this->update_each & update_quadrature_points)
+      if (contains(this->update_each, update_quadrature_points))
         shape_values.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each &
-          (update_covariant_transformation |
-           update_contravariant_transformation | update_JxW_values |
-           update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_jacobian_grads | update_inverse_jacobians |
-           update_jacobian_pushed_forward_grads |
-           update_jacobian_2nd_derivatives |
-           update_jacobian_pushed_forward_2nd_derivatives |
-           update_jacobian_3rd_derivatives |
-           update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(this->update_each,
+                   (update_covariant_transformation |
+                    update_contravariant_transformation | update_JxW_values |
+                    update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_jacobian_grads |
+                    update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_2nd_derivatives |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_3rd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         shape_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each &
-          (update_jacobian_grads | update_jacobian_pushed_forward_grads))
+      if (contains(this->update_each,
+                   (update_jacobian_grads |
+                    update_jacobian_pushed_forward_grads)))
         shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each & (update_jacobian_2nd_derivatives |
-                               update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains(this->update_each,
+                   (update_jacobian_2nd_derivatives |
+                    update_jacobian_pushed_forward_2nd_derivatives)))
         shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each & (update_jacobian_3rd_derivatives |
-                               update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(this->update_each,
+                   (update_jacobian_3rd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
       // now also fill the various fields with their correct values
@@ -234,9 +239,10 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (this->update_each &
-          (update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_JxW_values | update_inverse_jacobians))
+      if (contains(this->update_each,
+                   (update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_JxW_values |
+                    update_inverse_jacobians)))
         {
           aux.resize(dim - 1,
                      AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
@@ -851,18 +857,20 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (contains(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (contains(out,
+                   (update_covariant_transformation | update_JxW_values |
+                    update_jacobians | update_jacobian_grads |
+                    update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (contains(out,
+                   (update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -871,12 +879,12 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (contains(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (contains(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1047,11 +1055,11 @@ MappingQ<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!contains(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1332,11 +1340,11 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
   const UpdateFlags          update_flags = data.update_each;
   const std::vector<double> &weights      = quadrature.get_weights();
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!contains(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1404,9 +1412,9 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(update_flags & update_inverse_jacobians ||
-           update_flags & update_jacobians ||
-           update_flags & update_quadrature_points,
+  Assert(contains(update_flags,
+                  update_inverse_jacobians | update_jacobians |
+                    update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -1574,7 +1582,8 @@ MappingQ<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -63,7 +63,8 @@ namespace GridTools
     if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
-        update_flags    = update_flags & ~update_vertex_to_cell_map;
+	// FIXME
+        update_flags    = static_cast<UpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -112,7 +113,8 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
-        update_flags        = update_flags & ~update_used_vertices_rtree;
+	// FIXME
+        update_flags        = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices_rtree));
       }
     return used_vertices_rtree;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -60,7 +60,7 @@ namespace GridTools
     std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_vertex_to_cell_map() const
   {
-    if ((update_flags & update_vertex_to_cell_map) != 0)
+    if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
         update_flags    = update_flags & ~update_vertex_to_cell_map;
@@ -74,7 +74,7 @@ namespace GridTools
   const std::vector<std::vector<Tensor<1, spacedim>>> &
   Cache<dim, spacedim>::get_vertex_to_cell_centers_directions() const
   {
-    if ((update_flags & update_vertex_to_cell_centers_directions) != 0)
+    if (contains(update_flags, update_vertex_to_cell_centers_directions))
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
@@ -89,7 +89,7 @@ namespace GridTools
   const std::map<unsigned int, Point<spacedim>> &
   Cache<dim, spacedim>::get_used_vertices() const
   {
-    if ((update_flags & update_used_vertices) != 0)
+    if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
         update_flags  = update_flags & ~update_used_vertices;
@@ -103,7 +103,7 @@ namespace GridTools
   const RTree<std::pair<Point<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_used_vertices_rtree() const
   {
-    if ((update_flags & update_used_vertices_rtree) != 0)
+    if (contains(update_flags, update_used_vertices_rtree))
       {
         const auto &used_vertices = get_used_vertices();
         std::vector<std::pair<Point<spacedim>, unsigned int>> vertices(
@@ -125,7 +125,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_cell_bounding_boxes_rtree) != 0)
+    if (contains(update_flags, update_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -149,7 +149,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_locally_owned_cell_bounding_boxes_rtree) != 0)
+    if (contains(update_flags, update_locally_owned_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -203,7 +203,7 @@ namespace GridTools
   const std::vector<std::set<unsigned int>> &
   Cache<dim, spacedim>::get_vertex_to_neighbor_subdomain() const
   {
-    if ((update_flags & update_vertex_to_neighbor_subdomain) != 0)
+    if (contains(update_flags, update_vertex_to_neighbor_subdomain))
       {
         vertex_to_neighbor_subdomain.clear();
         vertex_to_neighbor_subdomain.resize(tria->n_vertices());

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -63,8 +63,10 @@ namespace GridTools
     if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -79,8 +81,10 @@ namespace GridTools
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
       }
     return vertex_to_cell_centers;
   }
@@ -94,8 +98,10 @@ namespace GridTools
     if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_used_vertices));
       }
     return used_vertices;
   }
@@ -115,8 +121,10 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
-	// FIXME
-        update_flags        = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_used_vertices_rtree));
       }
     return used_vertices_rtree;
   }
@@ -140,8 +148,10 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
       }
     return cell_bounding_boxes_rtree;
   }
@@ -167,8 +177,11 @@ namespace GridTools
               std::make_pair(mapping->get_bounding_box(cell), cell));
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_locally_owned_cell_bounding_boxes_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(
+            ~update_locally_owned_cell_bounding_boxes_rtree));
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }
@@ -198,8 +211,10 @@ namespace GridTools
             covering_rtree[level] =
               GridTools::build_global_description_tree(boxes, MPI_COMM_SELF);
           }
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_covering_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_covering_rtree));
       }
 
     return covering_rtree[level];
@@ -220,8 +235,10 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -64,7 +64,7 @@ namespace GridTools
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
 	// FIXME
-        update_flags    = static_cast<UpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -79,7 +79,8 @@ namespace GridTools
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
-        update_flags = update_flags & ~update_vertex_to_cell_centers_directions;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
       }
     return vertex_to_cell_centers;
   }
@@ -93,7 +94,8 @@ namespace GridTools
     if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
-        update_flags  = update_flags & ~update_used_vertices;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices));
       }
     return used_vertices;
   }
@@ -138,7 +140,8 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
-        update_flags = update_flags & ~update_cell_bounding_boxes_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
       }
     return cell_bounding_boxes_rtree;
   }
@@ -164,8 +167,8 @@ namespace GridTools
               std::make_pair(mapping->get_bounding_box(cell), cell));
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
-        update_flags =
-          update_flags & ~update_locally_owned_cell_bounding_boxes_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_locally_owned_cell_bounding_boxes_rtree));
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }
@@ -176,7 +179,7 @@ namespace GridTools
   const RTree<std::pair<BoundingBox<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_covering_rtree(const unsigned int level) const
   {
-    if (update_flags & update_covering_rtree ||
+    if (contains(update_flags, update_covering_rtree) ||
         covering_rtree.find(level) == covering_rtree.end())
       {
         const auto boxes =
@@ -195,7 +198,8 @@ namespace GridTools
             covering_rtree[level] =
               GridTools::build_global_description_tree(boxes, MPI_COMM_SELF);
           }
-        update_flags = update_flags & ~update_covering_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_covering_rtree));
       }
 
     return covering_rtree[level];
@@ -216,7 +220,8 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
-        update_flags = update_flags & ~update_vertex_to_neighbor_subdomain;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -180,7 +180,7 @@ namespace NonMatching
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       this->mapping_output.initialize(this->n_quadrature_points, flags);
     this->finite_element_output.initialize(this->n_quadrature_points,
                                            *this->fe,
@@ -200,7 +200,7 @@ namespace NonMatching
 
     Threads::Task<std::unique_ptr<typename Mapping<dim>::InternalDataBase>>
       mapping_get_data;
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       mapping_get_data = Threads::new_task(&Mapping<dim>::get_data,
                                            *this->mapping,
                                            flags,
@@ -210,7 +210,7 @@ namespace NonMatching
 
     // Then collect answers from the two task above.
     this->fe_data = std::move(fe_get_data.return_value());
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       this->mapping_data = std::move(mapping_get_data.return_value());
     else
       this->mapping_data =

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -107,7 +107,7 @@ namespace NonMatching
   {
     // First call the mapping and let it generate the data specific to the
     // mapping.
-    if (this->update_flags & update_mapping)
+    if (contains(this->update_flags, update_mapping))
       {
         this->get_mapping().fill_fe_immersed_surface_values(
           this->present_cell,
@@ -176,7 +176,7 @@ namespace NonMatching
   {
     UpdateFlags flags = this->compute_update_flags(update_flags);
 
-    if ((flags & (update_JxW_values | update_normal_vectors)) != 0u)
+    if (contains(flags, (update_JxW_values | update_normal_vectors)))
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -1222,7 +1222,7 @@ DataOut<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present, which would only be useful on
   // faces, but we may not use it here.
   Assert(
-    !(update_flags & update_normal_vectors),
+    !contains(update_flags, update_normal_vectors),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -204,21 +204,21 @@ DataOut<dim, spacedim>::build_one_patch(
                   // we do not need to worry about getting any imaginary
                   // components to the postprocessor, and we can safely
                   // call the function that evaluates a scalar field
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     dataset->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_values);
 
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     dataset->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_gradients);
 
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     dataset->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
@@ -227,7 +227,7 @@ DataOut<dim, spacedim>::build_one_patch(
 
                   // Also fill some of the other fields postprocessors may
                   // want to access.
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -260,21 +260,21 @@ DataOut<dim, spacedim>::build_one_patch(
                     {
                       scratch_data.resize_system_vectors(n_components);
 
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         dataset->get_function_values(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_values);
 
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         dataset->get_function_gradients(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_gradients);
 
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         dataset->get_function_hessians(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
@@ -294,7 +294,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // First get the real component of the scalar solution
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -320,7 +320,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -346,7 +346,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -377,7 +377,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
                           // that follow the real one
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -403,7 +403,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -429,7 +429,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -484,7 +484,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // values, then the real and imaginary parts of the
                           // gradients, etc. This allows us to scope the
                           // temporary objects better
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               std::vector<Vector<double>> tmp(
                                 scratch_data.patch_values_system.solution_values
@@ -539,7 +539,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // Now do the exact same thing for the gradients
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               std::vector<std::vector<Tensor<1, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -590,7 +590,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // And finally the Hessians. Same scheme as above.
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               std::vector<std::vector<Tensor<2, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -643,7 +643,7 @@ DataOut<dim, spacedim>::build_one_patch(
                     }
 
                   // Now set other fields we may need
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -172,30 +172,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                 {
                   // at each point there is only one component of value,
                   // gradient etc.
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (contains(update_flags, update_normal_vectors))
                     data.patch_values_scalar.normals =
                       this_fe_patch_values.get_normal_vectors();
 
@@ -216,30 +216,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                   // at each point there is a vector valued function and its
                   // derivative...
                   data.resize_system_vectors(n_components);
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (contains(update_flags, update_normal_vectors))
                     data.patch_values_system.normals =
                       this_fe_patch_values.get_normal_vectors();
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -482,7 +482,7 @@ DataOutRotation<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present,
   // which would only be useful on faces, but
   // we may not use it here.
-  Assert(!(update_flags & update_normal_vectors),
+  Assert(contains(update_flags, update_normal_vectors),
          ExcMessage("The update of normal vectors may not be requested for "
                     "evaluation of data on cells via DataPostprocessor."));
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -220,26 +220,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                       // at each point there is
                       // only one component of
                       // value, gradient etc.
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (contains(update_flags, update_quadrature_points))
                         data.patch_values_scalar.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -261,26 +261,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
 
                       // at each point there is a vector valued function and
                       // its derivative...
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (contains(update_flags, update_quadrature_points))
                         data.patch_values_system.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -669,7 +669,7 @@ PointValueHistory<dim>::evaluate_field(
   const UpdateFlags update_flags =
     data_postprocessor.get_needed_update_flags() | update_quadrature_points;
   Assert(
-    !(update_flags & update_normal_vectors),
+    !(contains(update_flags, update_normal_vectors)),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));
@@ -756,13 +756,13 @@ PointValueHistory<dim>::evaluate_field(
           // type of the solution vector may be different from 'double',
           // but the DataPostprocessorInputs only allow for 'double'
           // data types
-          if (update_flags & update_values)
+          if (contains(update_flags, update_values))
             {
               fe_values.get_function_values(solution, scalar_solution_values);
               postprocessor_input.solution_values =
                 std::vector<double>(1, scalar_solution_values[selected_point]);
             }
-          if (update_flags & update_gradients)
+          if (contains(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                scalar_solution_gradients);
@@ -770,7 +770,7 @@ PointValueHistory<dim>::evaluate_field(
                 std::vector<Tensor<1, dim>>(
                   1, scalar_solution_gradients[selected_point]);
             }
-          if (update_flags & update_hessians)
+          if (contains(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               scalar_solution_hessians);
@@ -792,7 +792,7 @@ PointValueHistory<dim>::evaluate_field(
           // exact same idea as above
           DataPostprocessorInputs::Vector<dim> postprocessor_input;
 
-          if (update_flags & update_values)
+          if (contains(update_flags, update_values))
             {
               fe_values.get_function_values(solution, vector_solution_values);
               postprocessor_input.solution_values.resize(
@@ -801,7 +801,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_values[selected_point].end(),
                         postprocessor_input.solution_values[0].begin());
             }
-          if (update_flags & update_gradients)
+          if (contains(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                vector_solution_gradients);
@@ -811,7 +811,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_gradients[selected_point].end(),
                         postprocessor_input.solution_gradients[0].begin());
             }
-          if (update_flags & update_hessians)
+          if (contains(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               vector_solution_hessians);


### PR DESCRIPTION
Addresses https://github.com/dealii/dealii/pull/13150#discussion_r782803469 and the discussion starting at https://github.com/dealii/dealii/pull/13150#discussion_r778209647 by adding a public `contains` function in the `dealii` namespace that can be used instead of `operator&` for checking flags.
Of course, we still need `operator&` when composing flags. Currently, `operator&` is deleted to find all places where we should change code.

The name is also up for discussion.