### PR TITLE
Review of `references.bib`.

### DIFF
--- a/doc/doxygen/references.bib
+++ b/doc/doxygen/references.bib
@@ -6,9 +6,9 @@
   author =  {M. Mu},
   title =   {{PDE.M}art: A Network-based Problem-solving Environment for {PDE}s},
   journal = {ACM Transactions on Mathematical Software},
-  year =    2005,
-  volume =  31,
-  number =  4,
+  year =    {2005},
+  volume =  {31},
+  number =  {4},
   pages =   {508--531},
   url =     {https://doi.org/10.1145/1114268.1114272}
 }
@@ -21,9 +21,9 @@
   author =  {R.B. Kellogg},
   title =   {On the {P}oisson equation with intersecting interfaces},
   journal = {Applicable Analysis},
-  year  =   1974,
-  volume =  4,
-  number =  2,
+  year  =   {1974},
+  volume =  {4},
+  number =  {2},
   pages =   {101--129},
   url =     {https://doi.org/10.1080/00036817408839086}
 }
@@ -37,8 +37,9 @@
   title =   {Superconvergence of {C}$^0$-{Q}$^k$ Finite Element Method for Elliptic Equations with Approximated Coefficients},
   journal = {Journal of Scientific Computing},
   year =    {2020},
+  month =   dec,
   volume =  {82},
-  number =  {1}, 
+  number =  {1},
   doi =     {10.1007/s10915-019-01102-1},
   url =     {https://doi.org/10.1007/s10915-019-01102-1}
 }
@@ -52,8 +53,9 @@
   title =     {Implementation of the Continuous-Discontinuous {G}alerkin Finite Element Method},
   booktitle = {Numerical Mathematics and Advanced Applications 2011},
   publisher = {Springer Berlin Heidelberg},
-  year =      {2012},  
-  pages =     {315--322},  
+  year =      {2012},
+  month =     nov,
+  pages =     {315--322},
   doi =       {10.1007/978-3-642-33134-3_34},
   url =       {https://doi.org/10.1007/978-3-642-33134-3_34}
 }
@@ -67,8 +69,8 @@
   title =     {Mesh Adaptivity and Error Control for a Finite Element Approximation of the Elastic Wave Equation},
   booktitle = {Proceedings of the Fifth International Conference on Mathematical and Numerical Aspects of Wave Propagation (Waves2000), Santiago de Compostela, Spain, 2000},
   editor =    {Alfredo Berm\'udez and Dolores G\'omez and Christophe Hazard and Patrick Joly and Jean E. Roberts},
-  publisher = SIAM,
-  year =      2000,
+  publisher = {SIAM},
+  year =      {2000},
   pages =     {725--729}
 }
 
@@ -76,16 +78,18 @@
   author =  {W. Bangerth},
   title =   {Adaptive Finite Element Methods for the Identification of Distributed Parameters in Partial Differential Equations},
   school =  {University of Heidelberg},
-  year =    2002
+  year =    {2002},
+  doi =     {10.11588/heidok.00002508},
+  url =     {https://doi.org/10.11588/heidok.00002508}
 }
 
 @article{BR99b,
   author =  {W. Bangerth and R. Rannacher},
   title =   {Finite element approximation of the acoustic wave equation: Error control and mesh adaptation},
   journal = {East--West Journal of Numerical Mathematics},
-  year =    1999,
-  volume =  7,
-  number =  4,
+  year =    {1999},
+  volume =  {7},
+  number =  {4},
   pages =   {263--282}
 }
 
