### PR TITLE
Avoid 'using namespace' declarations.

### DIFF
--- a/source/algorithms/timestep_control.cc
+++ b/source/algorithms/timestep_control.cc
@@ -20,101 +20,104 @@
 
 DEAL_II_NAMESPACE_OPEN
 
-using namespace Algorithms;
-
-TimestepControl::TimestepControl(double start,
-                                 double final,
-                                 double tolerance,
-                                 double start_step,
-                                 double print_step,
-                                 double max_step)
-  : start_val(start)
-  , final_val(final)
-  , tolerance_val(tolerance)
-  , start_step_val(start_step)
-  , max_step_val(max_step)
-  , min_step_val(0)
-  , current_step_val(start_step)
-  , step_val(start_step)
-  , print_step(print_step)
-  , next_print_val(print_step > 0. ? start_val + print_step : start_val - 1.)
+namespace Algorithms
 {
-  now_val = start_val;
+  TimestepControl::TimestepControl(double start,
+                                   double final,
+                                   double tolerance,
+                                   double start_step,
+                                   double print_step,
+                                   double max_step)
+    : start_val(start)
+    , final_val(final)
+    , tolerance_val(tolerance)
+    , start_step_val(start_step)
+    , max_step_val(max_step)
+    , min_step_val(0)
+    , current_step_val(start_step)
+    , step_val(start_step)
+    , print_step(print_step)
+    , next_print_val(print_step > 0. ? start_val + print_step : start_val - 1.)
+  {
+    now_val = start_val;
 
-  // avoid compiler warning
-  (void)min_step_val;
-}
-
-
-
-void
-TimestepControl::declare_parameters(ParameterHandler &param)
-{
-  param.declare_entry("Start", "0.", Patterns::Double());
-  param.declare_entry("Final", "1.", Patterns::Double());
-  param.declare_entry("First step", "1.e-2", Patterns::Double(0.));
-  param.declare_entry("Max step", "1.", Patterns::Double(0.));
-  param.declare_entry("Tolerance", "1.e-2", Patterns::Double(0.));
-  param.declare_entry("Print step", "-1.", Patterns::Double());
-}
-
-
-
-void
-TimestepControl::parse_parameters(ParameterHandler &param)
-{
-  start(param.get_double("Start"));
-  start_step(param.get_double("First step"));
-  max_step(param.get_double("Max step"));
-  final(param.get_double("Final"));
-  tolerance(param.get_double("Tolerance"));
-  print_step = param.get_double("Print step");
-}
+    // avoid compiler warning
+    (void)min_step_val;
+  }
 
 
 
-bool
-TimestepControl::advance()
-{
-  bool changed = false;
-
-  // Try incrementing time by s
-  double now_trial = now_val + step_val;
-  current_step_val = step_val;
-
-  // If we just missed the final time, increase the step size a bit. This way,
-  // we avoid a very small final step. If the step shot over the final time,
-  // adjust it so we hit the final time exactly.
-  double s1 = .01 * step_val;
-  if (now_trial > final_val - s1)
-    {
-      current_step_val = final_val - now_val;
-      now_trial        = final_val;
-      changed          = true;
-    }
-
-  now_val = now_trial;
-  return changed;
-}
+  void
+  TimestepControl::declare_parameters(ParameterHandler &param)
+  {
+    param.declare_entry("Start", "0.", Patterns::Double());
+    param.declare_entry("Final", "1.", Patterns::Double());
+    param.declare_entry("First step", "1.e-2", Patterns::Double(0.));
+    param.declare_entry("Max step", "1.", Patterns::Double(0.));
+    param.declare_entry("Tolerance", "1.e-2", Patterns::Double(0.));
+    param.declare_entry("Print step", "-1.", Patterns::Double());
+  }
 
 
-bool
-TimestepControl::print()
-{
-  if (print_step == 0.)
-    return false;
-  if (print_step < 0.)
-    return true;
 
-  bool result = (now_val >= next_print_val);
+  void
+  TimestepControl::parse_parameters(ParameterHandler &param)
+  {
+    start(param.get_double("Start"));
+    start_step(param.get_double("First step"));
+    max_step(param.get_double("Max step"));
+    final(param.get_double("Final"));
+    tolerance(param.get_double("Tolerance"));
+    print_step = param.get_double("Print step");
+  }
 
-  if (result)
-    {
-      next_print_val += print_step;
-      if (next_print_val > final_val)
-        next_print_val = final_val;
-    }
-  return result;
-}
+
+
+  bool
+  TimestepControl::advance()
+  {
+    bool changed = false;
+
+    // Try incrementing time by s
+    double now_trial = now_val + step_val;
+    current_step_val = step_val;
+
+    // If we just missed the final time, increase the step size a bit. This way,
+    // we avoid a very small final step. If the step shot over the final time,
+    // adjust it so we hit the final time exactly.
+    double s1 = .01 * step_val;
+    if (now_trial > final_val - s1)
+      {
+        current_step_val = final_val - now_val;
+        now_trial        = final_val;
+        changed          = true;
+      }
+
+    now_val = now_trial;
+    return changed;
+  }
+
+
+  bool
+  TimestepControl::print()
+  {
+    if (print_step == 0.)
+      return false;
+    if (print_step < 0.)
+      return true;
+
+    bool result = (now_val >= next_print_val);
+
+    if (result)
+      {
+        next_print_val += print_step;
+        if (next_print_val > final_val)
+          next_print_val = final_val;
+      }
+    return result;
+  }
+
+} // namespace Algorithms
+
 
 DEAL_II_NAMESPACE_CLOSE

