### PR TITLE
Make naming of function arguments more uniform.

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -344,8 +344,8 @@ public:
    * entry.
    */
   unsigned int
-  child_cell_on_face(const unsigned int  face_n,
-                     const unsigned int  subface_n,
+  child_cell_on_face(const unsigned int  face,
+                     const unsigned int  subface,
                      const unsigned char face_orientation = 1) const;
 
   /**


### PR DESCRIPTION
We don't usually use _n as a suffix to indicate a _number or _index. In fact,
the implementation of the function also doesn't use the suffix used here
in the declaration.

/rebuild