### PR TITLE
Avoid implicit-bool conversion for stream objects.

### DIFF
--- a/include/deal.II/lac/affine_constraints.templates.h
+++ b/include/deal.II/lac/affine_constraints.templates.h
@@ -1260,7 +1260,7 @@ AffineConstraints<number>::print(std::ostream &out) const
         }
     }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 

--- a/include/deal.II/lac/chunk_sparse_matrix.templates.h
+++ b/include/deal.II/lac/chunk_sparse_matrix.templates.h
@@ -1455,14 +1455,14 @@ template <typename number>
 void
 ChunkSparseMatrix<number>::print(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
 
   Assert(false, ExcNotImplemented());
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1475,7 +1475,7 @@ ChunkSparseMatrix<number>::print_formatted(std::ostream &     out,
                                            const char *       zero_string,
                                            const double       denominator) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
@@ -1510,7 +1510,7 @@ ChunkSparseMatrix<number>::print_formatted(std::ostream &     out,
           out << std::setw(width) << zero_string << ' ';
       out << std::endl;
     };
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // reset output format
   out.precision(old_precision);
@@ -1524,7 +1524,7 @@ void
 ChunkSparseMatrix<number>::print_pattern(std::ostream &out,
                                          const double  threshold) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   Assert(cols != nullptr, ExcNeedsSparsityPattern());
   Assert(val != nullptr, ExcNotInitialized());
@@ -1555,7 +1555,7 @@ ChunkSparseMatrix<number>::print_pattern(std::ostream &out,
       out << std::endl;
     }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1564,7 +1564,7 @@ template <typename number>
 void
 ChunkSparseMatrix<number>::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // first the simple objects, bracketed in [...]
   out << '[' << max_len << "][";
@@ -1574,7 +1574,7 @@ ChunkSparseMatrix<number>::block_write(std::ostream &out) const
               reinterpret_cast<const char *>(val.get()));
   out << ']';
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1583,7 +1583,7 @@ template <typename number>
 void
 ChunkSparseMatrix<number>::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   char c;
 

--- a/include/deal.II/lac/cuda_sparse_matrix.h
+++ b/include/deal.II/lac/cuda_sparse_matrix.h
@@ -513,7 +513,7 @@ namespace CUDAWrappers
           }
         out << std::endl;
       };
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // reset output format
     out.precision(old_precision);

--- a/include/deal.II/lac/full_matrix.templates.h
+++ b/include/deal.II/lac/full_matrix.templates.h
@@ -1793,7 +1793,7 @@ FullMatrix<number>::print_formatted(std::ostream &     out,
       out << std::endl;
     };
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   // reset output format
   out.flags(old_flags);
   out.precision(old_precision);

--- a/include/deal.II/lac/la_parallel_vector.templates.h
+++ b/include/deal.II/lac/la_parallel_vector.templates.h
@@ -2112,7 +2112,7 @@ namespace LinearAlgebra
                                            const bool         across) const
     {
       Assert(partitioner.get() != nullptr, ExcInternalError());
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       std::ios::fmtflags old_flags     = out.flags();
       unsigned int       old_precision = out.precision(precision);
 
@@ -2185,7 +2185,7 @@ namespace LinearAlgebra
         }
 #endif
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       // reset output format
       out.flags(old_flags);
       out.precision(old_precision);

--- a/include/deal.II/lac/la_vector.templates.h
+++ b/include/deal.II/lac/la_vector.templates.h
@@ -551,7 +551,7 @@ namespace LinearAlgebra
   Vector<Number>::print_as_numpy_array(std::ostream &     out,
                                        const unsigned int precision) const
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
     boost::io::ios_flags_saver restore_flags(out);
 
     out.precision(precision);
@@ -561,7 +561,7 @@ namespace LinearAlgebra
       out << this->values[i] << ' ';
     out << '\n' << std::flush;
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -570,7 +570,7 @@ namespace LinearAlgebra
   void
   Vector<Number>::block_write(std::ostream &out) const
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // Other version of the following
     //  out << size() << std::endl << '[';
@@ -593,7 +593,7 @@ namespace LinearAlgebra
     const char outro = ']';
     out.write(&outro, 1);
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -602,7 +602,7 @@ namespace LinearAlgebra
   void
   Vector<Number>::block_read(std::istream &in)
   {
-    AssertThrow(in, ExcIO());
+    AssertThrow(in.fail() == false, ExcIO());
 
     size_type sz;
 

--- a/include/deal.II/lac/read_write_vector.templates.h
+++ b/include/deal.II/lac/read_write_vector.templates.h
@@ -1013,7 +1013,7 @@ namespace LinearAlgebra
                                  const unsigned int precision,
                                  const bool         scientific) const
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
     boost::io::ios_flags_saver restore_flags(out);
 
     out.precision(precision);
@@ -1030,7 +1030,7 @@ namespace LinearAlgebra
       out << '[' << idx << "]: " << values[i++] << '\n';
     out << std::flush;
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 

--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -1937,7 +1937,7 @@ SparseMatrix<number>::print_formatted(std::ostream &     out,
           out << std::setw(width) << zero_string << ' ';
       out << std::endl;
     };
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // reset output format
   out.precision(old_precision);
@@ -1965,7 +1965,7 @@ SparseMatrix<number>::print_pattern(std::ostream &out,
           out << ':';
       out << std::endl;
     };
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1975,7 +1975,7 @@ void
 SparseMatrix<number>::print_as_numpy_arrays(std::ostream &     out,
                                             const unsigned int precision) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   boost::io::ios_flags_saver restore_flags(out);
 
   out.precision(precision);
@@ -2013,7 +2013,7 @@ SparseMatrix<number>::print_as_numpy_arrays(std::ostream &     out,
   out << '\n';
   out << std::flush;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -2022,7 +2022,7 @@ template <typename number>
 void
 SparseMatrix<number>::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // first the simple objects,
   // bracketed in [...]
@@ -2033,7 +2033,7 @@ SparseMatrix<number>::block_write(std::ostream &out) const
               reinterpret_cast<const char *>(val.get()));
   out << ']';
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -2042,7 +2042,7 @@ template <typename number>
 void
 SparseMatrix<number>::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   char c;
 

