### PR TITLE
Explicitly delete a function that we don't want to be called.

### DIFF
--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -139,22 +139,6 @@ namespace Utilities
    */
   namespace MPI
   {
-#ifdef DOXYGEN
-    /**
-     * Given a pointer to an object of class T, return the matching
-     * `MPI_Datatype` to be used for MPI communication.
-     *
-     * As an example, passing an `int*` to this function returns `MPI_INT`.
-     *
-     * @note In reality, these functions are not template functions templated
-     * on the parameter T, but free standing inline function overloads. This
-     * templated version only exists so that it shows up in the documentation.
-     */
-    template <typename T>
-    MPI_Datatype
-    mpi_type_id(const T *);
-#endif
-
     /**
      * Return the number of MPI processes there exist in the given
      * @ref GlossMPICommunicator "communicator"
@@ -1327,9 +1311,26 @@ namespace Utilities
 
 
 
-#ifndef DOXYGEN
-
     /* --------------------------- inline functions ------------------------- */
+
+    /**
+     * Given a pointer to an object of class T, return the matching
+     * `MPI_Datatype` to be used for MPI communication.
+     *
+     * As an example, passing an `int*` to this function returns `MPI_INT`.
+     *
+     * @note In reality, these functions are not template functions templated
+     * on the parameter T, but free standing inline function overloads. This
+     * templated version only exists so that it shows up in the documentation.
+     * The `=delete` statement at the end of the declaration ensures that the
+     * compiler will never choose this general template and instead look
+     * for one of the overloads.
+     */
+    template <typename T>
+    inline MPI_Datatype
+    mpi_type_id(const T *) = delete;
+
+#ifndef DOXYGEN
 
 #  ifdef DEAL_II_WITH_MPI
     inline MPI_Datatype


### PR DESCRIPTION
This is a follow-up to #13367 and part of the series for #13357. It makes a function available to the compiler rather than to doxygen only, so that we can get a marginally better error message when trying to get the MPI data type for types that are not expressed in MPI. I had thought that we may be able to do
```
template <typename T>
    inline MPI_Datatype
    mpi_type_id(const T *) 
{
  static_assert (false, "No MPI type for type T.");
  return -1;
}
```
but the compiler then errors out right away upon seeing this function body, even though it is never instantiated. I have to admit that I don't like that, but it is what it is. At least, with this patch, the user gets pointed to a line in the code base that has an explanation attached to the reason why the function is not available.

/rebuild