### PR TITLE
Introduce a template variable mpi_type_id_for_type.

### DIFF
--- a/doc/news/changes/minor/20220227Bangerth
+++ b/doc/news/changes/minor/20220227Bangerth
@@ -1,0 +1,7 @@
+New: The template variable Utilities::MPI::mpi_type_id_for_type
+provides information about the `MPI_Datatype` that corresponds to a
+given type. This information is necessary in all MPI calls where one
+needs to provide an `MPI_Datatype` to identify the kinds of objects
+stored in a send or receive buffer.
+<br>
+(Wolfgang Bangerth, 2022/02/27)

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1305,28 +1305,14 @@ namespace Utilities
 
     namespace internal
     {
+      /**
+       * Given a pointer to an object of class T, the functions in this
+       * namespace return the matching
+       * `MPI_Datatype` to be used for MPI communication.
+       */
       namespace MPIDataTypes
       {
-        /**
-         * Given a pointer to an object of class T, return the matching
-         * `MPI_Datatype` to be used for MPI communication.
-         *
-         * As an example, passing an `int*` to this function returns `MPI_INT`.
-         *
-         * @note In reality, these functions are not template functions templated
-         * on the parameter T, but free standing inline function overloads. This
-         * templated version only exists so that it shows up in the
-         * documentation. The `=delete` statement at the end of the declaration
-         * ensures that the compiler will never choose this general template and
-         * instead look for one of the overloads.
-         */
-        template <typename T>
-        inline MPI_Datatype
-        mpi_type_id(const T *) = delete;
-
-#ifndef DOXYGEN
-
-#  ifdef DEAL_II_WITH_MPI
+#ifdef DEAL_II_WITH_MPI
         inline MPI_Datatype
         mpi_type_id(const bool *)
         {
@@ -1452,13 +1438,13 @@ namespace Utilities
         {
           return MPI_DOUBLE_COMPLEX;
         }
-#  endif
 #endif
       } // namespace MPIDataTypes
     }   // namespace internal
 
 
 
+#ifdef DEAL_II_WITH_MPI
     /**
      * A template variable that translates from the data type given as
      * template argument to the corresponding
@@ -1474,7 +1460,7 @@ namespace Utilities
     const MPI_Datatype mpi_type_id = internal::MPIDataTypes::mpi_type_id(
       static_cast<std::remove_cv_t<
         std::remove_reference_t<std::remove_all_extents_t<T>>> *>(nullptr));
-
+#endif
 
 #ifndef DOXYGEN
     namespace internal

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1303,154 +1303,180 @@ namespace Utilities
 
     /* --------------------------- inline functions ------------------------- */
 
-    /**
-     * Given a pointer to an object of class T, return the matching
-     * `MPI_Datatype` to be used for MPI communication.
-     *
-     * As an example, passing an `int*` to this function returns `MPI_INT`.
-     *
-     * @note In reality, these functions are not template functions templated
-     * on the parameter T, but free standing inline function overloads. This
-     * templated version only exists so that it shows up in the documentation.
-     * The `=delete` statement at the end of the declaration ensures that the
-     * compiler will never choose this general template and instead look
-     * for one of the overloads.
-     */
-    template <typename T>
-    inline MPI_Datatype
-    mpi_type_id(const T *) = delete;
+    namespace internal
+    {
+      namespace MPIDataTypes
+      {
+        /**
+         * Given a pointer to an object of class T, return the matching
+         * `MPI_Datatype` to be used for MPI communication.
+         *
+         * As an example, passing an `int*` to this function returns `MPI_INT`.
+         *
+         * @note In reality, these functions are not template functions templated
+         * on the parameter T, but free standing inline function overloads. This
+         * templated version only exists so that it shows up in the
+         * documentation. The `=delete` statement at the end of the declaration
+         * ensures that the compiler will never choose this general template and
+         * instead look for one of the overloads.
+         */
+        template <typename T>
+        inline MPI_Datatype
+        mpi_type_id(const T *) = delete;
 
 #ifndef DOXYGEN
 
 #  ifdef DEAL_II_WITH_MPI
-    inline MPI_Datatype
-    mpi_type_id(const bool *)
-    {
-      return MPI_CXX_BOOL;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const bool *)
+        {
+          return MPI_CXX_BOOL;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const char *)
-    {
-      return MPI_CHAR;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const char *)
+        {
+          return MPI_CHAR;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const signed char *)
-    {
-      return MPI_SIGNED_CHAR;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const signed char *)
+        {
+          return MPI_SIGNED_CHAR;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const short *)
-    {
-      return MPI_SHORT;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const short *)
+        {
+          return MPI_SHORT;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const int *)
-    {
-      return MPI_INT;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const int *)
+        {
+          return MPI_INT;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const long int *)
-    {
-      return MPI_LONG;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const long int *)
+        {
+          return MPI_LONG;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const unsigned char *)
-    {
-      return MPI_UNSIGNED_CHAR;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const unsigned char *)
+        {
+          return MPI_UNSIGNED_CHAR;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const unsigned short *)
-    {
-      return MPI_UNSIGNED_SHORT;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const unsigned short *)
+        {
+          return MPI_UNSIGNED_SHORT;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const unsigned int *)
-    {
-      return MPI_UNSIGNED;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const unsigned int *)
+        {
+          return MPI_UNSIGNED;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const unsigned long int *)
-    {
-      return MPI_UNSIGNED_LONG;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const unsigned long int *)
+        {
+          return MPI_UNSIGNED_LONG;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const unsigned long long int *)
-    {
-      return MPI_UNSIGNED_LONG_LONG;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const unsigned long long int *)
+        {
+          return MPI_UNSIGNED_LONG_LONG;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const float *)
-    {
-      return MPI_FLOAT;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const float *)
+        {
+          return MPI_FLOAT;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const double *)
-    {
-      return MPI_DOUBLE;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const double *)
+        {
+          return MPI_DOUBLE;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const long double *)
-    {
-      return MPI_LONG_DOUBLE;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const long double *)
+        {
+          return MPI_LONG_DOUBLE;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const std::complex<float> *)
-    {
-      return MPI_COMPLEX;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const std::complex<float> *)
+        {
+          return MPI_COMPLEX;
+        }
 
 
 
-    inline MPI_Datatype
-    mpi_type_id(const std::complex<double> *)
-    {
-      return MPI_DOUBLE_COMPLEX;
-    }
+        inline MPI_Datatype
+        mpi_type_id(const std::complex<double> *)
+        {
+          return MPI_DOUBLE_COMPLEX;
+        }
 #  endif
+#endif
+      } // namespace MPIDataTypes
+    }   // namespace internal
 
 
+
+    /**
+     * A template variable that translates from the data type given as
+     * template argument to the corresponding
+     * `MPI_Datatype` to be used for MPI communication.
+     *
+     * As an example, the value of `mpi_type_id<int>` is `MPI_INT`. A
+     * common way to use this variable is when sending an object `obj`
+     * via MPI functions to another process, and using
+     * `mpi_type_id<decltype(obj)>` to infer the correct MPI type to
+     * use for the communication.
+     */
+    template <typename T>
+    const MPI_Datatype mpi_type_id = internal::MPIDataTypes::mpi_type_id(
+      static_cast<std::remove_cv_t<
+        std::remove_reference_t<std::remove_all_extents_t<T>>> *>(nullptr));
+
+
+#ifndef DOXYGEN
     namespace internal
     {
       // declaration for an internal function that lives in mpi.templates.h
@@ -1808,7 +1834,7 @@ namespace Utilities
 
           const int ierr = MPI_Bcast(buffer + total_sent_count,
                                      current_count,
-                                     mpi_type_id(buffer),
+                                     mpi_type_id<decltype(*buffer)>,
                                      root,
                                      comm);
           AssertThrowMPI(ierr);
@@ -1846,8 +1872,11 @@ namespace Utilities
         }
 
       // Exchange the size of buffer
-      int ierr = MPI_Bcast(
-        &buffer_size, 1, mpi_type_id(&buffer_size), root_process, comm);
+      int ierr = MPI_Bcast(&buffer_size,
+                           1,
+                           mpi_type_id<decltype(buffer_size)>,
+                           root_process,
+                           comm);
       AssertThrowMPI(ierr);
 
       // If not on the root process, correctly size the buffer to

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1471,6 +1471,12 @@ namespace Utilities
      * via MPI functions to another process, and using
      * `mpi_type_id_for_type<decltype(obj)>` to infer the correct MPI type to
      * use for the communication.
+     *
+     * The type `T` given here must be one of the data types supported
+     * by MPI, such as `int` or `double`. It may not be an array of
+     * objects of such a type, or a pointer to an object of such a
+     * type. The compiler will produce an error if this requirement is
+     * not satisfied.
      */
     template <typename T>
     const MPI_Datatype

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1338,6 +1338,14 @@ namespace Utilities
 
 
         inline MPI_Datatype
+        mpi_type_id(const wchar_t *)
+        {
+          return MPI_WCHAR;
+        }
+
+
+
+        inline MPI_Datatype
         mpi_type_id(const short *)
         {
           return MPI_SHORT;
@@ -1357,6 +1365,14 @@ namespace Utilities
         mpi_type_id(const long int *)
         {
           return MPI_LONG;
+        }
+
+
+
+        inline MPI_Datatype
+        mpi_type_id(const long long int *)
+        {
+          return MPI_LONG_LONG;
         }
 
 

--- a/include/deal.II/base/mpi.h
+++ b/include/deal.II/base/mpi.h
@@ -1450,16 +1450,16 @@ namespace Utilities
      * template argument to the corresponding
      * `MPI_Datatype` to be used for MPI communication.
      *
-     * As an example, the value of `mpi_type_id<int>` is `MPI_INT`. A
+     * As an example, the value of `mpi_type_id_for_type<int>` is `MPI_INT`. A
      * common way to use this variable is when sending an object `obj`
      * via MPI functions to another process, and using
-     * `mpi_type_id<decltype(obj)>` to infer the correct MPI type to
+     * `mpi_type_id_for_type<decltype(obj)>` to infer the correct MPI type to
      * use for the communication.
      */
     template <typename T>
-    const MPI_Datatype mpi_type_id = internal::MPIDataTypes::mpi_type_id(
-      static_cast<std::remove_cv_t<
-        std::remove_reference_t<std::remove_all_extents_t<T>>> *>(nullptr));
+    const MPI_Datatype
+      mpi_type_id_for_type = internal::MPIDataTypes::mpi_type_id(
+        static_cast<std::remove_cv_t<std::remove_reference_t<T>> *>(nullptr));
 #endif
 
 #ifndef DOXYGEN
@@ -1820,7 +1820,7 @@ namespace Utilities
 
           const int ierr = MPI_Bcast(buffer + total_sent_count,
                                      current_count,
-                                     mpi_type_id<decltype(*buffer)>,
+                                     mpi_type_id_for_type<decltype(*buffer)>,
                                      root,
                                      comm);
           AssertThrowMPI(ierr);
@@ -1860,7 +1860,7 @@ namespace Utilities
       // Exchange the size of buffer
       int ierr = MPI_Bcast(&buffer_size,
                            1,
-                           mpi_type_id<decltype(buffer_size)>,
+                           mpi_type_id_for_type<decltype(buffer_size)>,
                            root_process,
                            comm);
       AssertThrowMPI(ierr);

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -85,7 +85,7 @@ namespace Utilities
                               MPI_IN_PLACE,
                             static_cast<void *>(output.data()),
                             static_cast<int>(values.size()),
-                            mpi_type_id(values.data()),
+                            mpi_type_id<decltype(*values.data())>,
                             mpi_op,
                             mpi_communicator);
             AssertThrowMPI(ierr);
@@ -125,7 +125,7 @@ namespace Utilities
                               MPI_IN_PLACE,
                             static_cast<void *>(output.data()),
                             static_cast<int>(values.size() * 2),
-                            mpi_type_id(static_cast<T *>(nullptr)),
+                            mpi_type_id<T>,
                             mpi_op,
                             mpi_communicator);
             AssertThrowMPI(ierr);

