### PR TITLE
CMake: Allow to define multiple threads= variant tests

### DIFF
--- a/tests/a-framework/concurrent_threads.cc
+++ b/tests/a-framework/concurrent_threads.cc
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2003 - 2018 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+// test the testsuite framework.
+
+// Verify that the "threads=N" test annotation actually works.
+
+#include "../tests.h"
+
+int
+main()
+{
+  std::cout << "Number of threads " << dealii::MultithreadInfo::n_threads()
+            << std::endl;
+  return 0;
+}

--- a/tests/a-framework/concurrent_threads.threads=2.output
+++ b/tests/a-framework/concurrent_threads.threads=2.output
@@ -1,0 +1,1 @@
+Number of threads 2

--- a/tests/a-framework/concurrent_threads.threads=4.output
+++ b/tests/a-framework/concurrent_threads.threads=4.output
@@ -1,0 +1,1 @@
+Number of threads 4

--- a/tests/performance/collect_measurements
+++ b/tests/performance/collect_measurements
@@ -50,6 +50,10 @@ do
   test_name=${test_name/.release/}
   test_name=${test_name/.debug/}
 
+  # Some minor cleanup:
+  test_name=${test_name/mpirun_0-/}
+  test_name=${test_name/-threads_0/}
+
   {
     read -r test_type # first line of output file contains test type
     read -r           # skip second line


### PR DESCRIPTION
This change allow to define multiple test flavors with threads= similarly
to how we handle mpirun=. For example,

    category/test.cc
    category/test.threads=2.output
    category/test.threads=4.output

will now create one top level target to compile test.cc and define two
tests "category/test.threads=2.(release|debug)" and
"category/test.threads=4.(release|debug)" that execute the test program
with a threadpool size set to 2 and 4, respectively.