### PR TITLE
FEEval: do not cast const away during read_dof_values()

### DIFF
--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -199,7 +199,8 @@ namespace internal
   {
     static const bool value =
       has_begin<T>::value &&
-      (has_local_element<T>::value || is_serial_vector<T>::value) &&
+      (has_local_element<T>::value ||
+       is_serial_vector<typename std::remove_const<T>::type>::value) &&
       std::is_same<typename T::value_type, Number>::value;
   };
 

--- a/include/deal.II/matrix_free/vector_access_internal.h
+++ b/include/deal.II/matrix_free/vector_access_internal.h
@@ -247,10 +247,20 @@ namespace internal
                             VectorizedArrayType *dof_values,
                             std::integral_constant<bool, true>) const
     {
+#ifdef DEBUG
+      // in debug mode, run non-vectorized version because this path
+      // has additional checks (e.g., regarding ghosting)
+      process_dofs_vectorized(dofs_per_cell,
+                              dof_index,
+                              vec,
+                              dof_values,
+                              std::integral_constant<bool, false>());
+#else
       const Number *vec_ptr = vec.begin() + dof_index;
       for (unsigned int i = 0; i < dofs_per_cell;
            ++i, vec_ptr += VectorizedArrayType::size())
         dof_values[i].load(vec_ptr);
+#endif
     }
 
 
@@ -340,7 +350,17 @@ namespace internal
                        VectorizedArrayType &res,
                        std::integral_constant<bool, true>) const
     {
+#ifdef DEBUG
+      // in debug mode, run non-vectorized version because this path
+      // has additional checks (e.g., regarding ghosting)
+      process_dof_gather(indices,
+                         vec,
+                         constant_offset,
+                         res,
+                         std::integral_constant<bool, false>());
+#else
       res.gather(vec.begin() + constant_offset, indices);
+#endif
     }
 
 


### PR DESCRIPTION
This was an interesting "bug". I have passed to `FEEval::read_dof_values()` a clearly not ghosted vector and did not get any assert. The reason is that we (maybe me) do cast away the constness of the vector and when calling `LA::d:V::local_element()` we do not get the assert which is only available in the const version of this function.