### PR TITLE
Reimplement UpdateFlags as enum-like class

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,6 +8,6 @@
 # - performance-inefficient-string-concatenation: We don't care about "a"+to_string(5)+...
 # - performance-no-automatic-move: All modern compiler perform the return value optimization and we prefer to keep things const.
 
-Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation,-performance-no-automatic-move"
+Checks: "-*,cppcoreguidelines-pro-type-static-cast-downcast,google-readability-casting,modernize-*,-modernize-pass-by-value,-modernize-raw-string-literal,-modernize-use-auto,-modernize-use-override,-modernize-use-default-member-init,-modernize-use-transparent-functors,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-modernize-avoid-c-arrays,-modernize-concat-nested-namespaces,use-emplace,mpi-*,performance-*,-performance-inefficient-string-concatenation,-performance-no-automatic-move,readability-implicit-bool-conversion"
 
 WarningsAsErrors: '*'

--- a/doc/news/changes/minor/20220113DanielArndt
+++ b/doc/news/changes/minor/20220113DanielArndt
@@ -1,0 +1,5 @@
+New: contains_bits() provides a convenience global function allowing for
+UpdateFlags, CacheUpdateFlags, EvaluationFlags, and AssembleFlags to check if
+given flags contain other flags.
+<br>
+(Daniel Arndt, 2022/01/13)

--- a/examples/step-31/step-31.cc
+++ b/examples/step-31/step-31.cc
@@ -1230,7 +1230,7 @@ namespace Step31
       stokes_fe,
       quadrature_formula,
       update_values | update_quadrature_points | update_JxW_values |
-        (rebuild_stokes_matrix == true ? update_gradients : UpdateFlags(0)));
+        (rebuild_stokes_matrix == true ? update_gradients : update_default));
 
     FEValues<dim> temperature_fe_values(temperature_fe,
                                         quadrature_formula,

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -2324,7 +2324,7 @@ namespace Step32
         mapping,
         quadrature_formula,
         (update_values | update_quadrature_points | update_JxW_values |
-         (rebuild_stokes_matrix == true ? update_gradients : UpdateFlags(0))),
+         (rebuild_stokes_matrix == true ? update_gradients : update_default)),
         temperature_fe,
         update_values),
       Assembly::CopyData::StokesSystem<dim>(stokes_fe));

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -372,7 +372,8 @@ protected:
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (contains(data_ptr->update_each, update_gradients | update_hessians))
+    if (contains_bits(data_ptr->update_each,
+                      update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -372,8 +372,7 @@ protected:
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (contains_bits(data_ptr->update_each,
-                      update_gradients | update_hessians))
+    if (data_ptr->update_each.contains(update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_face.h
+++ b/include/deal.II/fe/fe_face.h
@@ -372,8 +372,7 @@ protected:
     (void)n_q_points;
 
     // No derivatives of this element are implemented.
-    if (data_ptr->update_each & update_gradients ||
-        data_ptr->update_each & update_hessians)
+    if (contains(data_ptr->update_each, update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -281,14 +281,17 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      contains(update_flags, update_values) ? this->n_dofs_per_cell() : 0);
+      contains_bits(update_flags, update_values) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      contains(update_flags, update_gradients) ? this->n_dofs_per_cell() : 0);
+      contains_bits(update_flags, update_gradients) ? this->n_dofs_per_cell() :
+                                                      0);
     std::vector<Tensor<2, dim>> grad_grads(
-      contains(update_flags, update_hessians) ? this->n_dofs_per_cell() : 0);
+      contains_bits(update_flags, update_hessians) ? this->n_dofs_per_cell() :
+                                                     0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      contains(update_flags, update_3rd_derivatives) ? this->n_dofs_per_cell() :
-                                                       0);
+      contains_bits(update_flags, update_3rd_derivatives) ?
+        this->n_dofs_per_cell() :
+        0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -308,26 +311,26 @@ protected:
     // quadrature points summed over *all* faces or subfaces, whereas
     // the number of output slots equals the number of quadrature
     // points on only *one* face)
-    if (contains(update_flags, update_values) &&
+    if (contains_bits(update_flags, update_values) &&
         !((output_data.shape_values.n_rows() > 0) &&
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains(update_flags, update_gradients))
+    if (contains_bits(update_flags, update_gradients))
       data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains(update_flags, update_hessians))
+    if (contains_bits(update_flags, update_hessians))
       data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains(update_flags, update_3rd_derivatives))
+    if (contains_bits(update_flags, update_3rd_derivatives))
       data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if (contains(update_flags,
-                 (update_values | update_gradients | update_hessians |
-                  update_3rd_derivatives)))
+    if (contains_bits(update_flags,
+                      (update_values | update_gradients | update_hessians |
+                       update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),
@@ -344,7 +347,7 @@ protected:
           // faces and subfaces, but we later on copy only a portion of it
           // into the output object; in that case, copy the data from all
           // faces into the scratch object
-          if (contains(update_flags, update_values))
+          if (contains_bits(update_flags, update_values))
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
@@ -358,15 +361,15 @@ protected:
           // for everything else, derivatives need to be transformed,
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
-          if (contains(update_flags, update_gradients))
+          if (contains_bits(update_flags, update_gradients))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
-          if (contains(update_flags, update_hessians))
+          if (contains_bits(update_flags, update_hessians))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
-          if (contains(update_flags, update_3rd_derivatives))
+          if (contains_bits(update_flags, update_3rd_derivatives))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -308,7 +308,7 @@ protected:
     // quadrature points summed over *all* faces or subfaces, whereas
     // the number of output slots equals the number of quadrature
     // points on only *one* face)
-    if ((update_flags & update_values) &&
+    if (contains(update_flags, update_values) &&
         !((output_data.shape_values.n_rows() > 0) &&
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -325,8 +325,8 @@ protected:
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if ((update_flags & (update_values | update_gradients | update_hessians |
-                         update_3rd_derivatives)) != 0u)
+    if (contains(update_flags, (update_values | update_gradients | update_hessians |
+                         update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -288,7 +288,7 @@ protected:
       contains(update_flags, update_hessians) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
       contains(update_flags, update_3rd_derivatives) ? this->n_dofs_per_cell() :
-                                                      0);
+                                                       0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -325,8 +325,9 @@ protected:
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if (contains(update_flags, (update_values | update_gradients | update_hessians |
-                         update_3rd_derivatives)))
+    if (contains(update_flags,
+                 (update_values | update_gradients | update_hessians |
+                  update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -281,13 +281,13 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      (update_flags & update_values) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_values) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      (update_flags & update_gradients) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_gradients) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<2, dim>> grad_grads(
-      (update_flags & update_hessians) != 0u ? this->n_dofs_per_cell() : 0);
+      contains(update_flags, update_hessians) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      (update_flags & update_3rd_derivatives) != 0u ? this->n_dofs_per_cell() :
+      contains(update_flags, update_3rd_derivatives) ? this->n_dofs_per_cell() :
                                                       0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
@@ -313,13 +313,13 @@ protected:
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_gradients) != 0u)
+    if (contains(update_flags, update_gradients))
       data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_hessians) != 0u)
+    if (contains(update_flags, update_hessians))
       data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if ((update_flags & update_3rd_derivatives) != 0u)
+    if (contains(update_flags, update_3rd_derivatives))
       data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
@@ -343,7 +343,7 @@ protected:
           // faces and subfaces, but we later on copy only a portion of it
           // into the output object; in that case, copy the data from all
           // faces into the scratch object
-          if ((update_flags & update_values) != 0u)
+          if (contains(update_flags, update_values))
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
@@ -357,15 +357,15 @@ protected:
           // for everything else, derivatives need to be transformed,
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
-          if ((update_flags & update_gradients) != 0u)
+          if (contains(update_flags, update_gradients))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
-          if ((update_flags & update_hessians) != 0u)
+          if (contains(update_flags, update_hessians))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
-          if ((update_flags & update_3rd_derivatives) != 0u)
+          if (contains(update_flags, update_3rd_derivatives))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.h
+++ b/include/deal.II/fe/fe_poly.h
@@ -281,17 +281,14 @@ protected:
     // polynomial to put the values and derivatives of shape functions
     // to put there, depending on what the user requested
     std::vector<double> values(
-      contains_bits(update_flags, update_values) ? this->n_dofs_per_cell() : 0);
+      update_flags.contains(update_values) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<1, dim>> grads(
-      contains_bits(update_flags, update_gradients) ? this->n_dofs_per_cell() :
-                                                      0);
+      update_flags.contains(update_gradients) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<2, dim>> grad_grads(
-      contains_bits(update_flags, update_hessians) ? this->n_dofs_per_cell() :
-                                                     0);
+      update_flags.contains(update_hessians) ? this->n_dofs_per_cell() : 0);
     std::vector<Tensor<3, dim>> third_derivatives(
-      contains_bits(update_flags, update_3rd_derivatives) ?
-        this->n_dofs_per_cell() :
-        0);
+      update_flags.contains(update_3rd_derivatives) ? this->n_dofs_per_cell() :
+                                                      0);
     std::vector<Tensor<4, dim>>
       fourth_derivatives; // won't be needed, so leave empty
 
@@ -311,26 +308,25 @@ protected:
     // quadrature points summed over *all* faces or subfaces, whereas
     // the number of output slots equals the number of quadrature
     // points on only *one* face)
-    if (contains_bits(update_flags, update_values) &&
+    if (update_flags.contains(update_values) &&
         !((output_data.shape_values.n_rows() > 0) &&
           (output_data.shape_values.n_cols() == n_q_points)))
       data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains_bits(update_flags, update_gradients))
+    if (update_flags.contains(update_gradients))
       data.shape_gradients.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains_bits(update_flags, update_hessians))
+    if (update_flags.contains(update_hessians))
       data.shape_hessians.reinit(this->n_dofs_per_cell(), n_q_points);
 
-    if (contains_bits(update_flags, update_3rd_derivatives))
+    if (update_flags.contains(update_3rd_derivatives))
       data.shape_3rd_derivatives.reinit(this->n_dofs_per_cell(), n_q_points);
 
     // next already fill those fields of which we have information by
     // now. note that the shape gradients are only those on the unit
     // cell, and need to be transformed when visiting an actual cell
-    if (contains_bits(update_flags,
-                      (update_values | update_gradients | update_hessians |
-                       update_3rd_derivatives)))
+    if (update_flags.contains((update_values | update_gradients |
+                               update_hessians | update_3rd_derivatives)))
       for (unsigned int i = 0; i < n_q_points; ++i)
         {
           poly_space->evaluate(quadrature.point(i),
@@ -347,7 +343,7 @@ protected:
           // faces and subfaces, but we later on copy only a portion of it
           // into the output object; in that case, copy the data from all
           // faces into the scratch object
-          if (contains_bits(update_flags, update_values))
+          if (update_flags.contains(update_values))
             if (output_data.shape_values.n_rows() > 0)
               {
                 if (output_data.shape_values.n_cols() == n_q_points)
@@ -361,15 +357,15 @@ protected:
           // for everything else, derivatives need to be transformed,
           // so we write them into our scratch space and only later
           // copy stuff into where FEValues wants it
-          if (contains_bits(update_flags, update_gradients))
+          if (update_flags.contains(update_gradients))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_gradients[k][i] = grads[k];
 
-          if (contains_bits(update_flags, update_hessians))
+          if (update_flags.contains(update_hessians))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_hessians[k][i] = grad_grads[k];
 
-          if (contains_bits(update_flags, update_3rd_derivatives))
+          if (update_flags.contains(update_3rd_derivatives))
             for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
               data.shape_3rd_derivatives[k][i] = third_derivatives[k];
         }

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -193,19 +193,19 @@ FE_Poly<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values;
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation |
            update_gradients | update_jacobian_pushed_forward_grads;
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     out |= update_3rd_derivatives | update_covariant_transformation |
            update_hessians | update_gradients |
            update_jacobian_pushed_forward_grads |
            update_jacobian_pushed_forward_2nd_derivatives;
-  if ((flags & update_normal_vectors) != 0u)
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -381,12 +381,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < n_q_points; ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, n_q_points),
@@ -394,7 +394,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -407,7 +407,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         correct_hessians(output_data, mapping_data, n_q_points);
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -473,12 +473,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
@@ -486,7 +486,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -499,7 +499,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if ((flags & update_3rd_derivatives) != 0u)
+  if (contains(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -193,19 +193,19 @@ FE_Poly<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     out |= update_values;
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     out |= update_hessians | update_covariant_transformation |
            update_gradients | update_jacobian_pushed_forward_grads;
-  if (contains_bits(flags, update_3rd_derivatives))
+  if (flags.contains(update_3rd_derivatives))
     out |= update_3rd_derivatives | update_covariant_transformation |
            update_hessians | update_gradients |
            update_jacobian_pushed_forward_grads |
            update_jacobian_pushed_forward_2nd_derivatives;
-  if (contains_bits(flags, update_normal_vectors))
+  if (flags.contains(update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -239,7 +239,7 @@ higher_derivatives_need_correcting(
 {
   // If higher derivatives weren't requested we don't need to correct them.
   const bool update_higher_derivatives =
-    contains_bits(update_flags, update_hessians | update_3rd_derivatives);
+    update_flags.contains(update_hessians | update_3rd_derivatives);
   if (!update_higher_derivatives)
     return false;
 
@@ -293,7 +293,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
-  if (contains_bits(flags, update_gradients) &&
+  if (flags.contains(update_gradients) &&
       (cell_similarity != CellSimilarity::translation))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
@@ -301,7 +301,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
                         mapping_internal,
                         make_array_view(output_data.shape_gradients, k));
 
-  if (contains_bits(flags, update_hessians) &&
+  if (flags.contains(update_hessians) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -314,7 +314,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (contains_bits(flags, update_3rd_derivatives) &&
+  if (flags.contains(update_3rd_derivatives) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -381,12 +381,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < n_q_points; ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, n_q_points),
@@ -394,7 +394,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -407,7 +407,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         correct_hessians(output_data, mapping_data, n_q_points);
     }
 
-  if (contains_bits(flags, update_3rd_derivatives))
+  if (flags.contains(update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -473,12 +473,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
@@ -486,7 +486,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -499,7 +499,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (contains_bits(flags, update_3rd_derivatives))
+  if (flags.contains(update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -239,7 +239,7 @@ higher_derivatives_need_correcting(
 {
   // If higher derivatives weren't requested we don't need to correct them.
   const bool update_higher_derivatives =
-    (update_flags & update_hessians) || (update_flags & update_3rd_derivatives);
+    contains(update_flags, update_hessians | update_3rd_derivatives);
   if (!update_higher_derivatives)
     return false;
 
@@ -293,7 +293,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
-  if (((flags & update_gradients) != 0u) &&
+  if (contains(flags, update_gradients) &&
       (cell_similarity != CellSimilarity::translation))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
@@ -301,7 +301,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
                         mapping_internal,
                         make_array_view(output_data.shape_gradients, k));
 
-  if (((flags & update_hessians) != 0u) &&
+  if (contains(flags, update_hessians) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -314,7 +314,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (((flags & update_3rd_derivatives) != 0u) &&
+  if (contains(flags, update_3rd_derivatives) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)

--- a/include/deal.II/fe/fe_poly.templates.h
+++ b/include/deal.II/fe/fe_poly.templates.h
@@ -193,19 +193,19 @@ FE_Poly<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     out |= update_values;
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation |
            update_gradients | update_jacobian_pushed_forward_grads;
-  if (contains(flags, update_3rd_derivatives))
+  if (contains_bits(flags, update_3rd_derivatives))
     out |= update_3rd_derivatives | update_covariant_transformation |
            update_hessians | update_gradients |
            update_jacobian_pushed_forward_grads |
            update_jacobian_pushed_forward_2nd_derivatives;
-  if (contains(flags, update_normal_vectors))
+  if (contains_bits(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -239,7 +239,7 @@ higher_derivatives_need_correcting(
 {
   // If higher derivatives weren't requested we don't need to correct them.
   const bool update_higher_derivatives =
-    contains(update_flags, update_hessians | update_3rd_derivatives);
+    contains_bits(update_flags, update_hessians | update_3rd_derivatives);
   if (!update_higher_derivatives)
     return false;
 
@@ -293,7 +293,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
   // transform gradients and higher derivatives. there is nothing to do
   // for values since we already emplaced them into output_data when
   // we were in get_data()
-  if (contains(flags, update_gradients) &&
+  if (contains_bits(flags, update_gradients) &&
       (cell_similarity != CellSimilarity::translation))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(make_array_view(fe_data.shape_gradients, k),
@@ -301,7 +301,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
                         mapping_internal,
                         make_array_view(output_data.shape_gradients, k));
 
-  if (contains(flags, update_hessians) &&
+  if (contains_bits(flags, update_hessians) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -314,7 +314,7 @@ FE_Poly<dim, spacedim>::fill_fe_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (contains(flags, update_3rd_derivatives) &&
+  if (contains_bits(flags, update_3rd_derivatives) &&
       (cell_similarity != CellSimilarity::translation))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -381,12 +381,12 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < n_q_points; ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, n_q_points),
@@ -394,7 +394,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -407,7 +407,7 @@ FE_Poly<dim, spacedim>::fill_fe_face_values(
         correct_hessians(output_data, mapping_data, n_q_points);
     }
 
-  if (contains(flags, update_3rd_derivatives))
+  if (contains_bits(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -473,12 +473,12 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
   // transform gradients and higher derivatives. we also have to copy
   // the values (unlike in the case of fill_fe_values()) since
   // we need to take into account the offsets
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       for (unsigned int i = 0; i < quadrature.size(); ++i)
         output_data.shape_values(k, i) = fe_data.shape_values[k][i + offset];
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
       mapping.transform(
         make_array_view(fe_data.shape_gradients, k, offset, quadrature.size()),
@@ -486,7 +486,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         mapping_internal,
         make_array_view(output_data.shape_gradients, k));
 
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(
@@ -499,7 +499,7 @@ FE_Poly<dim, spacedim>::fill_fe_subface_values(
         correct_hessians(output_data, mapping_data, quadrature.size());
     }
 
-  if (contains(flags, update_3rd_derivatives))
+  if (contains_bits(flags, update_3rd_derivatives))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         mapping.transform(make_array_view(fe_data.shape_3rd_derivatives,

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (contains_bits(data.update_each, update_values))
+    if (data.update_each.contains(update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),
@@ -156,7 +156,7 @@ protected:
       }
     // No derivatives of this element
     // are implemented.
-    if (contains_bits(data.update_each, update_gradients | update_hessians))
+    if (data.update_each.contains(update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (contains(data.update_each, update_values))
+    if (contains_bits(data.update_each, update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),
@@ -156,7 +156,7 @@ protected:
       }
     // No derivatives of this element
     // are implemented.
-    if (contains(data.update_each, update_gradients | update_hessians))
+    if (contains_bits(data.update_each, update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if(contains(data.update_each, update_values))
+    if (contains(data.update_each, update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),

--- a/include/deal.II/fe/fe_poly_face.h
+++ b/include/deal.II/fe/fe_poly_face.h
@@ -136,7 +136,7 @@ protected:
     // initialize fields only if really
     // necessary. otherwise, don't
     // allocate memory
-    if (data.update_each & update_values)
+    if(contains(data.update_each, update_values))
       {
         values.resize(poly_space.n());
         data.shape_values.resize(poly_space.n(),
@@ -156,8 +156,7 @@ protected:
       }
     // No derivatives of this element
     // are implemented.
-    if (data.update_each & update_gradients ||
-        data.update_each & update_hessians)
+    if (contains(data.update_each, update_gradients | update_hessians))
       {
         Assert(false, ExcNotImplemented());
       }

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -61,10 +61,7 @@ UpdateFlags
 FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
-  // FIXME
-  UpdateFlags out =
-    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
-                             static_cast<unsigned int>(update_values));
+  UpdateFlags out = flags & update_values;
   if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
   if (contains(flags, update_hessians))

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -62,11 +62,11 @@ FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if (contains(flags, update_normal_vectors))
+  if (contains_bits(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -133,7 +133,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if (contains(fe_data.update_each, update_values))
+  if (contains_bits(fe_data.update_each, update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -230,7 +230,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if (contains(fe_data.update_each, update_values))
+  if (contains_bits(fe_data.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)
@@ -241,8 +241,10 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
             fe_data.shape_values[k][i + offset];
     }
 
-  Assert(!contains(fe_data.update_each, update_gradients), ExcNotImplemented());
-  Assert(!contains(fe_data.update_each, update_hessians), ExcNotImplemented());
+  Assert(!contains_bits(fe_data.update_each, update_gradients),
+         ExcNotImplemented());
+  Assert(!contains_bits(fe_data.update_each, update_hessians),
+         ExcNotImplemented());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -62,11 +62,11 @@ FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if (contains_bits(flags, update_normal_vectors))
+  if (flags.contains(update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -133,7 +133,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if (contains_bits(fe_data.update_each, update_values))
+  if (fe_data.update_each.contains(update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -230,7 +230,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if (contains_bits(fe_data.update_each, update_values))
+  if (fe_data.update_each.contains(update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)
@@ -241,10 +241,8 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
             fe_data.shape_values[k][i + offset];
     }
 
-  Assert(!contains_bits(fe_data.update_each, update_gradients),
-         ExcNotImplemented());
-  Assert(!contains_bits(fe_data.update_each, update_hessians),
-         ExcNotImplemented());
+  Assert(!fe_data.update_each.contains(update_gradients), ExcNotImplemented());
+  Assert(!fe_data.update_each.contains(update_hessians), ExcNotImplemented());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -62,12 +62,14 @@ FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
   // FIXME
-  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
-  if(contains(flags, update_gradients))
+  UpdateFlags out =
+    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
+                             static_cast<unsigned int>(update_values));
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if(contains(flags, update_normal_vectors))
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -134,7 +136,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if(contains(fe_data.update_each, update_values))
+  if (contains(fe_data.update_each, update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -231,7 +233,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if(contains(fe_data.update_each, update_values))
+  if (contains(fe_data.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)

--- a/include/deal.II/fe/fe_poly_face.templates.h
+++ b/include/deal.II/fe/fe_poly_face.templates.h
@@ -61,12 +61,13 @@ UpdateFlags
 FE_PolyFace<PolynomialType, dim, spacedim>::requires_update_flags(
   const UpdateFlags flags) const
 {
-  UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  // FIXME
+  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
+  if(contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if(contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if(contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -133,7 +134,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_face_values(
 
   AssertDimension(quadrature.size(), 1);
 
-  if (fe_data.update_each & update_values)
+  if(contains(fe_data.update_each, update_values))
     for (unsigned int i = 0; i < quadrature[0].size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -230,7 +231,7 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
   const unsigned int foffset = fe_data.shape_values.size() * face_no;
   const unsigned int offset  = sub_no * quadrature.size();
 
-  if (fe_data.update_each & update_values)
+  if(contains(fe_data.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         for (unsigned int i = 0; i < quadrature.size(); ++i)
@@ -241,8 +242,8 @@ FE_PolyFace<PolynomialType, dim, spacedim>::fill_fe_subface_values(
             fe_data.shape_values[k][i + offset];
     }
 
-  Assert(!(fe_data.update_each & update_gradients), ExcNotImplemented());
-  Assert(!(fe_data.update_each & update_hessians), ExcNotImplemented());
+  Assert(!contains(fe_data.update_each, update_gradients), ExcNotImplemented());
+  Assert(!contains(fe_data.update_each, update_hessians), ExcNotImplemented());
 }
 
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,8 +301,8 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if (contains(update_flags,
-                 (update_values | update_gradients | update_hessians)))
+    if (contains_bits(update_flags,
+                      (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really
@@ -325,7 +325,7 @@ protected:
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;
 
-    if (contains(update_flags, update_values))
+    if (contains_bits(update_flags, update_values))
       {
         values.resize(this->n_dofs_per_cell());
         data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -333,7 +333,7 @@ protected:
           data.transformed_shape_values.resize(n_q_points);
       }
 
-    if (contains(update_flags, update_gradients))
+    if (contains_bits(update_flags, update_gradients))
       {
         grads.resize(this->n_dofs_per_cell());
         data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -343,7 +343,7 @@ protected:
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
-    if (contains(update_flags, update_hessians))
+    if (contains_bits(update_flags, update_hessians))
       {
         grad_grads.resize(this->n_dofs_per_cell());
         data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -359,7 +359,7 @@ protected:
     // node values N_i holds
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
-    if (contains(update_flags, (update_values | update_gradients)))
+    if (contains_bits(update_flags, (update_values | update_gradients)))
       for (unsigned int k = 0; k < n_q_points; ++k)
         {
           poly_space->evaluate(quadrature.point(k),
@@ -369,7 +369,7 @@ protected:
                                third_derivatives,
                                fourth_derivatives);
 
-          if (contains(update_flags, update_values))
+          if (contains_bits(update_flags, update_values))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -384,7 +384,7 @@ protected:
                   }
             }
 
-          if (contains(update_flags, update_gradients))
+          if (contains_bits(update_flags, update_gradients))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -399,7 +399,7 @@ protected:
                   }
             }
 
-          if (contains(update_flags, update_hessians))
+          if (contains_bits(update_flags, update_hessians))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -325,7 +325,7 @@ protected:
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;
 
-    if ((update_flags & update_values) != 0u)
+    if (contains(update_flags, update_values))
       {
         values.resize(this->n_dofs_per_cell());
         data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -333,7 +333,7 @@ protected:
           data.transformed_shape_values.resize(n_q_points);
       }
 
-    if ((update_flags & update_gradients) != 0u)
+    if (contains(update_flags, update_gradients))
       {
         grads.resize(this->n_dofs_per_cell());
         data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -343,7 +343,7 @@ protected:
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
-    if ((update_flags & update_hessians) != 0u)
+    if (contains(update_flags, update_hessians))
       {
         grad_grads.resize(this->n_dofs_per_cell());
         data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -369,7 +369,7 @@ protected:
                                third_derivatives,
                                fourth_derivatives);
 
-          if ((update_flags & update_values) != 0u)
+          if (contains(update_flags, update_values))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -384,7 +384,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_gradients) != 0u)
+          if (contains(update_flags, update_gradients))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -399,7 +399,7 @@ protected:
                   }
             }
 
-          if ((update_flags & update_hessians) != 0u)
+          if (contains(update_flags, update_hessians))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,8 +301,7 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if ((update_flags & (update_values | update_gradients | update_hessians)) !=
-        0u)
+    if (contains(update_flags, (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really
@@ -359,7 +358,7 @@ protected:
     // node values N_i holds
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
-    if ((update_flags & (update_values | update_gradients)) != 0u)
+    if (contains(update_flags, (update_values | update_gradients)))
       for (unsigned int k = 0; k < n_q_points; ++k)
         {
           poly_space->evaluate(quadrature.point(k),

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,7 +301,8 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if (contains(update_flags, (update_values | update_gradients | update_hessians)))
+    if (contains(update_flags,
+                 (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really

--- a/include/deal.II/fe/fe_poly_tensor.h
+++ b/include/deal.II/fe/fe_poly_tensor.h
@@ -301,8 +301,8 @@ protected:
     std::vector<Tensor<4, dim>> third_derivatives(0);
     std::vector<Tensor<5, dim>> fourth_derivatives(0);
 
-    if (contains_bits(update_flags,
-                      (update_values | update_gradients | update_hessians)))
+    if (update_flags.contains(
+          (update_values | update_gradients | update_hessians)))
       data.dof_sign_change.resize(this->dofs_per_cell);
 
     // initialize fields only if really
@@ -325,7 +325,7 @@ protected:
     const bool update_transformed_shape_hessian_tensors =
       update_transformed_shape_values;
 
-    if (contains_bits(update_flags, update_values))
+    if (update_flags.contains(update_values))
       {
         values.resize(this->n_dofs_per_cell());
         data.shape_values.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -333,7 +333,7 @@ protected:
           data.transformed_shape_values.resize(n_q_points);
       }
 
-    if (contains_bits(update_flags, update_gradients))
+    if (update_flags.contains(update_gradients))
       {
         grads.resize(this->n_dofs_per_cell());
         data.shape_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -343,7 +343,7 @@ protected:
           data.untransformed_shape_grads.resize(n_q_points);
       }
 
-    if (contains_bits(update_flags, update_hessians))
+    if (update_flags.contains(update_hessians))
       {
         grad_grads.resize(this->n_dofs_per_cell());
         data.shape_grad_grads.reinit(this->n_dofs_per_cell(), n_q_points);
@@ -359,7 +359,7 @@ protected:
     // node values N_i holds
     // N_i(v_j)=\delta_ij for all basis
     // functions v_j
-    if (contains_bits(update_flags, (update_values | update_gradients)))
+    if (update_flags.contains((update_values | update_gradients)))
       for (unsigned int k = 0; k < n_q_points; ++k)
         {
           poly_space->evaluate(quadrature.point(k),
@@ -369,7 +369,7 @@ protected:
                                third_derivatives,
                                fourth_derivatives);
 
-          if (contains_bits(update_flags, update_values))
+          if (update_flags.contains(update_values))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -384,7 +384,7 @@ protected:
                   }
             }
 
-          if (contains_bits(update_flags, update_gradients))
+          if (update_flags.contains(update_gradients))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)
@@ -399,7 +399,7 @@ protected:
                   }
             }
 
-          if (contains_bits(update_flags, update_hessians))
+          if (update_flags.contains(update_hessians))
             {
               if (inverse_node_matrix.n_cols() == 0)
                 for (unsigned int i = 0; i < this->n_dofs_per_cell(); ++i)

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -327,18 +327,11 @@ operator|=(UpdateFlags &f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline UpdateFlags
-operator&(const UpdateFlags f1, const UpdateFlags f2) = delete;
-/*{
+operator&(const UpdateFlags f1, const UpdateFlags f2)
+{
   using enum_type = std::underlying_type_t<UpdateFlags>;
   return static_cast<UpdateFlags>(static_cast<enum_type>(f1) &
                                   static_cast<enum_type>(f2));
-}*/
-
-inline bool
-contains(const UpdateFlags flags, const UpdateFlags mask)
-{
-  using enum_type = std::underlying_type_t<UpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
 }
 
 
@@ -349,12 +342,25 @@ contains(const UpdateFlags flags, const UpdateFlags mask)
  * @ref UpdateFlags
  */
 inline UpdateFlags &
-operator&=(UpdateFlags &f1, const UpdateFlags f2) = delete;
-/*{
+operator&=(UpdateFlags &f1, const UpdateFlags f2)
+{
   f1 = f1 & f2;
   return f1;
-}*/
+}
 
+
+/**
+ * Global operator which checks if the flags contained in the first argument
+ * contain the flags contained in the second argument.
+ *
+ * @ref UpdateFlags
+ */
+inline bool
+contains(const UpdateFlags flags, const UpdateFlags mask)
+{
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
+}
 
 
 /**

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -33,6 +33,12 @@ DEAL_II_NAMESPACE_OPEN
 #ifndef DOXYGEN
 template <int, int>
 class FiniteElement;
+class UpdateFlags;
+
+namespace internal
+{
+  constexpr UpdateFlags make_update_flags(int);
+}
 #endif
 
 /*!@addtogroup feaccess */
@@ -63,10 +69,54 @@ class FiniteElement;
  * and
  * @ref FE_vs_Mapping_vs_FEValues "How Mapping, FiniteElement, and FEValues work together".
  */
-enum UpdateFlags
+class UpdateFlags
 {
+	public:
+
+/**
+ * Return an object in which all bits are set which are set in the current
+ * object or in the input argument @p in.
+ */
+constexpr UpdateFlags
+operator|(const UpdateFlags in) const;
+
+/**
+ * Set the bits from the input argument @p in also in the current object.
+ */
+constexpr UpdateFlags &
+operator|=(const UpdateFlags in);
+
+/**
+ * Return an object in which all bits are set which are set in the current
+ * object as well as in the input argument @p in.
+ */
+constexpr UpdateFlags
+operator&(const UpdateFlags in) const;
+
+/**
+ * Clear all the bits in the current object if they are not also set in the
+ * input argument @p in.
+ */
+constexpr UpdateFlags &
+operator&=(const UpdateFlags in);
+
+/**
+ * Check if the current object and the input argument @p in are equal.
+ */ 
+    constexpr bool operator==(const UpdateFlags in) const;
+
+/**
+ * Check if the current object and the input argument @p in are not equal.
+ */
+    constexpr bool operator!=(const UpdateFlags in) const;
+
+/**
+ *  Check if the current objects contains the flags given in the input argument @p in.
+ */
+    constexpr bool contains(const UpdateFlags in) const;
+
   //! No update
-  update_default = 0,
+  static const UpdateFlags update_default;
   //! Shape function values
   /**
    * Compute the values of the shape functions at the quadrature points on the
@@ -75,32 +125,32 @@ enum UpdateFlags
    * cell, but they are different for more complicated elements, such as
    * FE_RaviartThomas elements.
    */
-  update_values = 0x0001,
+  static const UpdateFlags update_values;
   //! Shape function gradients
   /**
    * Compute the gradients of the shape functions in coordinates of the real
    * cell.
    */
-  update_gradients = 0x0002,
+  static const UpdateFlags update_gradients;
   //! Second derivatives of shape functions
   /**
    * Compute the second derivatives of the shape functions in coordinates of
    * the real cell.
    */
-  update_hessians = 0x0004,
+  static const UpdateFlags update_hessians;
   //! Third derivatives of shape functions
   /**
    * Compute the third derivatives of the shape functions in coordinates of
    * the real cell
    */
-  update_3rd_derivatives = 0x0008,
+  static const UpdateFlags update_3rd_derivatives;
   //! Outer normal vector, not normalized
   /**
    * Vector product of tangential vectors, yielding a normal vector with a
    * length corresponding to the surface element; may be more efficient than
    * computing both.
    */
-  update_boundary_forms = 0x0010,
+  static const UpdateFlags update_boundary_forms;
   //! Transformed quadrature points
   /**
    * Compute the quadrature points location in real cell coordinates.
@@ -119,114 +169,117 @@ enum UpdateFlags
    * In the context of DataPostprocessor,
    * DataPostprocessorInputs::CommonInputs::evaluation_points will be updated.
    */
-  update_quadrature_points = 0x0020,
+  static const UpdateFlags update_quadrature_points;
   //! Transformed quadrature weights
   /**
    * Compute the quadrature weights on the real cell, i.e. the weights of the
    * quadrature rule multiplied with the determinant of the Jacobian of the
    * transformation from reference to real cell.
    */
-  update_JxW_values = 0x0040,
+  static const UpdateFlags update_JxW_values;
   //! Normal vectors
   /**
    * Compute the normal vectors, either for a face or for a cell of
    * codimension one. Setting this flag for any other object will raise an
    * error.
    */
-  update_normal_vectors = 0x0080,
+  static const UpdateFlags  update_normal_vectors;
   //! Volume element
   /**
    * Compute the Jacobian of the transformation from the reference cell to the
    * real cell.
    */
-  update_jacobians = 0x0100,
+  static const UpdateFlags  update_jacobians;
   //! Gradient of volume element
   /**
    * Compute the derivatives of the Jacobian of the transformation.
    */
-  update_jacobian_grads = 0x0200,
+  static const UpdateFlags update_jacobian_grads;
   //! Volume element
   /**
    * Compute the inverse Jacobian of the transformation from the reference
    * cell to the real cell.
    */
-  update_inverse_jacobians = 0x0400,
+  static const UpdateFlags update_inverse_jacobians;
   //! Covariant transformation
   /**
    * Compute all values the Mapping needs to perform a contravariant
    * transformation of vectors. For special mappings like MappingCartesian
    * this may be simpler than #update_inverse_jacobians.
    */
-  update_covariant_transformation = 0x0800,
+  static const UpdateFlags update_covariant_transformation;
   //! Contravariant transformation
   /**
    * Compute all values the Mapping needs to perform a contravariant
    * transformation of vectors. For special mappings like MappingCartesian
    * this may be simpler than #update_jacobians.
    */
-  update_contravariant_transformation = 0x1000,
+  static const UpdateFlags update_contravariant_transformation;
   //! Shape function values of transformation
   /**
    * Compute the shape function values of the transformation defined by the
    * Mapping.
    */
-  update_transformation_values = 0x2000,
+  static const UpdateFlags update_transformation_values;
   //! Shape function gradients of transformation
   /**
    * Compute the shape function gradients of the transformation defined by the
    * Mapping.
    */
-  update_transformation_gradients = 0x4000,
+  static const UpdateFlags update_transformation_gradients;
   //! Determinant of the Jacobian
   /**
    * Compute the volume element in each quadrature point.
    */
-  update_volume_elements = 0x10000,
+  static const UpdateFlags update_volume_elements;
   /**
    * Compute the derivatives of the Jacobian of the transformation pushed
    * forward to the real cell coordinates.
    */
-  update_jacobian_pushed_forward_grads = 0x100000,
+  static const UpdateFlags update_jacobian_pushed_forward_grads;
   /**
    * Compute the second derivatives of the Jacobian of the transformation.
    */
-  update_jacobian_2nd_derivatives = 0x200000,
+  static const UpdateFlags update_jacobian_2nd_derivatives;
   /**
    * Compute the second derivatives of the Jacobian of the transformation
    * pushed forward to the real cell coordinates.
    */
-  update_jacobian_pushed_forward_2nd_derivatives = 0x400000,
+  static const UpdateFlags update_jacobian_pushed_forward_2nd_derivatives;
   /**
    * Compute the third derivatives of the Jacobian of the transformation.
    */
-  update_jacobian_3rd_derivatives = 0x800000,
+  static const UpdateFlags update_jacobian_3rd_derivatives;
   /**
    * Compute the third derivatives of the Jacobian of the transformation
    * pushed forward to the real cell coordinates.
    */
-  update_jacobian_pushed_forward_3rd_derivatives = 0x1000000,
+  static const UpdateFlags update_jacobian_pushed_forward_3rd_derivatives;
   //! Values needed for Piola transform
   /**
    * Combination of the flags needed for Piola transform of Hdiv elements.
    */
-  update_piola = update_volume_elements | update_contravariant_transformation,
+  static const UpdateFlags update_piola;
   /**
    * Combination of the flags that require a mapping calculation
    */
-  update_mapping =
-    // Direct data
-  update_quadrature_points | update_JxW_values | update_jacobians |
-  update_jacobian_grads | update_jacobian_pushed_forward_grads |
-  update_jacobian_2nd_derivatives |
-  update_jacobian_pushed_forward_2nd_derivatives |
-  update_jacobian_3rd_derivatives |
-  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
-  update_boundary_forms | update_normal_vectors |
-  // Transformation dependence
-  update_covariant_transformation | update_contravariant_transformation |
-  update_transformation_values | update_transformation_gradients |
-  // Volume data
-  update_volume_elements
+  static const UpdateFlags update_mapping;
+
+	private:
+  /**
+   * An integer representing the flags.
+   */
+  int field;
+
+  /**
+   * Private constructor only to be used internally.
+   */
+  constexpr UpdateFlags(int i);
+
+  /**
+   * Friend declaration so that make_enum can call the private constructor.
+   */
+  friend constexpr UpdateFlags make_enum(int);
 };
 
 
@@ -240,128 +293,170 @@ inline StreamType &
 operator<<(StreamType &s, const UpdateFlags u)
 {
   s << " UpdateFlags|";
-  if (u & update_values)
+  if (u & UpdateFlags::update_values)
     s << "values|";
-  if (u & update_gradients)
+  if (u & UpdateFlags::update_gradients)
     s << "gradients|";
-  if (u & update_hessians)
+  if (u & UpdateFlags::update_hessians)
     s << "hessians|";
-  if (u & update_3rd_derivatives)
+  if (u & UpdateFlags::update_3rd_derivatives)
     s << "3rd_derivatives|";
-  if (u & update_quadrature_points)
+  if (u & UpdateFlags::update_quadrature_points)
     s << "quadrature_points|";
-  if (u & update_JxW_values)
+  if (u & UpdateFlags::update_JxW_values)
     s << "JxW_values|";
-  if (u & update_normal_vectors)
+  if (u & UpdateFlags::update_normal_vectors)
     s << "normal_vectors|";
-  if (u & update_jacobians)
+  if (u & UpdateFlags::update_jacobians)
     s << "jacobians|";
-  if (u & update_inverse_jacobians)
+  if (u & UpdateFlags::update_inverse_jacobians)
     s << "inverse_jacobians|";
-  if (u & update_jacobian_grads)
+  if (u & UpdateFlags::update_jacobian_grads)
     s << "jacobian_grads|";
-  if (u & update_covariant_transformation)
+  if (u & UpdateFlags::update_covariant_transformation)
     s << "covariant_transformation|";
-  if (u & update_contravariant_transformation)
+  if (u & UpdateFlags::update_contravariant_transformation)
     s << "contravariant_transformation|";
-  if (u & update_transformation_values)
+  if (u & UpdateFlags::update_transformation_values)
     s << "transformation_values|";
-  if (u & update_transformation_gradients)
+  if (u & UpdateFlags::update_transformation_gradients)
     s << "transformation_gradients|";
-  if (u & update_jacobian_pushed_forward_grads)
+  if (u & UpdateFlags::update_jacobian_pushed_forward_grads)
     s << "jacobian_pushed_forward_grads|";
-  if (u & update_jacobian_2nd_derivatives)
+  if (u & UpdateFlags::update_jacobian_2nd_derivatives)
     s << "jacobian_2nd_derivatives|";
-  if (u & update_jacobian_pushed_forward_2nd_derivatives)
+  if (u & UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives)
     s << "jacobian_pushed_forward_2nd_derivatives|";
-  if (u & update_jacobian_3rd_derivatives)
+  if (u & UpdateFlags::update_jacobian_3rd_derivatives)
     s << "jacobian_3rd_derivatives|";
-  if (u & update_jacobian_pushed_forward_3rd_derivatives)
+  if (u & UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives)
     s << "jacobian_pushed_forward_3rd_derivatives|";
 
   // TODO: check that 'u' really only has the flags set that are handled above
   return s;
 }
 
+// Import all flags into the global namespace.
+constexpr UpdateFlags update_default = internal::make_enum(0);
+constexpr UpdateFlags UpdateFlags::update_values = internal::make_enum(0x0001);
+constexpr UpdateFlags UpdateFlags::update_gradients = internal::make_enum(0x0002);
+constexpr UpdateFlags UpdateFlags::update_hessians = internal::make_enum(0x0004);
+constexpr UpdateFlags UpdateFlags::update_3rd_derivatives = internal::make_enum(0x0008);
+constexpr UpdateFlags UpdateFlags::update_boundary_forms = internal::make_enum(0x0010);
+constexpr UpdateFlags UpdateFlags::update_quadrature_points = internal::make_enum(0x0020);
+constexpr UpdateFlags UpdateFlags::update_JxW_values = internal::make_enum(0x0040);
+constexpr UpdateFlags UpdateFlags::update_normal_vectors = internal::make_enum(0x0080);
+constexpr UpdateFlags UpdateFlags::update_jacobians = internal::make_enum(0x01000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_grads = internal::make_enum(0x02000:
+constexpr UpdateFlags UpdateFlags::update_inverse_jacobians = internal::make_enum(0x0400);
+constexpr UpdateFlags UpdateFlags::update_covariant_transformation = internal::make_enum(0x0800);
+constexpr UpdateFlags UpdateFlags::update_contravariant_transformation = internal::make_enum(0x1000);
+constexpr UpdateFlags UpdateFlags::update_transformation_values = internal::make_enum(0x2000);
+constexpr UpdateFlags UpdateFlags::update_transformation_gradients = internal::make_enum(0x4000);
+constexpr UpdateFlags UpdateFlags::update_volume_elements = internal::make_enum(0x10000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads = internal::make_enum(0x100000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives = internal::make_enum(0x200000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives = internal::make_enum(0x400000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives = internal::make_enum(0x800000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives = internal::make_enum(0x1000000);
+constexpr UpdateFlags UpdateFlags::update_piola = update_volume_elements | update_contravariant_transformation,
+constexpr UpdateFlags UpdateFlags::update_mapping =
+update_quadrature_points | update_JxW_values | update_jacobians |
+update_jacobian_grads | update_jacobian_pushed_forward_grads |
+update_jacobian_2nd_derivatives |
+update_jacobian_pushed_forward_2nd_derivatives |
+update_jacobian_3rd_derivatives |
+update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+update_boundary_forms | update_normal_vectors |
+update_covariant_transformation | update_contravariant_transformation |
+update_transformation_values | update_transformation_gradients |
+update_volume_elements;
 
-/**
- * Global operator which returns an object in which all bits are set which are
- * either set in the first or the second argument. This operator exists since
- * if it did not then the result of the bit-or <tt>operator |</tt> would be an
- * integer which would in turn trigger a compiler warning when we tried to
- * assign it to an object of type UpdateFlags.
- *
- * @ref UpdateFlags
- */
-inline UpdateFlags
-operator|(const UpdateFlags f1, const UpdateFlags f2)
+
+// Class member definitions
+
+inline constexpr UpdateFlags
+UpdateFlags::operator|(const UpdateFlags in) const
 {
-  using enum_type = std::underlying_type_t<UpdateFlags>;
-  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) |
-                                  static_cast<enum_type>(f2));
+  return internal::make_enum(field | in.field);
 }
 
 
 
-/**
- * Global operator which sets the bits from the second argument also in the
- * first one.
- *
- * @ref UpdateFlags
- */
-inline UpdateFlags &
-operator|=(UpdateFlags &f1, const UpdateFlags f2)
+inline constexpr UpdateFlags &
+UpdateFlags::operator|=(const UpdateFlags in)
 {
-  f1 = f1 | f2;
-  return f1;
+  field = field | in.field;
+  return *this;
 }
 
 
-/**
- * Global operator which returns an object in which all bits are set which are
- * set in the first as well as the second argument. This operator exists since
- * if it did not then the result of the bit-and <tt>operator &</tt> would be
- * an integer which would in turn trigger a compiler warning when we tried to
- * assign it to an object of type UpdateFlags.
- *
- * @ref UpdateFlags
- */
-inline UpdateFlags
-operator&(const UpdateFlags f1, const UpdateFlags f2)
+
+inline constexpr UpdateFlags
+UpdateFlags::operator&(const UpdateFlags in) const
 {
-  using enum_type = std::underlying_type_t<UpdateFlags>;
-  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) &
-                                  static_cast<enum_type>(f2));
+  return internal::make_enum(field & in.field);
 }
 
 
-/**
- * Global operator which clears all the bits in the first argument if they are
- * not also set in the second argument.
- *
- * @ref UpdateFlags
- */
-inline UpdateFlags &
-operator&=(UpdateFlags &f1, const UpdateFlags f2)
+
+inline constexpr UpdateFlags &
+UpdateFlags::operator&=(const UpdateFlags in)
 {
-  f1 = f1 & f2;
-  return f1;
+  field = field & in.field;
+  return *this;
 }
 
 
-/**
- * Global operator which checks if the flags contained in the first argument
- * contain the flags contained in the second argument.
- *
- * @ref UpdateFlags
- */
-inline bool
-contains_bits(const UpdateFlags flags, const UpdateFlags mask)
+
+inline constexpr bool
+UpdateFlags::operator==(const UpdateFlags in) const
 {
-  using enum_type = std::underlying_type_t<UpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
+  return field == in.field;
 }
 
+
+
+inline constexpr bool
+UpdateFlags::operator!=(const UpdateFlags in) const
+{
+  return field != in.field;
+}
+
+
+inline constexpr bool
+UpdateFlags::contains(const UpdateFlags in)
+{
+  return (field & in.field)!=0;
+}
+
+constexpr UpdateFlags UpdateFlags::update_default = update_default;
+constexpr UpdateFlags UpdateFlags::update_values = update_values;
+constexpr UpdateFlags UpdateFlags::update_gradients = update_gradients;
+constexpr UpdateFlags UpdateFlags::update_hessians = update_hessians;
+constexpr UpdateFlags UpdateFlags::update_3rd_derivatives = update_3rd_derivatives;
+constexpr UpdateFlags UpdateFlags::update_boundary_forms = update_boundary_forms;
+constexpr UpdateFlags UpdateFlags::update_quadrature_points = iupdate_quadrature_points;
+constexpr UpdateFlags UpdateFlags::update_JxW_values = update_JxW_values;
+constexpr UpdateFlags UpdateFlags::update_normal_vectors = update_normal_vectors;
+constexpr UpdateFlags UpdateFlags::update_jacobians = update_jacobians;
+constexpr UpdateFlags UpdateFlags::update_jacobian_grads = update_jacobian_grads;
+constexpr UpdateFlags UpdateFlags::update_inverse_jacobians = update_inverses_jacobians;
+constexpr UpdateFlags UpdateFlags::update_covariant_transformation = update_covariant_transformation;
+constexpr UpdateFlags UpdateFlags::update_contravariant_transformation = update_contravariant_transformation;
+constexpr UpdateFlags UpdateFlags::update_transformation_values = update_transformation_values;
+constexpr UpdateFlags UpdateFlags::update_transformation_gradients = update_transformation_gradients;
+constexpr UpdateFlags UpdateFlags::update_volume_elements = update_volume_elements;
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads = update_jacobian_pushed_forward_grad;,
+constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives = update_jacobian_2nd_derivatives;
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives = update_jacobian_pushed_forward_2nd_derivatives;
+constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives = update_jacobian_3rd_derivatives;
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives = update_jacobian_pushed_forward_3rd_derivatives;
+constexpr UpdateFlags UpdateFlags::update_piola = update_piola;
+constexpr UpdateFlags UpdateFlags::update_mapping = update_mapping;
+
+inline constexpr UpdateFlags::UpdateFlags(int i) : field(in)
+{}
 
 /**
  * This enum definition is used for storing similarities of the current cell

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -356,7 +356,7 @@ operator&=(UpdateFlags &f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline bool
-contains(const UpdateFlags flags, const UpdateFlags mask)
+contains_bits(const UpdateFlags flags, const UpdateFlags mask)
 {
   using enum_type = std::underlying_type_t<UpdateFlags>;
   return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -414,117 +414,30 @@ UpdateFlags::contains(const UpdateFlags in) const
 }
 
 // Import all flags into the global namespace.
-constexpr UpdateFlags update_default   = internal::make_update_flags(0);
-constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
-constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
-constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
-constexpr UpdateFlags update_3rd_derivatives =
-  internal::make_update_flags(0x0008);
-constexpr UpdateFlags update_boundary_forms =
-  internal::make_update_flags(0x0010);
-constexpr UpdateFlags update_quadrature_points =
-  internal::make_update_flags(0x0020);
-constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
-constexpr UpdateFlags update_normal_vectors =
-  internal::make_update_flags(0x0080);
-constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
-constexpr UpdateFlags update_jacobian_grads =
-  internal::make_update_flags(0x0200);
-constexpr UpdateFlags update_inverse_jacobians =
-  internal::make_update_flags(0x0400);
-constexpr UpdateFlags update_covariant_transformation =
-  internal::make_update_flags(0x0800);
-constexpr UpdateFlags update_contravariant_transformation =
-  internal::make_update_flags(0x1000);
-constexpr UpdateFlags update_transformation_values =
-  internal::make_update_flags(0x2000);
-constexpr UpdateFlags update_transformation_gradients =
-  internal::make_update_flags(0x4000);
-constexpr UpdateFlags update_volume_elements =
-  internal::make_update_flags(0x10000);
-constexpr UpdateFlags update_jacobian_pushed_forward_grads =
-  internal::make_update_flags(0x100000);
-constexpr UpdateFlags update_jacobian_2nd_derivatives =
-  internal::make_update_flags(0x200000);
-constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives =
-  internal::make_update_flags(0x400000);
-constexpr UpdateFlags update_jacobian_3rd_derivatives =
-  internal::make_update_flags(0x800000);
-constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
-  internal::make_update_flags(0x1000000);
-constexpr UpdateFlags update_piola =
-  update_volume_elements | update_contravariant_transformation;
-constexpr UpdateFlags update_mapping =
-  update_quadrature_points | update_JxW_values | update_jacobians |
-  update_jacobian_grads | update_jacobian_pushed_forward_grads |
-  update_jacobian_2nd_derivatives |
-  update_jacobian_pushed_forward_2nd_derivatives |
-  update_jacobian_3rd_derivatives |
-  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
-  update_boundary_forms | update_normal_vectors |
-  update_covariant_transformation | update_contravariant_transformation |
-  update_transformation_values | update_transformation_gradients |
-  update_volume_elements;
-
-constexpr UpdateFlags UpdateFlags::update_default =
-  internal::make_update_flags(0);
-constexpr UpdateFlags UpdateFlags::update_values =
-  internal::make_update_flags(0x0001);
-constexpr UpdateFlags UpdateFlags::update_gradients =
-  internal::make_update_flags(0x0002);
-constexpr UpdateFlags UpdateFlags::update_hessians =
-  internal::make_update_flags(0x0004);
-constexpr UpdateFlags UpdateFlags::update_3rd_derivatives =
-  internal::make_update_flags(0x0008);
-constexpr UpdateFlags UpdateFlags::update_boundary_forms =
-  internal::make_update_flags(0x0010);
-constexpr UpdateFlags UpdateFlags::update_quadrature_points =
-  internal::make_update_flags(0x0020);
-constexpr UpdateFlags UpdateFlags::update_JxW_values =
-  internal::make_update_flags(0x0040);
-constexpr UpdateFlags UpdateFlags::update_normal_vectors =
-  internal::make_update_flags(0x0080);
-constexpr UpdateFlags UpdateFlags::update_jacobians =
-  internal::make_update_flags(0x0100);
-constexpr UpdateFlags UpdateFlags::update_jacobian_grads =
-  internal::make_update_flags(0x0200);
-constexpr UpdateFlags UpdateFlags::update_inverse_jacobians =
-  internal::make_update_flags(0x0400);
-constexpr UpdateFlags UpdateFlags::update_covariant_transformation =
-  internal::make_update_flags(0x0800);
-constexpr UpdateFlags UpdateFlags::update_contravariant_transformation =
-  internal::make_update_flags(0x1000);
-constexpr UpdateFlags UpdateFlags::update_transformation_values =
-  internal::make_update_flags(0x2000);
-constexpr UpdateFlags UpdateFlags::update_transformation_gradients =
-  internal::make_update_flags(0x4000);
-constexpr UpdateFlags UpdateFlags::update_volume_elements =
-  internal::make_update_flags(0x10000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads =
-  internal::make_update_flags(0x100000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives =
-  internal::make_update_flags(0x200000);
-constexpr UpdateFlags
-  UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
-    internal::make_update_flags(0x400000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
-  internal::make_update_flags(0x800000);
-constexpr UpdateFlags
-  UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives =
-    internal::make_update_flags(0x1000000);
-constexpr UpdateFlags UpdateFlags::update_piola =
-  update_volume_elements | update_contravariant_transformation;
-constexpr UpdateFlags UpdateFlags::update_mapping =
-  update_quadrature_points | update_JxW_values | update_jacobians |
-  update_jacobian_grads | update_jacobian_pushed_forward_grads |
-  update_jacobian_2nd_derivatives |
-  update_jacobian_pushed_forward_2nd_derivatives |
-  update_jacobian_3rd_derivatives |
-  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
-  update_boundary_forms | update_normal_vectors |
-  update_covariant_transformation | update_contravariant_transformation |
-  update_transformation_values | update_transformation_gradients |
-  update_volume_elements;
+constexpr UpdateFlags update_default;
+constexpr UpdateFlags update_values;
+constexpr UpdateFlags update_gradients;
+constexpr UpdateFlags update_hessians;
+constexpr UpdateFlags update_3rd_derivatives;
+constexpr UpdateFlags update_boundary_forms;
+constexpr UpdateFlags update_quadrature_points;
+constexpr UpdateFlags update_JxW_values;
+constexpr UpdateFlags update_normal_vectors;
+constexpr UpdateFlags update_jacobians;
+constexpr UpdateFlags update_jacobian_grads;
+constexpr UpdateFlags update_inverse_jacobians;
+constexpr UpdateFlags update_covariant_transformation;
+constexpr UpdateFlags update_contravariant_transformation;
+constexpr UpdateFlags update_transformation_values;
+constexpr UpdateFlags update_transformation_gradients;
+constexpr UpdateFlags update_volume_elements;
+constexpr UpdateFlags update_jacobian_pushed_forward_grads;
+constexpr UpdateFlags update_jacobian_2nd_derivatives;
+constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives;
+constexpr UpdateFlags update_jacobian_3rd_derivatives;
+constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives;
+constexpr UpdateFlags update_piola;
+constexpr UpdateFlags update_mapping;
 
 /**
  * This enum definition is used for storing similarities of the current cell

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -345,6 +345,9 @@ operator<<(StreamType &s, const UpdateFlags u)
   return s;
 }
 
+
+#ifndef DOXYGEN
+
 namespace internal
 {
   constexpr UpdateFlags
@@ -438,6 +441,8 @@ constexpr UpdateFlags update_jacobian_3rd_derivatives;
 constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives;
 constexpr UpdateFlags update_piola;
 constexpr UpdateFlags update_mapping;
+
+#endif
 
 /**
  * This enum definition is used for storing similarities of the current cell

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -421,47 +421,73 @@ UpdateFlags::contains(const UpdateFlags in) const
   return (field & in.field) != 0;
 }
 
+#endif
+
 // Import all flags into the global namespace.
-constexpr UpdateFlags update_default   = internal::make_update_flags(0);
-constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
+//! @copydoc UpdateFlags::update_default
+constexpr UpdateFlags update_default = internal::make_update_flags(0);
+//! @copydoc UpdateFlags::update_values
+constexpr UpdateFlags update_values = internal::make_update_flags(0x0001);
+//! @copydoc UpdateFlags::update_gradients
 constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
-constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
+//! @copydoc UpdateFlags::update_hessians
+constexpr UpdateFlags update_hessians = internal::make_update_flags(0x0004);
+//! @copydoc UpdateFlags::update_3rd_derivatives
 constexpr UpdateFlags update_3rd_derivatives =
   internal::make_update_flags(0x0008);
+//! @copydoc UpdateFlags::update_boundary_forms
 constexpr UpdateFlags update_boundary_forms =
   internal::make_update_flags(0x0010);
+//! @copydoc UpdateFlags::update_quadrature_points
 constexpr UpdateFlags update_quadrature_points =
   internal::make_update_flags(0x0020);
+//! @copydoc UpdateFlags::update_JxW_values
 constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
+//! @copydoc UpdateFlags::update_normal_vectors
 constexpr UpdateFlags update_normal_vectors =
   internal::make_update_flags(0x0080);
+//! @copydoc UpdateFlags::update_jacobians
 constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
+//! @copydoc UpdateFlags::update_jacobian_grads
 constexpr UpdateFlags update_jacobian_grads =
   internal::make_update_flags(0x0200);
+//! @copydoc UpdateFlags::update_inverse_jacobians
 constexpr UpdateFlags update_inverse_jacobians =
   internal::make_update_flags(0x0400);
+//! @copydoc UpdateFlags::update_covariant_transformation
 constexpr UpdateFlags update_covariant_transformation =
   internal::make_update_flags(0x0800);
+//! @copydoc UpdateFlags::update_contravariant_transformation
 constexpr UpdateFlags update_contravariant_transformation =
   internal::make_update_flags(0x1000);
+//! @copydoc UpdateFlags::update_transformation_values
 constexpr UpdateFlags update_transformation_values =
   internal::make_update_flags(0x2000);
+//! @copydoc UpdateFlags::update_transformation_gradients
 constexpr UpdateFlags update_transformation_gradients =
   internal::make_update_flags(0x4000);
+//! @copydoc UpdateFlags::update_volume_elements
 constexpr UpdateFlags update_volume_elements =
   internal::make_update_flags(0x10000);
+//! @copydoc UpdateFlags::update_jacobian_pushed_forward_grads
 constexpr UpdateFlags update_jacobian_pushed_forward_grads =
   internal::make_update_flags(0x100000);
+//! @copydoc UpdateFlags::update_jacobian_2nd_derivatives
 constexpr UpdateFlags update_jacobian_2nd_derivatives =
   internal::make_update_flags(0x200000);
+//! @copydoc UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives
 constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives =
   internal::make_update_flags(0x400000);
+//! @copydoc UpdateFlags::update_jacobian_3rd_derivatives
 constexpr UpdateFlags update_jacobian_3rd_derivatives =
   internal::make_update_flags(0x800000);
+//! @copydoc UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives
 constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
   internal::make_update_flags(0x1000000);
+//! @copydoc UpdateFlags::update_piola
 constexpr UpdateFlags update_piola =
   update_volume_elements | update_contravariant_transformation;
+//! @copydoc UpdateFlags::update_mapping
 constexpr UpdateFlags update_mapping =
   update_quadrature_points | update_JxW_values | update_jacobians |
   update_jacobian_grads | update_jacobian_pushed_forward_grads |
@@ -474,7 +500,7 @@ constexpr UpdateFlags update_mapping =
   update_transformation_values | update_transformation_gradients |
   update_volume_elements;
 
-#endif
+
 
 /**
  * This enum definition is used for storing similarities of the current cell

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -296,8 +296,9 @@ operator<<(StreamType &s, const UpdateFlags u)
 inline UpdateFlags
 operator|(const UpdateFlags f1, const UpdateFlags f2)
 {
-  return static_cast<UpdateFlags>(static_cast<unsigned int>(f1) |
-                                  static_cast<unsigned int>(f2));
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) |
+                                  static_cast<enum_type>(f2));
 }
 
 
@@ -326,10 +327,17 @@ operator|=(UpdateFlags &f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline UpdateFlags
-operator&(const UpdateFlags f1, const UpdateFlags f2)
+operator&(const UpdateFlags f1, const UpdateFlags f2) = delete;
+/*{
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return static_cast<UpdateFlags>(static_cast<enum_type>(f1) &
+                                  static_cast<enum_type>(f2));
+}*/
+
+bool contains(const UpdateFlags flags, const UpdateFlags mask)
 {
-  return static_cast<UpdateFlags>(static_cast<unsigned int>(f1) &
-                                  static_cast<unsigned int>(f2));
+  using enum_type = std::underlying_type_t<UpdateFlags>;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
 }
 
 
@@ -340,11 +348,11 @@ operator&(const UpdateFlags f1, const UpdateFlags f2)
  * @ref UpdateFlags
  */
 inline UpdateFlags &
-operator&=(UpdateFlags &f1, const UpdateFlags f2)
-{
+operator&=(UpdateFlags &f1, const UpdateFlags f2) = delete;
+/*{
   f1 = f1 & f2;
   return f1;
-}
+}*/
 
 
 

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -73,9 +73,10 @@ namespace internal
 class UpdateFlags
 {
 public:
-  constexpr UpdateFlags()
-    : field(0)
-  {}
+  /**
+   * Default constructor corresponding to no flag set.
+   */
+  constexpr UpdateFlags();
 
   /**
    * Return an object in which all bits are set which are set in the current
@@ -357,6 +358,10 @@ namespace internal
   }
 } // namespace internal
 
+inline constexpr UpdateFlags::UpdateFlags()
+  : field(0)
+{}
+
 inline constexpr UpdateFlags::UpdateFlags(int i)
   : field(i)
 {}
@@ -417,30 +422,57 @@ UpdateFlags::contains(const UpdateFlags in) const
 }
 
 // Import all flags into the global namespace.
-constexpr UpdateFlags update_default;
-constexpr UpdateFlags update_values;
-constexpr UpdateFlags update_gradients;
-constexpr UpdateFlags update_hessians;
-constexpr UpdateFlags update_3rd_derivatives;
-constexpr UpdateFlags update_boundary_forms;
-constexpr UpdateFlags update_quadrature_points;
-constexpr UpdateFlags update_JxW_values;
-constexpr UpdateFlags update_normal_vectors;
-constexpr UpdateFlags update_jacobians;
-constexpr UpdateFlags update_jacobian_grads;
-constexpr UpdateFlags update_inverse_jacobians;
-constexpr UpdateFlags update_covariant_transformation;
-constexpr UpdateFlags update_contravariant_transformation;
-constexpr UpdateFlags update_transformation_values;
-constexpr UpdateFlags update_transformation_gradients;
-constexpr UpdateFlags update_volume_elements;
-constexpr UpdateFlags update_jacobian_pushed_forward_grads;
-constexpr UpdateFlags update_jacobian_2nd_derivatives;
-constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives;
-constexpr UpdateFlags update_jacobian_3rd_derivatives;
-constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives;
-constexpr UpdateFlags update_piola;
-constexpr UpdateFlags update_mapping;
+constexpr UpdateFlags update_default   = internal::make_update_flags(0);
+constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
+constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
+constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
+constexpr UpdateFlags update_3rd_derivatives =
+  internal::make_update_flags(0x0008);
+constexpr UpdateFlags update_boundary_forms =
+  internal::make_update_flags(0x0010);
+constexpr UpdateFlags update_quadrature_points =
+  internal::make_update_flags(0x0020);
+constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
+constexpr UpdateFlags update_normal_vectors =
+  internal::make_update_flags(0x0080);
+constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
+constexpr UpdateFlags update_jacobian_grads =
+  internal::make_update_flags(0x0200);
+constexpr UpdateFlags update_inverse_jacobians =
+  internal::make_update_flags(0x0400);
+constexpr UpdateFlags update_covariant_transformation =
+  internal::make_update_flags(0x0800);
+constexpr UpdateFlags update_contravariant_transformation =
+  internal::make_update_flags(0x1000);
+constexpr UpdateFlags update_transformation_values =
+  internal::make_update_flags(0x2000);
+constexpr UpdateFlags update_transformation_gradients =
+  internal::make_update_flags(0x4000);
+constexpr UpdateFlags update_volume_elements =
+  internal::make_update_flags(0x10000);
+constexpr UpdateFlags update_jacobian_pushed_forward_grads =
+  internal::make_update_flags(0x100000);
+constexpr UpdateFlags update_jacobian_2nd_derivatives =
+  internal::make_update_flags(0x200000);
+constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives =
+  internal::make_update_flags(0x400000);
+constexpr UpdateFlags update_jacobian_3rd_derivatives =
+  internal::make_update_flags(0x800000);
+constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
+  internal::make_update_flags(0x1000000);
+constexpr UpdateFlags update_piola =
+  update_volume_elements | update_contravariant_transformation;
+constexpr UpdateFlags update_mapping =
+  update_quadrature_points | update_JxW_values | update_jacobians |
+  update_jacobian_grads | update_jacobian_pushed_forward_grads |
+  update_jacobian_2nd_derivatives |
+  update_jacobian_pushed_forward_2nd_derivatives |
+  update_jacobian_3rd_derivatives |
+  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+  update_boundary_forms | update_normal_vectors |
+  update_covariant_transformation | update_contravariant_transformation |
+  update_transformation_values | update_transformation_gradients |
+  update_volume_elements;
 
 #endif
 

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -334,10 +334,11 @@ operator&(const UpdateFlags f1, const UpdateFlags f2) = delete;
                                   static_cast<enum_type>(f2));
 }*/
 
-bool contains(const UpdateFlags flags, const UpdateFlags mask)
+inline bool
+contains(const UpdateFlags flags, const UpdateFlags mask)
 {
   using enum_type = std::underlying_type_t<UpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
 }
 
 

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -37,7 +37,8 @@ class UpdateFlags;
 
 namespace internal
 {
-  constexpr UpdateFlags make_update_flags(int);
+  constexpr UpdateFlags
+  make_update_flags(int);
 }
 #endif
 
@@ -71,49 +72,55 @@ namespace internal
  */
 class UpdateFlags
 {
-	public:
+public:
+  constexpr UpdateFlags()
+    : field(0)
+  {}
 
-/**
- * Return an object in which all bits are set which are set in the current
- * object or in the input argument @p in.
- */
-constexpr UpdateFlags
-operator|(const UpdateFlags in) const;
+  /**
+   * Return an object in which all bits are set which are set in the current
+   * object or in the input argument @p in.
+   */
+  constexpr UpdateFlags
+  operator|(const UpdateFlags in) const;
 
-/**
- * Set the bits from the input argument @p in also in the current object.
- */
-constexpr UpdateFlags &
-operator|=(const UpdateFlags in);
+  /**
+   * Set the bits from the input argument @p in also in the current object.
+   */
+  constexpr UpdateFlags &
+  operator|=(const UpdateFlags in);
 
-/**
- * Return an object in which all bits are set which are set in the current
- * object as well as in the input argument @p in.
- */
-constexpr UpdateFlags
-operator&(const UpdateFlags in) const;
+  /**
+   * Return an object in which all bits are set which are set in the current
+   * object as well as in the input argument @p in.
+   */
+  constexpr UpdateFlags
+  operator&(const UpdateFlags in) const;
 
-/**
- * Clear all the bits in the current object if they are not also set in the
- * input argument @p in.
- */
-constexpr UpdateFlags &
-operator&=(const UpdateFlags in);
+  /**
+   * Clear all the bits in the current object if they are not also set in the
+   * input argument @p in.
+   */
+  constexpr UpdateFlags &
+  operator&=(const UpdateFlags in);
 
-/**
- * Check if the current object and the input argument @p in are equal.
- */ 
-    constexpr bool operator==(const UpdateFlags in) const;
+  /**
+   * Check if the current object and the input argument @p in are equal.
+   */
+  constexpr bool
+  operator==(const UpdateFlags in) const;
 
-/**
- * Check if the current object and the input argument @p in are not equal.
- */
-    constexpr bool operator!=(const UpdateFlags in) const;
+  /**
+   * Check if the current object and the input argument @p in are not equal.
+   */
+  constexpr bool
+  operator!=(const UpdateFlags in) const;
 
-/**
- *  Check if the current objects contains the flags given in the input argument @p in.
- */
-    constexpr bool contains(const UpdateFlags in) const;
+  /**
+   *  Check if the current objects contains the flags given in the input argument @p in.
+   */
+  constexpr bool
+  contains(const UpdateFlags in) const;
 
   //! No update
   static const UpdateFlags update_default;
@@ -183,13 +190,13 @@ operator&=(const UpdateFlags in);
    * codimension one. Setting this flag for any other object will raise an
    * error.
    */
-  static const UpdateFlags  update_normal_vectors;
+  static const UpdateFlags update_normal_vectors;
   //! Volume element
   /**
    * Compute the Jacobian of the transformation from the reference cell to the
    * real cell.
    */
-  static const UpdateFlags  update_jacobians;
+  static const UpdateFlags update_jacobians;
   //! Gradient of volume element
   /**
    * Compute the derivatives of the Jacobian of the transformation.
@@ -265,7 +272,7 @@ operator&=(const UpdateFlags in);
    */
   static const UpdateFlags update_mapping;
 
-	private:
+private:
   /**
    * An integer representing the flags.
    */
@@ -274,12 +281,14 @@ operator&=(const UpdateFlags in);
   /**
    * Private constructor only to be used internally.
    */
-  constexpr UpdateFlags(int i);
+  constexpr explicit UpdateFlags(int i);
 
   /**
-   * Friend declaration so that make_enum can call the private constructor.
+   * Friend declaration so that make_update_flags can call the private
+   * constructor.
    */
-  friend constexpr UpdateFlags make_enum(int);
+  friend constexpr UpdateFlags
+  internal::make_update_flags(int);
 };
 
 
@@ -336,49 +345,23 @@ operator<<(StreamType &s, const UpdateFlags u)
   return s;
 }
 
-// Import all flags into the global namespace.
-constexpr UpdateFlags update_default = internal::make_enum(0);
-constexpr UpdateFlags UpdateFlags::update_values = internal::make_enum(0x0001);
-constexpr UpdateFlags UpdateFlags::update_gradients = internal::make_enum(0x0002);
-constexpr UpdateFlags UpdateFlags::update_hessians = internal::make_enum(0x0004);
-constexpr UpdateFlags UpdateFlags::update_3rd_derivatives = internal::make_enum(0x0008);
-constexpr UpdateFlags UpdateFlags::update_boundary_forms = internal::make_enum(0x0010);
-constexpr UpdateFlags UpdateFlags::update_quadrature_points = internal::make_enum(0x0020);
-constexpr UpdateFlags UpdateFlags::update_JxW_values = internal::make_enum(0x0040);
-constexpr UpdateFlags UpdateFlags::update_normal_vectors = internal::make_enum(0x0080);
-constexpr UpdateFlags UpdateFlags::update_jacobians = internal::make_enum(0x01000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_grads = internal::make_enum(0x02000:
-constexpr UpdateFlags UpdateFlags::update_inverse_jacobians = internal::make_enum(0x0400);
-constexpr UpdateFlags UpdateFlags::update_covariant_transformation = internal::make_enum(0x0800);
-constexpr UpdateFlags UpdateFlags::update_contravariant_transformation = internal::make_enum(0x1000);
-constexpr UpdateFlags UpdateFlags::update_transformation_values = internal::make_enum(0x2000);
-constexpr UpdateFlags UpdateFlags::update_transformation_gradients = internal::make_enum(0x4000);
-constexpr UpdateFlags UpdateFlags::update_volume_elements = internal::make_enum(0x10000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads = internal::make_enum(0x100000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives = internal::make_enum(0x200000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives = internal::make_enum(0x400000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives = internal::make_enum(0x800000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives = internal::make_enum(0x1000000);
-constexpr UpdateFlags UpdateFlags::update_piola = update_volume_elements | update_contravariant_transformation,
-constexpr UpdateFlags UpdateFlags::update_mapping =
-update_quadrature_points | update_JxW_values | update_jacobians |
-update_jacobian_grads | update_jacobian_pushed_forward_grads |
-update_jacobian_2nd_derivatives |
-update_jacobian_pushed_forward_2nd_derivatives |
-update_jacobian_3rd_derivatives |
-update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
-update_boundary_forms | update_normal_vectors |
-update_covariant_transformation | update_contravariant_transformation |
-update_transformation_values | update_transformation_gradients |
-update_volume_elements;
+namespace internal
+{
+  constexpr UpdateFlags
+  make_update_flags(int field)
+  {
+    return UpdateFlags(field);
+  }
+} // namespace internal
 
-
-// Class member definitions
+inline constexpr UpdateFlags::UpdateFlags(int i)
+  : field(i)
+{}
 
 inline constexpr UpdateFlags
 UpdateFlags::operator|(const UpdateFlags in) const
 {
-  return internal::make_enum(field | in.field);
+  return internal::make_update_flags(field | in.field);
 }
 
 
@@ -395,7 +378,7 @@ UpdateFlags::operator|=(const UpdateFlags in)
 inline constexpr UpdateFlags
 UpdateFlags::operator&(const UpdateFlags in) const
 {
-  return internal::make_enum(field & in.field);
+  return internal::make_update_flags(field & in.field);
 }
 
 
@@ -425,38 +408,123 @@ UpdateFlags::operator!=(const UpdateFlags in) const
 
 
 inline constexpr bool
-UpdateFlags::contains(const UpdateFlags in)
+UpdateFlags::contains(const UpdateFlags in) const
 {
-  return (field & in.field)!=0;
+  return (field & in.field) != 0;
 }
 
-constexpr UpdateFlags UpdateFlags::update_default = update_default;
-constexpr UpdateFlags UpdateFlags::update_values = update_values;
-constexpr UpdateFlags UpdateFlags::update_gradients = update_gradients;
-constexpr UpdateFlags UpdateFlags::update_hessians = update_hessians;
-constexpr UpdateFlags UpdateFlags::update_3rd_derivatives = update_3rd_derivatives;
-constexpr UpdateFlags UpdateFlags::update_boundary_forms = update_boundary_forms;
-constexpr UpdateFlags UpdateFlags::update_quadrature_points = iupdate_quadrature_points;
-constexpr UpdateFlags UpdateFlags::update_JxW_values = update_JxW_values;
-constexpr UpdateFlags UpdateFlags::update_normal_vectors = update_normal_vectors;
-constexpr UpdateFlags UpdateFlags::update_jacobians = update_jacobians;
-constexpr UpdateFlags UpdateFlags::update_jacobian_grads = update_jacobian_grads;
-constexpr UpdateFlags UpdateFlags::update_inverse_jacobians = update_inverses_jacobians;
-constexpr UpdateFlags UpdateFlags::update_covariant_transformation = update_covariant_transformation;
-constexpr UpdateFlags UpdateFlags::update_contravariant_transformation = update_contravariant_transformation;
-constexpr UpdateFlags UpdateFlags::update_transformation_values = update_transformation_values;
-constexpr UpdateFlags UpdateFlags::update_transformation_gradients = update_transformation_gradients;
-constexpr UpdateFlags UpdateFlags::update_volume_elements = update_volume_elements;
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads = update_jacobian_pushed_forward_grad;,
-constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives = update_jacobian_2nd_derivatives;
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives = update_jacobian_pushed_forward_2nd_derivatives;
-constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives = update_jacobian_3rd_derivatives;
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives = update_jacobian_pushed_forward_3rd_derivatives;
-constexpr UpdateFlags UpdateFlags::update_piola = update_piola;
-constexpr UpdateFlags UpdateFlags::update_mapping = update_mapping;
+// Import all flags into the global namespace.
+constexpr UpdateFlags update_default   = internal::make_update_flags(0);
+constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
+constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
+constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
+constexpr UpdateFlags update_3rd_derivatives =
+  internal::make_update_flags(0x0008);
+constexpr UpdateFlags update_boundary_forms =
+  internal::make_update_flags(0x0010);
+constexpr UpdateFlags update_quadrature_points =
+  internal::make_update_flags(0x0020);
+constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
+constexpr UpdateFlags update_normal_vectors =
+  internal::make_update_flags(0x0080);
+constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
+constexpr UpdateFlags update_jacobian_grads =
+  internal::make_update_flags(0x0200);
+constexpr UpdateFlags update_inverse_jacobians =
+  internal::make_update_flags(0x0400);
+constexpr UpdateFlags update_covariant_transformation =
+  internal::make_update_flags(0x0800);
+constexpr UpdateFlags update_contravariant_transformation =
+  internal::make_update_flags(0x1000);
+constexpr UpdateFlags update_transformation_values =
+  internal::make_update_flags(0x2000);
+constexpr UpdateFlags update_transformation_gradients =
+  internal::make_update_flags(0x4000);
+constexpr UpdateFlags update_volume_elements =
+  internal::make_update_flags(0x10000);
+constexpr UpdateFlags update_jacobian_pushed_forward_grads =
+  internal::make_update_flags(0x100000);
+constexpr UpdateFlags update_jacobian_2nd_derivatives =
+  internal::make_update_flags(0x200000);
+constexpr UpdateFlags update_jacobian_pushed_forward_2nd_derivatives =
+  internal::make_update_flags(0x400000);
+constexpr UpdateFlags update_jacobian_3rd_derivatives =
+  internal::make_update_flags(0x800000);
+constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
+  internal::make_update_flags(0x1000000);
+constexpr UpdateFlags update_piola =
+  update_volume_elements | update_contravariant_transformation;
+constexpr UpdateFlags update_mapping =
+  update_quadrature_points | update_JxW_values | update_jacobians |
+  update_jacobian_grads | update_jacobian_pushed_forward_grads |
+  update_jacobian_2nd_derivatives |
+  update_jacobian_pushed_forward_2nd_derivatives |
+  update_jacobian_3rd_derivatives |
+  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+  update_boundary_forms | update_normal_vectors |
+  update_covariant_transformation | update_contravariant_transformation |
+  update_transformation_values | update_transformation_gradients |
+  update_volume_elements;
 
-inline constexpr UpdateFlags::UpdateFlags(int i) : field(in)
-{}
+constexpr UpdateFlags UpdateFlags::update_default =
+  internal::make_update_flags(0);
+constexpr UpdateFlags UpdateFlags::update_values =
+  internal::make_update_flags(0x0001);
+constexpr UpdateFlags UpdateFlags::update_gradients =
+  internal::make_update_flags(0x0002);
+constexpr UpdateFlags UpdateFlags::update_hessians =
+  internal::make_update_flags(0x0004);
+constexpr UpdateFlags UpdateFlags::update_3rd_derivatives =
+  internal::make_update_flags(0x0008);
+constexpr UpdateFlags UpdateFlags::update_boundary_forms =
+  internal::make_update_flags(0x0010);
+constexpr UpdateFlags UpdateFlags::update_quadrature_points =
+  internal::make_update_flags(0x0020);
+constexpr UpdateFlags UpdateFlags::update_JxW_values =
+  internal::make_update_flags(0x0040);
+constexpr UpdateFlags UpdateFlags::update_normal_vectors =
+  internal::make_update_flags(0x0080);
+constexpr UpdateFlags UpdateFlags::update_jacobians =
+  internal::make_update_flags(0x0100);
+constexpr UpdateFlags UpdateFlags::update_jacobian_grads =
+  internal::make_update_flags(0x0200);
+constexpr UpdateFlags UpdateFlags::update_inverse_jacobians =
+  internal::make_update_flags(0x0400);
+constexpr UpdateFlags UpdateFlags::update_covariant_transformation =
+  internal::make_update_flags(0x0800);
+constexpr UpdateFlags UpdateFlags::update_contravariant_transformation =
+  internal::make_update_flags(0x1000);
+constexpr UpdateFlags UpdateFlags::update_transformation_values =
+  internal::make_update_flags(0x2000);
+constexpr UpdateFlags UpdateFlags::update_transformation_gradients =
+  internal::make_update_flags(0x4000);
+constexpr UpdateFlags UpdateFlags::update_volume_elements =
+  internal::make_update_flags(0x10000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads =
+  internal::make_update_flags(0x100000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives =
+  internal::make_update_flags(0x200000);
+constexpr UpdateFlags
+  UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
+    internal::make_update_flags(0x400000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
+  internal::make_update_flags(0x800000);
+constexpr UpdateFlags
+  UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives =
+    internal::make_update_flags(0x1000000);
+constexpr UpdateFlags UpdateFlags::update_piola =
+  update_volume_elements | update_contravariant_transformation;
+constexpr UpdateFlags UpdateFlags::update_mapping =
+  update_quadrature_points | update_JxW_values | update_jacobians |
+  update_jacobian_grads | update_jacobian_pushed_forward_grads |
+  update_jacobian_2nd_derivatives |
+  update_jacobian_pushed_forward_2nd_derivatives |
+  update_jacobian_3rd_derivatives |
+  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+  update_boundary_forms | update_normal_vectors |
+  update_covariant_transformation | update_contravariant_transformation |
+  update_transformation_values | update_transformation_gradients |
+  update_volume_elements;
 
 /**
  * This enum definition is used for storing similarities of the current cell

--- a/include/deal.II/fe/fe_update_flags.h
+++ b/include/deal.II/fe/fe_update_flags.h
@@ -302,43 +302,43 @@ inline StreamType &
 operator<<(StreamType &s, const UpdateFlags u)
 {
   s << " UpdateFlags|";
-  if (u & UpdateFlags::update_values)
+  if (u.contains(UpdateFlags::update_values))
     s << "values|";
-  if (u & UpdateFlags::update_gradients)
+  if (u.contains(UpdateFlags::update_gradients))
     s << "gradients|";
-  if (u & UpdateFlags::update_hessians)
+  if (u.contains(UpdateFlags::update_hessians))
     s << "hessians|";
-  if (u & UpdateFlags::update_3rd_derivatives)
+  if (u.contains(UpdateFlags::update_3rd_derivatives))
     s << "3rd_derivatives|";
-  if (u & UpdateFlags::update_quadrature_points)
+  if (u.contains(UpdateFlags::update_quadrature_points))
     s << "quadrature_points|";
-  if (u & UpdateFlags::update_JxW_values)
+  if (u.contains(UpdateFlags::update_JxW_values))
     s << "JxW_values|";
-  if (u & UpdateFlags::update_normal_vectors)
+  if (u.contains(UpdateFlags::update_normal_vectors))
     s << "normal_vectors|";
-  if (u & UpdateFlags::update_jacobians)
+  if (u.contains(UpdateFlags::update_jacobians))
     s << "jacobians|";
-  if (u & UpdateFlags::update_inverse_jacobians)
+  if (u.contains(UpdateFlags::update_inverse_jacobians))
     s << "inverse_jacobians|";
-  if (u & UpdateFlags::update_jacobian_grads)
+  if (u.contains(UpdateFlags::update_jacobian_grads))
     s << "jacobian_grads|";
-  if (u & UpdateFlags::update_covariant_transformation)
+  if (u.contains(UpdateFlags::update_covariant_transformation))
     s << "covariant_transformation|";
-  if (u & UpdateFlags::update_contravariant_transformation)
+  if (u.contains(UpdateFlags::update_contravariant_transformation))
     s << "contravariant_transformation|";
-  if (u & UpdateFlags::update_transformation_values)
+  if (u.contains(UpdateFlags::update_transformation_values))
     s << "transformation_values|";
-  if (u & UpdateFlags::update_transformation_gradients)
+  if (u.contains(UpdateFlags::update_transformation_gradients))
     s << "transformation_gradients|";
-  if (u & UpdateFlags::update_jacobian_pushed_forward_grads)
+  if (u.contains(UpdateFlags::update_jacobian_pushed_forward_grads))
     s << "jacobian_pushed_forward_grads|";
-  if (u & UpdateFlags::update_jacobian_2nd_derivatives)
+  if (u.contains(UpdateFlags::update_jacobian_2nd_derivatives))
     s << "jacobian_2nd_derivatives|";
-  if (u & UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives)
+  if (u.contains(UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives))
     s << "jacobian_pushed_forward_2nd_derivatives|";
-  if (u & UpdateFlags::update_jacobian_3rd_derivatives)
+  if (u.contains(UpdateFlags::update_jacobian_3rd_derivatives))
     s << "jacobian_3rd_derivatives|";
-  if (u & UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives)
+  if (u.contains(UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives))
     s << "jacobian_pushed_forward_3rd_derivatives|";
 
   // TODO: check that 'u' really only has the flags set that are handled above

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -5572,7 +5572,7 @@ FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5608,7 +5608,7 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5636,7 +5636,7 @@ FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5672,7 +5672,7 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5699,7 +5699,7 @@ FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5735,7 +5735,7 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5762,7 +5762,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5798,7 +5798,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5850,7 +5850,7 @@ template <int dim, int spacedim>
 inline const std::vector<Point<spacedim>> &
 FEValuesBase<dim, spacedim>::get_quadrature_points() const
 {
-  Assert(this->update_flags & update_quadrature_points,
+  Assert(contains(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.quadrature_points;
@@ -5862,7 +5862,7 @@ template <int dim, int spacedim>
 inline const std::vector<double> &
 FEValuesBase<dim, spacedim>::get_JxW_values() const
 {
-  Assert(this->update_flags & update_JxW_values,
+  Assert(contains(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.JxW_values;
@@ -5874,7 +5874,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobians() const
 {
-  Assert(this->update_flags & update_jacobians,
+  Assert(contains(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobians;
@@ -5886,7 +5886,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<2, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_grads() const
 {
-  Assert(this->update_flags & update_jacobian_grads,
+  Assert(contains(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_grads;
@@ -5899,7 +5899,7 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_grad(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_grads,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads[i];
@@ -5911,7 +5911,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<3, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_grads() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_grads,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads;
@@ -5923,7 +5923,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<3, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_2nd_derivative(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives[i];
@@ -5935,7 +5935,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<3, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_2nd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives;
@@ -5948,7 +5948,7 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5961,7 +5961,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_2nd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5974,7 +5974,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<4, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_3rd_derivative(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives[i];
@@ -5986,7 +5986,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<4, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_3rd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives;
@@ -5999,7 +5999,7 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6012,7 +6012,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(this->update_flags & update_jacobian_pushed_forward_3rd_derivatives,
+  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6025,7 +6025,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, spacedim, dim>> &
 FEValuesBase<dim, spacedim>::get_inverse_jacobians() const
 {
-  Assert(this->update_flags & update_inverse_jacobians,
+  Assert(contains(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.inverse_jacobians;
@@ -6079,7 +6079,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 FEValuesBase<dim, spacedim>::quadrature_point(const unsigned int i) const
 {
-  Assert(this->update_flags & update_quadrature_points,
+  Assert(contains(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   AssertIndexRange(i, this->mapping_output.quadrature_points.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6093,7 +6093,7 @@ template <int dim, int spacedim>
 inline double
 FEValuesBase<dim, spacedim>::JxW(const unsigned int i) const
 {
-  Assert(this->update_flags & update_JxW_values,
+  Assert(contains(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   AssertIndexRange(i, this->mapping_output.JxW_values.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6107,7 +6107,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobians,
+  Assert(contains(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   AssertIndexRange(i, this->mapping_output.jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6121,7 +6121,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<2, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_grad(const unsigned int i) const
 {
-  Assert(this->update_flags & update_jacobian_grads,
+  Assert(contains(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   AssertIndexRange(i, this->mapping_output.jacobian_grads.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6135,7 +6135,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, spacedim, dim> &
 FEValuesBase<dim, spacedim>::inverse_jacobian(const unsigned int i) const
 {
-  Assert(this->update_flags & update_inverse_jacobians,
+  Assert(contains(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   AssertIndexRange(i, this->mapping_output.inverse_jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6149,7 +6149,7 @@ template <int dim, int spacedim>
 inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::normal_vector(const unsigned int i) const
 {
-  Assert(this->update_flags & update_normal_vectors,
+  Assert(contains(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
   AssertIndexRange(i, this->mapping_output.normal_vectors.size());
@@ -6233,7 +6233,7 @@ inline const Tensor<1, spacedim> &
 FEFaceValuesBase<dim, spacedim>::boundary_form(const unsigned int i) const
 {
   AssertIndexRange(i, this->mapping_output.boundary_forms.size());
-  Assert(this->update_flags & update_boundary_forms,
+  Assert(contains(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4675,7 +4675,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4698,7 +4698,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -4720,7 +4720,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -4743,7 +4743,7 @@ namespace FEValuesViews
                                const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -4781,7 +4781,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4821,7 +4821,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4858,7 +4858,7 @@ namespace FEValuesViews
     // this function works like in the case above
 
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     // same as for the scalar case except that we have one more index
@@ -5030,7 +5030,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -5070,7 +5070,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -5177,7 +5177,7 @@ namespace FEValuesViews
                                             const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5212,7 +5212,7 @@ namespace FEValuesViews
                                            const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5257,7 +5257,7 @@ namespace FEValuesViews
     const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5335,7 +5335,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5385,7 +5385,7 @@ namespace FEValuesViews
                                        const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5441,7 +5441,7 @@ namespace FEValuesViews
                                      const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4653,7 +4653,7 @@ namespace FEValuesViews
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(
-      fe_values->update_flags & update_values,
+      contains(fe_values->update_flags, update_values),
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
         "update_values"))));
 
@@ -5948,7 +5948,8 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5961,7 +5962,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5999,7 +6001,8 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6012,7 +6015,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains(this->update_flags,
+                  update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4653,7 +4653,7 @@ namespace FEValuesViews
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(
-      contains(fe_values->update_flags, update_values),
+      contains_bits(fe_values->update_flags, update_values),
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
         "update_values"))));
 
@@ -4675,7 +4675,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4698,7 +4698,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -4720,7 +4720,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -4743,7 +4743,7 @@ namespace FEValuesViews
                                const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -4781,7 +4781,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4821,7 +4821,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4858,7 +4858,7 @@ namespace FEValuesViews
     // this function works like in the case above
 
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     // same as for the scalar case except that we have one more index
@@ -5030,7 +5030,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -5070,7 +5070,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -5177,7 +5177,7 @@ namespace FEValuesViews
                                             const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5212,7 +5212,7 @@ namespace FEValuesViews
                                            const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5257,7 +5257,7 @@ namespace FEValuesViews
     const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5335,7 +5335,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5385,7 +5385,7 @@ namespace FEValuesViews
                                        const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5441,7 +5441,7 @@ namespace FEValuesViews
                                      const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5572,7 +5572,7 @@ FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5608,7 +5608,7 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5636,7 +5636,7 @@ FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5672,7 +5672,7 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5699,7 +5699,7 @@ FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5735,7 +5735,7 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5762,7 +5762,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5798,7 +5798,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5850,7 +5850,7 @@ template <int dim, int spacedim>
 inline const std::vector<Point<spacedim>> &
 FEValuesBase<dim, spacedim>::get_quadrature_points() const
 {
-  Assert(contains(this->update_flags, update_quadrature_points),
+  Assert(contains_bits(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.quadrature_points;
@@ -5862,7 +5862,7 @@ template <int dim, int spacedim>
 inline const std::vector<double> &
 FEValuesBase<dim, spacedim>::get_JxW_values() const
 {
-  Assert(contains(this->update_flags, update_JxW_values),
+  Assert(contains_bits(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.JxW_values;
@@ -5874,7 +5874,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobians() const
 {
-  Assert(contains(this->update_flags, update_jacobians),
+  Assert(contains_bits(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobians;
@@ -5886,7 +5886,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<2, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_grads() const
 {
-  Assert(contains(this->update_flags, update_jacobian_grads),
+  Assert(contains_bits(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_grads;
@@ -5899,7 +5899,8 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_grad(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads[i];
@@ -5911,7 +5912,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<3, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_grads() const
 {
-  Assert(contains(this->update_flags, update_jacobian_pushed_forward_grads),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads;
@@ -5923,7 +5925,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<3, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_2nd_derivative(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
+  Assert(contains_bits(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives[i];
@@ -5935,7 +5937,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<3, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_2nd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_2nd_derivatives),
+  Assert(contains_bits(this->update_flags, update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives;
@@ -5948,8 +5950,8 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags,
-                  update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5962,8 +5964,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(contains(this->update_flags,
-                  update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5976,7 +5978,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<4, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_3rd_derivative(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives[i];
@@ -5988,7 +5990,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<4, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_3rd_derivatives() const
 {
-  Assert(contains(this->update_flags, update_jacobian_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives;
@@ -6001,8 +6003,8 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(contains(this->update_flags,
-                  update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6015,8 +6017,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(contains(this->update_flags,
-                  update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(contains_bits(this->update_flags,
+                       update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6029,7 +6031,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, spacedim, dim>> &
 FEValuesBase<dim, spacedim>::get_inverse_jacobians() const
 {
-  Assert(contains(this->update_flags, update_inverse_jacobians),
+  Assert(contains_bits(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.inverse_jacobians;
@@ -6083,7 +6085,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 FEValuesBase<dim, spacedim>::quadrature_point(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_quadrature_points),
+  Assert(contains_bits(this->update_flags, update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   AssertIndexRange(i, this->mapping_output.quadrature_points.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6097,7 +6099,7 @@ template <int dim, int spacedim>
 inline double
 FEValuesBase<dim, spacedim>::JxW(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_JxW_values),
+  Assert(contains_bits(this->update_flags, update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   AssertIndexRange(i, this->mapping_output.JxW_values.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6111,7 +6113,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobians),
+  Assert(contains_bits(this->update_flags, update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   AssertIndexRange(i, this->mapping_output.jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6125,7 +6127,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<2, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_grad(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_jacobian_grads),
+  Assert(contains_bits(this->update_flags, update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   AssertIndexRange(i, this->mapping_output.jacobian_grads.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6139,7 +6141,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, spacedim, dim> &
 FEValuesBase<dim, spacedim>::inverse_jacobian(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_inverse_jacobians),
+  Assert(contains_bits(this->update_flags, update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   AssertIndexRange(i, this->mapping_output.inverse_jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6153,7 +6155,7 @@ template <int dim, int spacedim>
 inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::normal_vector(const unsigned int i) const
 {
-  Assert(contains(this->update_flags, update_normal_vectors),
+  Assert(contains_bits(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
   AssertIndexRange(i, this->mapping_output.normal_vectors.size());
@@ -6237,7 +6239,7 @@ inline const Tensor<1, spacedim> &
 FEFaceValuesBase<dim, spacedim>::boundary_form(const unsigned int i) const
 {
   AssertIndexRange(i, this->mapping_output.boundary_forms.size());
-  Assert(contains(this->update_flags, update_boundary_forms),
+  Assert(contains_bits(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
 

--- a/include/deal.II/fe/fe_values.h
+++ b/include/deal.II/fe/fe_values.h
@@ -4653,7 +4653,7 @@ namespace FEValuesViews
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
     Assert(
-      contains_bits(fe_values->update_flags, update_values),
+      fe_values->update_flags.contains(update_values),
       ((typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
         "update_values"))));
 
@@ -4675,7 +4675,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4698,7 +4698,7 @@ namespace FEValuesViews
                                  const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -4720,7 +4720,7 @@ namespace FEValuesViews
                                           const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -4743,7 +4743,7 @@ namespace FEValuesViews
                                const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -4781,7 +4781,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4821,7 +4821,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -4858,7 +4858,7 @@ namespace FEValuesViews
     // this function works like in the case above
 
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     // same as for the scalar case except that we have one more index
@@ -5030,7 +5030,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
 
@@ -5070,7 +5070,7 @@ namespace FEValuesViews
   {
     // this function works like in the case above
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
 
@@ -5177,7 +5177,7 @@ namespace FEValuesViews
                                             const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5212,7 +5212,7 @@ namespace FEValuesViews
                                            const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5257,7 +5257,7 @@ namespace FEValuesViews
     const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5335,7 +5335,7 @@ namespace FEValuesViews
                                   const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
 
@@ -5385,7 +5385,7 @@ namespace FEValuesViews
                                        const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5441,7 +5441,7 @@ namespace FEValuesViews
                                      const unsigned int q_point) const
   {
     AssertIndexRange(shape_function, fe_values->fe->n_dofs_per_cell());
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
 
@@ -5572,7 +5572,7 @@ FEValuesBase<dim, spacedim>::shape_value(const unsigned int i,
                                          const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5608,7 +5608,7 @@ FEValuesBase<dim, spacedim>::shape_value_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5636,7 +5636,7 @@ FEValuesBase<dim, spacedim>::shape_grad(const unsigned int i,
                                         const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5672,7 +5672,7 @@ FEValuesBase<dim, spacedim>::shape_grad_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5699,7 +5699,7 @@ FEValuesBase<dim, spacedim>::shape_hessian(const unsigned int i,
                                            const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5735,7 +5735,7 @@ FEValuesBase<dim, spacedim>::shape_hessian_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5762,7 +5762,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative(const unsigned int i,
                                                   const unsigned int j) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(fe->is_primitive(i), ExcShapeFunctionNotPrimitive(i));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5798,7 +5798,7 @@ FEValuesBase<dim, spacedim>::shape_3rd_derivative_component(
   const unsigned int component) const
 {
   AssertIndexRange(i, fe->n_dofs_per_cell());
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertIndexRange(component, fe->n_components());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5850,7 +5850,7 @@ template <int dim, int spacedim>
 inline const std::vector<Point<spacedim>> &
 FEValuesBase<dim, spacedim>::get_quadrature_points() const
 {
-  Assert(contains_bits(this->update_flags, update_quadrature_points),
+  Assert(this->update_flags.contains(update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.quadrature_points;
@@ -5862,7 +5862,7 @@ template <int dim, int spacedim>
 inline const std::vector<double> &
 FEValuesBase<dim, spacedim>::get_JxW_values() const
 {
-  Assert(contains_bits(this->update_flags, update_JxW_values),
+  Assert(this->update_flags.contains(update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.JxW_values;
@@ -5874,7 +5874,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobians() const
 {
-  Assert(contains_bits(this->update_flags, update_jacobians),
+  Assert(this->update_flags.contains(update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobians;
@@ -5886,7 +5886,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<2, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_grads() const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_grads),
+  Assert(this->update_flags.contains(update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_grads;
@@ -5899,8 +5899,7 @@ inline const Tensor<3, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_grad(
   const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_grads),
+  Assert(this->update_flags.contains(update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads[i];
@@ -5912,8 +5911,7 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<3, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_grads() const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_grads),
+  Assert(this->update_flags.contains(update_jacobian_pushed_forward_grads),
          ExcAccessToUninitializedField("update_jacobian_pushed_forward_grads"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_pushed_forward_grads;
@@ -5925,7 +5923,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<3, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_2nd_derivative(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_2nd_derivatives),
+  Assert(this->update_flags.contains(update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives[i];
@@ -5937,7 +5935,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<3, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_2nd_derivatives() const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_2nd_derivatives),
+  Assert(this->update_flags.contains(update_jacobian_2nd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_2nd_derivatives;
@@ -5950,8 +5948,8 @@ inline const Tensor<4, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_2nd_derivative(
   const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(this->update_flags.contains(
+           update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5964,8 +5962,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<4, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_2nd_derivatives() const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_2nd_derivatives),
+  Assert(this->update_flags.contains(
+           update_jacobian_pushed_forward_2nd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_2nd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -5978,7 +5976,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<4, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_3rd_derivative(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_3rd_derivatives),
+  Assert(this->update_flags.contains(update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives[i];
@@ -5990,7 +5988,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<4, dim, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_3rd_derivatives() const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_3rd_derivatives),
+  Assert(this->update_flags.contains(update_jacobian_3rd_derivatives),
          ExcAccessToUninitializedField("update_jacobian_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.jacobian_3rd_derivatives;
@@ -6003,8 +6001,8 @@ inline const Tensor<5, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_pushed_forward_3rd_derivative(
   const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(this->update_flags.contains(
+           update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6017,8 +6015,8 @@ template <int dim, int spacedim>
 inline const std::vector<Tensor<5, spacedim>> &
 FEValuesBase<dim, spacedim>::get_jacobian_pushed_forward_3rd_derivatives() const
 {
-  Assert(contains_bits(this->update_flags,
-                       update_jacobian_pushed_forward_3rd_derivatives),
+  Assert(this->update_flags.contains(
+           update_jacobian_pushed_forward_3rd_derivatives),
          ExcAccessToUninitializedField(
            "update_jacobian_pushed_forward_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6031,7 +6029,7 @@ template <int dim, int spacedim>
 inline const std::vector<DerivativeForm<1, spacedim, dim>> &
 FEValuesBase<dim, spacedim>::get_inverse_jacobians() const
 {
-  Assert(contains_bits(this->update_flags, update_inverse_jacobians),
+  Assert(this->update_flags.contains(update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   return this->mapping_output.inverse_jacobians;
@@ -6085,7 +6083,7 @@ template <int dim, int spacedim>
 inline const Point<spacedim> &
 FEValuesBase<dim, spacedim>::quadrature_point(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_quadrature_points),
+  Assert(this->update_flags.contains(update_quadrature_points),
          ExcAccessToUninitializedField("update_quadrature_points"));
   AssertIndexRange(i, this->mapping_output.quadrature_points.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6099,7 +6097,7 @@ template <int dim, int spacedim>
 inline double
 FEValuesBase<dim, spacedim>::JxW(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_JxW_values),
+  Assert(this->update_flags.contains(update_JxW_values),
          ExcAccessToUninitializedField("update_JxW_values"));
   AssertIndexRange(i, this->mapping_output.JxW_values.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6113,7 +6111,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_jacobians),
+  Assert(this->update_flags.contains(update_jacobians),
          ExcAccessToUninitializedField("update_jacobians"));
   AssertIndexRange(i, this->mapping_output.jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6127,7 +6125,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<2, dim, spacedim> &
 FEValuesBase<dim, spacedim>::jacobian_grad(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_jacobian_grads),
+  Assert(this->update_flags.contains(update_jacobian_grads),
          ExcAccessToUninitializedField("update_jacobians_grads"));
   AssertIndexRange(i, this->mapping_output.jacobian_grads.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6141,7 +6139,7 @@ template <int dim, int spacedim>
 inline const DerivativeForm<1, spacedim, dim> &
 FEValuesBase<dim, spacedim>::inverse_jacobian(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_inverse_jacobians),
+  Assert(this->update_flags.contains(update_inverse_jacobians),
          ExcAccessToUninitializedField("update_inverse_jacobians"));
   AssertIndexRange(i, this->mapping_output.inverse_jacobians.size());
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -6155,7 +6153,7 @@ template <int dim, int spacedim>
 inline const Tensor<1, spacedim> &
 FEValuesBase<dim, spacedim>::normal_vector(const unsigned int i) const
 {
-  Assert(contains_bits(this->update_flags, update_normal_vectors),
+  Assert(this->update_flags.contains(update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
   AssertIndexRange(i, this->mapping_output.normal_vectors.size());
@@ -6239,7 +6237,7 @@ inline const Tensor<1, spacedim> &
 FEFaceValuesBase<dim, spacedim>::boundary_form(const unsigned int i) const
 {
   AssertIndexRange(i, this->mapping_output.boundary_forms.size());
-  Assert(contains_bits(this->update_flags, update_boundary_forms),
+  Assert(this->update_flags.contains(update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
 

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1125,16 +1125,15 @@ namespace internal
       constexpr unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
       EvaluationFlags::EvaluationFlags evaluation_flag =
-        (contains_bits(update_flags, update_quadrature_points) ?
+        (update_flags.contains(update_quadrature_points) ?
            EvaluationFlags::values :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (contains_bits(update_flags,
-                            update_contravariant_transformation)) ?
+             (update_flags.contains(update_contravariant_transformation)) ?
            EvaluationFlags::gradients :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (contains_bits(update_flags, update_jacobian_grads)) ?
+             (update_flags.contains(update_jacobian_grads)) ?
            EvaluationFlags::hessians :
            EvaluationFlags::nothing);
 
@@ -1232,13 +1231,13 @@ namespace internal
                                              j][in_comp];
                   }
         }
-      if (contains_bits(update_flags, update_covariant_transformation))
+      if (update_flags.contains(update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.covariant[point] =
               (data.contravariant[point]).covariant_form();
 
-      if (contains_bits(update_flags, update_volume_elements))
+      if (update_flags.contains(update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.volume_elements[point] =
@@ -1299,7 +1298,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         for (unsigned int point = 0; point < quadrature_points.size(); ++point)
           {
             const double *  shape = &data.shape(point + data_set, 0);
@@ -1331,7 +1330,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains_bits(update_flags, update_contravariant_transformation))
+      if (update_flags.contains(update_contravariant_transformation))
         // if the current cell is just a
         // translation of the previous one, no
         // need to recompute jacobians...
@@ -1372,7 +1371,7 @@ namespace internal
               }
           }
 
-      if (contains_bits(update_flags, update_covariant_transformation))
+      if (update_flags.contains(update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1383,7 +1382,7 @@ namespace internal
               }
           }
 
-      if (contains_bits(update_flags, update_volume_elements))
+      if (update_flags.contains(update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1410,7 +1409,7 @@ namespace internal
       std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags, update_jacobian_grads))
+      if (update_flags.contains(update_jacobian_grads))
         {
           const unsigned int n_q_points = jacobian_grads.size();
 
@@ -1457,7 +1456,7 @@ namespace internal
       std::vector<Tensor<3, spacedim>> &jacobian_pushed_forward_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
+      if (update_flags.contains(update_jacobian_pushed_forward_grads))
         {
           const unsigned int n_q_points = jacobian_pushed_forward_grads.size();
 
@@ -1531,7 +1530,7 @@ namespace internal
       std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
+      if (update_flags.contains(update_jacobian_2nd_derivatives))
         {
           const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -1587,8 +1586,7 @@ namespace internal
       std::vector<Tensor<4, spacedim>> &jacobian_pushed_forward_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags,
-                        update_jacobian_pushed_forward_2nd_derivatives))
+      if (update_flags.contains(update_jacobian_pushed_forward_2nd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_2nd_derivatives.size();
@@ -1689,7 +1687,7 @@ namespace internal
       std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
+      if (update_flags.contains(update_jacobian_3rd_derivatives))
         {
           const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1748,8 +1746,7 @@ namespace internal
       std::vector<Tensor<5, spacedim>> &jacobian_pushed_forward_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains_bits(update_flags,
-                        update_jacobian_pushed_forward_3rd_derivatives))
+      if (update_flags.contains(update_jacobian_pushed_forward_3rd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_3rd_derivatives.size();
@@ -1882,16 +1879,15 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains_bits(update_flags,
-                        (update_boundary_forms | update_normal_vectors |
-                         update_jacobians | update_JxW_values |
-                         update_inverse_jacobians)))
+      if (update_flags.contains((update_boundary_forms | update_normal_vectors |
+                                 update_jacobians | update_JxW_values |
+                                 update_inverse_jacobians)))
         {
-          if (contains_bits(update_flags, update_boundary_forms))
+          if (update_flags.contains(update_boundary_forms))
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-          if (contains_bits(update_flags, update_normal_vectors))
+          if (update_flags.contains(update_normal_vectors))
             AssertDimension(output_data.normal_vectors.size(), n_q_points);
-          if (contains_bits(update_flags, update_JxW_values))
+          if (update_flags.contains(update_JxW_values))
             AssertDimension(output_data.JxW_values.size(), n_q_points);
 
           Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1924,7 +1920,7 @@ namespace internal
                 make_array_view(data.aux[d].begin(), data.aux[d].end()));
             }
 
-          if (contains_bits(update_flags, update_boundary_forms))
+          if (update_flags.contains(update_boundary_forms))
             {
               // if dim==spacedim, we can use the unit tangentials to compute
               // the boundary form by simply taking the cross product
@@ -1994,7 +1990,7 @@ namespace internal
                 }
             }
 
-          if (contains_bits(update_flags, update_JxW_values))
+          if (update_flags.contains(update_JxW_values))
             for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
               {
                 output_data.JxW_values[i] =
@@ -2008,17 +2004,17 @@ namespace internal
                   }
               }
 
-          if (contains_bits(update_flags, update_normal_vectors))
+          if (update_flags.contains(update_normal_vectors))
             for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
               output_data.normal_vectors[i] =
                 Point<spacedim>(output_data.boundary_forms[i] /
                                 output_data.boundary_forms[i].norm());
 
-          if (contains_bits(update_flags, update_jacobians))
+          if (update_flags.contains(update_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.jacobians[point] = data.contravariant[point];
 
-          if (contains_bits(update_flags, update_inverse_jacobians))
+          if (update_flags.contains(update_inverse_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.inverse_jacobians[point] =
                 data.covariant[point].transpose();
@@ -2127,8 +2123,8 @@ namespace internal
         {
           case mapping_contravariant:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2141,11 +2137,11 @@ namespace internal
 
           case mapping_piola:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains_bits(data.update_each, update_volume_elements),
+              Assert(data.update_each.contains(update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -2165,8 +2161,8 @@ namespace internal
           // rather than DerivativeForm
           case mapping_covariant:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2208,12 +2204,11 @@ namespace internal
         {
           case mapping_contravariant_gradient:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2232,8 +2227,7 @@ namespace internal
 
           case mapping_covariant_gradient:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2252,15 +2246,14 @@ namespace internal
 
           case mapping_piola_gradient:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains_bits(data.update_each, update_volume_elements),
+              Assert(data.update_each.contains(update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2311,12 +2304,11 @@ namespace internal
         {
           case mapping_contravariant_hessian:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2357,8 +2349,7 @@ namespace internal
 
           case mapping_covariant_hessian:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2400,15 +2391,14 @@ namespace internal
 
           case mapping_piola_hessian:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_covariant_transformation),
+              Assert(data.update_each.contains(update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains_bits(data.update_each, update_volume_elements),
+              Assert(data.update_each.contains(update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
 
@@ -2483,8 +2473,8 @@ namespace internal
         {
           case mapping_covariant:
             {
-              Assert(contains_bits(data.update_each,
-                                   update_contravariant_transformation),
+              Assert(data.update_each.contains(
+                       update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1125,14 +1125,15 @@ namespace internal
       constexpr unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
       EvaluationFlags::EvaluationFlags evaluation_flag =
-        (update_flags & update_quadrature_points ? EvaluationFlags::values :
-                                                   EvaluationFlags::nothing) |
+        (contains(update_flags, update_quadrature_points) ?
+           EvaluationFlags::values :
+           EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (update_flags & update_contravariant_transformation) ?
+             (contains(update_flags, update_contravariant_transformation)) ?
            EvaluationFlags::gradients :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (update_flags & update_jacobian_grads) ?
+             (contains(update_flags, update_jacobian_grads)) ?
            EvaluationFlags::hessians :
            EvaluationFlags::nothing);
 
@@ -1229,13 +1230,13 @@ namespace internal
                                              j][in_comp];
                   }
         }
-      if (update_flags & update_covariant_transformation)
+      if (contains(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.covariant[point] =
               (data.contravariant[point]).covariant_form();
 
-      if (update_flags & update_volume_elements)
+      if (contains(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.volume_elements[point] =
@@ -1296,7 +1297,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         for (unsigned int point = 0; point < quadrature_points.size(); ++point)
           {
             const double *  shape = &data.shape(point + data_set, 0);
@@ -1328,7 +1329,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags & update_contravariant_transformation)
+      if (contains(update_flags, update_contravariant_transformation))
         // if the current cell is just a
         // translation of the previous one, no
         // need to recompute jacobians...
@@ -1369,7 +1370,7 @@ namespace internal
               }
           }
 
-      if (update_flags & update_covariant_transformation)
+      if (contains(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1380,7 +1381,7 @@ namespace internal
               }
           }
 
-      if (update_flags & update_volume_elements)
+      if (contains(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1407,7 +1408,7 @@ namespace internal
       std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_grads)
+      if (contains(update_flags, update_jacobian_grads))
         {
           const unsigned int n_q_points = jacobian_grads.size();
 
@@ -1454,7 +1455,7 @@ namespace internal
       std::vector<Tensor<3, spacedim>> &jacobian_pushed_forward_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_grads)
+      if (contains(update_flags, update_jacobian_pushed_forward_grads))
         {
           const unsigned int n_q_points = jacobian_pushed_forward_grads.size();
 
@@ -1528,7 +1529,7 @@ namespace internal
       std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_2nd_derivatives)
+      if (contains(update_flags, update_jacobian_2nd_derivatives))
         {
           const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -1584,7 +1585,8 @@ namespace internal
       std::vector<Tensor<4, spacedim>> &jacobian_pushed_forward_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_2nd_derivatives)
+      if (contains(update_flags,
+                   update_jacobian_pushed_forward_2nd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_2nd_derivatives.size();
@@ -1685,7 +1687,7 @@ namespace internal
       std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_3rd_derivatives)
+      if (contains(update_flags, update_jacobian_3rd_derivatives))
         {
           const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1744,7 +1746,8 @@ namespace internal
       std::vector<Tensor<5, spacedim>> &jacobian_pushed_forward_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (update_flags & update_jacobian_pushed_forward_3rd_derivatives)
+      if (contains(update_flags,
+                   update_jacobian_pushed_forward_3rd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_3rd_derivatives.size();
@@ -1877,15 +1880,16 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (update_flags &
-          (update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_JxW_values | update_inverse_jacobians))
+      if (contains(update_flags,
+                   (update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_JxW_values |
+                    update_inverse_jacobians)))
         {
-          if (update_flags & update_boundary_forms)
+          if (contains(update_flags, update_boundary_forms))
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             AssertDimension(output_data.normal_vectors.size(), n_q_points);
-          if (update_flags & update_JxW_values)
+          if (contains(update_flags, update_JxW_values))
             AssertDimension(output_data.JxW_values.size(), n_q_points);
 
           Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1918,7 +1922,7 @@ namespace internal
                 make_array_view(data.aux[d].begin(), data.aux[d].end()));
             }
 
-          if (update_flags & update_boundary_forms)
+          if (contains(update_flags, update_boundary_forms))
             {
               // if dim==spacedim, we can use the unit tangentials to compute
               // the boundary form by simply taking the cross product
@@ -1988,7 +1992,7 @@ namespace internal
                 }
             }
 
-          if (update_flags & update_JxW_values)
+          if (contains(update_flags, update_JxW_values))
             for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
               {
                 output_data.JxW_values[i] =
@@ -2002,17 +2006,17 @@ namespace internal
                   }
               }
 
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
               output_data.normal_vectors[i] =
                 Point<spacedim>(output_data.boundary_forms[i] /
                                 output_data.boundary_forms[i].norm());
 
-          if (update_flags & update_jacobians)
+          if (contains(update_flags, update_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.jacobians[point] = data.contravariant[point];
 
-          if (update_flags & update_inverse_jacobians)
+          if (contains(update_flags, update_inverse_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.inverse_jacobians[point] =
                 data.covariant[point].transpose();
@@ -2121,7 +2125,8 @@ namespace internal
         {
           case mapping_contravariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2134,10 +2139,11 @@ namespace internal
 
           case mapping_piola:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -2157,7 +2163,8 @@ namespace internal
           // rather than DerivativeForm
           case mapping_covariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2199,10 +2206,12 @@ namespace internal
         {
           case mapping_contravariant_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2221,7 +2230,8 @@ namespace internal
 
           case mapping_covariant_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2240,13 +2250,15 @@ namespace internal
 
           case mapping_piola_gradient:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2297,10 +2309,12 @@ namespace internal
         {
           case mapping_contravariant_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2341,7 +2355,8 @@ namespace internal
 
           case mapping_covariant_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2383,13 +2398,15 @@ namespace internal
 
           case mapping_piola_hessian:
             {
-              Assert(data.update_each & update_covariant_transformation,
+              Assert(contains(data.update_each,
+                              update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(data.update_each & update_volume_elements,
+              Assert(contains(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
 
@@ -2464,7 +2481,8 @@ namespace internal
         {
           case mapping_covariant:
             {
-              Assert(data.update_each & update_contravariant_transformation,
+              Assert(contains(data.update_each,
+                              update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1125,31 +1125,32 @@ namespace internal
       constexpr unsigned int n_hessians     = (dim * (dim + 1)) / 2;
 
       EvaluationFlags::EvaluationFlags evaluation_flag =
-        (contains(update_flags, update_quadrature_points) ?
+        (contains_bits(update_flags, update_quadrature_points) ?
            EvaluationFlags::values :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (contains(update_flags, update_contravariant_transformation)) ?
+             (contains_bits(update_flags,
+                            update_contravariant_transformation)) ?
            EvaluationFlags::gradients :
            EvaluationFlags::nothing) |
         ((cell_similarity != CellSimilarity::translation) &&
-             (contains(update_flags, update_jacobian_grads)) ?
+             (contains_bits(update_flags, update_jacobian_grads)) ?
            EvaluationFlags::hessians :
            EvaluationFlags::nothing);
 
-      Assert(!(contains(evaluation_flag, EvaluationFlags::values)) ||
+      Assert(!(contains_bits(evaluation_flag, EvaluationFlags::values)) ||
                n_q_points > 0,
              ExcInternalError());
-      Assert(!(contains(evaluation_flag, EvaluationFlags::values)) ||
+      Assert(!(contains_bits(evaluation_flag, EvaluationFlags::values)) ||
                n_q_points == quadrature_points.size(),
              ExcDimensionMismatch(n_q_points, quadrature_points.size()));
-      Assert(!(contains(evaluation_flag, EvaluationFlags::gradients)) ||
+      Assert(!(contains_bits(evaluation_flag, EvaluationFlags::gradients)) ||
                data.n_shape_functions > 0,
              ExcInternalError());
-      Assert(!(contains(evaluation_flag, EvaluationFlags::gradients)) ||
+      Assert(!(contains_bits(evaluation_flag, EvaluationFlags::gradients)) ||
                n_q_points == data.contravariant.size(),
              ExcDimensionMismatch(n_q_points, data.contravariant.size()));
-      Assert(!(contains(evaluation_flag, EvaluationFlags::hessians)) ||
+      Assert(!(contains_bits(evaluation_flag, EvaluationFlags::hessians)) ||
                n_q_points == jacobian_grads.size(),
              ExcDimensionMismatch(n_q_points, jacobian_grads.size()));
 
@@ -1196,7 +1197,7 @@ namespace internal
         }
 
       // do the postprocessing
-      if (contains(evaluation_flag, EvaluationFlags::values))
+      if (contains_bits(evaluation_flag, EvaluationFlags::values))
         {
           for (unsigned int out_comp = 0; out_comp < n_comp; ++out_comp)
             for (unsigned int i = 0; i < n_q_points; ++i)
@@ -1207,7 +1208,7 @@ namespace internal
                   eval.begin_values()[out_comp * n_q_points + i][in_comp];
         }
 
-      if (contains(evaluation_flag, EvaluationFlags::gradients))
+      if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
         {
           std::fill(data.contravariant.begin(),
                     data.contravariant.end(),
@@ -1231,19 +1232,19 @@ namespace internal
                                              j][in_comp];
                   }
         }
-      if (contains(update_flags, update_covariant_transformation))
+      if (contains_bits(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.covariant[point] =
               (data.contravariant[point]).covariant_form();
 
-      if (contains(update_flags, update_volume_elements))
+      if (contains_bits(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           for (unsigned int point = 0; point < n_q_points; ++point)
             data.volume_elements[point] =
               data.contravariant[point].determinant();
 
-      if (contains(evaluation_flag, EvaluationFlags::hessians))
+      if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
         {
           constexpr int desymmetrize_3d[6][2] = {
             {0, 0}, {1, 1}, {2, 2}, {0, 1}, {0, 2}, {1, 2}};
@@ -1298,7 +1299,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         for (unsigned int point = 0; point < quadrature_points.size(); ++point)
           {
             const double *  shape = &data.shape(point + data_set, 0);
@@ -1330,7 +1331,7 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains(update_flags, update_contravariant_transformation))
+      if (contains_bits(update_flags, update_contravariant_transformation))
         // if the current cell is just a
         // translation of the previous one, no
         // need to recompute jacobians...
@@ -1371,7 +1372,7 @@ namespace internal
               }
           }
 
-      if (contains(update_flags, update_covariant_transformation))
+      if (contains_bits(update_flags, update_covariant_transformation))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1382,7 +1383,7 @@ namespace internal
               }
           }
 
-      if (contains(update_flags, update_volume_elements))
+      if (contains_bits(update_flags, update_volume_elements))
         if (cell_similarity != CellSimilarity::translation)
           {
             const unsigned int n_q_points = data.contravariant.size();
@@ -1409,7 +1410,7 @@ namespace internal
       std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags, update_jacobian_grads))
+      if (contains_bits(update_flags, update_jacobian_grads))
         {
           const unsigned int n_q_points = jacobian_grads.size();
 
@@ -1456,7 +1457,7 @@ namespace internal
       std::vector<Tensor<3, spacedim>> &jacobian_pushed_forward_grads)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags, update_jacobian_pushed_forward_grads))
+      if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
         {
           const unsigned int n_q_points = jacobian_pushed_forward_grads.size();
 
@@ -1530,7 +1531,7 @@ namespace internal
       std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags, update_jacobian_2nd_derivatives))
+      if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
         {
           const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -1586,8 +1587,8 @@ namespace internal
       std::vector<Tensor<4, spacedim>> &jacobian_pushed_forward_2nd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags,
-                   update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains_bits(update_flags,
+                        update_jacobian_pushed_forward_2nd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_2nd_derivatives.size();
@@ -1688,7 +1689,7 @@ namespace internal
       std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags, update_jacobian_3rd_derivatives))
+      if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
         {
           const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1747,8 +1748,8 @@ namespace internal
       std::vector<Tensor<5, spacedim>> &jacobian_pushed_forward_3rd_derivatives)
     {
       const UpdateFlags update_flags = data.update_each;
-      if (contains(update_flags,
-                   update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains_bits(update_flags,
+                        update_jacobian_pushed_forward_3rd_derivatives))
         {
           const unsigned int n_q_points =
             jacobian_pushed_forward_3rd_derivatives.size();
@@ -1881,16 +1882,16 @@ namespace internal
     {
       const UpdateFlags update_flags = data.update_each;
 
-      if (contains(update_flags,
-                   (update_boundary_forms | update_normal_vectors |
-                    update_jacobians | update_JxW_values |
-                    update_inverse_jacobians)))
+      if (contains_bits(update_flags,
+                        (update_boundary_forms | update_normal_vectors |
+                         update_jacobians | update_JxW_values |
+                         update_inverse_jacobians)))
         {
-          if (contains(update_flags, update_boundary_forms))
+          if (contains_bits(update_flags, update_boundary_forms))
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-          if (contains(update_flags, update_normal_vectors))
+          if (contains_bits(update_flags, update_normal_vectors))
             AssertDimension(output_data.normal_vectors.size(), n_q_points);
-          if (contains(update_flags, update_JxW_values))
+          if (contains_bits(update_flags, update_JxW_values))
             AssertDimension(output_data.JxW_values.size(), n_q_points);
 
           Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1923,7 +1924,7 @@ namespace internal
                 make_array_view(data.aux[d].begin(), data.aux[d].end()));
             }
 
-          if (contains(update_flags, update_boundary_forms))
+          if (contains_bits(update_flags, update_boundary_forms))
             {
               // if dim==spacedim, we can use the unit tangentials to compute
               // the boundary form by simply taking the cross product
@@ -1993,7 +1994,7 @@ namespace internal
                 }
             }
 
-          if (contains(update_flags, update_JxW_values))
+          if (contains_bits(update_flags, update_JxW_values))
             for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
               {
                 output_data.JxW_values[i] =
@@ -2007,17 +2008,17 @@ namespace internal
                   }
               }
 
-          if (contains(update_flags, update_normal_vectors))
+          if (contains_bits(update_flags, update_normal_vectors))
             for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
               output_data.normal_vectors[i] =
                 Point<spacedim>(output_data.boundary_forms[i] /
                                 output_data.boundary_forms[i].norm());
 
-          if (contains(update_flags, update_jacobians))
+          if (contains_bits(update_flags, update_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.jacobians[point] = data.contravariant[point];
 
-          if (contains(update_flags, update_inverse_jacobians))
+          if (contains_bits(update_flags, update_inverse_jacobians))
             for (unsigned int point = 0; point < n_q_points; ++point)
               output_data.inverse_jacobians[point] =
                 data.covariant[point].transpose();
@@ -2126,8 +2127,8 @@ namespace internal
         {
           case mapping_contravariant:
             {
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2140,11 +2141,11 @@ namespace internal
 
           case mapping_piola:
             {
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains(data.update_each, update_volume_elements),
+              Assert(contains_bits(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -2164,8 +2165,8 @@ namespace internal
           // rather than DerivativeForm
           case mapping_covariant:
             {
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2207,12 +2208,12 @@ namespace internal
         {
           case mapping_contravariant_gradient:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2231,8 +2232,8 @@ namespace internal
 
           case mapping_covariant_gradient:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2251,15 +2252,15 @@ namespace internal
 
           case mapping_piola_gradient:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains(data.update_each, update_volume_elements),
+              Assert(contains_bits(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
               Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -2310,12 +2311,12 @@ namespace internal
         {
           case mapping_contravariant_hessian:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
 
@@ -2356,8 +2357,8 @@ namespace internal
 
           case mapping_covariant_hessian:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 
@@ -2399,15 +2400,15 @@ namespace internal
 
           case mapping_piola_hessian:
             {
-              Assert(contains(data.update_each,
-                              update_covariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_covariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_contravariant_transformation"));
-              Assert(contains(data.update_each, update_volume_elements),
+              Assert(contains_bits(data.update_each, update_volume_elements),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_volume_elements"));
 
@@ -2482,8 +2483,8 @@ namespace internal
         {
           case mapping_covariant:
             {
-              Assert(contains(data.update_each,
-                              update_contravariant_transformation),
+              Assert(contains_bits(data.update_each,
+                                   update_contravariant_transformation),
                      typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                        "update_covariant_transformation"));
 

--- a/include/deal.II/fe/mapping_q_internal.h
+++ b/include/deal.II/fe/mapping_q_internal.h
@@ -1137,18 +1137,19 @@ namespace internal
            EvaluationFlags::hessians :
            EvaluationFlags::nothing);
 
-      Assert(!(evaluation_flag & EvaluationFlags::values) || n_q_points > 0,
+      Assert(!(contains(evaluation_flag, EvaluationFlags::values)) ||
+               n_q_points > 0,
              ExcInternalError());
-      Assert(!(evaluation_flag & EvaluationFlags::values) ||
+      Assert(!(contains(evaluation_flag, EvaluationFlags::values)) ||
                n_q_points == quadrature_points.size(),
              ExcDimensionMismatch(n_q_points, quadrature_points.size()));
-      Assert(!(evaluation_flag & EvaluationFlags::gradients) ||
+      Assert(!(contains(evaluation_flag, EvaluationFlags::gradients)) ||
                data.n_shape_functions > 0,
              ExcInternalError());
-      Assert(!(evaluation_flag & EvaluationFlags::gradients) ||
+      Assert(!(contains(evaluation_flag, EvaluationFlags::gradients)) ||
                n_q_points == data.contravariant.size(),
              ExcDimensionMismatch(n_q_points, data.contravariant.size()));
-      Assert(!(evaluation_flag & EvaluationFlags::hessians) ||
+      Assert(!(contains(evaluation_flag, EvaluationFlags::hessians)) ||
                n_q_points == jacobian_grads.size(),
              ExcDimensionMismatch(n_q_points, jacobian_grads.size()));
 
@@ -1195,7 +1196,7 @@ namespace internal
         }
 
       // do the postprocessing
-      if (evaluation_flag & EvaluationFlags::values)
+      if (contains(evaluation_flag, EvaluationFlags::values))
         {
           for (unsigned int out_comp = 0; out_comp < n_comp; ++out_comp)
             for (unsigned int i = 0; i < n_q_points; ++i)
@@ -1206,7 +1207,7 @@ namespace internal
                   eval.begin_values()[out_comp * n_q_points + i][in_comp];
         }
 
-      if (evaluation_flag & EvaluationFlags::gradients)
+      if (contains(evaluation_flag, EvaluationFlags::gradients))
         {
           std::fill(data.contravariant.begin(),
                     data.contravariant.end(),
@@ -1242,7 +1243,7 @@ namespace internal
             data.volume_elements[point] =
               data.contravariant[point].determinant();
 
-      if (evaluation_flag & EvaluationFlags::hessians)
+      if (contains(evaluation_flag, EvaluationFlags::hessians))
         {
           constexpr int desymmetrize_3d[6][2] = {
             {0, 0}, {1, 1}, {2, 2}, {0, 1}, {0, 2}, {1, 2}};

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -169,11 +169,11 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags
-  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
-  {
+  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2) = delete;
+/*  {
     return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
                                          static_cast<unsigned int>(f2));
-  }
+  }*/
 
 
   /**
@@ -183,11 +183,17 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags &
-  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2)
-  {
+  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2) = delete;
+/*  {
     f1 = f1 & f2;
     return f1;
-  }
+  }*/
+
+bool contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
+{
+  using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
+}
 
 } // namespace GridTools
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -123,8 +123,9 @@ namespace GridTools
   inline CacheUpdateFlags
   operator|(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
   {
-    return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) |
-                                         static_cast<unsigned int>(f2));
+    using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+    return static_cast<CacheUpdateFlags>(static_cast<enum_type>(f1) |
+                                         static_cast<enum_type>(f2));
   }
 
   /**
@@ -139,8 +140,9 @@ namespace GridTools
   inline CacheUpdateFlags
   operator~(const CacheUpdateFlags f1)
   {
-    return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) ^
-                                         static_cast<unsigned int>(update_all));
+    using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+    return static_cast<CacheUpdateFlags>(static_cast<enum_type>(f1) ^
+                                         static_cast<enum_type>(update_all));
   }
 
 
@@ -169,11 +171,12 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags
-  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2) = delete;
-  /*  {
-      return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
-                                           static_cast<unsigned int>(f2));
-    }*/
+  operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2)
+  {
+    using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+    return static_cast<CacheUpdateFlags>(static_cast<enum_type>(f1) &
+                                         static_cast<enum_type>(f2));
+  }
 
 
   /**
@@ -183,19 +186,25 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline CacheUpdateFlags &
-  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2) = delete;
-  /*  {
-      f1 = f1 & f2;
-      return f1;
-    }*/
+  operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2)
+  {
+    f1 = f1 & f2;
+    return f1;
+  }
 
+
+  /**
+   * Global operator which checks if the flags contained in the first argument
+   * contain the flags contained in the second argument.
+   *
+   * @ref CacheUpdateFlags
+   */
   inline bool
   contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
   {
     using enum_type = std::underlying_type_t<CacheUpdateFlags>;
     return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
   }
-
 } // namespace GridTools
 DEAL_II_NAMESPACE_CLOSE
 

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -170,10 +170,10 @@ namespace GridTools
    */
   inline CacheUpdateFlags
   operator&(const CacheUpdateFlags f1, const CacheUpdateFlags f2) = delete;
-/*  {
-    return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
-                                         static_cast<unsigned int>(f2));
-  }*/
+  /*  {
+      return static_cast<CacheUpdateFlags>(static_cast<unsigned int>(f1) &
+                                           static_cast<unsigned int>(f2));
+    }*/
 
 
   /**
@@ -184,16 +184,17 @@ namespace GridTools
    */
   inline CacheUpdateFlags &
   operator&=(CacheUpdateFlags &f1, const CacheUpdateFlags f2) = delete;
-/*  {
-    f1 = f1 & f2;
-    return f1;
-  }*/
+  /*  {
+      f1 = f1 & f2;
+      return f1;
+    }*/
 
-bool contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
-{
-  using enum_type = std::underlying_type_t<CacheUpdateFlags>;
-  return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) !=0;
-}
+  inline bool
+  contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
+  {
+    using enum_type = std::underlying_type_t<CacheUpdateFlags>;
+    return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
+  }
 
 } // namespace GridTools
 DEAL_II_NAMESPACE_CLOSE

--- a/include/deal.II/grid/grid_tools_cache_update_flags.h
+++ b/include/deal.II/grid/grid_tools_cache_update_flags.h
@@ -200,7 +200,7 @@ namespace GridTools
    * @ref CacheUpdateFlags
    */
   inline bool
-  contains(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
+  contains_bits(const CacheUpdateFlags flags, const CacheUpdateFlags mask)
   {
     using enum_type = std::underlying_type_t<CacheUpdateFlags>;
     return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -860,7 +860,7 @@ namespace CUDAWrappers
 
     const unsigned int n_elements =
       data_host.n_cells * data_host.padding_length;
-    if (contains(update_flags, update_quadrature_points))
+    if (contains_bits(update_flags, update_quadrature_points))
       {
         data_host.q_points.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.q_points, data_host.q_points);
@@ -870,14 +870,14 @@ namespace CUDAWrappers
     Utilities::CUDA::copy_to_host(data.local_to_global,
                                   data_host.local_to_global);
 
-    if (contains(update_flags, update_gradients))
+    if (contains_bits(update_flags, update_gradients))
       {
         data_host.inv_jacobian.resize(n_elements * dim * dim);
         Utilities::CUDA::copy_to_host(data.inv_jacobian,
                                       data_host.inv_jacobian);
       }
 
-    if (contains(update_flags, update_JxW_values))
+    if (contains_bits(update_flags, update_JxW_values))
       {
         data_host.JxW.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.JxW, data_host.JxW);

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -860,7 +860,7 @@ namespace CUDAWrappers
 
     const unsigned int n_elements =
       data_host.n_cells * data_host.padding_length;
-    if (update_flags & update_quadrature_points)
+    if (contains(update_flags, update_quadrature_points))
       {
         data_host.q_points.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.q_points, data_host.q_points);
@@ -870,14 +870,14 @@ namespace CUDAWrappers
     Utilities::CUDA::copy_to_host(data.local_to_global,
                                   data_host.local_to_global);
 
-    if (update_flags & update_gradients)
+    if (contains(update_flags, update_gradients))
       {
         data_host.inv_jacobian.resize(n_elements * dim * dim);
         Utilities::CUDA::copy_to_host(data.inv_jacobian,
                                       data_host.inv_jacobian);
       }
 
-    if (update_flags & update_JxW_values)
+    if (contains(update_flags, update_JxW_values))
       {
         data_host.JxW.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.JxW, data_host.JxW);

--- a/include/deal.II/matrix_free/cuda_matrix_free.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.h
@@ -860,7 +860,7 @@ namespace CUDAWrappers
 
     const unsigned int n_elements =
       data_host.n_cells * data_host.padding_length;
-    if (contains_bits(update_flags, update_quadrature_points))
+    if (update_flags.contains(update_quadrature_points))
       {
         data_host.q_points.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.q_points, data_host.q_points);
@@ -870,14 +870,14 @@ namespace CUDAWrappers
     Utilities::CUDA::copy_to_host(data.local_to_global,
                                   data_host.local_to_global);
 
-    if (contains_bits(update_flags, update_gradients))
+    if (update_flags.contains(update_gradients))
       {
         data_host.inv_jacobian.resize(n_elements * dim * dim);
         Utilities::CUDA::copy_to_host(data.inv_jacobian,
                                       data_host.inv_jacobian);
       }
 
-    if (contains_bits(update_flags, update_JxW_values))
+    if (update_flags.contains(update_JxW_values))
       {
         data_host.JxW.resize(n_elements);
         Utilities::CUDA::copy_to_host(data.JxW, data_host.JxW);

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -300,13 +300,13 @@ namespace CUDAWrappers
 
       data->row_start.resize(n_colors);
 
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         data->q_points.resize(n_colors);
 
-      if (contains(update_flags, update_JxW_values))
+      if (contains_bits(update_flags, update_JxW_values))
         data->JxW.resize(n_colors);
 
-      if (contains(update_flags, update_gradients))
+      if (contains_bits(update_flags, update_gradients))
         data->inv_jacobian.resize(n_colors);
     }
 
@@ -349,13 +349,13 @@ namespace CUDAWrappers
 
       local_to_global_host.resize(n_cells * padding_length);
 
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         q_points_host.resize(n_cells * padding_length);
 
-      if (contains(update_flags, update_JxW_values))
+      if (contains_bits(update_flags, update_JxW_values))
         JxW_host.resize(n_cells * padding_length);
 
-      if (contains(update_flags, update_gradients))
+      if (contains_bits(update_flags, update_gradients))
         inv_jacobian_host.resize(n_cells * padding_length * dim * dim);
 
       constraint_mask_host.resize(n_cells);
@@ -398,7 +398,7 @@ namespace CUDAWrappers
       fe_values.reinit(cell);
 
       // Quadrature points
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         {
           const std::vector<Point<dim>> &q_points =
             fe_values.get_quadrature_points();
@@ -407,7 +407,7 @@ namespace CUDAWrappers
                     &q_points_host[cell_id * padding_length]);
         }
 
-      if (contains(update_flags, update_JxW_values))
+      if (contains_bits(update_flags, update_JxW_values))
         {
           std::vector<double> JxW_values_double = fe_values.get_JxW_values();
           const unsigned int  offset            = cell_id * padding_length;
@@ -415,7 +415,7 @@ namespace CUDAWrappers
             JxW_host[i + offset] = static_cast<Number>(JxW_values_double[i]);
         }
 
-      if (contains(update_flags, update_gradients))
+      if (contains_bits(update_flags, update_gradients))
         {
           const std::vector<DerivativeForm<1, dim, dim>> &inv_jacobians =
             fe_values.get_inverse_jacobians();
@@ -447,7 +447,7 @@ namespace CUDAWrappers
         n_cells * padding_length);
 
       // Quadrature points
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -460,7 +460,7 @@ namespace CUDAWrappers
         }
 
       // Jacobian determinants/quadrature weights
-      if (contains(update_flags, update_JxW_values))
+      if (contains_bits(update_flags, update_JxW_values))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -473,7 +473,7 @@ namespace CUDAWrappers
         }
 
       // Inverse jacobians
-      if (contains(update_flags, update_gradients))
+      if (contains_bits(update_flags, update_gradients))
         {
           // Reorder so that all J_11 elements are together, all J_12 elements
           // are together, etc., i.e., reorder indices from
@@ -902,7 +902,7 @@ namespace CUDAWrappers
       cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
 
     UpdateFlags update_flags = additional_data.mapping_update_flags;
-    if (contains(update_flags, update_gradients))
+    if (contains_bits(update_flags, update_gradients))
       update_flags |= update_JxW_values;
 
     if (additional_data.parallelization_scheme != parallel_over_elem &&
@@ -972,7 +972,7 @@ namespace CUDAWrappers
                          cudaMemcpyHostToDevice);
     AssertCuda(cuda_error);
 
-    if (contains(update_flags, update_gradients))
+    if (contains_bits(update_flags, update_gradients))
       {
         cuda_error =
           cudaMemcpyToSymbol(internal::get_global_shape_gradients<Number>(0),

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -300,13 +300,13 @@ namespace CUDAWrappers
 
       data->row_start.resize(n_colors);
 
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         data->q_points.resize(n_colors);
 
-      if (contains_bits(update_flags, update_JxW_values))
+      if (update_flags.contains(update_JxW_values))
         data->JxW.resize(n_colors);
 
-      if (contains_bits(update_flags, update_gradients))
+      if (update_flags.contains(update_gradients))
         data->inv_jacobian.resize(n_colors);
     }
 
@@ -349,13 +349,13 @@ namespace CUDAWrappers
 
       local_to_global_host.resize(n_cells * padding_length);
 
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         q_points_host.resize(n_cells * padding_length);
 
-      if (contains_bits(update_flags, update_JxW_values))
+      if (update_flags.contains(update_JxW_values))
         JxW_host.resize(n_cells * padding_length);
 
-      if (contains_bits(update_flags, update_gradients))
+      if (update_flags.contains(update_gradients))
         inv_jacobian_host.resize(n_cells * padding_length * dim * dim);
 
       constraint_mask_host.resize(n_cells);
@@ -398,7 +398,7 @@ namespace CUDAWrappers
       fe_values.reinit(cell);
 
       // Quadrature points
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         {
           const std::vector<Point<dim>> &q_points =
             fe_values.get_quadrature_points();
@@ -407,7 +407,7 @@ namespace CUDAWrappers
                     &q_points_host[cell_id * padding_length]);
         }
 
-      if (contains_bits(update_flags, update_JxW_values))
+      if (update_flags.contains(update_JxW_values))
         {
           std::vector<double> JxW_values_double = fe_values.get_JxW_values();
           const unsigned int  offset            = cell_id * padding_length;
@@ -415,7 +415,7 @@ namespace CUDAWrappers
             JxW_host[i + offset] = static_cast<Number>(JxW_values_double[i]);
         }
 
-      if (contains_bits(update_flags, update_gradients))
+      if (update_flags.contains(update_gradients))
         {
           const std::vector<DerivativeForm<1, dim, dim>> &inv_jacobians =
             fe_values.get_inverse_jacobians();
@@ -447,7 +447,7 @@ namespace CUDAWrappers
         n_cells * padding_length);
 
       // Quadrature points
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -460,7 +460,7 @@ namespace CUDAWrappers
         }
 
       // Jacobian determinants/quadrature weights
-      if (contains_bits(update_flags, update_JxW_values))
+      if (update_flags.contains(update_JxW_values))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -473,7 +473,7 @@ namespace CUDAWrappers
         }
 
       // Inverse jacobians
-      if (contains_bits(update_flags, update_gradients))
+      if (update_flags.contains(update_gradients))
         {
           // Reorder so that all J_11 elements are together, all J_12 elements
           // are together, etc., i.e., reorder indices from
@@ -902,7 +902,7 @@ namespace CUDAWrappers
       cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
 
     UpdateFlags update_flags = additional_data.mapping_update_flags;
-    if (contains_bits(update_flags, update_gradients))
+    if (update_flags.contains(update_gradients))
       update_flags |= update_JxW_values;
 
     if (additional_data.parallelization_scheme != parallel_over_elem &&
@@ -972,7 +972,7 @@ namespace CUDAWrappers
                          cudaMemcpyHostToDevice);
     AssertCuda(cuda_error);
 
-    if (contains_bits(update_flags, update_gradients))
+    if (update_flags.contains(update_gradients))
       {
         cuda_error =
           cudaMemcpyToSymbol(internal::get_global_shape_gradients<Number>(0),

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -300,13 +300,13 @@ namespace CUDAWrappers
 
       data->row_start.resize(n_colors);
 
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         data->q_points.resize(n_colors);
 
-      if (update_flags & update_JxW_values)
+      if (contains(update_flags, update_JxW_values))
         data->JxW.resize(n_colors);
 
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         data->inv_jacobian.resize(n_colors);
     }
 
@@ -349,13 +349,13 @@ namespace CUDAWrappers
 
       local_to_global_host.resize(n_cells * padding_length);
 
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         q_points_host.resize(n_cells * padding_length);
 
-      if (update_flags & update_JxW_values)
+      if (contains(update_flags, update_JxW_values))
         JxW_host.resize(n_cells * padding_length);
 
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         inv_jacobian_host.resize(n_cells * padding_length * dim * dim);
 
       constraint_mask_host.resize(n_cells);
@@ -398,7 +398,7 @@ namespace CUDAWrappers
       fe_values.reinit(cell);
 
       // Quadrature points
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         {
           const std::vector<Point<dim>> &q_points =
             fe_values.get_quadrature_points();
@@ -407,7 +407,7 @@ namespace CUDAWrappers
                     &q_points_host[cell_id * padding_length]);
         }
 
-      if (update_flags & update_JxW_values)
+      if (contains(update_flags, update_JxW_values))
         {
           std::vector<double> JxW_values_double = fe_values.get_JxW_values();
           const unsigned int  offset            = cell_id * padding_length;
@@ -415,7 +415,7 @@ namespace CUDAWrappers
             JxW_host[i + offset] = static_cast<Number>(JxW_values_double[i]);
         }
 
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         {
           const std::vector<DerivativeForm<1, dim, dim>> &inv_jacobians =
             fe_values.get_inverse_jacobians();
@@ -447,7 +447,7 @@ namespace CUDAWrappers
         n_cells * padding_length);
 
       // Quadrature points
-      if (update_flags & update_quadrature_points)
+      if (contains(update_flags, update_quadrature_points))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -460,7 +460,7 @@ namespace CUDAWrappers
         }
 
       // Jacobian determinants/quadrature weights
-      if (update_flags & update_JxW_values)
+      if (contains(update_flags, update_JxW_values))
         {
           if (data->parallelization_scheme ==
               MatrixFree<dim, Number>::parallel_over_elem)
@@ -473,7 +473,7 @@ namespace CUDAWrappers
         }
 
       // Inverse jacobians
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         {
           // Reorder so that all J_11 elements are together, all J_12 elements
           // are together, etc., i.e., reorder indices from
@@ -902,7 +902,7 @@ namespace CUDAWrappers
       cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte);
 
     UpdateFlags update_flags = additional_data.mapping_update_flags;
-    if (update_flags & update_gradients)
+    if (contains(update_flags, update_gradients))
       update_flags |= update_JxW_values;
 
     if (additional_data.parallelization_scheme != parallel_over_elem &&
@@ -972,7 +972,7 @@ namespace CUDAWrappers
                          cudaMemcpyHostToDevice);
     AssertCuda(cuda_error);
 
-    if (update_flags & update_gradients)
+    if (contains(update_flags, update_gradients))
       {
         cuda_error =
           cudaMemcpyToSymbol(internal::get_global_shape_gradients<Number>(0),

--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -72,8 +72,9 @@ namespace EvaluationFlags
   inline EvaluationFlags
   operator|(const EvaluationFlags f1, const EvaluationFlags f2)
   {
-    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) |
-                                        static_cast<unsigned int>(f2));
+    using enum_type = std::underlying_type_t<EvaluationFlags>;
+    return static_cast<EvaluationFlags>(static_cast<enum_type>(f1) |
+                                        static_cast<enum_type>(f2));
   }
 
 
@@ -102,13 +103,13 @@ namespace EvaluationFlags
    * @ref EvaluationFlags
    */
   inline EvaluationFlags
-  operator&(const EvaluationFlags f1, const EvaluationFlags f2) = delete;
-
-  inline bool
-  contains(EvaluationFlags f1, EvaluationFlags f2)
+  operator&(const EvaluationFlags f1, const EvaluationFlags f2)
   {
-    return static_cast<unsigned int>(f1) & static_cast<unsigned int>(f2) == 0;
+    using enum_type = std::underlying_type_t<EvaluationFlags>;
+    return static_cast<EvaluationFlags>(static_cast<enum_type>(f1) &
+                                        static_cast<enum_type>(f2));
   }
+
 
   /**
    * Global operator which clears all the bits in the first argument if they are
@@ -117,13 +118,41 @@ namespace EvaluationFlags
    * @ref EvaluationFlags
    */
   inline EvaluationFlags &
-  operator&=(EvaluationFlags &f1, const EvaluationFlags f2) = delete;
+  operator&=(EvaluationFlags &f1, const EvaluationFlags f2)
+  {
+    f1 = f1 & f2;
+    return f1;
+  }
 
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * not set in the argument. This operator exists since
+   * if it did not then the result of the bit-negation <tt>operator ~</tt> would
+   * be an integer which would in turn trigger a compiler warning when we tried
+   * to assign it to an object of type EvaluationFlags.
+   *
+   * @ref EvaluationFlags
+   */
   inline EvaluationFlags
   operator~(const EvaluationFlags f)
   {
     using enum_type = std::underlying_type_t<EvaluationFlags>;
     return static_cast<EvaluationFlags>(~static_cast<enum_type>(f));
+  }
+
+
+  /**
+   * Global operator which checks if the flags contained in the first argument
+   * contain the flags contained in the second argument.
+   *
+   * @ref EvaluationFlags
+   */
+  inline bool
+  contains(const EvaluationFlags flags, const EvaluationFlags mask)
+  {
+    using enum_type = std::underlying_type_t<EvaluationFlags>;
+    return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
   }
 } // namespace EvaluationFlags
 

--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -149,7 +149,7 @@ namespace EvaluationFlags
    * @ref EvaluationFlags
    */
   inline bool
-  contains(const EvaluationFlags flags, const EvaluationFlags mask)
+  contains_bits(const EvaluationFlags flags, const EvaluationFlags mask)
   {
     using enum_type = std::underlying_type_t<EvaluationFlags>;
     return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;

--- a/include/deal.II/matrix_free/evaluation_flags.h
+++ b/include/deal.II/matrix_free/evaluation_flags.h
@@ -102,12 +102,13 @@ namespace EvaluationFlags
    * @ref EvaluationFlags
    */
   inline EvaluationFlags
-  operator&(const EvaluationFlags f1, const EvaluationFlags f2)
-  {
-    return static_cast<EvaluationFlags>(static_cast<unsigned int>(f1) &
-                                        static_cast<unsigned int>(f2));
-  }
+  operator&(const EvaluationFlags f1, const EvaluationFlags f2) = delete;
 
+  inline bool
+  contains(EvaluationFlags f1, EvaluationFlags f2)
+  {
+    return static_cast<unsigned int>(f1) & static_cast<unsigned int>(f2) == 0;
+  }
 
   /**
    * Global operator which clears all the bits in the first argument if they are
@@ -116,12 +117,14 @@ namespace EvaluationFlags
    * @ref EvaluationFlags
    */
   inline EvaluationFlags &
-  operator&=(EvaluationFlags &f1, const EvaluationFlags f2)
-  {
-    f1 = f1 & f2;
-    return f1;
-  }
+  operator&=(EvaluationFlags &f1, const EvaluationFlags f2) = delete;
 
+  inline EvaluationFlags
+  operator~(const EvaluationFlags f)
+  {
+    using enum_type = std::underlying_type_t<EvaluationFlags>;
+    return static_cast<EvaluationFlags>(~static_cast<enum_type>(f));
+  }
 } // namespace EvaluationFlags
 
 

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -279,12 +279,12 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (contains(evaluation_flag, EvaluationFlags::values))
+              if (contains_bits(evaluation_flag, EvaluationFlags::values))
                 eval0.template values<0, true, false>(values_dofs, values_quad);
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 eval0.template gradients<0, true, false>(values_dofs,
                                                          gradients_quad);
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 eval0.template hessians<0, true, false>(values_dofs,
                                                         hessians_quad);
 
@@ -300,15 +300,16 @@ namespace internal
           for (unsigned int c = 0; c < n_components; ++c)
             {
               // grad x
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 {
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
                   eval1.template values<1, true, false>(temp1, gradients_quad);
                 }
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xy
-                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     eval0.template gradients<0, true, false>(values_dofs,
                                                              temp1);
                   eval1.template gradients<1, true, false>(temp1,
@@ -322,19 +323,19 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 eval1.template gradients<1, true, false>(temp1,
                                                          gradients_quad +
                                                            n_q_points);
 
               // grad yy
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 eval1.template hessians<1, true, false>(temp1,
                                                         hessians_quad +
                                                           n_q_points);
 
               // val: can use values applied in x
-              if (contains(evaluation_flag, EvaluationFlags::values))
+              if (contains_bits(evaluation_flag, EvaluationFlags::values))
                 eval1.template values<1, true, false>(temp1, values_quad);
 
               // advance to the next component in 1D array
@@ -348,7 +349,7 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 {
                   // grad x
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
@@ -356,10 +357,11 @@ namespace internal
                   eval2.template values<2, true, false>(temp2, gradients_quad);
                 }
 
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xz
-                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     {
                       eval0.template gradients<0, true, false>(values_dofs,
                                                                temp1);
@@ -383,7 +385,7 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 {
                   eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template values<2, true, false>(temp2,
@@ -391,10 +393,11 @@ namespace internal
                                                           n_q_points);
                 }
 
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad yz
-                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template gradients<2, true, false>(temp2,
                                                            hessians_quad +
@@ -410,21 +413,21 @@ namespace internal
               // grad z: can use the values applied in x direction stored in
               // temp1
               eval1.template values<1, true, false>(temp1, temp2);
-              if (contains(evaluation_flag, EvaluationFlags::gradients))
+              if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
                 eval2.template gradients<2, true, false>(temp2,
                                                          gradients_quad +
                                                            2 * n_q_points);
 
               // grad zz: can use the values applied in x and y direction stored
               // in temp2
-              if (contains(evaluation_flag, EvaluationFlags::hessians))
+              if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 eval2.template hessians<2, true, false>(temp2,
                                                         hessians_quad +
                                                           2 * n_q_points);
 
               // val: can use the values applied in x & y direction stored in
               // temp2
-              if (contains(evaluation_flag, EvaluationFlags::values))
+              if (contains_bits(evaluation_flag, EvaluationFlags::values))
                 eval2.template values<2, true, false>(temp2, values_quad);
 
               // advance to the next component in 1D array
@@ -442,7 +445,7 @@ namespace internal
     // case additional dof for FE_Q_DG0: add values; gradients and second
     // derivatives evaluate to zero
     if (type == MatrixFreeFunctions::tensor_symmetric_plus_dg0 &&
-        (contains(evaluation_flag, EvaluationFlags::values)))
+        (contains_bits(evaluation_flag, EvaluationFlags::values)))
       {
         values_quad -= n_components * n_q_points;
         values_dofs -= n_components * dofs_per_comp;
@@ -526,7 +529,7 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (contains(integration_flag, EvaluationFlags::values))
+              if (contains_bits(integration_flag, EvaluationFlags::values))
                 {
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(values_quad,
@@ -535,9 +538,10 @@ namespace internal
                     eval0.template values<0, false, true>(values_quad,
                                                           values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::gradients))
+              if (contains_bits(integration_flag, EvaluationFlags::gradients))
                 {
-                  if ((contains(integration_flag, EvaluationFlags::values)) ||
+                  if ((contains_bits(integration_flag,
+                                     EvaluationFlags::values)) ||
                       add_into_values_array == true)
                     eval0.template gradients<0, false, true>(gradients_quad,
                                                              values_dofs);
@@ -545,10 +549,12 @@ namespace internal
                     eval0.template gradients<0, false, false>(gradients_quad,
                                                               values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::hessians))
+              if (contains_bits(integration_flag, EvaluationFlags::hessians))
                 {
-                  if (contains(integration_flag, EvaluationFlags::values) ||
-                      contains(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(hessians_quad,
                                                             values_dofs);
@@ -568,8 +574,9 @@ namespace internal
         case 2:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((contains(integration_flag, EvaluationFlags::values)) &&
-                  (!contains(integration_flag, EvaluationFlags::gradients)))
+              if ((contains_bits(integration_flag, EvaluationFlags::values)) &&
+                  (!contains_bits(integration_flag,
+                                  EvaluationFlags::gradients)))
                 {
                   eval1.template values<1, false, false>(values_quad, temp1);
                   if (add_into_values_array == false)
@@ -577,12 +584,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp1, values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::gradients))
+              if (contains_bits(integration_flag, EvaluationFlags::gradients))
                 {
                   eval1.template gradients<1, false, false>(gradients_quad +
                                                               n_q_points,
                                                             temp1);
-                  if (contains(integration_flag, EvaluationFlags::values))
+                  if (contains_bits(integration_flag, EvaluationFlags::values))
                     eval1.template values<1, false, true>(values_quad, temp1);
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(temp1, values_dofs);
@@ -591,13 +598,15 @@ namespace internal
                   eval1.template values<1, false, false>(gradients_quad, temp1);
                   eval0.template gradients<0, false, true>(temp1, values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::hessians))
+              if (contains_bits(integration_flag, EvaluationFlags::hessians))
                 {
                   // grad xx
                   eval1.template values<1, false, false>(hessians_quad, temp1);
 
-                  if (contains(integration_flag, EvaluationFlags::values) ||
-                      contains(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp1, values_dofs);
                   else
@@ -628,8 +637,9 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((contains(integration_flag, EvaluationFlags::values)) &&
-                  (!contains(integration_flag, EvaluationFlags::gradients)))
+              if ((contains_bits(integration_flag, EvaluationFlags::values)) &&
+                  (!contains_bits(integration_flag,
+                                  EvaluationFlags::gradients)))
                 {
                   eval2.template values<2, false, false>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
@@ -638,12 +648,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp2, values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::gradients))
+              if (contains_bits(integration_flag, EvaluationFlags::gradients))
                 {
                   eval2.template gradients<2, false, false>(gradients_quad +
                                                               2 * n_q_points,
                                                             temp1);
-                  if (contains(integration_flag, EvaluationFlags::values))
+                  if (contains_bits(integration_flag, EvaluationFlags::values))
                     eval2.template values<2, false, true>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
                   eval2.template values<2, false, false>(gradients_quad +
@@ -658,14 +668,16 @@ namespace internal
                   eval1.template values<1, false, false>(temp1, temp2);
                   eval0.template gradients<0, false, true>(temp2, values_dofs);
                 }
-              if (contains(integration_flag, EvaluationFlags::hessians))
+              if (contains_bits(integration_flag, EvaluationFlags::hessians))
                 {
                   // grad xx
                   eval2.template values<2, false, false>(hessians_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
 
-                  if (contains(integration_flag, EvaluationFlags::values) ||
-                      contains(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp2, values_dofs);
                   else
@@ -725,7 +737,7 @@ namespace internal
       {
         values_dofs -= n_components * dofs_per_comp - dofs_per_comp + 1;
         values_quad -= n_components * n_q_points;
-        if (contains(integration_flag, EvaluationFlags::values))
+        if (contains_bits(integration_flag, EvaluationFlags::values))
           for (unsigned int c = 0; c < n_components; ++c)
             {
               values_dofs[0] = values_quad[0];
@@ -790,7 +802,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if (contains(evaluation_flag, EvaluationFlags::values))
+    if (contains_bits(evaluation_flag, EvaluationFlags::values))
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -807,7 +819,7 @@ namespace internal
           }
       }
 
-    if (contains(evaluation_flag, EvaluationFlags::gradients))
+    if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -832,7 +844,7 @@ namespace internal
           }
       }
 
-    if (contains(evaluation_flag, EvaluationFlags::hessians))
+    if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
       Assert(false, ExcNotImplemented());
   }
 
@@ -852,7 +864,7 @@ namespace internal
                        const bool add_into_values_array)
   {
     // TODO: implement hessians
-    AssertThrow(!contains(integration_flag, EvaluationFlags::hessians),
+    AssertThrow(!contains_bits(integration_flag, EvaluationFlags::hessians),
                 ExcNotImplemented());
 
     const std::size_t n_dofs =
@@ -864,7 +876,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if (contains(integration_flag, EvaluationFlags::values))
+    if (contains_bits(integration_flag, EvaluationFlags::values))
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -885,7 +897,7 @@ namespace internal
           }
       }
 
-    if (contains(integration_flag, EvaluationFlags::gradients))
+    if (contains_bits(integration_flag, EvaluationFlags::gradients))
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -902,7 +914,8 @@ namespace internal
                           n_q_points);
 
                 if ((add_into_values_array == false &&
-                     !contains(integration_flag, EvaluationFlags::values)) &&
+                     !contains_bits(integration_flag,
+                                    EvaluationFlags::values)) &&
                     d == 0)
                   eval.template gradients<0, false, false>(
                     gradients_quad_ptr, values_dofs_actual_ptr);
@@ -1377,7 +1390,7 @@ namespace internal
 
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (contains(evaluation_flag, EvaluationFlags::values))
+        if (contains_bits(evaluation_flag, EvaluationFlags::values))
           for (unsigned int i = 0; i < n_points; ++i)
             fe_eval.begin_values()[n_points * c + i] =
               values_dofs[n_points * c + i];
@@ -1414,8 +1427,8 @@ namespace internal
       eval(AlignedVector<Number>(),
            shape.shape_gradients_collocation_eo,
            shape.shape_hessians_collocation_eo);
-    if (contains(evaluation_flag,
-                 (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+    if (contains_bits(evaluation_flag,
+                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         eval.template gradients<0, true, false>(values_dofs, gradients_quad);
         if (dim > 1)
@@ -1426,7 +1439,7 @@ namespace internal
                                                   gradients_quad +
                                                     2 * n_points);
       }
-    if (contains(evaluation_flag, EvaluationFlags::hessians))
+    if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
       {
         eval.template hessians<0, true, false>(values_dofs, hessians_quad);
         if (dim > 1)
@@ -1467,7 +1480,7 @@ namespace internal
 
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (contains(integration_flag, EvaluationFlags::values))
+        if (contains_bits(integration_flag, EvaluationFlags::values))
           {
             if (add_into_values_array)
               for (unsigned int i = 0; i < n_points; ++i)
@@ -1479,14 +1492,14 @@ namespace internal
                   fe_eval.begin_values()[n_points * c + i];
           }
 
-        do_integrate(fe_eval.get_shape_info().data.front(),
-                     integration_flag,
-                     values_dofs + c * n_points,
-                     fe_eval.begin_gradients() + c * dim * n_points,
-                     fe_eval.begin_hessians() +
-                       c * dim * (dim + 1) / 2 * n_points,
-                     add_into_values_array ||
-                       (contains(integration_flag, EvaluationFlags::values)));
+        do_integrate(
+          fe_eval.get_shape_info().data.front(),
+          integration_flag,
+          values_dofs + c * n_points,
+          fe_eval.begin_gradients() + c * dim * n_points,
+          fe_eval.begin_hessians() + c * dim * (dim + 1) / 2 * n_points,
+          add_into_values_array ||
+            (contains_bits(integration_flag, EvaluationFlags::values)));
       }
   }
 
@@ -1515,7 +1528,7 @@ namespace internal
            shape.shape_hessians_collocation_eo);
     constexpr std::size_t n_points = Utilities::pow(fe_degree + 1, dim);
 
-    if (contains(integration_flag, EvaluationFlags::hessians))
+    if (contains_bits(integration_flag, EvaluationFlags::hessians))
       {
         // diagonal
         // grad xx
@@ -1535,7 +1548,7 @@ namespace internal
         if (dim == 2)
           {
             // grad xy, queue into gradient
-            if (contains(integration_flag, EvaluationFlags::gradients))
+            if (contains_bits(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<1, false, true>(hessians_quad +
                                                         2 * n_points,
                                                       gradients_quad);
@@ -1547,7 +1560,7 @@ namespace internal
         if (dim == 3)
           {
             // grad xy, queue into gradient
-            if (contains(integration_flag, EvaluationFlags::gradients))
+            if (contains_bits(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<1, false, true>(hessians_quad +
                                                         3 * n_points,
                                                       gradients_quad);
@@ -1562,7 +1575,7 @@ namespace internal
                                                     gradients_quad);
 
             // grad yz
-            if (contains(integration_flag, EvaluationFlags::gradients))
+            if (contains_bits(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<2, false, true>(
                 hessians_quad + 5 * n_points, gradients_quad + n_points);
             else
@@ -1573,16 +1586,16 @@ namespace internal
         // if we did not integrate gradients, set the last slot to zero
         // which was not touched before, in order to avoid the if
         // statement in the gradients loop below
-        if (!contains(integration_flag, EvaluationFlags::gradients))
+        if (!contains_bits(integration_flag, EvaluationFlags::gradients))
           for (unsigned int q = 0; q < n_points; ++q)
             gradients_quad[(dim - 1) * n_points + q] = Number();
       }
 
-    if (contains(integration_flag,
-                 (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+    if (contains_bits(integration_flag,
+                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         if (add_into_values_array ||
-            contains(integration_flag, EvaluationFlags::hessians))
+            contains_bits(integration_flag, EvaluationFlags::hessians))
           eval.template gradients<0, false, true>(gradients_quad, values_dofs);
         else
           eval.template gradients<0, false, false>(gradients_quad, values_dofs);
@@ -1662,8 +1675,9 @@ namespace internal
                               fe_eval.begin_values() + c * n_q_points);
 
         // apply derivatives in the collocation space
-        if (contains(evaluation_flag,
-                     (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+        if (contains_bits(evaluation_flag,
+                          (EvaluationFlags::gradients |
+                           EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
                         evaluation_flag & (EvaluationFlags::gradients |
@@ -1701,18 +1715,19 @@ namespace internal
     for (unsigned int c = 0; c < n_components; ++c)
       {
         // apply derivatives in collocation space
-        if (contains(integration_flag,
-                     (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+        if (contains_bits(integration_flag,
+                          (EvaluationFlags::gradients |
+                           EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
-            do_integrate(shape_data,
-                         integration_flag & (EvaluationFlags::gradients |
-                                             EvaluationFlags::hessians),
-                         fe_eval.begin_values() + c * n_q_points,
-                         fe_eval.begin_gradients() + c * dim * n_q_points,
-                         fe_eval.begin_hessians() +
-                           c * dim * (dim + 1) / 2 * n_q_points,
-                         /*add_into_values_array=*/
-                         contains(integration_flag, EvaluationFlags::values));
+            do_integrate(
+              shape_data,
+              integration_flag &
+                (EvaluationFlags::gradients | EvaluationFlags::hessians),
+              fe_eval.begin_values() + c * n_q_points,
+              fe_eval.begin_gradients() + c * dim * n_q_points,
+              fe_eval.begin_hessians() + c * dim * (dim + 1) / 2 * n_q_points,
+              /*add_into_values_array=*/
+              contains_bits(integration_flag, EvaluationFlags::values));
 
         // transform back to the original space
         FEEvaluationImplBasisChange<
@@ -2066,8 +2081,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if (contains(evaluation_flag, EvaluationFlags::values) &&
-          (!contains(evaluation_flag, EvaluationFlags::gradients)))
+      if (contains_bits(evaluation_flag, EvaluationFlags::values) &&
+          (!contains_bits(evaluation_flag, EvaluationFlags::gradients)))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2093,7 +2108,7 @@ namespace internal
             values_dofs += 3 * n_dofs;
             values_quad += n_q_points;
           }
-      else if (contains(evaluation_flag, EvaluationFlags::gradients))
+      else if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2134,7 +2149,8 @@ namespace internal
                                                                gradients_quad +
                                                                  n_q_points);
 
-                      if (contains(evaluation_flag, EvaluationFlags::values))
+                      if (contains_bits(evaluation_flag,
+                                        EvaluationFlags::values))
                         eval1.template values<1, true, false>(scratch_data,
                                                               values_quad);
                     }
@@ -2151,7 +2167,7 @@ namespace internal
                                                           n_q_points);
                   eval0.template gradients<0, true, false>(values_dofs,
                                                            gradients_quad);
-                  if (contains(evaluation_flag, EvaluationFlags::values))
+                  if (contains_bits(evaluation_flag, EvaluationFlags::values))
                     eval0.template values<0, true, false>(values_dofs,
                                                           values_quad);
                   break;
@@ -2167,7 +2183,7 @@ namespace internal
             gradients_quad += dim * n_q_points;
           }
 
-      if (contains(evaluation_flag, EvaluationFlags::hessians))
+      if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
         {
           values_dofs = values_dofs_ptr;
           for (unsigned int c = 0; c < n_components; ++c)
@@ -2268,8 +2284,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if (contains(integration_flag, EvaluationFlags::values) &&
-          !contains(integration_flag, EvaluationFlags::gradients))
+      if (contains_bits(integration_flag, EvaluationFlags::values) &&
+          !contains_bits(integration_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2293,7 +2309,7 @@ namespace internal
             values_dofs += 3 * n_dofs;
             values_quad += n_q_points;
           }
-      else if (contains(integration_flag, EvaluationFlags::gradients))
+      else if (contains_bits(integration_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2318,7 +2334,8 @@ namespace internal
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
-                      if (contains(integration_flag, EvaluationFlags::values))
+                      if (contains_bits(integration_flag,
+                                        EvaluationFlags::values))
                         eval_grad.template gradients<1, false, true>(
                           gradients_quad + n_q_points, values_quad);
                       else
@@ -2333,7 +2350,8 @@ namespace internal
                     }
                   else
                     {
-                      if (contains(integration_flag, EvaluationFlags::values))
+                      if (contains_bits(integration_flag,
+                                        EvaluationFlags::values))
                         {
                           eval1.template values<1, false, false>(values_quad,
                                                                  scratch_data);
@@ -2361,7 +2379,7 @@ namespace internal
                                                          values_dofs + n_dofs);
                   eval0.template gradients<0, false, false>(gradients_quad,
                                                             values_dofs);
-                  if (contains(integration_flag, EvaluationFlags::values))
+                  if (contains_bits(integration_flag, EvaluationFlags::values))
                     eval0.template values<0, false, true>(values_quad,
                                                           values_dofs);
                   break;
@@ -2377,7 +2395,7 @@ namespace internal
             gradients_quad += dim * n_q_points;
           }
 
-      if (contains(integration_flag, EvaluationFlags::hessians))
+      if (contains_bits(integration_flag, EvaluationFlags::hessians))
         {
           values_dofs = values_dofs_ptr;
           for (unsigned int c = 0; c < n_components; ++c)
@@ -2388,9 +2406,9 @@ namespace internal
                     // grad xx
                     eval1.template values<1, false, false>(hessians_quad,
                                                            scratch_data);
-                    if (contains(integration_flag,
-                                 (EvaluationFlags::values |
-                                  EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag,
+                                      (EvaluationFlags::values |
+                                       EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(scratch_data,
                                                               values_dofs);
                     else
@@ -2423,7 +2441,8 @@ namespace internal
                     eval1.template values<1, false, false>(hessians_quad +
                                                              4 * n_q_points,
                                                            scratch_data);
-                    if (contains(integration_flag, EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag,
+                                      EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(scratch_data,
                                                                values_dofs +
                                                                  n_dofs);
@@ -2442,9 +2461,9 @@ namespace internal
                     break;
                   case 2:
                     // grad xx
-                    if (contains(integration_flag,
-                                 (EvaluationFlags::values |
-                                  EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag,
+                                      (EvaluationFlags::values |
+                                       EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(hessians_quad,
                                                               values_dofs);
                     else
@@ -2455,7 +2474,8 @@ namespace internal
                     eval0.template values<0, false, false>(
                       hessians_quad + n_q_points, values_dofs + 2 * n_dofs);
                     // grad xy
-                    if (contains(integration_flag, EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag,
+                                      EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(
                         hessians_quad + 2 * n_q_points, values_dofs + n_dofs);
                     else
@@ -2464,9 +2484,11 @@ namespace internal
                     break;
                   case 1:
                     values_dofs[2] = hessians_quad[0];
-                    if (!contains(integration_flag, EvaluationFlags::values))
+                    if (!contains_bits(integration_flag,
+                                       EvaluationFlags::values))
                       values_dofs[0] = 0;
-                    if (!contains(integration_flag, EvaluationFlags::gradients))
+                    if (!contains_bits(integration_flag,
+                                       EvaluationFlags::gradients))
                       values_dofs[1] = 0;
                     break;
                   default:
@@ -2575,13 +2597,13 @@ namespace internal
 
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (contains(flag, EvaluationFlags::hessians))
+              if (contains_bits(flag, EvaluationFlags::hessians))
                 evalf.template apply_face<face_direction,
                                           do_evaluate,
                                           add_into_output,
                                           2,
                                           lex_faces>(input, output);
-              else if (contains(flag, EvaluationFlags::gradients))
+              else if (contains_bits(flag, EvaluationFlags::gradients))
                 evalf.template apply_face<face_direction,
                                           do_evaluate,
                                           add_into_output,
@@ -2737,7 +2759,7 @@ namespace internal
   {
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (contains(flag, EvaluationFlags::values))
+        if (contains_bits(flag, EvaluationFlags::values))
           {
             if (integrate)
               for (unsigned int q = 0; q < n_q_points; ++q)
@@ -2748,7 +2770,7 @@ namespace internal
             for (unsigned int q = 0; q < n_q_points; ++q)
               values_quad[c * n_q_points + q] = tmp_values[q];
           }
-        if (contains(flag, EvaluationFlags::gradients))
+        if (contains_bits(flag, EvaluationFlags::gradients))
           for (unsigned int d = 0; d < dim; ++d)
             {
               if (integrate)
@@ -2762,7 +2784,7 @@ namespace internal
               for (unsigned int q = 0; q < n_q_points; ++q)
                 gradients_quad[(c * dim + d) * n_q_points + q] = tmp_values[q];
             }
-        if (contains(flag, EvaluationFlags::hessians))
+        if (contains_bits(flag, EvaluationFlags::hessians))
           {
             const unsigned int hdim = (dim * (dim + 1)) / 2;
             for (unsigned int d = 0; d < hdim; ++d)
@@ -2802,7 +2824,7 @@ namespace internal
   {
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (contains(flag, EvaluationFlags::values))
+        if (contains_bits(flag, EvaluationFlags::values))
           {
             if (integrate)
               for (unsigned int q = 0; q < n_q_points; ++q)
@@ -2813,7 +2835,7 @@ namespace internal
             for (unsigned int q = 0; q < n_q_points; ++q)
               values_quad[c * n_q_points + q][v] = tmp_values[q];
           }
-        if (contains(flag, EvaluationFlags::gradients))
+        if (contains_bits(flag, EvaluationFlags::gradients))
           for (unsigned int d = 0; d < dim; ++d)
             {
               Assert(gradients_quad != nullptr, ExcInternalError());
@@ -2829,7 +2851,7 @@ namespace internal
                 gradients_quad[(c * dim + d) * n_q_points + q][v] =
                   tmp_values[q];
             }
-        if (contains(flag, EvaluationFlags::hessians))
+        if (contains_bits(flag, EvaluationFlags::hessians))
           {
             Assert(hessians_quad != nullptr, ExcInternalError());
             const unsigned int hdim = (dim * (dim + 1)) / 2;
@@ -2876,7 +2898,7 @@ namespace internal
           using Eval =
             EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-          if (contains(evaluation_flag, EvaluationFlags::values))
+          if (contains_bits(evaluation_flag, EvaluationFlags::values))
             {
               const auto shape_values =
                 &shape_data.shape_values_face(face_no, face_orientation, 0);
@@ -2895,7 +2917,7 @@ namespace internal
                 }
             }
 
-          if (contains(evaluation_flag, EvaluationFlags::gradients))
+          if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
             {
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
@@ -2924,7 +2946,7 @@ namespace internal
                 }
             }
 
-          Assert(!(contains(evaluation_flag, EvaluationFlags::hessians)),
+          Assert(!(contains_bits(evaluation_flag, EvaluationFlags::hessians)),
                  ExcNotImplemented());
 
           return true;
@@ -3026,7 +3048,7 @@ namespace internal
           using Eval =
             EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-          if (contains(integration_flag, EvaluationFlags::values))
+          if (contains_bits(integration_flag, EvaluationFlags::values))
             {
               const auto shape_values =
                 &shape_data.shape_values_face(face_no, face_orientation, 0);
@@ -3045,7 +3067,7 @@ namespace internal
                 }
             }
 
-          if (contains(integration_flag, EvaluationFlags::gradients))
+          if (contains_bits(integration_flag, EvaluationFlags::gradients))
             {
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
@@ -3065,8 +3087,8 @@ namespace internal
                                 n_dofs,
                                 n_q_points);
 
-                      if (!(contains(integration_flag,
-                                     EvaluationFlags::values)) &&
+                      if (!(contains_bits(integration_flag,
+                                          EvaluationFlags::values)) &&
                           d == 0)
                         eval.template gradients<0, false, false>(
                           gradients_quad_ptr, values_dofs_actual_ptr);
@@ -3080,7 +3102,7 @@ namespace internal
                 }
             }
 
-          Assert(!(contains(integration_flag, EvaluationFlags::hessians)),
+          Assert(!(contains_bits(integration_flag, EvaluationFlags::hessians)),
                  ExcNotImplemented());
 
           return true;
@@ -3277,7 +3299,7 @@ namespace internal
     std::array<const unsigned int *, n_face_orientations> index_array_hermite =
       {};
     if (fe_degree > 1 &&
-        (contains(evaluation_flag, EvaluationFlags::gradients)))
+        (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
       {
         if (n_face_orientations == 1)
           index_array_hermite[0] =
@@ -3359,7 +3381,7 @@ namespace internal
               global_vector_ptr + dof_indices[0] + index_offset * n_lanes;
 
             if (fe_degree > 1 &&
-                (contains(evaluation_flag, EvaluationFlags::gradients)))
+                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3400,7 +3422,7 @@ namespace internal
               n_lanes);
             Number2_ *vector_ptr = global_vector_ptr + index_offset * n_lanes;
             if (fe_degree > 1 &&
-                (contains(evaluation_flag, EvaluationFlags::gradients)))
+                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3452,7 +3474,7 @@ namespace internal
               dof_info.n_vectorization_lanes_filled[dof_access_index][cell];
 
             if (fe_degree > 1 &&
-                (contains(evaluation_flag, EvaluationFlags::gradients)))
+                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
               {
                 if (n_filled_lanes == n_lanes)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3622,7 +3644,7 @@ namespace internal
               }
 
             if (fe_degree > 1 &&
-                (contains(evaluation_flag, EvaluationFlags::gradients)))
+                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
               {
                 if (vectorization_possible)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3856,11 +3878,11 @@ namespace internal
     {
       const unsigned int fe_degree = shape_info.data.front().fe_degree;
       if (fe_degree < 1 || !shape_info.data.front().nodal_at_cell_boundaries ||
-          (contains(evaluation_flag, EvaluationFlags::gradients) &&
+          (contains_bits(evaluation_flag, EvaluationFlags::gradients) &&
            (fe_degree < 2 ||
             shape_info.data.front().element_type !=
               MatrixFreeFunctions::tensor_symmetric_hermite)) ||
-          (contains(evaluation_flag, EvaluationFlags::hessians)) ||
+          (contains_bits(evaluation_flag, EvaluationFlags::hessians)) ||
           vector_ptr == nullptr ||
           shape_info.data.front().element_type >
             MatrixFreeFunctions::tensor_symmetric ||

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -1666,10 +1666,8 @@ namespace internal
                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
-                        static_cast<EvaluationFlags::EvaluationFlags>(
-                          unsigned(evaluation_flag) &
-                          unsigned(EvaluationFlags::gradients |
-                                   EvaluationFlags::hessians)),
+                        evaluation_flag & (EvaluationFlags::gradients |
+                                           EvaluationFlags::hessians),
                         fe_eval.begin_values() + c * n_q_points,
                         fe_eval.begin_gradients() + c * dim * n_q_points,
                         fe_eval.begin_hessians() +
@@ -1707,10 +1705,8 @@ namespace internal
                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_integrate(shape_data,
-                         static_cast<EvaluationFlags::EvaluationFlags>(
-                           static_cast<unsigned int>(integration_flag) &
-                           static_cast<unsigned>(EvaluationFlags::gradients |
-                                                 EvaluationFlags::hessians)),
+                         integration_flag & (EvaluationFlags::gradients |
+                                             EvaluationFlags::hessians),
                          fe_eval.begin_values() + c * n_q_points,
                          fe_eval.begin_gradients() + c * dim * n_q_points,
                          fe_eval.begin_hessians() +

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -308,8 +308,7 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xy
-                  if (!contains_bits(evaluation_flag,
-                                     EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
                     eval0.template gradients<0, true, false>(values_dofs,
                                                              temp1);
                   eval1.template gradients<1, true, false>(temp1,
@@ -360,8 +359,7 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xz
-                  if (!contains_bits(evaluation_flag,
-                                     EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
                     {
                       eval0.template gradients<0, true, false>(values_dofs,
                                                                temp1);
@@ -396,8 +394,7 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad yz
-                  if (!contains_bits(evaluation_flag,
-                                     EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
                     eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template gradients<2, true, false>(temp2,
                                                            hessians_quad +
@@ -445,7 +442,7 @@ namespace internal
     // case additional dof for FE_Q_DG0: add values; gradients and second
     // derivatives evaluate to zero
     if (type == MatrixFreeFunctions::tensor_symmetric_plus_dg0 &&
-        (contains_bits(evaluation_flag, EvaluationFlags::values)))
+        contains_bits(evaluation_flag, EvaluationFlags::values))
       {
         values_quad -= n_components * n_q_points;
         values_dofs -= n_components * dofs_per_comp;
@@ -540,8 +537,7 @@ namespace internal
                 }
               if (contains_bits(integration_flag, EvaluationFlags::gradients))
                 {
-                  if ((contains_bits(integration_flag,
-                                     EvaluationFlags::values)) ||
+                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
                       add_into_values_array == true)
                     eval0.template gradients<0, false, true>(gradients_quad,
                                                              values_dofs);
@@ -551,10 +547,8 @@ namespace internal
                 }
               if (contains_bits(integration_flag, EvaluationFlags::hessians))
                 {
-                  if (contains_bits(integration_flag,
-                                    EvaluationFlags::values) ||
-                      contains_bits(integration_flag,
-                                    EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
+                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(hessians_quad,
                                                             values_dofs);
@@ -574,9 +568,8 @@ namespace internal
         case 2:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((contains_bits(integration_flag, EvaluationFlags::values)) &&
-                  (!contains_bits(integration_flag,
-                                  EvaluationFlags::gradients)))
+              if (contains_bits(integration_flag, EvaluationFlags::values) &&
+                  (!contains_bits(integration_flag, EvaluationFlags::gradients)))
                 {
                   eval1.template values<1, false, false>(values_quad, temp1);
                   if (add_into_values_array == false)
@@ -603,10 +596,8 @@ namespace internal
                   // grad xx
                   eval1.template values<1, false, false>(hessians_quad, temp1);
 
-                  if (contains_bits(integration_flag,
-                                    EvaluationFlags::values) ||
-                      contains_bits(integration_flag,
-                                    EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
+                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp1, values_dofs);
                   else
@@ -637,9 +628,8 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((contains_bits(integration_flag, EvaluationFlags::values)) &&
-                  (!contains_bits(integration_flag,
-                                  EvaluationFlags::gradients)))
+              if (contains_bits(integration_flag, EvaluationFlags::values) &&
+                  (!contains_bits(integration_flag, EvaluationFlags::gradients)))
                 {
                   eval2.template values<2, false, false>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
@@ -674,10 +664,8 @@ namespace internal
                   eval2.template values<2, false, false>(hessians_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
 
-                  if (contains_bits(integration_flag,
-                                    EvaluationFlags::values) ||
-                      contains_bits(integration_flag,
-                                    EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
+                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp2, values_dofs);
                   else
@@ -914,8 +902,7 @@ namespace internal
                           n_q_points);
 
                 if ((add_into_values_array == false &&
-                     !contains_bits(integration_flag,
-                                    EvaluationFlags::values)) &&
+                     !contains_bits(integration_flag, EvaluationFlags::values)) &&
                     d == 0)
                   eval.template gradients<0, false, false>(
                     gradients_quad_ptr, values_dofs_actual_ptr);
@@ -1428,7 +1415,7 @@ namespace internal
            shape.shape_gradients_collocation_eo,
            shape.shape_hessians_collocation_eo);
     if (contains_bits(evaluation_flag,
-                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+          (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         eval.template gradients<0, true, false>(values_dofs, gradients_quad);
         if (dim > 1)
@@ -1492,14 +1479,14 @@ namespace internal
                   fe_eval.begin_values()[n_points * c + i];
           }
 
-        do_integrate(
-          fe_eval.get_shape_info().data.front(),
-          integration_flag,
-          values_dofs + c * n_points,
-          fe_eval.begin_gradients() + c * dim * n_points,
-          fe_eval.begin_hessians() + c * dim * (dim + 1) / 2 * n_points,
-          add_into_values_array ||
-            (contains_bits(integration_flag, EvaluationFlags::values)));
+        do_integrate(fe_eval.get_shape_info().data.front(),
+                     integration_flag,
+                     values_dofs + c * n_points,
+                     fe_eval.begin_gradients() + c * dim * n_points,
+                     fe_eval.begin_hessians() +
+                       c * dim * (dim + 1) / 2 * n_points,
+                     add_into_values_array ||
+                       contains_bits(integration_flag, EvaluationFlags::values));
       }
   }
 
@@ -1592,7 +1579,7 @@ namespace internal
       }
 
     if (contains_bits(integration_flag,
-                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+          (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         if (add_into_values_array ||
             contains_bits(integration_flag, EvaluationFlags::hessians))
@@ -1676,8 +1663,7 @@ namespace internal
 
         // apply derivatives in the collocation space
         if (contains_bits(evaluation_flag,
-                          (EvaluationFlags::gradients |
-                           EvaluationFlags::hessians)))
+              (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
                         evaluation_flag & (EvaluationFlags::gradients |
@@ -1716,18 +1702,17 @@ namespace internal
       {
         // apply derivatives in collocation space
         if (contains_bits(integration_flag,
-                          (EvaluationFlags::gradients |
-                           EvaluationFlags::hessians)))
+              (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
-            do_integrate(
-              shape_data,
-              integration_flag &
-                (EvaluationFlags::gradients | EvaluationFlags::hessians),
-              fe_eval.begin_values() + c * n_q_points,
-              fe_eval.begin_gradients() + c * dim * n_q_points,
-              fe_eval.begin_hessians() + c * dim * (dim + 1) / 2 * n_q_points,
-              /*add_into_values_array=*/
-              contains_bits(integration_flag, EvaluationFlags::values));
+            do_integrate(shape_data,
+                         integration_flag & (EvaluationFlags::gradients |
+                                             EvaluationFlags::hessians),
+                         fe_eval.begin_values() + c * n_q_points,
+                         fe_eval.begin_gradients() + c * dim * n_q_points,
+                         fe_eval.begin_hessians() +
+                           c * dim * (dim + 1) / 2 * n_q_points,
+                         /*add_into_values_array=*/
+                         contains_bits(integration_flag, EvaluationFlags::values));
 
         // transform back to the original space
         FEEvaluationImplBasisChange<
@@ -2082,7 +2067,7 @@ namespace internal
       Number *values_dofs_ptr = values_dofs;
 
       if (contains_bits(evaluation_flag, EvaluationFlags::values) &&
-          (!contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+          !contains_bits(evaluation_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2149,8 +2134,7 @@ namespace internal
                                                                gradients_quad +
                                                                  n_q_points);
 
-                      if (contains_bits(evaluation_flag,
-                                        EvaluationFlags::values))
+                      if (contains_bits(evaluation_flag, EvaluationFlags::values))
                         eval1.template values<1, true, false>(scratch_data,
                                                               values_quad);
                     }
@@ -2334,8 +2318,7 @@ namespace internal
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
-                      if (contains_bits(integration_flag,
-                                        EvaluationFlags::values))
+                      if (contains_bits(integration_flag, EvaluationFlags::values))
                         eval_grad.template gradients<1, false, true>(
                           gradients_quad + n_q_points, values_quad);
                       else
@@ -2350,8 +2333,7 @@ namespace internal
                     }
                   else
                     {
-                      if (contains_bits(integration_flag,
-                                        EvaluationFlags::values))
+                      if (contains_bits(integration_flag, EvaluationFlags::values))
                         {
                           eval1.template values<1, false, false>(values_quad,
                                                                  scratch_data);
@@ -2406,9 +2388,8 @@ namespace internal
                     // grad xx
                     eval1.template values<1, false, false>(hessians_quad,
                                                            scratch_data);
-                    if (contains_bits(integration_flag,
-                                      (EvaluationFlags::values |
-                                       EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag, (EvaluationFlags::values |
+                                                   EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(scratch_data,
                                                               values_dofs);
                     else
@@ -2441,8 +2422,7 @@ namespace internal
                     eval1.template values<1, false, false>(hessians_quad +
                                                              4 * n_q_points,
                                                            scratch_data);
-                    if (contains_bits(integration_flag,
-                                      EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag, EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(scratch_data,
                                                                values_dofs +
                                                                  n_dofs);
@@ -2461,9 +2441,8 @@ namespace internal
                     break;
                   case 2:
                     // grad xx
-                    if (contains_bits(integration_flag,
-                                      (EvaluationFlags::values |
-                                       EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag, (EvaluationFlags::values |
+                                                   EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(hessians_quad,
                                                               values_dofs);
                     else
@@ -2474,8 +2453,7 @@ namespace internal
                     eval0.template values<0, false, false>(
                       hessians_quad + n_q_points, values_dofs + 2 * n_dofs);
                     // grad xy
-                    if (contains_bits(integration_flag,
-                                      EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag, EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(
                         hessians_quad + 2 * n_q_points, values_dofs + n_dofs);
                     else
@@ -2484,11 +2462,9 @@ namespace internal
                     break;
                   case 1:
                     values_dofs[2] = hessians_quad[0];
-                    if (!contains_bits(integration_flag,
-                                       EvaluationFlags::values))
+                    if (!contains_bits(integration_flag, EvaluationFlags::values))
                       values_dofs[0] = 0;
-                    if (!contains_bits(integration_flag,
-                                       EvaluationFlags::gradients))
+                    if (!contains_bits(integration_flag, EvaluationFlags::gradients))
                       values_dofs[1] = 0;
                     break;
                   default:
@@ -2946,7 +2922,7 @@ namespace internal
                 }
             }
 
-          Assert(!(contains_bits(evaluation_flag, EvaluationFlags::hessians)),
+          Assert(!contains_bits(evaluation_flag, EvaluationFlags::hessians),
                  ExcNotImplemented());
 
           return true;
@@ -3087,8 +3063,8 @@ namespace internal
                                 n_dofs,
                                 n_q_points);
 
-                      if (!(contains_bits(integration_flag,
-                                          EvaluationFlags::values)) &&
+                      if (!contains_bits(integration_flag,
+                            EvaluationFlags::values) &&
                           d == 0)
                         eval.template gradients<0, false, false>(
                           gradients_quad_ptr, values_dofs_actual_ptr);
@@ -3102,7 +3078,7 @@ namespace internal
                 }
             }
 
-          Assert(!(contains_bits(integration_flag, EvaluationFlags::hessians)),
+          Assert(!contains_bits(integration_flag, EvaluationFlags::hessians),
                  ExcNotImplemented());
 
           return true;
@@ -3299,7 +3275,7 @@ namespace internal
     std::array<const unsigned int *, n_face_orientations> index_array_hermite =
       {};
     if (fe_degree > 1 &&
-        (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+        contains_bits(evaluation_flag, EvaluationFlags::gradients))
       {
         if (n_face_orientations == 1)
           index_array_hermite[0] =
@@ -3381,7 +3357,7 @@ namespace internal
               global_vector_ptr + dof_indices[0] + index_offset * n_lanes;
 
             if (fe_degree > 1 &&
-                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+                contains_bits(evaluation_flag, EvaluationFlags::gradients))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3422,7 +3398,7 @@ namespace internal
               n_lanes);
             Number2_ *vector_ptr = global_vector_ptr + index_offset * n_lanes;
             if (fe_degree > 1 &&
-                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+                contains_bits(evaluation_flag, EvaluationFlags::gradients))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3474,7 +3450,7 @@ namespace internal
               dof_info.n_vectorization_lanes_filled[dof_access_index][cell];
 
             if (fe_degree > 1 &&
-                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+                contains_bits(evaluation_flag, EvaluationFlags::gradients))
               {
                 if (n_filled_lanes == n_lanes)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3644,7 +3620,7 @@ namespace internal
               }
 
             if (fe_degree > 1 &&
-                (contains_bits(evaluation_flag, EvaluationFlags::gradients)))
+                contains_bits(evaluation_flag, EvaluationFlags::gradients))
               {
                 if (vectorization_possible)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3882,7 +3858,7 @@ namespace internal
            (fe_degree < 2 ||
             shape_info.data.front().element_type !=
               MatrixFreeFunctions::tensor_symmetric_hermite)) ||
-          (contains_bits(evaluation_flag, EvaluationFlags::hessians)) ||
+          contains_bits(evaluation_flag, EvaluationFlags::hessians) ||
           vector_ptr == nullptr ||
           shape_info.data.front().element_type >
             MatrixFreeFunctions::tensor_symmetric ||

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -279,12 +279,12 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::values))
                 eval0.template values<0, true, false>(values_dofs, values_quad);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 eval0.template gradients<0, true, false>(values_dofs,
                                                          gradients_quad);
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 eval0.template hessians<0, true, false>(values_dofs,
                                                         hessians_quad);
 
@@ -300,15 +300,15 @@ namespace internal
           for (unsigned int c = 0; c < n_components; ++c)
             {
               // grad x
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 {
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
                   eval1.template values<1, true, false>(temp1, gradients_quad);
                 }
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xy
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
                     eval0.template gradients<0, true, false>(values_dofs,
                                                              temp1);
                   eval1.template gradients<1, true, false>(temp1,
@@ -322,19 +322,19 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 eval1.template gradients<1, true, false>(temp1,
                                                          gradients_quad +
                                                            n_q_points);
 
               // grad yy
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 eval1.template hessians<1, true, false>(temp1,
                                                         hessians_quad +
                                                           n_q_points);
 
               // val: can use values applied in x
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::values))
                 eval1.template values<1, true, false>(temp1, values_quad);
 
               // advance to the next component in 1D array
@@ -348,7 +348,7 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 {
                   // grad x
                   eval0.template gradients<0, true, false>(values_dofs, temp1);
@@ -356,10 +356,10 @@ namespace internal
                   eval2.template values<2, true, false>(temp2, gradients_quad);
                 }
 
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xz
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
                     {
                       eval0.template gradients<0, true, false>(values_dofs,
                                                                temp1);
@@ -383,7 +383,7 @@ namespace internal
 
               // grad y
               eval0.template values<0, true, false>(values_dofs, temp1);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 {
                   eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template values<2, true, false>(temp2,
@@ -391,10 +391,10 @@ namespace internal
                                                           n_q_points);
                 }
 
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad yz
-                  if ((evaluation_flag & EvaluationFlags::gradients) == 0u)
+                  if (!contains(evaluation_flag, EvaluationFlags::gradients))
                     eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template gradients<2, true, false>(temp2,
                                                            hessians_quad +
@@ -410,21 +410,21 @@ namespace internal
               // grad z: can use the values applied in x direction stored in
               // temp1
               eval1.template values<1, true, false>(temp1, temp2);
-              if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::gradients))
                 eval2.template gradients<2, true, false>(temp2,
                                                          gradients_quad +
                                                            2 * n_q_points);
 
               // grad zz: can use the values applied in x and y direction stored
               // in temp2
-              if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::hessians))
                 eval2.template hessians<2, true, false>(temp2,
                                                         hessians_quad +
                                                           2 * n_q_points);
 
               // val: can use the values applied in x & y direction stored in
               // temp2
-              if ((evaluation_flag & EvaluationFlags::values) != 0u)
+              if (contains(evaluation_flag, EvaluationFlags::values))
                 eval2.template values<2, true, false>(temp2, values_quad);
 
               // advance to the next component in 1D array
@@ -442,7 +442,7 @@ namespace internal
     // case additional dof for FE_Q_DG0: add values; gradients and second
     // derivatives evaluate to zero
     if (type == MatrixFreeFunctions::tensor_symmetric_plus_dg0 &&
-        ((evaluation_flag & EvaluationFlags::values) != 0u))
+        (contains(evaluation_flag, EvaluationFlags::values)))
       {
         values_quad -= n_components * n_q_points;
         values_dofs -= n_components * dofs_per_comp;
@@ -526,7 +526,7 @@ namespace internal
         case 1:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if ((integration_flag & EvaluationFlags::values) != 0u)
+              if (contains(integration_flag, EvaluationFlags::values))
                 {
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(values_quad,
@@ -535,9 +535,9 @@ namespace internal
                     eval0.template values<0, false, true>(values_quad,
                                                           values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(integration_flag, EvaluationFlags::gradients))
                 {
-                  if (((integration_flag & EvaluationFlags::values) != 0u) ||
+                  if ((contains(integration_flag, EvaluationFlags::values)) ||
                       add_into_values_array == true)
                     eval0.template gradients<0, false, true>(gradients_quad,
                                                              values_dofs);
@@ -545,10 +545,10 @@ namespace internal
                     eval0.template gradients<0, false, false>(gradients_quad,
                                                               values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(integration_flag, EvaluationFlags::hessians))
                 {
-                  if ((integration_flag & EvaluationFlags::values) != 0u ||
-                      (integration_flag & EvaluationFlags::gradients) != 0u ||
+                  if (contains(integration_flag, EvaluationFlags::values) ||
+                      contains(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(hessians_quad,
                                                             values_dofs);
@@ -568,8 +568,8 @@ namespace internal
         case 2:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (((integration_flag & EvaluationFlags::values) != 0u) &&
-                  ((integration_flag & EvaluationFlags::gradients) == 0u))
+              if ((contains(integration_flag, EvaluationFlags::values)) &&
+                  (!contains(integration_flag, EvaluationFlags::gradients)))
                 {
                   eval1.template values<1, false, false>(values_quad, temp1);
                   if (add_into_values_array == false)
@@ -577,12 +577,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp1, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(integration_flag, EvaluationFlags::gradients))
                 {
                   eval1.template gradients<1, false, false>(gradients_quad +
                                                               n_q_points,
                                                             temp1);
-                  if ((integration_flag & EvaluationFlags::values) != 0u)
+                  if (contains(integration_flag, EvaluationFlags::values))
                     eval1.template values<1, false, true>(values_quad, temp1);
                   if (add_into_values_array == false)
                     eval0.template values<0, false, false>(temp1, values_dofs);
@@ -591,13 +591,13 @@ namespace internal
                   eval1.template values<1, false, false>(gradients_quad, temp1);
                   eval0.template gradients<0, false, true>(temp1, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(integration_flag, EvaluationFlags::hessians))
                 {
                   // grad xx
                   eval1.template values<1, false, false>(hessians_quad, temp1);
 
-                  if ((integration_flag & EvaluationFlags::values) != 0u ||
-                      (integration_flag & EvaluationFlags::gradients) != 0u ||
+                  if (contains(integration_flag, EvaluationFlags::values) ||
+                      contains(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp1, values_dofs);
                   else
@@ -628,8 +628,8 @@ namespace internal
         case 3:
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (((integration_flag & EvaluationFlags::values) != 0u) &&
-                  ((integration_flag & EvaluationFlags::gradients) == 0u))
+              if ((contains(integration_flag, EvaluationFlags::values)) &&
+                  (!contains(integration_flag, EvaluationFlags::gradients)))
                 {
                   eval2.template values<2, false, false>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
@@ -638,12 +638,12 @@ namespace internal
                   else
                     eval0.template values<0, false, true>(temp2, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::gradients) != 0u)
+              if (contains(integration_flag, EvaluationFlags::gradients))
                 {
                   eval2.template gradients<2, false, false>(gradients_quad +
                                                               2 * n_q_points,
                                                             temp1);
-                  if ((integration_flag & EvaluationFlags::values) != 0u)
+                  if (contains(integration_flag, EvaluationFlags::values))
                     eval2.template values<2, false, true>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
                   eval2.template values<2, false, false>(gradients_quad +
@@ -658,14 +658,14 @@ namespace internal
                   eval1.template values<1, false, false>(temp1, temp2);
                   eval0.template gradients<0, false, true>(temp2, values_dofs);
                 }
-              if ((integration_flag & EvaluationFlags::hessians) != 0u)
+              if (contains(integration_flag, EvaluationFlags::hessians))
                 {
                   // grad xx
                   eval2.template values<2, false, false>(hessians_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
 
-                  if ((integration_flag & EvaluationFlags::values) != 0u ||
-                      (integration_flag & EvaluationFlags::gradients) != 0u ||
+                  if (contains(integration_flag, EvaluationFlags::values) ||
+                      contains(integration_flag, EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp2, values_dofs);
                   else
@@ -725,7 +725,7 @@ namespace internal
       {
         values_dofs -= n_components * dofs_per_comp - dofs_per_comp + 1;
         values_quad -= n_components * n_q_points;
-        if ((integration_flag & EvaluationFlags::values) != 0u)
+        if (contains(integration_flag, EvaluationFlags::values))
           for (unsigned int c = 0; c < n_components; ++c)
             {
               values_dofs[0] = values_quad[0];
@@ -790,7 +790,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if ((evaluation_flag & EvaluationFlags::values) != 0u)
+    if (contains(evaluation_flag, EvaluationFlags::values))
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -807,7 +807,7 @@ namespace internal
           }
       }
 
-    if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+    if (contains(evaluation_flag, EvaluationFlags::gradients))
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -832,7 +832,7 @@ namespace internal
           }
       }
 
-    if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+    if (contains(evaluation_flag, EvaluationFlags::hessians))
       Assert(false, ExcNotImplemented());
   }
 
@@ -852,7 +852,7 @@ namespace internal
                        const bool add_into_values_array)
   {
     // TODO: implement hessians
-    AssertThrow(!(integration_flag & EvaluationFlags::hessians),
+    AssertThrow(!contains(integration_flag, EvaluationFlags::hessians),
                 ExcNotImplemented());
 
     const std::size_t n_dofs =
@@ -864,7 +864,7 @@ namespace internal
     using Eval =
       EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-    if ((integration_flag & EvaluationFlags::values) != 0u)
+    if (contains(integration_flag, EvaluationFlags::values))
       {
         const auto shape_values    = shape_data.front().shape_values.data();
         auto       values_quad_ptr = fe_eval.begin_values();
@@ -885,7 +885,7 @@ namespace internal
           }
       }
 
-    if ((integration_flag & EvaluationFlags::gradients) != 0u)
+    if (contains(integration_flag, EvaluationFlags::gradients))
       {
         const auto shape_gradients = shape_data.front().shape_gradients.data();
         auto       gradients_quad_ptr     = fe_eval.begin_gradients();
@@ -902,7 +902,7 @@ namespace internal
                           n_q_points);
 
                 if ((add_into_values_array == false &&
-                     (integration_flag & EvaluationFlags::values) == 0) &&
+                     !contains(integration_flag, EvaluationFlags::values)) &&
                     d == 0)
                   eval.template gradients<0, false, false>(
                     gradients_quad_ptr, values_dofs_actual_ptr);
@@ -1377,7 +1377,7 @@ namespace internal
 
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if ((evaluation_flag & EvaluationFlags::values) != 0u)
+        if (contains(evaluation_flag, EvaluationFlags::values))
           for (unsigned int i = 0; i < n_points; ++i)
             fe_eval.begin_values()[n_points * c + i] =
               values_dofs[n_points * c + i];
@@ -1414,8 +1414,8 @@ namespace internal
       eval(AlignedVector<Number>(),
            shape.shape_gradients_collocation_eo,
            shape.shape_hessians_collocation_eo);
-    if ((evaluation_flag &
-         (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+    if (contains(evaluation_flag,
+                 (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         eval.template gradients<0, true, false>(values_dofs, gradients_quad);
         if (dim > 1)
@@ -1426,7 +1426,7 @@ namespace internal
                                                   gradients_quad +
                                                     2 * n_points);
       }
-    if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+    if (contains(evaluation_flag, EvaluationFlags::hessians))
       {
         eval.template hessians<0, true, false>(values_dofs, hessians_quad);
         if (dim > 1)
@@ -1467,7 +1467,7 @@ namespace internal
 
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if ((integration_flag & EvaluationFlags::values) != 0u)
+        if (contains(integration_flag, EvaluationFlags::values))
           {
             if (add_into_values_array)
               for (unsigned int i = 0; i < n_points; ++i)
@@ -1486,7 +1486,7 @@ namespace internal
                      fe_eval.begin_hessians() +
                        c * dim * (dim + 1) / 2 * n_points,
                      add_into_values_array ||
-                       ((integration_flag & EvaluationFlags::values) != 0u));
+                       (contains(integration_flag, EvaluationFlags::values)));
       }
   }
 
@@ -1515,7 +1515,7 @@ namespace internal
            shape.shape_hessians_collocation_eo);
     constexpr std::size_t n_points = Utilities::pow(fe_degree + 1, dim);
 
-    if ((integration_flag & EvaluationFlags::hessians) != 0u)
+    if (contains(integration_flag, EvaluationFlags::hessians))
       {
         // diagonal
         // grad xx
@@ -1535,7 +1535,7 @@ namespace internal
         if (dim == 2)
           {
             // grad xy, queue into gradient
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (contains(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<1, false, true>(hessians_quad +
                                                         2 * n_points,
                                                       gradients_quad);
@@ -1547,7 +1547,7 @@ namespace internal
         if (dim == 3)
           {
             // grad xy, queue into gradient
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (contains(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<1, false, true>(hessians_quad +
                                                         3 * n_points,
                                                       gradients_quad);
@@ -1562,7 +1562,7 @@ namespace internal
                                                     gradients_quad);
 
             // grad yz
-            if ((integration_flag & EvaluationFlags::gradients) != 0u)
+            if (contains(integration_flag, EvaluationFlags::gradients))
               eval.template gradients<2, false, true>(
                 hessians_quad + 5 * n_points, gradients_quad + n_points);
             else
@@ -1573,16 +1573,16 @@ namespace internal
         // if we did not integrate gradients, set the last slot to zero
         // which was not touched before, in order to avoid the if
         // statement in the gradients loop below
-        if ((integration_flag & EvaluationFlags::gradients) == 0u)
+        if (!contains(integration_flag, EvaluationFlags::gradients))
           for (unsigned int q = 0; q < n_points; ++q)
             gradients_quad[(dim - 1) * n_points + q] = Number();
       }
 
-    if ((integration_flag &
-         (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+    if (contains(integration_flag,
+                 (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         if (add_into_values_array ||
-            (integration_flag & EvaluationFlags::hessians) != 0u)
+            contains(integration_flag, EvaluationFlags::hessians))
           eval.template gradients<0, false, true>(gradients_quad, values_dofs);
         else
           eval.template gradients<0, false, false>(gradients_quad, values_dofs);
@@ -1662,12 +1662,14 @@ namespace internal
                               fe_eval.begin_values() + c * n_q_points);
 
         // apply derivatives in the collocation space
-        if ((evaluation_flag &
-             (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+        if (contains(evaluation_flag,
+                     (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
-                        evaluation_flag & (EvaluationFlags::gradients |
-                                           EvaluationFlags::hessians),
+                        static_cast<EvaluationFlags::EvaluationFlags>(
+                          unsigned(evaluation_flag) &
+                          unsigned(EvaluationFlags::gradients |
+                                   EvaluationFlags::hessians)),
                         fe_eval.begin_values() + c * n_q_points,
                         fe_eval.begin_gradients() + c * dim * n_q_points,
                         fe_eval.begin_hessians() +
@@ -1701,18 +1703,20 @@ namespace internal
     for (unsigned int c = 0; c < n_components; ++c)
       {
         // apply derivatives in collocation space
-        if ((integration_flag &
-             (EvaluationFlags::gradients | EvaluationFlags::hessians)) != 0u)
+        if (contains(integration_flag,
+                     (EvaluationFlags::gradients | EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_integrate(shape_data,
-                         integration_flag & (EvaluationFlags::gradients |
-                                             EvaluationFlags::hessians),
+                         static_cast<EvaluationFlags::EvaluationFlags>(
+                           static_cast<unsigned int>(integration_flag) &
+                           static_cast<unsigned>(EvaluationFlags::gradients |
+                                                 EvaluationFlags::hessians)),
                          fe_eval.begin_values() + c * n_q_points,
                          fe_eval.begin_gradients() + c * dim * n_q_points,
                          fe_eval.begin_hessians() +
                            c * dim * (dim + 1) / 2 * n_q_points,
                          /*add_into_values_array=*/
-                         integration_flag & EvaluationFlags::values);
+                         contains(integration_flag, EvaluationFlags::values));
 
         // transform back to the original space
         FEEvaluationImplBasisChange<
@@ -2066,8 +2070,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if ((evaluation_flag & EvaluationFlags::values) != 0u &&
-          ((evaluation_flag & EvaluationFlags::gradients) == 0u))
+      if (contains(evaluation_flag, EvaluationFlags::values) &&
+          (!contains(evaluation_flag, EvaluationFlags::gradients)))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2093,7 +2097,7 @@ namespace internal
             values_dofs += 3 * n_dofs;
             values_quad += n_q_points;
           }
-      else if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+      else if (contains(evaluation_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2134,7 +2138,7 @@ namespace internal
                                                                gradients_quad +
                                                                  n_q_points);
 
-                      if ((evaluation_flag & EvaluationFlags::values) != 0u)
+                      if (contains(evaluation_flag, EvaluationFlags::values))
                         eval1.template values<1, true, false>(scratch_data,
                                                               values_quad);
                     }
@@ -2151,7 +2155,7 @@ namespace internal
                                                           n_q_points);
                   eval0.template gradients<0, true, false>(values_dofs,
                                                            gradients_quad);
-                  if ((evaluation_flag & EvaluationFlags::values) != 0u)
+                  if (contains(evaluation_flag, EvaluationFlags::values))
                     eval0.template values<0, true, false>(values_dofs,
                                                           values_quad);
                   break;
@@ -2167,7 +2171,7 @@ namespace internal
             gradients_quad += dim * n_q_points;
           }
 
-      if ((evaluation_flag & EvaluationFlags::hessians) != 0u)
+      if (contains(evaluation_flag, EvaluationFlags::hessians))
         {
           values_dofs = values_dofs_ptr;
           for (unsigned int c = 0; c < n_components; ++c)
@@ -2268,8 +2272,8 @@ namespace internal
       // keep a copy of the original pointer for the case of the Hessians
       Number *values_dofs_ptr = values_dofs;
 
-      if ((integration_flag & EvaluationFlags::values) != 0u &&
-          (integration_flag & EvaluationFlags::gradients) == 0u)
+      if (contains(integration_flag, EvaluationFlags::values) &&
+          !contains(integration_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2293,7 +2297,7 @@ namespace internal
             values_dofs += 3 * n_dofs;
             values_quad += n_q_points;
           }
-      else if ((integration_flag & EvaluationFlags::gradients) != 0u)
+      else if (contains(integration_flag, EvaluationFlags::gradients))
         for (unsigned int c = 0; c < n_components; ++c)
           {
             switch (dim)
@@ -2318,7 +2322,7 @@ namespace internal
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
-                      if ((integration_flag & EvaluationFlags::values) != 0u)
+                      if (contains(integration_flag, EvaluationFlags::values))
                         eval_grad.template gradients<1, false, true>(
                           gradients_quad + n_q_points, values_quad);
                       else
@@ -2333,7 +2337,7 @@ namespace internal
                     }
                   else
                     {
-                      if ((integration_flag & EvaluationFlags::values) != 0u)
+                      if (contains(integration_flag, EvaluationFlags::values))
                         {
                           eval1.template values<1, false, false>(values_quad,
                                                                  scratch_data);
@@ -2361,7 +2365,7 @@ namespace internal
                                                          values_dofs + n_dofs);
                   eval0.template gradients<0, false, false>(gradients_quad,
                                                             values_dofs);
-                  if ((integration_flag & EvaluationFlags::values) != 0u)
+                  if (contains(integration_flag, EvaluationFlags::values))
                     eval0.template values<0, false, true>(values_quad,
                                                           values_dofs);
                   break;
@@ -2377,7 +2381,7 @@ namespace internal
             gradients_quad += dim * n_q_points;
           }
 
-      if ((integration_flag & EvaluationFlags::hessians) != 0u)
+      if (contains(integration_flag, EvaluationFlags::hessians))
         {
           values_dofs = values_dofs_ptr;
           for (unsigned int c = 0; c < n_components; ++c)
@@ -2388,8 +2392,9 @@ namespace internal
                     // grad xx
                     eval1.template values<1, false, false>(hessians_quad,
                                                            scratch_data);
-                    if ((integration_flag & (EvaluationFlags::values |
-                                             EvaluationFlags::gradients)) != 0u)
+                    if (contains(integration_flag,
+                                 (EvaluationFlags::values |
+                                  EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(scratch_data,
                                                               values_dofs);
                     else
@@ -2422,7 +2427,7 @@ namespace internal
                     eval1.template values<1, false, false>(hessians_quad +
                                                              4 * n_q_points,
                                                            scratch_data);
-                    if ((integration_flag & EvaluationFlags::gradients) != 0u)
+                    if (contains(integration_flag, EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(scratch_data,
                                                                values_dofs +
                                                                  n_dofs);
@@ -2441,8 +2446,9 @@ namespace internal
                     break;
                   case 2:
                     // grad xx
-                    if ((integration_flag & (EvaluationFlags::values |
-                                             EvaluationFlags::gradients)) != 0u)
+                    if (contains(integration_flag,
+                                 (EvaluationFlags::values |
+                                  EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(hessians_quad,
                                                               values_dofs);
                     else
@@ -2453,7 +2459,7 @@ namespace internal
                     eval0.template values<0, false, false>(
                       hessians_quad + n_q_points, values_dofs + 2 * n_dofs);
                     // grad xy
-                    if ((integration_flag & EvaluationFlags::gradients) != 0u)
+                    if (contains(integration_flag, EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(
                         hessians_quad + 2 * n_q_points, values_dofs + n_dofs);
                     else
@@ -2462,9 +2468,9 @@ namespace internal
                     break;
                   case 1:
                     values_dofs[2] = hessians_quad[0];
-                    if ((integration_flag & EvaluationFlags::values) == 0u)
+                    if (!contains(integration_flag, EvaluationFlags::values))
                       values_dofs[0] = 0;
-                    if ((integration_flag & EvaluationFlags::gradients) == 0u)
+                    if (!contains(integration_flag, EvaluationFlags::gradients))
                       values_dofs[1] = 0;
                     break;
                   default:
@@ -2573,13 +2579,13 @@ namespace internal
 
           for (unsigned int c = 0; c < n_components; ++c)
             {
-              if (flag & EvaluationFlags::hessians)
+              if (contains(flag, EvaluationFlags::hessians))
                 evalf.template apply_face<face_direction,
                                           do_evaluate,
                                           add_into_output,
                                           2,
                                           lex_faces>(input, output);
-              else if (flag & EvaluationFlags::gradients)
+              else if (contains(flag, EvaluationFlags::gradients))
                 evalf.template apply_face<face_direction,
                                           do_evaluate,
                                           add_into_output,
@@ -2735,7 +2741,7 @@ namespace internal
   {
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (flag & EvaluationFlags::values)
+        if (contains(flag, EvaluationFlags::values))
           {
             if (integrate)
               for (unsigned int q = 0; q < n_q_points; ++q)
@@ -2746,7 +2752,7 @@ namespace internal
             for (unsigned int q = 0; q < n_q_points; ++q)
               values_quad[c * n_q_points + q] = tmp_values[q];
           }
-        if (flag & EvaluationFlags::gradients)
+        if (contains(flag, EvaluationFlags::gradients))
           for (unsigned int d = 0; d < dim; ++d)
             {
               if (integrate)
@@ -2760,7 +2766,7 @@ namespace internal
               for (unsigned int q = 0; q < n_q_points; ++q)
                 gradients_quad[(c * dim + d) * n_q_points + q] = tmp_values[q];
             }
-        if (flag & EvaluationFlags::hessians)
+        if (contains(flag, EvaluationFlags::hessians))
           {
             const unsigned int hdim = (dim * (dim + 1)) / 2;
             for (unsigned int d = 0; d < hdim; ++d)
@@ -2800,7 +2806,7 @@ namespace internal
   {
     for (unsigned int c = 0; c < n_components; ++c)
       {
-        if (flag & EvaluationFlags::values)
+        if (contains(flag, EvaluationFlags::values))
           {
             if (integrate)
               for (unsigned int q = 0; q < n_q_points; ++q)
@@ -2811,7 +2817,7 @@ namespace internal
             for (unsigned int q = 0; q < n_q_points; ++q)
               values_quad[c * n_q_points + q][v] = tmp_values[q];
           }
-        if (flag & EvaluationFlags::gradients)
+        if (contains(flag, EvaluationFlags::gradients))
           for (unsigned int d = 0; d < dim; ++d)
             {
               Assert(gradients_quad != nullptr, ExcInternalError());
@@ -2827,7 +2833,7 @@ namespace internal
                 gradients_quad[(c * dim + d) * n_q_points + q][v] =
                   tmp_values[q];
             }
-        if (flag & EvaluationFlags::hessians)
+        if (contains(flag, EvaluationFlags::hessians))
           {
             Assert(hessians_quad != nullptr, ExcInternalError());
             const unsigned int hdim = (dim * (dim + 1)) / 2;
@@ -2874,7 +2880,7 @@ namespace internal
           using Eval =
             EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-          if (evaluation_flag & EvaluationFlags::values)
+          if (contains(evaluation_flag, EvaluationFlags::values))
             {
               const auto shape_values =
                 &shape_data.shape_values_face(face_no, face_orientation, 0);
@@ -2893,7 +2899,7 @@ namespace internal
                 }
             }
 
-          if (evaluation_flag & EvaluationFlags::gradients)
+          if (contains(evaluation_flag, EvaluationFlags::gradients))
             {
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
@@ -2922,7 +2928,7 @@ namespace internal
                 }
             }
 
-          Assert(!(evaluation_flag & EvaluationFlags::hessians),
+          Assert(!(contains(evaluation_flag, EvaluationFlags::hessians)),
                  ExcNotImplemented());
 
           return true;
@@ -3024,7 +3030,7 @@ namespace internal
           using Eval =
             EvaluatorTensorProduct<evaluate_general, 1, 0, 0, Number, Number>;
 
-          if (integration_flag & EvaluationFlags::values)
+          if (contains(integration_flag, EvaluationFlags::values))
             {
               const auto shape_values =
                 &shape_data.shape_values_face(face_no, face_orientation, 0);
@@ -3043,7 +3049,7 @@ namespace internal
                 }
             }
 
-          if (integration_flag & EvaluationFlags::gradients)
+          if (contains(integration_flag, EvaluationFlags::gradients))
             {
               auto gradients_quad_ptr     = fe_eval.begin_gradients();
               auto values_dofs_actual_ptr = values_dofs;
@@ -3063,7 +3069,8 @@ namespace internal
                                 n_dofs,
                                 n_q_points);
 
-                      if (!(integration_flag & EvaluationFlags::values) &&
+                      if (!(contains(integration_flag,
+                                     EvaluationFlags::values)) &&
                           d == 0)
                         eval.template gradients<0, false, false>(
                           gradients_quad_ptr, values_dofs_actual_ptr);
@@ -3077,7 +3084,7 @@ namespace internal
                 }
             }
 
-          Assert(!(integration_flag & EvaluationFlags::hessians),
+          Assert(!(contains(integration_flag, EvaluationFlags::hessians)),
                  ExcNotImplemented());
 
           return true;
@@ -3273,7 +3280,8 @@ namespace internal
     // face_to_cell_index_hermite
     std::array<const unsigned int *, n_face_orientations> index_array_hermite =
       {};
-    if (fe_degree > 1 && (evaluation_flag & EvaluationFlags::gradients))
+    if (fe_degree > 1 &&
+        (contains(evaluation_flag, EvaluationFlags::gradients)))
       {
         if (n_face_orientations == 1)
           index_array_hermite[0] =
@@ -3354,7 +3362,8 @@ namespace internal
             Number2_ *vector_ptr =
               global_vector_ptr + dof_indices[0] + index_offset * n_lanes;
 
-            if (fe_degree > 1 && (evaluation_flag & EvaluationFlags::gradients))
+            if (fe_degree > 1 &&
+                (contains(evaluation_flag, EvaluationFlags::gradients)))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3394,7 +3403,8 @@ namespace internal
               dof_info.n_vectorization_lanes_filled[dof_access_index][cell],
               n_lanes);
             Number2_ *vector_ptr = global_vector_ptr + index_offset * n_lanes;
-            if (fe_degree > 1 && (evaluation_flag & EvaluationFlags::gradients))
+            if (fe_degree > 1 &&
+                (contains(evaluation_flag, EvaluationFlags::gradients)))
               {
                 for (unsigned int i = 0; i < dofs_per_face; ++i)
                   {
@@ -3445,7 +3455,8 @@ namespace internal
             const unsigned int n_filled_lanes =
               dof_info.n_vectorization_lanes_filled[dof_access_index][cell];
 
-            if (fe_degree > 1 && (evaluation_flag & EvaluationFlags::gradients))
+            if (fe_degree > 1 &&
+                (contains(evaluation_flag, EvaluationFlags::gradients)))
               {
                 if (n_filled_lanes == n_lanes)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3614,7 +3625,8 @@ namespace internal
                 dof_indices = reordered_indices.data();
               }
 
-            if (fe_degree > 1 && (evaluation_flag & EvaluationFlags::gradients))
+            if (fe_degree > 1 &&
+                (contains(evaluation_flag, EvaluationFlags::gradients)))
               {
                 if (vectorization_possible)
                   for (unsigned int i = 0; i < dofs_per_face; ++i)
@@ -3848,11 +3860,11 @@ namespace internal
     {
       const unsigned int fe_degree = shape_info.data.front().fe_degree;
       if (fe_degree < 1 || !shape_info.data.front().nodal_at_cell_boundaries ||
-          (evaluation_flag & EvaluationFlags::gradients &&
+          (contains(evaluation_flag, EvaluationFlags::gradients) &&
            (fe_degree < 2 ||
             shape_info.data.front().element_type !=
               MatrixFreeFunctions::tensor_symmetric_hermite)) ||
-          (evaluation_flag & EvaluationFlags::hessians) ||
+          (contains(evaluation_flag, EvaluationFlags::hessians)) ||
           vector_ptr == nullptr ||
           shape_info.data.front().element_type >
             MatrixFreeFunctions::tensor_symmetric ||

--- a/include/deal.II/matrix_free/evaluation_kernels.h
+++ b/include/deal.II/matrix_free/evaluation_kernels.h
@@ -308,7 +308,8 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xy
-                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     eval0.template gradients<0, true, false>(values_dofs,
                                                              temp1);
                   eval1.template gradients<1, true, false>(temp1,
@@ -359,7 +360,8 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad xz
-                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     {
                       eval0.template gradients<0, true, false>(values_dofs,
                                                                temp1);
@@ -394,7 +396,8 @@ namespace internal
               if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
                 {
                   // grad yz
-                  if (!contains_bits(evaluation_flag, EvaluationFlags::gradients))
+                  if (!contains_bits(evaluation_flag,
+                                     EvaluationFlags::gradients))
                     eval1.template gradients<1, true, false>(temp1, temp2);
                   eval2.template gradients<2, true, false>(temp2,
                                                            hessians_quad +
@@ -537,7 +540,8 @@ namespace internal
                 }
               if (contains_bits(integration_flag, EvaluationFlags::gradients))
                 {
-                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
                       add_into_values_array == true)
                     eval0.template gradients<0, false, true>(gradients_quad,
                                                              values_dofs);
@@ -547,8 +551,10 @@ namespace internal
                 }
               if (contains_bits(integration_flag, EvaluationFlags::hessians))
                 {
-                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
-                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(hessians_quad,
                                                             values_dofs);
@@ -569,7 +575,8 @@ namespace internal
           for (unsigned int c = 0; c < n_components; ++c)
             {
               if (contains_bits(integration_flag, EvaluationFlags::values) &&
-                  (!contains_bits(integration_flag, EvaluationFlags::gradients)))
+                  (!contains_bits(integration_flag,
+                                  EvaluationFlags::gradients)))
                 {
                   eval1.template values<1, false, false>(values_quad, temp1);
                   if (add_into_values_array == false)
@@ -596,8 +603,10 @@ namespace internal
                   // grad xx
                   eval1.template values<1, false, false>(hessians_quad, temp1);
 
-                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
-                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp1, values_dofs);
                   else
@@ -629,7 +638,8 @@ namespace internal
           for (unsigned int c = 0; c < n_components; ++c)
             {
               if (contains_bits(integration_flag, EvaluationFlags::values) &&
-                  (!contains_bits(integration_flag, EvaluationFlags::gradients)))
+                  (!contains_bits(integration_flag,
+                                  EvaluationFlags::gradients)))
                 {
                   eval2.template values<2, false, false>(values_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
@@ -664,8 +674,10 @@ namespace internal
                   eval2.template values<2, false, false>(hessians_quad, temp1);
                   eval1.template values<1, false, false>(temp1, temp2);
 
-                  if (contains_bits(integration_flag, EvaluationFlags::values) ||
-                      contains_bits(integration_flag, EvaluationFlags::gradients) ||
+                  if (contains_bits(integration_flag,
+                                    EvaluationFlags::values) ||
+                      contains_bits(integration_flag,
+                                    EvaluationFlags::gradients) ||
                       add_into_values_array == true)
                     eval0.template hessians<0, false, true>(temp2, values_dofs);
                   else
@@ -902,7 +914,8 @@ namespace internal
                           n_q_points);
 
                 if ((add_into_values_array == false &&
-                     !contains_bits(integration_flag, EvaluationFlags::values)) &&
+                     !contains_bits(integration_flag,
+                                    EvaluationFlags::values)) &&
                     d == 0)
                   eval.template gradients<0, false, false>(
                     gradients_quad_ptr, values_dofs_actual_ptr);
@@ -1415,7 +1428,7 @@ namespace internal
            shape.shape_gradients_collocation_eo,
            shape.shape_hessians_collocation_eo);
     if (contains_bits(evaluation_flag,
-          (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         eval.template gradients<0, true, false>(values_dofs, gradients_quad);
         if (dim > 1)
@@ -1486,7 +1499,8 @@ namespace internal
                      fe_eval.begin_hessians() +
                        c * dim * (dim + 1) / 2 * n_points,
                      add_into_values_array ||
-                       contains_bits(integration_flag, EvaluationFlags::values));
+                       contains_bits(integration_flag,
+                                     EvaluationFlags::values));
       }
   }
 
@@ -1579,7 +1593,7 @@ namespace internal
       }
 
     if (contains_bits(integration_flag,
-          (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+                      (EvaluationFlags::gradients | EvaluationFlags::hessians)))
       {
         if (add_into_values_array ||
             contains_bits(integration_flag, EvaluationFlags::hessians))
@@ -1663,7 +1677,8 @@ namespace internal
 
         // apply derivatives in the collocation space
         if (contains_bits(evaluation_flag,
-              (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+                          (EvaluationFlags::gradients |
+                           EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
             do_evaluate(shape_data,
                         evaluation_flag & (EvaluationFlags::gradients |
@@ -1702,17 +1717,18 @@ namespace internal
       {
         // apply derivatives in collocation space
         if (contains_bits(integration_flag,
-              (EvaluationFlags::gradients | EvaluationFlags::hessians)))
+                          (EvaluationFlags::gradients |
+                           EvaluationFlags::hessians)))
           FEEvaluationImplCollocation<dim, n_q_points_1d - 1, Number>::
-            do_integrate(shape_data,
-                         integration_flag & (EvaluationFlags::gradients |
-                                             EvaluationFlags::hessians),
-                         fe_eval.begin_values() + c * n_q_points,
-                         fe_eval.begin_gradients() + c * dim * n_q_points,
-                         fe_eval.begin_hessians() +
-                           c * dim * (dim + 1) / 2 * n_q_points,
-                         /*add_into_values_array=*/
-                         contains_bits(integration_flag, EvaluationFlags::values));
+            do_integrate(
+              shape_data,
+              integration_flag &
+                (EvaluationFlags::gradients | EvaluationFlags::hessians),
+              fe_eval.begin_values() + c * n_q_points,
+              fe_eval.begin_gradients() + c * dim * n_q_points,
+              fe_eval.begin_hessians() + c * dim * (dim + 1) / 2 * n_q_points,
+              /*add_into_values_array=*/
+              contains_bits(integration_flag, EvaluationFlags::values));
 
         // transform back to the original space
         FEEvaluationImplBasisChange<
@@ -2134,7 +2150,8 @@ namespace internal
                                                                gradients_quad +
                                                                  n_q_points);
 
-                      if (contains_bits(evaluation_flag, EvaluationFlags::values))
+                      if (contains_bits(evaluation_flag,
+                                        EvaluationFlags::values))
                         eval1.template values<1, true, false>(scratch_data,
                                                               values_quad);
                     }
@@ -2318,7 +2335,8 @@ namespace internal
                         eval_grad(AlignedVector<Number>(),
                                   data.shape_gradients_collocation_eo,
                                   AlignedVector<Number>());
-                      if (contains_bits(integration_flag, EvaluationFlags::values))
+                      if (contains_bits(integration_flag,
+                                        EvaluationFlags::values))
                         eval_grad.template gradients<1, false, true>(
                           gradients_quad + n_q_points, values_quad);
                       else
@@ -2333,7 +2351,8 @@ namespace internal
                     }
                   else
                     {
-                      if (contains_bits(integration_flag, EvaluationFlags::values))
+                      if (contains_bits(integration_flag,
+                                        EvaluationFlags::values))
                         {
                           eval1.template values<1, false, false>(values_quad,
                                                                  scratch_data);
@@ -2388,8 +2407,9 @@ namespace internal
                     // grad xx
                     eval1.template values<1, false, false>(hessians_quad,
                                                            scratch_data);
-                    if (contains_bits(integration_flag, (EvaluationFlags::values |
-                                                   EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag,
+                                      (EvaluationFlags::values |
+                                       EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(scratch_data,
                                                               values_dofs);
                     else
@@ -2422,7 +2442,8 @@ namespace internal
                     eval1.template values<1, false, false>(hessians_quad +
                                                              4 * n_q_points,
                                                            scratch_data);
-                    if (contains_bits(integration_flag, EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag,
+                                      EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(scratch_data,
                                                                values_dofs +
                                                                  n_dofs);
@@ -2441,8 +2462,9 @@ namespace internal
                     break;
                   case 2:
                     // grad xx
-                    if (contains_bits(integration_flag, (EvaluationFlags::values |
-                                                   EvaluationFlags::gradients)))
+                    if (contains_bits(integration_flag,
+                                      (EvaluationFlags::values |
+                                       EvaluationFlags::gradients)))
                       eval0.template hessians<0, false, true>(hessians_quad,
                                                               values_dofs);
                     else
@@ -2453,7 +2475,8 @@ namespace internal
                     eval0.template values<0, false, false>(
                       hessians_quad + n_q_points, values_dofs + 2 * n_dofs);
                     // grad xy
-                    if (contains_bits(integration_flag, EvaluationFlags::gradients))
+                    if (contains_bits(integration_flag,
+                                      EvaluationFlags::gradients))
                       eval0.template gradients<0, false, true>(
                         hessians_quad + 2 * n_q_points, values_dofs + n_dofs);
                     else
@@ -2462,9 +2485,11 @@ namespace internal
                     break;
                   case 1:
                     values_dofs[2] = hessians_quad[0];
-                    if (!contains_bits(integration_flag, EvaluationFlags::values))
+                    if (!contains_bits(integration_flag,
+                                       EvaluationFlags::values))
                       values_dofs[0] = 0;
-                    if (!contains_bits(integration_flag, EvaluationFlags::gradients))
+                    if (!contains_bits(integration_flag,
+                                       EvaluationFlags::gradients))
                       values_dofs[1] = 0;
                     break;
                   default:
@@ -3064,7 +3089,7 @@ namespace internal
                                 n_q_points);
 
                       if (!contains_bits(integration_flag,
-                            EvaluationFlags::values) &&
+                                         EvaluationFlags::values) &&
                           d == 0)
                         eval.template gradients<0, false, false>(
                           gradients_quad_ptr, values_dofs_actual_ptr);

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7358,9 +7358,9 @@ FEEvaluation<dim,
            this->mapped_geometry->is_initialized(),
          ExcNotInitialized());
 
-  Assert(!contains_bits(integration_flag, ~(EvaluationFlags::values |
-                                      EvaluationFlags::gradients |
-                                      EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage(
            "Only EvaluationFlags::values, EvaluationFlags::gradients, and "
            "EvaluationFlags::hessians are supported."));
@@ -7871,9 +7871,9 @@ FEFaceEvaluation<dim,
   evaluate(const VectorizedArrayType *            values_array,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains_bits(evaluation_flag, ~(EvaluationFlags::values |
-                                     EvaluationFlags::gradients |
-                                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -7997,9 +7997,9 @@ FEFaceEvaluation<dim,
   integrate(const EvaluationFlags::EvaluationFlags integration_flag,
             VectorizedArrayType *                  values_array)
 {
-  Assert(!contains_bits(integration_flag, ~(EvaluationFlags::values |
-                                      EvaluationFlags::gradients |
-                                      EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -8079,9 +8079,9 @@ FEFaceEvaluation<dim,
   gather_evaluate(const VectorType &                     input_vector,
                   const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains_bits(evaluation_flag, ~(EvaluationFlags::values |
-                                     EvaluationFlags::gradients |
-                                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7358,9 +7358,9 @@ FEEvaluation<dim,
            this->mapped_geometry->is_initialized(),
          ExcNotInitialized());
 
-  Assert(!contains_bits(integration_flag,
-                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag, ~(EvaluationFlags::values |
+                                      EvaluationFlags::gradients |
+                                      EvaluationFlags::hessians)),
          ExcMessage(
            "Only EvaluationFlags::values, EvaluationFlags::gradients, and "
            "EvaluationFlags::hessians are supported."));
@@ -7871,9 +7871,9 @@ FEFaceEvaluation<dim,
   evaluate(const VectorizedArrayType *            values_array,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains_bits(evaluation_flag,
-                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag, ~(EvaluationFlags::values |
+                                     EvaluationFlags::gradients |
+                                     EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -7997,9 +7997,9 @@ FEFaceEvaluation<dim,
   integrate(const EvaluationFlags::EvaluationFlags integration_flag,
             VectorizedArrayType *                  values_array)
 {
-  Assert(!contains_bits(integration_flag,
-                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag, ~(EvaluationFlags::values |
+                                      EvaluationFlags::gradients |
+                                      EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -8079,9 +8079,9 @@ FEFaceEvaluation<dim,
   gather_evaluate(const VectorType &                     input_vector,
                   const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains_bits(evaluation_flag,
-                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag, ~(EvaluationFlags::values |
+                                     EvaluationFlags::gradients |
+                                     EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7087,7 +7087,7 @@ FEEvaluation<dim,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
   const bool hessians_on_general_cells =
-    evaluation_flag & EvaluationFlags::hessians &&
+    contains(evaluation_flag, EvaluationFlags::hessians) &&
     (this->cell_type > internal::MatrixFreeFunctions::affine);
   EvaluationFlags::EvaluationFlags evaluation_flag_actual = evaluation_flag;
   if (hessians_on_general_cells)
@@ -7108,11 +7108,11 @@ FEEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if ((evaluation_flag_actual & EvaluationFlags::values) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::gradients) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }
@@ -7344,13 +7344,13 @@ FEEvaluation<dim,
             const bool                             sum_into_values_array)
 {
 #  ifdef DEBUG
-  if ((integration_flag & EvaluationFlags::values) != 0u)
+  if (contains(integration_flag, EvaluationFlags::values))
     Assert(this->values_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
-  if ((integration_flag & EvaluationFlags::gradients) != 0u)
+  if (contains(integration_flag, EvaluationFlags::gradients))
     Assert(this->gradients_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
-  if ((integration_flag & EvaluationFlags::hessians) != 0u)
+  if (contains(integration_flag, EvaluationFlags::hessians))
     Assert(this->hessians_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
 #  endif
@@ -7358,18 +7358,20 @@ FEEvaluation<dim,
            this->mapped_geometry->is_initialized(),
          ExcNotInitialized());
 
-  Assert(
-    (integration_flag & ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                          EvaluationFlags::hessians)) == 0,
-    ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, and "
-               "EvaluationFlags::hessians are supported."));
+  Assert(!contains(integration_flag,
+                   static_cast<EvaluationFlags::EvaluationFlags>(
+                     ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                       EvaluationFlags::hessians))),
+         ExcMessage(
+           "Only EvaluationFlags::values, EvaluationFlags::gradients, and "
+           "EvaluationFlags::hessians are supported."));
 
   EvaluationFlags::EvaluationFlags integration_flag_actual = integration_flag;
-  if (integration_flag & EvaluationFlags::hessians &&
+  if (contains(integration_flag, EvaluationFlags::hessians) &&
       (this->cell_type > internal::MatrixFreeFunctions::affine))
     {
       unsigned int size = n_components * dim * n_q_points;
-      if ((integration_flag & EvaluationFlags::gradients) != 0u)
+      if (contains(integration_flag, EvaluationFlags::gradients))
         {
           for (unsigned int i = 0; i < size; ++i)
             this->gradients_quad[i] += this->gradients_from_hessians_quad[i];
@@ -7870,14 +7872,15 @@ FEFaceEvaluation<dim,
   evaluate(const VectorizedArrayType *            values_array,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert((evaluation_flag &
-          ~(EvaluationFlags::values | EvaluationFlags::gradients |
-            EvaluationFlags::hessians)) == 0,
+  Assert(!contains(evaluation_flag,
+                   static_cast<EvaluationFlags::EvaluationFlags>(
+                     ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                       EvaluationFlags::hessians))),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
   const bool hessians_on_general_cells =
-    evaluation_flag & EvaluationFlags::hessians &&
+    contains(evaluation_flag, EvaluationFlags::hessians) &&
     (this->cell_type > internal::MatrixFreeFunctions::affine);
   EvaluationFlags::EvaluationFlags evaluation_flag_actual = evaluation_flag;
   if (hessians_on_general_cells)
@@ -7894,11 +7897,11 @@ FEFaceEvaluation<dim,
       n_components, evaluation_flag_actual, values_array, *this);
 
 #  ifdef DEBUG
-  if ((evaluation_flag_actual & EvaluationFlags::values) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::gradients) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if ((evaluation_flag_actual & EvaluationFlags::hessians) != 0u)
+  if (contains(evaluation_flag_actual, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }
@@ -7996,18 +7999,18 @@ FEFaceEvaluation<dim,
   integrate(const EvaluationFlags::EvaluationFlags integration_flag,
             VectorizedArrayType *                  values_array)
 {
-  Assert((integration_flag &
-          ~(EvaluationFlags::values | EvaluationFlags::gradients |
-            EvaluationFlags::hessians)) == 0,
+  Assert(!contains(integration_flag,
+                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                     EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
   EvaluationFlags::EvaluationFlags integration_flag_actual = integration_flag;
-  if (((integration_flag & EvaluationFlags::hessians) != 0u) &&
+  if ((contains(integration_flag, EvaluationFlags::hessians)) &&
       (this->cell_type > internal::MatrixFreeFunctions::affine))
     {
       unsigned int size = n_components * dim * n_q_points;
-      if ((integration_flag & EvaluationFlags::gradients) != 0u)
+      if (contains(integration_flag, EvaluationFlags::gradients))
         {
           for (unsigned int i = 0; i < size; ++i)
             this->gradients_quad[i] += this->gradients_from_hessians_quad[i];
@@ -8078,9 +8081,9 @@ FEFaceEvaluation<dim,
   gather_evaluate(const VectorType &                     input_vector,
                   const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert((evaluation_flag &
-          ~(EvaluationFlags::values | EvaluationFlags::gradients |
-            EvaluationFlags::hessians)) == 0,
+  Assert(!contains(evaluation_flag,
+                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                     EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -8140,11 +8143,11 @@ FEFaceEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if (evaluation_flag & EvaluationFlags::values)
+  if (contains(evaluation_flag, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if (evaluation_flag & EvaluationFlags::gradients)
+  if (contains(evaluation_flag, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if (evaluation_flag & EvaluationFlags::hessians)
+  if (contains(evaluation_flag, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7087,7 +7087,7 @@ FEEvaluation<dim,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
   const bool hessians_on_general_cells =
-    contains(evaluation_flag, EvaluationFlags::hessians) &&
+    contains_bits(evaluation_flag, EvaluationFlags::hessians) &&
     (this->cell_type > internal::MatrixFreeFunctions::affine);
   EvaluationFlags::EvaluationFlags evaluation_flag_actual = evaluation_flag;
   if (hessians_on_general_cells)
@@ -7108,11 +7108,11 @@ FEEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if (contains(evaluation_flag_actual, EvaluationFlags::values))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if (contains(evaluation_flag_actual, EvaluationFlags::gradients))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if (contains(evaluation_flag_actual, EvaluationFlags::hessians))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }
@@ -7344,13 +7344,13 @@ FEEvaluation<dim,
             const bool                             sum_into_values_array)
 {
 #  ifdef DEBUG
-  if (contains(integration_flag, EvaluationFlags::values))
+  if (contains_bits(integration_flag, EvaluationFlags::values))
     Assert(this->values_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
-  if (contains(integration_flag, EvaluationFlags::gradients))
+  if (contains_bits(integration_flag, EvaluationFlags::gradients))
     Assert(this->gradients_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
-  if (contains(integration_flag, EvaluationFlags::hessians))
+  if (contains_bits(integration_flag, EvaluationFlags::hessians))
     Assert(this->hessians_quad_submitted == true,
            internal::ExcAccessToUninitializedField());
 #  endif
@@ -7358,19 +7358,19 @@ FEEvaluation<dim,
            this->mapped_geometry->is_initialized(),
          ExcNotInitialized());
 
-  Assert(!contains(integration_flag,
-                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage(
            "Only EvaluationFlags::values, EvaluationFlags::gradients, and "
            "EvaluationFlags::hessians are supported."));
 
   EvaluationFlags::EvaluationFlags integration_flag_actual = integration_flag;
-  if (contains(integration_flag, EvaluationFlags::hessians) &&
+  if (contains_bits(integration_flag, EvaluationFlags::hessians) &&
       (this->cell_type > internal::MatrixFreeFunctions::affine))
     {
       unsigned int size = n_components * dim * n_q_points;
-      if (contains(integration_flag, EvaluationFlags::gradients))
+      if (contains_bits(integration_flag, EvaluationFlags::gradients))
         {
           for (unsigned int i = 0; i < size; ++i)
             this->gradients_quad[i] += this->gradients_from_hessians_quad[i];
@@ -7871,14 +7871,14 @@ FEFaceEvaluation<dim,
   evaluate(const VectorizedArrayType *            values_array,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains(evaluation_flag,
-                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
   const bool hessians_on_general_cells =
-    contains(evaluation_flag, EvaluationFlags::hessians) &&
+    contains_bits(evaluation_flag, EvaluationFlags::hessians) &&
     (this->cell_type > internal::MatrixFreeFunctions::affine);
   EvaluationFlags::EvaluationFlags evaluation_flag_actual = evaluation_flag;
   if (hessians_on_general_cells)
@@ -7895,11 +7895,11 @@ FEFaceEvaluation<dim,
       n_components, evaluation_flag_actual, values_array, *this);
 
 #  ifdef DEBUG
-  if (contains(evaluation_flag_actual, EvaluationFlags::values))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if (contains(evaluation_flag_actual, EvaluationFlags::gradients))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if (contains(evaluation_flag_actual, EvaluationFlags::hessians))
+  if (contains_bits(evaluation_flag_actual, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }
@@ -7997,18 +7997,18 @@ FEFaceEvaluation<dim,
   integrate(const EvaluationFlags::EvaluationFlags integration_flag,
             VectorizedArrayType *                  values_array)
 {
-  Assert(!contains(integration_flag,
-                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(integration_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
   EvaluationFlags::EvaluationFlags integration_flag_actual = integration_flag;
-  if ((contains(integration_flag, EvaluationFlags::hessians)) &&
+  if ((contains_bits(integration_flag, EvaluationFlags::hessians)) &&
       (this->cell_type > internal::MatrixFreeFunctions::affine))
     {
       unsigned int size = n_components * dim * n_q_points;
-      if (contains(integration_flag, EvaluationFlags::gradients))
+      if (contains_bits(integration_flag, EvaluationFlags::gradients))
         {
           for (unsigned int i = 0; i < size; ++i)
             this->gradients_quad[i] += this->gradients_from_hessians_quad[i];
@@ -8079,9 +8079,9 @@ FEFaceEvaluation<dim,
   gather_evaluate(const VectorType &                     input_vector,
                   const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
-  Assert(!contains(evaluation_flag,
-                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                     EvaluationFlags::hessians)),
+  Assert(!contains_bits(evaluation_flag,
+                        ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                          EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 
@@ -8141,11 +8141,11 @@ FEFaceEvaluation<dim,
     }
 
 #  ifdef DEBUG
-  if (contains(evaluation_flag, EvaluationFlags::values))
+  if (contains_bits(evaluation_flag, EvaluationFlags::values))
     this->values_quad_initialized = true;
-  if (contains(evaluation_flag, EvaluationFlags::gradients))
+  if (contains_bits(evaluation_flag, EvaluationFlags::gradients))
     this->gradients_quad_initialized = true;
-  if (contains(evaluation_flag, EvaluationFlags::hessians))
+  if (contains_bits(evaluation_flag, EvaluationFlags::hessians))
     this->hessians_quad_initialized = true;
 #  endif
 }

--- a/include/deal.II/matrix_free/fe_evaluation.h
+++ b/include/deal.II/matrix_free/fe_evaluation.h
@@ -7359,9 +7359,8 @@ FEEvaluation<dim,
          ExcNotInitialized());
 
   Assert(!contains(integration_flag,
-                   static_cast<EvaluationFlags::EvaluationFlags>(
-                     ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                       EvaluationFlags::hessians))),
+                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                     EvaluationFlags::hessians)),
          ExcMessage(
            "Only EvaluationFlags::values, EvaluationFlags::gradients, and "
            "EvaluationFlags::hessians are supported."));
@@ -7873,9 +7872,8 @@ FEFaceEvaluation<dim,
            const EvaluationFlags::EvaluationFlags evaluation_flag)
 {
   Assert(!contains(evaluation_flag,
-                   static_cast<EvaluationFlags::EvaluationFlags>(
-                     ~(EvaluationFlags::values | EvaluationFlags::gradients |
-                       EvaluationFlags::hessians))),
+                   ~(EvaluationFlags::values | EvaluationFlags::gradients |
+                     EvaluationFlags::hessians)),
          ExcMessage("Only EvaluationFlags::values, EvaluationFlags::gradients, "
                     "and EvaluationFlags::hessians are supported."));
 

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -949,8 +949,8 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
     return;
 
   AssertDimension(solution_values.size(), fe->dofs_per_cell);
-  if ((((evaluation_flag & EvaluationFlags::values) != 0u) ||
-       ((evaluation_flag & EvaluationFlags::gradients) != 0u)) &&
+  if (((contains(evaluation_flag, EvaluationFlags::values)) ||
+       (contains(evaluation_flag, EvaluationFlags::gradients))) &&
       !poly.empty())
     {
       // fast path with tensor product evaluation
@@ -990,12 +990,12 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
               polynomials_are_hat_functions);
 
           // convert back to standard format
-          if ((evaluation_flag & EvaluationFlags::values) != 0u)
+          if (contains(evaluation_flag, EvaluationFlags::values))
             for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
               internal::FEPointEvaluation::
                 EvaluatorTypeTraits<dim, n_components, Number>::set_value(
                   val_and_grad.first, j, values[i + j]);
-          if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+          if (contains(evaluation_flag, EvaluationFlags::gradients))
             {
               Assert(contains(update_flags,
                               update_gradients | update_inverse_jacobians),
@@ -1021,15 +1021,15 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
             }
         }
     }
-  else if (((evaluation_flag & EvaluationFlags::values) != 0u) ||
-           ((evaluation_flag & EvaluationFlags::gradients) != 0u))
+  else if ((contains(evaluation_flag, EvaluationFlags::values)) ||
+           (contains(evaluation_flag, EvaluationFlags::gradients)))
     {
       // slow path with FEValues
       Assert(fe_values.get() != nullptr,
              ExcMessage(
                "Not initialized. Please call FEPointEvaluation::reinit()!"));
 
-      if ((evaluation_flag & EvaluationFlags::values) != 0u)
+      if (contains(evaluation_flag, EvaluationFlags::values))
         {
           values.resize(unit_points.size());
           std::fill(values.begin(), values.end(), value_type());
@@ -1052,7 +1052,7 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
             }
         }
 
-      if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
+      if (contains(evaluation_flag, EvaluationFlags::gradients))
         {
           gradients.resize(unit_points.size());
           std::fill(gradients.begin(), gradients.end(), gradient_type());

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -836,12 +836,12 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::FEPointEvaluation(
     }
 
   // translate update flags
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     update_flags_mapping |= update_jacobians;
-  if (((update_flags & update_gradients) != 0u) ||
-      ((update_flags & update_inverse_jacobians) != 0u))
+  if ((contains(update_flags, update_gradients)) ||
+      (contains(update_flags, update_inverse_jacobians)))
     update_flags_mapping |= update_inverse_jacobians;
-  if ((update_flags & update_quadrature_points) != 0u)
+  if (contains(update_flags, update_quadrature_points))
     update_flags_mapping |= update_quadrature_points;
 }
 
@@ -920,9 +920,9 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::reinit(
           mapping_data.quadrature_points[q] = fe_values->quadrature_point(q);
     }
 
-  if ((update_flags & update_values) != 0)
+  if (contains(update_flags, update_values))
     values.resize(unit_points.size(), numbers::signaling_nan<value_type>());
-  if ((update_flags & update_gradients) != 0)
+  if (contains(update_flags, update_gradients))
     gradients.resize(unit_points.size(),
                      numbers::signaling_nan<gradient_type>());
 }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -997,12 +997,13 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::evaluate(
                   val_and_grad.first, j, values[i + j]);
           if ((evaluation_flag & EvaluationFlags::gradients) != 0u)
             {
-              Assert(update_flags & update_gradients ||
-                       update_flags & update_inverse_jacobians,
+              Assert(contains(update_flags,
+                              update_gradients | update_inverse_jacobians),
                      ExcNotInitialized());
               for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
                 {
-                  Assert(update_flags_mapping & update_inverse_jacobians,
+                  Assert(contains(update_flags_mapping,
+                                  update_inverse_jacobians),
                          ExcNotInitialized());
                   internal::FEPointEvaluation::EvaluatorTypeTraits<
                     dim,
@@ -1139,7 +1140,7 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::integrate(
           if ((integration_flags & EvaluationFlags::gradients) != 0u)
             for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
               {
-                Assert(update_flags_mapping & update_inverse_jacobians,
+                Assert(contains(update_flags_mapping, update_inverse_jacobians),
                        ExcNotInitialized());
                 gradients[i + j] =
                   static_cast<typename internal::FEPointEvaluation::
@@ -1308,7 +1309,7 @@ inline DerivativeForm<1, dim, spacedim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::jacobian(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_jacobians, ExcNotInitialized());
+  Assert(contains(update_flags_mapping, update_jacobians), ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.jacobians.size());
   return mapping_data.jacobians[point_index];
 }
@@ -1320,7 +1321,7 @@ inline DerivativeForm<1, spacedim, dim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::inverse_jacobian(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_inverse_jacobians ||
+  Assert(contains(update_flags_mapping, update_inverse_jacobians) ||
            update_flags_mapping & update_gradients,
          ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.inverse_jacobians.size());
@@ -1334,7 +1335,8 @@ inline Point<spacedim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::real_point(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping & update_quadrature_points, ExcNotInitialized());
+  Assert(contains(update_flags_mapping, update_quadrature_points),
+         ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.quadrature_points.size());
   return mapping_data.quadrature_points[point_index];
 }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -909,13 +909,13 @@ FEPointEvaluation<n_components, dim, spacedim, Number>::reinit(
         update_flags | update_flags_mapping);
       fe_values->reinit(cell);
       mapping_data.initialize(unit_points.size(), update_flags_mapping);
-      if ((update_flags_mapping & update_jacobians) != 0)
+      if (contains(update_flags_mapping, update_jacobians))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.jacobians[q] = fe_values->jacobian(q);
-      if ((update_flags_mapping & update_inverse_jacobians) != 0)
+      if (contains(update_flags_mapping, update_inverse_jacobians))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.inverse_jacobians[q] = fe_values->inverse_jacobian(q);
-      if ((update_flags_mapping & update_quadrature_points) != 0)
+      if (contains(update_flags_mapping, update_quadrature_points))
         for (unsigned int q = 0; q < unit_points.size(); ++q)
           mapping_data.quadrature_points[q] = fe_values->quadrature_point(q);
     }

--- a/include/deal.II/matrix_free/fe_point_evaluation.h
+++ b/include/deal.II/matrix_free/fe_point_evaluation.h
@@ -1320,7 +1320,8 @@ inline DerivativeForm<1, spacedim, dim>
 FEPointEvaluation<n_components, dim, spacedim, Number>::inverse_jacobian(
   const unsigned int point_index) const
 {
-  Assert(update_flags_mapping.contains(update_inverse_jacobians | update_gradients),
+  Assert(update_flags_mapping.contains(update_inverse_jacobians |
+                                       update_gradients),
          ExcNotInitialized());
   AssertIndexRange(point_index, mapping_data.inverse_jacobians.size());
   return mapping_data.inverse_jacobians[point_index];

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -171,7 +171,7 @@ namespace internal
       mapping_info_storage.data_index_offsets.resize(1);
       mapping_info_storage.JxW_values.resize(fe_values.n_quadrature_points);
       mapping_info_storage.jacobians[0].resize(fe_values.n_quadrature_points);
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         {
           mapping_info_storage.quadrature_point_offsets.resize(1, 0);
           mapping_info_storage.quadrature_points.resize(

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -171,7 +171,7 @@ namespace internal
       mapping_info_storage.data_index_offsets.resize(1);
       mapping_info_storage.JxW_values.resize(fe_values.n_quadrature_points);
       mapping_info_storage.jacobians[0].resize(fe_values.n_quadrature_points);
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         {
           mapping_info_storage.quadrature_point_offsets.resize(1, 0);
           mapping_info_storage.quadrature_points.resize(

--- a/include/deal.II/matrix_free/mapping_data_on_the_fly.h
+++ b/include/deal.II/matrix_free/mapping_data_on_the_fly.h
@@ -171,7 +171,7 @@ namespace internal
       mapping_info_storage.data_index_offsets.resize(1);
       mapping_info_storage.JxW_values.resize(fe_values.n_quadrature_points);
       mapping_info_storage.jacobians[0].resize(fe_values.n_quadrature_points);
-      if ((update_flags & update_quadrature_points) != 0u)
+      if (contains(update_flags, update_quadrature_points))
         {
           mapping_info_storage.quadrature_point_offsets.resize(1, 0);
           mapping_info_storage.quadrature_points.resize(

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -88,12 +88,12 @@ namespace internal
           update_flags_cells, quad);
 
       this->update_flags_boundary_faces =
-        ((update_flags_inner_faces | update_flags_boundary_faces).contains(
-                       update_quadrature_points) ?
+        ((update_flags_inner_faces | update_flags_boundary_faces)
+             .contains(update_quadrature_points) ?
            update_quadrature_points :
            update_default) |
-        ((update_flags_inner_faces | update_flags_boundary_faces).contains(
-                       update_jacobian_grads | update_hessians) ?
+        ((update_flags_inner_faces | update_flags_boundary_faces)
+             .contains(update_jacobian_grads | update_hessians) ?
            update_jacobian_grads :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -2889,7 +2889,7 @@ namespace internal
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
             cell_type.size() * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_quadrature_points) != 0)
+          if (contains(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
@@ -2911,7 +2911,7 @@ namespace internal
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
-                if ((update_flags & update_quadrature_points) != 0u)
+                if (contains(update_flags, update_quadrature_points))
                   face_data_by_cells[my_q].quadrature_point_offsets
                     [i * GeometryInfo<dim>::faces_per_cell + face] =
                     (i * GeometryInfo<dim>::faces_per_cell + face) *
@@ -2923,22 +2923,22 @@ namespace internal
             storage_length * GeometryInfo<dim>::faces_per_cell);
           face_data_by_cells[my_q].jacobians[1].resize_fast(
             storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_normal_vectors) != 0u)
+          if (contains(update_flags, update_normal_vectors))
             face_data_by_cells[my_q].normal_vectors.resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if ((contains(update_flags, update_normal_vectors)) &&
+              (contains(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (((update_flags & update_normal_vectors) != 0u) &&
-              ((update_flags & update_jacobians) != 0u))
+          if ((contains(update_flags, update_normal_vectors)) &&
+              (contains(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((update_flags & update_jacobian_grads) != 0u)
+          if (contains(update_flags, update_jacobian_grads))
             face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
 
-          if ((update_flags & update_quadrature_points) != 0u)
+          if (contains(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_points.resize_fast(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
@@ -3012,10 +3012,10 @@ namespace internal
                   // copy data for affine data type
                   if (cell_type[cell] <= affine)
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (contains(update_flags, update_JxW_values))
                         face_data_by_cells[my_q].JxW_values[offset][v] =
                           fe_val.JxW(0) / fe_val.get_quadrature().weight(0);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (contains(update_flags, update_jacobians))
                         {
                           DerivativeForm<1, dim, dim> inv_jac =
                             fe_val.jacobian(0).covariant_form();
@@ -3029,7 +3029,7 @@ namespace internal
                                   inv_jac[d][ee];
                               }
                         }
-                      if (is_local && ((update_flags & update_jacobians) != 0u))
+                      if (is_local && (contains(update_flags, update_jacobians)))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3046,11 +3046,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (contains(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (contains(update_flags, update_normal_vectors))
                         for (unsigned int d = 0; d < dim; ++d)
                           face_data_by_cells[my_q]
                             .normal_vectors[offset][d][v] =
@@ -3059,12 +3059,12 @@ namespace internal
                   // copy data for general data type
                   else
                     {
-                      if ((update_flags & update_JxW_values) != 0u)
+                      if (contains(update_flags, update_JxW_values))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           face_data_by_cells[my_q].JxW_values[offset + q][v] =
                             fe_val.JxW(q);
-                      if ((update_flags & update_jacobians) != 0u)
+                      if (contains(update_flags, update_jacobians))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3081,11 +3081,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if ((update_flags & update_jacobian_grads) != 0u)
+                      if (contains(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if ((update_flags & update_normal_vectors) != 0u)
+                      if (contains(update_flags, update_normal_vectors))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           for (unsigned int d = 0; d < dim; ++d)
@@ -3093,7 +3093,7 @@ namespace internal
                               .normal_vectors[offset + q][d][v] =
                               fe_val.normal_vector(q)[d];
                     }
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                          ++q)
                       for (unsigned int d = 0; d < dim; ++d)
@@ -3102,8 +3102,8 @@ namespace internal
                              [cell * GeometryInfo<dim>::faces_per_cell + face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if ((contains(update_flags, update_normal_vectors)) &&
+                  (contains(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);
@@ -3112,8 +3112,8 @@ namespace internal
                     .normals_times_jacobians[0][offset + q] =
                     face_data_by_cells[my_q].normal_vectors[offset + q] *
                     face_data_by_cells[my_q].jacobians[0][offset + q];
-              if (((update_flags & update_normal_vectors) != 0u) &&
-                  ((update_flags & update_jacobians) != 0u))
+              if ((contains(update_flags, update_normal_vectors)) &&
+                  (contains(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -88,12 +88,12 @@ namespace internal
           update_flags_cells, quad);
 
       this->update_flags_boundary_faces =
-        (contains(update_flags_inner_faces | update_flags_boundary_faces,
-                  update_quadrature_points) ?
+        (contains_bits(update_flags_inner_faces | update_flags_boundary_faces,
+                       update_quadrature_points) ?
            update_quadrature_points :
            update_default) |
-        (contains(update_flags_inner_faces | update_flags_boundary_faces,
-                  update_jacobian_grads | update_hessians) ?
+        (contains_bits(update_flags_inner_faces | update_flags_boundary_faces,
+                       update_jacobian_grads | update_hessians) ?
            update_jacobian_grads :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;
@@ -429,7 +429,7 @@ namespace internal
 
             // extract quadrature points and store them temporarily. if we have
             // Cartesian cells, we can compress the indices
-            if (contains(update_flags, update_quadrature_points))
+            if (contains_bits(update_flags, update_quadrature_points))
               for (unsigned int q = 0; q < n_q_points; ++q)
                 {
                   const Point<dim> &point = fe_val.quadrature_point(q);
@@ -498,7 +498,7 @@ namespace internal
                     // for the second, third quadrature formula). in any case,
                     // the flag update_jacobian_grads will be set in that case
                     if (cell_cartesian == false && n_q_points == 1 &&
-                        contains(update_flags, update_jacobian_grads))
+                        contains_bits(update_flags, update_jacobian_grads))
                       {
                         const DerivativeForm<1, dim, dim> &jac =
                           fe_val.jacobian(0);
@@ -571,7 +571,7 @@ namespace internal
                 // Jacobian which is needed in user code. however, we would like
                 // to perform that on vectorized data types instead of doubles
                 // or floats. to this end, copy the gradients first
-                if (contains(update_flags, update_jacobian_grads))
+                if (contains_bits(update_flags, update_jacobian_grads))
                   {
                     const DerivativeForm<2, dim, dim> &jacobian_grad =
                       fe_val.jacobian_grad(q);
@@ -644,12 +644,12 @@ namespace internal
           fe_values[i].resize(max_active_fe_index + 1);
         const UpdateFlags update_flags = mapping_info.update_flags_cells;
         const UpdateFlags update_flags_feval =
-          (contains(update_flags, update_jacobians) ? update_jacobians :
-                                                      update_default) |
-          (contains(update_flags, update_jacobian_grads) ?
+          (contains_bits(update_flags, update_jacobians) ? update_jacobians :
+                                                           update_default) |
+          (contains_bits(update_flags, update_jacobian_grads) ?
              update_jacobian_grads :
              update_default) |
-          (contains(update_flags, update_quadrature_points) ?
+          (contains_bits(update_flags, update_quadrature_points) ?
              update_quadrature_points :
              update_default);
 
@@ -793,7 +793,7 @@ namespace internal
                         transpose(invert(jac));
                       data.first[my_q].jacobians[0].push_back(inv_jac);
 
-                      if (contains(update_flags, update_jacobian_grads))
+                      if (contains_bits(update_flags, update_jacobian_grads))
                         data.first[my_q].jacobian_gradients[0].push_back(
                           process_jacobian_gradient(inv_jac,
                                                     inv_jac,
@@ -801,7 +801,7 @@ namespace internal
                     }
                 }
 
-              if (contains(update_flags, update_quadrature_points))
+              if (contains_bits(update_flags, update_quadrature_points))
                 {
                   // eventually we turn to the quadrature points that we can
                   // compress in case we have affine cells. we also need to
@@ -1153,13 +1153,14 @@ namespace internal
                   FEEvaluationFactory<dim, VectorizedDouble>::evaluate(
                     dim,
                     EvaluationFlags::values | EvaluationFlags::gradients |
-                      (contains(update_flags_cells, update_jacobian_grads) ?
+                      (contains_bits(update_flags_cells,
+                                     update_jacobian_grads) ?
                          EvaluationFlags::hessians :
                          EvaluationFlags::nothing),
                     eval.begin_dof_values(),
                     eval);
                 }
-              if (contains(update_flags_cells, update_quadrature_points))
+              if (contains_bits(update_flags_cells, update_quadrature_points))
                 {
                   Point<dim, VectorizedArrayType> *quadrature_points =
                     my_data.quadrature_points.data() +
@@ -1232,7 +1233,8 @@ namespace internal
                                                vv,
                                                my_data.jacobians[0][idx][d][e]);
 
-                    if (contains(update_flags_cells, update_jacobian_grads) &&
+                    if (contains_bits(update_flags_cells,
+                                      update_jacobian_grads) &&
                         cell_type[cell] > affine)
                       {
                         Tensor<3, dim, VectorizedDouble> jac_grad;
@@ -1361,10 +1363,10 @@ namespace internal
             data_cells_local.back().first[my_q].JxW_values.size());
           cell_data[my_q].jacobians[0].resize_fast(
             cell_data[my_q].JxW_values.size());
-          if (contains(update_flags_cells, update_jacobian_grads))
+          if (contains_bits(update_flags_cells, update_jacobian_grads))
             cell_data[my_q].jacobian_gradients[0].resize_fast(
               cell_data[my_q].JxW_values.size());
-          if (contains(update_flags_cells, update_quadrature_points))
+          if (contains_bits(update_flags_cells, update_quadrature_points))
             {
               cell_data[my_q].quadrature_point_offsets.resize(cell_type.size());
               cell_data[my_q].quadrature_points.resize_fast(
@@ -1715,8 +1717,8 @@ namespace internal
                                       compare_norm_jac)
                                 cell_is_cartesian = false;
 
-                          if (contains(fe_face_values.get_update_flags(),
-                                       update_quadrature_points))
+                          if (contains_bits(fe_face_values.get_update_flags(),
+                                            update_quadrature_points))
                             for (unsigned int d = 0; d < dim; ++d)
                               face_data.quadrature_points[q][d][v] =
                                 fe_face_values.quadrature_point(q)[d];
@@ -1738,8 +1740,8 @@ namespace internal
                                 face_data.normal_vectors[q][d][v] =
                                   face_data.normal_vectors[q][d][0];
                               }
-                          if (contains(fe_face_values.get_update_flags(),
-                                       update_quadrature_points))
+                          if (contains_bits(fe_face_values.get_update_flags(),
+                                            update_quadrature_points))
                             for (unsigned int d = 0; d < dim; ++d)
                               face_data.quadrature_points[q][d][v] =
                                 face_data.quadrature_points[q][d][0];
@@ -1884,13 +1886,13 @@ namespace internal
                 }
 
               // Fill in quadrature points
-              if (contains(fe_face_values.get_update_flags(),
-                           update_quadrature_points))
+              if (contains_bits(fe_face_values.get_update_flags(),
+                                update_quadrature_points))
                 {
                   data.first[my_q].quadrature_point_offsets.push_back(
                     data.first[my_q].quadrature_points.size());
-                  if (contains(fe_face_values.get_update_flags(),
-                               update_quadrature_points))
+                  if (contains_bits(fe_face_values.get_update_flags(),
+                                    update_quadrature_points))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       data.first[my_q].quadrature_points.push_back(
                         face_data.quadrature_points[q]);
@@ -2080,13 +2082,13 @@ namespace internal
               FEFaceEvaluationFactory<dim, VectorizedDouble>::evaluate(
                 dim,
                 EvaluationFlags::values | EvaluationFlags::gradients |
-                  (contains(update_flags_faces, update_jacobian_grads) ?
+                  (contains_bits(update_flags_faces, update_jacobian_grads) ?
                      EvaluationFlags::hessians :
                      EvaluationFlags::nothing),
                 eval_int.begin_dof_values(),
                 eval_int);
 
-              if (contains(update_flags_faces, update_quadrature_points))
+              if (contains_bits(update_flags_faces, update_quadrature_points))
                 for (unsigned int q = 0; q < n_q_points; ++q)
                   for (unsigned int d = 0; d < dim; ++d)
                     store_vectorized_array(
@@ -2181,7 +2183,7 @@ namespace internal
                           my_data.jacobians[0][offset + q][d][e]);
                     }
 
-                  if (contains(update_flags_faces, update_jacobian_grads))
+                  if (contains_bits(update_flags_faces, update_jacobian_grads))
                     {
                       compute_jacobian_grad(
                         interior_face_no, 0, q, inv_jac, eval_int);
@@ -2250,7 +2252,8 @@ namespace internal
                   FEFaceEvaluationFactory<dim, VectorizedDouble>::evaluate(
                     dim,
                     EvaluationFlags::values | EvaluationFlags::gradients |
-                      (contains(update_flags_faces, update_jacobian_grads) ?
+                      (contains_bits(update_flags_faces,
+                                     update_jacobian_grads) ?
                          EvaluationFlags::hessians :
                          EvaluationFlags::nothing),
                     eval_ext.begin_dof_values(),
@@ -2285,7 +2288,8 @@ namespace internal
                               my_data.jacobians[1][offset + q][d][e]);
                         }
 
-                      if (contains(update_flags_faces, update_jacobian_grads))
+                      if (contains_bits(update_flags_faces,
+                                        update_jacobian_grads))
                         {
                           compute_jacobian_grad(
                             exterior_face_no, 1, q, inv_jac, eval_ext);
@@ -2405,7 +2409,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if (contains(update_flags_common, update_jacobian_grads))
+          if (contains_bits(update_flags_common, update_jacobian_grads))
             {
               face_data[my_q].jacobian_gradients[0].resize_fast(
                 face_data[my_q].JxW_values.size());
@@ -2416,7 +2420,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].normals_times_jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if (contains(update_flags_common, update_quadrature_points))
+          if (contains_bits(update_flags_common, update_quadrature_points))
             {
               face_data[my_q].quadrature_point_offsets.resize(face_type.size());
               face_data[my_q].quadrature_points.resize_fast(
@@ -2648,10 +2652,10 @@ namespace internal
 
           my_data.JxW_values.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
-          if (contains(update_flags_cells, update_jacobian_grads))
+          if (contains_bits(update_flags_cells, update_jacobian_grads))
             my_data.jacobian_gradients[0].resize_fast(max_size);
 
-          if (contains(update_flags_cells, update_quadrature_points))
+          if (contains_bits(update_flags_cells, update_quadrature_points))
             {
               my_data.quadrature_point_offsets.resize(cell_type.size());
               for (unsigned int cell = 1; cell < cell_type.size(); ++cell)
@@ -2775,7 +2779,7 @@ namespace internal
           my_data.normal_vectors.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
           my_data.jacobians[1].resize_fast(max_size);
-          if (contains(update_flags_common, update_jacobian_grads))
+          if (contains_bits(update_flags_common, update_jacobian_grads))
             {
               my_data.jacobian_gradients[0].resize_fast(max_size);
               my_data.jacobian_gradients[1].resize_fast(max_size);
@@ -2783,7 +2787,7 @@ namespace internal
           my_data.normals_times_jacobians[0].resize_fast(max_size);
           my_data.normals_times_jacobians[1].resize_fast(max_size);
 
-          if (contains(update_flags_common, update_quadrature_points))
+          if (contains_bits(update_flags_common, update_quadrature_points))
             {
               my_data.quadrature_point_offsets.resize(face_type.size());
               my_data.quadrature_point_offsets[0] = 0;
@@ -2879,7 +2883,7 @@ namespace internal
       const unsigned int n_quads = face_data_by_cells.size();
       const unsigned int n_lanes = VectorizedArrayType::size();
       UpdateFlags        update_flags =
-        (contains(update_flags_faces_by_cells, update_quadrature_points) ?
+        (contains_bits(update_flags_faces_by_cells, update_quadrature_points) ?
            update_quadrature_points :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;
@@ -2892,7 +2896,7 @@ namespace internal
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
             cell_type.size() * GeometryInfo<dim>::faces_per_cell);
-          if (contains(update_flags, update_quadrature_points))
+          if (contains_bits(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
@@ -2914,7 +2918,7 @@ namespace internal
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
-                if (contains(update_flags, update_quadrature_points))
+                if (contains_bits(update_flags, update_quadrature_points))
                   face_data_by_cells[my_q].quadrature_point_offsets
                     [i * GeometryInfo<dim>::faces_per_cell + face] =
                     (i * GeometryInfo<dim>::faces_per_cell + face) *
@@ -2926,22 +2930,22 @@ namespace internal
             storage_length * GeometryInfo<dim>::faces_per_cell);
           face_data_by_cells[my_q].jacobians[1].resize_fast(
             storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (contains(update_flags, update_normal_vectors))
+          if (contains_bits(update_flags, update_normal_vectors))
             face_data_by_cells[my_q].normal_vectors.resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((contains(update_flags, update_normal_vectors)) &&
-              (contains(update_flags, update_jacobians)))
+          if ((contains_bits(update_flags, update_normal_vectors)) &&
+              (contains_bits(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((contains(update_flags, update_normal_vectors)) &&
-              (contains(update_flags, update_jacobians)))
+          if ((contains_bits(update_flags, update_normal_vectors)) &&
+              (contains_bits(update_flags, update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (contains(update_flags, update_jacobian_grads))
+          if (contains_bits(update_flags, update_jacobian_grads))
             face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
 
-          if (contains(update_flags, update_quadrature_points))
+          if (contains_bits(update_flags, update_quadrature_points))
             face_data_by_cells[my_q].quadrature_points.resize_fast(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
@@ -3015,10 +3019,10 @@ namespace internal
                   // copy data for affine data type
                   if (cell_type[cell] <= affine)
                     {
-                      if (contains(update_flags, update_JxW_values))
+                      if (contains_bits(update_flags, update_JxW_values))
                         face_data_by_cells[my_q].JxW_values[offset][v] =
                           fe_val.JxW(0) / fe_val.get_quadrature().weight(0);
-                      if (contains(update_flags, update_jacobians))
+                      if (contains_bits(update_flags, update_jacobians))
                         {
                           DerivativeForm<1, dim, dim> inv_jac =
                             fe_val.jacobian(0).covariant_form();
@@ -3033,7 +3037,7 @@ namespace internal
                               }
                         }
                       if (is_local &&
-                          (contains(update_flags, update_jacobians)))
+                          (contains_bits(update_flags, update_jacobians)))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3050,11 +3054,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if (contains(update_flags, update_jacobian_grads))
+                      if (contains_bits(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if (contains(update_flags, update_normal_vectors))
+                      if (contains_bits(update_flags, update_normal_vectors))
                         for (unsigned int d = 0; d < dim; ++d)
                           face_data_by_cells[my_q]
                             .normal_vectors[offset][d][v] =
@@ -3063,12 +3067,12 @@ namespace internal
                   // copy data for general data type
                   else
                     {
-                      if (contains(update_flags, update_JxW_values))
+                      if (contains_bits(update_flags, update_JxW_values))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           face_data_by_cells[my_q].JxW_values[offset + q][v] =
                             fe_val.JxW(q);
-                      if (contains(update_flags, update_jacobians))
+                      if (contains_bits(update_flags, update_jacobians))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3085,11 +3089,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if (contains(update_flags, update_jacobian_grads))
+                      if (contains_bits(update_flags, update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if (contains(update_flags, update_normal_vectors))
+                      if (contains_bits(update_flags, update_normal_vectors))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           for (unsigned int d = 0; d < dim; ++d)
@@ -3097,7 +3101,7 @@ namespace internal
                               .normal_vectors[offset + q][d][v] =
                               fe_val.normal_vector(q)[d];
                     }
-                  if (contains(update_flags, update_quadrature_points))
+                  if (contains_bits(update_flags, update_quadrature_points))
                     for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                          ++q)
                       for (unsigned int d = 0; d < dim; ++d)
@@ -3106,8 +3110,8 @@ namespace internal
                              [cell * GeometryInfo<dim>::faces_per_cell + face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
-              if ((contains(update_flags, update_normal_vectors)) &&
-                  (contains(update_flags, update_jacobians)))
+              if ((contains_bits(update_flags, update_normal_vectors)) &&
+                  (contains_bits(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);
@@ -3116,8 +3120,8 @@ namespace internal
                     .normals_times_jacobians[0][offset + q] =
                     face_data_by_cells[my_q].normal_vectors[offset + q] *
                     face_data_by_cells[my_q].jacobians[0][offset + q];
-              if ((contains(update_flags, update_normal_vectors)) &&
-                  (contains(update_flags, update_jacobians)))
+              if ((contains_bits(update_flags, update_normal_vectors)) &&
+                  (contains_bits(update_flags, update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);

--- a/include/deal.II/matrix_free/mapping_info.templates.h
+++ b/include/deal.II/matrix_free/mapping_info.templates.h
@@ -88,11 +88,11 @@ namespace internal
           update_flags_cells, quad);
 
       this->update_flags_boundary_faces =
-        (contains_bits(update_flags_inner_faces | update_flags_boundary_faces,
+        ((update_flags_inner_faces | update_flags_boundary_faces).contains(
                        update_quadrature_points) ?
            update_quadrature_points :
            update_default) |
-        (contains_bits(update_flags_inner_faces | update_flags_boundary_faces,
+        ((update_flags_inner_faces | update_flags_boundary_faces).contains(
                        update_jacobian_grads | update_hessians) ?
            update_jacobian_grads :
            update_default) |
@@ -429,7 +429,7 @@ namespace internal
 
             // extract quadrature points and store them temporarily. if we have
             // Cartesian cells, we can compress the indices
-            if (contains_bits(update_flags, update_quadrature_points))
+            if (update_flags.contains(update_quadrature_points))
               for (unsigned int q = 0; q < n_q_points; ++q)
                 {
                   const Point<dim> &point = fe_val.quadrature_point(q);
@@ -498,7 +498,7 @@ namespace internal
                     // for the second, third quadrature formula). in any case,
                     // the flag update_jacobian_grads will be set in that case
                     if (cell_cartesian == false && n_q_points == 1 &&
-                        contains_bits(update_flags, update_jacobian_grads))
+                        update_flags.contains(update_jacobian_grads))
                       {
                         const DerivativeForm<1, dim, dim> &jac =
                           fe_val.jacobian(0);
@@ -571,7 +571,7 @@ namespace internal
                 // Jacobian which is needed in user code. however, we would like
                 // to perform that on vectorized data types instead of doubles
                 // or floats. to this end, copy the gradients first
-                if (contains_bits(update_flags, update_jacobian_grads))
+                if (update_flags.contains(update_jacobian_grads))
                   {
                     const DerivativeForm<2, dim, dim> &jacobian_grad =
                       fe_val.jacobian_grad(q);
@@ -644,12 +644,12 @@ namespace internal
           fe_values[i].resize(max_active_fe_index + 1);
         const UpdateFlags update_flags = mapping_info.update_flags_cells;
         const UpdateFlags update_flags_feval =
-          (contains_bits(update_flags, update_jacobians) ? update_jacobians :
-                                                           update_default) |
-          (contains_bits(update_flags, update_jacobian_grads) ?
+          (update_flags.contains(update_jacobians) ? update_jacobians :
+                                                     update_default) |
+          (update_flags.contains(update_jacobian_grads) ?
              update_jacobian_grads :
              update_default) |
-          (contains_bits(update_flags, update_quadrature_points) ?
+          (update_flags.contains(update_quadrature_points) ?
              update_quadrature_points :
              update_default);
 
@@ -793,7 +793,7 @@ namespace internal
                         transpose(invert(jac));
                       data.first[my_q].jacobians[0].push_back(inv_jac);
 
-                      if (contains_bits(update_flags, update_jacobian_grads))
+                      if (update_flags.contains(update_jacobian_grads))
                         data.first[my_q].jacobian_gradients[0].push_back(
                           process_jacobian_gradient(inv_jac,
                                                     inv_jac,
@@ -801,7 +801,7 @@ namespace internal
                     }
                 }
 
-              if (contains_bits(update_flags, update_quadrature_points))
+              if (update_flags.contains(update_quadrature_points))
                 {
                   // eventually we turn to the quadrature points that we can
                   // compress in case we have affine cells. we also need to
@@ -1153,14 +1153,13 @@ namespace internal
                   FEEvaluationFactory<dim, VectorizedDouble>::evaluate(
                     dim,
                     EvaluationFlags::values | EvaluationFlags::gradients |
-                      (contains_bits(update_flags_cells,
-                                     update_jacobian_grads) ?
+                      (update_flags_cells.contains(update_jacobian_grads) ?
                          EvaluationFlags::hessians :
                          EvaluationFlags::nothing),
                     eval.begin_dof_values(),
                     eval);
                 }
-              if (contains_bits(update_flags_cells, update_quadrature_points))
+              if (update_flags_cells.contains(update_quadrature_points))
                 {
                   Point<dim, VectorizedArrayType> *quadrature_points =
                     my_data.quadrature_points.data() +
@@ -1233,8 +1232,7 @@ namespace internal
                                                vv,
                                                my_data.jacobians[0][idx][d][e]);
 
-                    if (contains_bits(update_flags_cells,
-                                      update_jacobian_grads) &&
+                    if (update_flags_cells.contains(update_jacobian_grads) &&
                         cell_type[cell] > affine)
                       {
                         Tensor<3, dim, VectorizedDouble> jac_grad;
@@ -1363,10 +1361,10 @@ namespace internal
             data_cells_local.back().first[my_q].JxW_values.size());
           cell_data[my_q].jacobians[0].resize_fast(
             cell_data[my_q].JxW_values.size());
-          if (contains_bits(update_flags_cells, update_jacobian_grads))
+          if (update_flags_cells.contains(update_jacobian_grads))
             cell_data[my_q].jacobian_gradients[0].resize_fast(
               cell_data[my_q].JxW_values.size());
-          if (contains_bits(update_flags_cells, update_quadrature_points))
+          if (update_flags_cells.contains(update_quadrature_points))
             {
               cell_data[my_q].quadrature_point_offsets.resize(cell_type.size());
               cell_data[my_q].quadrature_points.resize_fast(
@@ -1717,8 +1715,8 @@ namespace internal
                                       compare_norm_jac)
                                 cell_is_cartesian = false;
 
-                          if (contains_bits(fe_face_values.get_update_flags(),
-                                            update_quadrature_points))
+                          if (fe_face_values.get_update_flags().contains(
+                                update_quadrature_points))
                             for (unsigned int d = 0; d < dim; ++d)
                               face_data.quadrature_points[q][d][v] =
                                 fe_face_values.quadrature_point(q)[d];
@@ -1740,8 +1738,8 @@ namespace internal
                                 face_data.normal_vectors[q][d][v] =
                                   face_data.normal_vectors[q][d][0];
                               }
-                          if (contains_bits(fe_face_values.get_update_flags(),
-                                            update_quadrature_points))
+                          if (fe_face_values.get_update_flags().contains(
+                                update_quadrature_points))
                             for (unsigned int d = 0; d < dim; ++d)
                               face_data.quadrature_points[q][d][v] =
                                 face_data.quadrature_points[q][d][0];
@@ -1886,13 +1884,13 @@ namespace internal
                 }
 
               // Fill in quadrature points
-              if (contains_bits(fe_face_values.get_update_flags(),
-                                update_quadrature_points))
+              if (fe_face_values.get_update_flags().contains(
+                    update_quadrature_points))
                 {
                   data.first[my_q].quadrature_point_offsets.push_back(
                     data.first[my_q].quadrature_points.size());
-                  if (contains_bits(fe_face_values.get_update_flags(),
-                                    update_quadrature_points))
+                  if (fe_face_values.get_update_flags().contains(
+                        update_quadrature_points))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       data.first[my_q].quadrature_points.push_back(
                         face_data.quadrature_points[q]);
@@ -2082,13 +2080,13 @@ namespace internal
               FEFaceEvaluationFactory<dim, VectorizedDouble>::evaluate(
                 dim,
                 EvaluationFlags::values | EvaluationFlags::gradients |
-                  (contains_bits(update_flags_faces, update_jacobian_grads) ?
+                  (update_flags_faces.contains(update_jacobian_grads) ?
                      EvaluationFlags::hessians :
                      EvaluationFlags::nothing),
                 eval_int.begin_dof_values(),
                 eval_int);
 
-              if (contains_bits(update_flags_faces, update_quadrature_points))
+              if (update_flags_faces.contains(update_quadrature_points))
                 for (unsigned int q = 0; q < n_q_points; ++q)
                   for (unsigned int d = 0; d < dim; ++d)
                     store_vectorized_array(
@@ -2183,7 +2181,7 @@ namespace internal
                           my_data.jacobians[0][offset + q][d][e]);
                     }
 
-                  if (contains_bits(update_flags_faces, update_jacobian_grads))
+                  if (update_flags_faces.contains(update_jacobian_grads))
                     {
                       compute_jacobian_grad(
                         interior_face_no, 0, q, inv_jac, eval_int);
@@ -2252,8 +2250,7 @@ namespace internal
                   FEFaceEvaluationFactory<dim, VectorizedDouble>::evaluate(
                     dim,
                     EvaluationFlags::values | EvaluationFlags::gradients |
-                      (contains_bits(update_flags_faces,
-                                     update_jacobian_grads) ?
+                      (update_flags_faces.contains(update_jacobian_grads) ?
                          EvaluationFlags::hessians :
                          EvaluationFlags::nothing),
                     eval_ext.begin_dof_values(),
@@ -2288,8 +2285,7 @@ namespace internal
                               my_data.jacobians[1][offset + q][d][e]);
                         }
 
-                      if (contains_bits(update_flags_faces,
-                                        update_jacobian_grads))
+                      if (update_flags_faces.contains(update_jacobian_grads))
                         {
                           compute_jacobian_grad(
                             exterior_face_no, 1, q, inv_jac, eval_ext);
@@ -2409,7 +2405,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if (contains_bits(update_flags_common, update_jacobian_grads))
+          if (update_flags_common.contains(update_jacobian_grads))
             {
               face_data[my_q].jacobian_gradients[0].resize_fast(
                 face_data[my_q].JxW_values.size());
@@ -2420,7 +2416,7 @@ namespace internal
             face_data[my_q].JxW_values.size());
           face_data[my_q].normals_times_jacobians[1].resize_fast(
             face_data[my_q].JxW_values.size());
-          if (contains_bits(update_flags_common, update_quadrature_points))
+          if (update_flags_common.contains(update_quadrature_points))
             {
               face_data[my_q].quadrature_point_offsets.resize(face_type.size());
               face_data[my_q].quadrature_points.resize_fast(
@@ -2652,10 +2648,10 @@ namespace internal
 
           my_data.JxW_values.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
-          if (contains_bits(update_flags_cells, update_jacobian_grads))
+          if (update_flags_cells.contains(update_jacobian_grads))
             my_data.jacobian_gradients[0].resize_fast(max_size);
 
-          if (contains_bits(update_flags_cells, update_quadrature_points))
+          if (update_flags_cells.contains(update_quadrature_points))
             {
               my_data.quadrature_point_offsets.resize(cell_type.size());
               for (unsigned int cell = 1; cell < cell_type.size(); ++cell)
@@ -2779,7 +2775,7 @@ namespace internal
           my_data.normal_vectors.resize_fast(max_size);
           my_data.jacobians[0].resize_fast(max_size);
           my_data.jacobians[1].resize_fast(max_size);
-          if (contains_bits(update_flags_common, update_jacobian_grads))
+          if (update_flags_common.contains(update_jacobian_grads))
             {
               my_data.jacobian_gradients[0].resize_fast(max_size);
               my_data.jacobian_gradients[1].resize_fast(max_size);
@@ -2787,7 +2783,7 @@ namespace internal
           my_data.normals_times_jacobians[0].resize_fast(max_size);
           my_data.normals_times_jacobians[1].resize_fast(max_size);
 
-          if (contains_bits(update_flags_common, update_quadrature_points))
+          if (update_flags_common.contains(update_quadrature_points))
             {
               my_data.quadrature_point_offsets.resize(face_type.size());
               my_data.quadrature_point_offsets[0] = 0;
@@ -2883,7 +2879,7 @@ namespace internal
       const unsigned int n_quads = face_data_by_cells.size();
       const unsigned int n_lanes = VectorizedArrayType::size();
       UpdateFlags        update_flags =
-        (contains_bits(update_flags_faces_by_cells, update_quadrature_points) ?
+        (update_flags_faces_by_cells.contains(update_quadrature_points) ?
            update_quadrature_points :
            update_default) |
         update_normal_vectors | update_JxW_values | update_jacobians;
@@ -2896,7 +2892,7 @@ namespace internal
           AssertDimension(cell_type.size(), cells.size() / n_lanes);
           face_data_by_cells[my_q].data_index_offsets.resize(
             cell_type.size() * GeometryInfo<dim>::faces_per_cell);
-          if (contains_bits(update_flags, update_quadrature_points))
+          if (update_flags.contains(update_quadrature_points))
             face_data_by_cells[my_q].quadrature_point_offsets.resize(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell);
           std::size_t storage_length = 0;
@@ -2918,7 +2914,7 @@ namespace internal
                     storage_length +=
                       face_data_by_cells[my_q].descriptor[0].n_q_points;
                   }
-                if (contains_bits(update_flags, update_quadrature_points))
+                if (update_flags.contains(update_quadrature_points))
                   face_data_by_cells[my_q].quadrature_point_offsets
                     [i * GeometryInfo<dim>::faces_per_cell + face] =
                     (i * GeometryInfo<dim>::faces_per_cell + face) *
@@ -2930,22 +2926,22 @@ namespace internal
             storage_length * GeometryInfo<dim>::faces_per_cell);
           face_data_by_cells[my_q].jacobians[1].resize_fast(
             storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (contains_bits(update_flags, update_normal_vectors))
+          if (update_flags.contains(update_normal_vectors))
             face_data_by_cells[my_q].normal_vectors.resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((contains_bits(update_flags, update_normal_vectors)) &&
-              (contains_bits(update_flags, update_jacobians)))
+          if ((update_flags.contains(update_normal_vectors)) &&
+              (update_flags.contains(update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if ((contains_bits(update_flags, update_normal_vectors)) &&
-              (contains_bits(update_flags, update_jacobians)))
+          if ((update_flags.contains(update_normal_vectors)) &&
+              (update_flags.contains(update_jacobians)))
             face_data_by_cells[my_q].normals_times_jacobians[1].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
-          if (contains_bits(update_flags, update_jacobian_grads))
+          if (update_flags.contains(update_jacobian_grads))
             face_data_by_cells[my_q].jacobian_gradients[0].resize_fast(
               storage_length * GeometryInfo<dim>::faces_per_cell);
 
-          if (contains_bits(update_flags, update_quadrature_points))
+          if (update_flags.contains(update_quadrature_points))
             face_data_by_cells[my_q].quadrature_points.resize_fast(
               cell_type.size() * GeometryInfo<dim>::faces_per_cell *
               face_data_by_cells[my_q].descriptor[0].n_q_points);
@@ -3019,10 +3015,10 @@ namespace internal
                   // copy data for affine data type
                   if (cell_type[cell] <= affine)
                     {
-                      if (contains_bits(update_flags, update_JxW_values))
+                      if (update_flags.contains(update_JxW_values))
                         face_data_by_cells[my_q].JxW_values[offset][v] =
                           fe_val.JxW(0) / fe_val.get_quadrature().weight(0);
-                      if (contains_bits(update_flags, update_jacobians))
+                      if (update_flags.contains(update_jacobians))
                         {
                           DerivativeForm<1, dim, dim> inv_jac =
                             fe_val.jacobian(0).covariant_form();
@@ -3036,8 +3032,7 @@ namespace internal
                                   inv_jac[d][ee];
                               }
                         }
-                      if (is_local &&
-                          (contains_bits(update_flags, update_jacobians)))
+                      if (is_local && (update_flags.contains(update_jacobians)))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3054,11 +3049,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if (contains_bits(update_flags, update_jacobian_grads))
+                      if (update_flags.contains(update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if (contains_bits(update_flags, update_normal_vectors))
+                      if (update_flags.contains(update_normal_vectors))
                         for (unsigned int d = 0; d < dim; ++d)
                           face_data_by_cells[my_q]
                             .normal_vectors[offset][d][v] =
@@ -3067,12 +3062,12 @@ namespace internal
                   // copy data for general data type
                   else
                     {
-                      if (contains_bits(update_flags, update_JxW_values))
+                      if (update_flags.contains(update_JxW_values))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           face_data_by_cells[my_q].JxW_values[offset + q][v] =
                             fe_val.JxW(q);
-                      if (contains_bits(update_flags, update_jacobians))
+                      if (update_flags.contains(update_jacobians))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           {
@@ -3089,11 +3084,11 @@ namespace internal
                                     inv_jac[d][ee];
                                 }
                           }
-                      if (contains_bits(update_flags, update_jacobian_grads))
+                      if (update_flags.contains(update_jacobian_grads))
                         {
                           Assert(false, ExcNotImplemented());
                         }
-                      if (contains_bits(update_flags, update_normal_vectors))
+                      if (update_flags.contains(update_normal_vectors))
                         for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                              ++q)
                           for (unsigned int d = 0; d < dim; ++d)
@@ -3101,7 +3096,7 @@ namespace internal
                               .normal_vectors[offset + q][d][v] =
                               fe_val.normal_vector(q)[d];
                     }
-                  if (contains_bits(update_flags, update_quadrature_points))
+                  if (update_flags.contains(update_quadrature_points))
                     for (unsigned int q = 0; q < fe_val.n_quadrature_points;
                          ++q)
                       for (unsigned int d = 0; d < dim; ++d)
@@ -3110,8 +3105,8 @@ namespace internal
                              [cell * GeometryInfo<dim>::faces_per_cell + face] +
                            q][d][v] = fe_val.quadrature_point(q)[d];
                 }
-              if ((contains_bits(update_flags, update_normal_vectors)) &&
-                  (contains_bits(update_flags, update_jacobians)))
+              if ((update_flags.contains(update_normal_vectors)) &&
+                  (update_flags.contains(update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);
@@ -3120,8 +3115,8 @@ namespace internal
                     .normals_times_jacobians[0][offset + q] =
                     face_data_by_cells[my_q].normal_vectors[offset + q] *
                     face_data_by_cells[my_q].jacobians[0][offset + q];
-              if ((contains_bits(update_flags, update_normal_vectors)) &&
-                  (contains_bits(update_flags, update_jacobians)))
+              if ((update_flags.contains(update_normal_vectors)) &&
+                  (update_flags.contains(update_jacobians)))
                 for (unsigned int q = 0; q < (cell_type[cell] <= affine ?
                                                 1 :
                                                 fe_val.n_quadrature_points);

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -134,11 +134,11 @@ namespace internal
       // for Hessian information, need inverse Jacobians and the derivative of
       // Jacobians (these two together will give use the gradients of the
       // inverse Jacobians, which is what we need)
-      if (contains(update_flags, update_hessians) ||
-          contains(update_flags, update_jacobian_grads))
+      if (contains_bits(update_flags, update_hessians) ||
+          contains_bits(update_flags, update_jacobian_grads))
         new_flags |= update_jacobian_grads;
 
-      if (contains(update_flags, update_quadrature_points))
+      if (contains_bits(update_flags, update_quadrature_points))
         new_flags |= update_quadrature_points;
 
       // there is one more thing: if we have a quadrature formula with only

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -134,11 +134,11 @@ namespace internal
       // for Hessian information, need inverse Jacobians and the derivative of
       // Jacobians (these two together will give use the gradients of the
       // inverse Jacobians, which is what we need)
-      if ((update_flags & update_hessians) != 0u ||
-          (update_flags & update_jacobian_grads) != 0u)
+      if (contains(update_flags, update_hessians) ||
+          contains(update_flags, update_jacobian_grads))
         new_flags |= update_jacobian_grads;
 
-      if ((update_flags & update_quadrature_points) != 0u)
+      if (contains(update_flags, update_quadrature_points))
         new_flags |= update_quadrature_points;
 
       // there is one more thing: if we have a quadrature formula with only

--- a/include/deal.II/matrix_free/mapping_info_storage.templates.h
+++ b/include/deal.II/matrix_free/mapping_info_storage.templates.h
@@ -134,11 +134,11 @@ namespace internal
       // for Hessian information, need inverse Jacobians and the derivative of
       // Jacobians (these two together will give use the gradients of the
       // inverse Jacobians, which is what we need)
-      if (contains_bits(update_flags, update_hessians) ||
-          contains_bits(update_flags, update_jacobian_grads))
+      if (update_flags.contains(update_hessians) ||
+          update_flags.contains(update_jacobian_grads))
         new_flags |= update_jacobian_grads;
 
-      if (contains_bits(update_flags, update_quadrature_points))
+      if (update_flags.contains(update_quadrature_points))
         new_flags |= update_quadrature_points;
 
       // there is one more thing: if we have a quadrature formula with only

--- a/include/deal.II/meshworker/assemble_flags.h
+++ b/include/deal.II/meshworker/assemble_flags.h
@@ -144,8 +144,9 @@ namespace MeshWorker
   inline AssembleFlags
   operator|(AssembleFlags f1, AssembleFlags f2)
   {
-    return static_cast<AssembleFlags>(static_cast<unsigned int>(f1) |
-                                      static_cast<unsigned int>(f2));
+    using enum_type = std::underlying_type_t<AssembleFlags>;
+    return static_cast<AssembleFlags>(static_cast<enum_type>(f1) |
+                                      static_cast<enum_type>(f2));
   }
 
 
@@ -174,12 +175,11 @@ namespace MeshWorker
    * @ref AssembleFlags
    */
   inline AssembleFlags
-  operator&(AssembleFlags f1, AssembleFlags f2) = delete;
-
-  inline bool
-  contains(AssembleFlags f1, AssembleFlags f2)
+  operator&(AssembleFlags f1, AssembleFlags f2)
   {
-    return static_cast<unsigned int>(f1) & static_cast<unsigned int>(f2) == 0;
+    using enum_type = std::underlying_type_t<AssembleFlags>;
+    return static_cast<AssembleFlags>(static_cast<enum_type>(f1) &
+                                      static_cast<enum_type>(f2));
   }
 
 
@@ -190,7 +190,42 @@ namespace MeshWorker
    * @ref AssembleFlags
    */
   inline AssembleFlags &
-  operator&=(AssembleFlags &f1, AssembleFlags f2) = delete;
+  operator&=(AssembleFlags &f1, AssembleFlags f2)
+  {
+    f1 = f1 & f2;
+    return f1;
+  }
+
+
+  /**
+   * Global operator which returns an object in which all bits are set which are
+   * not set in the argument. This operator exists since
+   * if it did not then the result of the bit-negation <tt>operator ~</tt> would
+   * be an integer which would in turn trigger a compiler warning when we tried
+   * to assign it to an object of type AssembleFlags.
+   *
+   * @ref AssembleFlags
+   */
+  inline AssembleFlags
+  operator~(const AssembleFlags f)
+  {
+    using enum_type = std::underlying_type_t<AssembleFlags>;
+    return static_cast<AssembleFlags>(~static_cast<enum_type>(f));
+  }
+
+
+  /**
+   * Global operator which checks if the flags contained in the first argument
+   * contain the flags contained in the second argument.
+   *
+   * @ref AssembleFlags
+   */
+  inline bool
+  contains(const AssembleFlags flags, const AssembleFlags mask)
+  {
+    using enum_type = std::underlying_type_t<AssembleFlags>;
+    return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;
+  }
 } // namespace MeshWorker
 
 /*@}*/

--- a/include/deal.II/meshworker/assemble_flags.h
+++ b/include/deal.II/meshworker/assemble_flags.h
@@ -221,7 +221,7 @@ namespace MeshWorker
    * @ref AssembleFlags
    */
   inline bool
-  contains(const AssembleFlags flags, const AssembleFlags mask)
+  contains_bits(const AssembleFlags flags, const AssembleFlags mask)
   {
     using enum_type = std::underlying_type_t<AssembleFlags>;
     return (static_cast<enum_type>(flags) & static_cast<enum_type>(mask)) != 0;

--- a/include/deal.II/meshworker/assemble_flags.h
+++ b/include/deal.II/meshworker/assemble_flags.h
@@ -174,10 +174,12 @@ namespace MeshWorker
    * @ref AssembleFlags
    */
   inline AssembleFlags
-  operator&(AssembleFlags f1, AssembleFlags f2)
+  operator&(AssembleFlags f1, AssembleFlags f2) = delete;
+
+  inline bool
+  contains(AssembleFlags f1, AssembleFlags f2)
   {
-    return static_cast<AssembleFlags>(static_cast<unsigned int>(f1) &
-                                      static_cast<unsigned int>(f2));
+    return static_cast<unsigned int>(f1) & static_cast<unsigned int>(f2) == 0;
   }
 
 
@@ -188,11 +190,7 @@ namespace MeshWorker
    * @ref AssembleFlags
    */
   inline AssembleFlags &
-  operator&=(AssembleFlags &f1, AssembleFlags f2)
-  {
-    f1 = f1 & f2;
-    return f1;
-  }
+  operator&=(AssembleFlags &f1, AssembleFlags f2) = delete;
 } // namespace MeshWorker
 
 /*@}*/

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -786,13 +786,13 @@ namespace MeshWorker
                                             const BlockInfo *block_info)
   {
     initialize_update_flags();
-    initialize_gauss_quadrature((contains_bits(cell_flags, update_values)) ?
+    initialize_gauss_quadrature((cell_flags.contains(update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                (contains_bits(boundary_flags, update_values)) ?
+                                (boundary_flags.contains(update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                (contains_bits(face_flags, update_values)) ?
+                                (face_flags.contains(update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
                                 false);

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -786,13 +786,13 @@ namespace MeshWorker
                                             const BlockInfo *block_info)
   {
     initialize_update_flags();
-    initialize_gauss_quadrature((contains(cell_flags, update_values)) ?
+    initialize_gauss_quadrature((contains_bits(cell_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                (contains(boundary_flags, update_values)) ?
+                                (contains_bits(boundary_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                (contains(face_flags, update_values)) ?
+                                (contains_bits(face_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
                                 false);

--- a/include/deal.II/meshworker/integration_info.h
+++ b/include/deal.II/meshworker/integration_info.h
@@ -786,13 +786,13 @@ namespace MeshWorker
                                             const BlockInfo *block_info)
   {
     initialize_update_flags();
-    initialize_gauss_quadrature(((cell_flags & update_values) != 0) ?
+    initialize_gauss_quadrature((contains(cell_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((boundary_flags & update_values) != 0) ?
+                                (contains(boundary_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
-                                ((face_flags & update_values) != 0) ?
+                                (contains(face_flags, update_values)) ?
                                   (el.tensor_degree() + 1) :
                                   el.tensor_degree(),
                                 false);

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -366,15 +366,15 @@ namespace MeshWorker
              "conditions is not satisfied."));
 
     Assert(
-      flags &
-        (assemble_own_interior_faces_once | assemble_own_interior_faces_both) !=
-          (assemble_own_interior_faces_once | assemble_own_interior_faces_both),
+      (flags &
+       (assemble_own_interior_faces_once | assemble_own_interior_faces_both)) !=
+        (assemble_own_interior_faces_once | assemble_own_interior_faces_both),
       ExcMessage(
         "You can only specify 'assemble_own_interior_faces_once' "
         "OR 'assemble_own_interior_faces_both', but not both of these flags."));
 
-    Assert(flags & (assemble_ghost_faces_once | assemble_ghost_faces_both) !=
-                     (assemble_ghost_faces_once | assemble_ghost_faces_both),
+    Assert((flags & (assemble_ghost_faces_once | assemble_ghost_faces_both)) !=
+             (assemble_ghost_faces_once | assemble_ghost_faces_both),
            ExcMessage(
              "You can only specify 'assemble_ghost_faces_once' "
              "OR 'assemble_ghost_faces_both', but not both of these flags."));

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -345,7 +345,7 @@ namespace MeshWorker
   )
   {
     Assert(
-      (!cell_worker) == !flags.contains(work_on_cells),
+      (!cell_worker) == !contains_bits(flags, work_on_cells),
       ExcMessage(
         "If you provide a cell worker function, you also need to request "
         "that work should be done on cells by setting the 'work_on_cells' flag. "
@@ -353,9 +353,9 @@ namespace MeshWorker
         "cannot set the 'work_on_cells' flag. One of these two "
         "conditions is not satisfied."));
 
-    Assert((!face_worker) ==
-             !flags.contains((assemble_own_interior_faces_once |
-                              assemble_own_interior_faces_both)),
+    Assert((!face_worker) == !contains_bits(flags,
+                                            (assemble_own_interior_faces_once |
+                                             assemble_own_interior_faces_both)),
            ExcMessage(
              "If you provide a face worker function, you also need to request "
              "that work should be done on interior faces by setting either the "
@@ -380,13 +380,13 @@ namespace MeshWorker
              "OR 'assemble_ghost_faces_both', but not both of these flags."));
 
     Assert(
-      !flags.contains(cells_after_faces) ||
-        flags.contains((assemble_own_cells | assemble_ghost_cells)),
+      !contains_bits(flags, cells_after_faces) ||
+        contains_bits(flags, (assemble_own_cells | assemble_ghost_cells)),
       ExcMessage(
         "The option 'cells_after_faces' only makes sense if you assemble on cells."));
 
     Assert(
-      (!face_worker) == !flags.contains(work_on_faces),
+      (!face_worker) == !contains_bits(flags, work_on_faces),
       ExcMessage(
         "If you provide a face worker function, you also need to request "
         "that work should be done on faces by setting the 'work_on_faces' flag. "
@@ -395,7 +395,7 @@ namespace MeshWorker
         "conditions is not satisfied."));
 
     Assert(
-      (!boundary_worker) == !flags.contains(assemble_boundary_faces),
+      (!boundary_worker) == !contains_bits(flags, assemble_boundary_faces),
       ExcMessage(
         "If you provide a boundary face worker function, you also need to request "
         "that work should be done on boundary faces by setting the 'assemble_boundary_faces' flag. "
@@ -430,19 +430,19 @@ namespace MeshWorker
           (current_subdomain_id == numbers::artificial_subdomain_id))
         return;
 
-      if (!flags.contains((cells_after_faces)) &&
-          ((flags.contains((assemble_own_cells)) && own_cell) ||
-           (flags.contains(assemble_ghost_cells) && !own_cell)))
+      if (!contains_bits(flags, (cells_after_faces)) &&
+          ((contains_bits(flags, (assemble_own_cells)) && own_cell) ||
+           (contains_bits(flags, assemble_ghost_cells) && !own_cell)))
         cell_worker(cell, scratch, copy);
 
-      if (flags.contains((work_on_faces | work_on_boundary)))
+      if (contains_bits(flags, (work_on_faces | work_on_boundary)))
         for (const unsigned int face_no : cell->face_indices())
           {
             if (cell->at_boundary(face_no) &&
                 !cell->has_periodic_neighbor(face_no))
               {
                 // only integrate boundary faces of own cells
-                if (flags.contains(assemble_boundary_faces) && own_cell)
+                if (contains_bits(flags, assemble_boundary_faces) && own_cell)
                   boundary_worker(cell, face_no, scratch, copy);
               }
             else
@@ -470,14 +470,16 @@ namespace MeshWorker
 
                 // skip if the user doesn't want faces between own cells
                 if (own_cell && own_neighbor &&
-                    !flags.contains((assemble_own_interior_faces_both |
-                                     assemble_own_interior_faces_once)))
+                    !contains_bits(flags,
+                                   (assemble_own_interior_faces_both |
+                                    assemble_own_interior_faces_once)))
                   continue;
 
                 // skip face to ghost
                 if (own_cell != own_neighbor &&
-                    !flags.contains(
-                      (assemble_ghost_faces_both | assemble_ghost_faces_once)))
+                    !contains_bits(flags,
+                                   (assemble_ghost_faces_both |
+                                    assemble_ghost_faces_once)))
                   continue;
 
                 // Deal with refinement edges from the refined side. Assuming
@@ -497,7 +499,8 @@ namespace MeshWorker
 
                     // skip if only one processor needs to assemble the face
                     // to a ghost cell and the fine cell is not ours.
-                    if (!own_cell && flags.contains(assemble_ghost_faces_once))
+                    if (!own_cell &&
+                        contains_bits(flags, assemble_ghost_faces_once))
                       continue;
 
                     const std::pair<unsigned int, unsigned int>
@@ -516,7 +519,7 @@ namespace MeshWorker
                                 scratch,
                                 copy);
 
-                    if (flags.contains(assemble_own_interior_faces_both))
+                    if (contains_bits(flags, assemble_own_interior_faces_both))
                       {
                         // If own faces are to be assembled from both sides,
                         // call the faceworker again with swapped arguments.
@@ -553,7 +556,7 @@ namespace MeshWorker
                                 scratch,
                                 copy);
 
-                    if (flags.contains(assemble_own_interior_faces_both))
+                    if (contains_bits(flags, assemble_own_interior_faces_both))
                       {
                         // If own faces are to be assembled from both sides,
                         // call the faceworker again with swapped arguments.
@@ -584,7 +587,8 @@ namespace MeshWorker
                     // AssembleFlags says otherwise). Here, we rely on cell
                     // comparison that will look at cell->index().
                     if (own_cell && own_neighbor &&
-                        flags.contains(assemble_own_interior_faces_once) &&
+                        contains_bits(flags,
+                                      assemble_own_interior_faces_once) &&
                         (neighbor < cell))
                       continue;
 
@@ -597,7 +601,7 @@ namespace MeshWorker
                     // the processor with the smaller (level-)subdomain id
                     // assemble the face.
                     if (own_cell && !own_neighbor &&
-                        flags.contains(assemble_ghost_faces_once) &&
+                        contains_bits(flags, assemble_ghost_faces_once) &&
                         (neighbor_subdomain_id < current_subdomain_id))
                       continue;
 
@@ -623,9 +627,9 @@ namespace MeshWorker
           } // faces
 
       // Execute the cell_worker if faces are handled before cells
-      if (flags.contains(cells_after_faces) &&
-          ((flags.contains(assemble_own_cells) && own_cell) ||
-           (flags.contains(assemble_ghost_cells) && !own_cell)))
+      if (contains_bits(flags, cells_after_faces) &&
+          ((contains_bits(flags, assemble_own_cells) && own_cell) ||
+           (contains_bits(flags, assemble_ghost_cells) && !own_cell)))
         cell_worker(cell, scratch, copy);
     };
 

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -345,7 +345,7 @@ namespace MeshWorker
   )
   {
     Assert(
-      (!cell_worker) == !contains(flags, work_on_cells),
+      (!cell_worker) == !contains_bits(flags, work_on_cells),
       ExcMessage(
         "If you provide a cell worker function, you also need to request "
         "that work should be done on cells by setting the 'work_on_cells' flag. "
@@ -353,9 +353,9 @@ namespace MeshWorker
         "cannot set the 'work_on_cells' flag. One of these two "
         "conditions is not satisfied."));
 
-    Assert((!face_worker) == !contains(flags,
-                                       (assemble_own_interior_faces_once |
-                                        assemble_own_interior_faces_both)),
+    Assert((!face_worker) == !contains_bits(flags,
+                                            (assemble_own_interior_faces_once |
+                                             assemble_own_interior_faces_both)),
            ExcMessage(
              "If you provide a face worker function, you also need to request "
              "that work should be done on interior faces by setting either the "
@@ -380,13 +380,13 @@ namespace MeshWorker
              "OR 'assemble_ghost_faces_both', but not both of these flags."));
 
     Assert(
-      !contains(flags, cells_after_faces) ||
-        contains(flags, (assemble_own_cells | assemble_ghost_cells)),
+      !contains_bits(flags, cells_after_faces) ||
+        contains_bits(flags, (assemble_own_cells | assemble_ghost_cells)),
       ExcMessage(
         "The option 'cells_after_faces' only makes sense if you assemble on cells."));
 
     Assert(
-      (!face_worker) == !contains(flags, work_on_faces),
+      (!face_worker) == !contains_bits(flags, work_on_faces),
       ExcMessage(
         "If you provide a face worker function, you also need to request "
         "that work should be done on faces by setting the 'work_on_faces' flag. "
@@ -395,7 +395,7 @@ namespace MeshWorker
         "conditions is not satisfied."));
 
     Assert(
-      (!boundary_worker) == !contains(flags, assemble_boundary_faces),
+      (!boundary_worker) == !contains_bits(flags, assemble_boundary_faces),
       ExcMessage(
         "If you provide a boundary face worker function, you also need to request "
         "that work should be done on boundary faces by setting the 'assemble_boundary_faces' flag. "
@@ -430,19 +430,19 @@ namespace MeshWorker
           (current_subdomain_id == numbers::artificial_subdomain_id))
         return;
 
-      if (!contains(flags, (cells_after_faces)) &&
-          ((contains(flags, (assemble_own_cells)) && own_cell) ||
-           (contains(flags, assemble_ghost_cells) && !own_cell)))
+      if (!contains_bits(flags, (cells_after_faces)) &&
+          ((contains_bits(flags, (assemble_own_cells)) && own_cell) ||
+           (contains_bits(flags, assemble_ghost_cells) && !own_cell)))
         cell_worker(cell, scratch, copy);
 
-      if (contains(flags, (work_on_faces | work_on_boundary)))
+      if (contains_bits(flags, (work_on_faces | work_on_boundary)))
         for (const unsigned int face_no : cell->face_indices())
           {
             if (cell->at_boundary(face_no) &&
                 !cell->has_periodic_neighbor(face_no))
               {
                 // only integrate boundary faces of own cells
-                if (contains(flags, assemble_boundary_faces) && own_cell)
+                if (contains_bits(flags, assemble_boundary_faces) && own_cell)
                   boundary_worker(cell, face_no, scratch, copy);
               }
             else
@@ -470,16 +470,16 @@ namespace MeshWorker
 
                 // skip if the user doesn't want faces between own cells
                 if (own_cell && own_neighbor &&
-                    !contains(flags,
-                              (assemble_own_interior_faces_both |
-                               assemble_own_interior_faces_once)))
+                    !contains_bits(flags,
+                                   (assemble_own_interior_faces_both |
+                                    assemble_own_interior_faces_once)))
                   continue;
 
                 // skip face to ghost
                 if (own_cell != own_neighbor &&
-                    !contains(flags,
-                              (assemble_ghost_faces_both |
-                               assemble_ghost_faces_once)))
+                    !contains_bits(flags,
+                                   (assemble_ghost_faces_both |
+                                    assemble_ghost_faces_once)))
                   continue;
 
                 // Deal with refinement edges from the refined side. Assuming
@@ -499,7 +499,8 @@ namespace MeshWorker
 
                     // skip if only one processor needs to assemble the face
                     // to a ghost cell and the fine cell is not ours.
-                    if (!own_cell && contains(flags, assemble_ghost_faces_once))
+                    if (!own_cell &&
+                        contains_bits(flags, assemble_ghost_faces_once))
                       continue;
 
                     const std::pair<unsigned int, unsigned int>
@@ -518,7 +519,7 @@ namespace MeshWorker
                                 scratch,
                                 copy);
 
-                    if (contains(flags, assemble_own_interior_faces_both))
+                    if (contains_bits(flags, assemble_own_interior_faces_both))
                       {
                         // If own faces are to be assembled from both sides,
                         // call the faceworker again with swapped arguments.
@@ -555,7 +556,7 @@ namespace MeshWorker
                                 scratch,
                                 copy);
 
-                    if (contains(flags, assemble_own_interior_faces_both))
+                    if (contains_bits(flags, assemble_own_interior_faces_both))
                       {
                         // If own faces are to be assembled from both sides,
                         // call the faceworker again with swapped arguments.
@@ -586,7 +587,8 @@ namespace MeshWorker
                     // AssembleFlags says otherwise). Here, we rely on cell
                     // comparison that will look at cell->index().
                     if (own_cell && own_neighbor &&
-                        contains(flags, assemble_own_interior_faces_once) &&
+                        contains_bits(flags,
+                                      assemble_own_interior_faces_once) &&
                         (neighbor < cell))
                       continue;
 
@@ -599,7 +601,7 @@ namespace MeshWorker
                     // the processor with the smaller (level-)subdomain id
                     // assemble the face.
                     if (own_cell && !own_neighbor &&
-                        contains(flags, assemble_ghost_faces_once) &&
+                        contains_bits(flags, assemble_ghost_faces_once) &&
                         (neighbor_subdomain_id < current_subdomain_id))
                       continue;
 
@@ -625,9 +627,9 @@ namespace MeshWorker
           } // faces
 
       // Execute the cell_worker if faces are handled before cells
-      if (contains(flags, cells_after_faces) &&
-          ((contains(flags, assemble_own_cells) && own_cell) ||
-           (contains(flags, assemble_ghost_cells) && !own_cell)))
+      if (contains_bits(flags, cells_after_faces) &&
+          ((contains_bits(flags, assemble_own_cells) && own_cell) ||
+           (contains_bits(flags, assemble_ghost_cells) && !own_cell)))
         cell_worker(cell, scratch, copy);
     };
 

--- a/include/deal.II/meshworker/mesh_loop.h
+++ b/include/deal.II/meshworker/mesh_loop.h
@@ -366,20 +366,15 @@ namespace MeshWorker
              "conditions is not satisfied."));
 
     Assert(
-      static_cast<AssembleFlags>(
-        static_cast<unsigned>(flags) &
-        static_cast<unsigned>(assemble_own_interior_faces_once |
-                              assemble_own_interior_faces_both)) !=
-        (assemble_own_interior_faces_once | assemble_own_interior_faces_both),
+      flags &
+        (assemble_own_interior_faces_once | assemble_own_interior_faces_both) !=
+          (assemble_own_interior_faces_once | assemble_own_interior_faces_both),
       ExcMessage(
         "You can only specify 'assemble_own_interior_faces_once' "
         "OR 'assemble_own_interior_faces_both', but not both of these flags."));
 
-    Assert(static_cast<AssembleFlags>(
-             static_cast<unsigned>(flags) &
-             static_cast<unsigned>(assemble_ghost_faces_once |
-                                   assemble_ghost_faces_both)) !=
-             (assemble_ghost_faces_once | assemble_ghost_faces_both),
+    Assert(flags & (assemble_ghost_faces_once | assemble_ghost_faces_both) !=
+                     (assemble_ghost_faces_once | assemble_ghost_faces_both),
            ExcMessage(
              "You can only specify 'assemble_ghost_faces_once' "
              "OR 'assemble_ghost_faces_both', but not both of these flags."));

--- a/include/deal.II/numerics/error_estimator.templates.h
+++ b/include/deal.II/numerics/error_estimator.templates.h
@@ -224,7 +224,7 @@ namespace internal
                           face_quadratures,
                           update_gradients | update_JxW_values |
                             (need_quadrature_points ? update_quadrature_points :
-                                                      UpdateFlags()) |
+                                                      update_default) |
                             update_normal_vectors)
     , fe_face_values_neighbor(mapping,
                               finite_element,

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -662,7 +662,7 @@ namespace MatrixCreator
         assembler_data(fe_collection,
                        update_values | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags()),
+                                                   update_default),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q_collection,
@@ -833,7 +833,7 @@ namespace MatrixCreator
         assembler_data(dof.get_fe_collection(),
                        update_values | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags()),
+                                                   update_default),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q,
@@ -1937,7 +1937,7 @@ namespace MatrixCreator
         assembler_data(fe_collection,
                        update_gradients | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags()),
+                                                   update_default),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q_collection,
@@ -2107,7 +2107,7 @@ namespace MatrixCreator
         assembler_data(dof.get_fe_collection(),
                        update_gradients | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags()),
+                                                   update_default),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q,

--- a/include/deal.II/numerics/matrix_creator.templates.h
+++ b/include/deal.II/numerics/matrix_creator.templates.h
@@ -662,7 +662,7 @@ namespace MatrixCreator
         assembler_data(fe_collection,
                        update_values | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags(0)),
+                                                   UpdateFlags()),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q_collection,
@@ -833,7 +833,7 @@ namespace MatrixCreator
         assembler_data(dof.get_fe_collection(),
                        update_values | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags(0)),
+                                                   UpdateFlags()),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q,
@@ -1937,7 +1937,7 @@ namespace MatrixCreator
         assembler_data(fe_collection,
                        update_gradients | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags(0)),
+                                                   UpdateFlags()),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q_collection,
@@ -2107,7 +2107,7 @@ namespace MatrixCreator
         assembler_data(dof.get_fe_collection(),
                        update_gradients | update_JxW_values |
                          (coefficient != nullptr ? update_quadrature_points :
-                                                   UpdateFlags(0)),
+                                                   UpdateFlags()),
                        coefficient,
                        /*rhs_function=*/nullptr,
                        q,

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -175,7 +175,7 @@ namespace VectorTools
         }
 
 
-      if (update_flags & update_values)
+      if (contains(update_flags, update_values))
         {
           // first compute the exact solution (vectors) at the quadrature
           // points. try to do this as efficient as possible by avoiding a
@@ -209,7 +209,7 @@ namespace VectorTools
         }
 
       // Do the same for gradients, if required
-      if (update_flags & update_gradients)
+      if (contains(update_flags, update_gradients))
         {
           // try to be a little clever to avoid recursive virtual function
           // calls when calling gradient_list for functions that are really
@@ -236,7 +236,7 @@ namespace VectorTools
           // tangential gradients in the finite element function, not the full
           // gradient. This is taken care of, by subtracting the normal
           // component of the gradient from the exact function.
-          if (update_flags & update_normal_vectors)
+          if (contains(update_flags, update_normal_vectors))
             for (unsigned int k = 0; k < n_components; ++k)
               for (const auto q : fe_values.quadrature_point_indices())
                 {
@@ -292,7 +292,7 @@ namespace VectorTools
               }
 
             // Compute the root only if no derivative values are added later
-            if (!(update_flags & update_gradients))
+            if (!(contains(update_flags, update_gradients)))
               diff = std::pow(diff, 1. / exponent);
             break;
 
@@ -524,9 +524,9 @@ namespace VectorTools
             const unsigned int n_q_points = fe_values.n_quadrature_points;
             data.resize_vectors(n_q_points, n_components);
 
-            if (update_flags & update_values)
+            if (contains(update_flags, update_values))
               fe_values.get_function_values(fe_function, data.function_values);
-            if (update_flags & update_gradients)
+            if (contains(update_flags, update_gradients))
               fe_values.get_function_gradients(fe_function,
                                                data.function_grads);
 

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -175,7 +175,7 @@ namespace VectorTools
         }
 
 
-      if (contains_bits(update_flags, update_values))
+      if (update_flags.contains(update_values))
         {
           // first compute the exact solution (vectors) at the quadrature
           // points. try to do this as efficient as possible by avoiding a
@@ -209,7 +209,7 @@ namespace VectorTools
         }
 
       // Do the same for gradients, if required
-      if (contains_bits(update_flags, update_gradients))
+      if (update_flags.contains(update_gradients))
         {
           // try to be a little clever to avoid recursive virtual function
           // calls when calling gradient_list for functions that are really
@@ -236,7 +236,7 @@ namespace VectorTools
           // tangential gradients in the finite element function, not the full
           // gradient. This is taken care of, by subtracting the normal
           // component of the gradient from the exact function.
-          if (contains_bits(update_flags, update_normal_vectors))
+          if (update_flags.contains(update_normal_vectors))
             for (unsigned int k = 0; k < n_components; ++k)
               for (const auto q : fe_values.quadrature_point_indices())
                 {
@@ -292,7 +292,7 @@ namespace VectorTools
               }
 
             // Compute the root only if no derivative values are added later
-            if (!(contains_bits(update_flags, update_gradients)))
+            if (!(update_flags.contains(update_gradients)))
               diff = std::pow(diff, 1. / exponent);
             break;
 
@@ -524,9 +524,9 @@ namespace VectorTools
             const unsigned int n_q_points = fe_values.n_quadrature_points;
             data.resize_vectors(n_q_points, n_components);
 
-            if (contains_bits(update_flags, update_values))
+            if (update_flags.contains(update_values))
               fe_values.get_function_values(fe_function, data.function_values);
-            if (contains_bits(update_flags, update_gradients))
+            if (update_flags.contains(update_gradients))
               fe_values.get_function_gradients(fe_function,
                                                data.function_grads);
 

--- a/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
+++ b/include/deal.II/numerics/vector_tools_integrate_difference.templates.h
@@ -175,7 +175,7 @@ namespace VectorTools
         }
 
 
-      if (contains(update_flags, update_values))
+      if (contains_bits(update_flags, update_values))
         {
           // first compute the exact solution (vectors) at the quadrature
           // points. try to do this as efficient as possible by avoiding a
@@ -209,7 +209,7 @@ namespace VectorTools
         }
 
       // Do the same for gradients, if required
-      if (contains(update_flags, update_gradients))
+      if (contains_bits(update_flags, update_gradients))
         {
           // try to be a little clever to avoid recursive virtual function
           // calls when calling gradient_list for functions that are really
@@ -236,7 +236,7 @@ namespace VectorTools
           // tangential gradients in the finite element function, not the full
           // gradient. This is taken care of, by subtracting the normal
           // component of the gradient from the exact function.
-          if (contains(update_flags, update_normal_vectors))
+          if (contains_bits(update_flags, update_normal_vectors))
             for (unsigned int k = 0; k < n_components; ++k)
               for (const auto q : fe_values.quadrature_point_indices())
                 {
@@ -292,7 +292,7 @@ namespace VectorTools
               }
 
             // Compute the root only if no derivative values are added later
-            if (!(contains(update_flags, update_gradients)))
+            if (!(contains_bits(update_flags, update_gradients)))
               diff = std::pow(diff, 1. / exponent);
             break;
 
@@ -524,9 +524,9 @@ namespace VectorTools
             const unsigned int n_q_points = fe_values.n_quadrature_points;
             data.resize_vectors(n_q_points, n_components);
 
-            if (contains(update_flags, update_values))
+            if (contains_bits(update_flags, update_values))
               fe_values.get_function_values(fe_function, data.function_values);
-            if (contains(update_flags, update_gradients))
+            if (contains_bits(update_flags, update_gradients))
               fe_values.get_function_gradients(fe_function,
                                                data.function_grads);
 

--- a/source/fe/CMakeLists.txt
+++ b/source/fe/CMakeLists.txt
@@ -55,6 +55,7 @@ SET(_unity_include_src
   fe_simplex_p.cc
   fe_simplex_p_bubbles.cc
   fe_trace.cc
+  fe_update_flags.cc
   fe_values_extractors.cc
   fe_wedge_p.cc
   mapping_c1.cc

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -262,8 +262,7 @@ FE_DGPNonparametric<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = flags;
 
-  if (contains_bits(flags,
-                    (update_values | update_gradients | update_hessians)))
+  if (flags.contains((update_values | update_gradients | update_hessians)))
     out |= update_quadrature_points;
 
   return out;
@@ -318,28 +317,26 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
+  Assert(fe_internal.update_each.contains(update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains_bits(fe_internal.update_each, update_values) ?
-      this->n_dofs_per_cell() :
-      0);
+  std::vector<double> values(fe_internal.update_each.contains(update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains_bits(fe_internal.update_each, update_gradients) ?
+    fe_internal.update_each.contains(update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains_bits(fe_internal.update_each, update_hessians) ?
+    fe_internal.update_each.contains(update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains_bits(fe_internal.update_each,
-                    (update_values | update_gradients)))
+  if (fe_internal.update_each.contains((update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -349,15 +346,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains_bits(fe_internal.update_each, update_values))
+        if (fe_internal.update_each.contains(update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains_bits(fe_internal.update_each, update_gradients))
+        if (fe_internal.update_each.contains(update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains_bits(fe_internal.update_each, update_hessians))
+        if (fe_internal.update_each.contains(update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -381,28 +378,26 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
+  Assert(fe_internal.update_each.contains(update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains_bits(fe_internal.update_each, update_values) ?
-      this->n_dofs_per_cell() :
-      0);
+  std::vector<double> values(fe_internal.update_each.contains(update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains_bits(fe_internal.update_each, update_gradients) ?
+    fe_internal.update_each.contains(update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains_bits(fe_internal.update_each, update_hessians) ?
+    fe_internal.update_each.contains(update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains_bits(fe_internal.update_each,
-                    (update_values | update_gradients)))
+  if (fe_internal.update_each.contains((update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -412,15 +407,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains_bits(fe_internal.update_each, update_values))
+        if (fe_internal.update_each.contains(update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains_bits(fe_internal.update_each, update_gradients))
+        if (fe_internal.update_each.contains(update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains_bits(fe_internal.update_each, update_hessians))
+        if (fe_internal.update_each.contains(update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -445,28 +440,26 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
+  Assert(fe_internal.update_each.contains(update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains_bits(fe_internal.update_each, update_values) ?
-      this->n_dofs_per_cell() :
-      0);
+  std::vector<double> values(fe_internal.update_each.contains(update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains_bits(fe_internal.update_each, update_gradients) ?
+    fe_internal.update_each.contains(update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains_bits(fe_internal.update_each, update_hessians) ?
+    fe_internal.update_each.contains(update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains_bits(fe_internal.update_each,
-                    (update_values | update_gradients)))
+  if (fe_internal.update_each.contains((update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -476,15 +469,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains_bits(fe_internal.update_each, update_values))
+        if (fe_internal.update_each.contains(update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains_bits(fe_internal.update_each, update_gradients))
+        if (fe_internal.update_each.contains(update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains_bits(fe_internal.update_each, update_hessians))
+        if (fe_internal.update_each.contains(update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -262,7 +262,8 @@ FE_DGPNonparametric<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = flags;
 
-  if (contains(flags, (update_values | update_gradients | update_hessians)))
+  if (contains_bits(flags,
+                    (update_values | update_gradients | update_hessians)))
     out |= update_quadrature_points;
 
   return out;
@@ -317,26 +318,28 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains(fe_internal.update_each, update_quadrature_points),
+  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
-                               this->n_dofs_per_cell() :
-                               0);
+  std::vector<double> values(
+    contains_bits(fe_internal.update_each, update_values) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ?
+    contains_bits(fe_internal.update_each, update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ?
+    contains_bits(fe_internal.update_each, update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains(fe_internal.update_each, (update_values | update_gradients)))
+  if (contains_bits(fe_internal.update_each,
+                    (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -346,15 +349,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains(fe_internal.update_each, update_values))
+        if (contains_bits(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains(fe_internal.update_each, update_gradients))
+        if (contains_bits(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains(fe_internal.update_each, update_hessians))
+        if (contains_bits(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -378,26 +381,28 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains(fe_internal.update_each, update_quadrature_points),
+  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
-                               this->n_dofs_per_cell() :
-                               0);
+  std::vector<double> values(
+    contains_bits(fe_internal.update_each, update_values) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ?
+    contains_bits(fe_internal.update_each, update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ?
+    contains_bits(fe_internal.update_each, update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains(fe_internal.update_each, (update_values | update_gradients)))
+  if (contains_bits(fe_internal.update_each,
+                    (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -407,15 +412,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains(fe_internal.update_each, update_values))
+        if (contains_bits(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains(fe_internal.update_each, update_gradients))
+        if (contains_bits(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains(fe_internal.update_each, update_hessians))
+        if (contains_bits(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -440,26 +445,28 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(contains(fe_internal.update_each, update_quadrature_points),
+  Assert(contains_bits(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
-                               this->n_dofs_per_cell() :
-                               0);
+  std::vector<double> values(
+    contains_bits(fe_internal.update_each, update_values) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ?
+    contains_bits(fe_internal.update_each, update_gradients) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ?
+    contains_bits(fe_internal.update_each, update_hessians) ?
       this->n_dofs_per_cell() :
       0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains(fe_internal.update_each, (update_values | update_gradients)))
+  if (contains_bits(fe_internal.update_each,
+                    (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -469,15 +476,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (contains(fe_internal.update_each, update_values))
+        if (contains_bits(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (contains(fe_internal.update_each, update_gradients))
+        if (contains_bits(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (contains(fe_internal.update_each, update_hessians))
+        if (contains_bits(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -322,12 +322,17 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
@@ -378,16 +383,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (contains(fe_internal.update_each , (update_values | update_gradients)))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -435,12 +445,17 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
-  std::vector<double> values(
-    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
+  std::vector<double> values(contains(fe_internal.update_each, update_values) ?
+                               this->n_dofs_per_cell() :
+                               0);
   std::vector<Tensor<1, dim>> grads(
-    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<2, dim>> grad_grads(
-    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ?
+      this->n_dofs_per_cell() :
+      0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 

--- a/source/fe/fe_dgp_nonparametric.cc
+++ b/source/fe/fe_dgp_nonparametric.cc
@@ -262,7 +262,7 @@ FE_DGPNonparametric<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = flags;
 
-  if ((flags & (update_values | update_gradients | update_hessians)) != 0u)
+  if (contains(flags, (update_values | update_gradients | update_hessians)))
     out |= update_quadrature_points;
 
   return out;
@@ -317,21 +317,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -341,15 +341,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -373,21 +373,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each , (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -397,15 +397,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_face_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }
@@ -430,21 +430,21 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                                                      spacedim>
     &output_data) const
 {
-  Assert(fe_internal.update_each & update_quadrature_points,
+  Assert(contains(fe_internal.update_each, update_quadrature_points),
          ExcInternalError());
 
   const unsigned int n_q_points = mapping_data.quadrature_points.size();
 
   std::vector<double> values(
-    (fe_internal.update_each & update_values) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_values) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<1, dim>> grads(
-    (fe_internal.update_each & update_gradients) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_gradients) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<2, dim>> grad_grads(
-    (fe_internal.update_each & update_hessians) ? this->n_dofs_per_cell() : 0);
+    contains(fe_internal.update_each, update_hessians) ? this->n_dofs_per_cell() : 0);
   std::vector<Tensor<3, dim>> empty_vector_of_3rd_order_tensors;
   std::vector<Tensor<4, dim>> empty_vector_of_4th_order_tensors;
 
-  if (fe_internal.update_each & (update_values | update_gradients))
+  if (contains(fe_internal.update_each, (update_values | update_gradients)))
     for (unsigned int i = 0; i < n_q_points; ++i)
       {
         polynomial_space.evaluate(mapping_data.quadrature_points[i],
@@ -454,15 +454,15 @@ FE_DGPNonparametric<dim, spacedim>::fill_fe_subface_values(
                                   empty_vector_of_3rd_order_tensors,
                                   empty_vector_of_4th_order_tensors);
 
-        if (fe_internal.update_each & update_values)
+        if (contains(fe_internal.update_each, update_values))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_values[k][i] = values[k];
 
-        if (fe_internal.update_each & update_gradients)
+        if (contains(fe_internal.update_each, update_gradients))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_gradients[k][i] = grads[k];
 
-        if (fe_internal.update_each & update_hessians)
+        if (contains(fe_internal.update_each, update_hessians))
           for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
             output_data.shape_hessians[k][i] = grad_grads[k];
       }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if(contains(flags, update_values))
+          if (contains(flags, update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if(contains(flags, update_gradients))
+          if (contains(flags, update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if(contains(flags, update_hessians))
+          if (contains(flags, update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if(contains(base_flags, update_values))
+                  if (contains(base_flags, update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if(contains(base_flags, update_gradients))
+                  if (contains(base_flags, update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if(contains(base_flags, update_hessians))
+                  if (contains(base_flags, update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if(contains(flags, update_hessians))
+          if (contains(flags, update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if(contains(flags, update_gradients))
+          if (contains(flags, update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if(contains(flags, update_values))
+          if (contains(flags, update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if(contains(flags, update_gradients))
+  if (contains(flags, update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if(contains(flags, update_values))
+  if (contains(flags, update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if (flags & update_values)
+          if(contains(flags, update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if (flags & update_gradients)
+          if(contains(flags, update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if (flags & update_hessians)
+          if(contains(flags, update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if (base_flags & update_values)
+                  if(contains(base_flags, update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if (base_flags & update_gradients)
+                  if(contains(base_flags, update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if (base_flags & update_hessians)
+                  if(contains(base_flags, update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if (flags & update_hessians)
+          if(contains(flags, update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (flags & update_gradients)
+          if(contains(flags, update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (flags & update_values)
+          if(contains(flags, update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if (flags & update_hessians)
+  if(contains(flags, update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if (flags & update_gradients)
+  if(contains(flags, update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if (flags & update_values)
+  if(contains(flags, update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -305,15 +305,15 @@ FE_Enriched<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
   if (is_enriched)
     {
       // if we ask for values or gradients, then we would need quadrature points
-      if (contains(flags, (update_values | update_gradients)))
+      if (contains_bits(flags, (update_values | update_gradients)))
         out |= update_quadrature_points;
 
       // if need gradients, add update_values due to product rule
-      if (contains(out, update_gradients))
+      if (contains_bits(out, update_gradients))
         out |= update_values;
     }
 
-  Assert(!contains(flags, update_3rd_derivatives), ExcNotImplemented());
+  Assert(!contains_bits(flags, update_3rd_derivatives), ExcNotImplemented());
 
   return out;
 }
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if (contains(flags, update_values))
+          if (contains_bits(flags, update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if (contains(flags, update_gradients))
+          if (contains_bits(flags, update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if (contains(flags, update_hessians))
+          if (contains_bits(flags, update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if (contains(base_flags, update_values))
+                  if (contains_bits(base_flags, update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if (contains(base_flags, update_gradients))
+                  if (contains_bits(base_flags, update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if (contains(base_flags, update_hessians))
+                  if (contains_bits(base_flags, update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if (contains(flags, update_hessians))
+          if (contains_bits(flags, update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (contains(flags, update_gradients))
+          if (contains_bits(flags, update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (contains(flags, update_values))
+          if (contains_bits(flags, update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -305,15 +305,15 @@ FE_Enriched<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
   if (is_enriched)
     {
       // if we ask for values or gradients, then we would need quadrature points
-      if ((flags & (update_values | update_gradients)) != 0u)
+      if (contains(flags, (update_values | update_gradients)))
         out |= update_quadrature_points;
 
       // if need gradients, add update_values due to product rule
-      if ((out & update_gradients) != 0u)
+      if (contains(out, update_gradients))
         out |= update_values;
     }
 
-  Assert(!(flags & update_3rd_derivatives), ExcNotImplemented());
+  Assert(!contains(flags, update_3rd_derivatives), ExcNotImplemented());
 
   return out;
 }

--- a/source/fe/fe_enriched.cc
+++ b/source/fe/fe_enriched.cc
@@ -305,15 +305,15 @@ FE_Enriched<dim, spacedim>::requires_update_flags(const UpdateFlags flags) const
   if (is_enriched)
     {
       // if we ask for values or gradients, then we would need quadrature points
-      if (contains_bits(flags, (update_values | update_gradients)))
+      if (flags.contains((update_values | update_gradients)))
         out |= update_quadrature_points;
 
       // if need gradients, add update_values due to product rule
-      if (contains_bits(out, update_gradients))
+      if (out.contains(update_gradients))
         out |= update_values;
     }
 
-  Assert(!contains_bits(flags, update_3rd_derivatives), ExcNotImplemented());
+  Assert(!flags.contains(update_3rd_derivatives), ExcNotImplemented());
 
   return out;
 }
@@ -347,13 +347,13 @@ FE_Enriched<dim, spacedim>::setup_data(
       data.enrichment[base].resize(this->element_multiplicity(base));
       for (unsigned int m = 0; m < this->element_multiplicity(base); ++m)
         {
-          if (contains_bits(flags, update_values))
+          if (flags.contains(update_values))
             data.enrichment[base][m].values.resize(n_q_points);
 
-          if (contains_bits(flags, update_gradients))
+          if (flags.contains(update_gradients))
             data.enrichment[base][m].gradients.resize(n_q_points);
 
-          if (contains_bits(flags, update_hessians))
+          if (flags.contains(update_hessians))
             data.enrichment[base][m].hessians.resize(n_q_points);
         }
     }
@@ -703,17 +703,17 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                    s < this->n_nonzero_components(system_index);
                    ++s)
                 {
-                  if (contains_bits(base_flags, update_values))
+                  if (base_flags.contains(update_values))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_values[out_index + s][q] =
                         base_data.shape_values(in_index + s, q);
 
-                  if (contains_bits(base_flags, update_gradients))
+                  if (base_flags.contains(update_gradients))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_gradients[out_index + s][q] =
                         base_data.shape_gradients[in_index + s][q];
 
-                  if (contains_bits(base_flags, update_hessians))
+                  if (base_flags.contains(update_hessians))
                     for (unsigned int q = 0; q < n_q_points; ++q)
                       output_data.shape_hessians[out_index + s][q] =
                         base_data.shape_hessians[in_index + s][q];
@@ -750,7 +750,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                  ExcMessage(
                    "Only scalar-valued enrichment functions are allowed"));
 
-          if (contains_bits(flags, update_hessians))
+          if (flags.contains(update_hessians))
             {
               Assert(fe_data.enrichment[base_no][m].hessians.size() ==
                        n_q_points,
@@ -763,7 +763,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (contains_bits(flags, update_gradients))
+          if (flags.contains(update_gradients))
             {
               Assert(fe_data.enrichment[base_no][m].gradients.size() ==
                        n_q_points,
@@ -776,7 +776,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
                     mapping_data.quadrature_points[q]);
             }
 
-          if (contains_bits(flags, update_values))
+          if (flags.contains(update_values))
             {
               Assert(fe_data.enrichment[base_no][m].values.size() == n_q_points,
                      ExcDimensionMismatch(
@@ -796,7 +796,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
   // output_data.shape_XYZ contains values of standard FEM and we overwrite
   // it with the updated one in the following order: hessians -> gradients ->
   // values
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     {
       for (unsigned int base_no = 1; base_no < this->n_base_elements();
            base_no++)
@@ -829,7 +829,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
         }
     }
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;
@@ -852,7 +852,7 @@ FE_Enriched<dim, spacedim>::multiply_by_enrichment(
             }
       }
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int base_no = 1; base_no < this->n_base_elements(); ++base_no)
       {
         for (unsigned int m = 0;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -677,11 +677,11 @@ UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if (contains(flags, update_normal_vectors))
+  if (contains_bits(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -726,7 +726,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if (contains(fe_internal.update_each, update_values))
+  if (contains_bits(fe_internal.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -676,10 +676,7 @@ template <int spacedim>
 UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
-  // FIXME
-  UpdateFlags out =
-    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
-                             static_cast<unsigned int>(update_values));
+  UpdateFlags out = flags & update_values;
   if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
   if (contains(flags, update_hessians))

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -677,11 +677,11 @@ UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = flags & update_values;
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if (contains_bits(flags, update_normal_vectors))
+  if (flags.contains(update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -726,7 +726,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if (contains_bits(fe_internal.update_each, update_values))
+  if (fe_internal.update_each.contains(update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -677,12 +677,14 @@ UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
   // FIXME
-  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
-  if(contains(flags, update_gradients))
+  UpdateFlags out =
+    static_cast<UpdateFlags>(static_cast<unsigned int>(flags) &
+                             static_cast<unsigned int>(update_values));
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if(contains(flags, update_hessians))
+  if (contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if(contains(flags, update_normal_vectors))
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -727,7 +729,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if(contains(fe_internal.update_each, update_values))
+  if (contains(fe_internal.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_face.cc
+++ b/source/fe/fe_face.cc
@@ -676,12 +676,13 @@ template <int spacedim>
 UpdateFlags
 FE_FaceQ<1, spacedim>::requires_update_flags(const UpdateFlags flags) const
 {
-  UpdateFlags out = flags & update_values;
-  if ((flags & update_gradients) != 0u)
+  // FIXME
+  UpdateFlags out = static_cast<UpdateFlags>(static_cast<unsigned int>(flags) & static_cast<unsigned int>(update_values));
+  if(contains(flags, update_gradients))
     out |= update_gradients | update_covariant_transformation;
-  if ((flags & update_hessians) != 0u)
+  if(contains(flags, update_hessians))
     out |= update_hessians | update_covariant_transformation;
-  if ((flags & update_normal_vectors) != 0u)
+  if(contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
 
   return out;
@@ -726,7 +727,7 @@ FE_FaceQ<1, spacedim>::fill_fe_face_values(
     &output_data) const
 {
   const unsigned int foffset = face;
-  if (fe_internal.update_each & update_values)
+  if(contains(fe_internal.update_each, update_values))
     {
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values(k, 0) = 0.;

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,20 +165,20 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 vertices_per_cell, std::vector<double>(dim)));
 
   // Resize shape function arrays according to update flags:
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     {
       data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     {
       data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
   // Not implementing second derivatives yet:
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     {
       Assert(false, ExcNotImplemented());
     }
@@ -401,7 +401,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             cell_type2_offset + degree * degree;
           const unsigned int cell_type3_offset2 = cell_type3_offset1 + degree;
 
-          if (contains(flags, (update_values | update_gradients)))
+          if (contains_bits(flags, (update_values | update_gradients)))
             {
               // compute all points we must evaluate the 1d polynomials at:
               std::vector<Point<dim>> cell_points(n_q_points);
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients) ? 3 : 2);
+                    contains_bits(flags, update_gradients) ? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -446,7 +446,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                         cell_points[q][1], polyy[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if (contains(flags, update_values))
+                  if (contains_bits(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -483,7 +483,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                           data.shape_values[dof_index3_2][q][1] = polyx[j][0];
                         }
                     }
-                  if (contains(flags, update_gradients))
+                  if (contains_bits(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -799,7 +799,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
 
               // for cell-based shape functions:
               // these don't depend on the cell, so can precompute all here:
-              if (contains(flags, (update_values | update_gradients)))
+              if (contains_bits(flags, (update_values | update_gradients)))
                 {
                   // Cell-based shape functions:
                   //
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients) ? 3 : 2);
+                    contains_bits(flags, update_gradients) ? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -882,7 +882,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                             cell_points[q][2], polyz[i]);
                         }
                       // Now use these to compute the shape functions:
-                      if (contains(flags, update_values))
+                      if (contains_bits(flags, update_values))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -965,7 +965,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 }
                             }
                         }
-                      if (contains(flags, update_gradients))
+                      if (contains_bits(flags, update_gradients))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1129,11 +1129,11 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains(flags, update_values) ||
+  Assert(!contains_bits(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!contains(flags, update_values) ||
+  Assert(!contains_bits(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
@@ -1155,7 +1155,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
     {
       case 2:
         {
-          if (contains(flags, (update_values | update_gradients)))
+          if (contains_bits(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients) ? 3 : 2);
+                contains_bits(flags, update_gradients) ? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1267,7 +1267,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                           IntegratedLegendrePolynomials[i + 1].value(
                             edge_sigma_values[m][q], poly[i - 1]);
                         }
-                      if (contains(flags, update_values))
+                      if (contains_bits(flags, update_values))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1292,7 +1292,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if (contains(flags, update_gradients))
+                      if (contains_bits(flags, update_gradients))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1340,7 +1340,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       case 3:
         {
-          if (contains(flags, (update_values | update_gradients)))
+          if (contains_bits(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients) ? 3 : 2);
+                contains_bits(flags, update_gradients) ? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1454,7 +1454,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 edge_sigma_values[m][q], poly[i]);
                             }
                         }
-                      if (contains(flags, update_values))
+                      if (contains_bits(flags, update_values))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1478,7 +1478,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if (contains(flags, update_gradients))
+                      if (contains_bits(flags, update_gradients))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1562,15 +1562,15 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
     {
       const UpdateFlags flags(fe_data.update_each);
 
-      if (contains(flags, (update_values | update_gradients)))
+      if (contains_bits(flags, (update_values | update_gradients)))
         {
           const unsigned int n_q_points = quadrature.size();
 
-          Assert(!contains(flags, update_values) ||
+          Assert(!contains_bits(flags, update_values) ||
                    fe_data.shape_values.size() == this->n_dofs_per_cell(),
                  ExcDimensionMismatch(fe_data.shape_values.size(),
                                       this->n_dofs_per_cell()));
-          Assert(!contains(flags, update_values) ||
+          Assert(!contains_bits(flags, update_values) ||
                    fe_data.shape_values[0].size() == n_q_points,
                  ExcDimensionMismatch(fe_data.shape_values[0].size(),
                                       n_q_points));
@@ -1688,8 +1688,8 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length(contains(flags, update_gradients) ? 3 :
-                                                                             2);
+          const unsigned int poly_length(
+            contains_bits(flags, update_gradients) ? 3 : 2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
           std::vector<std::vector<double>> polyeta(
@@ -1753,7 +1753,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                         face_eta_values[m][q], polyeta[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if (contains(flags, update_values))
+                  if (contains_bits(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1805,7 +1805,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if (contains(flags, update_gradients))
+                  if (contains_bits(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1902,7 +1902,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
         }
-      if (contains(flags, update_hessians))
+      if (contains_bits(flags, update_hessians))
         {
           Assert(false, ExcNotImplemented());
         }
@@ -1942,15 +1942,15 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains(flags, update_values) ||
+  Assert(!contains_bits(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!contains(flags, update_values) ||
+  Assert(!contains_bits(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -1976,7 +1976,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
             }
         }
     }
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2083,7 +2083,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
                                              cell->face_rotation(face_no),
                                              n_q_points);
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2112,7 +2112,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
             }
         }
     }
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2188,15 +2188,15 @@ FE_NedelecSZ<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     out |= update_values | update_covariant_transformation;
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     out |= update_gradients | update_values |
            update_jacobian_pushed_forward_grads |
            update_covariant_transformation;
 
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     //     Assert (false, ExcNotImplemented());
     out |= update_hessians | update_values | update_gradients |
            update_jacobian_pushed_forward_grads |

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -401,7 +401,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             cell_type2_offset + degree * degree;
           const unsigned int cell_type3_offset2 = cell_type3_offset1 + degree;
 
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // compute all points we must evaluate the 1d polynomials at:
               std::vector<Point<dim>> cell_points(n_q_points);
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    (flags & update_gradients) != 0u ? 3 : 2);
+                    contains(flags, update_gradients)? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -799,7 +799,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
 
               // for cell-based shape functions:
               // these don't depend on the cell, so can precompute all here:
-              if ((flags & (update_values | update_gradients)) != 0u)
+              if (contains(flags, (update_values | update_gradients)))
                 {
                   // Cell-based shape functions:
                   //
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    (flags & update_gradients) != 0u ? 3 : 2);
+                    contains(flags, update_gradients)? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -1129,11 +1129,11 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
@@ -1155,7 +1155,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
     {
       case 2:
         {
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                (flags & update_gradients) != 0u ? 3 : 2);
+                contains(flags, update_gradients)? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1340,7 +1340,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       case 3:
         {
-          if ((flags & (update_values | update_gradients)) != 0u)
+          if (contains(flags, (update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                (flags & update_gradients) != 0u ? 3 : 2);
+                contains(flags, update_gradients)? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1562,15 +1562,15 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
     {
       const UpdateFlags flags(fe_data.update_each);
 
-      if ((flags & (update_values | update_gradients)) != 0u)
+      if (contains(flags, (update_values | update_gradients)))
         {
           const unsigned int n_q_points = quadrature.size();
 
-          Assert(!(flags & update_values) ||
+          Assert(!contains(flags, update_values) ||
                    fe_data.shape_values.size() == this->n_dofs_per_cell(),
                  ExcDimensionMismatch(fe_data.shape_values.size(),
                                       this->n_dofs_per_cell()));
-          Assert(!(flags & update_values) ||
+          Assert(!contains(flags, update_values) ||
                    fe_data.shape_values[0].size() == n_q_points,
                  ExcDimensionMismatch(fe_data.shape_values[0].size(),
                                       n_q_points));
@@ -1688,7 +1688,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length((flags & update_gradients) != 0u ? 3 :
+          const unsigned int poly_length(contains(flags, update_gradients)? 3 :
                                                                             2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
@@ -1942,11 +1942,11 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!(flags & update_values) ||
+  Assert(!contains(flags, update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,20 +165,20 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 vertices_per_cell, std::vector<double>(dim)));
 
   // Resize shape function arrays according to update flags:
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     {
       data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     {
       data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
   // Not implementing second derivatives yet:
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     {
       Assert(false, ExcNotImplemented());
     }
@@ -401,7 +401,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
             cell_type2_offset + degree * degree;
           const unsigned int cell_type3_offset2 = cell_type3_offset1 + degree;
 
-          if (contains_bits(flags, (update_values | update_gradients)))
+          if (flags.contains((update_values | update_gradients)))
             {
               // compute all points we must evaluate the 1d polynomials at:
               std::vector<Point<dim>> cell_points(n_q_points);
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    contains_bits(flags, update_gradients) ? 3 : 2);
+                    flags.contains(update_gradients) ? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -446,7 +446,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                         cell_points[q][1], polyy[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if (contains_bits(flags, update_values))
+                  if (flags.contains(update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -483,7 +483,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                           data.shape_values[dof_index3_2][q][1] = polyx[j][0];
                         }
                     }
-                  if (contains_bits(flags, update_gradients))
+                  if (flags.contains(update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -799,7 +799,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
 
               // for cell-based shape functions:
               // these don't depend on the cell, so can precompute all here:
-              if (contains_bits(flags, (update_values | update_gradients)))
+              if (flags.contains((update_values | update_gradients)))
                 {
                   // Cell-based shape functions:
                   //
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    contains_bits(flags, update_gradients) ? 3 : 2);
+                    flags.contains(update_gradients) ? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -882,7 +882,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                             cell_points[q][2], polyz[i]);
                         }
                       // Now use these to compute the shape functions:
-                      if (contains_bits(flags, update_values))
+                      if (flags.contains(update_values))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -965,7 +965,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 }
                             }
                         }
-                      if (contains_bits(flags, update_gradients))
+                      if (flags.contains(update_gradients))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1129,11 +1129,11 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains_bits(flags, update_values) ||
+  Assert(!flags.contains(update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!contains_bits(flags, update_values) ||
+  Assert(!flags.contains(update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
@@ -1155,7 +1155,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
     {
       case 2:
         {
-          if (contains_bits(flags, (update_values | update_gradients)))
+          if (flags.contains((update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains_bits(flags, update_gradients) ? 3 : 2);
+                flags.contains(update_gradients) ? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1267,7 +1267,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                           IntegratedLegendrePolynomials[i + 1].value(
                             edge_sigma_values[m][q], poly[i - 1]);
                         }
-                      if (contains_bits(flags, update_values))
+                      if (flags.contains(update_values))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1292,7 +1292,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if (contains_bits(flags, update_gradients))
+                      if (flags.contains(update_gradients))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1340,7 +1340,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
         }
       case 3:
         {
-          if (contains_bits(flags, (update_values | update_gradients)))
+          if (flags.contains((update_values | update_gradients)))
             {
               // Define an edge numbering so that each edge, E_{m} = [e^{m}_{1},
               // e^{m}_{2}] e1 = higher global numbering of the two local
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains_bits(flags, update_gradients) ? 3 : 2);
+                flags.contains(update_gradients) ? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1454,7 +1454,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 edge_sigma_values[m][q], poly[i]);
                             }
                         }
-                      if (contains_bits(flags, update_values))
+                      if (flags.contains(update_values))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1478,7 +1478,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if (contains_bits(flags, update_gradients))
+                      if (flags.contains(update_gradients))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1562,15 +1562,15 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
     {
       const UpdateFlags flags(fe_data.update_each);
 
-      if (contains_bits(flags, (update_values | update_gradients)))
+      if (flags.contains((update_values | update_gradients)))
         {
           const unsigned int n_q_points = quadrature.size();
 
-          Assert(!contains_bits(flags, update_values) ||
+          Assert(!flags.contains(update_values) ||
                    fe_data.shape_values.size() == this->n_dofs_per_cell(),
                  ExcDimensionMismatch(fe_data.shape_values.size(),
                                       this->n_dofs_per_cell()));
-          Assert(!contains_bits(flags, update_values) ||
+          Assert(!flags.contains(update_values) ||
                    fe_data.shape_values[0].size() == n_q_points,
                  ExcDimensionMismatch(fe_data.shape_values[0].size(),
                                       n_q_points));
@@ -1688,8 +1688,8 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length(
-            contains_bits(flags, update_gradients) ? 3 : 2);
+          const unsigned int poly_length(flags.contains(update_gradients) ? 3 :
+                                                                            2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
           std::vector<std::vector<double>> polyeta(
@@ -1753,7 +1753,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                         face_eta_values[m][q], polyeta[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if (contains_bits(flags, update_values))
+                  if (flags.contains(update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1805,7 +1805,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if (contains_bits(flags, update_gradients))
+                  if (flags.contains(update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1902,7 +1902,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
         }
-      if (contains_bits(flags, update_hessians))
+      if (flags.contains(update_hessians))
         {
           Assert(false, ExcNotImplemented());
         }
@@ -1942,15 +1942,15 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
   const UpdateFlags  flags(fe_data.update_each);
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains_bits(flags, update_values) ||
+  Assert(!flags.contains(update_values) ||
            fe_data.shape_values.size() == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size(),
                               this->n_dofs_per_cell()));
-  Assert(!contains_bits(flags, update_values) ||
+  Assert(!flags.contains(update_values) ||
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -1976,7 +1976,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
             }
         }
     }
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2083,7 +2083,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
                                              cell->face_rotation(face_no),
                                              n_q_points);
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2112,7 +2112,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
             }
         }
     }
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2188,15 +2188,15 @@ FE_NedelecSZ<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     out |= update_values | update_covariant_transformation;
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     out |= update_gradients | update_values |
            update_jacobian_pushed_forward_grads |
            update_covariant_transformation;
 
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     //     Assert (false, ExcNotImplemented());
     out |= update_hessians | update_values | update_gradients |
            update_jacobian_pushed_forward_grads |

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -165,20 +165,20 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 vertices_per_cell, std::vector<double>(dim)));
 
   // Resize shape function arrays according to update flags:
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       data.shape_values.resize(this->n_dofs_per_cell(),
                                std::vector<Tensor<1, dim>>(n_q_points));
     }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       data.shape_grads.resize(this->n_dofs_per_cell(),
                               std::vector<DerivativeForm<1, dim, dim>>(
                                 n_q_points));
     }
   // Not implementing second derivatives yet:
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     {
       Assert(false, ExcNotImplemented());
     }
@@ -446,7 +446,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                         cell_points[q][1], polyy[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (contains(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -483,7 +483,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                           data.shape_values[dof_index3_2][q][1] = polyx[j][0];
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (contains(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -882,7 +882,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                             cell_points[q][2], polyz[i]);
                         }
                       // Now use these to compute the shape functions:
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -965,7 +965,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           for (unsigned int k = 0; k < degree; ++k)
                             {
@@ -1267,7 +1267,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                           IntegratedLegendrePolynomials[i + 1].value(
                             edge_sigma_values[m][q], poly[i - 1]);
                         }
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1292,7 +1292,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           // Lowest order edge shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1454,7 +1454,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 edge_sigma_values[m][q], poly[i]);
                             }
                         }
-                      if ((flags & update_values) != 0u)
+                      if (contains(flags, update_values))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d = 0; d < dim; ++d)
@@ -1478,7 +1478,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
                                 }
                             }
                         }
-                      if ((flags & update_gradients) != 0u)
+                      if (contains(flags, update_gradients))
                         {
                           // Lowest order shape functions:
                           for (unsigned int d1 = 0; d1 < dim; ++d1)
@@ -1753,7 +1753,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                         face_eta_values[m][q], polyeta[i]);
                     }
                   // Now use these to compute the shape functions:
-                  if ((flags & update_values) != 0u)
+                  if (contains(flags, update_values))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1805,7 +1805,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                             }
                         }
                     }
-                  if ((flags & update_gradients) != 0u)
+                  if (contains(flags, update_gradients))
                     {
                       for (unsigned int j = 0; j < degree; ++j)
                         {
@@ -1902,7 +1902,7 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
         }
-      if ((flags & update_hessians) != 0u)
+      if (contains(flags, update_hessians))
         {
           Assert(false, ExcNotImplemented());
         }
@@ -1950,7 +1950,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
            fe_data.shape_values[0].size() == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values[0].size(), n_q_points));
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -1976,7 +1976,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_values(
             }
         }
     }
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2083,7 +2083,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
                                              cell->face_rotation(face_no),
                                              n_q_points);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     {
       // Now have all shape_values stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2112,7 +2112,7 @@ FE_NedelecSZ<dim, spacedim>::fill_fe_face_values(
             }
         }
     }
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     {
       // Now have all shape_grads stored on the reference cell.
       // Must now transform to the physical cell.
@@ -2188,15 +2188,15 @@ FE_NedelecSZ<dim, spacedim>::requires_update_flags(
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values | update_covariant_transformation;
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients | update_values |
            update_jacobian_pushed_forward_grads |
            update_covariant_transformation;
 
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     //     Assert (false, ExcNotImplemented());
     out |= update_hessians | update_values | update_gradients |
            update_jacobian_pushed_forward_grads |

--- a/source/fe/fe_nedelec_sz.cc
+++ b/source/fe/fe_nedelec_sz.cc
@@ -429,7 +429,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // Note that this will need to be updated if we're supporting
                   // update_hessians.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients)? 3 : 2);
+                    contains(flags, update_gradients) ? 3 : 2);
 
                   std::vector<std::vector<double>> polyx(
                     degree, std::vector<double>(poly_length));
@@ -855,7 +855,7 @@ FE_NedelecSZ<dim, spacedim>::get_data(
                   // only need poly values and 1st derivative for update_values,
                   // but need 2nd derivative too for update_gradients.
                   const unsigned int poly_length(
-                    contains(flags, update_gradients)? 3 : 2);
+                    contains(flags, update_gradients) ? 3 : 2);
                   // Loop through quad points:
                   for (unsigned int q = 0; q < n_q_points; ++q)
                     {
@@ -1249,7 +1249,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients)? 3 : 2);
+                contains(flags, update_gradients) ? 3 : 2);
 
               for (unsigned int m = 0; m < lines_per_cell; ++m)
                 {
@@ -1437,7 +1437,7 @@ FE_NedelecSZ<dim, spacedim>::fill_edge_values(
               // derivatives of the 1d polynomials, but only first derivatives
               // for the shape values.
               const unsigned int poly_length(
-                contains(flags, update_gradients)? 3 : 2);
+                contains(flags, update_gradients) ? 3 : 2);
               std::vector<std::vector<double>> poly(
                 degree, std::vector<double>(poly_length));
               for (unsigned int m = 0; m < lines_per_cell; ++m)
@@ -1688,8 +1688,8 @@ FE_NedelecSZ<dim, spacedim>::fill_face_values(
                 }
             }
           // Now can generate the basis
-          const unsigned int poly_length(contains(flags, update_gradients)? 3 :
-                                                                            2);
+          const unsigned int poly_length(contains(flags, update_gradients) ? 3 :
+                                                                             2);
           std::vector<std::vector<double>> polyxi(
             degree, std::vector<double>(poly_length));
           std::vector<std::vector<double>> polyeta(

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -51,13 +51,13 @@ FE_P1NC::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     out |= update_values | update_quadrature_points;
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     out |= update_gradients;
-  if ((flags & update_normal_vectors) != 0u)
+  if (contains(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
-  if ((flags & update_hessians) != 0u)
+  if (contains(flags, update_hessians))
     out |= update_hessians;
 
   return out;
@@ -227,14 +227,14 @@ FE_P1NC::fill_fe_values(
   ndarray<double, 4, 3> coeffs = get_linear_shape_coefficients(cell);
 
   // compute on the cell
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -268,7 +268,7 @@ FE_P1NC::fill_fe_face_values(
                                    quadrature[0],
                                    face_no);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
@@ -281,7 +281,7 @@ FE_P1NC::fill_fe_face_values(
              coeffs[k][1] * quadrature_point(1) + coeffs[k][2]);
         }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
     this->reference_cell(), quadrature, face_no, sub_no);
 
-  if ((flags & update_values) != 0u)
+  if (contains(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -327,7 +327,7 @@ FE_P1NC::fill_fe_subface_values(
           }
       }
 
-  if ((flags & update_gradients) != 0u)
+  if (contains(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -148,7 +148,7 @@ FE_P1NC::get_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -174,7 +174,7 @@ FE_P1NC::get_face_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -198,7 +198,7 @@ FE_P1NC::get_subface_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if ((data_ptr->update_each & update_hessians) != 0u)
+  if (contains(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -51,13 +51,13 @@ FE_P1NC::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     out |= update_values | update_quadrature_points;
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     out |= update_gradients;
-  if (contains_bits(flags, update_normal_vectors))
+  if (flags.contains(update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
-  if (contains_bits(flags, update_hessians))
+  if (flags.contains(update_hessians))
     out |= update_hessians;
 
   return out;
@@ -148,7 +148,7 @@ FE_P1NC::get_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains_bits(data_ptr->update_each, update_hessians))
+  if (data_ptr->update_each.contains(update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -174,7 +174,7 @@ FE_P1NC::get_face_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains_bits(data_ptr->update_each, update_hessians))
+  if (data_ptr->update_each.contains(update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -198,7 +198,7 @@ FE_P1NC::get_subface_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains_bits(data_ptr->update_each, update_hessians))
+  if (data_ptr->update_each.contains(update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -227,14 +227,14 @@ FE_P1NC::fill_fe_values(
   ndarray<double, 4, 3> coeffs = get_linear_shape_coefficients(cell);
 
   // compute on the cell
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -268,7 +268,7 @@ FE_P1NC::fill_fe_face_values(
                                    quadrature[0],
                                    face_no);
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
@@ -281,7 +281,7 @@ FE_P1NC::fill_fe_face_values(
              coeffs[k][1] * quadrature_point(1) + coeffs[k][2]);
         }
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
     this->reference_cell(), quadrature, face_no, sub_no);
 
-  if (contains_bits(flags, update_values))
+  if (flags.contains(update_values))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -327,7 +327,7 @@ FE_P1NC::fill_fe_subface_values(
           }
       }
 
-  if (contains_bits(flags, update_gradients))
+  if (flags.contains(update_gradients))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =

--- a/source/fe/fe_p1nc.cc
+++ b/source/fe/fe_p1nc.cc
@@ -51,13 +51,13 @@ FE_P1NC::requires_update_flags(const UpdateFlags flags) const
 {
   UpdateFlags out = update_default;
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     out |= update_values | update_quadrature_points;
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     out |= update_gradients;
-  if (contains(flags, update_normal_vectors))
+  if (contains_bits(flags, update_normal_vectors))
     out |= update_normal_vectors | update_JxW_values;
-  if (contains(flags, update_hessians))
+  if (contains_bits(flags, update_hessians))
     out |= update_hessians;
 
   return out;
@@ -148,7 +148,7 @@ FE_P1NC::get_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains(data_ptr->update_each, update_hessians))
+  if (contains_bits(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -174,7 +174,7 @@ FE_P1NC::get_face_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains(data_ptr->update_each, update_hessians))
+  if (contains_bits(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -198,7 +198,7 @@ FE_P1NC::get_subface_data(
   output_data.initialize(n_q_points, FE_P1NC(), data_ptr->update_each);
 
   // this is a linear element, so its second derivatives are zero
-  if (contains(data_ptr->update_each, update_hessians))
+  if (contains_bits(data_ptr->update_each, update_hessians))
     output_data.shape_hessians.fill(Tensor<2, 2>());
 
   return data_ptr;
@@ -227,14 +227,14 @@ FE_P1NC::fill_fe_values(
   ndarray<double, 4, 3> coeffs = get_linear_shape_coefficients(cell);
 
   // compute on the cell
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_values[k][i] =
           (coeffs[k][0] * mapping_data.quadrature_points[i](0) +
            coeffs[k][1] * mapping_data.quadrature_points[i](1) + coeffs[k][2]);
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int i = 0; i < n_q_points; ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -268,7 +268,7 @@ FE_P1NC::fill_fe_face_values(
                                    quadrature[0],
                                    face_no);
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         {
@@ -281,7 +281,7 @@ FE_P1NC::fill_fe_face_values(
              coeffs[k][1] * quadrature_point(1) + coeffs[k][2]);
         }
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_face.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =
@@ -312,7 +312,7 @@ FE_P1NC::fill_fe_subface_values(
   const Quadrature<2> quadrature_on_subface = QProjector<2>::project_to_subface(
     this->reference_cell(), quadrature, face_no, sub_no);
 
-  if (contains(flags, update_values))
+  if (contains_bits(flags, update_values))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       {
         for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
@@ -327,7 +327,7 @@ FE_P1NC::fill_fe_subface_values(
           }
       }
 
-  if (contains(flags, update_gradients))
+  if (contains_bits(flags, update_gradients))
     for (unsigned int i = 0; i < quadrature_on_subface.size(); ++i)
       for (unsigned int k = 0; k < this->n_dofs_per_cell(); ++k)
         output_data.shape_gradients[k][i] =

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -2425,14 +2425,14 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
         {
           case mapping_none:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives;
@@ -2441,16 +2441,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_raviart_thomas:
           case mapping_piola:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values | update_piola |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2462,16 +2462,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           case mapping_contravariant:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_piola;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2483,15 +2483,15 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_nedelec:
           case mapping_covariant:
             {
-              if ((flags & update_values) != 0u)
+              if (contains(flags, update_values))
                 out |= update_values | update_covariant_transformation;
 
-              if ((flags & update_gradients) != 0u)
+              if (contains(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation;
 
-              if ((flags & update_hessians) != 0u)
+              if (contains(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -454,11 +454,11 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains_bits(fe_data.update_each, update_values) ||
+  Assert(!fe_data.update_each.contains(update_values) ||
            fe_data.shape_values.size()[0] == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size()[0],
                               this->n_dofs_per_cell()));
-  Assert(!contains_bits(fe_data.update_each, update_values) ||
+  Assert(!fe_data.update_each.contains(update_values) ||
            fe_data.shape_values.size()[1] == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values.size()[1], n_q_points));
 
@@ -513,7 +513,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains_bits(fe_data.update_each, update_values))
+      if (fe_data.update_each.contains(update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -550,7 +550,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // the previous one; or, even if it is a translation, if we use
       // mappings other than the standard mappings that require us to
       // recompute values and derivatives because of possible sign changes
-      if (contains_bits(fe_data.update_each, update_values) &&
+      if (fe_data.update_each.contains(update_values) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -621,7 +621,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update gradients. apply the same logic as above
-      if (contains_bits(fe_data.update_each, update_gradients) &&
+      if (fe_data.update_each.contains(update_gradients) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -764,7 +764,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update hessians. apply the same logic as above
-      if (contains_bits(fe_data.update_each, update_hessians) &&
+      if (fe_data.update_each.contains(update_hessians) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1038,7 +1038,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // third derivatives are not implemented
-      if (contains_bits(fe_data.update_each, update_3rd_derivatives) &&
+      if (fe_data.update_each.contains(update_3rd_derivatives) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1143,7 +1143,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains_bits(fe_data.update_each, update_values))
+      if (fe_data.update_each.contains(update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1174,7 +1174,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (contains_bits(fe_data.update_each, update_values))
+      if (fe_data.update_each.contains(update_values))
         {
           switch (mapping_kind)
             {
@@ -1260,7 +1260,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (contains_bits(fe_data.update_each, update_gradients))
+      if (fe_data.update_each.contains(update_gradients))
         {
           switch (mapping_kind)
             {
@@ -1428,7 +1428,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (contains_bits(fe_data.update_each, update_hessians))
+      if (fe_data.update_each.contains(update_hessians))
         {
           switch (mapping_kind)
             {
@@ -1727,7 +1727,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
         }
 
       // third derivatives are not implemented
-      if (contains_bits(fe_data.update_each, update_3rd_derivatives))
+      if (fe_data.update_each.contains(update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -1829,7 +1829,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains_bits(fe_data.update_each, update_values))
+      if (fe_data.update_each.contains(update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1860,7 +1860,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (contains_bits(fe_data.update_each, update_values))
+      if (fe_data.update_each.contains(update_values))
         {
           switch (mapping_kind)
             {
@@ -1949,7 +1949,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (contains_bits(fe_data.update_each, update_gradients))
+      if (fe_data.update_each.contains(update_gradients))
         {
           const ArrayView<Tensor<2, spacedim>> transformed_shape_grads =
             make_array_view(fe_data.transformed_shape_grads,
@@ -2103,7 +2103,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (contains_bits(fe_data.update_each, update_hessians))
+      if (fe_data.update_each.contains(update_hessians))
         {
           switch (mapping_kind)
             {
@@ -2401,7 +2401,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
         }
 
       // third derivatives are not implemented
-      if (contains_bits(fe_data.update_each, update_3rd_derivatives))
+      if (fe_data.update_each.contains(update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -2425,14 +2425,14 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
         {
           case mapping_none:
             {
-              if (contains_bits(flags, update_values))
+              if (flags.contains(update_values))
                 out |= update_values;
 
-              if (contains_bits(flags, update_gradients))
+              if (flags.contains(update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads;
 
-              if (contains_bits(flags, update_hessians))
+              if (flags.contains(update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives;
@@ -2441,16 +2441,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_raviart_thomas:
           case mapping_piola:
             {
-              if (contains_bits(flags, update_values))
+              if (flags.contains(update_values))
                 out |= update_values | update_piola;
 
-              if (contains_bits(flags, update_gradients))
+              if (flags.contains(update_gradients))
                 out |= update_gradients | update_values | update_piola |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if (contains_bits(flags, update_hessians))
+              if (flags.contains(update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2462,16 +2462,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           case mapping_contravariant:
             {
-              if (contains_bits(flags, update_values))
+              if (flags.contains(update_values))
                 out |= update_values | update_piola;
 
-              if (contains_bits(flags, update_gradients))
+              if (flags.contains(update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if (contains_bits(flags, update_hessians))
+              if (flags.contains(update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2483,15 +2483,15 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_nedelec:
           case mapping_covariant:
             {
-              if (contains_bits(flags, update_values))
+              if (flags.contains(update_values))
                 out |= update_values | update_covariant_transformation;
 
-              if (contains_bits(flags, update_gradients))
+              if (flags.contains(update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation;
 
-              if (contains_bits(flags, update_hessians))
+              if (flags.contains(update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -454,11 +454,11 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!contains(fe_data.update_each, update_values) ||
+  Assert(!contains_bits(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[0] == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size()[0],
                               this->n_dofs_per_cell()));
-  Assert(!contains(fe_data.update_each, update_values) ||
+  Assert(!contains_bits(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[1] == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values.size()[1], n_q_points));
 
@@ -513,7 +513,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains(fe_data.update_each, update_values))
+      if (contains_bits(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -550,7 +550,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // the previous one; or, even if it is a translation, if we use
       // mappings other than the standard mappings that require us to
       // recompute values and derivatives because of possible sign changes
-      if (contains(fe_data.update_each, update_values) &&
+      if (contains_bits(fe_data.update_each, update_values) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -621,7 +621,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update gradients. apply the same logic as above
-      if (contains(fe_data.update_each, update_gradients) &&
+      if (contains_bits(fe_data.update_each, update_gradients) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -764,7 +764,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update hessians. apply the same logic as above
-      if (contains(fe_data.update_each, update_hessians) &&
+      if (contains_bits(fe_data.update_each, update_hessians) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1038,7 +1038,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // third derivatives are not implemented
-      if (contains(fe_data.update_each, update_3rd_derivatives) &&
+      if (contains_bits(fe_data.update_each, update_3rd_derivatives) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1143,7 +1143,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains(fe_data.update_each, update_values))
+      if (contains_bits(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1174,7 +1174,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (contains(fe_data.update_each, update_values))
+      if (contains_bits(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1260,7 +1260,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (contains(fe_data.update_each, update_gradients))
+      if (contains_bits(fe_data.update_each, update_gradients))
         {
           switch (mapping_kind)
             {
@@ -1428,7 +1428,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (contains(fe_data.update_each, update_hessians))
+      if (contains_bits(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -1727,7 +1727,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
         }
 
       // third derivatives are not implemented
-      if (contains(fe_data.update_each, update_3rd_derivatives))
+      if (contains_bits(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -1829,7 +1829,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (contains(fe_data.update_each, update_values))
+      if (contains_bits(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1860,7 +1860,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (contains(fe_data.update_each, update_values))
+      if (contains_bits(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1949,7 +1949,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (contains(fe_data.update_each, update_gradients))
+      if (contains_bits(fe_data.update_each, update_gradients))
         {
           const ArrayView<Tensor<2, spacedim>> transformed_shape_grads =
             make_array_view(fe_data.transformed_shape_grads,
@@ -2103,7 +2103,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (contains(fe_data.update_each, update_hessians))
+      if (contains_bits(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -2401,7 +2401,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
         }
 
       // third derivatives are not implemented
-      if (contains(fe_data.update_each, update_3rd_derivatives))
+      if (contains_bits(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -2425,14 +2425,14 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
         {
           case mapping_none:
             {
-              if (contains(flags, update_values))
+              if (contains_bits(flags, update_values))
                 out |= update_values;
 
-              if (contains(flags, update_gradients))
+              if (contains_bits(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads;
 
-              if (contains(flags, update_hessians))
+              if (contains_bits(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives;
@@ -2441,16 +2441,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_raviart_thomas:
           case mapping_piola:
             {
-              if (contains(flags, update_values))
+              if (contains_bits(flags, update_values))
                 out |= update_values | update_piola;
 
-              if (contains(flags, update_gradients))
+              if (contains_bits(flags, update_gradients))
                 out |= update_gradients | update_values | update_piola |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if (contains(flags, update_hessians))
+              if (contains_bits(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2462,16 +2462,16 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
 
           case mapping_contravariant:
             {
-              if (contains(flags, update_values))
+              if (contains_bits(flags, update_values))
                 out |= update_values | update_piola;
 
-              if (contains(flags, update_gradients))
+              if (contains_bits(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation |
                        update_contravariant_transformation;
 
-              if (contains(flags, update_hessians))
+              if (contains_bits(flags, update_hessians))
                 out |= update_hessians | update_piola | update_values |
                        update_gradients | update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |
@@ -2483,15 +2483,15 @@ FE_PolyTensor<dim, spacedim>::requires_update_flags(
           case mapping_nedelec:
           case mapping_covariant:
             {
-              if (contains(flags, update_values))
+              if (contains_bits(flags, update_values))
                 out |= update_values | update_covariant_transformation;
 
-              if (contains(flags, update_gradients))
+              if (contains_bits(flags, update_gradients))
                 out |= update_gradients | update_values |
                        update_jacobian_pushed_forward_grads |
                        update_covariant_transformation;
 
-              if (contains(flags, update_hessians))
+              if (contains_bits(flags, update_hessians))
                 out |= update_hessians | update_values | update_gradients |
                        update_jacobian_pushed_forward_grads |
                        update_jacobian_pushed_forward_2nd_derivatives |

--- a/source/fe/fe_poly_tensor.cc
+++ b/source/fe/fe_poly_tensor.cc
@@ -454,11 +454,11 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
 
   const unsigned int n_q_points = quadrature.size();
 
-  Assert(!(fe_data.update_each & update_values) ||
+  Assert(!contains(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[0] == this->n_dofs_per_cell(),
          ExcDimensionMismatch(fe_data.shape_values.size()[0],
                               this->n_dofs_per_cell()));
-  Assert(!(fe_data.update_each & update_values) ||
+  Assert(!contains(fe_data.update_each, update_values) ||
            fe_data.shape_values.size()[1] == n_q_points,
          ExcDimensionMismatch(fe_data.shape_values.size()[1], n_q_points));
 
@@ -513,7 +513,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -550,7 +550,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
       // the previous one; or, even if it is a translation, if we use
       // mappings other than the standard mappings that require us to
       // recompute values and derivatives because of possible sign changes
-      if (fe_data.update_each & update_values &&
+      if (contains(fe_data.update_each, update_values) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -621,7 +621,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update gradients. apply the same logic as above
-      if (fe_data.update_each & update_gradients &&
+      if (contains(fe_data.update_each, update_gradients) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -764,7 +764,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // update hessians. apply the same logic as above
-      if (fe_data.update_each & update_hessians &&
+      if (contains(fe_data.update_each, update_hessians) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1038,7 +1038,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives &&
+      if (contains(fe_data.update_each, update_3rd_derivatives) &&
           ((cell_similarity != CellSimilarity::translation) ||
            ((mapping_kind == mapping_piola) ||
             (mapping_kind == mapping_raviart_thomas) ||
@@ -1143,7 +1143,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1174,7 +1174,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1260,7 +1260,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (fe_data.update_each & update_gradients)
+      if (contains(fe_data.update_each, update_gradients))
         {
           switch (mapping_kind)
             {
@@ -1428,7 +1428,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
             }
         }
 
-      if (fe_data.update_each & update_hessians)
+      if (contains(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -1727,7 +1727,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_face_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives)
+      if (contains(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }
@@ -1829,7 +1829,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
       // fe_poly_tensor.h.
       double dof_sign = 1.0;
       // under some circumstances fe_data.dof_sign_change is not allocated
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         dof_sign = fe_data.dof_sign_change[dof_index];
 
       if (is_quad_dof)
@@ -1860,7 +1860,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
           [dof_index * this->n_components() +
            this->get_nonzero_components(dof_index).first_selected_component()];
 
-      if (fe_data.update_each & update_values)
+      if (contains(fe_data.update_each, update_values))
         {
           switch (mapping_kind)
             {
@@ -1949,7 +1949,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (fe_data.update_each & update_gradients)
+      if (contains(fe_data.update_each, update_gradients))
         {
           const ArrayView<Tensor<2, spacedim>> transformed_shape_grads =
             make_array_view(fe_data.transformed_shape_grads,
@@ -2103,7 +2103,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
             }
         }
 
-      if (fe_data.update_each & update_hessians)
+      if (contains(fe_data.update_each, update_hessians))
         {
           switch (mapping_kind)
             {
@@ -2401,7 +2401,7 @@ FE_PolyTensor<dim, spacedim>::fill_fe_subface_values(
         }
 
       // third derivatives are not implemented
-      if (fe_data.update_each & update_3rd_derivatives)
+      if (contains(fe_data.update_each, update_3rd_derivatives))
         {
           Assert(false, ExcNotImplemented())
         }

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,9 +1225,8 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (contains_bits(flags,
-                    (update_values | update_gradients | update_hessians |
-                     update_3rd_derivatives)))
+  if (flags.contains((update_values | update_gradients | update_hessians |
+                      update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1369,7 +1368,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if (contains_bits(base_flags, update_values))
+              if (base_flags.contains(update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1377,7 +1376,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if (contains_bits(base_flags, update_gradients))
+              if (base_flags.contains(update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1385,7 +1384,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if (contains_bits(base_flags, update_hessians))
+              if (base_flags.contains(update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1393,7 +1392,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if (contains_bits(base_flags, update_3rd_derivatives))
+              if (base_flags.contains(update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,8 +1225,8 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (flags & (update_values | update_gradients | update_hessians |
-               update_3rd_derivatives))
+  if (contains(flags,(update_values | update_gradients | update_hessians |
+               update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1368,7 +1368,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if (base_flags & update_values)
+              if(contains(base_flags, update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1376,7 +1376,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if (base_flags & update_gradients)
+              if(contains(base_flags, update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1384,7 +1384,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if (base_flags & update_hessians)
+              if(contains(base_flags, update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1392,7 +1392,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if (base_flags & update_3rd_derivatives)
+              if(contains(base_flags, update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,9 +1225,9 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (contains(flags,
-               (update_values | update_gradients | update_hessians |
-                update_3rd_derivatives)))
+  if (contains_bits(flags,
+                    (update_values | update_gradients | update_hessians |
+                     update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1369,7 +1369,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if (contains(base_flags, update_values))
+              if (contains_bits(base_flags, update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1377,7 +1377,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if (contains(base_flags, update_gradients))
+              if (contains_bits(base_flags, update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1385,7 +1385,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if (contains(base_flags, update_hessians))
+              if (contains_bits(base_flags, update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1393,7 +1393,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if (contains(base_flags, update_3rd_derivatives))
+              if (contains_bits(base_flags, update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_system.cc
+++ b/source/fe/fe_system.cc
@@ -1225,8 +1225,9 @@ FESystem<dim, spacedim>::compute_fill(
   // want to avoid this if this class is called in a WorkStream context where
   // we very carefully allocate objects only on the thread where they
   // will actually be used; spawning new tasks here would be counterproductive
-  if (contains(flags,(update_values | update_gradients | update_hessians |
-               update_3rd_derivatives)))
+  if (contains(flags,
+               (update_values | update_gradients | update_hessians |
+                update_3rd_derivatives)))
     for (unsigned int base_no = 0; base_no < this->n_base_elements(); ++base_no)
       {
         const FiniteElement<dim, spacedim> &base_fe = base_element(base_no);
@@ -1368,7 +1369,7 @@ FESystem<dim, spacedim>::compute_fill(
                        base_fe.n_nonzero_components(base_index),
                      ExcInternalError());
 
-              if(contains(base_flags, update_values))
+              if (contains(base_flags, update_values))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1376,7 +1377,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_values[out_index + s][q] =
                       base_data.shape_values(in_index + s, q);
 
-              if(contains(base_flags, update_gradients))
+              if (contains(base_flags, update_gradients))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1384,7 +1385,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_gradients[out_index + s][q] =
                       base_data.shape_gradients[in_index + s][q];
 
-              if(contains(base_flags, update_hessians))
+              if (contains(base_flags, update_hessians))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)
@@ -1392,7 +1393,7 @@ FESystem<dim, spacedim>::compute_fill(
                     output_data.shape_hessians[out_index + s][q] =
                       base_data.shape_hessians[in_index + s][q];
 
-              if(contains(base_flags, update_3rd_derivatives))
+              if (contains(base_flags, update_3rd_derivatives))
                 for (unsigned int s = 0;
                      s < this->n_nonzero_components(system_index);
                      ++s)

--- a/source/fe/fe_update_flags.cc
+++ b/source/fe/fe_update_flags.cc
@@ -77,55 +77,49 @@ constexpr UpdateFlags update_mapping =
   update_transformation_values | update_transformation_gradients |
   update_volume_elements;
 
-constexpr UpdateFlags UpdateFlags::update_default =
-  internal::make_update_flags(0);
-constexpr UpdateFlags UpdateFlags::update_values =
-  internal::make_update_flags(0x0001);
-constexpr UpdateFlags UpdateFlags::update_gradients =
-  internal::make_update_flags(0x0002);
-constexpr UpdateFlags UpdateFlags::update_hessians =
-  internal::make_update_flags(0x0004);
-constexpr UpdateFlags UpdateFlags::update_3rd_derivatives =
+constexpr UpdateFlags update_default   = internal::make_update_flags(0);
+constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
+constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
+constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
+constexpr UpdateFlags update_3rd_derivatives =
   internal::make_update_flags(0x0008);
-constexpr UpdateFlags UpdateFlags::update_boundary_forms =
+constexpr UpdateFlags update_boundary_forms =
   internal::make_update_flags(0x0010);
-constexpr UpdateFlags UpdateFlags::update_quadrature_points =
+constexpr UpdateFlags update_quadrature_points =
   internal::make_update_flags(0x0020);
-constexpr UpdateFlags UpdateFlags::update_JxW_values =
-  internal::make_update_flags(0x0040);
-constexpr UpdateFlags UpdateFlags::update_normal_vectors =
+constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
+constexpr UpdateFlags update_normal_vectors =
   internal::make_update_flags(0x0080);
-constexpr UpdateFlags UpdateFlags::update_jacobians =
-  internal::make_update_flags(0x0100);
-constexpr UpdateFlags UpdateFlags::update_jacobian_grads =
+constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
+constexpr UpdateFlags update_jacobian_grads =
   internal::make_update_flags(0x0200);
-constexpr UpdateFlags UpdateFlags::update_inverse_jacobians =
+constexpr UpdateFlags update_inverse_jacobians =
   internal::make_update_flags(0x0400);
-constexpr UpdateFlags UpdateFlags::update_covariant_transformation =
+constexpr UpdateFlags update_covariant_transformation =
   internal::make_update_flags(0x0800);
-constexpr UpdateFlags UpdateFlags::update_contravariant_transformation =
+constexpr UpdateFlags update_contravariant_transformation =
   internal::make_update_flags(0x1000);
-constexpr UpdateFlags UpdateFlags::update_transformation_values =
+constexpr UpdateFlags update_transformation_values =
   internal::make_update_flags(0x2000);
-constexpr UpdateFlags UpdateFlags::update_transformation_gradients =
+constexpr UpdateFlags update_transformation_gradients =
   internal::make_update_flags(0x4000);
-constexpr UpdateFlags UpdateFlags::update_volume_elements =
+constexpr UpdateFlags update_volume_elements =
   internal::make_update_flags(0x10000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads =
+constexpr UpdateFlags update_jacobian_pushed_forward_grads =
   internal::make_update_flags(0x100000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives =
+constexpr UpdateFlags update_jacobian_2nd_derivatives =
   internal::make_update_flags(0x200000);
 constexpr UpdateFlags
   UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
     internal::make_update_flags(0x400000);
-constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
+constexpr UpdateFlags update_jacobian_3rd_derivatives =
   internal::make_update_flags(0x800000);
 constexpr UpdateFlags
   UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives =
     internal::make_update_flags(0x1000000);
-constexpr UpdateFlags UpdateFlags::update_piola =
+constexpr UpdateFlags update_piola =
   update_volume_elements | update_contravariant_transformation;
-constexpr UpdateFlags UpdateFlags::update_mapping =
+constexpr UpdateFlags update_mapping =
   update_quadrature_points | update_JxW_values | update_jacobians |
   update_jacobian_grads | update_jacobian_pushed_forward_grads |
   update_jacobian_2nd_derivatives |

--- a/source/fe/fe_update_flags.cc
+++ b/source/fe/fe_update_flags.cc
@@ -61,7 +61,7 @@ constexpr UpdateFlags
     internal::make_update_flags(0x400000);
 constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
   internal::make_update_flags(0x800000);
-  constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
+constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
   internal::make_update_flags(0x1000000);
 constexpr UpdateFlags update_piola =
   update_volume_elements | update_contravariant_transformation;
@@ -77,7 +77,7 @@ constexpr UpdateFlags update_mapping =
   update_transformation_values | update_transformation_gradients |
   update_volume_elements;
 
-  constexpr UpdateFlags UpdateFlags::update_default =
+constexpr UpdateFlags UpdateFlags::update_default =
   internal::make_update_flags(0);
 constexpr UpdateFlags UpdateFlags::update_values =
   internal::make_update_flags(0x0001);

--- a/source/fe/fe_update_flags.cc
+++ b/source/fe/fe_update_flags.cc
@@ -61,65 +61,12 @@ constexpr UpdateFlags
     internal::make_update_flags(0x400000);
 constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
   internal::make_update_flags(0x800000);
-constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
-  internal::make_update_flags(0x1000000);
-constexpr UpdateFlags update_piola =
-  update_volume_elements | update_contravariant_transformation;
-constexpr UpdateFlags update_mapping =
-  update_quadrature_points | update_JxW_values | update_jacobians |
-  update_jacobian_grads | update_jacobian_pushed_forward_grads |
-  update_jacobian_2nd_derivatives |
-  update_jacobian_pushed_forward_2nd_derivatives |
-  update_jacobian_3rd_derivatives |
-  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
-  update_boundary_forms | update_normal_vectors |
-  update_covariant_transformation | update_contravariant_transformation |
-  update_transformation_values | update_transformation_gradients |
-  update_volume_elements;
-
-constexpr UpdateFlags update_default   = internal::make_update_flags(0);
-constexpr UpdateFlags update_values    = internal::make_update_flags(0x0001);
-constexpr UpdateFlags update_gradients = internal::make_update_flags(0x0002);
-constexpr UpdateFlags update_hessians  = internal::make_update_flags(0x0004);
-constexpr UpdateFlags update_3rd_derivatives =
-  internal::make_update_flags(0x0008);
-constexpr UpdateFlags update_boundary_forms =
-  internal::make_update_flags(0x0010);
-constexpr UpdateFlags update_quadrature_points =
-  internal::make_update_flags(0x0020);
-constexpr UpdateFlags update_JxW_values = internal::make_update_flags(0x0040);
-constexpr UpdateFlags update_normal_vectors =
-  internal::make_update_flags(0x0080);
-constexpr UpdateFlags update_jacobians = internal::make_update_flags(0x0100);
-constexpr UpdateFlags update_jacobian_grads =
-  internal::make_update_flags(0x0200);
-constexpr UpdateFlags update_inverse_jacobians =
-  internal::make_update_flags(0x0400);
-constexpr UpdateFlags update_covariant_transformation =
-  internal::make_update_flags(0x0800);
-constexpr UpdateFlags update_contravariant_transformation =
-  internal::make_update_flags(0x1000);
-constexpr UpdateFlags update_transformation_values =
-  internal::make_update_flags(0x2000);
-constexpr UpdateFlags update_transformation_gradients =
-  internal::make_update_flags(0x4000);
-constexpr UpdateFlags update_volume_elements =
-  internal::make_update_flags(0x10000);
-constexpr UpdateFlags update_jacobian_pushed_forward_grads =
-  internal::make_update_flags(0x100000);
-constexpr UpdateFlags update_jacobian_2nd_derivatives =
-  internal::make_update_flags(0x200000);
-constexpr UpdateFlags
-  UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
-    internal::make_update_flags(0x400000);
-constexpr UpdateFlags update_jacobian_3rd_derivatives =
-  internal::make_update_flags(0x800000);
 constexpr UpdateFlags
   UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives =
     internal::make_update_flags(0x1000000);
-constexpr UpdateFlags update_piola =
+constexpr UpdateFlags UpdateFlags::update_piola =
   update_volume_elements | update_contravariant_transformation;
-constexpr UpdateFlags update_mapping =
+constexpr UpdateFlags UpdateFlags::update_mapping =
   update_quadrature_points | update_JxW_values | update_jacobians |
   update_jacobian_grads | update_jacobian_pushed_forward_grads |
   update_jacobian_2nd_derivatives |

--- a/source/fe/fe_update_flags.cc
+++ b/source/fe/fe_update_flags.cc
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2000 - 2021 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+#include <deal.II/fe/fe_update_flags.h>
+
+DEAL_II_NAMESPACE_OPEN
+
+constexpr UpdateFlags UpdateFlags::update_default =
+  internal::make_update_flags(0);
+constexpr UpdateFlags UpdateFlags::update_values =
+  internal::make_update_flags(0x0001);
+constexpr UpdateFlags UpdateFlags::update_gradients =
+  internal::make_update_flags(0x0002);
+constexpr UpdateFlags UpdateFlags::update_hessians =
+  internal::make_update_flags(0x0004);
+constexpr UpdateFlags UpdateFlags::update_3rd_derivatives =
+  internal::make_update_flags(0x0008);
+constexpr UpdateFlags UpdateFlags::update_boundary_forms =
+  internal::make_update_flags(0x0010);
+constexpr UpdateFlags UpdateFlags::update_quadrature_points =
+  internal::make_update_flags(0x0020);
+constexpr UpdateFlags UpdateFlags::update_JxW_values =
+  internal::make_update_flags(0x0040);
+constexpr UpdateFlags UpdateFlags::update_normal_vectors =
+  internal::make_update_flags(0x0080);
+constexpr UpdateFlags UpdateFlags::update_jacobians =
+  internal::make_update_flags(0x0100);
+constexpr UpdateFlags UpdateFlags::update_jacobian_grads =
+  internal::make_update_flags(0x0200);
+constexpr UpdateFlags UpdateFlags::update_inverse_jacobians =
+  internal::make_update_flags(0x0400);
+constexpr UpdateFlags UpdateFlags::update_covariant_transformation =
+  internal::make_update_flags(0x0800);
+constexpr UpdateFlags UpdateFlags::update_contravariant_transformation =
+  internal::make_update_flags(0x1000);
+constexpr UpdateFlags UpdateFlags::update_transformation_values =
+  internal::make_update_flags(0x2000);
+constexpr UpdateFlags UpdateFlags::update_transformation_gradients =
+  internal::make_update_flags(0x4000);
+constexpr UpdateFlags UpdateFlags::update_volume_elements =
+  internal::make_update_flags(0x10000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads =
+  internal::make_update_flags(0x100000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives =
+  internal::make_update_flags(0x200000);
+constexpr UpdateFlags
+  UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
+    internal::make_update_flags(0x400000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
+  internal::make_update_flags(0x800000);
+  constexpr UpdateFlags update_jacobian_pushed_forward_3rd_derivatives =
+  internal::make_update_flags(0x1000000);
+constexpr UpdateFlags update_piola =
+  update_volume_elements | update_contravariant_transformation;
+constexpr UpdateFlags update_mapping =
+  update_quadrature_points | update_JxW_values | update_jacobians |
+  update_jacobian_grads | update_jacobian_pushed_forward_grads |
+  update_jacobian_2nd_derivatives |
+  update_jacobian_pushed_forward_2nd_derivatives |
+  update_jacobian_3rd_derivatives |
+  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+  update_boundary_forms | update_normal_vectors |
+  update_covariant_transformation | update_contravariant_transformation |
+  update_transformation_values | update_transformation_gradients |
+  update_volume_elements;
+
+  constexpr UpdateFlags UpdateFlags::update_default =
+  internal::make_update_flags(0);
+constexpr UpdateFlags UpdateFlags::update_values =
+  internal::make_update_flags(0x0001);
+constexpr UpdateFlags UpdateFlags::update_gradients =
+  internal::make_update_flags(0x0002);
+constexpr UpdateFlags UpdateFlags::update_hessians =
+  internal::make_update_flags(0x0004);
+constexpr UpdateFlags UpdateFlags::update_3rd_derivatives =
+  internal::make_update_flags(0x0008);
+constexpr UpdateFlags UpdateFlags::update_boundary_forms =
+  internal::make_update_flags(0x0010);
+constexpr UpdateFlags UpdateFlags::update_quadrature_points =
+  internal::make_update_flags(0x0020);
+constexpr UpdateFlags UpdateFlags::update_JxW_values =
+  internal::make_update_flags(0x0040);
+constexpr UpdateFlags UpdateFlags::update_normal_vectors =
+  internal::make_update_flags(0x0080);
+constexpr UpdateFlags UpdateFlags::update_jacobians =
+  internal::make_update_flags(0x0100);
+constexpr UpdateFlags UpdateFlags::update_jacobian_grads =
+  internal::make_update_flags(0x0200);
+constexpr UpdateFlags UpdateFlags::update_inverse_jacobians =
+  internal::make_update_flags(0x0400);
+constexpr UpdateFlags UpdateFlags::update_covariant_transformation =
+  internal::make_update_flags(0x0800);
+constexpr UpdateFlags UpdateFlags::update_contravariant_transformation =
+  internal::make_update_flags(0x1000);
+constexpr UpdateFlags UpdateFlags::update_transformation_values =
+  internal::make_update_flags(0x2000);
+constexpr UpdateFlags UpdateFlags::update_transformation_gradients =
+  internal::make_update_flags(0x4000);
+constexpr UpdateFlags UpdateFlags::update_volume_elements =
+  internal::make_update_flags(0x10000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_pushed_forward_grads =
+  internal::make_update_flags(0x100000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_2nd_derivatives =
+  internal::make_update_flags(0x200000);
+constexpr UpdateFlags
+  UpdateFlags::update_jacobian_pushed_forward_2nd_derivatives =
+    internal::make_update_flags(0x400000);
+constexpr UpdateFlags UpdateFlags::update_jacobian_3rd_derivatives =
+  internal::make_update_flags(0x800000);
+constexpr UpdateFlags
+  UpdateFlags::update_jacobian_pushed_forward_3rd_derivatives =
+    internal::make_update_flags(0x1000000);
+constexpr UpdateFlags UpdateFlags::update_piola =
+  update_volume_elements | update_contravariant_transformation;
+constexpr UpdateFlags UpdateFlags::update_mapping =
+  update_quadrature_points | update_JxW_values | update_jacobians |
+  update_jacobian_grads | update_jacobian_pushed_forward_grads |
+  update_jacobian_2nd_derivatives |
+  update_jacobian_pushed_forward_2nd_derivatives |
+  update_jacobian_3rd_derivatives |
+  update_jacobian_pushed_forward_3rd_derivatives | update_inverse_jacobians |
+  update_boundary_forms | update_normal_vectors |
+  update_covariant_transformation | update_contravariant_transformation |
+  update_transformation_values | update_transformation_gradients |
+  update_volume_elements;
+
+DEAL_II_NAMESPACE_CLOSE

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1549,7 +1549,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1580,7 +1580,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1604,7 +1604,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1634,7 +1634,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1658,7 +1658,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1688,7 +1688,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1712,7 +1712,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1742,7 +1742,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1767,7 +1767,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1798,7 +1798,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1822,7 +1822,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1852,7 +1852,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1876,7 +1876,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1906,7 +1906,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1931,7 +1931,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1962,7 +1962,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1986,7 +1986,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2017,7 +2017,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2041,7 +2041,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2071,7 +2071,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2095,7 +2095,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2125,7 +2125,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2149,7 +2149,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2184,7 +2184,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_hessians),
+    Assert(fe_values->update_flags.contains(update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2212,7 +2212,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2243,7 +2243,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
+    Assert(fe_values->update_flags.contains(update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2267,7 +2267,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2297,7 +2297,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2321,7 +2321,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2353,7 +2353,7 @@ namespace FEValuesViews
       std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2377,7 +2377,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2407,7 +2407,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains_bits(fe_values->update_flags, update_values),
+    Assert(fe_values->update_flags.contains(update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2431,7 +2431,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2462,7 +2462,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2486,7 +2486,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2517,7 +2517,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains_bits(fe_values->update_flags, update_gradients),
+    Assert(fe_values->update_flags.contains(update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2705,55 +2705,55 @@ namespace internal
       const unsigned int n_quadrature_points,
       const UpdateFlags  flags)
     {
-      if (contains_bits(flags, update_quadrature_points))
+      if (flags.contains(update_quadrature_points))
         this->quadrature_points.resize(
           n_quadrature_points,
           Point<spacedim>(numbers::signaling_nan<Tensor<1, spacedim>>()));
 
-      if (contains_bits(flags, update_JxW_values))
+      if (flags.contains(update_JxW_values))
         this->JxW_values.resize(n_quadrature_points,
                                 numbers::signaling_nan<double>());
 
-      if (contains_bits(flags, update_jacobians))
+      if (flags.contains(update_jacobians))
         this->jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, dim, spacedim>>());
 
-      if (contains_bits(flags, update_jacobian_grads))
+      if (flags.contains(update_jacobian_grads))
         this->jacobian_grads.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<2, dim, spacedim>>());
 
-      if (contains_bits(flags, update_jacobian_pushed_forward_grads))
+      if (flags.contains(update_jacobian_pushed_forward_grads))
         this->jacobian_pushed_forward_grads.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<3, spacedim>>());
 
-      if (contains_bits(flags, update_jacobian_2nd_derivatives))
+      if (flags.contains(update_jacobian_2nd_derivatives))
         this->jacobian_2nd_derivatives.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<3, dim, spacedim>>());
 
-      if (contains_bits(flags, update_jacobian_pushed_forward_2nd_derivatives))
+      if (flags.contains(update_jacobian_pushed_forward_2nd_derivatives))
         this->jacobian_pushed_forward_2nd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<4, spacedim>>());
 
-      if (contains_bits(flags, update_jacobian_3rd_derivatives))
+      if (flags.contains(update_jacobian_3rd_derivatives))
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
-      if (contains_bits(flags, update_jacobian_pushed_forward_3rd_derivatives))
+      if (flags.contains(update_jacobian_pushed_forward_3rd_derivatives))
         this->jacobian_pushed_forward_3rd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<5, spacedim>>());
 
-      if (contains_bits(flags, update_inverse_jacobians))
+      if (flags.contains(update_inverse_jacobians))
         this->inverse_jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, spacedim, dim>>());
 
-      if (contains_bits(flags, update_boundary_forms))
+      if (flags.contains(update_boundary_forms))
         this->boundary_forms.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
 
-      if (contains_bits(flags, update_normal_vectors))
+      if (flags.contains(update_normal_vectors))
         this->normal_vectors.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
     }
@@ -2806,14 +2806,14 @@ namespace internal
 
       // with the number of rows now known, initialize those fields
       // that we will need to their correct size
-      if (contains_bits(flags, update_values))
+      if (flags.contains(update_values))
         {
           this->shape_values.reinit(n_nonzero_shape_components,
                                     n_quadrature_points);
           this->shape_values.fill(numbers::signaling_nan<double>());
         }
 
-      if (contains_bits(flags, update_gradients))
+      if (flags.contains(update_gradients))
         {
           this->shape_gradients.reinit(n_nonzero_shape_components,
                                        n_quadrature_points);
@@ -2821,7 +2821,7 @@ namespace internal
             numbers::signaling_nan<Tensor<1, spacedim>>());
         }
 
-      if (contains_bits(flags, update_hessians))
+      if (flags.contains(update_hessians))
         {
           this->shape_hessians.reinit(n_nonzero_shape_components,
                                       n_quadrature_points);
@@ -2829,7 +2829,7 @@ namespace internal
             numbers::signaling_nan<Tensor<2, spacedim>>());
         }
 
-      if (contains_bits(flags, update_3rd_derivatives))
+      if (flags.contains(update_3rd_derivatives))
         {
           this->shape_3rd_derivatives.reinit(n_nonzero_shape_components,
                                              n_quadrature_points);
@@ -3358,7 +3358,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> &values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3383,7 +3383,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> & values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3408,7 +3408,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
 
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3438,7 +3438,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
@@ -3466,7 +3466,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_values),
+  Assert(this->update_flags.contains(update_values),
          ExcAccessToUninitializedField("update_values"));
 
   // Size of indices must be a multiple of dofs_per_cell such that an integer
@@ -3498,7 +3498,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3524,7 +3524,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3549,7 +3549,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
     &gradients) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3582,7 +3582,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains_bits(this->update_flags, update_gradients),
+  Assert(this->update_flags.contains(update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3610,7 +3610,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3635,7 +3635,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3661,7 +3661,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3691,7 +3691,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3719,7 +3719,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> &laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3744,7 +3744,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> & laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3768,7 +3768,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 {
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3798,7 +3798,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3828,7 +3828,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   using Number = typename InputVector::value_type;
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains_bits(this->update_flags, update_hessians),
+  Assert(this->update_flags.contains(update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3856,7 +3856,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3882,7 +3882,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
     &third_derivatives) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3909,7 +3909,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3939,7 +3939,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
+  Assert(this->update_flags.contains(update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3972,7 +3972,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEValuesBase<dim, spacedim>::get_normal_vectors() const
 {
-  Assert(contains_bits(this->update_flags, update_normal_vectors),
+  Assert(this->update_flags.contains(update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
 
@@ -4225,7 +4225,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   // You can compute normal vectors to the cells only in the
   // codimension one case.
   if (dim != spacedim - 1)
-    Assert(contains_bits(update_flags, update_normal_vectors) == false,
+    Assert(update_flags.contains(update_normal_vectors) == false,
            ExcMessage("You can only pass the 'update_normal_vectors' "
                       "flag to FEFaceValues or FESubfaceValues objects, "
                       "but not to an FEValues object unless the "
@@ -4235,7 +4235,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4255,7 +4255,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     mapping_get_data = Threads::new_task(
       [&]() { return this->mapping->get_data(flags, quadrature); });
 
@@ -4263,7 +4263,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4339,7 +4339,7 @@ FEValues<dim, spacedim>::do_reinit()
   // specific to the mapping. also let it inspect the
   // cell similarity flag and, if necessary, update
   // it
-  if (contains_bits(this->update_flags, update_mapping))
+  if (this->update_flags.contains(update_mapping))
     {
       this->cell_similarity =
         this->get_mapping().fill_fe_values(this->present_cell,
@@ -4419,7 +4419,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEFaceValuesBase<dim, spacedim>::get_boundary_forms() const
 {
-  Assert(contains_bits(this->update_flags, update_boundary_forms),
+  Assert(this->update_flags.contains(update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
   return this->mapping_output.boundary_forms;
@@ -4515,7 +4515,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4550,7 +4550,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     mapping_get_data = Threads::new_task(mapping_get_face_data,
                                          *this->mapping,
                                          flags,
@@ -4560,7 +4560,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4651,7 +4651,7 @@ FEFaceValues<dim, spacedim>::do_reinit(const unsigned int face_no)
     this->present_cell;
   this->present_face_index = cell->face_index(face_no);
 
-  if (contains_bits(this->update_flags, update_mapping))
+  if (this->update_flags.contains(update_mapping))
     {
       this->get_mapping().fill_fe_face_values(this->present_cell,
                                               face_no,
@@ -4753,7 +4753,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4774,7 +4774,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     mapping_get_data =
       Threads::new_task(&Mapping<dim, spacedim>::get_subface_data,
                         *this->mapping,
@@ -4785,7 +4785,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains_bits(flags, update_mapping))
+  if (flags.contains(update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4975,7 +4975,7 @@ FESubfaceValues<dim, spacedim>::do_reinit(const unsigned int face_no,
     }
 
   // now ask the mapping and the finite element to do the actual work
-  if (contains_bits(this->update_flags, update_mapping))
+  if (this->update_flags.contains(update_mapping))
     {
       this->get_mapping().fill_fe_subface_values(this->present_cell,
                                                  face_no,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1549,7 +1549,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1580,7 +1580,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1604,7 +1604,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1634,7 +1634,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1658,7 +1658,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1688,7 +1688,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1712,7 +1712,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1742,7 +1742,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1767,7 +1767,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1798,7 +1798,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1822,7 +1822,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1852,7 +1852,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1876,7 +1876,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1906,7 +1906,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1931,7 +1931,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1962,7 +1962,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1986,7 +1986,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2017,7 +2017,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2041,7 +2041,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2071,7 +2071,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2095,7 +2095,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2125,7 +2125,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2149,7 +2149,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2184,7 +2184,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(contains(fe_values->update_flags, update_hessians),
+    Assert(contains_bits(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2212,7 +2212,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2243,7 +2243,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
+    Assert(contains_bits(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2267,7 +2267,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2297,7 +2297,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2321,7 +2321,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2353,7 +2353,7 @@ namespace FEValuesViews
       std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2377,7 +2377,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2407,7 +2407,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(contains(fe_values->update_flags, update_values),
+    Assert(contains_bits(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2431,7 +2431,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2462,7 +2462,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2486,7 +2486,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2517,7 +2517,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(contains(fe_values->update_flags, update_gradients),
+    Assert(contains_bits(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2705,55 +2705,55 @@ namespace internal
       const unsigned int n_quadrature_points,
       const UpdateFlags  flags)
     {
-      if (contains(flags, update_quadrature_points))
+      if (contains_bits(flags, update_quadrature_points))
         this->quadrature_points.resize(
           n_quadrature_points,
           Point<spacedim>(numbers::signaling_nan<Tensor<1, spacedim>>()));
 
-      if (contains(flags, update_JxW_values))
+      if (contains_bits(flags, update_JxW_values))
         this->JxW_values.resize(n_quadrature_points,
                                 numbers::signaling_nan<double>());
 
-      if (contains(flags, update_jacobians))
+      if (contains_bits(flags, update_jacobians))
         this->jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, dim, spacedim>>());
 
-      if (contains(flags, update_jacobian_grads))
+      if (contains_bits(flags, update_jacobian_grads))
         this->jacobian_grads.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<2, dim, spacedim>>());
 
-      if (contains(flags, update_jacobian_pushed_forward_grads))
+      if (contains_bits(flags, update_jacobian_pushed_forward_grads))
         this->jacobian_pushed_forward_grads.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<3, spacedim>>());
 
-      if (contains(flags, update_jacobian_2nd_derivatives))
+      if (contains_bits(flags, update_jacobian_2nd_derivatives))
         this->jacobian_2nd_derivatives.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<3, dim, spacedim>>());
 
-      if (contains(flags, update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains_bits(flags, update_jacobian_pushed_forward_2nd_derivatives))
         this->jacobian_pushed_forward_2nd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<4, spacedim>>());
 
-      if (contains(flags, update_jacobian_3rd_derivatives))
+      if (contains_bits(flags, update_jacobian_3rd_derivatives))
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
-      if (contains(flags, update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains_bits(flags, update_jacobian_pushed_forward_3rd_derivatives))
         this->jacobian_pushed_forward_3rd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<5, spacedim>>());
 
-      if (contains(flags, update_inverse_jacobians))
+      if (contains_bits(flags, update_inverse_jacobians))
         this->inverse_jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, spacedim, dim>>());
 
-      if (contains(flags, update_boundary_forms))
+      if (contains_bits(flags, update_boundary_forms))
         this->boundary_forms.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
 
-      if (contains(flags, update_normal_vectors))
+      if (contains_bits(flags, update_normal_vectors))
         this->normal_vectors.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
     }
@@ -2806,14 +2806,14 @@ namespace internal
 
       // with the number of rows now known, initialize those fields
       // that we will need to their correct size
-      if (contains(flags, update_values))
+      if (contains_bits(flags, update_values))
         {
           this->shape_values.reinit(n_nonzero_shape_components,
                                     n_quadrature_points);
           this->shape_values.fill(numbers::signaling_nan<double>());
         }
 
-      if (contains(flags, update_gradients))
+      if (contains_bits(flags, update_gradients))
         {
           this->shape_gradients.reinit(n_nonzero_shape_components,
                                        n_quadrature_points);
@@ -2821,7 +2821,7 @@ namespace internal
             numbers::signaling_nan<Tensor<1, spacedim>>());
         }
 
-      if (contains(flags, update_hessians))
+      if (contains_bits(flags, update_hessians))
         {
           this->shape_hessians.reinit(n_nonzero_shape_components,
                                       n_quadrature_points);
@@ -2829,7 +2829,7 @@ namespace internal
             numbers::signaling_nan<Tensor<2, spacedim>>());
         }
 
-      if (contains(flags, update_3rd_derivatives))
+      if (contains_bits(flags, update_3rd_derivatives))
         {
           this->shape_3rd_derivatives.reinit(n_nonzero_shape_components,
                                              n_quadrature_points);
@@ -3358,7 +3358,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> &values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3383,7 +3383,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> & values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3408,7 +3408,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
 
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3438,7 +3438,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
@@ -3466,7 +3466,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_values),
+  Assert(contains_bits(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   // Size of indices must be a multiple of dofs_per_cell such that an integer
@@ -3498,7 +3498,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3524,7 +3524,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3549,7 +3549,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
     &gradients) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3582,7 +3582,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains(this->update_flags, update_gradients),
+  Assert(contains_bits(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3610,7 +3610,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3635,7 +3635,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3661,7 +3661,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3691,7 +3691,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3719,7 +3719,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> &laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3744,7 +3744,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> & laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3768,7 +3768,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 {
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3798,7 +3798,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3828,7 +3828,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   using Number = typename InputVector::value_type;
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(contains(this->update_flags, update_hessians),
+  Assert(contains_bits(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3856,7 +3856,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3882,7 +3882,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
     &third_derivatives) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3909,7 +3909,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3939,7 +3939,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(contains(this->update_flags, update_3rd_derivatives),
+  Assert(contains_bits(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3972,7 +3972,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEValuesBase<dim, spacedim>::get_normal_vectors() const
 {
-  Assert(contains(this->update_flags, update_normal_vectors),
+  Assert(contains_bits(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
 
@@ -4225,7 +4225,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   // You can compute normal vectors to the cells only in the
   // codimension one case.
   if (dim != spacedim - 1)
-    Assert(contains(update_flags, update_normal_vectors) == false,
+    Assert(contains_bits(update_flags, update_normal_vectors) == false,
            ExcMessage("You can only pass the 'update_normal_vectors' "
                       "flag to FEFaceValues or FESubfaceValues objects, "
                       "but not to an FEValues object unless the "
@@ -4235,7 +4235,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4255,7 +4255,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     mapping_get_data = Threads::new_task(
       [&]() { return this->mapping->get_data(flags, quadrature); });
 
@@ -4263,7 +4263,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4339,7 +4339,7 @@ FEValues<dim, spacedim>::do_reinit()
   // specific to the mapping. also let it inspect the
   // cell similarity flag and, if necessary, update
   // it
-  if (contains(this->update_flags, update_mapping))
+  if (contains_bits(this->update_flags, update_mapping))
     {
       this->cell_similarity =
         this->get_mapping().fill_fe_values(this->present_cell,
@@ -4419,7 +4419,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEFaceValuesBase<dim, spacedim>::get_boundary_forms() const
 {
-  Assert(contains(this->update_flags, update_boundary_forms),
+  Assert(contains_bits(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
   return this->mapping_output.boundary_forms;
@@ -4515,7 +4515,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4550,7 +4550,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     mapping_get_data = Threads::new_task(mapping_get_face_data,
                                          *this->mapping,
                                          flags,
@@ -4560,7 +4560,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4651,7 +4651,7 @@ FEFaceValues<dim, spacedim>::do_reinit(const unsigned int face_no)
     this->present_cell;
   this->present_face_index = cell->face_index(face_no);
 
-  if (contains(this->update_flags, update_mapping))
+  if (contains_bits(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_face_values(this->present_cell,
                                               face_no,
@@ -4753,7 +4753,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4774,7 +4774,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     mapping_get_data =
       Threads::new_task(&Mapping<dim, spacedim>::get_subface_data,
                         *this->mapping,
@@ -4785,7 +4785,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if (contains(flags, update_mapping))
+  if (contains_bits(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4975,7 +4975,7 @@ FESubfaceValues<dim, spacedim>::do_reinit(const unsigned int face_no,
     }
 
   // now ask the mapping and the finite element to do the actual work
-  if (contains(this->update_flags, update_mapping))
+  if (contains_bits(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_subface_values(this->present_cell,
                                                  face_no,

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -2705,55 +2705,55 @@ namespace internal
       const unsigned int n_quadrature_points,
       const UpdateFlags  flags)
     {
-      if ((flags & update_quadrature_points) != 0u)
+      if (contains(flags, update_quadrature_points))
         this->quadrature_points.resize(
           n_quadrature_points,
           Point<spacedim>(numbers::signaling_nan<Tensor<1, spacedim>>()));
 
-      if ((flags & update_JxW_values) != 0u)
+      if (contains(flags, update_JxW_values))
         this->JxW_values.resize(n_quadrature_points,
                                 numbers::signaling_nan<double>());
 
-      if ((flags & update_jacobians) != 0u)
+      if (contains(flags, update_jacobians))
         this->jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, dim, spacedim>>());
 
-      if ((flags & update_jacobian_grads) != 0u)
+      if (contains(flags, update_jacobian_grads))
         this->jacobian_grads.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<2, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_grads) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_grads))
         this->jacobian_pushed_forward_grads.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<3, spacedim>>());
 
-      if ((flags & update_jacobian_2nd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_2nd_derivatives))
         this->jacobian_2nd_derivatives.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<3, dim, spacedim>>());
 
-      if ((flags & update_jacobian_pushed_forward_2nd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_2nd_derivatives))
         this->jacobian_pushed_forward_2nd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<4, spacedim>>());
 
-      if ((flags & update_jacobian_3rd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_3rd_derivatives))
         this->jacobian_3rd_derivatives.resize(n_quadrature_points);
 
-      if ((flags & update_jacobian_pushed_forward_3rd_derivatives) != 0u)
+      if (contains(flags, update_jacobian_pushed_forward_3rd_derivatives))
         this->jacobian_pushed_forward_3rd_derivatives.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<5, spacedim>>());
 
-      if ((flags & update_inverse_jacobians) != 0u)
+      if (contains(flags, update_inverse_jacobians))
         this->inverse_jacobians.resize(
           n_quadrature_points,
           numbers::signaling_nan<DerivativeForm<1, spacedim, dim>>());
 
-      if ((flags & update_boundary_forms) != 0u)
+      if (contains(flags, update_boundary_forms))
         this->boundary_forms.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
 
-      if ((flags & update_normal_vectors) != 0u)
+      if (contains(flags, update_normal_vectors))
         this->normal_vectors.resize(
           n_quadrature_points, numbers::signaling_nan<Tensor<1, spacedim>>());
     }
@@ -2806,14 +2806,14 @@ namespace internal
 
       // with the number of rows now known, initialize those fields
       // that we will need to their correct size
-      if ((flags & update_values) != 0u)
+      if (contains(flags, update_values))
         {
           this->shape_values.reinit(n_nonzero_shape_components,
                                     n_quadrature_points);
           this->shape_values.fill(numbers::signaling_nan<double>());
         }
 
-      if ((flags & update_gradients) != 0u)
+      if (contains(flags, update_gradients))
         {
           this->shape_gradients.reinit(n_nonzero_shape_components,
                                        n_quadrature_points);
@@ -2821,7 +2821,7 @@ namespace internal
             numbers::signaling_nan<Tensor<1, spacedim>>());
         }
 
-      if ((flags & update_hessians) != 0u)
+      if (contains(flags, update_hessians))
         {
           this->shape_hessians.reinit(n_nonzero_shape_components,
                                       n_quadrature_points);
@@ -2829,7 +2829,7 @@ namespace internal
             numbers::signaling_nan<Tensor<2, spacedim>>());
         }
 
-      if ((flags & update_3rd_derivatives) != 0u)
+      if (contains(flags, update_3rd_derivatives))
         {
           this->shape_3rd_derivatives.reinit(n_nonzero_shape_components,
                                              n_quadrature_points);
@@ -4235,7 +4235,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4255,7 +4255,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data = Threads::new_task(
       [&]() { return this->mapping->get_data(flags, quadrature); });
 
@@ -4263,7 +4263,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4515,7 +4515,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4550,7 +4550,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data = Threads::new_task(mapping_get_face_data,
                                          *this->mapping,
                                          flags,
@@ -4560,7 +4560,7 @@ FEFaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =
@@ -4753,7 +4753,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   const UpdateFlags flags = this->compute_update_flags(update_flags);
 
   // initialize the base classes
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_output.initialize(this->max_n_quadrature_points, flags);
   this->finite_element_output.initialize(this->max_n_quadrature_points,
                                          *this->fe,
@@ -4774,7 +4774,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   Threads::Task<
     std::unique_ptr<typename Mapping<dim, spacedim>::InternalDataBase>>
     mapping_get_data;
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     mapping_get_data =
       Threads::new_task(&Mapping<dim, spacedim>::get_subface_data,
                         *this->mapping,
@@ -4785,7 +4785,7 @@ FESubfaceValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
 
   // then collect answers from the two task above
   this->fe_data = std::move(fe_get_data.return_value());
-  if ((flags & update_mapping) != 0u)
+  if (contains(flags, update_mapping))
     this->mapping_data = std::move(mapping_get_data.return_value());
   else
     this->mapping_data =

--- a/source/fe/fe_values.cc
+++ b/source/fe/fe_values.cc
@@ -1549,7 +1549,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1580,7 +1580,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1604,7 +1604,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1634,7 +1634,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1658,7 +1658,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1688,7 +1688,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1712,7 +1712,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1742,7 +1742,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1767,7 +1767,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1798,7 +1798,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1822,7 +1822,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1852,7 +1852,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1876,7 +1876,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1906,7 +1906,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1931,7 +1931,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1962,7 +1962,7 @@ namespace FEValuesViews
       solution_symmetric_gradient_type<typename InputVector::value_type>>
       &symmetric_gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -1986,7 +1986,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2017,7 +2017,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2041,7 +2041,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2071,7 +2071,7 @@ namespace FEValuesViews
     std::vector<solution_curl_type<typename InputVector::value_type>> &curls)
     const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2095,7 +2095,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2125,7 +2125,7 @@ namespace FEValuesViews
     std::vector<solution_hessian_type<typename InputVector::value_type>>
       &hessians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2149,7 +2149,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2184,7 +2184,7 @@ namespace FEValuesViews
     std::vector<solution_laplacian_type<typename InputVector::value_type>>
       &laplacians) const
   {
-    Assert(fe_values->update_flags & update_hessians,
+    Assert(contains(fe_values->update_flags, update_hessians),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_hessians")));
     Assert(laplacians.size() == fe_values->n_quadrature_points,
@@ -2212,7 +2212,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2243,7 +2243,7 @@ namespace FEValuesViews
       solution_third_derivative_type<typename InputVector::value_type>>
       &third_derivatives) const
   {
-    Assert(fe_values->update_flags & update_3rd_derivatives,
+    Assert(contains(fe_values->update_flags, update_3rd_derivatives),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_3rd_derivatives")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2267,7 +2267,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2297,7 +2297,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2321,7 +2321,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2353,7 +2353,7 @@ namespace FEValuesViews
       std::vector<solution_divergence_type<typename InputVector::value_type>>
         &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2377,7 +2377,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2407,7 +2407,7 @@ namespace FEValuesViews
     std::vector<solution_value_type<typename InputVector::value_type>> &values)
     const
   {
-    Assert(fe_values->update_flags & update_values,
+    Assert(contains(fe_values->update_flags, update_values),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_values")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2431,7 +2431,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2462,7 +2462,7 @@ namespace FEValuesViews
     std::vector<solution_divergence_type<typename InputVector::value_type>>
       &divergences) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2486,7 +2486,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -2517,7 +2517,7 @@ namespace FEValuesViews
     std::vector<solution_gradient_type<typename InputVector::value_type>>
       &gradients) const
   {
-    Assert(fe_values->update_flags & update_gradients,
+    Assert(contains(fe_values->update_flags, update_gradients),
            (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
              "update_gradients")));
     Assert(fe_values->present_cell.is_initialized(),
@@ -3358,7 +3358,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> &values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3383,7 +3383,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   std::vector<typename InputVector::value_type> & values) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3408,7 +3408,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
 
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3438,7 +3438,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   boost::container::small_vector<Number, 200> dof_values(dofs_per_cell);
@@ -3466,7 +3466,7 @@ FEValuesBase<dim, spacedim>::get_function_values(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_values,
+  Assert(contains(this->update_flags, update_values),
          ExcAccessToUninitializedField("update_values"));
 
   // Size of indices must be a multiple of dofs_per_cell such that an integer
@@ -3498,7 +3498,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3524,7 +3524,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3549,7 +3549,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
     &gradients) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3582,7 +3582,7 @@ FEValuesBase<dim, spacedim>::get_function_gradients(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_gradients,
+  Assert(contains(this->update_flags, update_gradients),
          ExcAccessToUninitializedField("update_gradients"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3610,7 +3610,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3635,7 +3635,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3661,7 +3661,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3691,7 +3691,7 @@ FEValuesBase<dim, spacedim>::get_function_hessians(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3719,7 +3719,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> &laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   Assert(present_cell.is_initialized(), ExcNotReinited());
@@ -3744,7 +3744,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   std::vector<typename InputVector::value_type> & laplacians) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe->n_components(), 1);
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3768,7 +3768,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
 {
   using Number = typename InputVector::value_type;
   Assert(present_cell.is_initialized(), ExcNotReinited());
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
 
@@ -3798,7 +3798,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   // number of function values is generated in each point.
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3828,7 +3828,7 @@ FEValuesBase<dim, spacedim>::get_function_laplacians(
   using Number = typename InputVector::value_type;
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
-  Assert(this->update_flags & update_hessians,
+  Assert(contains(this->update_flags, update_hessians),
          ExcAccessToUninitializedField("update_hessians"));
 
   boost::container::small_vector<Number, 200> dof_values(indices.size());
@@ -3856,7 +3856,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
 {
   using Number = typename InputVector::value_type;
   AssertDimension(fe->n_components(), 1);
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3882,7 +3882,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
     &third_derivatives) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
   AssertDimension(indices.size(), dofs_per_cell);
@@ -3909,7 +3909,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(present_cell.is_initialized(), ExcNotReinited());
   AssertDimension(fe_function.size(), present_cell.n_dofs_for_dof_handler());
@@ -3939,7 +3939,7 @@ FEValuesBase<dim, spacedim>::get_function_third_derivatives(
   const bool quadrature_points_fastest) const
 {
   using Number = typename InputVector::value_type;
-  Assert(this->update_flags & update_3rd_derivatives,
+  Assert(contains(this->update_flags, update_3rd_derivatives),
          ExcAccessToUninitializedField("update_3rd_derivatives"));
   Assert(indices.size() % dofs_per_cell == 0,
          ExcNotMultiple(indices.size(), dofs_per_cell));
@@ -3972,7 +3972,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEValuesBase<dim, spacedim>::get_normal_vectors() const
 {
-  Assert(this->update_flags & update_normal_vectors,
+  Assert(contains(this->update_flags, update_normal_vectors),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_normal_vectors")));
 
@@ -4225,7 +4225,7 @@ FEValues<dim, spacedim>::initialize(const UpdateFlags update_flags)
   // You can compute normal vectors to the cells only in the
   // codimension one case.
   if (dim != spacedim - 1)
-    Assert((update_flags & update_normal_vectors) == false,
+    Assert(contains(update_flags, update_normal_vectors) == false,
            ExcMessage("You can only pass the 'update_normal_vectors' "
                       "flag to FEFaceValues or FESubfaceValues objects, "
                       "but not to an FEValues object unless the "
@@ -4339,7 +4339,7 @@ FEValues<dim, spacedim>::do_reinit()
   // specific to the mapping. also let it inspect the
   // cell similarity flag and, if necessary, update
   // it
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->cell_similarity =
         this->get_mapping().fill_fe_values(this->present_cell,
@@ -4419,7 +4419,7 @@ template <int dim, int spacedim>
 const std::vector<Tensor<1, spacedim>> &
 FEFaceValuesBase<dim, spacedim>::get_boundary_forms() const
 {
-  Assert(this->update_flags & update_boundary_forms,
+  Assert(contains(this->update_flags, update_boundary_forms),
          (typename FEValuesBase<dim, spacedim>::ExcAccessToUninitializedField(
            "update_boundary_forms")));
   return this->mapping_output.boundary_forms;
@@ -4651,7 +4651,7 @@ FEFaceValues<dim, spacedim>::do_reinit(const unsigned int face_no)
     this->present_cell;
   this->present_face_index = cell->face_index(face_no);
 
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_face_values(this->present_cell,
                                               face_no,
@@ -4975,7 +4975,7 @@ FESubfaceValues<dim, spacedim>::do_reinit(const unsigned int face_no,
     }
 
   // now ask the mapping and the finite element to do the actual work
-  if (this->update_flags & update_mapping)
+  if (contains(this->update_flags, update_mapping))
     {
       this->get_mapping().fill_fe_subface_values(this->present_cell,
                                                  face_no,

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -360,7 +360,8 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains(data.update_each,
+                   update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
@@ -374,7 +375,8 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(data.update_each,
+                   update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -729,7 +731,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -740,7 +743,8 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -790,7 +794,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -817,7 +822,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -831,7 +837,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -848,7 +855,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -900,7 +908,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -927,7 +936,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -941,7 +951,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -958,7 +969,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),
@@ -997,7 +1009,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1039,7 +1052,8 @@ MappingCartesian<dim, spacedim>::transform(
           Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1079,7 +1093,8 @@ MappingCartesian<dim, spacedim>::transform(
           Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
           Assert(contains(data.update_each, update_volume_elements),

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,7 +98,7 @@ MappingCartesian<dim, spacedim>::requires_update_flags(
   // since they can be computed from the normal vectors without much
   // further ado
   UpdateFlags out = in;
-  if ((out & update_boundary_forms) != 0u)
+  if (contains(out, update_boundary_forms))
     out |= update_normal_vectors;
 
   return out;
@@ -220,7 +220,7 @@ MappingCartesian<dim, spacedim>::maybe_update_cell_quadrature_points(
   const InternalData &                                        data,
   std::vector<Point<dim>> &quadrature_points) const
 {
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::cell();
 
@@ -240,7 +240,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
 {
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
         ReferenceCells::get_hypercube<dim>(),
@@ -273,7 +273,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
       AssertIndexRange(sub_no, cell->face(face_no)->n_children());
     }
 
-  if (data.update_each & update_quadrature_points)
+  if (contains(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
         ReferenceCells::get_hypercube<dim>(),
@@ -322,7 +322,7 @@ MappingCartesian<dim, spacedim>::maybe_update_normal_vectors(
   std::vector<Tensor<1, dim>> &normal_vectors) const
 {
   // compute normal vectors. All normals on a face have the same value.
-  if (data.update_each & update_normal_vectors)
+  if (contains(data.update_each, update_normal_vectors))
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
       std::fill(normal_vectors.begin(),
@@ -343,38 +343,38 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
 {
   if (cell_similarity != CellSimilarity::translation)
     {
-      if (data.update_each & update_jacobian_grads)
+      if (contains(data.update_each, update_jacobian_grads))
         for (unsigned int i = 0; i < output_data.jacobian_grads.size(); ++i)
           output_data.jacobian_grads[i] = DerivativeForm<2, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_grads)
+      if (contains(data.update_each, update_jacobian_pushed_forward_grads))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_grads.size();
              ++i)
           output_data.jacobian_pushed_forward_grads[i] = Tensor<3, spacedim>();
 
-      if (data.update_each & update_jacobian_2nd_derivatives)
+      if (contains(data.update_each, update_jacobian_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_2nd_derivatives.size();
              ++i)
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_2nd_derivatives)
+      if (contains(data.update_each, update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
           output_data.jacobian_pushed_forward_2nd_derivatives[i] =
             Tensor<4, spacedim>();
 
-      if (data.update_each & update_jacobian_3rd_derivatives)
+      if (contains(data.update_each, update_jacobian_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_3rd_derivatives.size();
              ++i)
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (data.update_each & update_jacobian_pushed_forward_3rd_derivatives)
+      if (contains(data.update_each, update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -390,7 +390,7 @@ void
 MappingCartesian<dim, spacedim>::maybe_update_volume_elements(
   const InternalData &data) const
 {
-  if (data.update_each & update_volume_elements)
+  if (contains(data.update_each, update_volume_elements))
     {
       double volume = data.cell_extents[0];
       for (unsigned int d = 1; d < dim; ++d)
@@ -411,7 +411,7 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobians(
 {
   // "compute" Jacobian at the quadrature points, which are all the
   // same
-  if (data.update_each & update_jacobians)
+  if (contains(data.update_each, update_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.jacobians.size(); ++i)
         {
@@ -433,7 +433,7 @@ MappingCartesian<dim, spacedim>::maybe_update_inverse_jacobians(
 {
   // "compute" inverse Jacobian at the quadrature points, which are
   // all the same
-  if (data.update_each & update_inverse_jacobians)
+  if (contains(data.update_each, update_inverse_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.inverse_jacobians.size(); ++i)
         {
@@ -470,14 +470,14 @@ MappingCartesian<dim, spacedim>::fill_fe_values(
 
   // compute Jacobian determinant. all values are equal and are the
   // product of the local lengths in each coordinate direction
-  if (data.update_each & (update_JxW_values | update_volume_elements))
+  if (contains(data.update_each, (update_JxW_values | update_volume_elements)))
     if (cell_similarity != CellSimilarity::translation)
       {
         double J = data.cell_extents[0];
         for (unsigned int d = 1; d < dim; ++d)
           J *= data.cell_extents[d];
         data.volume_element = J;
-        if (data.update_each & update_JxW_values)
+        if (contains(data.update_each, update_JxW_values))
           for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
             output_data.JxW_values[i] = J * quadrature.weight(i);
       }
@@ -504,9 +504,9 @@ MappingCartesian<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(update_flags & update_inverse_jacobians ||
-           update_flags & update_jacobians ||
-           update_flags & update_quadrature_points,
+  Assert(contains(update_flags, update_inverse_jacobians) ||
+           contains(update_flags, update_jacobians) ||
+           contains(update_flags, update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -564,11 +564,11 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       output_data.JxW_values[i] = J * quadrature[0].weight(i);
 
-  if (data.update_each & update_boundary_forms)
+  if (contains(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -611,7 +611,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     {
       // Here, cell->face(face_no)->n_children() would be the right
       // choice, but unfortunately the current function is also called
@@ -625,7 +625,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
         output_data.JxW_values[i] = J * quadrature.weight(i) / n_subfaces;
     }
 
-  if (data.update_each & update_boundary_forms)
+  if (contains(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -661,7 +661,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
                                       data,
                                       output_data.quadrature_points);
 
-  if (data.update_each & update_normal_vectors)
+  if (contains(data.update_each, update_normal_vectors))
     for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
       {
         // The normals are n = J^{-T} * \hat{n} before normalizing.
@@ -675,7 +675,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         output_data.normal_vectors[i] = normal;
       }
 
-  if (data.update_each & update_JxW_values)
+  if (contains(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       {
         const Tensor<1, dim> &ref_space_normal = quadrature.normal_vector(i);
@@ -717,7 +717,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -729,7 +729,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -740,10 +740,10 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -777,7 +777,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -790,7 +790,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -803,7 +803,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -817,7 +817,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -831,10 +831,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -848,10 +848,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -887,7 +887,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -900,7 +900,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -913,7 +913,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -927,7 +927,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -941,10 +941,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -958,10 +958,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -997,7 +997,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1036,10 +1036,10 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_contravariant_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1057,7 +1057,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1076,13 +1076,13 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_hessian:
         {
-          Assert(data.update_each & update_covariant_transformation,
+          Assert(contains(data.update_each, update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(data.update_each & update_volume_elements,
+          Assert(contains(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,7 +98,7 @@ MappingCartesian<dim, spacedim>::requires_update_flags(
   // since they can be computed from the normal vectors without much
   // further ado
   UpdateFlags out = in;
-  if (contains_bits(out, update_boundary_forms))
+  if (out.contains(update_boundary_forms))
     out |= update_normal_vectors;
 
   return out;
@@ -220,7 +220,7 @@ MappingCartesian<dim, spacedim>::maybe_update_cell_quadrature_points(
   const InternalData &                                        data,
   std::vector<Point<dim>> &quadrature_points) const
 {
-  if (contains_bits(data.update_each, update_quadrature_points))
+  if (data.update_each.contains(update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::cell();
 
@@ -240,7 +240,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
 {
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
-  if (contains_bits(data.update_each, update_quadrature_points))
+  if (data.update_each.contains(update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
         ReferenceCells::get_hypercube<dim>(),
@@ -273,7 +273,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
       AssertIndexRange(sub_no, cell->face(face_no)->n_children());
     }
 
-  if (contains_bits(data.update_each, update_quadrature_points))
+  if (data.update_each.contains(update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
         ReferenceCells::get_hypercube<dim>(),
@@ -322,7 +322,7 @@ MappingCartesian<dim, spacedim>::maybe_update_normal_vectors(
   std::vector<Tensor<1, dim>> &normal_vectors) const
 {
   // compute normal vectors. All normals on a face have the same value.
-  if (contains_bits(data.update_each, update_normal_vectors))
+  if (data.update_each.contains(update_normal_vectors))
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
       std::fill(normal_vectors.begin(),
@@ -343,40 +343,40 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
 {
   if (cell_similarity != CellSimilarity::translation)
     {
-      if (contains_bits(data.update_each, update_jacobian_grads))
+      if (data.update_each.contains(update_jacobian_grads))
         for (unsigned int i = 0; i < output_data.jacobian_grads.size(); ++i)
           output_data.jacobian_grads[i] = DerivativeForm<2, dim, spacedim>();
 
-      if (contains_bits(data.update_each, update_jacobian_pushed_forward_grads))
+      if (data.update_each.contains(update_jacobian_pushed_forward_grads))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_grads.size();
              ++i)
           output_data.jacobian_pushed_forward_grads[i] = Tensor<3, spacedim>();
 
-      if (contains_bits(data.update_each, update_jacobian_2nd_derivatives))
+      if (data.update_each.contains(update_jacobian_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_2nd_derivatives.size();
              ++i)
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (contains_bits(data.update_each,
-                        update_jacobian_pushed_forward_2nd_derivatives))
+      if (data.update_each.contains(
+            update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
           output_data.jacobian_pushed_forward_2nd_derivatives[i] =
             Tensor<4, spacedim>();
 
-      if (contains_bits(data.update_each, update_jacobian_3rd_derivatives))
+      if (data.update_each.contains(update_jacobian_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_3rd_derivatives.size();
              ++i)
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (contains_bits(data.update_each,
-                        update_jacobian_pushed_forward_3rd_derivatives))
+      if (data.update_each.contains(
+            update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -392,7 +392,7 @@ void
 MappingCartesian<dim, spacedim>::maybe_update_volume_elements(
   const InternalData &data) const
 {
-  if (contains_bits(data.update_each, update_volume_elements))
+  if (data.update_each.contains(update_volume_elements))
     {
       double volume = data.cell_extents[0];
       for (unsigned int d = 1; d < dim; ++d)
@@ -413,7 +413,7 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobians(
 {
   // "compute" Jacobian at the quadrature points, which are all the
   // same
-  if (contains_bits(data.update_each, update_jacobians))
+  if (data.update_each.contains(update_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.jacobians.size(); ++i)
         {
@@ -435,7 +435,7 @@ MappingCartesian<dim, spacedim>::maybe_update_inverse_jacobians(
 {
   // "compute" inverse Jacobian at the quadrature points, which are
   // all the same
-  if (contains_bits(data.update_each, update_inverse_jacobians))
+  if (data.update_each.contains(update_inverse_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.inverse_jacobians.size(); ++i)
         {
@@ -472,15 +472,14 @@ MappingCartesian<dim, spacedim>::fill_fe_values(
 
   // compute Jacobian determinant. all values are equal and are the
   // product of the local lengths in each coordinate direction
-  if (contains_bits(data.update_each,
-                    (update_JxW_values | update_volume_elements)))
+  if (data.update_each.contains((update_JxW_values | update_volume_elements)))
     if (cell_similarity != CellSimilarity::translation)
       {
         double J = data.cell_extents[0];
         for (unsigned int d = 1; d < dim; ++d)
           J *= data.cell_extents[d];
         data.volume_element = J;
-        if (contains_bits(data.update_each, update_JxW_values))
+        if (data.update_each.contains(update_JxW_values))
           for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
             output_data.JxW_values[i] = J * quadrature.weight(i);
       }
@@ -507,9 +506,9 @@ MappingCartesian<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(contains_bits(update_flags, update_inverse_jacobians) ||
-           contains_bits(update_flags, update_jacobians) ||
-           contains_bits(update_flags, update_quadrature_points),
+  Assert(update_flags.contains(update_inverse_jacobians) ||
+           update_flags.contains(update_jacobians) ||
+           update_flags.contains(update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -567,11 +566,11 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (contains_bits(data.update_each, update_JxW_values))
+  if (data.update_each.contains(update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       output_data.JxW_values[i] = J * quadrature[0].weight(i);
 
-  if (contains_bits(data.update_each, update_boundary_forms))
+  if (data.update_each.contains(update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -614,7 +613,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (contains_bits(data.update_each, update_JxW_values))
+  if (data.update_each.contains(update_JxW_values))
     {
       // Here, cell->face(face_no)->n_children() would be the right
       // choice, but unfortunately the current function is also called
@@ -628,7 +627,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
         output_data.JxW_values[i] = J * quadrature.weight(i) / n_subfaces;
     }
 
-  if (contains_bits(data.update_each, update_boundary_forms))
+  if (data.update_each.contains(update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -664,7 +663,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
                                       data,
                                       output_data.quadrature_points);
 
-  if (contains_bits(data.update_each, update_normal_vectors))
+  if (data.update_each.contains(update_normal_vectors))
     for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
       {
         // The normals are n = J^{-T} * \hat{n} before normalizing.
@@ -678,7 +677,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         output_data.normal_vectors[i] = normal;
       }
 
-  if (contains_bits(data.update_each, update_JxW_values))
+  if (data.update_each.contains(update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       {
         const Tensor<1, dim> &ref_space_normal = quadrature.normal_vector(i);
@@ -720,8 +719,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -733,8 +731,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -745,11 +742,10 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -783,8 +779,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -797,8 +792,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -811,8 +805,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -826,8 +819,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -841,11 +833,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -859,11 +850,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -899,8 +889,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -913,8 +902,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -927,8 +915,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -942,8 +929,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -957,11 +943,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -975,11 +960,10 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -1015,8 +999,7 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1055,12 +1038,10 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_contravariant_hessian:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1078,8 +1059,7 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_hessian:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1098,15 +1078,13 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_hessian:
         {
-          Assert(contains_bits(data.update_each,
-                               update_covariant_transformation),
+          Assert(data.update_each.contains(update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains_bits(data.update_each, update_volume_elements),
+          Assert(data.update_each.contains(update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 

--- a/source/fe/mapping_cartesian.cc
+++ b/source/fe/mapping_cartesian.cc
@@ -98,7 +98,7 @@ MappingCartesian<dim, spacedim>::requires_update_flags(
   // since they can be computed from the normal vectors without much
   // further ado
   UpdateFlags out = in;
-  if (contains(out, update_boundary_forms))
+  if (contains_bits(out, update_boundary_forms))
     out |= update_normal_vectors;
 
   return out;
@@ -220,7 +220,7 @@ MappingCartesian<dim, spacedim>::maybe_update_cell_quadrature_points(
   const InternalData &                                        data,
   std::vector<Point<dim>> &quadrature_points) const
 {
-  if (contains(data.update_each, update_quadrature_points))
+  if (contains_bits(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::cell();
 
@@ -240,7 +240,7 @@ MappingCartesian<dim, spacedim>::maybe_update_face_quadrature_points(
 {
   AssertIndexRange(face_no, GeometryInfo<dim>::faces_per_cell);
 
-  if (contains(data.update_each, update_quadrature_points))
+  if (contains_bits(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::face(
         ReferenceCells::get_hypercube<dim>(),
@@ -273,7 +273,7 @@ MappingCartesian<dim, spacedim>::maybe_update_subface_quadrature_points(
       AssertIndexRange(sub_no, cell->face(face_no)->n_children());
     }
 
-  if (contains(data.update_each, update_quadrature_points))
+  if (contains_bits(data.update_each, update_quadrature_points))
     {
       const auto offset = QProjector<dim>::DataSetDescriptor::subface(
         ReferenceCells::get_hypercube<dim>(),
@@ -322,7 +322,7 @@ MappingCartesian<dim, spacedim>::maybe_update_normal_vectors(
   std::vector<Tensor<1, dim>> &normal_vectors) const
 {
   // compute normal vectors. All normals on a face have the same value.
-  if (contains(data.update_each, update_normal_vectors))
+  if (contains_bits(data.update_each, update_normal_vectors))
     {
       Assert(face_no < GeometryInfo<dim>::faces_per_cell, ExcInternalError());
       std::fill(normal_vectors.begin(),
@@ -343,40 +343,40 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobian_derivatives(
 {
   if (cell_similarity != CellSimilarity::translation)
     {
-      if (contains(data.update_each, update_jacobian_grads))
+      if (contains_bits(data.update_each, update_jacobian_grads))
         for (unsigned int i = 0; i < output_data.jacobian_grads.size(); ++i)
           output_data.jacobian_grads[i] = DerivativeForm<2, dim, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_pushed_forward_grads))
+      if (contains_bits(data.update_each, update_jacobian_pushed_forward_grads))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_grads.size();
              ++i)
           output_data.jacobian_pushed_forward_grads[i] = Tensor<3, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_2nd_derivatives))
+      if (contains_bits(data.update_each, update_jacobian_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_2nd_derivatives.size();
              ++i)
           output_data.jacobian_2nd_derivatives[i] =
             DerivativeForm<3, dim, spacedim>();
 
-      if (contains(data.update_each,
-                   update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains_bits(data.update_each,
+                        update_jacobian_pushed_forward_2nd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_2nd_derivatives.size();
              ++i)
           output_data.jacobian_pushed_forward_2nd_derivatives[i] =
             Tensor<4, spacedim>();
 
-      if (contains(data.update_each, update_jacobian_3rd_derivatives))
+      if (contains_bits(data.update_each, update_jacobian_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_3rd_derivatives.size();
              ++i)
           output_data.jacobian_3rd_derivatives[i] =
             DerivativeForm<4, dim, spacedim>();
 
-      if (contains(data.update_each,
-                   update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains_bits(data.update_each,
+                        update_jacobian_pushed_forward_3rd_derivatives))
         for (unsigned int i = 0;
              i < output_data.jacobian_pushed_forward_3rd_derivatives.size();
              ++i)
@@ -392,7 +392,7 @@ void
 MappingCartesian<dim, spacedim>::maybe_update_volume_elements(
   const InternalData &data) const
 {
-  if (contains(data.update_each, update_volume_elements))
+  if (contains_bits(data.update_each, update_volume_elements))
     {
       double volume = data.cell_extents[0];
       for (unsigned int d = 1; d < dim; ++d)
@@ -413,7 +413,7 @@ MappingCartesian<dim, spacedim>::maybe_update_jacobians(
 {
   // "compute" Jacobian at the quadrature points, which are all the
   // same
-  if (contains(data.update_each, update_jacobians))
+  if (contains_bits(data.update_each, update_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.jacobians.size(); ++i)
         {
@@ -435,7 +435,7 @@ MappingCartesian<dim, spacedim>::maybe_update_inverse_jacobians(
 {
   // "compute" inverse Jacobian at the quadrature points, which are
   // all the same
-  if (contains(data.update_each, update_inverse_jacobians))
+  if (contains_bits(data.update_each, update_inverse_jacobians))
     if (cell_similarity != CellSimilarity::translation)
       for (unsigned int i = 0; i < output_data.inverse_jacobians.size(); ++i)
         {
@@ -472,14 +472,15 @@ MappingCartesian<dim, spacedim>::fill_fe_values(
 
   // compute Jacobian determinant. all values are equal and are the
   // product of the local lengths in each coordinate direction
-  if (contains(data.update_each, (update_JxW_values | update_volume_elements)))
+  if (contains_bits(data.update_each,
+                    (update_JxW_values | update_volume_elements)))
     if (cell_similarity != CellSimilarity::translation)
       {
         double J = data.cell_extents[0];
         for (unsigned int d = 1; d < dim; ++d)
           J *= data.cell_extents[d];
         data.volume_element = J;
-        if (contains(data.update_each, update_JxW_values))
+        if (contains_bits(data.update_each, update_JxW_values))
           for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
             output_data.JxW_values[i] = J * quadrature.weight(i);
       }
@@ -506,9 +507,9 @@ MappingCartesian<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(contains(update_flags, update_inverse_jacobians) ||
-           contains(update_flags, update_jacobians) ||
-           contains(update_flags, update_quadrature_points),
+  Assert(contains_bits(update_flags, update_inverse_jacobians) ||
+           contains_bits(update_flags, update_jacobians) ||
+           contains_bits(update_flags, update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -566,11 +567,11 @@ MappingCartesian<dim, spacedim>::fill_fe_face_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (contains(data.update_each, update_JxW_values))
+  if (contains_bits(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       output_data.JxW_values[i] = J * quadrature[0].weight(i);
 
-  if (contains(data.update_each, update_boundary_forms))
+  if (contains_bits(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -613,7 +614,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
     if (d != GeometryInfo<dim>::unit_normal_direction[face_no])
       J *= data.cell_extents[d];
 
-  if (contains(data.update_each, update_JxW_values))
+  if (contains_bits(data.update_each, update_JxW_values))
     {
       // Here, cell->face(face_no)->n_children() would be the right
       // choice, but unfortunately the current function is also called
@@ -627,7 +628,7 @@ MappingCartesian<dim, spacedim>::fill_fe_subface_values(
         output_data.JxW_values[i] = J * quadrature.weight(i) / n_subfaces;
     }
 
-  if (contains(data.update_each, update_boundary_forms))
+  if (contains_bits(data.update_each, update_boundary_forms))
     for (unsigned int i = 0; i < output_data.boundary_forms.size(); ++i)
       output_data.boundary_forms[i] = J * output_data.normal_vectors[i];
 
@@ -663,7 +664,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
                                       data,
                                       output_data.quadrature_points);
 
-  if (contains(data.update_each, update_normal_vectors))
+  if (contains_bits(data.update_each, update_normal_vectors))
     for (unsigned int i = 0; i < output_data.normal_vectors.size(); ++i)
       {
         // The normals are n = J^{-T} * \hat{n} before normalizing.
@@ -677,7 +678,7 @@ MappingCartesian<dim, spacedim>::fill_fe_immersed_surface_values(
         output_data.normal_vectors[i] = normal;
       }
 
-  if (contains(data.update_each, update_JxW_values))
+  if (contains_bits(data.update_each, update_JxW_values))
     for (unsigned int i = 0; i < output_data.JxW_values.size(); ++i)
       {
         const Tensor<1, dim> &ref_space_normal = quadrature.normal_vector(i);
@@ -719,7 +720,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -731,8 +733,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -743,11 +745,11 @@ MappingCartesian<dim, spacedim>::transform(
         }
       case mapping_piola:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -781,7 +783,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -794,8 +797,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -808,7 +811,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -822,8 +826,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -837,11 +841,11 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -855,11 +859,11 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -895,7 +899,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -908,8 +913,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -922,7 +927,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -936,8 +942,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_contravariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -951,11 +957,11 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -969,11 +975,11 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 
@@ -1009,8 +1015,8 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1049,11 +1055,12 @@ MappingCartesian<dim, spacedim>::transform(
     {
       case mapping_contravariant_hessian:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
 
@@ -1071,7 +1078,8 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_covariant_hessian:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 
@@ -1090,14 +1098,15 @@ MappingCartesian<dim, spacedim>::transform(
 
       case mapping_piola_hessian:
         {
-          Assert(contains(data.update_each, update_covariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_covariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_contravariant_transformation"));
-          Assert(contains(data.update_each, update_volume_elements),
+          Assert(contains_bits(data.update_each, update_volume_elements),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_volume_elements"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -91,21 +91,21 @@ MappingFE<dim, spacedim>::InternalData::initialize(
 
   const unsigned int n_q_points = q.size();
 
-  if (contains(this->update_each, update_covariant_transformation))
+  if (contains_bits(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_contravariant_transformation))
+  if (contains_bits(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_volume_elements))
+  if (contains_bits(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains(this->update_each, update_quadrature_points))
+  if (contains_bits(this->update_each, update_quadrature_points))
     shape_values.resize(n_shape_functions * n_q_points);
 
-  if (contains(
+  if (contains_bits(
         this->update_each,
         (update_covariant_transformation | update_contravariant_transformation |
          update_JxW_values | update_boundary_forms | update_normal_vectors |
@@ -117,18 +117,19 @@ MappingFE<dim, spacedim>::InternalData::initialize(
          update_jacobian_pushed_forward_3rd_derivatives)))
     shape_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains(this->update_each,
-               (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
+  if (contains_bits(this->update_each,
+                    (update_jacobian_grads |
+                     update_jacobian_pushed_forward_grads)))
     shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains(this->update_each,
-               (update_jacobian_2nd_derivatives |
-                update_jacobian_pushed_forward_2nd_derivatives)))
+  if (contains_bits(this->update_each,
+                    (update_jacobian_2nd_derivatives |
+                     update_jacobian_pushed_forward_2nd_derivatives)))
     shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains(this->update_each,
-               (update_jacobian_3rd_derivatives |
-                update_jacobian_pushed_forward_3rd_derivatives)))
+  if (contains_bits(this->update_each,
+                    (update_jacobian_3rd_derivatives |
+                     update_jacobian_pushed_forward_3rd_derivatives)))
     shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
   // now also fill the various fields with their correct values
@@ -149,10 +150,10 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 {
   initialize(update_flags, q, n_original_q_points);
 
-  if (contains(this->update_each,
-               (update_boundary_forms | update_normal_vectors |
-                update_jacobians | update_JxW_values |
-                update_inverse_jacobians)))
+  if (contains_bits(this->update_each,
+                    (update_boundary_forms | update_normal_vectors |
+                     update_jacobians | update_JxW_values |
+                     update_inverse_jacobians)))
     {
       aux.resize(dim - 1,
                  std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -289,7 +290,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_quadrature_points))
+        if (contains_bits(update_flags, update_quadrature_points))
           for (unsigned int point = 0; point < n_q_points; ++point)
             {
               const double *  shape = &data.shape(point + data_set, 0);
@@ -322,7 +323,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_contravariant_transformation))
+        if (contains_bits(update_flags, update_contravariant_transformation))
           // if the current cell is just a
           // translation of the previous one, no
           // need to recompute jacobians...
@@ -362,7 +363,7 @@ namespace internal
                 }
             }
 
-        if (contains(update_flags, update_covariant_transformation))
+        if (contains_bits(update_flags, update_covariant_transformation))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -372,7 +373,7 @@ namespace internal
                 }
             }
 
-        if (contains(update_flags, update_volume_elements))
+        if (contains_bits(update_flags, update_volume_elements))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -397,7 +398,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_grads))
+        if (contains_bits(update_flags, update_jacobian_grads))
           {
             AssertIndexRange(n_q_points, jacobian_grads.size() + 1);
 
@@ -444,7 +445,7 @@ namespace internal
         const unsigned int                n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_pushed_forward_grads))
+        if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_grads.size() + 1);
@@ -518,7 +519,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_2nd_derivatives))
+        if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_2nd_derivatives.size() + 1);
 
@@ -574,8 +575,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags,
-                     update_jacobian_pushed_forward_2nd_derivatives))
+        if (contains_bits(update_flags,
+                          update_jacobian_pushed_forward_2nd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_2nd_derivatives.size() +
@@ -678,7 +679,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_3rd_derivatives))
+        if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_3rd_derivatives.size() + 1);
 
@@ -737,8 +738,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags,
-                     update_jacobian_pushed_forward_3rd_derivatives))
+        if (contains_bits(update_flags,
+                          update_jacobian_pushed_forward_3rd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_3rd_derivatives.size() +
@@ -1029,20 +1030,20 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains(out, (update_JxW_values | update_normal_vectors)))
+      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out,
-                   (update_covariant_transformation | update_JxW_values |
-                    update_jacobians | update_jacobian_grads |
-                    update_boundary_forms | update_normal_vectors)))
+      if (contains_bits(out,
+                        (update_covariant_transformation | update_JxW_values |
+                         update_jacobians | update_jacobian_grads |
+                         update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains(out,
-                   (update_inverse_jacobians |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(out,
+                        (update_inverse_jacobians |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1051,12 +1052,12 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains(out, update_contravariant_transformation))
+      if (contains_bits(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if (contains(out, update_normal_vectors))
+      if (contains_bits(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1220,11 +1221,11 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(contains(update_flags, update_normal_vectors)) ||
+      Assert(!(contains_bits(update_flags, update_normal_vectors)) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1272,12 +1273,12 @@ MappingFE<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if (contains(update_flags, update_normal_vectors))
+                    if (contains_bits(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if (contains(update_flags, update_normal_vectors))
+                    if (contains_bits(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1310,7 +1311,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_jacobians))
+  if (contains_bits(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1319,7 +1320,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_inverse_jacobians))
+  if (contains_bits(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1365,18 +1366,18 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags,
-                     (update_boundary_forms | update_normal_vectors |
-                      update_jacobians | update_JxW_values |
-                      update_inverse_jacobians)))
+        if (contains_bits(update_flags,
+                          (update_boundary_forms | update_normal_vectors |
+                           update_jacobians | update_JxW_values |
+                           update_inverse_jacobians)))
           {
-            if (contains(update_flags, update_boundary_forms))
+            if (contains_bits(update_flags, update_boundary_forms))
               AssertIndexRange(n_q_points,
                                output_data.boundary_forms.size() + 1);
-            if (contains(update_flags, update_normal_vectors))
+            if (contains_bits(update_flags, update_normal_vectors))
               AssertIndexRange(n_q_points,
                                output_data.normal_vectors.size() + 1);
-            if (contains(update_flags, update_JxW_values))
+            if (contains_bits(update_flags, update_JxW_values))
               AssertIndexRange(n_q_points, output_data.JxW_values.size() + 1);
 
             Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1405,7 +1406,7 @@ namespace internal
                   make_array_view(data.aux[d]));
               }
 
-            if (contains(update_flags, update_boundary_forms))
+            if (contains_bits(update_flags, update_boundary_forms))
               {
                 // if dim==spacedim, we can use the unit tangentials to
                 // compute the boundary form by simply taking the cross
@@ -1476,7 +1477,7 @@ namespace internal
                   }
               }
 
-            if (contains(update_flags, update_JxW_values))
+            if (contains_bits(update_flags, update_JxW_values))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 {
                   output_data.JxW_values[i] =
@@ -1496,17 +1497,17 @@ namespace internal
                     }
                 }
 
-            if (contains(update_flags, update_normal_vectors))
+            if (contains_bits(update_flags, update_normal_vectors))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 output_data.normal_vectors[i] =
                   Point<spacedim>(output_data.boundary_forms[i] /
                                   output_data.boundary_forms[i].norm());
 
-            if (contains(update_flags, update_jacobians))
+            if (contains_bits(update_flags, update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains(update_flags, update_inverse_jacobians))
+            if (contains_bits(update_flags, update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1726,8 +1727,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1741,12 +1742,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1767,8 +1768,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1808,12 +1809,13 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1833,7 +1835,8 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1853,16 +1856,17 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1913,12 +1917,13 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1960,7 +1965,8 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2003,16 +2009,17 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -2085,8 +2092,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2186,8 +2193,8 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -91,40 +91,44 @@ MappingFE<dim, spacedim>::InternalData::initialize(
 
   const unsigned int n_q_points = q.size();
 
-  if (this->update_each & update_covariant_transformation)
+  if (contains(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (this->update_each & update_contravariant_transformation)
+  if (contains(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (this->update_each & update_volume_elements)
+  if (contains(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (this->update_each & update_quadrature_points)
+  if (contains(this->update_each, update_quadrature_points))
     shape_values.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each &
-      (update_covariant_transformation | update_contravariant_transformation |
-       update_JxW_values | update_boundary_forms | update_normal_vectors |
-       update_jacobians | update_jacobian_grads | update_inverse_jacobians |
-       update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
-       update_jacobian_pushed_forward_2nd_derivatives |
-       update_jacobian_3rd_derivatives |
-       update_jacobian_pushed_forward_3rd_derivatives))
+  if (contains(
+        this->update_each,
+        (update_covariant_transformation | update_contravariant_transformation |
+         update_JxW_values | update_boundary_forms | update_normal_vectors |
+         update_jacobians | update_jacobian_grads | update_inverse_jacobians |
+         update_jacobian_pushed_forward_grads |
+         update_jacobian_2nd_derivatives |
+         update_jacobian_pushed_forward_2nd_derivatives |
+         update_jacobian_3rd_derivatives |
+         update_jacobian_pushed_forward_3rd_derivatives)))
     shape_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each &
-      (update_jacobian_grads | update_jacobian_pushed_forward_grads))
+  if (contains(this->update_each,
+               (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
     shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each & (update_jacobian_2nd_derivatives |
-                           update_jacobian_pushed_forward_2nd_derivatives))
+  if (contains(this->update_each,
+               (update_jacobian_2nd_derivatives |
+                update_jacobian_pushed_forward_2nd_derivatives)))
     shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (this->update_each & (update_jacobian_3rd_derivatives |
-                           update_jacobian_pushed_forward_3rd_derivatives))
+  if (contains(this->update_each,
+               (update_jacobian_3rd_derivatives |
+                update_jacobian_pushed_forward_3rd_derivatives)))
     shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
   // now also fill the various fields with their correct values
@@ -145,9 +149,10 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 {
   initialize(update_flags, q, n_original_q_points);
 
-  if (this->update_each &
-      (update_boundary_forms | update_normal_vectors | update_jacobians |
-       update_JxW_values | update_inverse_jacobians))
+  if (contains(this->update_each,
+               (update_boundary_forms | update_normal_vectors |
+                update_jacobians | update_JxW_values |
+                update_inverse_jacobians)))
     {
       aux.resize(dim - 1,
                  std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -284,7 +289,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags & update_quadrature_points)
+        if (contains(update_flags, update_quadrature_points))
           for (unsigned int point = 0; point < n_q_points; ++point)
             {
               const double *  shape = &data.shape(point + data_set, 0);
@@ -317,7 +322,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags & update_contravariant_transformation)
+        if (contains(update_flags, update_contravariant_transformation))
           // if the current cell is just a
           // translation of the previous one, no
           // need to recompute jacobians...
@@ -357,7 +362,7 @@ namespace internal
                 }
             }
 
-        if (update_flags & update_covariant_transformation)
+        if (contains(update_flags, update_covariant_transformation))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -367,7 +372,7 @@ namespace internal
                 }
             }
 
-        if (update_flags & update_volume_elements)
+        if (contains(update_flags, update_volume_elements))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -392,7 +397,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_grads)
+        if (contains(update_flags, update_jacobian_grads))
           {
             AssertIndexRange(n_q_points, jacobian_grads.size() + 1);
 
@@ -439,7 +444,7 @@ namespace internal
         const unsigned int                n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_grads)
+        if (contains(update_flags, update_jacobian_pushed_forward_grads))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_grads.size() + 1);
@@ -513,7 +518,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_2nd_derivatives)
+        if (contains(update_flags, update_jacobian_2nd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_2nd_derivatives.size() + 1);
 
@@ -569,7 +574,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_2nd_derivatives)
+        if (contains(update_flags,
+                     update_jacobian_pushed_forward_2nd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_2nd_derivatives.size() +
@@ -672,7 +678,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_3rd_derivatives)
+        if (contains(update_flags, update_jacobian_3rd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_3rd_derivatives.size() + 1);
 
@@ -731,7 +737,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (update_flags & update_jacobian_pushed_forward_3rd_derivatives)
+        if (contains(update_flags,
+                     update_jacobian_pushed_forward_3rd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_3rd_derivatives.size() +
@@ -1022,18 +1029,20 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (containes(out,(update_JxW_values | update_normal_vectors)))
+      if (contains(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out, (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)))
+      if (contains(out,
+                   (update_covariant_transformation | update_JxW_values |
+                    update_jacobians | update_jacobian_grads |
+                    update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
       if (contains(out,
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)))
+                   (update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1211,11 +1220,11 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!(contains(update_flags, update_normal_vectors)) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1356,17 +1365,18 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (update_flags &
-            (update_boundary_forms | update_normal_vectors | update_jacobians |
-             update_JxW_values | update_inverse_jacobians))
+        if (contains(update_flags,
+                     (update_boundary_forms | update_normal_vectors |
+                      update_jacobians | update_JxW_values |
+                      update_inverse_jacobians)))
           {
-            if (update_flags & update_boundary_forms)
+            if (contains(update_flags, update_boundary_forms))
               AssertIndexRange(n_q_points,
                                output_data.boundary_forms.size() + 1);
-            if (update_flags & update_normal_vectors)
+            if (contains(update_flags, update_normal_vectors))
               AssertIndexRange(n_q_points,
                                output_data.normal_vectors.size() + 1);
-            if (update_flags & update_JxW_values)
+            if (contains(update_flags, update_JxW_values))
               AssertIndexRange(n_q_points, output_data.JxW_values.size() + 1);
 
             Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1395,7 +1405,7 @@ namespace internal
                   make_array_view(data.aux[d]));
               }
 
-            if (update_flags & update_boundary_forms)
+            if (contains(update_flags, update_boundary_forms))
               {
                 // if dim==spacedim, we can use the unit tangentials to
                 // compute the boundary form by simply taking the cross
@@ -1466,7 +1476,7 @@ namespace internal
                   }
               }
 
-            if (update_flags & update_JxW_values)
+            if (contains(update_flags, update_JxW_values))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 {
                   output_data.JxW_values[i] =
@@ -1486,17 +1496,17 @@ namespace internal
                     }
                 }
 
-            if (update_flags & update_normal_vectors)
+            if (contains(update_flags, update_normal_vectors))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 output_data.normal_vectors[i] =
                   Point<spacedim>(output_data.boundary_forms[i] /
                                   output_data.boundary_forms[i].norm());
 
-            if (update_flags & update_jacobians)
+            if (contains(update_flags, update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (update_flags & update_inverse_jacobians)
+            if (contains(update_flags, update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1716,7 +1726,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1730,7 +1741,8 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -1755,7 +1767,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1799,7 +1812,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1843,7 +1857,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -1902,7 +1917,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1991,7 +2007,8 @@ namespace internal
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
@@ -2068,7 +2085,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each, update_contravariant_transformation),
+                  contains(data.update_each,
+                           update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2168,7 +2186,8 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each, update_contravariant_transformation),
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -91,45 +91,43 @@ MappingFE<dim, spacedim>::InternalData::initialize(
 
   const unsigned int n_q_points = q.size();
 
-  if (contains_bits(this->update_each, update_covariant_transformation))
+  if (this->update_each.contains(update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_contravariant_transformation))
+  if (this->update_each.contains(update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_volume_elements))
+  if (this->update_each.contains(update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains_bits(this->update_each, update_quadrature_points))
+  if (this->update_each.contains(update_quadrature_points))
     shape_values.resize(n_shape_functions * n_q_points);
 
-  if (contains_bits(
-        this->update_each,
-        (update_covariant_transformation | update_contravariant_transformation |
+  if (this->update_each.contains(
+        update_covariant_transformation | update_contravariant_transformation |
          update_JxW_values | update_boundary_forms | update_normal_vectors |
          update_jacobians | update_jacobian_grads | update_inverse_jacobians |
          update_jacobian_pushed_forward_grads |
          update_jacobian_2nd_derivatives |
          update_jacobian_pushed_forward_2nd_derivatives |
          update_jacobian_3rd_derivatives |
-         update_jacobian_pushed_forward_3rd_derivatives)))
+         update_jacobian_pushed_forward_3rd_derivatives))
     shape_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains_bits(this->update_each,
-                    (update_jacobian_grads |
-                     update_jacobian_pushed_forward_grads)))
+  if (this->update_each.contains(
+        (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
     shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains_bits(this->update_each,
-                    (update_jacobian_2nd_derivatives |
-                     update_jacobian_pushed_forward_2nd_derivatives)))
+  if (this->update_each.contains(
+        (update_jacobian_2nd_derivatives |
+         update_jacobian_pushed_forward_2nd_derivatives)))
     shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-  if (contains_bits(this->update_each,
-                    (update_jacobian_3rd_derivatives |
-                     update_jacobian_pushed_forward_3rd_derivatives)))
+  if (this->update_each.contains(
+        (update_jacobian_3rd_derivatives |
+         update_jacobian_pushed_forward_3rd_derivatives)))
     shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
   // now also fill the various fields with their correct values
@@ -150,10 +148,9 @@ MappingFE<dim, spacedim>::InternalData::initialize_face(
 {
   initialize(update_flags, q, n_original_q_points);
 
-  if (contains_bits(this->update_each,
-                    (update_boundary_forms | update_normal_vectors |
-                     update_jacobians | update_JxW_values |
-                     update_inverse_jacobians)))
+  if (this->update_each.contains(
+        (update_boundary_forms | update_normal_vectors | update_jacobians |
+         update_JxW_values | update_inverse_jacobians)))
     {
       aux.resize(dim - 1,
                  std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -290,7 +287,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_quadrature_points))
+        if (update_flags.contains(update_quadrature_points))
           for (unsigned int point = 0; point < n_q_points; ++point)
             {
               const double *  shape = &data.shape(point + data_set, 0);
@@ -323,7 +320,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_contravariant_transformation))
+        if (update_flags.contains(update_contravariant_transformation))
           // if the current cell is just a
           // translation of the previous one, no
           // need to recompute jacobians...
@@ -363,7 +360,7 @@ namespace internal
                 }
             }
 
-        if (contains_bits(update_flags, update_covariant_transformation))
+        if (update_flags.contains(update_covariant_transformation))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -373,7 +370,7 @@ namespace internal
                 }
             }
 
-        if (contains_bits(update_flags, update_volume_elements))
+        if (update_flags.contains(update_volume_elements))
           if (cell_similarity != CellSimilarity::translation)
             {
               for (unsigned int point = 0; point < n_q_points; ++point)
@@ -398,7 +395,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_grads))
+        if (update_flags.contains(update_jacobian_grads))
           {
             AssertIndexRange(n_q_points, jacobian_grads.size() + 1);
 
@@ -445,7 +442,7 @@ namespace internal
         const unsigned int                n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
+        if (update_flags.contains(update_jacobian_pushed_forward_grads))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_grads.size() + 1);
@@ -519,7 +516,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
+        if (update_flags.contains(update_jacobian_2nd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_2nd_derivatives.size() + 1);
 
@@ -575,8 +572,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags,
-                          update_jacobian_pushed_forward_2nd_derivatives))
+        if (update_flags.contains(
+              update_jacobian_pushed_forward_2nd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_2nd_derivatives.size() +
@@ -679,7 +676,7 @@ namespace internal
         const unsigned int                             n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
+        if (update_flags.contains(update_jacobian_3rd_derivatives))
           {
             AssertIndexRange(n_q_points, jacobian_3rd_derivatives.size() + 1);
 
@@ -738,8 +735,8 @@ namespace internal
         const unsigned int n_q_points)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags,
-                          update_jacobian_pushed_forward_3rd_derivatives))
+        if (update_flags.contains(
+              update_jacobian_pushed_forward_3rd_derivatives))
           {
             AssertIndexRange(n_q_points,
                              jacobian_pushed_forward_3rd_derivatives.size() +
@@ -1030,20 +1027,18 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
+      if (out.contains((update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains_bits(out,
-                        (update_covariant_transformation | update_JxW_values |
-                         update_jacobians | update_jacobian_grads |
-                         update_boundary_forms | update_normal_vectors)))
+      if (out.contains((update_covariant_transformation | update_JxW_values |
+                        update_jacobians | update_jacobian_grads |
+                        update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains_bits(out,
-                        (update_inverse_jacobians |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (out.contains((update_inverse_jacobians |
+                        update_jacobian_pushed_forward_grads |
+                        update_jacobian_pushed_forward_2nd_derivatives |
+                        update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1052,12 +1047,12 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains_bits(out, update_contravariant_transformation))
+      if (out.contains(update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if (contains_bits(out, update_normal_vectors))
+      if (out.contains(update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1221,11 +1216,11 @@ MappingFE<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (update_flags.contains((update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(contains_bits(update_flags, update_normal_vectors)) ||
+      Assert(!(update_flags.contains(update_normal_vectors)) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1273,12 +1268,12 @@ MappingFE<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if (contains_bits(update_flags, update_normal_vectors))
+                    if (update_flags.contains(update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if (contains_bits(update_flags, update_normal_vectors))
+                    if (update_flags.contains(update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1311,7 +1306,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_jacobians))
+  if (update_flags.contains(update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1320,7 +1315,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_inverse_jacobians))
+  if (update_flags.contains(update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1366,18 +1361,17 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags,
-                          (update_boundary_forms | update_normal_vectors |
-                           update_jacobians | update_JxW_values |
-                           update_inverse_jacobians)))
+        if (update_flags.contains((
+              update_boundary_forms | update_normal_vectors | update_jacobians |
+              update_JxW_values | update_inverse_jacobians)))
           {
-            if (contains_bits(update_flags, update_boundary_forms))
+            if (update_flags.contains(update_boundary_forms))
               AssertIndexRange(n_q_points,
                                output_data.boundary_forms.size() + 1);
-            if (contains_bits(update_flags, update_normal_vectors))
+            if (update_flags.contains(update_normal_vectors))
               AssertIndexRange(n_q_points,
                                output_data.normal_vectors.size() + 1);
-            if (contains_bits(update_flags, update_JxW_values))
+            if (update_flags.contains(update_JxW_values))
               AssertIndexRange(n_q_points, output_data.JxW_values.size() + 1);
 
             Assert(data.aux.size() + 1 >= dim, ExcInternalError());
@@ -1406,7 +1400,7 @@ namespace internal
                   make_array_view(data.aux[d]));
               }
 
-            if (contains_bits(update_flags, update_boundary_forms))
+            if (update_flags.contains(update_boundary_forms))
               {
                 // if dim==spacedim, we can use the unit tangentials to
                 // compute the boundary form by simply taking the cross
@@ -1477,7 +1471,7 @@ namespace internal
                   }
               }
 
-            if (contains_bits(update_flags, update_JxW_values))
+            if (update_flags.contains(update_JxW_values))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 {
                   output_data.JxW_values[i] =
@@ -1497,17 +1491,17 @@ namespace internal
                     }
                 }
 
-            if (contains_bits(update_flags, update_normal_vectors))
+            if (update_flags.contains(update_normal_vectors))
               for (unsigned int i = 0; i < n_q_points; ++i)
                 output_data.normal_vectors[i] =
                   Point<spacedim>(output_data.boundary_forms[i] /
                                   output_data.boundary_forms[i].norm());
 
-            if (contains_bits(update_flags, update_jacobians))
+            if (update_flags.contains(update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains_bits(update_flags, update_inverse_jacobians))
+            if (update_flags.contains(update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1727,8 +1721,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1742,12 +1736,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1768,8 +1762,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1809,13 +1803,12 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1835,8 +1828,7 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1856,17 +1848,16 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1917,13 +1908,12 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1965,8 +1955,7 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2009,17 +1998,16 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -2092,8 +2080,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2193,8 +2181,7 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -107,13 +107,12 @@ MappingFE<dim, spacedim>::InternalData::initialize(
 
   if (this->update_each.contains(
         update_covariant_transformation | update_contravariant_transformation |
-         update_JxW_values | update_boundary_forms | update_normal_vectors |
-         update_jacobians | update_jacobian_grads | update_inverse_jacobians |
-         update_jacobian_pushed_forward_grads |
-         update_jacobian_2nd_derivatives |
-         update_jacobian_pushed_forward_2nd_derivatives |
-         update_jacobian_3rd_derivatives |
-         update_jacobian_pushed_forward_3rd_derivatives))
+        update_JxW_values | update_boundary_forms | update_normal_vectors |
+        update_jacobians | update_jacobian_grads | update_inverse_jacobians |
+        update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
+        update_jacobian_pushed_forward_2nd_derivatives |
+        update_jacobian_3rd_derivatives |
+        update_jacobian_pushed_forward_3rd_derivatives))
     shape_derivatives.resize(n_shape_functions * n_q_points);
 
   if (this->update_each.contains(

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1263,12 +1263,12 @@ MappingFE<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1301,7 +1301,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1310,7 +1310,7 @@ MappingFE<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)

--- a/source/fe/mapping_fe.cc
+++ b/source/fe/mapping_fe.cc
@@ -1022,18 +1022,18 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (containes(out,(update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
+      if (contains(out, (update_covariant_transformation | update_JxW_values |
                   update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+                  update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if ((out &
+      if (contains(out,
            (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
             update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+            update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -1042,12 +1042,12 @@ MappingFE<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (contains(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (contains(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1716,7 +1716,7 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1730,11 +1730,11 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1755,7 +1755,7 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1795,11 +1795,11 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1819,7 +1819,7 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1839,15 +1839,15 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1898,11 +1898,11 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1944,7 +1944,7 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1987,15 +1987,15 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  data.update_each & update_covariant_transformation,
+                  contains(data.update_each, update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  data.update_each & update_volume_elements,
+                  contains(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -2068,7 +2068,7 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  data.update_each & update_contravariant_transformation,
+                  contains(data.update_each, update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -2168,7 +2168,7 @@ MappingFE<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each, update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -483,20 +483,18 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
+      if (out.contains((update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains_bits(out,
-                        (update_covariant_transformation | update_JxW_values |
-                         update_jacobians | update_jacobian_grads |
-                         update_boundary_forms | update_normal_vectors)))
+      if (out.contains((update_covariant_transformation | update_JxW_values |
+                        update_jacobians | update_jacobian_grads |
+                        update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains_bits(out,
-                        (update_inverse_jacobians |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (out.contains((update_inverse_jacobians |
+                        update_jacobian_pushed_forward_grads |
+                        update_jacobian_pushed_forward_2nd_derivatives |
+                        update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation
@@ -505,10 +503,10 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // Jacobi matrix of the transformation.
       // Therefore these values have to be
       // updated for each cell.
-      if (contains_bits(out, update_contravariant_transformation))
+      if (out.contains(update_contravariant_transformation))
         out |= update_JxW_values;
 
-      if (contains_bits(out, update_normal_vectors))
+      if (out.contains(update_normal_vectors))
         out |= update_JxW_values;
     }
 
@@ -534,38 +532,36 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_data(
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains_bits(data.update_each, update_quadrature_points))
+  if (data.update_each.contains(update_quadrature_points))
     data.shape_values.resize(data.n_shape_functions * n_q_points);
 
-  if (contains_bits(
-        data.update_each,
+  if (data.update_each.contains(
         (update_covariant_transformation | update_contravariant_transformation |
          update_JxW_values | update_boundary_forms | update_normal_vectors |
          update_jacobians | update_jacobian_grads | update_inverse_jacobians)))
     data.shape_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains_bits(data.update_each, update_covariant_transformation))
+  if (data.update_each.contains(update_covariant_transformation))
     data.covariant.resize(n_original_q_points);
 
-  if (contains_bits(data.update_each, update_contravariant_transformation))
+  if (data.update_each.contains(update_contravariant_transformation))
     data.contravariant.resize(n_original_q_points);
 
-  if (contains_bits(data.update_each, update_volume_elements))
+  if (data.update_each.contains(update_volume_elements))
     data.volume_elements.resize(n_original_q_points);
 
-  if (contains_bits(data.update_each,
-                    (update_jacobian_grads |
-                     update_jacobian_pushed_forward_grads)))
+  if (data.update_each.contains(
+        (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
     data.shape_second_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains_bits(data.update_each,
-                    (update_jacobian_2nd_derivatives |
-                     update_jacobian_pushed_forward_2nd_derivatives)))
+  if (data.update_each.contains(
+        (update_jacobian_2nd_derivatives |
+         update_jacobian_pushed_forward_2nd_derivatives)))
     data.shape_third_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains_bits(data.update_each,
-                    (update_jacobian_3rd_derivatives |
-                     update_jacobian_pushed_forward_3rd_derivatives)))
+  if (data.update_each.contains(
+        (update_jacobian_3rd_derivatives |
+         update_jacobian_pushed_forward_3rd_derivatives)))
     data.shape_fourth_derivatives.resize(data.n_shape_functions * n_q_points);
 
   compute_shapes_virtual(q.get_points(), data);
@@ -588,7 +584,7 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
 
   if (dim > 1)
     {
-      if (contains_bits(data.update_each, update_boundary_forms))
+      if (data.update_each.contains(update_boundary_forms))
         {
           data.aux.resize(
             dim - 1, std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -698,7 +694,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_quadrature_points))
+        if (update_flags.contains(update_quadrature_points))
           {
             for (unsigned int point = 0; point < quadrature_points.size();
                  ++point)
@@ -740,7 +736,7 @@ namespace internal
         const UpdateFlags update_flags = data.update_each;
 
         // then Jacobians
-        if (contains_bits(update_flags, update_contravariant_transformation))
+        if (update_flags.contains(update_contravariant_transformation))
           {
             const unsigned int n_q_points = data.contravariant.size();
 
@@ -770,7 +766,7 @@ namespace internal
               }
           }
 
-        if (contains_bits(update_flags, update_covariant_transformation))
+        if (update_flags.contains(update_covariant_transformation))
           {
             AssertDimension(data.covariant.size(), data.contravariant.size());
             for (unsigned int point = 0; point < data.contravariant.size();
@@ -779,7 +775,7 @@ namespace internal
                 (data.contravariant[point]).covariant_form();
           }
 
-        if (contains_bits(update_flags, update_volume_elements))
+        if (update_flags.contains(update_volume_elements))
           {
             AssertDimension(data.contravariant.size(),
                             data.volume_elements.size());
@@ -808,7 +804,7 @@ namespace internal
         std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_grads))
+        if (update_flags.contains(update_jacobian_grads))
           {
             const unsigned int n_q_points = jacobian_grads.size();
 
@@ -858,7 +854,7 @@ namespace internal
         std::vector<Tensor<3, spacedim>> &  jacobian_pushed_forward_grads)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
+        if (update_flags.contains(update_jacobian_pushed_forward_grads))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_grads.size();
@@ -931,7 +927,7 @@ namespace internal
         std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
+        if (update_flags.contains(update_jacobian_2nd_derivatives))
           {
             const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -986,8 +982,8 @@ namespace internal
           &jacobian_pushed_forward_2nd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags,
-                          update_jacobian_pushed_forward_2nd_derivatives))
+        if (update_flags.contains(
+              update_jacobian_pushed_forward_2nd_derivatives))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_2nd_derivatives.size();
@@ -1082,7 +1078,7 @@ namespace internal
         std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
+        if (update_flags.contains(update_jacobian_3rd_derivatives))
           {
             const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1141,8 +1137,8 @@ namespace internal
           &jacobian_pushed_forward_3rd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains_bits(update_flags,
-                          update_jacobian_pushed_forward_3rd_derivatives))
+        if (update_flags.contains(
+              update_jacobian_pushed_forward_3rd_derivatives))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_3rd_derivatives.size();
@@ -1271,12 +1267,12 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_boundary_forms))
+        if (update_flags.contains(update_boundary_forms))
           {
             const unsigned int n_q_points = output_data.boundary_forms.size();
-            if (contains_bits(update_flags, update_normal_vectors))
+            if (update_flags.contains(update_normal_vectors))
               AssertDimension(output_data.normal_vectors.size(), n_q_points);
-            if (contains_bits(update_flags, update_JxW_values))
+            if (update_flags.contains(update_JxW_values))
               AssertDimension(output_data.JxW_values.size(), n_q_points);
 
             // map the unit tangentials to the real cell. checking for d!=dim-1
@@ -1366,12 +1362,12 @@ namespace internal
                   }
               }
 
-            if (contains_bits(update_flags,
-                              (update_normal_vectors | update_JxW_values)))
+            if (update_flags.contains(
+                  (update_normal_vectors | update_JxW_values)))
               for (unsigned int i = 0; i < output_data.boundary_forms.size();
                    ++i)
                 {
-                  if (contains_bits(update_flags, update_JxW_values))
+                  if (update_flags.contains(update_JxW_values))
                     {
                       output_data.JxW_values[i] =
                         output_data.boundary_forms[i].norm() *
@@ -1387,17 +1383,17 @@ namespace internal
                         }
                     }
 
-                  if (contains_bits(update_flags, update_normal_vectors))
+                  if (update_flags.contains(update_normal_vectors))
                     output_data.normal_vectors[i] =
                       Point<spacedim>(output_data.boundary_forms[i] /
                                       output_data.boundary_forms[i].norm());
                 }
 
-            if (contains_bits(update_flags, update_jacobians))
+            if (update_flags.contains(update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains_bits(update_flags, update_inverse_jacobians))
+            if (update_flags.contains(update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1538,11 +1534,11 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (update_flags.contains((update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains_bits(update_flags, update_normal_vectors) ||
+      Assert(!update_flags.contains(update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1583,7 +1579,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if (contains_bits(update_flags, update_normal_vectors))
+              if (update_flags.contains(update_normal_vectors))
                 {
                   Assert(spacedim - dim == 1,
                          ExcMessage("There is no cell normal in codim 2."));
@@ -1612,7 +1608,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_jacobians))
+  if (update_flags.contains(update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1620,7 +1616,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_inverse_jacobians))
+  if (update_flags.contains(update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1813,8 +1809,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1828,12 +1824,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1853,8 +1849,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1896,8 +1892,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1989,8 +1985,7 @@ MappingFEField<dim, spacedim, VectorType, void>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -483,20 +483,20 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains(out, (update_JxW_values | update_normal_vectors)))
+      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out,
-                   (update_covariant_transformation | update_JxW_values |
-                    update_jacobians | update_jacobian_grads |
-                    update_boundary_forms | update_normal_vectors)))
+      if (contains_bits(out,
+                        (update_covariant_transformation | update_JxW_values |
+                         update_jacobians | update_jacobian_grads |
+                         update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains(out,
-                   (update_inverse_jacobians |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(out,
+                        (update_inverse_jacobians |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation
@@ -505,10 +505,10 @@ MappingFEField<dim, spacedim, VectorType, void>::requires_update_flags(
       // Jacobi matrix of the transformation.
       // Therefore these values have to be
       // updated for each cell.
-      if (contains(out, update_contravariant_transformation))
+      if (contains_bits(out, update_contravariant_transformation))
         out |= update_JxW_values;
 
-      if (contains(out, update_normal_vectors))
+      if (contains_bits(out, update_normal_vectors))
         out |= update_JxW_values;
     }
 
@@ -534,37 +534,38 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_data(
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains(data.update_each, update_quadrature_points))
+  if (contains_bits(data.update_each, update_quadrature_points))
     data.shape_values.resize(data.n_shape_functions * n_q_points);
 
-  if (contains(
+  if (contains_bits(
         data.update_each,
         (update_covariant_transformation | update_contravariant_transformation |
          update_JxW_values | update_boundary_forms | update_normal_vectors |
          update_jacobians | update_jacobian_grads | update_inverse_jacobians)))
     data.shape_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains(data.update_each, update_covariant_transformation))
+  if (contains_bits(data.update_each, update_covariant_transformation))
     data.covariant.resize(n_original_q_points);
 
-  if (contains(data.update_each, update_contravariant_transformation))
+  if (contains_bits(data.update_each, update_contravariant_transformation))
     data.contravariant.resize(n_original_q_points);
 
-  if (contains(data.update_each, update_volume_elements))
+  if (contains_bits(data.update_each, update_volume_elements))
     data.volume_elements.resize(n_original_q_points);
 
-  if (contains(data.update_each,
-               (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
+  if (contains_bits(data.update_each,
+                    (update_jacobian_grads |
+                     update_jacobian_pushed_forward_grads)))
     data.shape_second_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains(data.update_each,
-               (update_jacobian_2nd_derivatives |
-                update_jacobian_pushed_forward_2nd_derivatives)))
+  if (contains_bits(data.update_each,
+                    (update_jacobian_2nd_derivatives |
+                     update_jacobian_pushed_forward_2nd_derivatives)))
     data.shape_third_derivatives.resize(data.n_shape_functions * n_q_points);
 
-  if (contains(data.update_each,
-               (update_jacobian_3rd_derivatives |
-                update_jacobian_pushed_forward_3rd_derivatives)))
+  if (contains_bits(data.update_each,
+                    (update_jacobian_3rd_derivatives |
+                     update_jacobian_pushed_forward_3rd_derivatives)))
     data.shape_fourth_derivatives.resize(data.n_shape_functions * n_q_points);
 
   compute_shapes_virtual(q.get_points(), data);
@@ -587,7 +588,7 @@ MappingFEField<dim, spacedim, VectorType, void>::compute_face_data(
 
   if (dim > 1)
     {
-      if (contains(data.update_each, update_boundary_forms))
+      if (contains_bits(data.update_each, update_boundary_forms))
         {
           data.aux.resize(
             dim - 1, std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -697,7 +698,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_quadrature_points))
+        if (contains_bits(update_flags, update_quadrature_points))
           {
             for (unsigned int point = 0; point < quadrature_points.size();
                  ++point)
@@ -739,7 +740,7 @@ namespace internal
         const UpdateFlags update_flags = data.update_each;
 
         // then Jacobians
-        if (contains(update_flags, update_contravariant_transformation))
+        if (contains_bits(update_flags, update_contravariant_transformation))
           {
             const unsigned int n_q_points = data.contravariant.size();
 
@@ -769,7 +770,7 @@ namespace internal
               }
           }
 
-        if (contains(update_flags, update_covariant_transformation))
+        if (contains_bits(update_flags, update_covariant_transformation))
           {
             AssertDimension(data.covariant.size(), data.contravariant.size());
             for (unsigned int point = 0; point < data.contravariant.size();
@@ -778,7 +779,7 @@ namespace internal
                 (data.contravariant[point]).covariant_form();
           }
 
-        if (contains(update_flags, update_volume_elements))
+        if (contains_bits(update_flags, update_volume_elements))
           {
             AssertDimension(data.contravariant.size(),
                             data.volume_elements.size());
@@ -807,7 +808,7 @@ namespace internal
         std::vector<DerivativeForm<2, dim, spacedim>> &jacobian_grads)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_grads))
+        if (contains_bits(update_flags, update_jacobian_grads))
           {
             const unsigned int n_q_points = jacobian_grads.size();
 
@@ -857,7 +858,7 @@ namespace internal
         std::vector<Tensor<3, spacedim>> &  jacobian_pushed_forward_grads)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_pushed_forward_grads))
+        if (contains_bits(update_flags, update_jacobian_pushed_forward_grads))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_grads.size();
@@ -930,7 +931,7 @@ namespace internal
         std::vector<DerivativeForm<3, dim, spacedim>> &jacobian_2nd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_2nd_derivatives))
+        if (contains_bits(update_flags, update_jacobian_2nd_derivatives))
           {
             const unsigned int n_q_points = jacobian_2nd_derivatives.size();
 
@@ -985,8 +986,8 @@ namespace internal
           &jacobian_pushed_forward_2nd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags,
-                     update_jacobian_pushed_forward_2nd_derivatives))
+        if (contains_bits(update_flags,
+                          update_jacobian_pushed_forward_2nd_derivatives))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_2nd_derivatives.size();
@@ -1081,7 +1082,7 @@ namespace internal
         std::vector<DerivativeForm<4, dim, spacedim>> &jacobian_3rd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags, update_jacobian_3rd_derivatives))
+        if (contains_bits(update_flags, update_jacobian_3rd_derivatives))
           {
             const unsigned int n_q_points = jacobian_3rd_derivatives.size();
 
@@ -1140,8 +1141,8 @@ namespace internal
           &jacobian_pushed_forward_3rd_derivatives)
       {
         const UpdateFlags update_flags = data.update_each;
-        if (contains(update_flags,
-                     update_jacobian_pushed_forward_3rd_derivatives))
+        if (contains_bits(update_flags,
+                          update_jacobian_pushed_forward_3rd_derivatives))
           {
             const unsigned int n_q_points =
               jacobian_pushed_forward_3rd_derivatives.size();
@@ -1270,12 +1271,12 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_boundary_forms))
+        if (contains_bits(update_flags, update_boundary_forms))
           {
             const unsigned int n_q_points = output_data.boundary_forms.size();
-            if (contains(update_flags, update_normal_vectors))
+            if (contains_bits(update_flags, update_normal_vectors))
               AssertDimension(output_data.normal_vectors.size(), n_q_points);
-            if (contains(update_flags, update_JxW_values))
+            if (contains_bits(update_flags, update_JxW_values))
               AssertDimension(output_data.JxW_values.size(), n_q_points);
 
             // map the unit tangentials to the real cell. checking for d!=dim-1
@@ -1365,12 +1366,12 @@ namespace internal
                   }
               }
 
-            if (contains(update_flags,
-                         (update_normal_vectors | update_JxW_values)))
+            if (contains_bits(update_flags,
+                              (update_normal_vectors | update_JxW_values)))
               for (unsigned int i = 0; i < output_data.boundary_forms.size();
                    ++i)
                 {
-                  if (contains(update_flags, update_JxW_values))
+                  if (contains_bits(update_flags, update_JxW_values))
                     {
                       output_data.JxW_values[i] =
                         output_data.boundary_forms[i].norm() *
@@ -1386,17 +1387,17 @@ namespace internal
                         }
                     }
 
-                  if (contains(update_flags, update_normal_vectors))
+                  if (contains_bits(update_flags, update_normal_vectors))
                     output_data.normal_vectors[i] =
                       Point<spacedim>(output_data.boundary_forms[i] /
                                       output_data.boundary_forms[i].norm());
                 }
 
-            if (contains(update_flags, update_jacobians))
+            if (contains_bits(update_flags, update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains(update_flags, update_inverse_jacobians))
+            if (contains_bits(update_flags, update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -1537,11 +1538,11 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains(update_flags, update_normal_vectors) ||
+      Assert(!contains_bits(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1582,7 +1583,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if (contains(update_flags, update_normal_vectors))
+              if (contains_bits(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim - dim == 1,
                          ExcMessage("There is no cell normal in codim 2."));
@@ -1611,7 +1612,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_jacobians))
+  if (contains_bits(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1619,7 +1620,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_inverse_jacobians))
+  if (contains_bits(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1812,8 +1813,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1827,12 +1828,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -1852,8 +1853,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1895,8 +1896,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1988,8 +1989,8 @@ MappingFEField<dim, spacedim, VectorType, void>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_fe_field.cc
+++ b/source/fe/mapping_fe_field.cc
@@ -1574,7 +1574,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (contains(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim - dim == 1,
                          ExcMessage("There is no cell normal in codim 2."));
@@ -1603,7 +1603,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1611,7 +1611,7 @@ MappingFEField<dim, spacedim, VectorType, void>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -84,18 +84,17 @@ MappingManifold<dim, spacedim>::InternalData::initialize(
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains_bits(this->update_each,
-                    (update_quadrature_points |
-                     update_contravariant_transformation)))
+  if (this->update_each.contains(
+        (update_quadrature_points | update_contravariant_transformation)))
     compute_manifold_quadrature_weights(q);
 
-  if (contains_bits(this->update_each, update_covariant_transformation))
+  if (this->update_each.contains(update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_contravariant_transformation))
+  if (this->update_each.contains(update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_volume_elements))
+  if (this->update_each.contains(update_volume_elements))
     volume_elements.resize(n_original_q_points);
 }
 
@@ -111,7 +110,7 @@ MappingManifold<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (contains_bits(this->update_each, update_boundary_forms))
+      if (this->update_each.contains(update_boundary_forms))
         {
           aux.resize(dim - 1,
                      std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -226,20 +225,18 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
+      if (out.contains((update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains_bits(out,
-                        (update_covariant_transformation | update_JxW_values |
-                         update_jacobians | update_jacobian_grads |
-                         update_boundary_forms | update_normal_vectors)))
+      if (out.contains((update_covariant_transformation | update_JxW_values |
+                        update_jacobians | update_jacobian_grads |
+                        update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains_bits(out,
-                        (update_inverse_jacobians |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (out.contains((update_inverse_jacobians |
+                        update_jacobian_pushed_forward_grads |
+                        update_jacobian_pushed_forward_2nd_derivatives |
+                        update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation used in the Piola
@@ -248,20 +245,19 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // knowing here whether the finite elements wants to use the
       // contravariant of the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains_bits(out, update_contravariant_transformation))
+      if (out.contains(update_contravariant_transformation))
         out |= update_JxW_values;
 
-      if (contains_bits(out, update_normal_vectors))
+      if (out.contains(update_normal_vectors))
         out |= update_JxW_values;
     }
 
   // Now throw an exception if we stumble upon something that was not
   // implemented yet
-  Assert(!contains_bits(out,
-                        (update_jacobian_grads |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)),
+  Assert(!out.contains((update_jacobian_grads |
+                        update_jacobian_pushed_forward_grads |
+                        update_jacobian_pushed_forward_2nd_derivatives |
+                        update_jacobian_pushed_forward_3rd_derivatives)),
          ExcNotImplemented());
 
   return out;
@@ -349,7 +345,7 @@ namespace internal
         AssertDimension(data.vertices.size(),
                         GeometryInfo<dim>::vertices_per_cell);
 
-        if (contains_bits(update_flags, update_quadrature_points))
+        if (update_flags.contains(update_quadrature_points))
           {
             for (unsigned int point = 0; point < quadrature_points.size();
                  ++point)
@@ -379,7 +375,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_contravariant_transformation))
+        if (update_flags.contains(update_contravariant_transformation))
           {
             const unsigned int n_q_points = data.contravariant.size();
 
@@ -441,7 +437,7 @@ namespace internal
                   }
               }
 
-            if (contains_bits(update_flags, update_covariant_transformation))
+            if (update_flags.contains(update_covariant_transformation))
               {
                 const unsigned int n_q_points = data.contravariant.size();
                 for (unsigned int point = 0; point < n_q_points; ++point)
@@ -451,7 +447,7 @@ namespace internal
                   }
               }
 
-            if (contains_bits(update_flags, update_volume_elements))
+            if (update_flags.contains(update_volume_elements))
               {
                 const unsigned int n_q_points = data.contravariant.size();
                 for (unsigned int point = 0; point < n_q_points; ++point)
@@ -502,11 +498,11 @@ MappingManifold<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (update_flags.contains((update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains_bits(update_flags, update_normal_vectors) ||
+      Assert(!update_flags.contains(update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -548,7 +544,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if (contains_bits(update_flags, update_normal_vectors))
+              if (update_flags.contains(update_normal_vectors))
                 {
                   Assert(spacedim == dim + 1,
                          ExcMessage(
@@ -580,7 +576,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_jacobians))
+  if (update_flags.contains(update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -588,7 +584,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_inverse_jacobians))
+  if (update_flags.contains(update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -633,12 +629,12 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains_bits(update_flags, update_boundary_forms))
+        if (update_flags.contains(update_boundary_forms))
           {
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-            if (contains_bits(update_flags, update_normal_vectors))
+            if (update_flags.contains(update_normal_vectors))
               AssertDimension(output_data.normal_vectors.size(), n_q_points);
-            if (contains_bits(update_flags, update_JxW_values))
+            if (update_flags.contains(update_JxW_values))
               AssertDimension(output_data.JxW_values.size(), n_q_points);
 
             // map the unit tangentials to the real cell. checking for d!=dim-1
@@ -743,12 +739,12 @@ namespace internal
                   }
               }
 
-            if (contains_bits(update_flags,
-                              (update_normal_vectors | update_JxW_values)))
+            if (update_flags.contains(
+                  (update_normal_vectors | update_JxW_values)))
               for (unsigned int i = 0; i < output_data.boundary_forms.size();
                    ++i)
                 {
-                  if (contains_bits(update_flags, update_JxW_values))
+                  if (update_flags.contains(update_JxW_values))
                     {
                       output_data.JxW_values[i] =
                         output_data.boundary_forms[i].norm() * weights[i];
@@ -762,17 +758,17 @@ namespace internal
                         }
                     }
 
-                  if (contains_bits(update_flags, update_normal_vectors))
+                  if (update_flags.contains(update_normal_vectors))
                     output_data.normal_vectors[i] =
                       Point<spacedim>(output_data.boundary_forms[i] /
                                       output_data.boundary_forms[i].norm());
                 }
 
-            if (contains_bits(update_flags, update_jacobians))
+            if (update_flags.contains(update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains_bits(update_flags, update_inverse_jacobians))
+            if (update_flags.contains(update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -843,8 +839,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -858,12 +854,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -884,8 +880,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -924,13 +920,12 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -950,8 +945,7 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -971,17 +965,16 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1031,13 +1024,12 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1079,8 +1071,7 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1123,17 +1114,16 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_covariant_transformation),
+                  data.update_each.contains(update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains_bits(data.update_each, update_volume_elements),
+                  data.update_each.contains(update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -1205,8 +1195,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains_bits(data.update_each,
-                                update_contravariant_transformation),
+                  data.update_each.contains(
+                    update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1375,8 +1365,7 @@ MappingManifold<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -84,18 +84,18 @@ MappingManifold<dim, spacedim>::InternalData::initialize(
 
   // see if we need the (transformation) shape function values
   // and/or gradients and resize the necessary arrays
-  if (contains(this->update_each,
-               (update_quadrature_points |
-                update_contravariant_transformation)))
+  if (contains_bits(this->update_each,
+                    (update_quadrature_points |
+                     update_contravariant_transformation)))
     compute_manifold_quadrature_weights(q);
 
-  if (contains(this->update_each, update_covariant_transformation))
+  if (contains_bits(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_contravariant_transformation))
+  if (contains_bits(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_volume_elements))
+  if (contains_bits(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 }
 
@@ -111,7 +111,7 @@ MappingManifold<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (contains(this->update_each, update_boundary_forms))
+      if (contains_bits(this->update_each, update_boundary_forms))
         {
           aux.resize(dim - 1,
                      std::vector<Tensor<1, spacedim>>(n_original_q_points));
@@ -226,20 +226,20 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains(out, (update_JxW_values | update_normal_vectors)))
+      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out,
-                   (update_covariant_transformation | update_JxW_values |
-                    update_jacobians | update_jacobian_grads |
-                    update_boundary_forms | update_normal_vectors)))
+      if (contains_bits(out,
+                        (update_covariant_transformation | update_JxW_values |
+                         update_jacobians | update_jacobian_grads |
+                         update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains(out,
-                   (update_inverse_jacobians |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(out,
+                        (update_inverse_jacobians |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation used in the Piola
@@ -248,20 +248,20 @@ MappingManifold<dim, spacedim>::requires_update_flags(
       // knowing here whether the finite elements wants to use the
       // contravariant of the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains(out, update_contravariant_transformation))
+      if (contains_bits(out, update_contravariant_transformation))
         out |= update_JxW_values;
 
-      if (contains(out, update_normal_vectors))
+      if (contains_bits(out, update_normal_vectors))
         out |= update_JxW_values;
     }
 
   // Now throw an exception if we stumble upon something that was not
   // implemented yet
-  Assert(!contains(out,
-                   (update_jacobian_grads |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)),
+  Assert(!contains_bits(out,
+                        (update_jacobian_grads |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)),
          ExcNotImplemented());
 
   return out;
@@ -349,7 +349,7 @@ namespace internal
         AssertDimension(data.vertices.size(),
                         GeometryInfo<dim>::vertices_per_cell);
 
-        if (contains(update_flags, update_quadrature_points))
+        if (contains_bits(update_flags, update_quadrature_points))
           {
             for (unsigned int point = 0; point < quadrature_points.size();
                  ++point)
@@ -379,7 +379,7 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_contravariant_transformation))
+        if (contains_bits(update_flags, update_contravariant_transformation))
           {
             const unsigned int n_q_points = data.contravariant.size();
 
@@ -441,7 +441,7 @@ namespace internal
                   }
               }
 
-            if (contains(update_flags, update_covariant_transformation))
+            if (contains_bits(update_flags, update_covariant_transformation))
               {
                 const unsigned int n_q_points = data.contravariant.size();
                 for (unsigned int point = 0; point < n_q_points; ++point)
@@ -451,7 +451,7 @@ namespace internal
                   }
               }
 
-            if (contains(update_flags, update_volume_elements))
+            if (contains_bits(update_flags, update_volume_elements))
               {
                 const unsigned int n_q_points = data.contravariant.size();
                 for (unsigned int point = 0; point < n_q_points; ++point)
@@ -502,11 +502,11 @@ MappingManifold<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains(update_flags, update_normal_vectors) ||
+      Assert(!contains_bits(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -548,7 +548,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if (contains(update_flags, update_normal_vectors))
+              if (contains_bits(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim == dim + 1,
                          ExcMessage(
@@ -580,7 +580,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_jacobians))
+  if (contains_bits(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -588,7 +588,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_inverse_jacobians))
+  if (contains_bits(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -633,12 +633,12 @@ namespace internal
       {
         const UpdateFlags update_flags = data.update_each;
 
-        if (contains(update_flags, update_boundary_forms))
+        if (contains_bits(update_flags, update_boundary_forms))
           {
             AssertDimension(output_data.boundary_forms.size(), n_q_points);
-            if (contains(update_flags, update_normal_vectors))
+            if (contains_bits(update_flags, update_normal_vectors))
               AssertDimension(output_data.normal_vectors.size(), n_q_points);
-            if (contains(update_flags, update_JxW_values))
+            if (contains_bits(update_flags, update_JxW_values))
               AssertDimension(output_data.JxW_values.size(), n_q_points);
 
             // map the unit tangentials to the real cell. checking for d!=dim-1
@@ -743,12 +743,12 @@ namespace internal
                   }
               }
 
-            if (contains(update_flags,
-                         (update_normal_vectors | update_JxW_values)))
+            if (contains_bits(update_flags,
+                              (update_normal_vectors | update_JxW_values)))
               for (unsigned int i = 0; i < output_data.boundary_forms.size();
                    ++i)
                 {
-                  if (contains(update_flags, update_JxW_values))
+                  if (contains_bits(update_flags, update_JxW_values))
                     {
                       output_data.JxW_values[i] =
                         output_data.boundary_forms[i].norm() * weights[i];
@@ -762,17 +762,17 @@ namespace internal
                         }
                     }
 
-                  if (contains(update_flags, update_normal_vectors))
+                  if (contains_bits(update_flags, update_normal_vectors))
                     output_data.normal_vectors[i] =
                       Point<spacedim>(output_data.boundary_forms[i] /
                                       output_data.boundary_forms[i].norm());
                 }
 
-            if (contains(update_flags, update_jacobians))
+            if (contains_bits(update_flags, update_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.jacobians[point] = data.contravariant[point];
 
-            if (contains(update_flags, update_inverse_jacobians))
+            if (contains_bits(update_flags, update_inverse_jacobians))
               for (unsigned int point = 0; point < n_q_points; ++point)
                 output_data.inverse_jacobians[point] =
                   data.covariant[point].transpose();
@@ -843,8 +843,8 @@ namespace internal
             case mapping_contravariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -858,12 +858,12 @@ namespace internal
             case mapping_piola:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 1, ExcMessage("Only for rank 1"));
@@ -884,8 +884,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -924,12 +924,13 @@ namespace internal
             case mapping_contravariant_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -949,7 +950,8 @@ namespace internal
             case mapping_covariant_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -969,16 +971,17 @@ namespace internal
             case mapping_piola_gradient:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
                 Assert(rank == 2, ExcMessage("Only for rank 2"));
@@ -1028,12 +1031,13 @@ namespace internal
             case mapping_contravariant_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
 
@@ -1075,7 +1079,8 @@ namespace internal
             case mapping_covariant_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1118,16 +1123,17 @@ namespace internal
             case mapping_piola_hessian:
               {
                 Assert(
-                  contains(data.update_each, update_covariant_transformation),
+                  contains_bits(data.update_each,
+                                update_covariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_contravariant_transformation"));
                 Assert(
-                  contains(data.update_each, update_volume_elements),
+                  contains_bits(data.update_each, update_volume_elements),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_volume_elements"));
 
@@ -1199,8 +1205,8 @@ namespace internal
             case mapping_covariant:
               {
                 Assert(
-                  contains(data.update_each,
-                           update_contravariant_transformation),
+                  contains_bits(data.update_each,
+                                update_contravariant_transformation),
                   typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                     "update_covariant_transformation"));
 
@@ -1369,8 +1375,8 @@ MappingManifold<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_manifold.cc
+++ b/source/fe/mapping_manifold.cc
@@ -543,7 +543,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
               output_data.JxW_values[point] =
                 std::sqrt(determinant(G)) * weights[point];
 
-              if ((update_flags & update_normal_vectors) != 0u)
+              if (contains(update_flags, update_normal_vectors))
                 {
                   Assert(spacedim == dim + 1,
                          ExcMessage(
@@ -575,7 +575,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -583,7 +583,7 @@ MappingManifold<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -1099,12 +1099,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if ((update_flags & update_normal_vectors) != 0u)
+                    if (contains(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1137,7 +1137,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1146,7 +1146,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1364,7 +1364,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
 
           output_data.JxW_values[point] = weights[point] * det * normal.norm();
 
-          if ((update_flags & update_normal_vectors) != 0u)
+          if (contains(update_flags, update_normal_vectors))
             {
               normal /= normal.norm();
               output_data.normal_vectors[point] = normal;
@@ -1373,7 +1373,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_jacobians) != 0u)
+  if (contains(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1381,7 +1381,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if ((update_flags & update_inverse_jacobians) != 0u)
+  if (contains(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1438,18 +1438,18 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (contains(update_flags, update_quadrature_points))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               output_data.quadrature_points[i + j][d] = result.first[d][j];
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (contains(update_flags, update_jacobians))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               for (unsigned int e = 0; e < dim; ++e)
                 output_data.jacobians[i + j][d][e] = result.second[e][d][j];
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (contains(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac(
               result.second);
@@ -1471,16 +1471,16 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if ((update_flags & update_quadrature_points) != 0u)
+        if (contains(update_flags, update_quadrature_points))
           output_data.quadrature_points[i] = result.first;
 
-        if ((update_flags & update_jacobians) != 0u)
+        if (contains(update_flags, update_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac = result.second;
             output_data.jacobians[i]             = jac.transpose();
           }
 
-        if ((update_flags & update_inverse_jacobians) != 0u)
+        if (contains(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac(result.second);
             DerivativeForm<1, spacedim, dim> inv_jac = jac.covariant_form();

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -94,20 +94,20 @@ MappingQ<dim, spacedim>::InternalData::initialize(
   const unsigned int n_q_points = q.size();
 
   const bool needs_higher_order_terms =
-    contains(this->update_each,
-             (update_jacobian_pushed_forward_grads |
-              update_jacobian_2nd_derivatives |
-              update_jacobian_pushed_forward_2nd_derivatives |
-              update_jacobian_3rd_derivatives |
-              update_jacobian_pushed_forward_3rd_derivatives));
+    contains_bits(this->update_each,
+                  (update_jacobian_pushed_forward_grads |
+                   update_jacobian_2nd_derivatives |
+                   update_jacobian_pushed_forward_2nd_derivatives |
+                   update_jacobian_3rd_derivatives |
+                   update_jacobian_pushed_forward_3rd_derivatives));
 
-  if (contains(this->update_each, update_covariant_transformation))
+  if (contains_bits(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_contravariant_transformation))
+  if (contains_bits(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains(this->update_each, update_volume_elements))
+  if (contains_bits(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   tensor_product_quadrature = q.is_tensor_product();
@@ -177,35 +177,35 @@ MappingQ<dim, spacedim>::InternalData::initialize(
     {
       // see if we need the (transformation) shape function values
       // and/or gradients and resize the necessary arrays
-      if (contains(this->update_each, update_quadrature_points))
+      if (contains_bits(this->update_each, update_quadrature_points))
         shape_values.resize(n_shape_functions * n_q_points);
 
-      if (contains(this->update_each,
-                   (update_covariant_transformation |
-                    update_contravariant_transformation | update_JxW_values |
-                    update_boundary_forms | update_normal_vectors |
-                    update_jacobians | update_jacobian_grads |
-                    update_inverse_jacobians |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_2nd_derivatives |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_3rd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(this->update_each,
+                        (update_covariant_transformation |
+                         update_contravariant_transformation |
+                         update_JxW_values | update_boundary_forms |
+                         update_normal_vectors | update_jacobians |
+                         update_jacobian_grads | update_inverse_jacobians |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_2nd_derivatives |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_3rd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         shape_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains(this->update_each,
-                   (update_jacobian_grads |
-                    update_jacobian_pushed_forward_grads)))
+      if (contains_bits(this->update_each,
+                        (update_jacobian_grads |
+                         update_jacobian_pushed_forward_grads)))
         shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains(this->update_each,
-                   (update_jacobian_2nd_derivatives |
-                    update_jacobian_pushed_forward_2nd_derivatives)))
+      if (contains_bits(this->update_each,
+                        (update_jacobian_2nd_derivatives |
+                         update_jacobian_pushed_forward_2nd_derivatives)))
         shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains(this->update_each,
-                   (update_jacobian_3rd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(this->update_each,
+                        (update_jacobian_3rd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
       // now also fill the various fields with their correct values
@@ -239,10 +239,10 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (contains(this->update_each,
-                   (update_boundary_forms | update_normal_vectors |
-                    update_jacobians | update_JxW_values |
-                    update_inverse_jacobians)))
+      if (contains_bits(this->update_each,
+                        (update_boundary_forms | update_normal_vectors |
+                         update_jacobians | update_JxW_values |
+                         update_inverse_jacobians)))
         {
           aux.resize(dim - 1,
                      AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
@@ -857,20 +857,20 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains(out, (update_JxW_values | update_normal_vectors)))
+      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains(out,
-                   (update_covariant_transformation | update_JxW_values |
-                    update_jacobians | update_jacobian_grads |
-                    update_boundary_forms | update_normal_vectors)))
+      if (contains_bits(out,
+                        (update_covariant_transformation | update_JxW_values |
+                         update_jacobians | update_jacobian_grads |
+                         update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains(out,
-                   (update_inverse_jacobians |
-                    update_jacobian_pushed_forward_grads |
-                    update_jacobian_pushed_forward_2nd_derivatives |
-                    update_jacobian_pushed_forward_3rd_derivatives)))
+      if (contains_bits(out,
+                        (update_inverse_jacobians |
+                         update_jacobian_pushed_forward_grads |
+                         update_jacobian_pushed_forward_2nd_derivatives |
+                         update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -879,12 +879,12 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains(out, update_contravariant_transformation))
+      if (contains_bits(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if (contains(out, update_normal_vectors))
+      if (contains_bits(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1055,11 +1055,11 @@ MappingQ<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains(update_flags, update_normal_vectors) ||
+      Assert(!contains_bits(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1107,12 +1107,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if (contains(update_flags, update_normal_vectors))
+                    if (contains_bits(update_flags, update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if (contains(update_flags, update_normal_vectors))
+                    if (contains_bits(update_flags, update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1145,7 +1145,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_jacobians))
+  if (contains_bits(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1154,7 +1154,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_inverse_jacobians))
+  if (contains_bits(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1340,11 +1340,11 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
   const UpdateFlags          update_flags = data.update_each;
   const std::vector<double> &weights      = quadrature.get_weights();
 
-  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains(update_flags, update_normal_vectors) ||
+      Assert(!contains_bits(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1372,7 +1372,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
 
           output_data.JxW_values[point] = weights[point] * det * normal.norm();
 
-          if (contains(update_flags, update_normal_vectors))
+          if (contains_bits(update_flags, update_normal_vectors))
             {
               normal /= normal.norm();
               output_data.normal_vectors[point] = normal;
@@ -1381,7 +1381,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_jacobians))
+  if (contains_bits(update_flags, update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1389,7 +1389,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains(update_flags, update_inverse_jacobians))
+  if (contains_bits(update_flags, update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1412,9 +1412,9 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(contains(update_flags,
-                  update_inverse_jacobians | update_jacobians |
-                    update_quadrature_points),
+  Assert(contains_bits(update_flags,
+                       update_inverse_jacobians | update_jacobians |
+                         update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -1446,18 +1446,18 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if (contains(update_flags, update_quadrature_points))
+        if (contains_bits(update_flags, update_quadrature_points))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               output_data.quadrature_points[i + j][d] = result.first[d][j];
 
-        if (contains(update_flags, update_jacobians))
+        if (contains_bits(update_flags, update_jacobians))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               for (unsigned int e = 0; e < dim; ++e)
                 output_data.jacobians[i + j][d][e] = result.second[e][d][j];
 
-        if (contains(update_flags, update_inverse_jacobians))
+        if (contains_bits(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac(
               result.second);
@@ -1479,16 +1479,16 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if (contains(update_flags, update_quadrature_points))
+        if (contains_bits(update_flags, update_quadrature_points))
           output_data.quadrature_points[i] = result.first;
 
-        if (contains(update_flags, update_jacobians))
+        if (contains_bits(update_flags, update_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac = result.second;
             output_data.jacobians[i]             = jac.transpose();
           }
 
-        if (contains(update_flags, update_inverse_jacobians))
+        if (contains_bits(update_flags, update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac(result.second);
             DerivativeForm<1, spacedim, dim> inv_jac = jac.covariant_form();
@@ -1582,8 +1582,8 @@ MappingQ<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains(data.update_each,
-                          update_contravariant_transformation),
+          Assert(contains_bits(data.update_each,
+                               update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -94,19 +94,20 @@ MappingQ<dim, spacedim>::InternalData::initialize(
   const unsigned int n_q_points = q.size();
 
   const bool needs_higher_order_terms =
-    this->update_each &
-    (update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
-     update_jacobian_pushed_forward_2nd_derivatives |
-     update_jacobian_3rd_derivatives |
-     update_jacobian_pushed_forward_3rd_derivatives);
+    contains(this->update_each,
+             (update_jacobian_pushed_forward_grads |
+              update_jacobian_2nd_derivatives |
+              update_jacobian_pushed_forward_2nd_derivatives |
+              update_jacobian_3rd_derivatives |
+              update_jacobian_pushed_forward_3rd_derivatives));
 
-  if (this->update_each & update_covariant_transformation)
+  if (contains(this->update_each, update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (this->update_each & update_contravariant_transformation)
+  if (contains(this->update_each, update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (this->update_each & update_volume_elements)
+  if (contains(this->update_each, update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   tensor_product_quadrature = q.is_tensor_product();
@@ -176,31 +177,35 @@ MappingQ<dim, spacedim>::InternalData::initialize(
     {
       // see if we need the (transformation) shape function values
       // and/or gradients and resize the necessary arrays
-      if (this->update_each & update_quadrature_points)
+      if (contains(this->update_each, update_quadrature_points))
         shape_values.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each &
-          (update_covariant_transformation |
-           update_contravariant_transformation | update_JxW_values |
-           update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_jacobian_grads | update_inverse_jacobians |
-           update_jacobian_pushed_forward_grads |
-           update_jacobian_2nd_derivatives |
-           update_jacobian_pushed_forward_2nd_derivatives |
-           update_jacobian_3rd_derivatives |
-           update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(this->update_each,
+                   (update_covariant_transformation |
+                    update_contravariant_transformation | update_JxW_values |
+                    update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_jacobian_grads |
+                    update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_2nd_derivatives |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_3rd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         shape_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each &
-          (update_jacobian_grads | update_jacobian_pushed_forward_grads))
+      if (contains(this->update_each,
+                   (update_jacobian_grads |
+                    update_jacobian_pushed_forward_grads)))
         shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each & (update_jacobian_2nd_derivatives |
-                               update_jacobian_pushed_forward_2nd_derivatives))
+      if (contains(this->update_each,
+                   (update_jacobian_2nd_derivatives |
+                    update_jacobian_pushed_forward_2nd_derivatives)))
         shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (this->update_each & (update_jacobian_3rd_derivatives |
-                               update_jacobian_pushed_forward_3rd_derivatives))
+      if (contains(this->update_each,
+                   (update_jacobian_3rd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
       // now also fill the various fields with their correct values
@@ -234,9 +239,10 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (this->update_each &
-          (update_boundary_forms | update_normal_vectors | update_jacobians |
-           update_JxW_values | update_inverse_jacobians))
+      if (contains(this->update_each,
+                   (update_boundary_forms | update_normal_vectors |
+                    update_jacobians | update_JxW_values |
+                    update_inverse_jacobians)))
         {
           aux.resize(dim - 1,
                      AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
@@ -851,18 +857,20 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if ((out & (update_JxW_values | update_normal_vectors)) != 0u)
+      if (contains(out, (update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if ((out & (update_covariant_transformation | update_JxW_values |
-                  update_jacobians | update_jacobian_grads |
-                  update_boundary_forms | update_normal_vectors)) != 0u)
+      if (contains(out,
+                   (update_covariant_transformation | update_JxW_values |
+                    update_jacobians | update_jacobian_grads |
+                    update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if ((out &
-           (update_inverse_jacobians | update_jacobian_pushed_forward_grads |
-            update_jacobian_pushed_forward_2nd_derivatives |
-            update_jacobian_pushed_forward_3rd_derivatives)) != 0u)
+      if (contains(out,
+                   (update_inverse_jacobians |
+                    update_jacobian_pushed_forward_grads |
+                    update_jacobian_pushed_forward_2nd_derivatives |
+                    update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -871,12 +879,12 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if ((out & update_contravariant_transformation) != 0u)
+      if (contains(out, update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if ((out & update_normal_vectors) != 0u)
+      if (contains(out, update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1047,11 +1055,11 @@ MappingQ<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!contains(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1332,11 +1340,11 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
   const UpdateFlags          update_flags = data.update_each;
   const std::vector<double> &weights      = quadrature.get_weights();
 
-  if ((update_flags & (update_normal_vectors | update_JxW_values)) != 0u)
+  if (contains(update_flags, (update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!(update_flags & update_normal_vectors) ||
+      Assert(!contains(update_flags, update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1404,9 +1412,9 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(update_flags & update_inverse_jacobians ||
-           update_flags & update_jacobians ||
-           update_flags & update_quadrature_points,
+  Assert(contains(update_flags,
+                  update_inverse_jacobians | update_jacobians |
+                    update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -1574,7 +1582,8 @@ MappingQ<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(data.update_each & update_contravariant_transformation,
+          Assert(contains(data.update_each,
+                          update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/fe/mapping_q.cc
+++ b/source/fe/mapping_q.cc
@@ -93,21 +93,19 @@ MappingQ<dim, spacedim>::InternalData::initialize(
 
   const unsigned int n_q_points = q.size();
 
-  const bool needs_higher_order_terms =
-    contains_bits(this->update_each,
-                  (update_jacobian_pushed_forward_grads |
-                   update_jacobian_2nd_derivatives |
-                   update_jacobian_pushed_forward_2nd_derivatives |
-                   update_jacobian_3rd_derivatives |
-                   update_jacobian_pushed_forward_3rd_derivatives));
+  const bool needs_higher_order_terms = this->update_each.contains(
+    (update_jacobian_pushed_forward_grads | update_jacobian_2nd_derivatives |
+     update_jacobian_pushed_forward_2nd_derivatives |
+     update_jacobian_3rd_derivatives |
+     update_jacobian_pushed_forward_3rd_derivatives));
 
-  if (contains_bits(this->update_each, update_covariant_transformation))
+  if (this->update_each.contains(update_covariant_transformation))
     covariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_contravariant_transformation))
+  if (this->update_each.contains(update_contravariant_transformation))
     contravariant.resize(n_original_q_points);
 
-  if (contains_bits(this->update_each, update_volume_elements))
+  if (this->update_each.contains(update_volume_elements))
     volume_elements.resize(n_original_q_points);
 
   tensor_product_quadrature = q.is_tensor_product();
@@ -177,35 +175,33 @@ MappingQ<dim, spacedim>::InternalData::initialize(
     {
       // see if we need the (transformation) shape function values
       // and/or gradients and resize the necessary arrays
-      if (contains_bits(this->update_each, update_quadrature_points))
+      if (this->update_each.contains(update_quadrature_points))
         shape_values.resize(n_shape_functions * n_q_points);
 
-      if (contains_bits(this->update_each,
-                        (update_covariant_transformation |
-                         update_contravariant_transformation |
-                         update_JxW_values | update_boundary_forms |
-                         update_normal_vectors | update_jacobians |
-                         update_jacobian_grads | update_inverse_jacobians |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_2nd_derivatives |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_3rd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (this->update_each.contains(
+            (update_covariant_transformation |
+             update_contravariant_transformation | update_JxW_values |
+             update_boundary_forms | update_normal_vectors | update_jacobians |
+             update_jacobian_grads | update_inverse_jacobians |
+             update_jacobian_pushed_forward_grads |
+             update_jacobian_2nd_derivatives |
+             update_jacobian_pushed_forward_2nd_derivatives |
+             update_jacobian_3rd_derivatives |
+             update_jacobian_pushed_forward_3rd_derivatives)))
         shape_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains_bits(this->update_each,
-                        (update_jacobian_grads |
-                         update_jacobian_pushed_forward_grads)))
+      if (this->update_each.contains(
+            (update_jacobian_grads | update_jacobian_pushed_forward_grads)))
         shape_second_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains_bits(this->update_each,
-                        (update_jacobian_2nd_derivatives |
-                         update_jacobian_pushed_forward_2nd_derivatives)))
+      if (this->update_each.contains(
+            (update_jacobian_2nd_derivatives |
+             update_jacobian_pushed_forward_2nd_derivatives)))
         shape_third_derivatives.resize(n_shape_functions * n_q_points);
 
-      if (contains_bits(this->update_each,
-                        (update_jacobian_3rd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (this->update_each.contains(
+            (update_jacobian_3rd_derivatives |
+             update_jacobian_pushed_forward_3rd_derivatives)))
         shape_fourth_derivatives.resize(n_shape_functions * n_q_points);
 
       // now also fill the various fields with their correct values
@@ -239,10 +235,9 @@ MappingQ<dim, spacedim>::InternalData::initialize_face(
 
   if (dim > 1)
     {
-      if (contains_bits(this->update_each,
-                        (update_boundary_forms | update_normal_vectors |
-                         update_jacobians | update_JxW_values |
-                         update_inverse_jacobians)))
+      if (this->update_each.contains(
+            (update_boundary_forms | update_normal_vectors | update_jacobians |
+             update_JxW_values | update_inverse_jacobians)))
         {
           aux.resize(dim - 1,
                      AlignedVector<Tensor<1, spacedim>>(n_original_q_points));
@@ -857,20 +852,18 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // update_boundary_forms is simply
       // ignored for the interior of a
       // cell.
-      if (contains_bits(out, (update_JxW_values | update_normal_vectors)))
+      if (out.contains((update_JxW_values | update_normal_vectors)))
         out |= update_boundary_forms;
 
-      if (contains_bits(out,
-                        (update_covariant_transformation | update_JxW_values |
-                         update_jacobians | update_jacobian_grads |
-                         update_boundary_forms | update_normal_vectors)))
+      if (out.contains((update_covariant_transformation | update_JxW_values |
+                        update_jacobians | update_jacobian_grads |
+                        update_boundary_forms | update_normal_vectors)))
         out |= update_contravariant_transformation;
 
-      if (contains_bits(out,
-                        (update_inverse_jacobians |
-                         update_jacobian_pushed_forward_grads |
-                         update_jacobian_pushed_forward_2nd_derivatives |
-                         update_jacobian_pushed_forward_3rd_derivatives)))
+      if (out.contains((update_inverse_jacobians |
+                        update_jacobian_pushed_forward_grads |
+                        update_jacobian_pushed_forward_2nd_derivatives |
+                        update_jacobian_pushed_forward_3rd_derivatives)))
         out |= update_covariant_transformation;
 
       // The contravariant transformation is used in the Piola
@@ -879,12 +872,12 @@ MappingQ<dim, spacedim>::requires_update_flags(const UpdateFlags in) const
       // knowing here whether the finite element wants to use the
       // contravariant or the Piola transforms, we add the JxW values
       // to the list of flags to be updated for each cell.
-      if (contains_bits(out, update_contravariant_transformation))
+      if (out.contains(update_contravariant_transformation))
         out |= update_volume_elements;
 
       // the same is true when computing normal vectors: they require
       // the determinant of the Jacobian
-      if (contains_bits(out, update_normal_vectors))
+      if (out.contains(update_normal_vectors))
         out |= update_volume_elements;
     }
 
@@ -1055,11 +1048,11 @@ MappingQ<dim, spacedim>::fill_fe_values(
   // Multiply quadrature weights by absolute value of Jacobian determinants or
   // the area element g=sqrt(DX^t DX) in case of codim > 0
 
-  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (update_flags.contains((update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains_bits(update_flags, update_normal_vectors) ||
+      Assert(!update_flags.contains(update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1107,12 +1100,12 @@ MappingQ<dim, spacedim>::fill_fe_values(
                     CellSimilarity::inverted_translation)
                   {
                     // we only need to flip the normal
-                    if (contains_bits(update_flags, update_normal_vectors))
+                    if (update_flags.contains(update_normal_vectors))
                       output_data.normal_vectors[point] *= -1.;
                   }
                 else
                   {
-                    if (contains_bits(update_flags, update_normal_vectors))
+                    if (update_flags.contains(update_normal_vectors))
                       {
                         Assert(spacedim == dim + 1,
                                ExcMessage(
@@ -1145,7 +1138,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
 
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_jacobians))
+  if (update_flags.contains(update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1154,7 +1147,7 @@ MappingQ<dim, spacedim>::fill_fe_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_inverse_jacobians))
+  if (update_flags.contains(update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       if (computed_cell_similarity != CellSimilarity::translation)
@@ -1340,11 +1333,11 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
   const UpdateFlags          update_flags = data.update_each;
   const std::vector<double> &weights      = quadrature.get_weights();
 
-  if (contains_bits(update_flags, (update_normal_vectors | update_JxW_values)))
+  if (update_flags.contains((update_normal_vectors | update_JxW_values)))
     {
       AssertDimension(output_data.JxW_values.size(), n_q_points);
 
-      Assert(!contains_bits(update_flags, update_normal_vectors) ||
+      Assert(!update_flags.contains(update_normal_vectors) ||
                (output_data.normal_vectors.size() == n_q_points),
              ExcDimensionMismatch(output_data.normal_vectors.size(),
                                   n_q_points));
@@ -1372,7 +1365,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
 
           output_data.JxW_values[point] = weights[point] * det * normal.norm();
 
-          if (contains_bits(update_flags, update_normal_vectors))
+          if (update_flags.contains(update_normal_vectors))
             {
               normal /= normal.norm();
               output_data.normal_vectors[point] = normal;
@@ -1381,7 +1374,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_jacobians))
+  if (update_flags.contains(update_jacobians))
     {
       AssertDimension(output_data.jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1389,7 +1382,7 @@ MappingQ<dim, spacedim>::fill_fe_immersed_surface_values(
     }
 
   // copy values from InternalData to vector given by reference
-  if (contains_bits(update_flags, update_inverse_jacobians))
+  if (update_flags.contains(update_inverse_jacobians))
     {
       AssertDimension(output_data.inverse_jacobians.size(), n_q_points);
       for (unsigned int point = 0; point < n_q_points; ++point)
@@ -1412,9 +1405,8 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
   if (update_flags == update_default)
     return;
 
-  Assert(contains_bits(update_flags,
-                       update_inverse_jacobians | update_jacobians |
-                         update_quadrature_points),
+  Assert(update_flags.contains(update_inverse_jacobians | update_jacobians |
+                               update_quadrature_points),
          ExcNotImplemented());
 
   output_data.initialize(unit_points.size(), update_flags);
@@ -1446,18 +1438,18 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if (contains_bits(update_flags, update_quadrature_points))
+        if (update_flags.contains(update_quadrature_points))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               output_data.quadrature_points[i + j][d] = result.first[d][j];
 
-        if (contains_bits(update_flags, update_jacobians))
+        if (update_flags.contains(update_jacobians))
           for (unsigned int j = 0; j < n_lanes && i + j < n_points; ++j)
             for (unsigned int d = 0; d < spacedim; ++d)
               for (unsigned int e = 0; e < dim; ++e)
                 output_data.jacobians[i + j][d][e] = result.second[e][d][j];
 
-        if (contains_bits(update_flags, update_inverse_jacobians))
+        if (update_flags.contains(update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim, VectorizedArray<double>> jac(
               result.second);
@@ -1479,16 +1471,16 @@ MappingQ<dim, spacedim>::fill_mapping_data_for_generic_points(
             polynomial_degree == 1,
             renumber_lexicographic_to_hierarchic);
 
-        if (contains_bits(update_flags, update_quadrature_points))
+        if (update_flags.contains(update_quadrature_points))
           output_data.quadrature_points[i] = result.first;
 
-        if (contains_bits(update_flags, update_jacobians))
+        if (update_flags.contains(update_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac = result.second;
             output_data.jacobians[i]             = jac.transpose();
           }
 
-        if (contains_bits(update_flags, update_inverse_jacobians))
+        if (update_flags.contains(update_inverse_jacobians))
           {
             DerivativeForm<1, spacedim, dim> jac(result.second);
             DerivativeForm<1, spacedim, dim> inv_jac = jac.covariant_form();
@@ -1582,8 +1574,7 @@ MappingQ<dim, spacedim>::transform(
     {
       case mapping_covariant_gradient:
         {
-          Assert(contains_bits(data.update_each,
-                               update_contravariant_transformation),
+          Assert(data.update_each.contains(update_contravariant_transformation),
                  typename FEValuesBase<dim>::ExcAccessToUninitializedField(
                    "update_covariant_transformation"));
 

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -149,7 +149,8 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if (contains_bits(update_flags, update_locally_owned_cell_bounding_boxes_rtree))
+    if (contains_bits(update_flags,
+                      update_locally_owned_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -163,7 +163,7 @@ namespace GridTools
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
         update_flags =
-          update_flag & ~update_locally_owned_cell_bounding_boxes_rtree;
+          update_flags & ~update_locally_owned_cell_bounding_boxes_rtree;
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -63,10 +63,7 @@ namespace GridTools
     if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_vertex_to_cell_map));
+        update_flags    = update_flags & ~update_vertex_to_cell_map;
       }
     return vertex_to_cells;
   }
@@ -81,10 +78,7 @@ namespace GridTools
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
+        update_flags = update_flags & ~update_vertex_to_cell_centers_directions;
       }
     return vertex_to_cell_centers;
   }
@@ -98,10 +92,7 @@ namespace GridTools
     if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_used_vertices));
+        update_flags  = update_flags & ~update_used_vertices;
       }
     return used_vertices;
   }
@@ -121,10 +112,7 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_used_vertices_rtree));
+        update_flags        = update_flags & ~update_used_vertices_rtree;
       }
     return used_vertices_rtree;
   }
@@ -148,10 +136,7 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
+        update_flags = update_flags & ~update_cell_bounding_boxes_rtree;
       }
     return cell_bounding_boxes_rtree;
   }
@@ -176,11 +161,8 @@ namespace GridTools
           boxes.emplace_back(mapping->get_bounding_box(cell), cell);
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(
-            ~update_locally_owned_cell_bounding_boxes_rtree));
+        update_flags =
+          update_flag & ~update_locally_owned_cell_bounding_boxes_rtree;
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }
@@ -210,10 +192,7 @@ namespace GridTools
             covering_rtree[level] =
               GridTools::build_global_description_tree(boxes, MPI_COMM_SELF);
           }
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_covering_rtree));
+        update_flags = update_flags & ~update_covering_rtree;
       }
 
     return covering_rtree[level];
@@ -234,10 +213,7 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
-        // FIXME
-        update_flags = static_cast<CacheUpdateFlags>(
-          static_cast<unsigned int>(update_flags) &
-          static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
+        update_flags = update_flags & ~update_vertex_to_neighbor_subdomain;
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -60,7 +60,7 @@ namespace GridTools
     std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_vertex_to_cell_map() const
   {
-    if (contains(update_flags, update_vertex_to_cell_map))
+    if (contains_bits(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
         update_flags    = update_flags & ~update_vertex_to_cell_map;
@@ -74,7 +74,7 @@ namespace GridTools
   const std::vector<std::vector<Tensor<1, spacedim>>> &
   Cache<dim, spacedim>::get_vertex_to_cell_centers_directions() const
   {
-    if (contains(update_flags, update_vertex_to_cell_centers_directions))
+    if (contains_bits(update_flags, update_vertex_to_cell_centers_directions))
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
@@ -89,7 +89,7 @@ namespace GridTools
   const std::map<unsigned int, Point<spacedim>> &
   Cache<dim, spacedim>::get_used_vertices() const
   {
-    if (contains(update_flags, update_used_vertices))
+    if (contains_bits(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
         update_flags  = update_flags & ~update_used_vertices;
@@ -103,7 +103,7 @@ namespace GridTools
   const RTree<std::pair<Point<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_used_vertices_rtree() const
   {
-    if (contains(update_flags, update_used_vertices_rtree))
+    if (contains_bits(update_flags, update_used_vertices_rtree))
       {
         const auto &used_vertices = get_used_vertices();
         std::vector<std::pair<Point<spacedim>, unsigned int>> vertices(
@@ -125,7 +125,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_cell_bounding_boxes_rtree() const
   {
-    if (contains(update_flags, update_cell_bounding_boxes_rtree))
+    if (contains_bits(update_flags, update_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -149,7 +149,8 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if (contains(update_flags, update_locally_owned_cell_bounding_boxes_rtree))
+    if (contains_bits(update_flags,
+                      update_locally_owned_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -173,7 +174,7 @@ namespace GridTools
   const RTree<std::pair<BoundingBox<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_covering_rtree(const unsigned int level) const
   {
-    if (contains(update_flags, update_covering_rtree) ||
+    if (contains_bits(update_flags, update_covering_rtree) ||
         covering_rtree.find(level) == covering_rtree.end())
       {
         const auto boxes =
@@ -202,7 +203,7 @@ namespace GridTools
   const std::vector<std::set<unsigned int>> &
   Cache<dim, spacedim>::get_vertex_to_neighbor_subdomain() const
   {
-    if (contains(update_flags, update_vertex_to_neighbor_subdomain))
+    if (contains_bits(update_flags, update_vertex_to_neighbor_subdomain))
       {
         vertex_to_neighbor_subdomain.clear();
         vertex_to_neighbor_subdomain.resize(tria->n_vertices());

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -63,7 +63,8 @@ namespace GridTools
     if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
-        update_flags    = update_flags & ~update_vertex_to_cell_map;
+	// FIXME
+        update_flags    = static_cast<UpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -112,7 +113,8 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
-        update_flags        = update_flags & ~update_used_vertices_rtree;
+	// FIXME
+        update_flags        = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices_rtree));
       }
     return used_vertices_rtree;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -149,8 +149,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if (contains_bits(update_flags,
-                      update_locally_owned_cell_bounding_boxes_rtree))
+    if (contains_bits(update_flags, update_locally_owned_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -64,7 +64,7 @@ namespace GridTools
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
 	// FIXME
-        update_flags    = static_cast<UpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -79,7 +79,8 @@ namespace GridTools
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
-        update_flags = update_flags & ~update_vertex_to_cell_centers_directions;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
       }
     return vertex_to_cell_centers;
   }
@@ -93,7 +94,8 @@ namespace GridTools
     if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
-        update_flags  = update_flags & ~update_used_vertices;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices));
       }
     return used_vertices;
   }
@@ -138,7 +140,8 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
-        update_flags = update_flags & ~update_cell_bounding_boxes_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
       }
     return cell_bounding_boxes_rtree;
   }
@@ -163,8 +166,8 @@ namespace GridTools
           boxes.emplace_back(mapping->get_bounding_box(cell), cell);
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
-        update_flags =
-          update_flags & ~update_locally_owned_cell_bounding_boxes_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_locally_owned_cell_bounding_boxes_rtree));
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }
@@ -175,7 +178,7 @@ namespace GridTools
   const RTree<std::pair<BoundingBox<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_covering_rtree(const unsigned int level) const
   {
-    if (update_flags & update_covering_rtree ||
+    if (contains(update_flags, update_covering_rtree) ||
         covering_rtree.find(level) == covering_rtree.end())
       {
         const auto boxes =
@@ -194,7 +197,8 @@ namespace GridTools
             covering_rtree[level] =
               GridTools::build_global_description_tree(boxes, MPI_COMM_SELF);
           }
-        update_flags = update_flags & ~update_covering_rtree;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_covering_rtree));
       }
 
     return covering_rtree[level];
@@ -215,7 +219,8 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
-        update_flags = update_flags & ~update_vertex_to_neighbor_subdomain;
+	// FIXME
+        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -63,8 +63,10 @@ namespace GridTools
     if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_map));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_cell_map));
       }
     return vertex_to_cells;
   }
@@ -79,8 +81,10 @@ namespace GridTools
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_cell_centers_directions));
       }
     return vertex_to_cell_centers;
   }
@@ -94,8 +98,10 @@ namespace GridTools
     if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_used_vertices));
       }
     return used_vertices;
   }
@@ -115,8 +121,10 @@ namespace GridTools
         for (const auto &it : used_vertices)
           vertices[i++] = std::make_pair(it.second, it.first);
         used_vertices_rtree = pack_rtree(vertices);
-	// FIXME
-        update_flags        = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_used_vertices_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_used_vertices_rtree));
       }
     return used_vertices_rtree;
   }
@@ -140,8 +148,10 @@ namespace GridTools
           boxes[i++] = std::make_pair(mapping->get_bounding_box(cell), cell);
 
         cell_bounding_boxes_rtree = pack_rtree(boxes);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_cell_bounding_boxes_rtree));
       }
     return cell_bounding_boxes_rtree;
   }
@@ -166,8 +176,11 @@ namespace GridTools
           boxes.emplace_back(mapping->get_bounding_box(cell), cell);
 
         locally_owned_cell_bounding_boxes_rtree = pack_rtree(boxes);
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_locally_owned_cell_bounding_boxes_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(
+            ~update_locally_owned_cell_bounding_boxes_rtree));
       }
     return locally_owned_cell_bounding_boxes_rtree;
   }
@@ -197,8 +210,10 @@ namespace GridTools
             covering_rtree[level] =
               GridTools::build_global_description_tree(boxes, MPI_COMM_SELF);
           }
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_covering_rtree));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_covering_rtree));
       }
 
     return covering_rtree[level];
@@ -219,8 +234,10 @@ namespace GridTools
                 vertex_to_neighbor_subdomain[cell->vertex_index(v)].insert(
                   cell->subdomain_id());
           }
-	// FIXME
-        update_flags    = static_cast<CacheUpdateFlags>(static_cast<unsigned int>(update_flags) & static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
+        // FIXME
+        update_flags = static_cast<CacheUpdateFlags>(
+          static_cast<unsigned int>(update_flags) &
+          static_cast<unsigned int>(~update_vertex_to_neighbor_subdomain));
       }
     return vertex_to_neighbor_subdomain;
   }

--- a/source/grid/grid_tools_cache.cc
+++ b/source/grid/grid_tools_cache.cc
@@ -60,7 +60,7 @@ namespace GridTools
     std::set<typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_vertex_to_cell_map() const
   {
-    if ((update_flags & update_vertex_to_cell_map) != 0)
+    if (contains(update_flags, update_vertex_to_cell_map))
       {
         vertex_to_cells = GridTools::vertex_to_cell_map(*tria);
         update_flags    = update_flags & ~update_vertex_to_cell_map;
@@ -74,7 +74,7 @@ namespace GridTools
   const std::vector<std::vector<Tensor<1, spacedim>>> &
   Cache<dim, spacedim>::get_vertex_to_cell_centers_directions() const
   {
-    if ((update_flags & update_vertex_to_cell_centers_directions) != 0)
+    if (contains(update_flags, update_vertex_to_cell_centers_directions))
       {
         vertex_to_cell_centers = GridTools::vertex_to_cell_centers_directions(
           *tria, get_vertex_to_cell_map());
@@ -89,7 +89,7 @@ namespace GridTools
   const std::map<unsigned int, Point<spacedim>> &
   Cache<dim, spacedim>::get_used_vertices() const
   {
-    if ((update_flags & update_used_vertices) != 0)
+    if (contains(update_flags, update_used_vertices))
       {
         used_vertices = GridTools::extract_used_vertices(*tria, *mapping);
         update_flags  = update_flags & ~update_used_vertices;
@@ -103,7 +103,7 @@ namespace GridTools
   const RTree<std::pair<Point<spacedim>, unsigned int>> &
   Cache<dim, spacedim>::get_used_vertices_rtree() const
   {
-    if ((update_flags & update_used_vertices_rtree) != 0)
+    if (contains(update_flags, update_used_vertices_rtree))
       {
         const auto &used_vertices = get_used_vertices();
         std::vector<std::pair<Point<spacedim>, unsigned int>> vertices(
@@ -125,7 +125,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_cell_bounding_boxes_rtree) != 0)
+    if (contains(update_flags, update_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -149,7 +149,7 @@ namespace GridTools
               typename Triangulation<dim, spacedim>::active_cell_iterator>> &
   Cache<dim, spacedim>::get_locally_owned_cell_bounding_boxes_rtree() const
   {
-    if ((update_flags & update_locally_owned_cell_bounding_boxes_rtree) != 0)
+    if (contains(update_flags, update_locally_owned_cell_bounding_boxes_rtree))
       {
         std::vector<std::pair<
           BoundingBox<spacedim>,
@@ -202,7 +202,7 @@ namespace GridTools
   const std::vector<std::set<unsigned int>> &
   Cache<dim, spacedim>::get_vertex_to_neighbor_subdomain() const
   {
-    if ((update_flags & update_vertex_to_neighbor_subdomain) != 0)
+    if (contains(update_flags, update_vertex_to_neighbor_subdomain))
       {
         vertex_to_neighbor_subdomain.clear();
         vertex_to_neighbor_subdomain.resize(tria->n_vertices());

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -107,7 +107,7 @@ namespace NonMatching
   {
     // First call the mapping and let it generate the data specific to the
     // mapping.
-    if (contains(this->update_flags, update_mapping))
+    if (contains_bits(this->update_flags, update_mapping))
       {
         this->get_mapping().fill_fe_immersed_surface_values(
           this->present_cell,
@@ -176,11 +176,11 @@ namespace NonMatching
   {
     UpdateFlags flags = this->compute_update_flags(update_flags);
 
-    if (contains(flags, (update_JxW_values | update_normal_vectors)))
+    if (contains_bits(flags, (update_JxW_values | update_normal_vectors)))
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.
-    if (contains(flags, update_mapping))
+    if (contains_bits(flags, update_mapping))
       this->mapping_output.initialize(this->n_quadrature_points, flags);
     this->finite_element_output.initialize(this->n_quadrature_points,
                                            *this->fe,
@@ -200,7 +200,7 @@ namespace NonMatching
 
     Threads::Task<std::unique_ptr<typename Mapping<dim>::InternalDataBase>>
       mapping_get_data;
-    if (contains(flags, update_mapping))
+    if (contains_bits(flags, update_mapping))
       mapping_get_data = Threads::new_task(&Mapping<dim>::get_data,
                                            *this->mapping,
                                            flags,
@@ -210,7 +210,7 @@ namespace NonMatching
 
     // Then collect answers from the two task above.
     this->fe_data = std::move(fe_get_data.return_value());
-    if (contains(flags, update_mapping))
+    if (contains_bits(flags, update_mapping))
       this->mapping_data = std::move(mapping_get_data.return_value());
     else
       this->mapping_data =

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -107,7 +107,7 @@ namespace NonMatching
   {
     // First call the mapping and let it generate the data specific to the
     // mapping.
-    if (contains_bits(this->update_flags, update_mapping))
+    if (this->update_flags.contains(update_mapping))
       {
         this->get_mapping().fill_fe_immersed_surface_values(
           this->present_cell,
@@ -176,11 +176,11 @@ namespace NonMatching
   {
     UpdateFlags flags = this->compute_update_flags(update_flags);
 
-    if (contains_bits(flags, (update_JxW_values | update_normal_vectors)))
+    if (flags.contains((update_JxW_values | update_normal_vectors)))
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.
-    if (contains_bits(flags, update_mapping))
+    if (flags.contains(update_mapping))
       this->mapping_output.initialize(this->n_quadrature_points, flags);
     this->finite_element_output.initialize(this->n_quadrature_points,
                                            *this->fe,
@@ -200,7 +200,7 @@ namespace NonMatching
 
     Threads::Task<std::unique_ptr<typename Mapping<dim>::InternalDataBase>>
       mapping_get_data;
-    if (contains_bits(flags, update_mapping))
+    if (flags.contains(update_mapping))
       mapping_get_data = Threads::new_task(&Mapping<dim>::get_data,
                                            *this->mapping,
                                            flags,
@@ -210,7 +210,7 @@ namespace NonMatching
 
     // Then collect answers from the two task above.
     this->fe_data = std::move(fe_get_data.return_value());
-    if (contains_bits(flags, update_mapping))
+    if (flags.contains(update_mapping))
       this->mapping_data = std::move(mapping_get_data.return_value());
     else
       this->mapping_data =

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -180,7 +180,7 @@ namespace NonMatching
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       this->mapping_output.initialize(this->n_quadrature_points, flags);
     this->finite_element_output.initialize(this->n_quadrature_points,
                                            *this->fe,
@@ -200,7 +200,7 @@ namespace NonMatching
 
     Threads::Task<std::unique_ptr<typename Mapping<dim>::InternalDataBase>>
       mapping_get_data;
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       mapping_get_data = Threads::new_task(&Mapping<dim>::get_data,
                                            *this->mapping,
                                            flags,
@@ -210,7 +210,7 @@ namespace NonMatching
 
     // Then collect answers from the two task above.
     this->fe_data = std::move(fe_get_data.return_value());
-    if ((flags & update_mapping) != 0u)
+    if (contains(flags, update_mapping))
       this->mapping_data = std::move(mapping_get_data.return_value());
     else
       this->mapping_data =

--- a/source/non_matching/fe_immersed_values.cc
+++ b/source/non_matching/fe_immersed_values.cc
@@ -107,7 +107,7 @@ namespace NonMatching
   {
     // First call the mapping and let it generate the data specific to the
     // mapping.
-    if (this->update_flags & update_mapping)
+    if (contains(this->update_flags, update_mapping))
       {
         this->get_mapping().fill_fe_immersed_surface_values(
           this->present_cell,
@@ -176,7 +176,7 @@ namespace NonMatching
   {
     UpdateFlags flags = this->compute_update_flags(update_flags);
 
-    if ((flags & (update_JxW_values | update_normal_vectors)) != 0u)
+    if (contains(flags, (update_JxW_values | update_normal_vectors)))
       flags |= update_covariant_transformation;
 
     // Initialize the base classes.

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -204,21 +204,21 @@ DataOut<dim, spacedim>::build_one_patch(
                   // we do not need to worry about getting any imaginary
                   // components to the postprocessor, and we can safely
                   // call the function that evaluates a scalar field
-                  if (contains(update_flags, update_values))
+                  if (contains_bits(update_flags, update_values))
                     dataset->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_values);
 
-                  if (contains(update_flags, update_gradients))
+                  if (contains_bits(update_flags, update_gradients))
                     dataset->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_gradients);
 
-                  if (contains(update_flags, update_hessians))
+                  if (contains_bits(update_flags, update_hessians))
                     dataset->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
@@ -227,7 +227,7 @@ DataOut<dim, spacedim>::build_one_patch(
 
                   // Also fill some of the other fields postprocessors may
                   // want to access.
-                  if (contains(update_flags, update_quadrature_points))
+                  if (contains_bits(update_flags, update_quadrature_points))
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -260,21 +260,21 @@ DataOut<dim, spacedim>::build_one_patch(
                     {
                       scratch_data.resize_system_vectors(n_components);
 
-                      if (contains(update_flags, update_values))
+                      if (contains_bits(update_flags, update_values))
                         dataset->get_function_values(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_values);
 
-                      if (contains(update_flags, update_gradients))
+                      if (contains_bits(update_flags, update_gradients))
                         dataset->get_function_gradients(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_gradients);
 
-                      if (contains(update_flags, update_hessians))
+                      if (contains_bits(update_flags, update_hessians))
                         dataset->get_function_hessians(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
@@ -294,7 +294,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // First get the real component of the scalar solution
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
-                          if (contains(update_flags, update_values))
+                          if (contains_bits(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -320,7 +320,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains(update_flags, update_gradients))
+                          if (contains_bits(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -346,7 +346,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains(update_flags, update_hessians))
+                          if (contains_bits(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -377,7 +377,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
                           // that follow the real one
-                          if (contains(update_flags, update_values))
+                          if (contains_bits(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -403,7 +403,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains(update_flags, update_gradients))
+                          if (contains_bits(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -429,7 +429,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains(update_flags, update_hessians))
+                          if (contains_bits(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -484,7 +484,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // values, then the real and imaginary parts of the
                           // gradients, etc. This allows us to scope the
                           // temporary objects better
-                          if (contains(update_flags, update_values))
+                          if (contains_bits(update_flags, update_values))
                             {
                               std::vector<Vector<double>> tmp(
                                 scratch_data.patch_values_system.solution_values
@@ -539,7 +539,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // Now do the exact same thing for the gradients
-                          if (contains(update_flags, update_gradients))
+                          if (contains_bits(update_flags, update_gradients))
                             {
                               std::vector<std::vector<Tensor<1, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -590,7 +590,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // And finally the Hessians. Same scheme as above.
-                          if (contains(update_flags, update_hessians))
+                          if (contains_bits(update_flags, update_hessians))
                             {
                               std::vector<std::vector<Tensor<2, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -643,7 +643,7 @@ DataOut<dim, spacedim>::build_one_patch(
                     }
 
                   // Now set other fields we may need
-                  if (contains(update_flags, update_quadrature_points))
+                  if (contains_bits(update_flags, update_quadrature_points))
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -1222,7 +1222,7 @@ DataOut<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present, which would only be useful on
   // faces, but we may not use it here.
   Assert(
-    !contains(update_flags, update_normal_vectors),
+    !contains_bits(update_flags, update_normal_vectors),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -1222,7 +1222,7 @@ DataOut<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present, which would only be useful on
   // faces, but we may not use it here.
   Assert(
-    !(update_flags & update_normal_vectors),
+    !contains(update_flags, update_normal_vectors),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -204,21 +204,21 @@ DataOut<dim, spacedim>::build_one_patch(
                   // we do not need to worry about getting any imaginary
                   // components to the postprocessor, and we can safely
                   // call the function that evaluates a scalar field
-                  if (contains_bits(update_flags, update_values))
+                  if (update_flags.contains(update_values))
                     dataset->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_values);
 
-                  if (contains_bits(update_flags, update_gradients))
+                  if (update_flags.contains(update_gradients))
                     dataset->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_gradients);
 
-                  if (contains_bits(update_flags, update_hessians))
+                  if (update_flags.contains(update_hessians))
                     dataset->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
@@ -227,7 +227,7 @@ DataOut<dim, spacedim>::build_one_patch(
 
                   // Also fill some of the other fields postprocessors may
                   // want to access.
-                  if (contains_bits(update_flags, update_quadrature_points))
+                  if (update_flags.contains(update_quadrature_points))
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -260,21 +260,21 @@ DataOut<dim, spacedim>::build_one_patch(
                     {
                       scratch_data.resize_system_vectors(n_components);
 
-                      if (contains_bits(update_flags, update_values))
+                      if (update_flags.contains(update_values))
                         dataset->get_function_values(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_values);
 
-                      if (contains_bits(update_flags, update_gradients))
+                      if (update_flags.contains(update_gradients))
                         dataset->get_function_gradients(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_gradients);
 
-                      if (contains_bits(update_flags, update_hessians))
+                      if (update_flags.contains(update_hessians))
                         dataset->get_function_hessians(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
@@ -294,7 +294,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // First get the real component of the scalar solution
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
-                          if (contains_bits(update_flags, update_values))
+                          if (update_flags.contains(update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -320,7 +320,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains_bits(update_flags, update_gradients))
+                          if (update_flags.contains(update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -346,7 +346,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains_bits(update_flags, update_hessians))
+                          if (update_flags.contains(update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -377,7 +377,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
                           // that follow the real one
-                          if (contains_bits(update_flags, update_values))
+                          if (update_flags.contains(update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -403,7 +403,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains_bits(update_flags, update_gradients))
+                          if (update_flags.contains(update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -429,7 +429,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if (contains_bits(update_flags, update_hessians))
+                          if (update_flags.contains(update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -484,7 +484,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // values, then the real and imaginary parts of the
                           // gradients, etc. This allows us to scope the
                           // temporary objects better
-                          if (contains_bits(update_flags, update_values))
+                          if (update_flags.contains(update_values))
                             {
                               std::vector<Vector<double>> tmp(
                                 scratch_data.patch_values_system.solution_values
@@ -539,7 +539,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // Now do the exact same thing for the gradients
-                          if (contains_bits(update_flags, update_gradients))
+                          if (update_flags.contains(update_gradients))
                             {
                               std::vector<std::vector<Tensor<1, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -590,7 +590,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // And finally the Hessians. Same scheme as above.
-                          if (contains_bits(update_flags, update_hessians))
+                          if (update_flags.contains(update_hessians))
                             {
                               std::vector<std::vector<Tensor<2, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -643,7 +643,7 @@ DataOut<dim, spacedim>::build_one_patch(
                     }
 
                   // Now set other fields we may need
-                  if (contains_bits(update_flags, update_quadrature_points))
+                  if (update_flags.contains(update_quadrature_points))
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -1222,7 +1222,7 @@ DataOut<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present, which would only be useful on
   // faces, but we may not use it here.
   Assert(
-    !contains_bits(update_flags, update_normal_vectors),
+    !update_flags.contains(update_normal_vectors),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));

--- a/source/numerics/data_out.cc
+++ b/source/numerics/data_out.cc
@@ -204,21 +204,21 @@ DataOut<dim, spacedim>::build_one_patch(
                   // we do not need to worry about getting any imaginary
                   // components to the postprocessor, and we can safely
                   // call the function that evaluates a scalar field
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     dataset->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_values);
 
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     dataset->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       scratch_data.patch_values_scalar.solution_gradients);
 
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     dataset->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
@@ -227,7 +227,7 @@ DataOut<dim, spacedim>::build_one_patch(
 
                   // Also fill some of the other fields postprocessors may
                   // want to access.
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     scratch_data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
@@ -260,21 +260,21 @@ DataOut<dim, spacedim>::build_one_patch(
                     {
                       scratch_data.resize_system_vectors(n_components);
 
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         dataset->get_function_values(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_values);
 
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         dataset->get_function_gradients(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           scratch_data.patch_values_system.solution_gradients);
 
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         dataset->get_function_hessians(
                           this_fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
@@ -294,7 +294,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // First get the real component of the scalar solution
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -320,7 +320,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -346,7 +346,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -377,7 +377,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // and copy the data into the
                           // scratch_data.patch_values_system output fields
                           // that follow the real one
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               dataset->get_function_values(
                                 this_fe_patch_values,
@@ -403,7 +403,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               dataset->get_function_gradients(
                                 this_fe_patch_values,
@@ -429,7 +429,7 @@ DataOut<dim, spacedim>::build_one_patch(
                                 }
                             }
 
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               dataset->get_function_hessians(
                                 this_fe_patch_values,
@@ -484,7 +484,7 @@ DataOut<dim, spacedim>::build_one_patch(
                           // values, then the real and imaginary parts of the
                           // gradients, etc. This allows us to scope the
                           // temporary objects better
-                          if ((update_flags & update_values) != 0u)
+                          if (contains(update_flags, update_values))
                             {
                               std::vector<Vector<double>> tmp(
                                 scratch_data.patch_values_system.solution_values
@@ -539,7 +539,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // Now do the exact same thing for the gradients
-                          if ((update_flags & update_gradients) != 0u)
+                          if (contains(update_flags, update_gradients))
                             {
                               std::vector<std::vector<Tensor<1, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -590,7 +590,7 @@ DataOut<dim, spacedim>::build_one_patch(
                             }
 
                           // And finally the Hessians. Same scheme as above.
-                          if ((update_flags & update_hessians) != 0u)
+                          if (contains(update_flags, update_hessians))
                             {
                               std::vector<std::vector<Tensor<2, spacedim>>> tmp(
                                 scratch_data.patch_values_system
@@ -643,7 +643,7 @@ DataOut<dim, spacedim>::build_one_patch(
                     }
 
                   // Now set other fields we may need
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     scratch_data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -172,30 +172,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                 {
                   // at each point there is only one component of value,
                   // gradient etc.
-                  if (contains(update_flags, update_values))
+                  if (contains_bits(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_values);
-                  if (contains(update_flags, update_gradients))
+                  if (contains_bits(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_gradients);
-                  if (contains(update_flags, update_hessians))
+                  if (contains_bits(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_hessians);
 
-                  if (contains(update_flags, update_quadrature_points))
+                  if (contains_bits(update_flags, update_quadrature_points))
                     data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if (contains(update_flags, update_normal_vectors))
+                  if (contains_bits(update_flags, update_normal_vectors))
                     data.patch_values_scalar.normals =
                       this_fe_patch_values.get_normal_vectors();
 
@@ -216,30 +216,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                   // at each point there is a vector valued function and its
                   // derivative...
                   data.resize_system_vectors(n_components);
-                  if (contains(update_flags, update_values))
+                  if (contains_bits(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_values);
-                  if (contains(update_flags, update_gradients))
+                  if (contains_bits(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_gradients);
-                  if (contains(update_flags, update_hessians))
+                  if (contains_bits(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_hessians);
 
-                  if (contains(update_flags, update_quadrature_points))
+                  if (contains_bits(update_flags, update_quadrature_points))
                     data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if (contains(update_flags, update_normal_vectors))
+                  if (contains_bits(update_flags, update_normal_vectors))
                     data.patch_values_system.normals =
                       this_fe_patch_values.get_normal_vectors();
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -172,30 +172,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                 {
                   // at each point there is only one component of value,
                   // gradient etc.
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (contains(update_flags, update_normal_vectors))
                     data.patch_values_scalar.normals =
                       this_fe_patch_values.get_normal_vectors();
 
@@ -216,30 +216,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                   // at each point there is a vector valued function and its
                   // derivative...
                   data.resize_system_vectors(n_components);
-                  if ((update_flags & update_values) != 0u)
+                  if (contains(update_flags, update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_values);
-                  if ((update_flags & update_gradients) != 0u)
+                  if (contains(update_flags, update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_gradients);
-                  if ((update_flags & update_hessians) != 0u)
+                  if (contains(update_flags, update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_hessians);
 
-                  if ((update_flags & update_quadrature_points) != 0u)
+                  if (contains(update_flags, update_quadrature_points))
                     data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if ((update_flags & update_normal_vectors) != 0u)
+                  if (contains(update_flags, update_normal_vectors))
                     data.patch_values_system.normals =
                       this_fe_patch_values.get_normal_vectors();
 

--- a/source/numerics/data_out_faces.cc
+++ b/source/numerics/data_out_faces.cc
@@ -172,30 +172,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                 {
                   // at each point there is only one component of value,
                   // gradient etc.
-                  if (contains_bits(update_flags, update_values))
+                  if (update_flags.contains(update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_values);
-                  if (contains_bits(update_flags, update_gradients))
+                  if (update_flags.contains(update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_gradients);
-                  if (contains_bits(update_flags, update_hessians))
+                  if (update_flags.contains(update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_scalar.solution_hessians);
 
-                  if (contains_bits(update_flags, update_quadrature_points))
+                  if (update_flags.contains(update_quadrature_points))
                     data.patch_values_scalar.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if (contains_bits(update_flags, update_normal_vectors))
+                  if (update_flags.contains(update_normal_vectors))
                     data.patch_values_scalar.normals =
                       this_fe_patch_values.get_normal_vectors();
 
@@ -216,30 +216,30 @@ DataOutFaces<dim, spacedim>::build_one_patch(
                   // at each point there is a vector valued function and its
                   // derivative...
                   data.resize_system_vectors(n_components);
-                  if (contains_bits(update_flags, update_values))
+                  if (update_flags.contains(update_values))
                     this->dof_data[dataset]->get_function_values(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_values);
-                  if (contains_bits(update_flags, update_gradients))
+                  if (update_flags.contains(update_gradients))
                     this->dof_data[dataset]->get_function_gradients(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_gradients);
-                  if (contains_bits(update_flags, update_hessians))
+                  if (update_flags.contains(update_hessians))
                     this->dof_data[dataset]->get_function_hessians(
                       this_fe_patch_values,
                       internal::DataOutImplementation::ComponentExtractor::
                         real_part,
                       data.patch_values_system.solution_hessians);
 
-                  if (contains_bits(update_flags, update_quadrature_points))
+                  if (update_flags.contains(update_quadrature_points))
                     data.patch_values_system.evaluation_points =
                       this_fe_patch_values.get_quadrature_points();
 
-                  if (contains_bits(update_flags, update_normal_vectors))
+                  if (update_flags.contains(update_normal_vectors))
                     data.patch_values_system.normals =
                       this_fe_patch_values.get_normal_vectors();
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -220,26 +220,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                       // at each point there is
                       // only one component of
                       // value, gradient etc.
-                      if (contains_bits(update_flags, update_values))
+                      if (update_flags.contains(update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_values);
-                      if (contains_bits(update_flags, update_gradients))
+                      if (update_flags.contains(update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_gradients);
-                      if (contains_bits(update_flags, update_hessians))
+                      if (update_flags.contains(update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_hessians);
 
-                      if (contains_bits(update_flags, update_quadrature_points))
+                      if (update_flags.contains(update_quadrature_points))
                         data.patch_values_scalar.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -261,26 +261,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
 
                       // at each point there is a vector valued function and
                       // its derivative...
-                      if (contains_bits(update_flags, update_values))
+                      if (update_flags.contains(update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_values);
-                      if (contains_bits(update_flags, update_gradients))
+                      if (update_flags.contains(update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_gradients);
-                      if (contains_bits(update_flags, update_hessians))
+                      if (update_flags.contains(update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_hessians);
 
-                      if (contains_bits(update_flags, update_quadrature_points))
+                      if (update_flags.contains(update_quadrature_points))
                         data.patch_values_system.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -482,7 +482,7 @@ DataOutRotation<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present,
   // which would only be useful on faces, but
   // we may not use it here.
-  Assert(!contains_bits(update_flags, update_normal_vectors),
+  Assert(!update_flags.contains(update_normal_vectors),
          ExcMessage("The update of normal vectors may not be requested for "
                     "evaluation of data on cells via DataPostprocessor."));
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -482,7 +482,7 @@ DataOutRotation<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present,
   // which would only be useful on faces, but
   // we may not use it here.
-  Assert(!(update_flags & update_normal_vectors),
+  Assert(contains(update_flags, update_normal_vectors),
          ExcMessage("The update of normal vectors may not be requested for "
                     "evaluation of data on cells via DataPostprocessor."));
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -220,26 +220,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                       // at each point there is
                       // only one component of
                       // value, gradient etc.
-                      if (contains(update_flags, update_values))
+                      if (contains_bits(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_values);
-                      if (contains(update_flags, update_gradients))
+                      if (contains_bits(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_gradients);
-                      if (contains(update_flags, update_hessians))
+                      if (contains_bits(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_hessians);
 
-                      if (contains(update_flags, update_quadrature_points))
+                      if (contains_bits(update_flags, update_quadrature_points))
                         data.patch_values_scalar.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -261,26 +261,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
 
                       // at each point there is a vector valued function and
                       // its derivative...
-                      if (contains(update_flags, update_values))
+                      if (contains_bits(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_values);
-                      if (contains(update_flags, update_gradients))
+                      if (contains_bits(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_gradients);
-                      if (contains(update_flags, update_hessians))
+                      if (contains_bits(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_hessians);
 
-                      if (contains(update_flags, update_quadrature_points))
+                      if (contains_bits(update_flags, update_quadrature_points))
                         data.patch_values_system.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -482,7 +482,7 @@ DataOutRotation<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present,
   // which would only be useful on faces, but
   // we may not use it here.
-  Assert(contains(update_flags, update_normal_vectors),
+  Assert(contains_bits(update_flags, update_normal_vectors),
          ExcMessage("The update of normal vectors may not be requested for "
                     "evaluation of data on cells via DataPostprocessor."));
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -482,7 +482,7 @@ DataOutRotation<dim, spacedim>::build_patches(
   // perhaps update_normal_vectors is present,
   // which would only be useful on faces, but
   // we may not use it here.
-  Assert(contains_bits(update_flags, update_normal_vectors),
+  Assert(!contains_bits(update_flags, update_normal_vectors),
          ExcMessage("The update of normal vectors may not be requested for "
                     "evaluation of data on cells via DataPostprocessor."));
 

--- a/source/numerics/data_out_rotation.cc
+++ b/source/numerics/data_out_rotation.cc
@@ -220,26 +220,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
                       // at each point there is
                       // only one component of
                       // value, gradient etc.
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_scalar.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (contains(update_flags, update_quadrature_points))
                         data.patch_values_scalar.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 
@@ -261,26 +261,26 @@ DataOutRotation<dim, spacedim>::build_one_patch(
 
                       // at each point there is a vector valued function and
                       // its derivative...
-                      if ((update_flags & update_values) != 0u)
+                      if (contains(update_flags, update_values))
                         this->dof_data[dataset]->get_function_values(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_values);
-                      if ((update_flags & update_gradients) != 0u)
+                      if (contains(update_flags, update_gradients))
                         this->dof_data[dataset]->get_function_gradients(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_gradients);
-                      if ((update_flags & update_hessians) != 0u)
+                      if (contains(update_flags, update_hessians))
                         this->dof_data[dataset]->get_function_hessians(
                           fe_patch_values,
                           internal::DataOutImplementation::ComponentExtractor::
                             real_part,
                           data.patch_values_system.solution_hessians);
 
-                      if ((update_flags & update_quadrature_points) != 0u)
+                      if (contains(update_flags, update_quadrature_points))
                         data.patch_values_system.evaluation_points =
                           fe_patch_values.get_quadrature_points();
 

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -669,7 +669,7 @@ PointValueHistory<dim>::evaluate_field(
   const UpdateFlags update_flags =
     data_postprocessor.get_needed_update_flags() | update_quadrature_points;
   Assert(
-    !(update_flags & update_normal_vectors),
+    !(contains(update_flags, update_normal_vectors)),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));
@@ -756,13 +756,13 @@ PointValueHistory<dim>::evaluate_field(
           // type of the solution vector may be different from 'double',
           // but the DataPostprocessorInputs only allow for 'double'
           // data types
-          if (update_flags & update_values)
+          if (contains(update_flags, update_values))
             {
               fe_values.get_function_values(solution, scalar_solution_values);
               postprocessor_input.solution_values =
                 std::vector<double>(1, scalar_solution_values[selected_point]);
             }
-          if (update_flags & update_gradients)
+          if (contains(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                scalar_solution_gradients);
@@ -770,7 +770,7 @@ PointValueHistory<dim>::evaluate_field(
                 std::vector<Tensor<1, dim>>(
                   1, scalar_solution_gradients[selected_point]);
             }
-          if (update_flags & update_hessians)
+          if (contains(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               scalar_solution_hessians);
@@ -792,7 +792,7 @@ PointValueHistory<dim>::evaluate_field(
           // exact same idea as above
           DataPostprocessorInputs::Vector<dim> postprocessor_input;
 
-          if (update_flags & update_values)
+          if (contains(update_flags, update_values))
             {
               fe_values.get_function_values(solution, vector_solution_values);
               postprocessor_input.solution_values.resize(
@@ -801,7 +801,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_values[selected_point].end(),
                         postprocessor_input.solution_values[0].begin());
             }
-          if (update_flags & update_gradients)
+          if (contains(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                vector_solution_gradients);
@@ -811,7 +811,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_gradients[selected_point].end(),
                         postprocessor_input.solution_gradients[0].begin());
             }
-          if (update_flags & update_hessians)
+          if (contains(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               vector_solution_hessians);

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -669,7 +669,7 @@ PointValueHistory<dim>::evaluate_field(
   const UpdateFlags update_flags =
     data_postprocessor.get_needed_update_flags() | update_quadrature_points;
   Assert(
-    !(contains(update_flags, update_normal_vectors)),
+    !(contains_bits(update_flags, update_normal_vectors)),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));
@@ -756,13 +756,13 @@ PointValueHistory<dim>::evaluate_field(
           // type of the solution vector may be different from 'double',
           // but the DataPostprocessorInputs only allow for 'double'
           // data types
-          if (contains(update_flags, update_values))
+          if (contains_bits(update_flags, update_values))
             {
               fe_values.get_function_values(solution, scalar_solution_values);
               postprocessor_input.solution_values =
                 std::vector<double>(1, scalar_solution_values[selected_point]);
             }
-          if (contains(update_flags, update_gradients))
+          if (contains_bits(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                scalar_solution_gradients);
@@ -770,7 +770,7 @@ PointValueHistory<dim>::evaluate_field(
                 std::vector<Tensor<1, dim>>(
                   1, scalar_solution_gradients[selected_point]);
             }
-          if (contains(update_flags, update_hessians))
+          if (contains_bits(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               scalar_solution_hessians);
@@ -792,7 +792,7 @@ PointValueHistory<dim>::evaluate_field(
           // exact same idea as above
           DataPostprocessorInputs::Vector<dim> postprocessor_input;
 
-          if (contains(update_flags, update_values))
+          if (contains_bits(update_flags, update_values))
             {
               fe_values.get_function_values(solution, vector_solution_values);
               postprocessor_input.solution_values.resize(
@@ -801,7 +801,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_values[selected_point].end(),
                         postprocessor_input.solution_values[0].begin());
             }
-          if (contains(update_flags, update_gradients))
+          if (contains_bits(update_flags, update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                vector_solution_gradients);
@@ -811,7 +811,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_gradients[selected_point].end(),
                         postprocessor_input.solution_gradients[0].begin());
             }
-          if (contains(update_flags, update_hessians))
+          if (contains_bits(update_flags, update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               vector_solution_hessians);

--- a/source/numerics/point_value_history.cc
+++ b/source/numerics/point_value_history.cc
@@ -669,7 +669,7 @@ PointValueHistory<dim>::evaluate_field(
   const UpdateFlags update_flags =
     data_postprocessor.get_needed_update_flags() | update_quadrature_points;
   Assert(
-    !(contains_bits(update_flags, update_normal_vectors)),
+    !(update_flags.contains(update_normal_vectors)),
     ExcMessage(
       "The update of normal vectors may not be requested for evaluation of "
       "data on cells via DataPostprocessor."));
@@ -756,13 +756,13 @@ PointValueHistory<dim>::evaluate_field(
           // type of the solution vector may be different from 'double',
           // but the DataPostprocessorInputs only allow for 'double'
           // data types
-          if (contains_bits(update_flags, update_values))
+          if (update_flags.contains(update_values))
             {
               fe_values.get_function_values(solution, scalar_solution_values);
               postprocessor_input.solution_values =
                 std::vector<double>(1, scalar_solution_values[selected_point]);
             }
-          if (contains_bits(update_flags, update_gradients))
+          if (update_flags.contains(update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                scalar_solution_gradients);
@@ -770,7 +770,7 @@ PointValueHistory<dim>::evaluate_field(
                 std::vector<Tensor<1, dim>>(
                   1, scalar_solution_gradients[selected_point]);
             }
-          if (contains_bits(update_flags, update_hessians))
+          if (update_flags.contains(update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               scalar_solution_hessians);
@@ -792,7 +792,7 @@ PointValueHistory<dim>::evaluate_field(
           // exact same idea as above
           DataPostprocessorInputs::Vector<dim> postprocessor_input;
 
-          if (contains_bits(update_flags, update_values))
+          if (update_flags.contains(update_values))
             {
               fe_values.get_function_values(solution, vector_solution_values);
               postprocessor_input.solution_values.resize(
@@ -801,7 +801,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_values[selected_point].end(),
                         postprocessor_input.solution_values[0].begin());
             }
-          if (contains_bits(update_flags, update_gradients))
+          if (update_flags.contains(update_gradients))
             {
               fe_values.get_function_gradients(solution,
                                                vector_solution_gradients);
@@ -811,7 +811,7 @@ PointValueHistory<dim>::evaluate_field(
                         vector_solution_gradients[selected_point].end(),
                         postprocessor_input.solution_gradients[0].begin());
             }
-          if (contains_bits(update_flags, update_hessians))
+          if (update_flags.contains(update_hessians))
             {
               fe_values.get_function_hessians(solution,
                                               vector_solution_hessians);

--- a/tests/simplex/step-31.cc
+++ b/tests/simplex/step-31.cc
@@ -636,7 +636,7 @@ namespace Step31
       stokes_fe,
       quadrature_formula,
       update_values | update_quadrature_points | update_JxW_values |
-        (rebuild_stokes_matrix == true ? update_gradients : UpdateFlags(0)));
+        (rebuild_stokes_matrix == true ? update_gradients : update_default));
     FEValues<dim>      temperature_fe_values(mapping,
                                         temperature_fe,
                                         quadrature_formula,


### PR DESCRIPTION
This is based on the approach described in https://github.com/dealii/dealii/pull/13229#issuecomment-1015531116 to provide an enum-like class for `UpdateFlags` in a (mostly) backward-compatible way.

For now, this class also defines a contains member function but that is, of course, up for discussion and it shouldn't be difficult to change it into an `operator bool()` operator.

Based on and supersedes #13229.