### PR TITLE
Minor adjustments to the pipe junction geometry.

### DIFF
--- a/include/deal.II/grid/grid_generator.h
+++ b/include/deal.II/grid/grid_generator.h
@@ -1050,7 +1050,7 @@ namespace GridGenerator
    * opening to match their index. All other boundary faces will be assigned
    * boundary ID 3.
    *
-   * <em>Manifold IDs</em> will be set on the mantles of each truncated cone in
+   * @ref GlossManifoldIndicator "Manifold IDs" will be set on the mantles of each truncated cone in
    * the same way. Each cone will have a special manifold object assigned, which
    * is based on the CylindricalManifold class. Further, all cells adjacent to
    * the mantle are given the manifold ID 3. If desired, you can assign an
@@ -1075,8 +1075,9 @@ namespace GridGenerator
    * @param aspect_ratio Aspect ratio of cells, specified as radial over z-extension.
    *                     Default ratio is $\Delta r/\Delta z = 1/2$.
    *
-   * Common configurations of tee fittings that can be generated with the
-   * following sets of parameters are:
+   * Common configurations of tee fittings (that is, "T" fittings, mimicking the
+   * geometry of the letter "T") can be generated with the
+   * following sets of parameters:
    * <div class="threecolumn" style="width: 80%; text-align: center;">
    *   <div>
    *     \htmlonly <style>div.image

--- a/source/grid/grid_generator_pipe_junction.cc
+++ b/source/grid/grid_generator_pipe_junction.cc
@@ -132,7 +132,7 @@ namespace
       virtual Point<spacedim>
       push_forward(const Point<3> &chart_point) const override;
 
-    protected:
+    private:
       /**
        * A vector orthogonal to the normal direction.
        */
@@ -148,7 +148,6 @@ namespace
        */
       const Point<spacedim> point_on_axis;
 
-    private:
       /**
        * Pipe segment properties to calculate its height.
        */
@@ -202,8 +201,7 @@ namespace
     std::unique_ptr<dealii::Manifold<dim, spacedim>>
     Manifold<dim, spacedim>::clone() const
     {
-      return std::make_unique<Manifold<dim, spacedim>>(
-        normal_direction, direction, point_on_axis, data, tolerance);
+      return std::make_unique<Manifold<dim, spacedim>>(*this);
     }
 
 


### PR DESCRIPTION
Follow-up to #13028. @marcfehling 

Primarily, the patch just changes the local `vector` typedef to `vector3d` since I was confused whether it might refer to `std::vector`. Otherwise really nice and clean code you produced there!

/rebuild