### PR TITLE
Fix MF for LA::vector

### DIFF
--- a/include/deal.II/matrix_free/type_traits.h
+++ b/include/deal.II/matrix_free/type_traits.h
@@ -273,8 +273,9 @@ namespace internal
   template <typename T>
   struct has_exchange_on_subset
   {
-    static const bool value =
-      has_begin<T>::value && has_local_element<T>::value;
+    static const bool value = has_begin<T>::value &&
+                              has_local_element<T>::value &&
+                              has_partitioners_are_compatible<T>::value;
   };
 
   // We need to have a separate declaration for static const members


### PR DESCRIPTION
The issue was that `LA::vector` does not have a partitioner and as a result partitioners cannot be compared.

Will be tested in #13260.