### PR TITLE
Remove an unnecessary 'using namespace std' declaration.

### DIFF
--- a/source/dofs/dof_renumbering.cc
+++ b/source/dofs/dof_renumbering.cc
@@ -72,7 +72,6 @@ namespace DoFRenumbering
     namespace boosttypes
     {
       using namespace ::boost;
-      using namespace std;
 
       using Graph     = adjacency_list<vecS,
                                    vecS,


### PR DESCRIPTION
We have a single `using namespace std` declaration in all of source/, include/, and examples/, and it turns out that it is also pointless and unnecessary. Get rid of it!

/rebuild