@@ -93,7 +97,7 @@
   author =    {W. Bangerth and R. Rannacher},
   title =     {Adaptive Finite Element Methods for Differential Equations},
   publisher = {Birkh{\"a}user Verlag},
-  year =      2003,
+  year =      {2003},
   url =       {https://doi.org/10.1007/978-3-0348-7605-6}
 }
 
@@ -101,9 +105,9 @@
   author =  {W. Bangerth and R. Rannacher},
   title =   {Adaptive Finite Element Techniques for the Acoustic Wave Equation},
   journal = {Journal of Computational Acoustics},
-  year =    2001,
-  volume =  9,
-  number =  2,
+  year =    {2001},
+  volume =  {9},
+  number =  {2},
   pages =   {575--591},
   url =     {https://doi.org/10.1142/S0218396X01000668}
 }
@@ -112,8 +116,8 @@
   author =  {R. Becker and R. Rannacher},
   title =   {An optimal control approach to error estimation and mesh adaptation in finite element methods},
   journal = {Acta Numerica},
-  year =    2001,
-  volume =  10,
+  year =    {2001},
+  volume =  {10},
   pages =   {1--102},
   url =     {https://doi.org/10.1017/S0962492901000010}
 }
@@ -122,7 +126,7 @@
   author =  {R. Becker},
   title =   {An Adaptive Finite Element Method for the Incompressible {N}avier--{S}tokes Equations on Time-dependent Domains},
   school =  {Universit{\"a}t Heidelberg},
-  year =    1995,
+  year =    {1995},
   url = {https://katalog.ub.uni-heidelberg.de/titel/9608091}
 }
 
@@ -131,15 +135,15 @@
   title =       {Weighted Error Estimators for the Incompressible {N}avier--{S}tokes Equations},
   institution = {Universit{\"a}t Heidelberg},
   type =        {Preprint 98-20},
-  year =        1998
+  year =        {1998}
 }
 
 @article{BR96r,
   author =  {R. Becker and R. Rannacher},
   title =   {A Feed-Back Approach to Error Control in Finite Element Methods: Basic Analysis and Examples},
   journal = {East--West Journal of Numerical Mathematics},
-  volume =  4,
-  year =    1996,
+  volume =  {4},
+  year =    {1996},
   pages =   {237--264}
 }
 
@@ -149,7 +153,7 @@
   booktitle = {ENUMATH 97},
   editor =    {H. G. Bock et al.},
   publisher = {World Scientific Publishing, Singapore},
-  year =      1998,
+  year =      {1998},
   pages =     {621--637}
 }
 
@@ -157,9 +161,9 @@
   author =  {C. F{\"u}hrer and G. Kanschat},
   title =   {A posteriori error control in radiative transfer},
   journal = {Computing},
-  year =    1997,
-  volume =  58,
-  number =  4,
+  year =    {1997},
+  volume =  {58},
+  number =  {4},
   pages =   {317--334},
   url =     {https://doi.org/10.1007/BF02684345}
 }
@@ -168,17 +172,17 @@
   author =  {R. Hartmann},
   title =   {Adaptive Finite Element Methods for the Compressible {E}uler Equations},
   school =  {Universit{\"a}t Heidelberg},
-  year =    2002
+  year =    {2002}
 }
 
 @article{HH01,
   author =    {R. Hartmann and P. Houston},
   title =     {Adaptive Discontinuous {G}alerkin Finite Element Methods for Nonlinear Hyperbolic Conservation Laws},
-  publisher = SIAM,
+  publisher = {SIAM},
   journal =   {Journal on Scientific Computing},
-  year =      2003,
-  volume =    24,
-  number =    3,
+  year =      {2003},
+  volume =    {24},
+  number =    {3},
   pages =     {979--1004}
 }
 
@@ -186,9 +190,9 @@
   author =  {R. Hartmann and P. Houston},
   title =   {Adaptive Discontinuous {G}alerkin Finite Element Methods for the Compressible {E}uler Equations},
   journal = {Journal of Computational Physics},
-  year =    2002,
-  volume =  183,
-  number =  2,
+  year =    {2002},
+  volume =  {183},
+  number =  {2},
   pages =   {508--532},
   url =     {https://doi.org/10.1137/S1064827501389084}
 }
@@ -198,16 +202,16 @@
   title =   {Parallel and Adaptive {G}alerkin Methods for Radiative Transfer Problems},
   school =  {Universit{\"a}t Heidelberg},
   type =    {Dissertation},
-  year =    1996
+  year =    {1996}
 }
 
 @article{RS97,
   author =  {R. Rannacher and F.-T. Suttmeier},
   title =   {A feed-back approach to error control in finite element methods: Application to linear elasticity},
   journal = {Computational Mechanics},
-  year =    1997,
-  volume =  19,
-  number =  5,
+  year =    {1997},
+  volume =  {19},
+  number =  {5},
   pages =   {434--446},
   url =     {https://doi.org/10.1007/s004660050191}
 }
@@ -216,9 +220,9 @@
   author =  {R. Rannacher and F.-T. Suttmeier},
   title =   {A posteriori error control in finite element methods via duality techniques: Application to perfect plasticity},
   journal = {Computational Mechanics},
-  year =    1998,
-  volume =  21,
-  number =  2,
+  year =    {1998},
+  volume =  {21},
+  number =  {2},
   pages =   {123--133},
   url =     {https://doi.org/10.1007/s004660050288}
 }
@@ -227,9 +231,9 @@
   author =  {R. Rannacher and F.-T. Suttmeier},
   title =   {A posteriori error estimation and mesh adaptation for finite element models in elasto-plasticity},
   journal = {Computer Methods in Applied Mechanics and Engineering},
-  year =    1999,
-  volume =  176,
-  number =  1,
+  year =    {1999},
+  volume =  {176},
+  number =  {1},
   pages =   {333--361},
   url =     {https://doi.org/10.1016/S0045-7825(98)00344-2}
 }
@@ -239,7 +243,7 @@
   title =   {Adaptive Finite Element Approximation of Problems in Elasto-Plasticity Theory},
   school =  {Universit{\"a}t Heidelberg},
   type =    {Dissertation},
-  year =    1996
+  year =    {1996}
 }
 
 
@@ -251,8 +255,8 @@
 @book{GNS08,
   author =    {I. Griva and S.G. Nash and A. Sofer},
   title =     {Linear and nonlinear optimization},
-  publisher = SIAM,
-  year =      2008,
+  publisher = {SIAM},
+  year =      {2008},
   edition =   {2nd},
   url =       {https://doi.org/10.1007/978-1-4939-7055-1}
 }
@@ -261,7 +265,7 @@
   author =    {J. Nocedal and S.J. Wright},
   title =     {Numerical Optimization},
   publisher = {Springer, New York},
-  year =      1999,
+  year =      {1999},
   series =    {Springer Series in Operations Research},
   url =       {https://doi.org/10.1007%2F978-0-387-40065-5}
 }
@@ -276,9 +280,9 @@
   author =  {S. Commend and A. Truty and T. Zimmermann},
   title =   {Stabilized finite elements applied to elastoplasticity: I. {M}ixed displacement–pressure formulation},
   journal = {Computer Methods in Applied Mechanics and Engineering},
-  year =    2004,
-  volume =  193,
-  number =  33,
+  year =    {2004},
+  volume =  {193},
+  number =  {33},
   pages =   {3559--3586},
   url =     {https://doi.org/10.1016/j.cma.2004.01.007}
 }
@@ -287,9 +291,9 @@
   author =  {H.-Y. Duan and Q. Lin},
   title =   {Mixed finite elements of least-squares type for elasticity},
   journal = {Computer Methods in Applied Mechanics and Engineering},
-  year =    2005,
-  volume =  194,
-  number =  9,
+  year =    {2005},
+  volume =  {194},
+  number =  {9},
   pages =   {1093--1112},
   url =     {https://doi.org/10.1016/j.cma.2004.06.033}
 }
@@ -303,8 +307,8 @@
   author =  {D. Silvester and A. Wathen},
   title =   {Fast iterative solution of stabilised {S}tokes systems. {P}art {II}: Using general block preconditioners},
   journal = {SIAM Journal on Numerical Analysis},
-  year =    1994,
-  volume =  31,
+  year =    {1994},
+  volume =  {31},
   pages =   {1352--1367},
   url =     {https://doi.org/10.1137/0731070}
 }
@@ -334,7 +338,6 @@
   doi = {10.1016/j.compfluid.2010.05.011},
   url = {https://doi.org/10.1016/j.compfluid.2010.05.011},
   year = {2010},
-  month = oct,
   publisher = {Elsevier {BV}},
   volume = {39},
   number = {9},
@@ -349,8 +352,8 @@
   author = 	 {M. Kronbichler and T. Heister and W. Bangerth},
   title = 	 {High Accuracy Mantle Convection Simulation through Modern Numerical Methods},
   journal = 	 {Geophysical Journal International},
-  year = 	 2012,
-  volume = 	 191,
+  year = 	 {2012},
+  volume = 	 {191},
   pages = 	 {12--29}
 }
 
@@ -359,12 +362,11 @@
   doi = {10.1137/120866208},
   url = {https://doi.org/10.1137/120866208},
   year = {2013},
-  month = jan,
   publisher = {Society for Industrial {\&} Applied Mathematics ({SIAM})},
   volume = {35},
   number = {1},
   pages = {B149--B175},
-  author = {Chih-Che Chueh and Ned Djilali and Wolfgang Bangerth},
+  author = {C.C. Chueh and N. Djilali and W. Bangerth},
   title = {An $h$-Adaptive Operator Splitting Method for Two-Phase Flow in 3D Heterogeneous Porous Media},
   journal = {{SIAM} Journal on Scientific Computing}
 }
@@ -374,13 +376,15 @@
   author =    {F. Brezzi and M. Fortin},
   title =        {Mixed and Hybrid Finite Element Methods},
   publisher =    {Springer},
-  year =         1991}
+  year =         {1991}
+}
 
 @Book{Chen2005,
   author =    {Z. Chen},
   title =        {Finite Element Methods and their Applications},
   publisher =    {Springer},
-  year =         2005}
+  year =         {2005}
+}
 
 @article{GuermondPasquetti2008,
   doi = {10.1016/j.crma.2008.05.013},
@@ -391,7 +395,7 @@
   volume = {346},
   number = {13-14},
   pages = {801--806},
-  author = {Jean-Luc Guermond and Richard Pasquetti},
+  author = {J.-L. Guermond and R. Pasquetti},
   title = {Entropy-based nonlinear viscosity for Fourier approximations of conservation laws},
   journal = {Comptes Rendus Mathematique}
 }
@@ -419,22 +423,24 @@
   volume = {7},
   number = {3},
   pages = {856--869},
-  author = {Youcef Saad and Martin H. Schultz},
+  author = {Y. Saad and M.H. Schultz},
   title = {{GMRES}: A Generalized Minimal Residual Algorithm for Solving Nonsymmetric Linear Systems},
   journal = {{SIAM} Journal on Scientific and Statistical Computing}
 }
 
 @Book{GolubVanLoan,
-  author =    {G. H. Golub and C. F. van Loan},
+  author =    {G.H. Golub and C.F. van Loan},
   title =        {Matrix Computations},
   publisher =    {Johns Hopkins},
-  year =         1996}
+  year =         {1996}
+}
 
 @Book{Zhang2005,
   author =    {F. Zhang},
   title =        {The Schur Complement and its Applications},
   publisher =    {Springer},
-  year =         2005}
+  year =         {2005}
+}
 
 
 % ------------------------------------
@@ -442,11 +448,12 @@
 % ------------------------------------
 
 @article{Brenner2005,
-  author =    {S. C. Brenner and L.-Y. Sung},
+  author =    {S.C. Brenner and L.-Y. Sung},
   title =     {C$^0$ Interior Penalty Methods for Fourth Order Elliptic Boundary Value Problems on Polygonal Domains},
   journal =   {Journal of Scientific Computing},
   publisher = {Springer Science and Business Media {LLC}},
   year =      {2005},
+  month =     jun,
   volume =    {22},
   number =    {1},
   pages =     {83--118},
@@ -472,6 +479,7 @@
   journal =   {Computer Methods in Applied Mechanics and Engineering},
   publisher = {Elsevier BV},
   year =      {2002},
+  month =     jul,
   volume =    {191},
   number =    {34},
   pages =     {3669--3750},
@@ -485,6 +493,7 @@
   journal =   {IMA Journal of Numerical Analysis},
   publisher = {Oxford University Press ({OUP})},
   year =      {2009},
+  month =     mar,
   volume =    {30},
   number =    {3},
   pages =     {777--798},
@@ -498,9 +507,10 @@
   journal =   {Computer Methods in Applied Mechanics and Engineering},
   publisher = {Elsevier BV},
   year =      {2007},
+  month =     jul,
   volume =    {196},
   number =    {35-36},
-  pages =     {3370--3380},      
+  pages =     {3370--3380},
   doi =       {10.1016/j.cma.2007.03.008},
   url =       {https://doi.org/10.1016/j.cma.2007.03.008}
 }
@@ -513,8 +523,8 @@
   author =    {O.A. Karakashian and F. Pascal},
   title =     {A posteriori error estimates for a discontinuous {G}alerkin approximation of second-order elliptic problems},
   journal =   {SIAM Journal on Numerical Analysis},
-  publisher = SIAM,
-  year =      {2003},  
+  publisher = {SIAM},
+  year =      {2003},
   volume =    {41},
   number =    {6},
   pages =     {2374--2399},
@@ -530,7 +540,7 @@
      TITLE = {Hybridizable discontinuous {G}alerkin methods for partial differential equations in continuum mechanics},
    JOURNAL = {Journal of Computational Physics},
       YEAR = {2012},
-    VOLUME = {231},      
+    VOLUME = {231},
     NUMBER = {18},
      PAGES = {5955--5988},
        DOI = {10.1016/j.jcp.2012.02.033},
@@ -554,6 +564,7 @@
   journal =   {AIAA Journal},
   publisher = {American Institute of Aeronautics and Astronautics ({AIAA})},
   year  =     {1965},
+  month =     feb,
   volume =    {3},
   number =    {2},
   pages =     {380--380},
@@ -640,7 +651,7 @@
   author =    {B. Smith and P. Bjorstad and W. Gropp},
   title =     {Domain decomposition: parallel multilevel methods for elliptic partial differential equations},
   publisher = {Cambridge University Press},
-  year =      {2004}  
+  year =      {2004}
 }
 
 @book{toselli2006domain,
@@ -667,11 +678,11 @@
 }
 
 @phdthesis{castelli2021numerical,
-  author    = {Castelli, G. F.},
+  author    = {G.F. Castelli},
   title     = {Numerical Investigation of {Cahn--Hilliard}-Type Phase-Field Models for Battery Active Particles},
   school    = {Karlsruhe Institute of Technology (KIT)},
   year      = {2021},
-  url       = {https://doi.org/10.5445/IR/1000141249},
+  url       = {https://doi.org/10.5445/IR/1000141249}
 }
 
 % ------------------------------------
@@ -682,8 +693,8 @@
   author =  {C.A. Kennedy and M.H. Carpenter and R.M. Lewis},
   title =   {Low-storage, explicit {R}unge--{K}utta schemes for the compressible {N}avier--{S}tokes equations},
   journal = {Applied Numerical Mathematics},
-  year =    2000,
-  volume =  35,  
+  year =    {2000},
+  volume =  {35},
   pages =   {177--219},
   doi =     {10.1016/S0168-9274(99)00141-5},
   url =     {https://doi.org/10.1016/S0168-9274(99)00141-5}
@@ -693,8 +704,8 @@
   author =  {K. Tselios and T.E. Simos},
   title =   {Optimized {R}unge--{K}utta methods with minimal dispersion and dissipation for problems arising from computational acoustics},
   journal = {Physics Letters A},
-  year =    2007,  
-  volume =  363,
+  year =    {2007},
+  volume =  {363},
   pages =   {38--48},
   doi =     {10.1016/j.physleta.2006.10.072},
   url =     {https://doi.org/10.1016/j.physleta.2006.10.072}
@@ -704,7 +715,7 @@
   author =  {M. Kronbichler and S. Schoeder and C. M\"uller and W.A. Wall},
   title =   {Comparison of implicit and explicit hybridizable discontinuous {G}alerkin methods for the acoustic wave equation},
   journal = {International Journal for Numerical Methods in Engineering},
-  year =    {2016}
+  year =    {2016},
   volume =  {106},
   number =  {9},
   pages =   {712--739},
@@ -717,8 +728,8 @@
   title =   {Efficient explicit time stepping of high order discontinuous {G}alerkin schemes for waves},
   journal = {SIAM Journal on Scientific Computing},
   year =    {2018},
-  volume =  40,
-  number =  6,
+  volume =  {40},
+  number =  {6},
   pages =   {C803--C826},
   doi =     {10.1137/18M1185399},
   url =     {https://doi.org/10.1137/18M1185399}
@@ -732,7 +743,6 @@
   volume =  {89},
   number =  {3},
   pages =   {71--102},
-%  doi =     {10.1002/fld.4683},  
   url =     {https://doi.org/10.1002/fld.4683}
 }
 
@@ -792,7 +802,7 @@
   title =     {Evaluating the accuracy of hybrid finite element/particle-in-cell methods for modelling incompressible {S}tokes flow},
   journal =   {Geophysical Journal International},
   publisher = {Oxford University Press},
-  year =      {2019},    
+  year =      {2019},
   volume =    {219},
   number =    {3},
   pages =     {1915--1938},
@@ -813,7 +823,7 @@
     NUMBER = {4},
      PAGES = {2466--2489},
        DOI = {10.1137/16M1074291},
-       URL = {https://doi.org/10.1137/16M1074291}       
+       URL = {https://doi.org/10.1137/16M1074291}
 }
 
 @article {GuermondPopov2016b,
@@ -824,7 +834,7 @@
     VOLUME = {321},
      PAGES = {908--926},
        DOI = {10.1016/j.jcp.2016.05.054},
-       URL = {https://doi.org/10.1016/j.jcp.2016.05.054}       
+       URL = {https://doi.org/10.1016/j.jcp.2016.05.054}
 }
 
 @article {GuermondEtAl2018,
@@ -848,7 +858,7 @@
       YEAR = {2004},
      PAGES = {xiv+524},
        DOI = {10.1007/978-1-4757-4355-5},
-       URL = {https://doi.org/10.1007/978-1-4757-4355-5}       
+       URL = {https://doi.org/10.1007/978-1-4757-4355-5}
 }
 
 @article {Brooks1982,
@@ -868,7 +878,7 @@
     AUTHOR = {C. Johnson and J. Pitk\"{a}ranta},
      TITLE = {An analysis of the discontinuous {G}alerkin method for a scalar hyperbolic equation},
    JOURNAL = {Mathematics of Computation},
-      YEAR = {1986},   
+      YEAR = {1986},
     VOLUME = {46},
     NUMBER = {173},
      PAGES = {1--26},
@@ -885,7 +895,7 @@
   chapter =   {10},
   pages =     {187-200},
   doi =       {10.1002/9780470989746.ch10},
-  url =       {https://doi.org/10.1002/9780470989746.ch10}  
+  url =       {https://doi.org/10.1002/9780470989746.ch10}
 }
 
 @book {Toro2009,
@@ -894,7 +904,7 @@
   PUBLISHER = {Springer-Verlag, Berlin, Heidelberg},
   year =      {2009},
   doi =       {10.1007/b79761},
-  url =       {https:doi.org/10.1007/b79761}  
+  url =       {https:doi.org/10.1007/b79761}
 }
 
 
@@ -907,7 +917,7 @@
   author =    {J. Freund and R. Stenberg},
   title =     {On weakly imposed boundary conditions for second order problems},
   booktitle = {Proceedings of the Ninth International Conference on Finite Elements in Fluids},
-  year =      1995,
+  year =      {1995},
   pages =     {327--336}
 }
 
@@ -917,6 +927,7 @@
   journal =   {Numerische Mathematik},
   publisher = {Springer Science and Business Media {LLC}},
   year =      {1999},
+  month =     feb,
   volume =    {81},
   number =    {4},
   pages =     {497--520},
@@ -930,6 +941,7 @@
   journal =   {International Journal of Multiphase Flow},
   publisher = {Elsevier BV},
   year =      {1999},
+  month =     aug,
   volume =    {25},
   number =    {5},
   pages =     {755--794},
@@ -943,6 +955,7 @@
   journal =   {Computer Methods in Applied Mechanics and Engineering},
   publisher = {Elsevier BV},
   year =      {2008},
+  month =     apr,
   volume =    {197},
   number =    {25-28},
   pages =     {2210--2231},
@@ -956,6 +969,7 @@
   journal =   {Computer Methods in Applied Mechanics and Engineering},
   publisher = {Elsevier BV},
   year =      {2012},
+  month =     jul,
   volume =    {229-232},
   pages =     {110--127},
   doi =       {10.1016/j.cma.2012.04.001},
@@ -1011,12 +1025,12 @@
 
 @inbook{Truesdell1960a,
   author    = {C. Truesdell and R. Toupin},
-  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statics},    
+  title     = {Encyclopedia of Physics: Principles of Thermodynamics and Statics},
   chapter   = {2: The classical field theories},
   publisher = {Springer-Verlag Berlin Heidelberg},
-  year      = {1960},  
+  year      = {1960},
   editor    = {S. Fl\"{u}gge},
-  volume    = {1},  
+  volume    = {1},
   pages     = {226--794},
   doi       = {10.1007/978-3-642-45943-6},
   url       = {https://doi.org/10.1007/978-3-642-45943-6}
@@ -1032,7 +1046,7 @@
   number    = {1},
   pages     = {167--178},
   doi       = {10.1007/BF01262690},
-  url       = {https://doi.org/10.1007/BF01262690}  
+  url       = {https://doi.org/10.1007/BF01262690}
 }
 
 @article{Coleman1967a,
@@ -1061,7 +1075,7 @@
   pages     = {209--305},
   address   = {New York},
   doi       = {10.1016/b978-0-08-021792-5.50012-4},
-  url       = {https://doi.org/10.1016/b978-0-08-021792-5.50012-4}  
+  url       = {https://doi.org/10.1016/b978-0-08-021792-5.50012-4}
 }
 
 @article{Holzapfel1996a,
@@ -1070,10 +1084,11 @@
   journal   = {International Journal of Solids and Structures},
   publisher = {Elsevier},
   year      = {1996},
+  month     = aug,
   volume    = {33},
   number    = {20--22},
   pages     = {3019--3034},
-%  doi       = {10.1016/0020-7683(95)00263-4},
+  doi       = {10.1016/0020-7683(95)00263-4},
   url       = {https://doi.org/10.1016/0020-7683(95)00263-4}
 }
 
@@ -1089,13 +1104,13 @@
   author    = {C. Linder and M. Tkachuk and C. Miehe},
   title     = {A micromechanically motivated diffusion-based transient network model and its incorporation into finite rubber viscoelasticity},
   journal   = {Journal of the Mechanics and Physics of Solids},
-  publisher = {Elsevier},  
+  publisher = {Elsevier},
   year      = {2011},
+  month     = oct,
   volume    = {59},
   number    = {10},
   pages     = {2134--2156},
-%  doi       = {10.1016/j.jmps.2011.05.005},
-  url       = {https://doi.org/10.1016/j.jmps.2011.05.005}  
+  url       = {https://doi.org/10.1016/j.jmps.2011.05.005}
 }
 
 @article{Pelteret2018a,
@@ -1115,6 +1130,7 @@
   title     = {Characterizing the time dependence of filled {EPDM}},
   journal   = {Rubber Chemistry and Technology},
   year      = {2011},
+  month     = jun,
   volume    = {84},
   number    = {2},
   pages     = {147--165},
@@ -1140,7 +1156,7 @@
   author =    {M. Ainsworth},
   title =     {A posteriori error estimation for discontinuous {G}alerkin finite element approximation},
   journal =   {SIAM Journal on Numerical Analysis},
-  publisher = SIAM,
+  publisher = {SIAM},
   year =      {2007},
   volume =    {45},
   number =    {4},
@@ -1155,7 +1171,7 @@
 
 @book{brenner2008,
   author    = {S. Brenner and R. Scott},
-  title     = {The {{Mathematical Theory}} of {{Finite Element Methods}}},  
+  title     = {The {{Mathematical Theory}} of {{Finite Element Methods}}},
   publisher = {{Springer-Verlag}},
   year      = {2008},
   edition   = {3},
@@ -1169,11 +1185,11 @@
   title   = {The \textit{hp}‐multigrid method applied to \textit{hp}‐adaptive refinement of triangular grids},
   journal = {Numerical Linear Algebra with Applications},
   year    = {2010},
+  month   = apr,
   volume  = {17},
-  number  = {2-3}
+  number  = {2-3},
   pages   = {211--228},
-  doi     = {10.1002/nla.700},
-  url     = {https://doi.org/10.1002/nla.700}  
+  url     = {https://doi.org/10.1002/nla.700}
 }
 
 @article{mitchell2014hp,
@@ -1182,7 +1198,7 @@
   journal = {ACM Transactions on Mathematical Software},
   year    = {2014},
   volume  = {41},
-  number  = {1}
+  number  = {1},
   pages   = {2/1-39},
   doi     = {10.1145/2629459},
   url     = {https://doi.org/10.1145/2629459}
@@ -1277,6 +1293,7 @@
   journal =   {Mathematical Programming},
   publisher = {Springer Science and Business Media {LLC}},
   year =      {2005},
+  month =     apr,
   volume =    {106},
   number =    {1},
   pages =     {25--57},
@@ -1288,8 +1305,9 @@
   author =    {J. Nocedal and A. W\"{a}chter and R.A. Waltz},
   title =     {Adaptive Barrier Update Strategies for Nonlinear Interior Methods},
   journal =   {SIAM Journal on Optimization},
-  publisher = {Society for Industrial {\&} Applied Mathematics (SIAM)},    
+  publisher = {Society for Industrial {\&} Applied Mathematics (SIAM)},
   year =      {2009},
+  month =     jan,
   volume =    {19},
   number =    {4},
   pages =     {1674--1693},
@@ -1375,7 +1393,7 @@
    author    = {C. Park and D. Sheen},
    title     = {P1-nonconforming quadrilateral finite element methods for second-order elliptic problems},
    journal   = {SIAM Journal on Numerical Analysis},
-   publisher = SIAM,
+   publisher = {SIAM},
    year      = {2003},
    volume    = {41},
    number    = {2},
@@ -1417,7 +1435,7 @@
   number    = {1--2},
   pages     = {165--178},
   doi       = {10.1016/S0168-9274(97)00083-4},
-  url       = {https://doi.org/10.1016/S0168-9274(97)00083-4}  
+  url       = {https://doi.org/10.1016/S0168-9274(97)00083-4}
 }
 
 @article{melenk2001hp,
@@ -1479,7 +1497,6 @@
   volume  = {4},
   number  = {1},
   pages   = {7},
-  doi     = {10.1186/s40323-017-0093-0},
   url     = {https://doi.org/10.1186/s40323-017-0093-0}
 }
 
@@ -1501,7 +1518,7 @@
   author =    {S. McConnell},
   title =     {Code Complete},
   publisher = {Microsoft Press},
-  year =      2004,
+  year =      {2004},
   edition =   {second}
 }
 
@@ -1509,7 +1526,7 @@
   author =    {S. Gottlieb and C.-W. Shu and E. Tadmor},
   title =     {Strong stability-preserving high-order time discretization methods},
   journal =   {SIAM review},
-  publisher = SIAM,
+  publisher = {SIAM},
   year =      {2001},
   volume =    {43},
   number =    {1},
@@ -1547,6 +1564,7 @@
   journal =   {Numerische Mathematik},
   publisher = {Springer Science and Business Media {LLC}},
   year =      {2004},
+  month =     sep,
   volume =    {99},
   number =    {1},
   pages =     {1--24},
@@ -1575,7 +1593,7 @@
    number =    {5},
    volume =    {40},
    pages =     {A2830--A2857},
-   DOI =       {10.1137/18m1175549},
+   doi =       {10.1137/18m1175549},
    url =       {https://doi.org/10.1137/18m1175549}
 }
 
@@ -1594,7 +1612,7 @@
 @online{quadpy,
   author =  {N. Schl{\"o}mer},
   title =   {quadpy: Your one-stop shop for numerical integration in {P}ython},
-  year =    2021,
+  year =    {2021},
   url =     {https://github.com/nschloe/quadpy/},
   urldate = {2021-02-08}
 }
@@ -1665,7 +1683,7 @@ title={{A numerical solution of the Navier-Stokes equations using the finite ele
 author={C. Taylor and P. Hood},
 journal={Comput. Fluids},
 volume={1},
-number={},
+number={1},
 pages={73--100},
 year={1973},
 doi = {10.1016/0045-7930(73)90027-3},


### PR DESCRIPTION
- strip trailing whitespaces
- add missing comma separators
- surround every field with curly braces (except `month`)
- added missing information for some entries
- adjust author fieds for naming convention from #12487

`doxygen` has trouble with a few entries. It's displaying information only partially, starts a new row which begins with `1`. (possibly beginning an enumeration).

I found that removing the `doi` and `month` entries fixes troubled entries, but I did not find the cause for it though. No information is lost as we provide the `doi` over the `url` field as well. This PR also recovers some lost `month` information from #12487.