### PR TITLE
Add ArborXWrappers::DistributedTree

### DIFF
--- a/cmake/modules/FindARBORX.cmake
+++ b/cmake/modules/FindARBORX.cmake
@@ -32,6 +32,36 @@ FIND_PACKAGE(ArborX
 
 IF(ArborX_FOUND)
   GET_PROPERTY(ARBORX_INSTALL_INCLUDE_DIR TARGET ArborX::ArborX PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+
+  #
+  # Check whether ArborX was compiled with MPI support
+  #
+  MESSAGE(STATUS
+    "Checking whether the found ArborX has MPI support:"
+    )
+
+  #
+  # Look for ArborX_Config.hpp - we'll query it to determine MPI support:
+  #
+  DEAL_II_FIND_FILE(ARBORX_CONFIG_HPP ArborX_Config.hpp
+    HINTS ${ARBORX_INSTALL_INCLUDE_DIR}
+    NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_PATH
+    NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH NO_CMAKE_FIND_ROOT_PATH
+    )
+
+  IF(EXISTS ${ARBORX_CONFIG_HPP})
+    #
+    # Determine whether ArborX was configured with MPI:
+    #
+    FILE(STRINGS "${ARBORX_CONFIG_HPP}" ARBORX_MPI_STRING
+      REGEX "#define ARBORX_ENABLE_MPI")
+    IF("${ARBORX_MPI_STRING}" STREQUAL "")
+      MESSAGE(STATUS "ArborX has no MPI support")
+    ELSE()
+      SET(DEAL_II_ARBORX_WITH_MPI TRUE)
+      MESSAGE(STATUS "ArborX has MPI support")
+    ENDIF()
+  ENDIF()
 ENDIF()
 
 DEAL_II_PACKAGE_HANDLE(ARBORX

--- a/doc/doxygen/options.dox.in
+++ b/doc/doxygen/options.dox.in
@@ -189,6 +189,7 @@ PREDEFINED             = DOXYGEN=1 \
                          DEAL_II_ADOLC_WITH_TAPELESS_REFCOUNTING=1 \
                          DEAL_II_DEPRECATED_EARLY= \
                          DEAL_II_WITH_ARBORX=1 \
+                         DEAL_II_ARBORX_WITH_MPI=1 \
                          DEAL_II_WITH_ARPACK=1 \
                          DEAL_II_ARPACK_WITH_PARPACK=1 \
                          DEAL_II_WITH_ASSIMP=1 \

--- a/doc/news/changes/minor/20220215Turcksin
+++ b/doc/news/changes/minor/20220215Turcksin
@@ -1,0 +1,6 @@
+New: Add new DistributedTree class based on ArborX. This class performs multiple
+kinds of geometric search on distributed objects: intersection of bounding boxes
+and intersection of bounding boxes with points. This class is the distributed
+equivalent of ArborXWrappers::BVH.
+<br>
+(Bruno Turcksin, 2022/02/15)

--- a/include/deal.II/arborx/distributed_tree.h
+++ b/include/deal.II/arborx/distributed_tree.h
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+#ifndef dealii_arborx_distributed_tree_h
+#define dealii_arborx_distributed_tree_h
+
+#include <deal.II/base/config.h>
+
+#if defined(DEAL_II_ARBORX_WITH_MPI) && defined(DEAL_II_WITH_MPI)
+#  include <deal.II/arborx/access_traits.h>
+
+#  include <ArborX_DistributedTree.hpp>
+#  include <Kokkos_Core.hpp>
+
+DEAL_II_NAMESPACE_OPEN
+
+namespace ArborXWrappers
+{
+  /**
+   * This class implements a wrapper around ArborX::DistributedTree, the
+   * distributed version of ArborX:BVH.
+   *
+   * Because ArborX uses Kokkos, Kokkos needs to be initialized and finalized
+   * before using this class.
+   */
+  class DistributedTree
+  {
+  public:
+    /**
+     * Constructor. Use a vector of BoundingBox @p bounding_boxes as primitives.
+     * The BoundingBox objects in @p bounding_boxes are local to the MPI process.
+     */
+    template <int dim, typename Number>
+    DistributedTree(
+      const MPI_Comm &                             comm,
+      const std::vector<BoundingBox<dim, Number>> &bounding_boxes);
+
+    /**
+     * Constructor. Use a vector of @p points as primitives. The Point objects
+     * in @p points are local to the MPI process.
+     */
+    template <int dim, typename Number>
+    DistributedTree(const MPI_Comm &                       comm,
+                    const std::vector<Point<dim, Number>> &points);
+
+    /**
+     * Return the indices and the MPI ranks of those BoundingBox objects that
+     * satisfy the @p queries.
+     * Because @p queries can contain multiple queries, the function returns a pair
+     * of indices and ranks and the associated offsets.
+     *
+     * Valid `QueryType` classes are
+     * ArborXWrappers::BoundingBoxIntersectPredicate,
+     * ArborXWrappers::BoundingBoxNearestPredicate,
+     * ArborXWrappers::PointIntersectPredicate, and
+     * ArborXWrappers::PointNearestPredicate,
+     */
+    template <typename QueryType>
+    std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
+    query(const QueryType &queries);
+
+  private:
+    /**
+     * Underlying ArborX object.
+     */
+    ArborX::DistributedTree<Kokkos::HostSpace> distributed_tree;
+  };
+
+
+
+  template <int dim, typename Number>
+  DistributedTree::DistributedTree(
+    const MPI_Comm &                             comm,
+    const std::vector<BoundingBox<dim, Number>> &bounding_boxes)
+    : distributed_tree(comm,
+                       Kokkos::DefaultHostExecutionSpace{},
+                       bounding_boxes)
+  {}
+
+
+
+  template <int dim, typename Number>
+  DistributedTree::DistributedTree(
+    const MPI_Comm &                       comm,
+    const std::vector<Point<dim, Number>> &points)
+    : distributed_tree(comm, Kokkos::DefaultHostExecutionSpace{}, points)
+  {}
+
+
+
+  template <typename QueryType>
+  std::pair<std::vector<std::pair<int, int>>, std::vector<int>>
+  DistributedTree::query(const QueryType &queries)
+  {
+    Kokkos::View<int *, Kokkos::HostSpace> offsets("offsets", 0);
+    Kokkos::View<Kokkos::pair<int, int> *, Kokkos::HostSpace> indices_ranks(
+      "indices_ranks", 0);
+    distributed_tree.query(Kokkos::DefaultHostExecutionSpace{},
+                           queries,
+                           indices_ranks,
+                           offsets);
+
+    std::vector<std::pair<int, int>> indices_ranks_vector;
+    for (unsigned int i = 0; i < indices_ranks.extent(0); ++i)
+      {
+        indices_ranks_vector.emplace_back(indices_ranks(i).first,
+                                          indices_ranks(i).second);
+      }
+
+    std::vector<int> offsets_vector;
+    offsets_vector.insert(offsets_vector.begin(),
+                          offsets.data(),
+                          offsets.data() + offsets.extent(0));
+
+    return {indices_ranks_vector, offsets_vector};
+  }
+} // namespace ArborXWrappers
+
+DEAL_II_NAMESPACE_CLOSE
+
+#endif
+#endif

--- a/include/deal.II/base/config.h.in
+++ b/include/deal.II/base/config.h.in
@@ -210,6 +210,9 @@
 #cmakedefine DEAL_II_ADOLC_WITH_ADVANCED_BRANCHING
 #cmakedefine DEAL_II_ADOLC_WITH_TAPELESS_REFCOUNTING
 
+/* cmake/modules/FindARBORX.cmake */
+#cmakedefine DEAL_II_ARBORX_WITH_MPI
+
 /* cmake/modules/FindARPACK.cmake */
 #cmakedefine DEAL_II_ARPACK_WITH_PARPACK
 

--- a/source/arborx/access_traits.cc
+++ b/source/arborx/access_traits.cc
@@ -171,9 +171,9 @@ namespace ArborX
   {
     // ArborX assumes that the point coordinates use float and that the point
     // is 3D
-    return {{static_cast<float>(v[i][0]),
-             static_cast<float>(v[i][1]),
-             dim == 2 ? 0 : static_cast<float>(v[i][2])}};
+    return {static_cast<float>(v[i][0]),
+            static_cast<float>(v[i][1]),
+            dim == 2 ? 0 : static_cast<float>(v[i][2])};
   }
 
 

--- a/tests/arborx/distributed_tree_intersect.cc
+++ b/tests/arborx/distributed_tree_intersect.cc
@@ -1,0 +1,201 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check ArborX wrapper: intersection of bounding boxes
+
+
+#include <deal.II/arborx/access_traits.h>
+#include <deal.II/arborx/distributed_tree.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include "../tests.h"
+
+
+void
+test_2d()
+{
+  std::vector<BoundingBox<2>> bounding_boxes;
+  std::vector<Point<2>>       points;
+
+  const unsigned int n_points_1d = 5;
+  const int          rank    = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int          n_procs = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int          offset_bb    = 2 * rank * n_points_1d;
+  const int          offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          points.emplace_back(j + offset_bb, i + offset_bb);
+        }
+    }
+
+  for (unsigned int i = 0; i < n_points_1d - 1; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d - 1; ++j)
+        {
+          unsigned int point_index = j + i * n_points_1d;
+          bounding_boxes.push_back(
+            std::make_pair(points[point_index],
+                           points[point_index + n_points_1d + 1]));
+        }
+    }
+
+  Point<2> point_a(0.5 + offset_query, 0.5 + offset_query);
+  Point<2> point_b(1.5 + offset_query, 1.5 + offset_query);
+  Point<2> point_c(2.2 + offset_query, 2.2 + offset_query);
+  Point<2> point_d(2.6 + offset_query, 2.6 + offset_query);
+
+  std::vector<BoundingBox<2>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree               distributed_tree(MPI_COMM_WORLD,
+                                                   bounding_boxes);
+  ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
+    query_bounding_boxes);
+  auto indices_ranks_offset = distributed_tree.query(bb_intersect);
+  auto indices_ranks        = indices_ranks_offset.first;
+  auto offsets              = indices_ranks_offset.second;
+
+  std::vector<int> indices_ref = {0, 1, 4, 5, 10};
+  std::vector<int> offsets_ref = {0, 4, 5};
+
+  AssertThrow(indices_ranks.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+void
+test_3d()
+{
+  std::vector<BoundingBox<3>> bounding_boxes;
+  std::vector<Point<3>>       points;
+
+  unsigned int n_points_1d  = 5;
+  const int    rank         = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int    n_procs      = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int    offset_bb    = 2 * rank * n_points_1d;
+  const int    offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          for (unsigned int k = 0; k < n_points_1d; ++k)
+            {
+              points.emplace_back(k + offset_bb, j + offset_bb, i + offset_bb);
+            }
+        }
+    }
+
+  for (unsigned int i = 0; i < n_points_1d - 1; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d - 1; ++j)
+        {
+          for (unsigned int k = 0; k < n_points_1d - 1; ++k)
+            {
+              unsigned int point_index =
+                k + j * n_points_1d + i * n_points_1d * n_points_1d;
+              bounding_boxes.push_back(
+                std::make_pair(points[point_index],
+                               points[point_index + n_points_1d * n_points_1d +
+                                      n_points_1d + 1]));
+            }
+        }
+    }
+
+  Point<3> point_a(0.5 + offset_query, 0.5 + offset_query, 0.5 + offset_query);
+  Point<3> point_b(1.5 + offset_query, 1.5 + offset_query, 1.5 + offset_query);
+  Point<3> point_c(2.2 + offset_query, 2.2 + offset_query, 2.2 + offset_query);
+  Point<3> point_d(2.6 + offset_query, 2.6 + offset_query, 2.6 + offset_query);
+
+  std::vector<BoundingBox<3>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree               distributed_tree(MPI_COMM_WORLD,
+                                                   bounding_boxes);
+  ArborXWrappers::BoundingBoxIntersectPredicate bb_intersect(
+    query_bounding_boxes);
+  auto indices_ranks_offset = distributed_tree.query(bb_intersect);
+  auto indices_ranks        = indices_ranks_offset.first;
+  auto offsets              = indices_ranks_offset.second;
+
+  std::vector<int> indices_ref = {0, 1, 4, 5, 16, 17, 20, 21, 42};
+  std::vector<int> offsets_ref = {0, 8, 9};
+
+  AssertThrow(indices_ranks.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
+  Utilities::MPI::MPI_InitFinalize mpi_init(argc, argv);
+
+  initlog();
+
+  // tests
+  test_2d();
+  test_3d();
+
+  Kokkos::finalize();
+}