--- a/include/deal.II/lac/sparse_matrix_ez.templates.h
+++ b/include/deal.II/lac/sparse_matrix_ez.templates.h
@@ -466,7 +466,7 @@ template <typename number>
 void
 SparseMatrixEZ<number>::print(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   const_iterator       i = begin();
   const const_iterator e = end();
@@ -487,7 +487,7 @@ SparseMatrixEZ<number>::print_formatted(std::ostream &     out,
                                         const char *       zero_string,
                                         const double       denominator) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   Assert(m() != 0, ExcNotInitialized());
   Assert(n() != 0, ExcNotInitialized());
 
@@ -533,7 +533,7 @@ template <typename number>
 void
 SparseMatrixEZ<number>::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // first the simple objects,
   // bracketed in [...]
@@ -551,7 +551,7 @@ SparseMatrixEZ<number>::block_write(std::ostream &out) const
 
   out << ']';
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -565,7 +565,7 @@ template <typename number>
 void
 SparseMatrixEZ<number>::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   char c;
   int  n;

--- a/include/deal.II/lac/trilinos_tpetra_vector.templates.h
+++ b/include/deal.II/lac/trilinos_tpetra_vector.templates.h
@@ -624,7 +624,7 @@ namespace LinearAlgebra
                           const bool         scientific,
                           const bool         across) const
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       boost::io::ios_flags_saver restore_flags(out);
 
       // Get a representation of the vector and loop over all
@@ -652,7 +652,7 @@ namespace LinearAlgebra
 
       // restore the representation
       // of the vector
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
 

--- a/include/deal.II/lac/vector.h
+++ b/include/deal.II/lac/vector.h
@@ -1401,13 +1401,13 @@ inline std::ostream &
 operator<<(std::ostream &out, const Vector<number> &v)
 {
   Assert(v.size() != 0, ExcEmptyObject());
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   for (typename Vector<number>::size_type i = 0; i < v.size() - 1; ++i)
     out << v(i) << ' ';
   out << v(v.size() - 1);
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   return out;
 }

--- a/include/deal.II/lac/vector.templates.h
+++ b/include/deal.II/lac/vector.templates.h
@@ -834,7 +834,7 @@ Vector<Number>::print(std::ostream &     out,
                       const bool         across) const
 {
   Assert(size() != 0, ExcEmptyObject());
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   std::ios::fmtflags old_flags     = out.flags();
   unsigned int       old_precision = out.precision(precision);
@@ -853,7 +853,7 @@ Vector<Number>::print(std::ostream &     out,
       out << values[i] << std::endl;
   out << std::endl;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   // reset output format
   out.flags(old_flags);
   out.precision(old_precision);
@@ -865,7 +865,7 @@ template <typename Number>
 void
 Vector<Number>::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // other version of the following
   //  out << size() << std::endl << '[';
@@ -889,7 +889,7 @@ Vector<Number>::block_write(std::ostream &out) const
   const char outro = ']';
   out.write(&outro, 1);
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -898,7 +898,7 @@ template <typename Number>
 void
 Vector<Number>::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   size_type sz;
 

--- a/source/base/data_out_base.cc
+++ b/source/base/data_out_base.cc
@@ -3322,7 +3322,7 @@ namespace DataOutBase
     // tested, therefore currently not allowed.
     AssertThrow(dim > 0, ExcNotImplemented());
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -3392,7 +3392,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -3412,7 +3412,7 @@ namespace DataOutBase
     // Point output is currently not implemented.
     AssertThrow(dim > 0, ExcNotImplemented());
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -3674,7 +3674,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -3692,7 +3692,7 @@ namespace DataOutBase
     const GnuplotFlags &flags,
     std::ostream &      out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most
@@ -4067,7 +4067,7 @@ namespace DataOutBase
     // make sure everything now gets to disk
     out.flush();
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -4093,7 +4093,7 @@ namespace DataOutBase
                     const PovrayFlags &             flags,
                     std::ostream &                  out)
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
       // verify that there are indeed patches to be written out. most
@@ -4410,7 +4410,7 @@ namespace DataOutBase
       // make sure everything now gets to disk
       out.flush();
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
   } // namespace
 
@@ -4465,7 +4465,7 @@ namespace DataOutBase
     const EpsFlags &flags,
     std::ostream &  out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -4765,7 +4765,7 @@ namespace DataOutBase
 
     out.flush();
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -4790,7 +4790,7 @@ namespace DataOutBase
     AssertThrow(dim > 0, ExcNotImplemented());
 
     Assert(dim <= 3, ExcNotImplemented());
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -4902,7 +4902,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -4920,7 +4920,7 @@ namespace DataOutBase
     const TecplotFlags &flags,
     std::ostream &      out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // The FEBLOCK or FEPOINT formats of tecplot only allows full elements (e.g.
     // triangles), not single points. Other tecplot format allow point output,
@@ -5061,7 +5061,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -5189,7 +5189,7 @@ namespace DataOutBase
       }
 
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #  ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -5477,7 +5477,7 @@ namespace DataOutBase
     const VtkFlags &flags,
     std::ostream &  out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
 #ifndef DEAL_II_WITH_MPI
     // verify that there are indeed patches to be written out. most of the
@@ -5712,14 +5712,14 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
   void
   write_vtu_header(std::ostream &out, const VtkFlags &flags)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
     out << "<?xml version=\"1.0\" ?> \n";
     out << "<!-- \n";
     out << "# vtk DataFile Version 3.0" << '\n'
@@ -5752,7 +5752,7 @@ namespace DataOutBase
   void
   write_vtu_footer(std::ostream &out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
     out << " </UnstructuredGrid>\n";
     out << "</VTKFile>\n";
   }
@@ -5795,7 +5795,7 @@ namespace DataOutBase
     const VtkFlags &flags,
     std::ostream &  out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // If the user provided physical units, make sure that they don't contain
     // quote characters as this would make the VTU file invalid XML and
@@ -6222,7 +6222,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -6240,7 +6240,7 @@ namespace DataOutBase
       &             nonscalar_data_ranges,
     const VtkFlags &flags)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // If the user provided physical units, make sure that they don't contain
     // quote characters as this would make the VTU file invalid XML and
