### PR TITLE
Fix warning regarding unused parameter

### DIFF
--- a/include/deal.II/base/mpi_consensus_algorithms.templates.h
+++ b/include/deal.II/base/mpi_consensus_algorithms.templates.h
@@ -501,6 +501,7 @@ namespace Utilities
       void
       NBX<T1, T2>::clean_up_and_end_communication(const MPI_Comm &comm)
       {
+        (void)comm;
 #ifdef DEAL_II_WITH_MPI
         // clean up
         {
@@ -528,8 +529,6 @@ namespace Utilities
           AssertThrowMPI(ierr);
 #  endif
         }
-#else
-        (void)comm;
 #endif
       }
 


### PR DESCRIPTION
This fixes the warning about an unused parameter in release mode, https://cdash.43-1.org/viewBuildError.php?type=1&buildid=73