--- a/tests/arborx/distributed_tree_intersect.mpirun=2.output
+++ b/tests/arborx/distributed_tree_intersect.mpirun=2.output
@@ -1,0 +1,3 @@
+
+DEAL::OK                                                                                                                                                                                                                                     
+DEAL::OK

--- a/tests/arborx/distributed_tree_nearest.cc
+++ b/tests/arborx/distributed_tree_nearest.cc
@@ -1,0 +1,330 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+// Check ArborX wrapper: nearest bounding boxes
+
+
+#include <deal.II/arborx/access_traits.h>
+#include <deal.II/arborx/bvh.h>
+
+#include <deal.II/base/bounding_box.h>
+
+#include "../tests.h"
+
+
+void
+test_bounding_box_2d()
+{
+  std::vector<BoundingBox<2>> bounding_boxes;
+  std::vector<Point<2>>       points;
+
+  unsigned int n_points_1d  = 5;
+  const int    rank         = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int    n_procs      = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int    offset_bb    = 2 * rank * n_points_1d;
+  const int    offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          points.emplace_back(j + offset_bb, i + offset_bb);
+        }
+    }
+
+  for (unsigned int i = 0; i < n_points_1d - 1; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d - 1; ++j)
+        {
+          unsigned int point_index = j + i * n_points_1d;
+          bounding_boxes.push_back(
+            std::make_pair(points[point_index],
+                           points[point_index + n_points_1d + 1]));
+        }
+    }
+
+  Point<2> point_a(-1.0 + offset_query, -1.0 + offset_query);
+  Point<2> point_b(-0.5 + offset_query, -0.5 + offset_query);
+  Point<2> point_c(5.2 + offset_query, 5.2 + offset_query);
+  Point<2> point_d(5.6 + offset_query, 5.6 + offset_query);
+
+  std::vector<BoundingBox<2>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree             distributed_tree(MPI_COMM_WORLD,
+                                                   bounding_boxes);
+  ArborXWrappers::BoundingBoxNearestPredicate bb_nearest(query_bounding_boxes,
+                                                         1);
+  auto indices_ranks_offsets = distributed_tree.query(bb_nearest);
+  auto indices               = indices_ranks_offsets.first;
+  auto offsets               = indices_ranks_offsets.second;
+
+  std::vector<int> indices_ref = {0, 15};
+  std::vector<int> offsets_ref = {0, 1, 2};
+
+  AssertThrow(indices.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+void
+test_point_2d()
+{
+  std::vector<Point<2>> points;
+
+  unsigned int n_points_1d  = 5;
+  const int    rank         = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int    n_procs      = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int    offset_pt    = 2 * rank * n_points_1d;
+  const int    offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          points.emplace_back(j + offset_pt, i + offset_pt);
+        }
+    }
+
+  Point<3> point_a(0.5 + offset_query, 0.5 + offset_query, 0.5 + offset_query);
+  Point<3> point_b(1.5 + offset_query, 1.5 + offset_query, 1.5 + offset_query);
+  Point<3> point_c(2.2 + offset_query, 2.2 + offset_query, 2.2 + offset_query);
+  Point<3> point_d(2.6 + offset_query, 2.6 + offset_query, 2.6 + offset_query);
+
+  std::vector<BoundingBox<3>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree distributed_tree(MPI_COMM_WORLD, points);
+  ArborXWrappers::BoundingBoxNearestPredicate bb_nearest(query_bounding_boxes,
+                                                         1);
+  auto indices_ranks_offset = distributed_tree.query(bb_nearest);
+  auto indices              = indices_ranks_offset.first;
+  auto offsets              = indices_ranks_offset.second;
+
+  std::vector<int> indices_ref = {6, 12};
+  std::vector<int> offsets_ref = {0, 1, 2};
+
+  AssertThrow(indices_ranks.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+
+  deallog << "OK" << std::endl;
+}
+
+void
+test_bounding_box_3d()
+{
+  std::vector<BoundingBox<3>> bounding_boxes;
+  std::vector<Point<3>>       points;
+
+  unsigned int n_points_1d  = 5;
+  const int    rank         = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int    n_procs      = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int    offset_bb    = 2 * rank * n_points_1d;
+  const int    offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          for (unsigned int k = 0; k < n_points_1d; ++k)
+            {
+              points.emplace_back(k + offset_bb, j + offset_bb, i + offset_bb);
+            }
+        }
+    }
+
+  for (unsigned int i = 0; i < n_points_1d - 1; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d - 1; ++j)
+        {
+          for (unsigned int k = 0; k < n_points_1d - 1; ++k)
+            {
+              unsigned int point_index =
+                k + j * n_points_1d + i * n_points_1d * n_points_1d;
+              bounding_boxes.push_back(
+                std::make_pair(points[point_index],
+                               points[point_index + n_points_1d * n_points_1d +
+                                      n_points_1d + 1]));
+            }
+        }
+    }
+
+  Point<3> point_a(-1.0 + offst_query, -1.0 + offst_query, -1.0 + offst_query);
+  Point<3> point_b(-0.5 + offst_query, -0.5 + offst_query, -0.5 + offst_query);
+  Point<3> point_c(10.2 + offst_query, 10.2 + offst_query, 10.2 + offst_query);
+  Point<3> point_d(10.6 + offst_query, 10.6 + offst_query, 10.6 + offst_query);
+
+  std::vector<BoundingBox<3>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree             distributed_tree(MPI_COMM_WORLD,
+                                                   bounding_boxes);
+  ArborXWrappers::BoundingBoxNearestPredicate bb_nearest(query_bounding_boxes,
+                                                         1);
+  auto indices_ranks_offsets = distributed_tree.query(bb_nearest);
+  auto indices_ranks         = indices_ranks_offsets.first;
+  auto offsets               = indices_ranks_offsets.second;
+
+  std::vector<int> indices_ref = {0, 63};
+  std::vector<int> offsets_ref = {0, 1, 2};
+
+  AssertThrow(indices_ranks.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+void
+test_point_3d()
+{
+  std::vector<Point<3>> points;
+
+  unsigned int n_points_1d  = 5;
+  const int    rank         = Utilities::MPI::this_mpi_process(MPI_COMM_WORLD);
+  const int    n_procs      = Utilities::MPI::n_mpi_processes(MPI_COMM_WORLD);
+  const int    offset_pt    = 2 * rank * n_points_1d;
+  const int    offset_query = 2 * ((rank + 1) % n_procs) * n_points_1d;
+  for (unsigned int i = 0; i < n_points_1d; ++i)
+    {
+      for (unsigned int j = 0; j < n_points_1d; ++j)
+        {
+          for (unsigned int k = 0; k < n_points_1d; ++k)
+            {
+              points.emplace_back(k + offset_pt, j + offset_pt, i + offset_pt);
+            }
+        }
+    }
+
+  Point<3> point_a(0.5 + offset_query, 0.5 + offset_query, 0.5 + offset_query);
+  Point<3> point_b(1.5 + offset_query, 1.5 + offset_query, 1.5 + offset_query);
+  Point<3> point_c(2.2 + offset_query, 2.2 + offset_query, 2.2 + offset_query);
+  Point<3> point_d(2.6 + offset_query, 2.6 + offset_query, 2.6 + offset_query);
+
+  std::vector<BoundingBox<3>> query_bounding_boxes;
+  query_bounding_boxes.emplace_back(std::make_pair(point_a, point_b));
+  query_bounding_boxes.emplace_back(std::make_pair(point_c, point_d));
+
+  ArborXWrappers::DistributedTree distributed_tree(MPI_COMM_WORLD, points);
+  ArborXWrappers::BoundingBoxNearestPredicate bb_nearest(query_bounding_boxes,
+                                                         1);
+  auto indices_ranks_offsets = distributed_tree.query(bb_nearest);
+  auto indices_ranks         = indices_offset.first;
+  auto offsets               = indices_offset.second;
+
+  std::vector<int> indices_ref = {31, 62};
+  std::vector<int> offsets_ref = {0, 1, 2};
+
+  AssertThrow(indices.size() == indices_ref.size(), ExcInternalError());
+  AssertThrow(offsets.size() == offsets_ref.size(), ExcInternalError());
+  for (unsigned int i = 0; i < offsets.size() - 1; ++i)
+    {
+      for (int j = offsets[i]; j < offsets[i + 1]; ++j)
+        {
+          // The indices associated to each query are not ordered.
+          bool found = false;
+          for (int k = offsets[i]; k < offsets[i + 1]; ++k)
+            {
+              if ((indices_ranks[j].first == indices_ref[k]) &&
+                  (indices_ranks[j].second == (rank + 1) % n_procs))
+                {
+                  found = true;
+                  break;
+                }
+            }
+          AssertThrow(found, ExcInternalError());
+        }
+    }
+  for (unsigned int i = 0; i < offsets.size(); ++i)
+    AssertThrow(offsets[i] == offsets_ref[i], ExcInternalError());
+  deallog << "OK" << std::endl;
+}
+
+int
+main(int argc, char **argv)
+{
+  // Initialize Kokkos
+  Kokkos::initialize(argc, argv);
+
+  initlog();
+
+  // tests
+  test_bounding_box_2d();
+  test_bounding_box_3d();
+  test_point_2d();
+  test_point_3d();
+
+  Kokkos::finalize();
+}

--- a/tests/arborx/distributed_tree_nearest.mpirun=2.output
+++ b/tests/arborx/distributed_tree_nearest.mpirun=2.output
@@ -1,0 +1,3 @@
+
+DEAL::OK                                                                                                                                                                                                                                     
+DEAL::OK


### PR DESCRIPTION
This PR adds supports for `ArborX::DistributedTree`. This is the distributed version of the `ArborX::BVH` which we already have wrappers for.  With this library, we can do spatial search and nearest neighbors search when the points/bounding boxes are distributed. 