### PR TITLE
Early deprecate functions in DoFTools

### DIFF
--- a/doc/news/changes/incompatibilities/20220212Munch
+++ b/doc/news/changes/incompatibilities/20220212Munch
@@ -1,0 +1,9 @@
+Deprecated: We have introduced new versions of
+DoFTools::extract_locally_active_dofs(),
+DoFTools::extract_locally_active_level_dofs(),
+DoFTools::extract_locally_relevant_dofs(), and
+DoFTools::extract_locally_relevant_level_dofs().
+These versions return the index sets directly.
+The old versions have been early deprecated.
+<br>
+(Peter Munch, 2022/02/23)

--- a/examples/step-16/step-16.cc
+++ b/examples/step-16/step-16.cc
@@ -432,10 +432,8 @@ namespace Step16
     std::vector<AffineConstraints<double>> boundary_constraints(n_levels);
     for (unsigned int level = 0; level < n_levels; ++level)
       {
-        IndexSet dofset;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      dofset);
+        const IndexSet dofset =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         boundary_constraints[level].reinit(dofset);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/examples/step-18/step-18.cc
+++ b/examples/step-18/step-18.cc
@@ -800,7 +800,8 @@ namespace Step18
   {
     dof_handler.distribute_dofs(fe);
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // The next step is to set up constraints due to hanging nodes. This has
     // been handled many times before:

--- a/examples/step-32/step-32.cc
+++ b/examples/step-32/step-32.cc
@@ -1864,16 +1864,16 @@ namespace Step32
       stokes_partitioning.push_back(stokes_index_set.get_view(0, n_u));
       stokes_partitioning.push_back(stokes_index_set.get_view(n_u, n_u + n_p));
 
-      DoFTools::extract_locally_relevant_dofs(stokes_dof_handler,
-                                              stokes_relevant_set);
+      stokes_relevant_set =
+        DoFTools::extract_locally_relevant_dofs(stokes_dof_handler);
       stokes_relevant_partitioning.push_back(
         stokes_relevant_set.get_view(0, n_u));
       stokes_relevant_partitioning.push_back(
         stokes_relevant_set.get_view(n_u, n_u + n_p));
 
       temperature_partitioning = temperature_dof_handler.locally_owned_dofs();
-      DoFTools::extract_locally_relevant_dofs(
-        temperature_dof_handler, temperature_relevant_partitioning);
+      temperature_relevant_partitioning =
+        DoFTools::extract_locally_relevant_dofs(temperature_dof_handler);
     }
 
     // Following this, we can compute constraints for the solution vectors,

--- a/examples/step-37/doc/results.dox
+++ b/examples/step-37/doc/results.dox
@@ -427,8 +427,7 @@ temporary vector and LinearAlgebra::distributed::Vector::copy_locally_owned_data
 as shown below.
 
 @code
-IndexSet locally_relevant_dofs;
-DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+const IndexSet locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
 LinearAlgebra::distributed::Vector<double> copy_vec(solution);
 solution.reinit(dof_handler.locally_owned_dofs(),
                 locally_relevant_dofs,

--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -792,8 +792,8 @@ namespace Step37
     pcout << "Number of degrees of freedom: " << dof_handler.n_dofs()
           << std::endl;
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
@@ -852,10 +852,8 @@ namespace Step37
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);
         level_constraints.add_lines(

--- a/examples/step-40/step-40.cc
+++ b/examples/step-40/step-40.cc
@@ -256,7 +256,8 @@ namespace Step40
     // around the locally owned cells; we need all of these degrees of
     // freedom, for example, to estimate the error on the local cells).
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     // Next, let us initialize the solution and right hand side vectors. As
     // mentioned above, the solution vector we seek does not only store

--- a/examples/step-42/step-42.cc
+++ b/examples/step-42/step-42.cc
@@ -973,9 +973,8 @@ namespace Step42
       dof_handler.distribute_dofs(fe);
 
       locally_owned_dofs = dof_handler.locally_owned_dofs();
-      locally_relevant_dofs.clear();
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
     }
 
     /* setup hanging nodes and Dirichlet constraints */

--- a/examples/step-45/step-45.cc
+++ b/examples/step-45/step-45.cc
@@ -374,9 +374,8 @@ namespace Step45
       owned_partitioning.push_back(locally_owned_dofs.get_view(n_u, n_u + n_p));
 
       relevant_partitioning.clear();
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       relevant_partitioning.push_back(locally_relevant_dofs.get_view(0, n_u));
       relevant_partitioning.push_back(
         locally_relevant_dofs.get_view(n_u, n_u + n_p));

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -427,7 +427,8 @@ namespace Step48
     // access in MPI-local numbers that need to match between the vector and
     // MatrixFree), so we just ask it to initialize the vectors to be sure the
     // ghost exchange is properly handled.
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
     DoFTools::make_hanging_node_constraints(dof_handler, constraints);

