### PR TITLE
Update docu of NonMatching::FEImmersedSurfaceValues

### DIFF
--- a/include/deal.II/non_matching/fe_immersed_values.h
+++ b/include/deal.II/non_matching/fe_immersed_values.h
@@ -60,7 +60,8 @@ namespace NonMatching
      * Constructor. Gets cell-independent data from mapping and finite element
      * objects, matching the quadrature rule and update flags.
      *
-     * @note Currently this class is only implemented for MappingCartesian.
+     * @note Currently this class is only implemented for MappingCartesian and
+     * MappingQ.
      */
     FEImmersedSurfaceValues(const Mapping<dim> &                  mapping,
                             const FiniteElement<dim> &            element,


### PR DESCRIPTION
@simonsticko Is this true? My guess that it depends if the mapping has implemented `fill_fe_immersed_surface_values` or is here another assumption?