### PR TITLE
Remove the prepare_for_answer() callback in consensus algorithms.

### DIFF
--- a/doc/news/changes/incompatibilities/20220118Bangerth
+++ b/doc/news/changes/incompatibilities/20220118Bangerth
@@ -1,0 +1,12 @@
+Changed: The two algorithms in the ConsensusAlgorithms namespace
+(along with their base class) required a callback function that
+correctly sized the buffer into which the answer to a request was to
+be written. These algorithms have been rewritten in ways that make
+this no longer necessary, and they now correctly size these buffers
+themselves. As a consequence, the ConsensusAlgorithms::Process class
+no longer has the `prepare_for_answer()` function, and the
+ConsensusAlgorithms::AnonymousProcess class no longer has a
+corresponding member variable; in the latter case, the constructor of
+the class also no longer takes an argument to this effect.
+<br>
+(Wolfgang Bangerth, Peter Munch, 2022/01/18)

--- a/include/deal.II/base/mpi_compute_index_owner_internal.h
+++ b/include/deal.II/base/mpi_compute_index_owner_internal.h
@@ -768,24 +768,14 @@ namespace Utilities
 
           /**
            * Implementation of
-           * Utilities::MPI::ConsensusAlgorithms::Process::prepare_buffer_for_answer().
-           */
-          virtual void
-          prepare_buffer_for_answer(
-            const unsigned int         other_rank,
-            std::vector<unsigned int> &recv_buffer) override
-          {
-            recv_buffer.resize(recv_indices[other_rank].size());
-          }
-
-          /**
-           * Implementation of
            * Utilities::MPI::ConsensusAlgorithms::Process::read_answer().
            */
           virtual void
           read_answer(const unsigned int               other_rank,
                       const std::vector<unsigned int> &recv_buffer) override
           {
+            Assert(recv_buffer.size() == recv_indices[other_rank].size(),
+                   ExcInternalError());
             Assert(recv_indices[other_rank].size() == recv_buffer.size(),
                    ExcMessage("Sizes do not match!"));
 

--- a/include/deal.II/base/mpi_consensus_algorithms.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.h
@@ -94,20 +94,6 @@ namespace Utilities
 
         /**
          * Prepare the buffer where the payload of the answer of the request to
-         * the process with the specified rank is saved in. The most obvious
-         * task is to resize the buffer, since it is empty when the function is
-         * called.
-         *
-         * @param[in]  other_rank Rank of the process.
-         * @param[out] recv_buffer Data to be sent as part of the request
-         * (optional).
-         */
-        virtual void
-        prepare_buffer_for_answer(const unsigned int other_rank,
-                                  std::vector<T2> &  recv_buffer);
-
-        /**
-         * Prepare the buffer where the payload of the answer of the request to
          * the process with the specified rank is saved in.
          *
          * @param[in]  other_rank Rank of the process.
@@ -572,8 +558,6 @@ namespace Utilities
          * @param function_compute_targets called during `compute_targets`.
          * @param function_create_request called during `create_request`.
          * @param function_answer_request called during `answer_request`.
-         * @param function_prepare_buffer_for_answer called during
-         *   `prepare_buffer_for_answer`.
          * @param function_read_answer called during `read_answer`.
          */
         AnonymousProcess(
@@ -585,8 +569,6 @@ namespace Utilities
                                    const std::vector<T1> &,
                                    std::vector<T2> &)>
             &function_answer_request = {},
-          const std::function<void(const unsigned int, std::vector<T2> &)>
-            &function_prepare_buffer_for_answer = {},
           const std::function<void(const unsigned int, const std::vector<T2> &)>
             &function_read_answer = {});
 
@@ -612,13 +594,6 @@ namespace Utilities
                        std::vector<T2> &      request_buffer) override;
 
         /**
-         * @copydoc Process::prepare_buffer_for_answer()
-         */
-        void
-        prepare_buffer_for_answer(const unsigned int other_rank,
-                                  std::vector<T2> &  recv_buffer) override;
-
-        /**
          * @copydoc Process::read_answer()
          */
         void
@@ -633,8 +608,6 @@ namespace Utilities
         const std::function<
           void(const unsigned int, const std::vector<T1> &, std::vector<T2> &)>
           function_answer_request;
-        const std::function<void(const int, std::vector<T2> &)>
-          function_prepare_buffer_for_answer;
         const std::function<void(const int, const std::vector<T2> &)>
           function_read_answer;
       };
@@ -650,14 +623,11 @@ namespace Utilities
         const std::function<void(const unsigned int,
                                  const std::vector<T1> &,
                                  std::vector<T2> &)> &function_answer_request,
-        const std::function<void(const unsigned int, std::vector<T2> &)>
-          &function_prepare_buffer_for_answer,
         const std::function<void(const unsigned int, const std::vector<T2> &)>
           &function_read_answer)
         : function_compute_targets(function_compute_targets)
         , function_create_request(function_create_request)
         , function_answer_request(function_answer_request)