--- a/include/deal.II/base/mpi.templates.h
+++ b/include/deal.II/base/mpi.templates.h
@@ -85,7 +85,7 @@ namespace Utilities
                               MPI_IN_PLACE,
                             static_cast<void *>(output.data()),
                             static_cast<int>(values.size()),
-                            mpi_type_id<decltype(*values.data())>,
+                            mpi_type_id_for_type<decltype(*values.data())>,
                             mpi_op,
                             mpi_communicator);
             AssertThrowMPI(ierr);
@@ -125,7 +125,7 @@ namespace Utilities
                               MPI_IN_PLACE,
                             static_cast<void *>(output.data()),
                             static_cast<int>(values.size() * 2),
-                            mpi_type_id<T>,
+                            mpi_type_id_for_type<T>,
                             mpi_op,
                             mpi_communicator);
             AssertThrowMPI(ierr);

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
@@ -106,13 +106,14 @@ namespace Utilities
       AssertIndexRange(recv_ranks.size(), recv_ptr.size());
       for (types::global_dof_index i = 0; i < recv_ranks.size(); ++i)
         {
-          const int ierr = MPI_Irecv(buffers.data() + recv_ptr[i],
-                                     recv_ptr[i + 1] - recv_ptr[i],
-                                     Utilities::MPI::mpi_type_id<Number>,
-                                     recv_ranks[i],
-                                     tag,
-                                     communicator,
-                                     &requests[i + send_ranks.size()]);
+          const int ierr =
+            MPI_Irecv(buffers.data() + recv_ptr[i],
+                      recv_ptr[i + 1] - recv_ptr[i],
+                      Utilities::MPI::mpi_type_id_for_type<Number>,
+                      recv_ranks[i],
+                      tag,
+                      communicator,
+                      &requests[i + send_ranks.size()]);
           AssertThrowMPI(ierr);
         }
 
