### PR TITLE
Remove unnecessary include file

### DIFF
--- a/source/dofs/dof_tools_sparsity.cc
+++ b/source/dofs/dof_tools_sparsity.cc
@@ -45,8 +45,6 @@
 #include <deal.II/lac/trilinos_sparsity_pattern.h>
 #include <deal.II/lac/vector.h>
 
-#include <deal.II/numerics/vector_tools.h>
-
 #include <algorithm>
 #include <numeric>
 


### PR DESCRIPTION
As far as I can see, there is not reference to `VectorTools` in this file.