-        , function_prepare_buffer_for_answer(function_prepare_buffer_for_answer)
         , function_read_answer(function_read_answer)
       {}
 
@@ -692,18 +662,6 @@ namespace Utilities
       {
         if (function_answer_request)
           function_answer_request(other_rank, buffer_recv, request_buffer);
-      }
-
-
-
-      template <typename T1, typename T2>
-      void
-      AnonymousProcess<T1, T2>::prepare_buffer_for_answer(
-        const unsigned int other_rank,
-        std::vector<T2> &  recv_buffer)
-      {
-        if (function_prepare_buffer_for_answer)
-          function_prepare_buffer_for_answer(other_rank, recv_buffer);
       }
 
 

--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -94,16 +94,6 @@ namespace Utilities
 
       template <typename T1, typename T2>
       void
-      Process<T1, T2>::prepare_buffer_for_answer(const unsigned int,
-                                                 std::vector<T2> &)
-      {
-        // nothing to do
-      }
-
-
-
-      template <typename T1, typename T2>
-      void
       Process<T1, T2>::read_answer(const unsigned int, const std::vector<T2> &)
       {
         // nothing to do
@@ -737,7 +727,6 @@ namespace Utilities
             std::vector<T2> request_buffer;
 
             this->process.create_request(0, send_buffer);
-            this->process.prepare_buffer_for_answer(0, recv_buffer);
             this->process.answer_request(0, send_buffer, request_buffer);
             recv_buffer = request_buffer;
             this->process.read_answer(0, recv_buffer);

--- a/include/deal.II/fe/fe_tools_extrapolate.templates.h
+++ b/include/deal.II/fe/fe_tools_extrapolate.templates.h
@@ -1152,12 +1152,6 @@ namespace FETools
           send_buffer = Utilities::pack(cells_for_this_destination, false);
         };
 
-      const auto prepare_buffer_for_answer =
-        [](const unsigned int /*other_rank*/, std::vector<char> &recv_buffer) {
-          // Nothing to do here, we don't actually want to send an answer
-          recv_buffer.clear();
-        };
-
       const auto answer_request =
         [&received_cells](const unsigned int       other_rank,
                           const std::vector<char> &buffer_recv,
@@ -1191,7 +1185,6 @@ namespace FETools
         operations(get_destinations,
                    create_request,
                    answer_request,
-                   prepare_buffer_for_answer,
                    read_answer);
 
       Utilities::MPI::ConsensusAlgorithms::Selector<char, char>(operations,

--- a/include/deal.II/matrix_free/matrix_free.templates.h
+++ b/include/deal.II/matrix_free/matrix_free.templates.h
@@ -2138,10 +2138,10 @@ MatrixFree<dim, Number, VectorizedArrayType>::initialize_indices(
 
                   AssertDimension(request_buffer.size(), buffer_recv.size());
                 },
-                [&](const auto other_rank, auto &recv_buffer) {
-                  recv_buffer.resize(cells_shared_ghosts[other_rank].size());
-                },
                 [&](const auto other_rank, const auto &recv_buffer) {
+                  Assert(recv_buffer.size() ==
+                           cells_shared_ghosts[other_rank].size(),
+                         ExcInternalError());
                   for (unsigned int i = 0; i < recv_buffer.size(); ++i)
                     {
                       cells[cells_shared_ghosts[other_rank][i].first] = {

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5998,18 +5998,6 @@ namespace GridTools
           if (perform_handshake)
             request_buffer = Utilities::pack(request_buffer_temp, false);
         },
-        [&](const unsigned int other_rank, std::vector<char> &recv_buffer) {
-          if (perform_handshake)
-            {
-              const auto other_rank_index = translate(other_rank);
-
-              recv_buffer =
-                Utilities::pack(std::vector<unsigned int>(
-                                  potential_owners_ptrs[other_rank_index + 1] -
-                                  potential_owners_ptrs[other_rank_index]),
-                                false);
-            }
-        },
         [&](const unsigned int       other_rank,
             const std::vector<char> &recv_buffer) {
           if (perform_handshake)

--- a/tests/base/consensus_algorithm_01.cc
+++ b/tests/base/consensus_algorithm_01.cc
@@ -46,9 +46,6 @@ test(const MPI_Comm &comm)
               << std::endl;
       request_buffer.push_back(my_rank);
     },
-    [&](const unsigned int other_rank, std::vector<T2> &recv_buffer) {
-      recv_buffer.resize(1);
-    },
     [&](const unsigned int other_rank, const std::vector<T2> &recv_buffer) {
       AssertDimension(other_rank, recv_buffer.front());
       deallog << "ConsensusAlgorithmProcess::function_read_answer() passed!"


### PR DESCRIPTION
The implementations of the two current algorithms no longer use this callback. Remove it from the Process class. In reference to #13213.

This is an incompatible change. I wonder how many others outside the deal.II project use this function. I could at least leave the constructor and variable in the `AnonymousProcess` class around, and just mark the old constructor as deprecated. The variable would simply be ignored. Thoughts?

/rebuild