--- a/examples/step-50/step-50.cc
+++ b/examples/step-50/step-50.cc
@@ -487,8 +487,8 @@ void LaplaceProblem<dim, degree>::setup_system()
 
   dof_handler.distribute_dofs(fe);
 
-  DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
-  locally_owned_dofs = dof_handler.locally_owned_dofs();
+  locally_relevant_dofs = DoFTools::extract_locally_relevant_dofs(dof_handler);
+  locally_owned_dofs    = dof_handler.locally_owned_dofs();
 
   solution.reinit(locally_owned_dofs, mpi_communicator);
   right_hand_side.reinit(locally_owned_dofs, mpi_communicator);
@@ -594,10 +594,9 @@ void LaplaceProblem<dim, degree>::setup_multigrid()
 
           for (unsigned int level = 0; level < n_levels; ++level)
             {
-              IndexSet relevant_dofs;
-              DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                            level,
-                                                            relevant_dofs);
+              const IndexSet relevant_dofs =
+                DoFTools::extract_locally_relevant_level_dofs(dof_handler,
+                                                              level);
               AffineConstraints<double> level_constraints;
               level_constraints.reinit(relevant_dofs);
               level_constraints.add_lines(
@@ -642,10 +641,9 @@ void LaplaceProblem<dim, degree>::setup_multigrid()
 
           for (unsigned int level = 0; level < n_levels; ++level)
             {
-              IndexSet dof_set;
-              DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                            level,
-                                                            dof_set);
+              const IndexSet dof_set =
+                DoFTools::extract_locally_relevant_level_dofs(dof_handler,
+                                                              level);
 
               {
 #ifdef USE_PETSC_LA
@@ -828,10 +826,8 @@ void LaplaceProblem<dim, degree>::assemble_multigrid()
     triangulation.n_global_levels());
   for (unsigned int level = 0; level < triangulation.n_global_levels(); ++level)
     {
-      IndexSet dof_set;
-      DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                    level,
-                                                    dof_set);
+      const IndexSet dof_set =
+        DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
       boundary_constraints[level].reinit(dof_set);
       boundary_constraints[level].add_lines(
         mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/examples/step-55/step-55.cc
+++ b/examples/step-55/step-55.cc
@@ -382,8 +382,8 @@ namespace Step55
     owned_partitioning[1] =
       dof_handler.locally_owned_dofs().get_view(n_u, n_u + n_p);
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     relevant_partitioning.resize(2);
     relevant_partitioning[0] = locally_relevant_dofs.get_view(0, n_u);
     relevant_partitioning[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);

--- a/examples/step-62/step-62.cc
+++ b/examples/step-62/step-62.cc
@@ -748,7 +748,8 @@ namespace step62
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/examples/step-63/step-63.cc
+++ b/examples/step-63/step-63.cc
@@ -814,9 +814,8 @@ namespace Step63
     for (unsigned int level = 0; level < triangulation.n_global_levels();
          ++level)
       {
-        IndexSet locally_owned_level_dof_indices;
-        DoFTools::extract_locally_relevant_level_dofs(
-          dof_handler, level, locally_owned_level_dof_indices);
+        const IndexSet locally_owned_level_dof_indices =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
         boundary_constraints[level].reinit(locally_owned_level_dof_indices);
         boundary_constraints[level].add_lines(
           mg_constrained_dofs.get_refinement_edge_indices(level));

--- a/examples/step-64/step-64.cu
+++ b/examples/step-64/step-64.cu
@@ -397,7 +397,8 @@ namespace Step64
     dof_handler.distribute_dofs(fe);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
     system_rhs_dev.reinit(locally_owned_dofs, mpi_communicator);
 
     constraints.clear();

--- a/examples/step-66/step-66.cc
+++ b/examples/step-66/step-66.cc
@@ -544,8 +544,8 @@ namespace Step66
     dof_handler.distribute_dofs(fe);
     dof_handler.distribute_mg_dofs();
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     constraints.clear();
     constraints.reinit(locally_relevant_dofs);
@@ -593,10 +593,8 @@ namespace Step66
 
     for (unsigned int level = 0; level < nlevels; ++level)
       {
-        IndexSet relevant_dofs;
-        DoFTools::extract_locally_relevant_level_dofs(dof_handler,
-                                                      level,
-                                                      relevant_dofs);
+        const IndexSet relevant_dofs =
+          DoFTools::extract_locally_relevant_level_dofs(dof_handler, level);
 
         AffineConstraints<double> level_constraints;
         level_constraints.reinit(relevant_dofs);

--- a/examples/step-68/step-68.cc
+++ b/examples/step-68/step-68.cc
@@ -474,8 +474,8 @@ namespace Step68
   {
     fluid_dh.distribute_dofs(fluid_fe);
     const IndexSet locally_owned_dofs = fluid_dh.locally_owned_dofs();
-    IndexSet       locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(fluid_dh, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(fluid_dh);
 
     velocity_field.reinit(locally_owned_dofs,
                           locally_relevant_dofs,

--- a/examples/step-69/step-69.cc
+++ b/examples/step-69/step-69.cc
@@ -713,7 +713,7 @@ namespace Step69
       locally_owned   = dof_handler.locally_owned_dofs();
       n_locally_owned = locally_owned.n_elements();
 
-      DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant);
+      locally_relevant   = DoFTools::extract_locally_relevant_dofs(dof_handler);
       n_locally_relevant = locally_relevant.n_elements();
 
       partitioner =

--- a/examples/step-70/step-70.cc
+++ b/examples/step-70/step-70.cc
@@ -1231,8 +1231,8 @@ namespace Step70
     fluid_owned_dofs[1] =
       fluid_dh.locally_owned_dofs().get_view(n_u, n_u + n_p);
 
-    IndexSet locally_relevant_dofs;
-    DoFTools::extract_locally_relevant_dofs(fluid_dh, locally_relevant_dofs);
+    const IndexSet locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(fluid_dh);
     fluid_relevant_dofs.resize(2);
     fluid_relevant_dofs[0] = locally_relevant_dofs.get_view(0, n_u);
     fluid_relevant_dofs[1] = locally_relevant_dofs.get_view(n_u, n_u + n_p);

--- a/examples/step-75/step-75.cc
+++ b/examples/step-75/step-75.cc
@@ -324,9 +324,8 @@ namespace Step75
     {
       AffineConstraints<number> constraints_without_dbc;
 
-      IndexSet locally_relevant_dofs;
-      DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                              locally_relevant_dofs);
+      const IndexSet locally_relevant_dofs =
+        DoFTools::extract_locally_relevant_dofs(dof_handler);
       constraints_without_dbc.reinit(locally_relevant_dofs);
 
       DoFTools::make_hanging_node_constraints(dof_handler,
@@ -777,9 +776,8 @@ namespace Step75
         const auto &dof_handler = dof_handlers[level];
         auto &      constraint  = constraints[level];
 
-        IndexSet locally_relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(dof_handler,
-                                                locally_relevant_dofs);
+        const IndexSet locally_relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(dof_handler);
         constraint.reinit(locally_relevant_dofs);
 
         DoFTools::make_hanging_node_constraints(dof_handler, constraint);
@@ -1105,7 +1103,8 @@ namespace Step75
     dof_handler.distribute_dofs(fe_collection);
 
     locally_owned_dofs = dof_handler.locally_owned_dofs();
-    DoFTools::extract_locally_relevant_dofs(dof_handler, locally_relevant_dofs);
+    locally_relevant_dofs =
+      DoFTools::extract_locally_relevant_dofs(dof_handler);
 
     locally_relevant_solution.reinit(locally_owned_dofs,
                                      locally_relevant_dofs,

--- a/include/deal.II/dofs/dof_tools.h
+++ b/include/deal.II/dofs/dof_tools.h
@@ -1554,6 +1554,26 @@ namespace DoFTools
    * with the locally owned subdomain id.
    */
   template <int dim, int spacedim>
+  IndexSet
+  extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler);
+
+  /**
+   * Extract the set of global DoF indices that are active on the current
+   * DoFHandler. For regular DoFHandlers, these are all DoF indices, but for
+   * DoFHandler objects built on parallel::distributed::Triangulation this set
+   * is a superset of DoFHandler::locally_owned_dofs() and contains all DoF
+   * indices that live on all locally owned cells (including on the interface
+   * to ghost cells). However, it does not contain the DoF indices that are
+   * exclusively defined on ghost or artificial cells (see
+   * @ref GlossArtificialCell "the glossary").
+   *
+   * The degrees of freedom identified by this function equal those obtained
+   * from the dof_indices_with_subdomain_association() function when called
+   * with the locally owned subdomain id.
+   *
+   * @deprecated Use the previous function instead.
+   */
+  template <int dim, int spacedim>
   void
   extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler,
                               IndexSet &                       dof_set);
@@ -1563,6 +1583,20 @@ namespace DoFTools
    * This function returns all DoF indices that live on
    * all locally owned cells (including on the interface to ghost cells) on the
    * given level.
+   */
+  template <int dim, int spacedim>
+  IndexSet
+  extract_locally_active_level_dofs(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const unsigned int               level);
+
+  /**
+   * Same function as above but for a certain (multigrid-)level.
+   * This function returns all DoF indices that live on
+   * all locally owned cells (including on the interface to ghost cells) on the
+   * given level.
+   *
+   * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
   void
@@ -1581,10 +1615,24 @@ namespace DoFTools
    * @ref GlossArtificialCell "the glossary").
    */
   template <int dim, int spacedim>
+  IndexSet
+  extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler);
+
+  /**
+   * Extract the set of global DoF indices that are active on the current
+   * DoFHandler. For regular DoFHandlers, these are all DoF indices, but for
+   * DoFHandler objects built on parallel::distributed::Triangulation this set
+   * is the union of DoFHandler::locally_owned_dofs() and the DoF indices on
+   * all ghost cells. In essence, it is the DoF indices on all cells that are
+   * not artificial (see
+   * @ref GlossArtificialCell "the glossary").
+   *
+   * @deprecated Use the previous function instead.
+   */
+  template <int dim, int spacedim>
   void
   extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler,
                                 IndexSet &                       dof_set);
-
 
   /**
    * Extract the set of locally owned DoF indices for each component within the
@@ -1638,10 +1686,21 @@ namespace DoFTools
   locally_relevant_dofs_per_subdomain(
     const DoFHandler<dim, spacedim> &dof_handler);
 
+  /**
+   * Same as extract_locally_relevant_dofs() but for multigrid DoFs for the
+   * given @p level.
+   */
+  template <int dim, int spacedim>
+  IndexSet
+  extract_locally_relevant_level_dofs(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const unsigned int               level);
 
   /**
    * Same as extract_locally_relevant_dofs() but for multigrid DoFs for the
    * given @p level.
+   *
+   * @deprecated Use the previous function instead.
    */
   template <int dim, int spacedim>
   void

--- a/include/deal.II/matrix_free/cuda_matrix_free.templates.h
+++ b/include/deal.II/matrix_free/cuda_matrix_free.templates.h
@@ -1077,8 +1077,8 @@ namespace CUDAWrappers
     IndexSet locally_relevant_dofs;
     if (comm)
       {
-        DoFTools::extract_locally_relevant_dofs(*dof_handler,
-                                                locally_relevant_dofs);
+        locally_relevant_dofs =
+          DoFTools::extract_locally_relevant_dofs(*dof_handler);
         partitioner = std::make_shared<Utilities::MPI::Partitioner>(
           dof_handler->locally_owned_dofs(), locally_relevant_dofs, *comm);
       }

--- a/include/deal.II/multigrid/mg_constrained_dofs.h
+++ b/include/deal.II/multigrid/mg_constrained_dofs.h
@@ -262,8 +262,8 @@ MGConstrainedDoFs::initialize(
         }
       else
         {
-          IndexSet relevant_dofs;
-          DoFTools::extract_locally_relevant_level_dofs(dof, l, relevant_dofs);
+          const IndexSet relevant_dofs =
+            DoFTools::extract_locally_relevant_level_dofs(dof, l);
           level_constraints[l].reinit(relevant_dofs);
         }
 

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -1048,12 +1048,11 @@ namespace DoFTools
 
 
   template <int dim, int spacedim>
-  void
-  extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-                              IndexSet &                       dof_set)
+  IndexSet
+  extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler)
   {
     // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_dofs();
+    IndexSet dof_set = dof_handler.locally_owned_dofs();
 
     // add the DoF on the adjacent ghost cells to the IndexSet, cache them
     // in a set. need to check each dof manually because we can't be sure
@@ -1075,19 +1074,30 @@ namespace DoFTools
     dof_set.add_indices(global_dof_indices.begin(), global_dof_indices.end());
 
     dof_set.compress();
+
+    return dof_set;
   }
 
 
 
   template <int dim, int spacedim>
   void
+  extract_locally_active_dofs(const DoFHandler<dim, spacedim> &dof_handler,
+                              IndexSet &                       dof_set)
+  {
+    dof_set = extract_locally_active_dofs(dof_handler);
+  }
+
+
+
+  template <int dim, int spacedim>
+  IndexSet
   extract_locally_active_level_dofs(
     const DoFHandler<dim, spacedim> &dof_handler,
-    IndexSet &                       dof_set,
     const unsigned int               level)
   {
     // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_mg_dofs(level);
+    IndexSet dof_set = dof_handler.locally_owned_mg_dofs(level);
 
     // add the DoF on the adjacent ghost cells to the IndexSet, cache them
     // in a set. need to check each dof manually because we can't be sure
@@ -1111,17 +1121,30 @@ namespace DoFTools
     dof_set.add_indices(global_dof_indices.begin(), global_dof_indices.end());
 
     dof_set.compress();
+
+    return dof_set;
   }
 
 
 
   template <int dim, int spacedim>
   void
-  extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler,
-                                IndexSet &                       dof_set)
+  extract_locally_active_level_dofs(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    IndexSet &                       dof_set,
+    const unsigned int               level)
+  {
+    dof_set = extract_locally_active_level_dofs(dof_handler, level);
+  }
+
+
+
+  template <int dim, int spacedim>
+  IndexSet
+  extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler)
   {
     // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_dofs();
+    IndexSet dof_set = dof_handler.locally_owned_dofs();
 
     // now add the DoF on the adjacent ghost cells to the IndexSet
 
@@ -1150,19 +1173,30 @@ namespace DoFTools
                         std::unique(dofs_on_ghosts.begin(),
                                     dofs_on_ghosts.end()));
     dof_set.compress();
