### PR TITLE
[9.3] Fix flags bug point_values

### DIFF
--- a/include/deal.II/numerics/vector_tools_evaluate.h
+++ b/include/deal.II/numerics/vector_tools_evaluate.h
@@ -234,7 +234,7 @@ namespace VectorTools
             if (evaluators[cell->active_fe_index()] == nullptr)
               evaluators[cell->active_fe_index()] =
                 std::make_unique<FEPointEvaluation<n_components, dim>>(
-                  cache.get_mapping(), cell->get_fe(), flags);
+                  cache.get_mapping(), cell->get_fe(), update_values);
             auto &evaluator = *evaluators[cell->active_fe_index()];
 
             evaluator.reinit(cell, unit_points);


### PR DESCRIPTION
`no known conversion for argument 3 from ‘const dealii::VectorTools::EvaluationFlags::EvaluationFlags’ to ‘dealii::UpdateFlags’`

Found through a compilation error in our user code. Use `update_values` like on current master branch (refactored code) to fix it.

@peterrum 