### PR TITLE
Use the new CA interface instead of using AnonymousProcess.

### DIFF
--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -432,11 +432,8 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          ConsensusAlgorithms::AnonymousProcess<char, char> process(
-            [&]() { return destinations; });
-          ConsensusAlgorithms::NBX<char, char> consensus_algorithm(process,
-                                                                   mpi_comm);
-          return consensus_algorithm.run();
+          return ConsensusAlgorithms::NBX<char, char>().run(
+            destinations, {}, {}, {}, mpi_comm);
         }
         // If that was not the case, we need to use the remainder of the code
         // below, i.e., just fall through the if condition above.
@@ -591,11 +588,9 @@ namespace Utilities
       if (Utilities::MPI::min((my_destinations_are_unique ? 1 : 0), mpi_comm) ==
           1)
         {
-          ConsensusAlgorithms::AnonymousProcess<char, char> process(
-            [&]() { return destinations; });
-          ConsensusAlgorithms::NBX<char, char> consensus_algorithm(process,
-                                                                   mpi_comm);
-          return consensus_algorithm.run().size();
+          return ConsensusAlgorithms::NBX<char, char>()
+            .run(destinations, {}, {}, {}, mpi_comm)
+            .size();
         }
       else
 #  endif

--- a/source/grid/grid_tools.cc
+++ b/source/grid/grid_tools.cc
@@ -5933,94 +5933,98 @@ namespace GridTools
         (std::find(marked_vertices.begin(), marked_vertices.end(), true) !=
          marked_vertices.end());
 