+
+    return dof_set;
   }
 
 
 
   template <int dim, int spacedim>
   void
+  extract_locally_relevant_dofs(const DoFHandler<dim, spacedim> &dof_handler,
+                                IndexSet &                       dof_set)
+  {
+    dof_set = extract_locally_relevant_dofs(dof_handler);
+  }
+
+
+
+  template <int dim, int spacedim>
+  IndexSet
   extract_locally_relevant_level_dofs(
     const DoFHandler<dim, spacedim> &dof_handler,
-    const unsigned int               level,
-    IndexSet &                       dof_set)
+    const unsigned int               level)
   {
     // collect all the locally owned dofs
-    dof_set = dof_handler.locally_owned_mg_dofs(level);
+    IndexSet dof_set = dof_handler.locally_owned_mg_dofs(level);
 
     // add the DoF on the adjacent ghost cells to the IndexSet
 
@@ -1198,6 +1232,20 @@ namespace DoFTools
                                     dofs_on_ghosts.end()));
 
     dof_set.compress();
+
+    return dof_set;
+  }
+
+
+
+  template <int dim, int spacedim>
+  void
+  extract_locally_relevant_level_dofs(
+    const DoFHandler<dim, spacedim> &dof_handler,
+    const unsigned int               level,
+    IndexSet &                       dof_set)
+  {
+    dof_set = extract_locally_relevant_level_dofs(dof_handler, level);
   }
 
 

