### PR TITLE
Hide forward declarations in `fe/fe.h` from doxygen.

### DIFF
--- a/include/deal.II/fe/fe.h
+++ b/include/deal.II/fe/fe.h
@@ -32,6 +32,8 @@
 
 DEAL_II_NAMESPACE_OPEN
 
+// Forward declarations:
+#ifndef DOXYGEN
 template <int dim, int spacedim>
 class FEValuesBase;
 template <int dim, int spacedim>
@@ -47,6 +49,7 @@ namespace NonMatching
 }
 template <int dim, int spacedim>
 class FESystem;
+#endif
 
 /**
  * This is the base class for finite elements in arbitrary dimensions. It


### PR DESCRIPTION
Doxygen points to the wrong include file for several forward declared classes. For example, `FESystem` is defined in `fe/fe_system.h`, and not `fe/fe.h` -- see [here](https://www.dealii.org/developer/doxygen/deal.II/classFESystem.html).