@@ -6375,7 +6375,7 @@ namespace DataOutBase
     out.flush();
 
     // assert the stream is still ok
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -6385,7 +6385,7 @@ namespace DataOutBase
     std::ostream &                                     out,
     const std::vector<std::pair<double, std::string>> &times_and_names)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     out << "<?xml version=\"1.0\"?>\n";
 
@@ -6412,7 +6412,7 @@ namespace DataOutBase
     out.flush();
     out.precision(ss);
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -6434,7 +6434,7 @@ namespace DataOutBase
   write_visit_record(std::ostream &                               out,
                      const std::vector<std::vector<std::string>> &piece_names)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     if (piece_names.size() == 0)
       return;
@@ -6464,7 +6464,7 @@ namespace DataOutBase
     const std::vector<std::pair<double, std::vector<std::string>>>
       &times_and_piece_names)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     if (times_and_piece_names.size() == 0)
       return;
@@ -7489,7 +7489,7 @@ namespace DataOutBase
     const Deal_II_IntermediateFlags & /*flags*/,
     std::ostream &out)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // first write tokens indicating the template parameters. we need this in
     // here because we may want to read in data again even if we don't know in
@@ -7527,7 +7527,7 @@ namespace DataOutBase
   std::pair<unsigned int, unsigned int>
   determine_intermediate_format_dimensions(std::istream &input)
   {
-    AssertThrow(input, ExcIO());
+    AssertThrow(input.fail() == false, ExcIO());
 
     unsigned int dim, spacedim;
     input >> dim >> spacedim;
@@ -8874,7 +8874,7 @@ template <int dim, int spacedim>
 void
 DataOutReader<dim, spacedim>::read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // first empty previous content
   {
@@ -8976,7 +8976,7 @@ DataOutReader<dim, spacedim>::read(std::istream &in)
       std::get<2>(nonscalar_data_ranges[i]) = name;
     }
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 }
 
 
@@ -9337,7 +9337,7 @@ namespace DataOutBase
   std::istream &
   operator>>(std::istream &in, Patch<dim, spacedim> &patch)
   {
-    AssertThrow(in, ExcIO());
+    AssertThrow(in.fail() == false, ExcIO());
 
     // read a header line and compare it to what we usually write. skip all
     // lines that contain only blanks at the start
@@ -9402,7 +9402,7 @@ namespace DataOutBase
       for (unsigned int j = 0; j < patch.data.n_cols(); ++j)
         in >> patch.data[i][j];
 
-    AssertThrow(in, ExcIO());
+    AssertThrow(in.fail() == false, ExcIO());
 
     return in;
   }

--- a/source/base/index_set.cc
+++ b/source/base/index_set.cc
@@ -455,7 +455,7 @@ IndexSet::write(std::ostream &out) const
 void
 IndexSet::read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   size_type    s;
   unsigned int n_ranges;