@@ -134,13 +135,14 @@ namespace Utilities
                    (send_ptr[i] == buffers.size() &&
                     send_ptr[i + 1] == send_ptr[i]),
                  ExcMessage("The input buffer doesn't contain enough entries"));
-          const int ierr = MPI_Isend(buffers.data() + send_ptr[i],
-                                     send_ptr[i + 1] - send_ptr[i],
-                                     Utilities::MPI::mpi_type_id<Number>,
-                                     send_ranks[i],
-                                     tag,
-                                     communicator,
-                                     &requests[i]);
+          const int ierr =
+            MPI_Isend(buffers.data() + send_ptr[i],
+                      send_ptr[i + 1] - send_ptr[i],
+                      Utilities::MPI::mpi_type_id_for_type<Number>,
+                      send_ranks[i],
+                      tag,
+                      communicator,
+                      &requests[i]);
           AssertThrowMPI(ierr);
         }
 #endif

--- a/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
+++ b/include/deal.II/base/mpi_noncontiguous_partitioner.templates.h
@@ -106,14 +106,13 @@ namespace Utilities
       AssertIndexRange(recv_ranks.size(), recv_ptr.size());
       for (types::global_dof_index i = 0; i < recv_ranks.size(); ++i)
         {
-          const int ierr =
-            MPI_Irecv(buffers.data() + recv_ptr[i],
-                      recv_ptr[i + 1] - recv_ptr[i],
-                      Utilities::MPI::mpi_type_id(buffers.data()),
-                      recv_ranks[i],
-                      tag,
-                      communicator,
-                      &requests[i + send_ranks.size()]);
+          const int ierr = MPI_Irecv(buffers.data() + recv_ptr[i],
+                                     recv_ptr[i + 1] - recv_ptr[i],
+                                     Utilities::MPI::mpi_type_id<Number>,
+                                     recv_ranks[i],
+                                     tag,
+                                     communicator,
+                                     &requests[i + send_ranks.size()]);
           AssertThrowMPI(ierr);
         }
 
@@ -135,14 +134,13 @@ namespace Utilities
                    (send_ptr[i] == buffers.size() &&
                     send_ptr[i + 1] == send_ptr[i]),
                  ExcMessage("The input buffer doesn't contain enough entries"));
