### PR TITLE
Do not free objects we still need.

### DIFF
--- a/include/deal.II/base/aligned_vector.h
+++ b/include/deal.II/base/aligned_vector.h
@@ -1663,7 +1663,7 @@ AlignedVector<T>::replicate_across_communicator(const MPI_Comm &   communicator,
     }
 
   // We no longer need the shmem roots communicator, so get rid of it
-  Utilities::MPI::free_communicator(shmem_group_communicator);
+  Utilities::MPI::free_communicator(shmem_roots_communicator);
 
 
   // **** Step 3 ****


### PR DESCRIPTION
It's not clear to me how this bug has slipped into our code base. We have a call to free a communicator that is clearly used again multiple times in the lines below. Predictably, we run into trouble when using the freed communicator a few lines later.

This patch simply removes the offending line. We do release the communicator in a separate place, namely the `Deleter` object that is used for the shmem shared data array. The deleter is set in line 1856, and implemented in line 1144.

Found while playing with https://github.com/geodynamics/aspect/pull/4086 .