### PR TITLE
Indent scripts

### DIFF
--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -39,7 +39,7 @@
 # changes.
 #
 
-if [ ! -f contrib/utilities/indent_common.sh ]; then
+if [ ! -f contrib/utilities/indent ]; then
   echo "*** This script must be run from the top-level directory of deal.II."
   exit 1
 fi
@@ -82,4 +82,3 @@ process_changed "tests include source examples cmake/scripts contrib/python-bind
 
 process_changed "tests include source examples cmake/scripts contrib/python-bindings doc" \
   ".*\.(cc|h|cu|cuh|html|dox|txt)" ensure_single_trailing_newline
-

--- a/contrib/utilities/indent
+++ b/contrib/utilities/indent
@@ -44,6 +44,11 @@ if [ ! -f contrib/utilities/indent ]; then
   exit 1
 fi
 
+if [ ! -f contrib/utilities/indent_common.sh ]; then
+  echo "*** This script requires contrib/utilities/indent_common.sh."
+  exit 1
+fi
+
 source contrib/utilities/indent_common.sh
 
 #

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -48,6 +48,11 @@ if [ ! -f contrib/utilities/indent-all ]; then
   exit 1
 fi
 
+if [ ! -f contrib/utilities/indent_common.sh ]; then
+  echo "*** This script requires contrib/utilities/indent_common.sh."
+  exit 1
+fi
+
 source contrib/utilities/indent_common.sh
 
 #

--- a/contrib/utilities/indent-all
+++ b/contrib/utilities/indent-all
@@ -43,7 +43,7 @@
 # changes.
 #
 
-if [ ! -f contrib/utilities/indent_common.sh ]; then
+if [ ! -f contrib/utilities/indent-all ]; then
   echo "*** This script must be run from the top-level directory of deal.II."
   exit 1
 fi
@@ -86,4 +86,3 @@ process "tests include source examples cmake/scripts contrib/python-bindings doc
 
 process "tests include source examples cmake/scripts contrib/python-bindings doc" \
   ".*\.(cc|h|cu|cuh|html|dox|txt)" ensure_single_trailing_newline
-


### PR DESCRIPTION
Just working on an auto indentation for shell files in dealii/candi, observed that in contrib/utilities the query might be adapted to reuqire the correct files.

Is there any rule, why some scripts have the suffix ``*.sh`` while others do not have?