-          const int ierr =
-            MPI_Isend(buffers.data() + send_ptr[i],
-                      send_ptr[i + 1] - send_ptr[i],
-                      Utilities::MPI::mpi_type_id(buffers.data()),
-                      send_ranks[i],
-                      tag,
-                      communicator,
-                      &requests[i]);
+          const int ierr = MPI_Isend(buffers.data() + send_ptr[i],
+                                     send_ptr[i + 1] - send_ptr[i],
+                                     Utilities::MPI::mpi_type_id<Number>,
+                                     send_ranks[i],
+                                     tag,
+                                     communicator,
+                                     &requests[i]);
           AssertThrowMPI(ierr);
         }
 #endif

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -571,7 +571,7 @@ namespace internal
             const auto ierr_1 = MPI_Isend(
               buffer.data(),
               buffer.size(),
-              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
+              Utilities::MPI::mpi_type_id_for_type<decltype(*buffer.data())>,
               i.first,
               Utilities::MPI::internal::Tags::fine_dof_handler_view_reinit,
               communicator,
@@ -640,7 +640,7 @@ namespace internal
             int       message_length;
             const int ierr_2 = MPI_Get_count(
               &status,
-              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
+              Utilities::MPI::mpi_type_id_for_type<decltype(*buffer.data())>,
               &message_length);
             AssertThrowMPI(ierr_2);
 
@@ -649,7 +649,7 @@ namespace internal
             const int ierr_3 = MPI_Recv(
               buffer.data(),
               buffer.size(),
-              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
+              Utilities::MPI::mpi_type_id_for_type<decltype(*buffer.data())>,
               status.MPI_SOURCE,
               Utilities::MPI::internal::Tags::fine_dof_handler_view_reinit,
               communicator,

--- a/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
+++ b/include/deal.II/multigrid/mg_transfer_global_coarsening.templates.h
@@ -571,7 +571,7 @@ namespace internal
             const auto ierr_1 = MPI_Isend(
               buffer.data(),
               buffer.size(),
-              Utilities::MPI::mpi_type_id(buffer.data()),
+              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
               i.first,
               Utilities::MPI::internal::Tags::fine_dof_handler_view_reinit,
               communicator,
@@ -638,10 +638,10 @@ namespace internal
             std::vector<types::global_dof_index> buffer;
 
             int       message_length;
-            const int ierr_2 =
-              MPI_Get_count(&status,
-                            Utilities::MPI::mpi_type_id(buffer.data()),
-                            &message_length);
+            const int ierr_2 = MPI_Get_count(
+              &status,
+              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
+              &message_length);
             AssertThrowMPI(ierr_2);
 
             buffer.resize(message_length);
@@ -649,7 +649,7 @@ namespace internal
             const int ierr_3 = MPI_Recv(
               buffer.data(),
               buffer.size(),
-              Utilities::MPI::mpi_type_id(buffer.data()),
+              Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
               status.MPI_SOURCE,
               Utilities::MPI::internal::Tags::fine_dof_handler_view_reinit,
               communicator,

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -89,21 +89,21 @@ namespace Utilities
   {
 #ifdef DEAL_II_WITH_MPI
     // Provide definitions of template variables for all valid instantiations.
-    template const MPI_Datatype mpi_type_id<bool>;
-    template const MPI_Datatype mpi_type_id<char>;
-    template const MPI_Datatype mpi_type_id<signed char>;
-    template const MPI_Datatype mpi_type_id<short>;
-    template const MPI_Datatype mpi_type_id<int>;
-    template const MPI_Datatype mpi_type_id<long int>;
-    template const MPI_Datatype mpi_type_id<unsigned char>;
-    template const MPI_Datatype mpi_type_id<unsigned short>;
-    template const MPI_Datatype mpi_type_id<unsigned long int>;
-    template const MPI_Datatype mpi_type_id<unsigned long long int>;
-    template const MPI_Datatype mpi_type_id<float>;
-    template const MPI_Datatype mpi_type_id<double>;
-    template const MPI_Datatype mpi_type_id<long double>;
-    template const MPI_Datatype mpi_type_id<std::complex<float>>;
-    template const MPI_Datatype mpi_type_id<std::complex<double>>;
+    template const MPI_Datatype mpi_type_id_for_type<bool>;
+    template const MPI_Datatype mpi_type_id_for_type<char>;
+    template const MPI_Datatype mpi_type_id_for_type<signed char>;
+    template const MPI_Datatype mpi_type_id_for_type<short>;
+    template const MPI_Datatype mpi_type_id_for_type<int>;
+    template const MPI_Datatype mpi_type_id_for_type<long int>;
+    template const MPI_Datatype mpi_type_id_for_type<unsigned char>;
+    template const MPI_Datatype mpi_type_id_for_type<unsigned short>;
+    template const MPI_Datatype mpi_type_id_for_type<unsigned long int>;
+    template const MPI_Datatype mpi_type_id_for_type<unsigned long long int>;
+    template const MPI_Datatype mpi_type_id_for_type<float>;
+    template const MPI_Datatype mpi_type_id_for_type<double>;
+    template const MPI_Datatype mpi_type_id_for_type<long double>;
+    template const MPI_Datatype mpi_type_id_for_type<std::complex<float>>;
+    template const MPI_Datatype mpi_type_id_for_type<std::complex<double>>;
 #endif
 
 

--- a/source/base/mpi.cc
+++ b/source/base/mpi.cc
@@ -87,6 +87,26 @@ namespace Utilities
 
   namespace MPI
   {
+#ifdef DEAL_II_WITH_MPI
+    // Provide definitions of template variables for all valid instantiations.
+    template const MPI_Datatype mpi_type_id<bool>;
+    template const MPI_Datatype mpi_type_id<char>;
+    template const MPI_Datatype mpi_type_id<signed char>;
+    template const MPI_Datatype mpi_type_id<short>;
+    template const MPI_Datatype mpi_type_id<int>;
+    template const MPI_Datatype mpi_type_id<long int>;
+    template const MPI_Datatype mpi_type_id<unsigned char>;
+    template const MPI_Datatype mpi_type_id<unsigned short>;
+    template const MPI_Datatype mpi_type_id<unsigned long int>;
+    template const MPI_Datatype mpi_type_id<unsigned long long int>;
+    template const MPI_Datatype mpi_type_id<float>;
+    template const MPI_Datatype mpi_type_id<double>;
+    template const MPI_Datatype mpi_type_id<long double>;
+    template const MPI_Datatype mpi_type_id<std::complex<float>>;
+    template const MPI_Datatype mpi_type_id<std::complex<double>>;
+#endif
+
+
     MinMaxAvg
     min_max_avg(const double my_value, const MPI_Comm &mpi_communicator)
     {

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -76,12 +76,13 @@ namespace Utilities
       types::global_dof_index prefix_sum = 0;
 
 #ifdef DEAL_II_WITH_MPI
-      const int ierr = MPI_Exscan(&local_size,
-                                  &prefix_sum,
-                                  1,
-                                  Utilities::MPI::mpi_type_id(&prefix_sum),
-                                  MPI_SUM,
-                                  communicator);
+      const int ierr =
+        MPI_Exscan(&local_size,
+                   &prefix_sum,
+                   1,
+                   Utilities::MPI::mpi_type_id<decltype(prefix_sum)>,
+                   MPI_SUM,
+                   communicator);
       AssertThrowMPI(ierr);
 #endif
 

--- a/source/base/partitioner.cc
+++ b/source/base/partitioner.cc
@@ -80,7 +80,7 @@ namespace Utilities
         MPI_Exscan(&local_size,
                    &prefix_sum,
                    1,
-                   Utilities::MPI::mpi_type_id<decltype(prefix_sum)>,
+                   Utilities::MPI::mpi_type_id_for_type<decltype(prefix_sum)>,
                    MPI_SUM,
                    communicator);
       AssertThrowMPI(ierr);

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -247,11 +247,12 @@ namespace Utilities
       Assert(count > 0, ExcInternalError());
       if (mpi_communicator_inactive_with_root != MPI_COMM_NULL)
         {
-          const int ierr = MPI_Bcast(value,
-                                     count,
-                                     Utilities::MPI::mpi_type_id(value),
-                                     0 /*from root*/,
-                                     mpi_communicator_inactive_with_root);
+          const int ierr =
+            MPI_Bcast(value,
+                      count,
+                      Utilities::MPI::mpi_type_id<decltype(*value)>,
+                      0 /*from root*/,
+                      mpi_communicator_inactive_with_root);
           AssertThrowMPI(ierr);
         }
     }

--- a/source/base/process_grid.cc
+++ b/source/base/process_grid.cc
@@ -250,7 +250,7 @@ namespace Utilities
           const int ierr =
             MPI_Bcast(value,
                       count,
-                      Utilities::MPI::mpi_type_id<decltype(*value)>,
+                      Utilities::MPI::mpi_type_id_for_type<decltype(*value)>,
                       0 /*from root*/,
                       mpi_communicator_inactive_with_root);
           AssertThrowMPI(ierr);

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -89,8 +89,8 @@ namespace RepartitioningPolicyTools
     const int ierr = MPI_Exscan(&process_has_active_locally_owned_cells,
                                 &offset,
                                 1,
-                                Utilities::MPI::mpi_type_id(
-                                  &process_has_active_locally_owned_cells),
+                                Utilities::MPI::mpi_type_id<decltype(
+                                  process_has_active_locally_owned_cells)>,
                                 MPI_SUM,
                                 comm);
     AssertThrowMPI(ierr);
@@ -308,12 +308,13 @@ namespace RepartitioningPolicyTools
     // determine partial sum of weights of this process
     uint64_t process_local_weight_offset = 0;
 
-    int ierr = MPI_Exscan(&process_local_weight,
-                          &process_local_weight_offset,
-                          1,
-                          Utilities::MPI::mpi_type_id(&process_local_weight),
-                          MPI_SUM,
-                          tria->get_communicator());
+    int ierr =
+      MPI_Exscan(&process_local_weight,
+                 &process_local_weight_offset,
+                 1,
+                 Utilities::MPI::mpi_type_id<decltype(process_local_weight)>,
+                 MPI_SUM,
+                 tria->get_communicator());
     AssertThrowMPI(ierr);
 
     // total weight of all processes
@@ -321,7 +322,7 @@ namespace RepartitioningPolicyTools
 
     ierr = MPI_Bcast(&total_weight,
                      1,
-                     Utilities::MPI::mpi_type_id(&total_weight),
+                     Utilities::MPI::mpi_type_id<decltype(total_weight)>,
                      n_subdomains - 1,
                      mpi_communicator);
     AssertThrowMPI(ierr);

--- a/source/distributed/repartitioning_policy_tools.cc
+++ b/source/distributed/repartitioning_policy_tools.cc
@@ -89,7 +89,7 @@ namespace RepartitioningPolicyTools
     const int ierr = MPI_Exscan(&process_has_active_locally_owned_cells,
                                 &offset,
                                 1,
-                                Utilities::MPI::mpi_type_id<decltype(
+                                Utilities::MPI::mpi_type_id_for_type<decltype(
                                   process_has_active_locally_owned_cells)>,
                                 MPI_SUM,
                                 comm);
@@ -308,23 +308,24 @@ namespace RepartitioningPolicyTools
     // determine partial sum of weights of this process
     uint64_t process_local_weight_offset = 0;
 
-    int ierr =
-      MPI_Exscan(&process_local_weight,
-                 &process_local_weight_offset,
-                 1,
-                 Utilities::MPI::mpi_type_id<decltype(process_local_weight)>,
-                 MPI_SUM,
-                 tria->get_communicator());
+    int ierr = MPI_Exscan(
+      &process_local_weight,
+      &process_local_weight_offset,
+      1,
+      Utilities::MPI::mpi_type_id_for_type<decltype(process_local_weight)>,
+      MPI_SUM,
+      tria->get_communicator());
     AssertThrowMPI(ierr);
 
     // total weight of all processes
     uint64_t total_weight = process_local_weight_offset + process_local_weight;
 
-    ierr = MPI_Bcast(&total_weight,
-                     1,
-                     Utilities::MPI::mpi_type_id<decltype(total_weight)>,
-                     n_subdomains - 1,
-                     mpi_communicator);
+    ierr =
+      MPI_Bcast(&total_weight,
+                1,
+                Utilities::MPI::mpi_type_id_for_type<decltype(total_weight)>,
+                n_subdomains - 1,
+                mpi_communicator);
     AssertThrowMPI(ierr);
 
     // setup partition

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -427,7 +427,7 @@ namespace parallel
       MPI_Exscan(&n_locally_owned_cells,
                  &cell_index,
                  1,
-                 Utilities::MPI::mpi_type_id(&n_locally_owned_cells),
+                 Utilities::MPI::mpi_type_id<decltype(n_locally_owned_cells)>,
                  MPI_SUM,
                  this->mpi_communicator);
     AssertThrowMPI(ierr);
@@ -493,13 +493,13 @@ namespace parallel
         std::vector<types::global_cell_index> cell_index(
           this->n_global_levels(), 0);
 
-        int ierr =
-          MPI_Exscan(n_locally_owned_cells.data(),
-                     cell_index.data(),
-                     this->n_global_levels(),
-                     Utilities::MPI::mpi_type_id(n_locally_owned_cells.data()),
-                     MPI_SUM,
-                     this->mpi_communicator);
+        int ierr = MPI_Exscan(
+          n_locally_owned_cells.data(),
+          cell_index.data(),
+          this->n_global_levels(),
+          Utilities::MPI::mpi_type_id<decltype(*n_locally_owned_cells.data())>,
+          MPI_SUM,
+          this->mpi_communicator);
         AssertThrowMPI(ierr);
 
         // 3) determine global number of "active" cells on each level
@@ -509,11 +509,12 @@ namespace parallel
         for (unsigned int l = 0; l < this->n_global_levels(); ++l)
           n_cells_level[l] = n_locally_owned_cells[l] + cell_index[l];
 
-        ierr = MPI_Bcast(n_cells_level.data(),
-                         this->n_global_levels(),
-                         Utilities::MPI::mpi_type_id(n_cells_level.data()),
-                         this->n_subdomains - 1,
-                         this->mpi_communicator);
+        ierr = MPI_Bcast(
+          n_cells_level.data(),
+          this->n_global_levels(),
+          Utilities::MPI::mpi_type_id<decltype(*n_cells_level.data())>,
+          this->n_subdomains - 1,
+          this->mpi_communicator);
         AssertThrowMPI(ierr);
 
         // 4) give global indices to locally-owned cells on level and mark

--- a/source/distributed/tria_base.cc
+++ b/source/distributed/tria_base.cc
@@ -423,13 +423,13 @@ namespace parallel
     // 2) determine the offset of each process
     types::global_cell_index cell_index = 0;
 
-    const int ierr =
-      MPI_Exscan(&n_locally_owned_cells,
-                 &cell_index,
-                 1,
-                 Utilities::MPI::mpi_type_id<decltype(n_locally_owned_cells)>,
-                 MPI_SUM,
-                 this->mpi_communicator);
+    const int ierr = MPI_Exscan(
+      &n_locally_owned_cells,
+      &cell_index,
+      1,
+      Utilities::MPI::mpi_type_id_for_type<decltype(n_locally_owned_cells)>,
+      MPI_SUM,
+      this->mpi_communicator);
     AssertThrowMPI(ierr);
 
     // 3) give global indices to locally-owned cells and mark all other cells as
@@ -493,13 +493,13 @@ namespace parallel
         std::vector<types::global_cell_index> cell_index(
           this->n_global_levels(), 0);
 
-        int ierr = MPI_Exscan(
-          n_locally_owned_cells.data(),
-          cell_index.data(),
-          this->n_global_levels(),
-          Utilities::MPI::mpi_type_id<decltype(*n_locally_owned_cells.data())>,
-          MPI_SUM,
-          this->mpi_communicator);
+        int ierr = MPI_Exscan(n_locally_owned_cells.data(),
+                              cell_index.data(),
+                              this->n_global_levels(),
+                              Utilities::MPI::mpi_type_id_for_type<decltype(
+                                *n_locally_owned_cells.data())>,
+                              MPI_SUM,
+                              this->mpi_communicator);
         AssertThrowMPI(ierr);
 
         // 3) determine global number of "active" cells on each level
@@ -512,7 +512,7 @@ namespace parallel
         ierr = MPI_Bcast(
           n_cells_level.data(),
           this->n_global_levels(),
-          Utilities::MPI::mpi_type_id<decltype(*n_cells_level.data())>,
+          Utilities::MPI::mpi_type_id_for_type<decltype(*n_cells_level.data())>,
           this->n_subdomains - 1,
           this->mpi_communicator);
         AssertThrowMPI(ierr);

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -184,14 +184,14 @@ ScaLAPACKMatrix<NumberType>::ScaLAPACKMatrix(
     }
   int ierr = MPI_Bcast(&n_rows,
                        1,
-                       Utilities::MPI::mpi_type_id(&n_rows),
+                       Utilities::MPI::mpi_type_id<decltype(n_rows)>,
                        0 /*from root*/,
                        process_grid->mpi_communicator);
   AssertThrowMPI(ierr);
 
   ierr = MPI_Bcast(&n_columns,
                    1,
-                   Utilities::MPI::mpi_type_id(&n_columns),
+                   Utilities::MPI::mpi_type_id<decltype(n_columns)>,
                    0 /*from root*/,
                    process_grid->mpi_communicator);
   AssertThrowMPI(ierr);

--- a/source/lac/scalapack.cc
+++ b/source/lac/scalapack.cc
@@ -184,14 +184,14 @@ ScaLAPACKMatrix<NumberType>::ScaLAPACKMatrix(
     }
   int ierr = MPI_Bcast(&n_rows,
                        1,
-                       Utilities::MPI::mpi_type_id<decltype(n_rows)>,
+                       Utilities::MPI::mpi_type_id_for_type<decltype(n_rows)>,
                        0 /*from root*/,
                        process_grid->mpi_communicator);
   AssertThrowMPI(ierr);
 
   ierr = MPI_Bcast(&n_columns,
                    1,
-                   Utilities::MPI::mpi_type_id<decltype(n_columns)>,
+                   Utilities::MPI::mpi_type_id_for_type<decltype(n_columns)>,
                    0 /*from root*/,
                    process_grid->mpi_communicator);
   AssertThrowMPI(ierr);

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -896,7 +896,7 @@ namespace internal
             const int ierr =
               MPI_Irecv(buffer.data() + ghost_targets_data[i][1] + offset,
                         ghost_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id(buffer.data()),
+                        Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
                         ghost_targets_data[i][0],
                         communication_channel + 1,
                         comm,
@@ -917,16 +917,15 @@ namespace internal
                   data_this[import_indices_data.second[j].first + l];
 
             // send data away
-            const int ierr =
-              MPI_Isend(temporary_storage.data() + import_targets_data[i][1],
-                        import_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id(data_this.data()),
-                        import_targets_data[i][0],
-                        communication_channel + 1,
-                        comm,
-                        requests.data() + sm_import_ranks.size() +
-                          sm_ghost_ranks.size() + ghost_targets_data.size() +
-                          i);
+            const int ierr = MPI_Isend(
+              temporary_storage.data() + import_targets_data[i][1],
+              import_targets_data[i][2],
+              Utilities::MPI::mpi_type_id<decltype(*data_this.data())>,
+              import_targets_data[i][0],
+              communication_channel + 1,
+              comm,
+              requests.data() + sm_import_ranks.size() + sm_ghost_ranks.size() +
+                ghost_targets_data.size() + i);
             AssertThrowMPI(ierr);
           }
 #endif
@@ -1173,7 +1172,7 @@ namespace internal
             const int ierr =
               MPI_Isend(buffer.data() + ghost_targets_data[i][1],
                         ghost_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id(buffer.data()),
+                        Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
                         ghost_targets_data[i][0],
                         communication_channel + 0,
                         comm,
@@ -1184,16 +1183,15 @@ namespace internal
 
         for (unsigned int i = 0; i < import_targets_data.size(); ++i)
           {
-            const int ierr =
-              MPI_Irecv(temporary_storage.data() + import_targets_data[i][1],
-                        import_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id(temporary_storage.data()),
-                        import_targets_data[i][0],
-                        communication_channel + 0,
-                        comm,
-                        requests.data() + sm_ghost_ranks.size() +
-                          sm_import_ranks.size() + ghost_targets_data.size() +
-                          i);
+            const int ierr = MPI_Irecv(
+              temporary_storage.data() + import_targets_data[i][1],
+              import_targets_data[i][2],
+              Utilities::MPI::mpi_type_id<decltype(*temporary_storage.data())>,
+              import_targets_data[i][0],
+              communication_channel + 0,
+              comm,
+              requests.data() + sm_ghost_ranks.size() + sm_import_ranks.size() +
+                ghost_targets_data.size() + i);
             AssertThrowMPI(ierr);
           }
 #endif

--- a/source/matrix_free/vector_data_exchange.cc
+++ b/source/matrix_free/vector_data_exchange.cc
@@ -893,15 +893,15 @@ namespace internal
               n_ghost_indices_in_larger_set_by_remote_rank[i] -
               ghost_targets_data[i][2];
 
-            const int ierr =
-              MPI_Irecv(buffer.data() + ghost_targets_data[i][1] + offset,
-                        ghost_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
-                        ghost_targets_data[i][0],
-                        communication_channel + 1,
-                        comm,
-                        requests.data() + sm_import_ranks.size() +
-                          sm_ghost_ranks.size() + i);
+            const int ierr = MPI_Irecv(
+              buffer.data() + ghost_targets_data[i][1] + offset,
+              ghost_targets_data[i][2],
+              Utilities::MPI::mpi_type_id_for_type<decltype(*buffer.data())>,
+              ghost_targets_data[i][0],
+              communication_channel + 1,
+              comm,
+              requests.data() + sm_import_ranks.size() + sm_ghost_ranks.size() +
+                i);
             AssertThrowMPI(ierr);
           }
 
@@ -920,7 +920,7 @@ namespace internal
             const int ierr = MPI_Isend(
               temporary_storage.data() + import_targets_data[i][1],
               import_targets_data[i][2],
-              Utilities::MPI::mpi_type_id<decltype(*data_this.data())>,
+              Utilities::MPI::mpi_type_id_for_type<decltype(*data_this.data())>,
               import_targets_data[i][0],
               communication_channel + 1,
               comm,
@@ -1169,29 +1169,31 @@ namespace internal
                   }
               }
 
-            const int ierr =
-              MPI_Isend(buffer.data() + ghost_targets_data[i][1],
-                        ghost_targets_data[i][2],
-                        Utilities::MPI::mpi_type_id<decltype(*buffer.data())>,
-                        ghost_targets_data[i][0],
-                        communication_channel + 0,
-                        comm,
-                        requests.data() + sm_ghost_ranks.size() +
-                          sm_import_ranks.size() + i);
+            const int ierr = MPI_Isend(
+              buffer.data() + ghost_targets_data[i][1],
+              ghost_targets_data[i][2],
+              Utilities::MPI::mpi_type_id_for_type<decltype(*buffer.data())>,
+              ghost_targets_data[i][0],
+              communication_channel + 0,
+              comm,
+              requests.data() + sm_ghost_ranks.size() + sm_import_ranks.size() +
+                i);
             AssertThrowMPI(ierr);
           }
 
         for (unsigned int i = 0; i < import_targets_data.size(); ++i)
           {
-            const int ierr = MPI_Irecv(
-              temporary_storage.data() + import_targets_data[i][1],
-              import_targets_data[i][2],
-              Utilities::MPI::mpi_type_id<decltype(*temporary_storage.data())>,
-              import_targets_data[i][0],
-              communication_channel + 0,
-              comm,
-              requests.data() + sm_ghost_ranks.size() + sm_import_ranks.size() +
-                ghost_targets_data.size() + i);
+            const int ierr =
+              MPI_Irecv(temporary_storage.data() + import_targets_data[i][1],
+                        import_targets_data[i][2],
+                        Utilities::MPI::mpi_type_id_for_type<decltype(
+                          *temporary_storage.data())>,
+                        import_targets_data[i][0],
+                        communication_channel + 0,
+                        comm,
+                        requests.data() + sm_ghost_ranks.size() +
+                          sm_import_ranks.size() + ghost_targets_data.size() +
+                          i);
             AssertThrowMPI(ierr);
           }
 #endif

--- a/tests/mpi/mpi_type_id_for_type_01.cc
+++ b/tests/mpi/mpi_type_id_for_type_01.cc
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2022 by the deal.II authors
+//
+// This file is part of the deal.II library.
+//
+// The deal.II library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE.md at
+// the top level directory of deal.II.
+//
+// ---------------------------------------------------------------------
+
+
+
+// Check Utilities::MPI::mpi_type_id_for_type
+
+
+#include <deal.II/base/mpi.h>
+#include <deal.II/base/template_constraints.h>
+
+#include <cstdint>
+
+#include "../tests.h"
+
+
+
+template <typename T>
+using mpi_type_id_for_type_t =
+  decltype(Utilities::MPI::internal::MPIDataTypes::mpi_type_id(
+    &std::declval<const T &>()));
+
+
+template <typename T>
+void
+test(const char *type, MPI_Datatype mpi_type)
+{
+  deallog << std::boolalpha;
+  deallog << "--------- Checking <" << type << "> ---------------" << std::endl;
+  deallog
+    << "T is supported: "
+    << internal::is_supported_operation<mpi_type_id_for_type_t, T> << std::endl;
+  deallog << "T[] is supported: "
+          << internal::is_supported_operation<mpi_type_id_for_type_t,
+                                              T[]> << std::endl;
+  deallog << "T* is supported: "
+          << internal::is_supported_operation<mpi_type_id_for_type_t,
+                                              T *> << std::endl;
+
+  Assert(Utilities::MPI::mpi_type_id_for_type<T> == mpi_type,
+         ExcInternalError());
+}
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  initlog();
+
+  // Go through the entire list of MPI-supported data types:
+#define TEST(a, b) test<a>(#a, b)
+  TEST(signed char, MPI_SIGNED_CHAR);
+  TEST(unsigned char, MPI_UNSIGNED_CHAR);
+  TEST(wchar_t, MPI_WCHAR);
+  TEST(short, MPI_SHORT);
+  TEST(unsigned short, MPI_UNSIGNED_SHORT);
+  TEST(int, MPI_INT);
+  TEST(unsigned int, MPI_UNSIGNED);
+  TEST(long, MPI_LONG);
+  TEST(unsigned long, MPI_UNSIGNED_LONG);
+  TEST(long long, MPI_LONG_LONG_INT);
+  TEST(long long int, MPI_LONG_LONG);
+  TEST(unsigned long long, MPI_UNSIGNED_LONG_LONG);
+  TEST(float, MPI_FLOAT);
+  TEST(double, MPI_DOUBLE);
+  TEST(long double, MPI_LONG_DOUBLE);
+
+  // The following types have their own MPI tags, but these tags are
+  // aliases for some of the types above and consequently are
+  // indistinguishable even though the tags are distinguishable. That
+  // is: while the type system cannot distinguish between 'unsigned
+  // char' and 'uint8_t', the tags 'MPI_SIGNED_CHAR' and 'MPI_INT8_T'
+  // are different. We cannot test, then, that the tag we get for
+  // these types equals their tags...
+
+  // TEST(int8_t, MPI_INT8_T);
+  // TEST(int16_t, MPI_INT16_T);
+  // TEST(int32_t, MPI_INT32_T);
+  // TEST(int64_t, MPI_INT64_T);
+  // TEST(uint8_t, MPI_UINT8_T);
+  // TEST(uint16_t, MPI_UINT16_T);
+  // TEST(uint32_t, MPI_UINT32_T);
+  // TEST(uint64_t, MPI_UINT64_T);
+
+  // Now make sure that the following type is not supported:
+  struct X
+  {};
+
+  using T = X;
+  deallog << "--------- Checking <X> ---------------" << std::endl;
+  deallog
+    << "T is supported: "
+    << internal::is_supported_operation<mpi_type_id_for_type_t, T> << std::endl;
+}

--- a/tests/mpi/mpi_type_id_for_type_01.output
+++ b/tests/mpi/mpi_type_id_for_type_01.output
@@ -1,0 +1,63 @@
+
+DEAL::--------- Checking <signed char> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <unsigned char> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <wchar_t> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <short> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <unsigned short> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <int> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <unsigned int> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <long> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <unsigned long> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <long long> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <long long int> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <unsigned long long> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <float> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <double> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <long double> ---------------
+DEAL::T is supported: true
+DEAL::T[] is supported: false
+DEAL::T* is supported: false
+DEAL::--------- Checking <X> ---------------
+DEAL::T is supported: false

--- a/tests/mpi/renumber_cuthill_mckee.cc
+++ b/tests/mpi/renumber_cuthill_mckee.cc
@@ -119,14 +119,16 @@ test()
           if (myid == i)
             MPI_Send(&renumbering[0],
                      renumbering.size(),
-                     Utilities::MPI::mpi_type_id(&complete_renumbering[0]),
+                     Utilities::MPI::mpi_type_id_for_type<decltype(
+                       complete_renumbering[0])>,
                      0,
                      i,
                      MPI_COMM_WORLD);
           else if (myid == 0)
             MPI_Recv(&complete_renumbering[offset],
                      dofs_per_proc[i].n_elements(),
-                     Utilities::MPI::mpi_type_id(&complete_renumbering[0]),
+                     Utilities::MPI::mpi_type_id_for_type<decltype(
+                       complete_renumbering[0])>,
                      i,
                      i,
                      MPI_COMM_WORLD,

--- a/tests/mpi/renumber_cuthill_mckee_02.cc
+++ b/tests/mpi/renumber_cuthill_mckee_02.cc
@@ -85,14 +85,16 @@ test()
       if (myid == i)
         MPI_Send(&renumbering[0],
                  renumbering.size(),
-                 Utilities::MPI::mpi_type_id(&complete_renumbering[0]),
+                 Utilities::MPI::mpi_type_id_for_type<decltype(
+                   complete_renumbering[0])>,
                  0,
                  i,
                  MPI_COMM_WORLD);
       else if (myid == 0)
         MPI_Recv(&complete_renumbering[offset],
                  locally_owned_dofs_per_processor[i].n_elements(),
-                 Utilities::MPI::mpi_type_id(&complete_renumbering[0]),
+                 Utilities::MPI::mpi_type_id_for_type<decltype(
+                   complete_renumbering[0])>,
                  i,
                  i,
                  MPI_COMM_WORLD,


### PR DESCRIPTION
This fixes #13377. Here are two thoughts:
* It takes more writing where we use it, because we now have to use the `decltype(obj)` in most places, rather than `*obj`. This is probably debatable. I personally like it because it makes it clear that what matters is the *type* of the object, not its *value*. But I would get if others feel differently.
* `Utilities::MPI::mpi_type_id` basically redirects back to the existing mechanism of the dispatch functions I wanted to get rid off. I need one level of indirection because I need to get rid of array, `const`, and reference type components. I wanted to make the `internal::mpi_type_id` things specializations of template variables, rather than specializations/overloads of the template functions we have. But that runs into difficulties because I cannot `=delete` the general template variable declarations. One can do this for template *functions*, which I had just done in #13393. I'm surprised this isn't possible in C++, but apparently that's how it is -- it is currently proposed for some later standard: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2041r1.html
* I could address this last point by simply providing this for the general template:
```
  namespace internal {
    template <typename>
    constexpr MPI_Datatype mpi_type_id;  // note: no initializer
  }
```
In such cases, the compiler will complain that the variable cannot be used to initialize another `constexpr` variable, though with a not very helpful error message. As a consequence, I didn't do this so far -- in some sense, it's an implementation detail that doesn't affect the public interface, and so maybe not such an important question.

/rebuild