### PR TITLE
step-55: init sparsity pattern with relevant dofs

### DIFF
--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -425,7 +425,7 @@ namespace Step55
           else
             coupling[c][d] = DoFTools::none;
 
-      BlockDynamicSparsityPattern dsp(dofs_per_block, dofs_per_block);
+      BlockDynamicSparsityPattern dsp(relevant_partitioning);
 
       DoFTools::make_sparsity_pattern(
         dof_handler, coupling, dsp, constraints, false);
@@ -453,7 +453,7 @@ namespace Step55
           else
             coupling[c][d] = DoFTools::none;
 
-      BlockDynamicSparsityPattern dsp(dofs_per_block, dofs_per_block);
+      BlockDynamicSparsityPattern dsp(relevant_partitioning);
 
       DoFTools::make_sparsity_pattern(
         dof_handler, coupling, dsp, constraints, false);


### PR DESCRIPTION
When increasing the problem size and solving `step-55` on plenty of MPI processes (~100), I noticed that `setup_system()` consumes a lot of memory.

I noticed that we initialize the `BlockDynamicSparsityPattern` with all dofs in the system.

I cross-checked with `step-40` where we initialize the corresponding `DynamicSparsityPattern` with locally relevant dofs, and proposed the same for `step-55` with this PR.

Are locally relevant dofs the right choice? The [documentation](https://www.dealii.org/developer/doxygen/deal.II/classBlockDynamicSparsityPattern.html#a84308030b94054c7cc4623219cda0091) says locally owned should be favored in most cases.