### PR TITLE
Revert "Add clang-tidy check"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,6 @@
 # - performance-inefficient-string-concatenation: We don't care about "a"+to_string(5)+...
 # - performance-no-automatic-move: All modern compiler perform the return value optimization and we prefer to keep things const.
 
-Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation,-performance-no-automatic-move,readability-implicit-bool-conversion"
+Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation,-performance-no-automatic-move"
 
 WarningsAsErrors: '*'


### PR DESCRIPTION
Master CI is currently failing, so I would suggest we revert this change for now.

This reverts commit 6c47ac1bd1bb48437f01abe027590d5dbaaad8ba introduced in #12265.