--- a/source/dofs/dof_tools.inst.in
+++ b/source/dofs/dof_tools.inst.in
@@ -19,11 +19,23 @@ for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
 #if deal_II_dimension <= deal_II_space_dimension
     namespace DoFTools
     \{
+      template IndexSet
+      extract_locally_relevant_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &dof_handler);
+
       template void
       extract_locally_relevant_dofs<deal_II_dimension, deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension>
           &       dof_handler,
         IndexSet &dof_set);
+
+      template IndexSet
+      extract_locally_relevant_level_dofs<deal_II_dimension,
+                                          deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &                dof_handler,
+        const unsigned int level);
 
       template void
       extract_locally_relevant_level_dofs<deal_II_dimension,
@@ -33,11 +45,23 @@ for (deal_II_dimension, deal_II_space_dimension : DIMENSIONS)
         const unsigned int level,
         IndexSet &         dof_set);
 
+      template IndexSet
+      extract_locally_active_dofs<deal_II_dimension, deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &dof_handler);
+
       template void
       extract_locally_active_dofs<deal_II_dimension, deal_II_space_dimension>(
         const DoFHandler<deal_II_dimension, deal_II_space_dimension>
           &       dof_handler,
         IndexSet &dof_set);
+
+      template IndexSet
+      extract_locally_active_level_dofs<deal_II_dimension,
+                                        deal_II_space_dimension>(
+        const DoFHandler<deal_II_dimension, deal_II_space_dimension>
+          &                dof_handler,
+        const unsigned int level);
 
       template void
       extract_locally_active_level_dofs<deal_II_dimension,


### PR DESCRIPTION
... many functions already return the `IndexSet`s directly.