### PR TITLE
support large buffers in MPI::broadcast()

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1862,11 +1862,8 @@ namespace Utilities
         }
 
       // Exchange the size of buffer
-      int ierr = MPI_Bcast(&buffer_size,
-                           1,
-                           internal::mpi_type_id(&buffer_size),
-                           root_process,
-                           comm);
+      int ierr = MPI_Bcast(
+        &buffer_size, 1, mpi_type_id(&buffer_size), root_process, comm);
       AssertThrowMPI(ierr);
 
       // If not on the root process, correctly size the buffer to
@@ -1874,9 +1871,7 @@ namespace Utilities
       if (this_mpi_process(comm) != root_process)
         buffer.resize(buffer_size);
 
-      ierr =
-        MPI_Bcast(buffer.data(), buffer_size, MPI_CHAR, root_process, comm);
-      AssertThrowMPI(ierr);
+      broadcast(buffer.data(), buffer_size, root_process, comm);
 
       if (Utilities::MPI::this_mpi_process(comm) == root_process)
         return object_to_send;

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1851,7 +1851,7 @@ namespace Utilities
       (void)n_procs;
 
       std::vector<char> buffer;
-      unsigned int      buffer_size = numbers::invalid_unsigned_int;
+      std::size_t       buffer_size = numbers::invalid_size_type;
 
       // On the root process, pack the data and determine what the
       // buffer size needs to be.
@@ -1862,7 +1862,11 @@ namespace Utilities
         }
 
       // Exchange the size of buffer
-      int ierr = MPI_Bcast(&buffer_size, 1, MPI_UNSIGNED, root_process, comm);
+      int ierr = MPI_Bcast(&buffer_size,
+                           1,
+                           internal::mpi_type_id(&buffer_size),
+                           root_process,
+                           comm);
       AssertThrowMPI(ierr);
 
       // If not on the root process, correctly size the buffer to


### PR DESCRIPTION
Now also support big buffers in the other broadcast routine by using the new function in #13368

fixes #13357

closes #13376 because it is contained here
