### PR TITLE
Hotfix: Avoid warning about implicit conversion to bool.

### DIFF
--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -879,18 +879,18 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::reinit(
   if (!poly.empty())
     {
       // Check the mapping data for consistency.
-      if (update_flags_mapping & update_jacobians)
+      if ((update_flags_mapping & update_jacobians) != 0u)
         Assert(precomputed_mapping_data.jacobians.size() == unit_points.size(),
                ExcDimensionMismatch(precomputed_mapping_data.jacobians.size(),
                                     unit_points.size()));
-      if (update_flags_mapping & update_inverse_jacobians)
+      if ((update_flags_mapping & update_inverse_jacobians) != 0u)
         Assert(precomputed_mapping_data.inverse_jacobians.size() ==
                  unit_points.size(),
                ExcDimensionMismatch(
                  precomputed_mapping_data.inverse_jacobians.size(),
                  unit_points.size()));
 
-      if (update_flags_mapping & update_quadrature_points)
+      if ((update_flags_mapping & update_quadrature_points) != 0u)
         Assert(precomputed_mapping_data.inverse_jacobians.size() ==
                  unit_points.size(),
                ExcDimensionMismatch(


### PR DESCRIPTION
Every single one of our PRs currently fails one CI check because of this:
```
[...]/fe_point_evaluation.h:882:11: error: implicit conversion 'dealii::UpdateFlags' -> bool [readability-implicit-bool-conversion,-warnings-as-errors]

[...]/fe_point_evaluation.h:886:11: error: implicit conversion 'dealii::UpdateFlags' -> bool [readability-implicit-bool-conversion,-warnings-as-errors]

[...]/fe_point_evaluation.h:893:11: error: implicit conversion 'dealii::UpdateFlags' -> bool [readability-implicit-bool-conversion,-warnings-as-errors]
```
This is because #12983 was proposed before but merged after #12265. This patch fixes the warning.

I recognize (after writing this patch) that the commit in question was reverted in #13254. The current patch is probably still useful, and would allow us to re-enable the patch reverted in #13254.

/rebuild