### PR TITLE
Use MPI::Utilities::free_communicator() where possible.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -1141,8 +1141,7 @@ AlignedVector<T>::Deleter::MPISharedMemDeleterAction::delete_array(
   ierr = MPI_Win_free(&shmem_window);
   AssertThrowMPI(ierr);
 
-  ierr = MPI_Comm_free(&shmem_group_communicator);
-  AssertThrowMPI(ierr);
+  Utilities::MPI::free_communicator(shmem_group_communicator);
 }
 
 #  endif
@@ -1558,8 +1557,7 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
              ExcInternalError());
 
     // And get rid of the temporary communicator
-    ierr = MPI_Comm_free(&shmem_group_communicator_temp);
-    AssertThrowMPI(ierr);
+    Utilities::MPI::free_communicator(shmem_group_communicator_temp);
   }
   const bool is_shmem_root =
     Utilities::MPI::this_mpi_process(shmem_group_communicator) == 0;
@@ -1665,10 +1663,7 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
     }
 
   // We no longer need the shmem roots communicator, so get rid of it
-  {
-    const int ierr = MPI_Comm_free(&shmem_roots_communicator);
-    AssertThrowMPI(ierr);
-  }
+  Utilities::MPI::free_communicator(shmem_group_communicator);
 
 
   // **** Step 3 ****

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -7841,8 +7841,7 @@ DataOutInterface<dim, spacedim>::write_vtu_with_pvtu_record(
       int ierr = MPI_Comm_split(mpi_communicator, color, rank, &comm_group);
       AssertThrowMPI(ierr);
       this->write_vtu_in_parallel(filename.c_str(), comm_group);
-      ierr = MPI_Comm_free(&comm_group);
-      AssertThrowMPI(ierr);
+      Utilities::MPI::free_communicator(comm_group);
 #else
       AssertThrow(false, ExcMessage("Logical error. Should not arrive here."));
 #endif

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -246,10 +246,8 @@ namespace Utilities
             }
           if (*new_comm != comm_old)
             {
-              ierr = MPI_Comm_free(&ic);
-              AssertThrowMPI(ierr);
-              ierr = MPI_Comm_free(&comm_old);
-              AssertThrowMPI(ierr);
+              Utilities::MPI::free_communicator(ic);
+              Utilities::MPI::free_communicator(comm_old);
             }
         }
 

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -235,7 +235,7 @@ namespace Utilities
         Cblacs_gridexit(blacs_context);
 
       if (mpi_communicator_inactive_with_root != MPI_COMM_NULL)
-        MPI_Comm_free(&mpi_communicator_inactive_with_root);
+        Utilities::MPI::free_communicator(mpi_communicator_inactive_with_root);
     }
 
 

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -1158,10 +1158,10 @@ namespace Utilities
       Epetra_MpiComm *mpi_comm = dynamic_cast<Epetra_MpiComm *>(&communicator);
       if (mpi_comm != nullptr)
         {
-          MPI_Comm comm  = mpi_comm->GetMpiComm();
-          *mpi_comm      = Epetra_MpiComm(MPI_COMM_SELF);
-          const int ierr = MPI_Comm_free(&comm);
-          AssertThrowMPI(ierr);
+          MPI_Comm comm = mpi_comm->GetMpiComm();
+          *mpi_comm     = Epetra_MpiComm(MPI_COMM_SELF);
+
+          Utilities::MPI::free_communicator(comm);
         }
 #  endif
     }

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -484,7 +484,7 @@ ScaLAPACKMatrix<NumberType>::copy_from(const LAPACKFullMatrix<NumberType> &B,
   MPI_Group_free(&group_A);
   MPI_Group_free(&group_B);
   if (MPI_COMM_NULL != communicator_B)
-    MPI_Comm_free(&communicator_B);
+    Utilities::MPI::free_communicator(communicator_B);
 
   state = LAPACKSupport::matrix;
 }
@@ -654,7 +654,7 @@ ScaLAPACKMatrix<NumberType>::copy_to(LAPACKFullMatrix<NumberType> &B,
   MPI_Group_free(&group_A);
   MPI_Group_free(&group_B);
   if (MPI_COMM_NULL != communicator_B)
-    MPI_Comm_free(&communicator_B);
+    Utilities::MPI::free_communicator(communicator_B);
 }
 
 
@@ -954,10 +954,7 @@ ScaLAPACKMatrix<NumberType>::copy_to(ScaLAPACKMatrix<NumberType> &dest) const
       Cblacs_gridexit(union_blacs_context);
 
       if (mpi_communicator_union != MPI_COMM_NULL)
-        {
-          ierr = MPI_Comm_free(&mpi_communicator_union);
-          AssertThrowMPI(ierr);
-        }
+        Utilities::MPI::free_communicator(mpi_communicator_union);
       ierr = MPI_Group_free(&group_source);
       AssertThrowMPI(ierr);
       ierr = MPI_Group_free(&group_dest);

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -378,6 +378,8 @@ namespace SUNDIALS
     set_functions_to_trigger_an_assert();
   }
 
+
+
   template <typename VectorType>
   ARKode<VectorType>::~ARKode()
   {
@@ -390,11 +392,7 @@ namespace SUNDIALS
 
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
-      {
-        const int ierr = MPI_Comm_free(&communicator);
-        (void)ierr;
-        AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
-      }
+      Utilities::MPI::free_communicator(communicator);
 #  endif
   }
 

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -213,11 +213,7 @@ namespace SUNDIALS
       IDAFree(&ida_mem);
 #  ifdef DEAL_II_WITH_MPI
     if (is_serial_vector<VectorType>::value == false)
-      {
-        const int ierr = MPI_Comm_free(&communicator);
-        (void)ierr;
-        AssertNothrow(ierr == MPI_SUCCESS, ExcMPI(ierr));
-      }
+      Utilities::MPI::free_communicator(communicator);
 #  endif
   }
 


### PR DESCRIPTION
I had forgotten about this function. Use it in all places where we currently free communicators. 

/rebuild