-      Utilities::MPI::ConsensusAlgorithms::AnonymousProcess<char, char> process(
-        [&]() { return potential_owners_ranks; },
-        [&](const unsigned int other_rank, std::vector<char> &send_buffer) {
-          const auto other_rank_index = translate(other_rank);
+      const auto create_request = [&](const unsigned int other_rank) {
+        const auto other_rank_index = translate(other_rank);
 
-          std::vector<std::pair<unsigned int, Point<spacedim>>> temp;
-          temp.reserve(potential_owners_ptrs[other_rank_index + 1] -
-                       potential_owners_ptrs[other_rank_index]);
+        std::vector<std::pair<unsigned int, Point<spacedim>>> temp;
+        temp.reserve(potential_owners_ptrs[other_rank_index + 1] -
+                     potential_owners_ptrs[other_rank_index]);
 
-          for (unsigned int i = potential_owners_ptrs[other_rank_index];
-               i < potential_owners_ptrs[other_rank_index + 1];
-               ++i)
-            temp.emplace_back(potential_owners_indices[i],
-                              points[potential_owners_indices[i]]);
+        for (unsigned int i = potential_owners_ptrs[other_rank_index];
+             i < potential_owners_ptrs[other_rank_index + 1];
+             ++i)
+          temp.emplace_back(potential_owners_indices[i],
+                            points[potential_owners_indices[i]]);
 
-          send_buffer = Utilities::pack(temp, false);
-        },
+        return Utilities::pack(temp, false);
+      };
+
+      const auto answer_request =
         [&](const unsigned int &     other_rank,
-            const std::vector<char> &recv_buffer,
-            std::vector<char> &      request_buffer) {
-          const auto recv_buffer_unpacked = Utilities::unpack<
-            std::vector<std::pair<unsigned int, Point<spacedim>>>>(recv_buffer,
-                                                                   false);
+            const std::vector<char> &request) -> std::vector<char> {
+        const auto recv_buffer_unpacked = Utilities::unpack<
+          std::vector<std::pair<unsigned int, Point<spacedim>>>>(request,
+                                                                 false);
 
-          std::vector<unsigned int> request_buffer_temp(
-            recv_buffer_unpacked.size(), 0);
+        std::vector<unsigned int> request_buffer_temp(
+          recv_buffer_unpacked.size(), 0);
 
-          if (has_relevant_vertices)
-            {
-              cell_hint = cache.get_triangulation().begin_active();
+        if (has_relevant_vertices)
+          {
+            cell_hint = cache.get_triangulation().begin_active();
 
-              for (unsigned int i = 0; i < recv_buffer_unpacked.size(); ++i)
-                {
-                  const auto &index_and_point = recv_buffer_unpacked[i];
+            for (unsigned int i = 0; i < recv_buffer_unpacked.size(); ++i)
+              {
+                const auto &index_and_point = recv_buffer_unpacked[i];
 
-                  const auto cells_and_reference_positions =
-                    find_all_locally_owned_active_cells_around_point(
-                      cache,
+                const auto cells_and_reference_positions =
+                  find_all_locally_owned_active_cells_around_point(
+                    cache,
+                    index_and_point.second,
+                    cell_hint,
+                    marked_vertices,
+                    tolerance,
+                    enforce_unique_mapping);
+
+                for (const auto &cell_and_reference_position :
+                     cells_and_reference_positions)
+                  {
+                    send_components.emplace_back(
+                      std::pair<int, int>(
+                        cell_and_reference_position.first->level(),
+                        cell_and_reference_position.first->index()),
+                      other_rank,
+                      index_and_point.first,
+                      cell_and_reference_position.second,
                       index_and_point.second,
-                      cell_hint,
-                      marked_vertices,
-                      tolerance,
-                      enforce_unique_mapping);
+                      numbers::invalid_unsigned_int);
+                  }
 
-                  for (const auto &cell_and_reference_position :
-                       cells_and_reference_positions)
-                    {
-                      send_components.emplace_back(
-                        std::pair<int, int>(
-                          cell_and_reference_position.first->level(),
-                          cell_and_reference_position.first->index()),
-                        other_rank,
-                        index_and_point.first,
-                        cell_and_reference_position.second,
-                        index_and_point.second,
-                        numbers::invalid_unsigned_int);
-                    }
+                request_buffer_temp[i] = cells_and_reference_positions.size();
+              }
+          }
 
-                  request_buffer_temp[i] = cells_and_reference_positions.size();
-                }
-            }
+        if (perform_handshake)
+          return Utilities::pack(request_buffer_temp, false);
+        else
+          return {};
+      };
 
-          if (perform_handshake)
-            request_buffer = Utilities::pack(request_buffer_temp, false);
-        },
-        [&](const unsigned int       other_rank,
-            const std::vector<char> &recv_buffer) {
-          if (perform_handshake)
-            {
-              const auto recv_buffer_unpacked =
-                Utilities::unpack<std::vector<unsigned int>>(recv_buffer,
-                                                             false);
+      const auto process_answer = [&](const unsigned int       other_rank,
+                                      const std::vector<char> &answer) {
+        if (perform_handshake)
+          {
+            const auto recv_buffer_unpacked =
+              Utilities::unpack<std::vector<unsigned int>>(answer, false);
 
-              const auto other_rank_index = translate(other_rank);
+            const auto other_rank_index = translate(other_rank);
 
-              for (unsigned int i = 0; i < recv_buffer_unpacked.size(); ++i)
-                for (unsigned int j = 0; j < recv_buffer_unpacked[i]; ++j)
-                  recv_components.emplace_back(
-                    other_rank,
-                    potential_owners_indices
-                      [i + potential_owners_ptrs[other_rank_index]],
-                    numbers::invalid_unsigned_int);
-            }
-        });
+            for (unsigned int i = 0; i < recv_buffer_unpacked.size(); ++i)
+              for (unsigned int j = 0; j < recv_buffer_unpacked[i]; ++j)
+                recv_components.emplace_back(
+                  other_rank,
+                  potential_owners_indices
+                    [i + potential_owners_ptrs[other_rank_index]],
+                  numbers::invalid_unsigned_int);
+          }
+      };
 
-      Utilities::MPI::ConsensusAlgorithms::Selector<char, char>(
-        process, cache.get_triangulation().get_communicator())
-        .run();
+      Utilities::MPI::ConsensusAlgorithms::Selector<char, char>().run(
+        potential_owners_ranks,
+        create_request,
+        answer_request,
+        process_answer,
+        cache.get_triangulation().get_communicator());
 
       if (true)
         {


### PR DESCRIPTION
This switches our uses of the CA algorithms from the old `AnonymousProcess` approach to using the interfaces introduced by #13208/#13272.

The patch might be easiest to read when ignoring whitespace changes. Basically, it does two things:
* Where previously we built an `AnonymousProcess` object that takes 3 unnamed lambda functions as arguments, I now generally just create 3 *named* lambda functions and pass these as arguments to the CA `run()` functions. Some of these functions are non-trivial and I thought it useful to give them names.
* In the old interface, these functions return their information through the last function argument. The new interface requires that they just `return` objects.

There should be no functional changes in this patch.

/rebuild