### PR TITLE
Define MPI_COMM_NULL when not using MPI.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -44,6 +44,9 @@ using MPI_Op       = int;
 #  ifndef MPI_COMM_SELF
 #    define MPI_COMM_SELF 0
 #  endif
+#  ifndef MPI_COMM_NULL
+#    define MPI_COMM_NULL 0
+#  endif
 #  ifndef MPI_REQUEST_NULL
 #    define MPI_REQUEST_NULL 0
 #  endif


### PR DESCRIPTION
MPI defines `MPI_COMM_NULL` as an invalid communicator. This patch defines it where we currently already `#define` it in the same way as we provide `MPI_COMM_SELF`.

/rebuild