@@ -465,7 +465,7 @@ IndexSet::read(std::istream &in)
   set_size(s);
   for (unsigned int i = 0; i < n_ranges; ++i)
     {
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
 
       size_type b, e;
       in >> b >> e;
@@ -477,7 +477,7 @@ IndexSet::read(std::istream &in)
 void
 IndexSet::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   out.write(reinterpret_cast<const char *>(&index_space_size),
             sizeof(index_space_size));
   std::size_t n_ranges = ranges.size();
@@ -485,7 +485,7 @@ IndexSet::block_write(std::ostream &out) const
   if (ranges.empty() == false)
     out.write(reinterpret_cast<const char *>(&*ranges.begin()),
               ranges.size() * sizeof(Range));
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 void

--- a/source/base/parameter_acceptor.cc
+++ b/source/base/parameter_acceptor.cc
@@ -94,7 +94,7 @@ void
 ParameterAcceptor::initialize(std::istream &input_stream, ParameterHandler &prm)
 
 {
-  AssertThrow(input_stream, ExcIO());
+  AssertThrow(input_stream.fail() == false, ExcIO());
   declare_all_parameters(prm);
   prm.parse_input(input_stream);
   parse_all_parameters(prm);

--- a/source/base/parameter_handler.cc
+++ b/source/base/parameter_handler.cc
@@ -401,7 +401,7 @@ ParameterHandler::parse_input(std::istream &     input,
                               const std::string &last_line,
                               const bool         skip_undefined)
 {
-  AssertThrow(input, ExcIO());
+  AssertThrow(input.fail() == false, ExcIO());
 
   // store subsections we are currently in
   const std::vector<std::string> saved_path = subsection_path;
@@ -700,7 +700,7 @@ void
 ParameterHandler::parse_input_from_xml(std::istream &in,
                                        const bool    skip_undefined)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
   // read the XML tree assuming that (as we
   // do in print_parameters(XML) it has only
   // a single top-level node called
@@ -756,7 +756,7 @@ void
 ParameterHandler::parse_input_from_json(std::istream &in,
                                         const bool    skip_undefined)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   boost::property_tree::ptree node_tree;
   // This boost function will raise an exception if this is not a valid JSON
@@ -1250,7 +1250,7 @@ std::ostream &
 ParameterHandler::print_parameters(std::ostream &    out,
                                    const OutputStyle style) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   assert_validity_of_output_style(style);
 
@@ -1369,7 +1369,7 @@ ParameterHandler::print_parameters(
     output_style = style | LaTeX;
 
   std::ofstream out(filename);
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   print_parameters(out, output_style);
 }
 
@@ -1383,7 +1383,7 @@ ParameterHandler::recursively_print_parameters(
   const unsigned int                 indent_level,
   std::ostream &                     out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // this function should not be necessary for XML or JSON output...
   Assert(!(style & (XML | JSON)), ExcInternalError());
@@ -2099,7 +2099,7 @@ MultipleParameterLoop::parse_input(std::istream &     input,
                                    const std::string &last_line,
                                    const bool         skip_undefined)
 {
-  AssertThrow(input, ExcIO());
+  AssertThrow(input.fail() == false, ExcIO());
 
   // Note that (to avoid infinite recursion) we have to explicitly call the
   // base class version of parse_input and *not* a wrapper (which may be

--- a/source/base/table_handler.cc
+++ b/source/base/table_handler.cc
@@ -382,7 +382,7 @@ TableHandler::set_scientific(const std::string &key, const bool scientific)
 void
 TableHandler::write_text(std::ostream &out, const TextOutputFormat format) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   boost::io::ios_flags_saver restore_flags(out);
 
   // first pad the table from below if necessary
@@ -600,7 +600,7 @@ TableHandler::write_tex(std::ostream &out, const bool with_header) const
 {
   // TODO[TH]: update code similar to
   // write_text() to use the cache
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   if (with_header)
     out << "\\documentclass[10pt]{report}" << '\n'
         << "\\usepackage{float}" << '\n'

--- a/source/base/utilities.cc
+++ b/source/base/utilities.cc
@@ -919,7 +919,7 @@ namespace Utilities
       std::ifstream cpuinfo;
       cpuinfo.open("/proc/loadavg");
 
-      AssertThrow(cpuinfo, ExcIO());
+      AssertThrow(cpuinfo.fail() == false, ExcIO());
 
       double load;
       cpuinfo >> load;

--- a/source/distributed/fully_distributed_tria.cc
+++ b/source/distributed/fully_distributed_tria.cc
@@ -626,7 +626,7 @@ namespace parallel
       {
         std::string   fname = std::string(filename) + ".info";
         std::ifstream f(fname.c_str());
-        AssertThrow(f, ExcIO());
+        AssertThrow(f.fail() == false, ExcIO());
         std::string firstline;
         getline(f, firstline); // skip first line
         f >> version >> numcpus >> attached_count_fixed >>

--- a/source/distributed/tria.cc
+++ b/source/distributed/tria.cc
@@ -2106,7 +2106,7 @@ namespace parallel
       {
         std::string   fname = std::string(filename) + ".info";
         std::ifstream f(fname.c_str());
-        AssertThrow(f, ExcIO());
+        AssertThrow(f.fail() == false, ExcIO());
         std::string firstline;
         getline(f, firstline); // skip first line
         f >> version >> numcpus >> attached_count_fixed >>

--- a/source/dofs/dof_tools.cc
+++ b/source/dofs/dof_tools.cc
@@ -2273,7 +2273,7 @@ namespace DoFTools
     std::ostream &                                            out,
     const std::map<types::global_dof_index, Point<spacedim>> &support_points)
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     std::map<Point<spacedim>,
              std::vector<types::global_dof_index>,

--- a/source/gmsh/utilities.cc
+++ b/source/gmsh/utilities.cc
@@ -97,7 +97,7 @@ namespace Gmsh
                            " file."));
 
     std::ifstream grid_file(msh_file_name);
-    Assert(grid_file, ExcIO());
+    Assert(grid_file.fail() == false, ExcIO());
 
     GridIn<2, spacedim> gridin;
     gridin.attach_triangulation(tria);

--- a/source/grid/grid_in.cc
+++ b/source/grid/grid_in.cc
@@ -622,7 +622,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
   Assert(tria != nullptr, ExcNoTriangulationSelected());
   Assert((dim == 2) || (dim == 3), ExcNotImplemented());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
   skip_comment_lines(in, '#'); // skip comments (if any) at beginning of file
 
   int tmp;
@@ -630,13 +630,13 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
   // loop over sections, read until section 2411 is found, and break once found
   while (true)
     {
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> tmp;
       AssertThrow(tmp == -1,
                   ExcMessage("Invalid UNV file format. "
                              "Expected '-1' before and after a section."));
 
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> tmp;
       AssertThrow(tmp >= 0, ExcUnknownSectionType(tmp));
       if (tmp != 2411)
@@ -645,7 +645,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           while (true)
             {
               std::string line;
-              AssertThrow(in, ExcIO());
+              AssertThrow(in.fail() == false, ExcIO());
               std::getline(in, line);
               // remove leading and trailing spaces in the line
               boost::algorithm::trim(line);
@@ -672,7 +672,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
       int    dummy;
       double x[3];
 
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> no;
 
       tmp = no;
@@ -681,7 +681,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
 
       in >> dummy >> dummy >> dummy;
 
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> x[0] >> x[1] >> x[2];
 
       vertices.emplace_back();
@@ -694,9 +694,9 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
       no_vertex++;
     }
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
   in >> tmp;
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
   in >> tmp;
 
   // section 2412 describes elements: see
@@ -723,7 +723,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
       int type;
       int dummy;
 
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> no;
 
       tmp = no;
@@ -741,7 +741,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           const auto reference_cell = ReferenceCells::get_hypercube<dim>();
           cells.emplace_back();
 
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           for (const unsigned int v : GeometryInfo<dim>::vertex_indices())
             in >> cells.back()
                     .vertices[reference_cell.unv_vertex_to_deal_vertex(v)];
@@ -758,12 +758,12 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
       else if (((type == 11) && (dim == 2)) ||
                ((type == 11) && (dim == 3))) // boundary line
         {
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           in >> dummy >> dummy >> dummy;
 
           subcelldata.boundary_lines.emplace_back();
 
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           for (unsigned int &vertex :
                subcelldata.boundary_lines.back().vertices)
             in >> vertex;
@@ -783,7 +783,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           const auto reference_cell = ReferenceCells::Quadrilateral;
           subcelldata.boundary_quads.emplace_back();
 
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           Assert(subcelldata.boundary_quads.back().vertices.size() ==
                    GeometryInfo<2>::vertices_per_cell,
                  ExcInternalError());
@@ -817,7 +817,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
 
   if (!in.eof())
     {
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> tmp;
 
       // section 2467 (2477) describes (materials - first and bcs - second) or
@@ -833,7 +833,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           int no;         // unv
           int dummy;
 
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           in >> dummy;
 
           tmp = dummy;
@@ -843,7 +843,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
           in >> dummy >> dummy >> dummy >> dummy >> dummy >> dummy >>
             n_entities;
 
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
           in >> id;
 
           const unsigned int n_lines =
@@ -861,7 +861,7 @@ GridIn<dim, spacedim>::read_unv(std::istream &in)
               for (unsigned int no_fragment = 0; no_fragment < n_fragments;
                    no_fragment++)
                 {
-                  AssertThrow(in, ExcIO());
+                  AssertThrow(in.fail() == false, ExcIO());
                   in >> dummy >> no >> dummy >> dummy;
 
                   if (cell_indices.count(no) > 0) // cell - material
@@ -899,7 +899,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
                                 const bool    apply_all_indicators_to_manifolds)
 {
   Assert(tria != nullptr, ExcNoTriangulationSelected());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // skip comments at start of file
   skip_comment_lines(in, '#');
@@ -912,7 +912,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
   in >> n_vertices >> n_cells >> dummy // number of data vectors
     >> dummy                           // cell data
     >> dummy;                          // model data
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // set up array of vertices
   std::vector<Point<spacedim>> vertices(n_vertices);
@@ -927,7 +927,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
       double x[3];
 
       // read vertex
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
       in >> vertex_number >> x[0] >> x[1] >> x[2];
 
       // store vertex
@@ -950,7 +950,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
       // cells at the top, there
       // should still be input here,
       // so check this:
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
 
       std::string cell_type;
 
@@ -1112,7 +1112,7 @@ GridIn<dim, spacedim>::read_ucd(std::istream &in,
   // check that no forbidden arrays are used
   Assert(subcelldata.check_consistency(dim), ExcInternalError());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // do some clean-up on vertices...
   GridTools::delete_unused_vertices(vertices, cells, subcelldata);
@@ -1169,7 +1169,7 @@ GridIn<dim, spacedim>::read_abaqus(std::istream &in,
   Assert((spacedim == 2 && dim == spacedim) ||
            (spacedim == 3 && (dim == spacedim || dim == spacedim - 1)),
          ExcNotImplemented());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // Read in the Abaqus file into an intermediate object
   // that is to be passed along to the UCD reader
@@ -1219,7 +1219,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
   Assert(tria != nullptr, ExcNoTriangulationSelected());
   Assert(dim == 2, ExcNotImplemented());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // skip comments at start of file
   skip_comment_lines(in, '#');
@@ -1366,7 +1366,7 @@ GridIn<dim, spacedim>::read_dbmesh(std::istream &in)
   // check that no forbidden arrays are used
   Assert(subcelldata.check_consistency(dim), ExcInternalError());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // do some clean-up on vertices...
   GridTools::delete_unused_vertices(vertices, cells, subcelldata);
@@ -1383,7 +1383,7 @@ void
 GridIn<dim, spacedim>::read_xda(std::istream &in)
 {
   Assert(tria != nullptr, ExcNoTriangulationSelected());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   const auto reference_cell = ReferenceCells::get_hypercube<dim>();
 
@@ -1413,7 +1413,7 @@ GridIn<dim, spacedim>::read_xda(std::istream &in)
     {
       // note that since in the input file we found the number of cells at the
       // top, there should still be input here, so check this:
-      AssertThrow(in, ExcIO());
+      AssertThrow(in.fail() == false, ExcIO());
 
       // XDA happens to use ExodusII's numbering because XDA/XDR is libMesh's
       // native format, and libMesh's node numberings come from ExodusII:
@@ -1434,7 +1434,7 @@ GridIn<dim, spacedim>::read_xda(std::istream &in)
           in >> dummy;
         }
     }
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // do some clean-up on vertices...
   GridTools::delete_unused_vertices(vertices, cells, subcelldata);
@@ -1451,7 +1451,7 @@ void
 GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
 {
   Assert(tria != nullptr, ExcNoTriangulationSelected());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // Start by making our life a bit easier: The file format
   // allows for comments in a whole bunch of places, including
@@ -1495,7 +1495,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
   // # Types
   // 3 obj
 
-  AssertThrow(whole_file, ExcIO());
+  AssertThrow(whole_file.fail() == false, ExcIO());
 
   {
     unsigned int version_major, version_minor;
@@ -1544,7 +1544,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
   //
   // # Mesh vertex coordinates
   // ...
-  AssertThrow(whole_file, ExcIO());
+  AssertThrow(whole_file.fail() == false, ExcIO());
   {
     unsigned int dummy;
     whole_file >> dummy >> dummy >> dummy;
@@ -1606,7 +1606,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
   //  6
   //  3
   //  [...]
-  AssertThrow(whole_file, ExcIO());
+  AssertThrow(whole_file.fail() == false, ExcIO());
 
   std::vector<CellData<dim>> cells;
   SubCellData                subcelldata;
@@ -1709,7 +1709,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
         n_vertices_per_element);
       for (unsigned int e = 0; e < n_elements; ++e)
         {
-          AssertThrow(whole_file, ExcIO());
+          AssertThrow(whole_file.fail() == false, ExcIO());
           for (unsigned int v = 0; v < n_vertices_per_element; ++v)
             {
               whole_file >> vertices_for_this_element[v];
@@ -1780,7 +1780,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
         {
           for (unsigned int e = 0; e < n_geom_entity_indices; ++e)
             {
-              AssertThrow(whole_file, ExcIO());
+              AssertThrow(whole_file.fail() == false, ExcIO());
               unsigned int geometric_entity_index;
               whole_file >> geometric_entity_index;
               if (object_type == ReferenceCells::Vertex)
@@ -1822,7 +1822,7 @@ GridIn<dim, spacedim>::read_comsol_mphtxt(std::istream &in)
             }
         }
     }
-  AssertThrow(whole_file, ExcIO());
+  AssertThrow(whole_file.fail() == false, ExcIO());
 
   // Now finally create the mesh. Because of the quirk with boundary
   // edges and faces described in the documentation of this function,
@@ -1997,7 +1997,7 @@ void
 GridIn<dim, spacedim>::read_msh(std::istream &in)
 {
   Assert(tria != nullptr, ExcNoTriangulationSelected());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   unsigned int n_vertices;
   unsigned int n_cells;
@@ -2352,7 +2352,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
             // cells at the top, there
             // should still be input here,
             // so check this:
-            AssertThrow(in, ExcIO());
+            AssertThrow(in.fail() == false, ExcIO());
 
             unsigned int nod_num;
 
@@ -2670,7 +2670,7 @@ GridIn<dim, spacedim>::read_msh(std::istream &in)
   // check that no forbidden arrays are used
   Assert(subcelldata.check_consistency(dim), ExcInternalError());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // check that we actually read some cells.
   AssertThrow(cells.size() > 0,
@@ -3155,7 +3155,7 @@ GridIn<2>::read_tecplot(std::istream &in)
   const unsigned int dim      = 2;
   const unsigned int spacedim = 2;
   Assert(tria != nullptr, ExcNoTriangulationSelected());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // skip comments at start of file
   skip_comment_lines(in, '#');
@@ -3362,7 +3362,7 @@ GridIn<2>::read_tecplot(std::istream &in)
           // we found the number of cells at
           // the top, there should still be
           // input here, so check this:
-          AssertThrow(in, ExcIO());
+          AssertThrow(in.fail() == false, ExcIO());
 
           // get the connectivity from the
           // input file. the vertices are
@@ -3378,7 +3378,7 @@ GridIn<2>::read_tecplot(std::istream &in)
   // used. as we do not read in any
   // subcelldata, nothing should happen here.
   Assert(subcelldata.check_consistency(dim), ExcInternalError());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // do some cleanup on cells
   GridTools::invert_all_negative_measure_cells(vertices, cells);
@@ -4390,7 +4390,7 @@ namespace
     // http://www.egr.msu.edu/software/abaqus/Documentation/docs/v6.7/books/usb/default.htm?startat=pt01ch02.html
     // http://www.cprogramming.com/tutorial/string.html
 
-    AssertThrow(input_stream, ExcIO());
+    AssertThrow(input_stream.fail() == false, ExcIO());
     std::string line;
 
     while (std::getline(input_stream, line))
@@ -4819,7 +4819,7 @@ namespace
     // http://www.dealii.org/developer/doxygen/deal.II/structGeometryInfo.html
     // http://people.scs.fsu.edu/~burkardt/data/ucd/ucd.html
 
-    AssertThrow(output, ExcIO());
+    AssertThrow(output.fail() == false, ExcIO());
 
     // save old formatting options
     const boost::io::ios_base_all_saver formatting_saver(output);

--- a/source/grid/grid_out.cc
+++ b/source/grid/grid_out.cc
@@ -783,7 +783,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
 {
   // TODO:[GK] allow for boundary faces only
   Assert(dx_flags.write_all_faces, ExcNotImplemented());
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   // Copied and adapted from write_ucd
   const std::vector<Point<spacedim>> &vertices    = tria.get_vertices();
   const std::vector<bool> &           vertex_used = tria.get_used_vertices();
@@ -1009,7 +1009,7 @@ GridOut::write_dx(const Triangulation<dim, spacedim> &tria,
   // disk
   out.flush();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1019,7 +1019,7 @@ void
 GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
                    std::ostream &                      out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // get the positions of the
   // vertices and whether they are
@@ -1110,7 +1110,7 @@ GridOut::write_msh(const Triangulation<dim, spacedim> &tria,
   // disk
   out.flush();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1119,7 +1119,7 @@ void
 GridOut::write_ucd(const Triangulation<dim, spacedim> &tria,
                    std::ostream &                      out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // get the positions of the
   // vertices and whether they are
@@ -1226,7 +1226,7 @@ GridOut::write_ucd(const Triangulation<dim, spacedim> &tria,
   // disk
   out.flush();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -1429,7 +1429,7 @@ GridOut::write_xfig(const Triangulation<2> &tria,
   // disk
   out.flush();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -2982,7 +2982,7 @@ void
 GridOut::write_mathgl(const Triangulation<dim, spacedim> &tria,
                       std::ostream &                      out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // (i) write header
   {
@@ -3104,7 +3104,7 @@ GridOut::write_mathgl(const Triangulation<dim, spacedim> &tria,
 
   // make sure everything now gets to the output stream
   out.flush();
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -3305,7 +3305,7 @@ void
 GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
                    std::ostream &                      out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // get the positions of the vertices
   const std::vector<Point<spacedim>> &vertices = tria.get_vertices();
@@ -3534,7 +3534,7 @@ GridOut::write_vtk(const Triangulation<dim, spacedim> &tria,
 
   out.flush();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -3544,7 +3544,7 @@ void
 GridOut::write_vtu(const Triangulation<dim, spacedim> &tria,
                    std::ostream &                      out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // convert the cells of the triangulation into a set of patches
   // and then have them output. since there is no data attached to
@@ -3581,7 +3581,7 @@ GridOut::write_vtu(const Triangulation<dim, spacedim> &tria,
     DataOutBase::write_vtu_footer(out);
 
   out << std::flush;
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -4183,7 +4183,7 @@ namespace internal
                   const Mapping<1, spacedim> *,
                   const GridOutFlags::Gnuplot &gnuplot_flags)
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
 
       for (const auto &cell : tria.active_cell_iterators())
         {
@@ -4201,7 +4201,7 @@ namespace internal
       // disk
       out.flush();
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
 
@@ -4213,7 +4213,7 @@ namespace internal
                   const Mapping<2, spacedim> *              mapping,
                   const GridOutFlags::Gnuplot &             gnuplot_flags)
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
 
       const int dim = 2;
 
@@ -4313,7 +4313,7 @@ namespace internal
       // make sure everything now gets to disk
       out.flush();
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
 
@@ -4325,7 +4325,7 @@ namespace internal
                   const Mapping<3, spacedim> *              mapping,
                   const GridOutFlags::Gnuplot &             gnuplot_flags)
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
 
       const int dim = 3;
 
@@ -4580,7 +4580,7 @@ namespace internal
       // make sure everything now gets to disk
       out.flush();
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
   } // namespace
 } // namespace internal
@@ -4684,7 +4684,7 @@ namespace internal
           static_cast<const GridOutFlags::EpsFlagsBase &>(eps_flags_2) :
           static_cast<const GridOutFlags::EpsFlagsBase &>(eps_flags_3);
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       const unsigned int n_points = eps_flags_base.n_boundary_face_points;
 
       // make up a list of lines by which
@@ -5091,7 +5091,7 @@ namespace internal
       // disk
       out.flush();
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
   } // namespace
 } // namespace internal

--- a/source/grid/persistent_tria.cc
+++ b/source/grid/persistent_tria.cc
@@ -175,7 +175,7 @@ PersistentTriangulation<dim, spacedim>::write_flags(std::ostream &out) const
 {
   const unsigned int n_flag_levels = refine_flags.size();
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   out << mn_persistent_tria_flags_begin << ' ' << n_flag_levels << std::endl;
 
@@ -193,7 +193,7 @@ PersistentTriangulation<dim, spacedim>::write_flags(std::ostream &out) const
 
   out << mn_persistent_tria_flags_end << std::endl;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -204,7 +204,7 @@ PersistentTriangulation<dim, spacedim>::read_flags(std::istream &in)
 {
   Assert(refine_flags.size() == 0 && coarsen_flags.size() == 0,
          ExcFlagsNotCleared());
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   unsigned int magic_number;
   in >> magic_number;
@@ -231,7 +231,7 @@ PersistentTriangulation<dim, spacedim>::read_flags(std::istream &in)
   AssertThrow(magic_number == mn_persistent_tria_flags_end,
               typename Triangulation<dim>::ExcGridReadError());
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 }
 
 

--- a/source/grid/reference_cell.cc
+++ b/source/grid/reference_cell.cc
@@ -546,7 +546,7 @@ ReferenceCell::gmsh_element_type() const
 std::ostream &
 operator<<(std::ostream &out, const ReferenceCell &reference_cell)
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // Output as an integer to avoid outputting it as a character with
   // potentially non-printing value:
@@ -559,7 +559,7 @@ operator<<(std::ostream &out, const ReferenceCell &reference_cell)
 std::istream &
 operator>>(std::istream &in, ReferenceCell &reference_cell)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   // Read the information as an integer and convert it to the correct type
   unsigned int value;

--- a/source/grid/tria.cc
+++ b/source/grid/tria.cc
@@ -16306,7 +16306,7 @@ Triangulation<dim, spacedim>::write_bool_vector(
   for (unsigned int position = 0; position < N; ++position)
     flags[position / 8] |= (v[position] ? (1 << (position % 8)) : 0);
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // format:
   // 0. magic number
@@ -16321,7 +16321,7 @@ Triangulation<dim, spacedim>::write_bool_vector(
 
   delete[] flags;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -16332,7 +16332,7 @@ Triangulation<dim, spacedim>::read_bool_vector(const unsigned int magic_number1,
                                                const unsigned int magic_number2,
                                                std::istream &     in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   unsigned int magic_number;
   in >> magic_number;
@@ -16358,7 +16358,7 @@ Triangulation<dim, spacedim>::read_bool_vector(const unsigned int magic_number1,
 
   delete[] flags;
 
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 }
 
 

--- a/source/lac/chunk_sparsity_pattern.cc
+++ b/source/lac/chunk_sparsity_pattern.cc
@@ -458,7 +458,7 @@ ChunkSparsityPattern::print(std::ostream &out) const
            (sparsity_pattern.colnums != nullptr),
          ExcEmptyObject());
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   for (size_type i = 0; i < sparsity_pattern.rows; ++i)
     for (size_type d = 0; (d < chunk_size) && (i * chunk_size + d < n_rows());
@@ -477,7 +477,7 @@ ChunkSparsityPattern::print(std::ostream &out) const
         out << ']' << std::endl;
       }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -489,7 +489,7 @@ ChunkSparsityPattern::print_gnuplot(std::ostream &out) const
            (sparsity_pattern.colnums != nullptr),
          ExcEmptyObject());
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // for each entry in the underlying sparsity pattern, repeat everything
   // chunk_size x chunk_size times
@@ -511,7 +511,7 @@ ChunkSparsityPattern::print_gnuplot(std::ostream &out) const
             out << sparsity_pattern.colnums[j] * chunk_size + d << " "
                 << -static_cast<signed int>(i * chunk_size + e) << std::endl;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -545,7 +545,7 @@ ChunkSparsityPattern::stores_only_added_elements() const
 void
 ChunkSparsityPattern::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // first the simple objects, bracketed in [...]
   out << '[' << rows << ' ' << cols << ' ' << chunk_size << ' ' << "][";
@@ -553,7 +553,7 @@ ChunkSparsityPattern::block_write(std::ostream &out) const
   sparsity_pattern.block_write(out);
   out << ']';
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -561,7 +561,7 @@ ChunkSparsityPattern::block_write(std::ostream &out) const
 void
 ChunkSparsityPattern::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   char c;
 

--- a/source/lac/cuda_vector.cu
+++ b/source/lac/cuda_vector.cu
@@ -634,7 +634,7 @@ namespace LinearAlgebra
                           const bool         scientific,
                           const bool) const
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       std::ios::fmtflags old_flags     = out.flags();
       unsigned int       old_precision = out.precision(precision);
 
@@ -655,7 +655,7 @@ namespace LinearAlgebra
         out << cpu_val[i] << std::endl;
       out << std::flush;
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       // reset output format
       out.flags(old_flags);
       out.precision(old_precision);

--- a/source/lac/dynamic_sparsity_pattern.cc
+++ b/source/lac/dynamic_sparsity_pattern.cc
@@ -534,7 +534,7 @@ DynamicSparsityPattern::print(std::ostream &out) const
       out << ']' << std::endl;
     }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -557,7 +557,7 @@ DynamicSparsityPattern::print_gnuplot(std::ostream &out) const
     }
 
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 

--- a/source/lac/lapack_full_matrix.cc
+++ b/source/lac/lapack_full_matrix.cc
@@ -2336,7 +2336,7 @@ LAPACKFullMatrix<number>::print_formatted(std::ostream &     out,
       out << std::endl;
     }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   // reset output format
   out.flags(old_flags);
   out.precision(old_precision);

--- a/source/lac/petsc_matrix_base.cc
+++ b/source/lac/petsc_matrix_base.cc
@@ -673,7 +673,7 @@ namespace PETScWrappers
         AssertThrow(ierr == 0, ExcPETScError(ierr));
       }
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 

--- a/source/lac/petsc_parallel_vector.cc
+++ b/source/lac/petsc_parallel_vector.cc
@@ -374,7 +374,7 @@ namespace PETScWrappers
                   const bool         scientific,
                   const bool         across) const
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
 
       // get a representation of the vector and
       // loop over all the elements
@@ -440,7 +440,7 @@ namespace PETScWrappers
       ierr = VecRestoreArray(vector, &val);
       AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
   } // namespace MPI

--- a/source/lac/petsc_vector_base.cc
+++ b/source/lac/petsc_vector_base.cc
@@ -869,7 +869,7 @@ namespace PETScWrappers
                     const bool         scientific,
                     const bool         across) const
   {
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
 
     // get a representation of the vector and
     // loop over all the elements
@@ -905,7 +905,7 @@ namespace PETScWrappers
     ierr = VecRestoreArray(vector, &val);
     AssertThrow(ierr == 0, ExcPETScError(ierr));
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 

--- a/source/lac/sparsity_pattern.cc
+++ b/source/lac/sparsity_pattern.cc
@@ -876,7 +876,7 @@ SparsityPatternBase::print(std::ostream &out) const
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   for (size_type i = 0; i < rows; ++i)
     {
@@ -887,7 +887,7 @@ SparsityPatternBase::print(std::ostream &out) const
       out << ']' << std::endl;
     }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -897,7 +897,7 @@ SparsityPatternBase::print_gnuplot(std::ostream &out) const
 {
   Assert((rowstart != nullptr) && (colnums != nullptr), ExcEmptyObject());
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   for (size_type i = 0; i < rows; ++i)
     for (size_type j = rowstart[i]; j < rowstart[i + 1]; ++j)
@@ -907,7 +907,7 @@ SparsityPatternBase::print_gnuplot(std::ostream &out) const
         // the order of output
         out << colnums[j] << " " << -static_cast<signed int>(i) << std::endl;
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 void
@@ -966,7 +966,7 @@ SparsityPatternBase::bandwidth() const
 void
 SparsityPattern::block_write(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 
   // first the simple objects, bracketed in [...]
   out << '[' << max_dim << ' ' << rows << ' ' << cols << ' ' << max_vec_len
@@ -982,7 +982,7 @@ SparsityPattern::block_write(std::ostream &out) const
               reinterpret_cast<const char *>(colnums.get()));
   out << ']';
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 
@@ -990,7 +990,7 @@ SparsityPattern::block_write(std::ostream &out) const
 void
 SparsityPattern::block_read(std::istream &in)
 {
-  AssertThrow(in, ExcIO());
+  AssertThrow(in.fail() == false, ExcIO());
 
   char c;
 

--- a/source/lac/trilinos_epetra_vector.cc
+++ b/source/lac/trilinos_epetra_vector.cc
@@ -615,7 +615,7 @@ namespace LinearAlgebra
                   const bool         scientific,
                   const bool         across) const
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       boost::io::ios_flags_saver restore_flags(out);
 
       // Get a representation of the vector and loop over all
@@ -642,7 +642,7 @@ namespace LinearAlgebra
 
       // restore the representation
       // of the vector
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
 

--- a/source/lac/trilinos_sparse_matrix.cc
+++ b/source/lac/trilinos_sparse_matrix.cc
@@ -2290,7 +2290,7 @@ namespace TrilinosWrappers
           }
       }
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 

--- a/source/lac/trilinos_sparsity_pattern.cc
+++ b/source/lac/trilinos_sparsity_pattern.cc
@@ -983,7 +983,7 @@ namespace TrilinosWrappers
           }
       }
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
 
@@ -1015,7 +1015,7 @@ namespace TrilinosWrappers
               << std::endl;
       }
 
-    AssertThrow(out, ExcIO());
+    AssertThrow(out.fail() == false, ExcIO());
   }
 
   // TODO: Implement!

--- a/source/lac/trilinos_vector.cc
+++ b/source/lac/trilinos_vector.cc
@@ -787,7 +787,7 @@ namespace TrilinosWrappers
                   const bool         scientific,
                   const bool         across) const
     {
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
       boost::io::ios_flags_saver restore_flags(out);
 
 
@@ -824,7 +824,7 @@ namespace TrilinosWrappers
           out << std::endl;
         }
 
-      AssertThrow(out, ExcIO());
+      AssertThrow(out.fail() == false, ExcIO());
     }
 
 

--- a/source/numerics/histogram.cc
+++ b/source/numerics/histogram.cc
@@ -224,7 +224,7 @@ Histogram::evaluate(const Vector<number> &values,
 void
 Histogram::write_gnuplot(std::ostream &out) const
 {
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
   Assert(!intervals.empty(),
          ExcMessage("There is nothing to write into the output file. "
                     "Did you forget to call the evaluate() function?"));
@@ -270,7 +270,7 @@ Histogram::write_gnuplot(std::ostream &out) const
         out << std::endl;
       }
 
-  AssertThrow(out, ExcIO());
+  AssertThrow(out.fail() == false, ExcIO());
 }
 
 


### PR DESCRIPTION
I got a report that said this:
```
> I get an xyzerror.log file that says:
> /An error occurred in line <5722> of file
> <C:\Jason\cpp\saati\fea-tools\dealii\source\base\data_out_base.cc> in
> function
>      write_vtu_header
> The violated condition was:
>      out/
> I don't know what the violated condition "out" means.
> Can you help with this?
```
It's hard to blame the reader -- `out` is not a good description of the condition that actually fails. What is happening here is that we have a stream object `out` whose state we test via the implicit-to-bool conversion: https://en.cppreference.com/w/cpp/io/basic_ios/operator_bool

This patch makes the test explicit by calling the function that underlies this implicit `operator bool()`, namely, `[io]stream.fail()`. It is a shame that the standards makers have used a negative word to denote this function, because this makes the condition we want to check (namely, `stream.fail() == false`) hard to read: It's a double-negative. I wished the standard would get rid of negative verbs. Now, the standard does have a function `stream.good()`, which would be much nicer to test, except that it is generally not what we care about here: `good()` returns `false` at the end of an input file even if the state of the stream is otherwise ok, see the table at the bottom of the link above. In other words, `stream.good()` is not the same as `!stream.fail()`. Nor is `stream.good()` equal to `!stream.bad()`, which I think is just a particularly terrible choice of semantics.

Either way, this patch might make things slightly more readable at the price of adding code. What are people's opinions about this?

/rebuild