### PR TITLE
Implement new Table<3, T>::reinit()

### DIFF
--- a/include/deal.II/base/table.h
+++ b/include/deal.II/base/table.h
@@ -1550,6 +1550,18 @@ public:
         const bool      C_style_indexing = true);
 
   /**
+   * Reinitialize the object. Passes down to the base class
+   * by converting the arguments to the data type requested by the base class.
+   */
+  void
+  reinit(const size_type size1,
+         const size_type size2,
+         const size_type size3,
+         const bool      omit_default_initialization = false);
+
+  using TableBase<3, T>::reinit;
+
+  /**
    * Access operator. Generate an object that accesses the requested two-
    * dimensional subobject of this three-dimensional table. Range checks are
    * performed.
@@ -3235,6 +3247,19 @@ inline Table<3, T>::Table(const size_type size1,
                     entries,
                     C_style_indexing)
 {}
+
+
+
+template <typename T>
+inline void
+Table<3, T>::reinit(const size_type size1,
+                    const size_type size2,
+                    const size_type size3,
+                    const bool      omit_default_initialization)
+{
+  this->TableBase<3, T>::reinit(TableIndices<3>(size1, size2, size3),
+                                omit_default_initialization);
+}
 
 
 


### PR DESCRIPTION
... to be consistent with the constructor and `Table<2, T>::reinit()`