--- a/source/grid/manifold.cc
+++ b/source/grid/manifold.cc
@@ -32,8 +32,6 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 
 DEAL_II_NAMESPACE_OPEN
 
-using namespace Manifolds;
-
 /* -------------------------- Manifold --------------------- */
 template <int dim, int spacedim>
 Point<spacedim>
@@ -318,7 +316,7 @@ Point<spacedim>
 Manifold<dim, spacedim>::get_new_point_on_line(
   const typename Triangulation<dim, spacedim>::line_iterator &line) const
 {
-  const auto points_weights = get_default_points_and_weights(line);
+  const auto points_weights = Manifolds::get_default_points_and_weights(line);
   return get_new_point(make_array_view(points_weights.first.begin(),
                                        points_weights.first.end()),
                        make_array_view(points_weights.second.begin(),
@@ -332,7 +330,7 @@ Point<spacedim>
 Manifold<dim, spacedim>::get_new_point_on_quad(
   const typename Triangulation<dim, spacedim>::quad_iterator &quad) const
 {
-  const auto points_weights = get_default_points_and_weights(quad);
+  const auto points_weights = Manifolds::get_default_points_and_weights(quad);
   return get_new_point(make_array_view(points_weights.first.begin(),
                                        points_weights.first.end()),
                        make_array_view(points_weights.second.begin(),
@@ -463,7 +461,8 @@ Point<3>
 Manifold<3, 3>::get_new_point_on_hex(
   const Triangulation<3, 3>::hex_iterator &hex) const
 {
-  const auto points_weights = get_default_points_and_weights(hex, true);
+  const auto points_weights =
+    Manifolds::get_default_points_and_weights(hex, true);
   return get_new_point(make_array_view(points_weights.first.begin(),
                                        points_weights.first.end()),
                        make_array_view(points_weights.second.begin(),

--- a/source/non_matching/quadrature_generator.cc
+++ b/source/non_matching/quadrature_generator.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 DEAL_II_NAMESPACE_OPEN
+
 namespace NonMatching
 {
   namespace internal
@@ -1252,8 +1253,6 @@ namespace NonMatching
       }
     } // namespace QuadratureGeneratorImplementation
   }   // namespace internal
-
-  using namespace internal::QuadratureGeneratorImplementation;
 
 
 

--- a/source/sundials/arkode.cc
+++ b/source/sundials/arkode.cc
@@ -61,8 +61,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace SUNDIALS
 {
-  using namespace internal;
-
   namespace
   {
     template <typename VectorType>
@@ -519,7 +517,8 @@ namespace SUNDIALS
 
     if (get_local_tolerances)
       {
-        const auto abs_tols = make_nvector_view(get_local_tolerances());
+        const auto abs_tols =
+          internal::make_nvector_view(get_local_tolerances());
         status =
           ARKodeSVtolerances(arkode_mem, data.relative_tolerance, abs_tols);
         AssertARKode(status);

--- a/source/sundials/ida.cc
+++ b/source/sundials/ida.cc
@@ -54,8 +54,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace SUNDIALS
 {
-  using namespace internal;
-
   namespace
   {
     template <typename VectorType>

--- a/source/sundials/kinsol.cc
+++ b/source/sundials/kinsol.cc
@@ -50,9 +50,6 @@ DEAL_II_NAMESPACE_OPEN
 
 namespace SUNDIALS
 {
-  using namespace internal;
-
-
   template <typename VectorType>
   KINSOL<VectorType>::AdditionalData::AdditionalData(
     const SolutionStrategy &strategy,
@@ -328,7 +325,7 @@ namespace SUNDIALS
   unsigned int
   KINSOL<VectorType>::solve(VectorType &initial_guess_and_solution)
   {
-    NVectorView<VectorType> u_scale, f_scale;
+    internal::NVectorView<VectorType> u_scale, f_scale;
 
     VectorType u_scale_temp, f_scale_temp;
 


### PR DESCRIPTION
These declarations are dangerous and lead to difficult to find errors when
used in header files, but also in .cc files when used in scopes that one
can re-enter and when we use unity builds. Avoid where possible.

/rebuild