### PR TITLE
Use the correct data type for a buffer size variable.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1778,7 +1778,7 @@ namespace Utilities
       (void)n_procs;
 
       std::vector<char> buffer;
-      unsigned int      buffer_size = numbers::invalid_unsigned_int;
+      std::size_t       buffer_size = numbers::invalid_size_type;
 
       // On the root process, pack the data and determine what the
       // buffer size needs to be.
@@ -1789,7 +1789,11 @@ namespace Utilities
         }
 
       // Exchange the size of buffer
-      int ierr = MPI_Bcast(&buffer_size, 1, MPI_UNSIGNED, root_process, comm);
+      int ierr = MPI_Bcast(&buffer_size,
+                           1,
+                           internal::mpi_type_id(&buffer_size),
+                           root_process,
+                           comm);
       AssertThrowMPI(ierr);
 
       // If not on the root process, correctly size the buffer to


### PR DESCRIPTION
#13357 is about the fact that `MPI::broadcast` doesn't notice at all if the object to send is larger than 2GB. This patch doesn't actually fix the inability to send such buffers (but @tjhei's promised follow-up to #13368 does), but at least it uses the correct data type for the buffer size.

/rebuild