### PR TITLE
Introduce ReferenceCell::n_isotropic_children().

### DIFF
--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1019,6 +1019,14 @@ ReferenceCell::n_faces() const
 
 
 inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+ReferenceCell::face_indices() const
+{
+  return {0U, n_faces()};
+}
+
+
+
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::vertex_indices() const
 {
   return {0U, n_vertices()};
@@ -1030,14 +1038,6 @@ inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::line_indices() const
 {
   return {0U, n_lines()};
-}
-
-
-
-inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
-ReferenceCell::face_indices() const
-{
-  return {0U, n_faces()};
 }
 
 

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -1147,6 +1147,7 @@ ReferenceCell::child_cell_on_face(
   const unsigned char face_orientation_raw) const
 {
   AssertIndexRange(face, n_faces());
+  AssertIndexRange(subface, face_reference_cell(face).n_isotropic_children());
 
   if (*this == ReferenceCells::Vertex)
     {

--- a/include/deal.II/grid/reference_cell.h
+++ b/include/deal.II/grid/reference_cell.h
@@ -279,6 +279,27 @@ public:
   face_indices() const;
 
   /**
+   * Return the number of cells one would get by isotropically
+   * refining the current cell. Here, "isotropic refinement"
+   * means that we subdivide in each "direction" of a cell.
+   * For example, a square would be refined into four children
+   * by introducing new vertices along each edge and a new
+   * vertex in the cell center. For triangles, one would introduce
+   * new vertices at the center of each edge, and connect them to
+   * obtain four children. Similar constructions can be done for
+   * the other reference cell types.
+   */
+  unsigned int
+  n_isotropic_children() const;
+
+  /**
+   * Return an object that can be thought of as an array containing all
+   * indices from zero to n_isotropic_children().
+   */
+  std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+  isotropic_child_indices() const;
+
+  /**
    * Return the reference-cell type of face @p face_no of the current
    * object. For example, if the current object is
    * ReferenceCells::Tetrahedron, then `face_no` must be between
@@ -1022,6 +1043,45 @@ inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
 ReferenceCell::face_indices() const
 {
   return {0U, n_faces()};
+}
+
+
+
+inline unsigned int
+ReferenceCell::n_isotropic_children() const
+{
+  if (*this == ReferenceCells::Vertex)
+    return 0;
+  else if (*this == ReferenceCells::Line)
+    return 2;
+  else if (*this == ReferenceCells::Triangle)
+    return 4;
+  else if (*this == ReferenceCells::Quadrilateral)
+    return 4;
+  else if (*this == ReferenceCells::Tetrahedron)
+    return 8;
+  else if (*this == ReferenceCells::Pyramid)
+    {
+      // We haven't yet decided how to refine pyramids. Update
+      // this when we have
+      Assert(false, ExcNotImplemented());
+      return numbers::invalid_unsigned_int;
+    }
+  else if (*this == ReferenceCells::Wedge)
+    return 8;
+  else if (*this == ReferenceCells::Hexahedron)
+    return 8;
+
+  Assert(false, ExcNotImplemented());
+  return numbers::invalid_unsigned_int;
+}
+
+
+
+inline std_cxx20::ranges::iota_view<unsigned int, unsigned int>
+ReferenceCell::isotropic_child_indices() const
+{
+  return {0U, n_isotropic_children()};
 }
 
 

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -5108,23 +5108,26 @@ namespace internal
                  triangulation.active_cell_iterators_on_level(level))
               if (cell->refine_flag_set())
                 {
+                  // Only support isotropic refinement
                   Assert(cell->refine_flag_set() ==
                            RefinementCase<dim>::cut_xyz,
                          ExcInternalError());
+
+                  // Now count up how many new cells, faces, edges, and vertices
+                  // we will need to allocate to do this refinement.
+                  new_cells += cell->reference_cell().n_isotropic_children();
 
                   if (cell->reference_cell() == ReferenceCells::Hexahedron)
                     {
                       ++needed_vertices;
                       needed_lines_single += 6;
                       needed_quads_single += 12;
-                      new_cells += 8;
                     }
                   else if (cell->reference_cell() ==
                            ReferenceCells::Tetrahedron)
                     {
                       needed_lines_single += 1;
                       needed_quads_single += 8;
-                      new_cells += 8;
                     }
                   else
                     {

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -5134,13 +5134,26 @@ namespace internal
                       Assert(false, ExcInternalError());
                     }
 
+                  // Also check whether we have to refine any of the faces and
+                  // edges that bound this cell. They may of course already be
+                  // refined, so we only *mark* them for refinement by setting
+                  // the user flags
                   for (const auto face : cell->face_indices())
-                    if (cell->face(face)->number_of_children() < 4)
+                    if (cell->face(face)->n_children() == 0)
                       cell->face(face)->set_user_flag();
+                    else
+                      Assert(cell->face(face)->n_children() ==
+                               cell->reference_cell()
+                                 .face_reference_cell(face)
+                                 .n_isotropic_children(),
+                             ExcInternalError());
 
                   for (const auto line : cell->line_indices())
                     if (cell->line(line)->has_children() == false)
                       cell->line(line)->set_user_flag();
+                    else
+                      Assert(cell->line(line)->n_children() == 2,
+                             ExcInternalError());
                 }
 
             const unsigned int used_cells =


### PR DESCRIPTION
I had a need to query the number of children of a cell, but it turns out that there is currently no function in `ReferenceCell` to do that. So I added one, but this is WIP because I don't know what we do (or intend to do) for refinement of tetrahedra and pyramids. Anyone remember the correct numbers to be added there?

/rebuild