### PR TITLE
Fix deduction matrix free

### DIFF
--- a/include/deal.II/lac/la_parallel_vector.h
+++ b/include/deal.II/lac/la_parallel_vector.h
@@ -1918,7 +1918,8 @@ namespace internal
       // void T::initialize_dof_vector(VectorType v)
       template <typename T>
       using initialize_dof_vector_t =
-        decltype(std::declval<T>().initialize_dof_vector());
+        decltype(std::declval<T>().initialize_dof_vector(
+          std::declval<LinearAlgebra::distributed::Vector<Number> &>()));
 
       template <typename T>
       static constexpr bool has_initialize_dof_vector =

--- a/tests/matrix_free/laplace_operator_02.cc
+++ b/tests/matrix_free/laplace_operator_02.cc
@@ -15,7 +15,8 @@
 
 
 
-// the same as laplace_operator_01, but tests heterogeneous Laplace operator.
+// the same as laplace_operator_01 (excluding the extra detection tests), but
+// tests heterogeneous Laplace operator.
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/utilities.h>

--- a/tests/matrix_free/laplace_operator_03.cc
+++ b/tests/matrix_free/laplace_operator_03.cc
@@ -15,8 +15,8 @@
 
 
 
-// the same as laplace_operator_01, but heterogeneous Laplace operator with a
-// single constant coefficient per cell
+// the same as laplace_operator_01 (excluding the extra detection tests), but
+// heterogeneous Laplace operator with a single constant coefficient per cell
 
 #include <deal.II/base/function.h>
 #include <deal.II/base/utilities.h>


### PR DESCRIPTION
This fixes a bug introduced in #13291: `initialize_dof_vector()` takes a vector as argument, so we won't get the correct detection unless we give it one. The other things we changed in 6bf718672dac are OK since they don't have function arguments.

We don't seem to have any tests that use this so I augmented two tests that use this class to check detection - that seemed a bit better than copying and pasting and changing one line in each.

/rebuild