### PR TITLE
Improve instruction-level parallelism for precondition_SSOR

### DIFF
--- a/include/deal.II/lac/sparse_matrix.templates.h
+++ b/include/deal.II/lac/sparse_matrix.templates.h
@@ -1501,7 +1501,11 @@ SparseMatrix<number>::precondition_SSOR(
           const size_type first_right_of_diagonal_index =
             pos_right_of_diagonal[row];
           number s = 0;
-          for (size_type j = first_right_of_diagonal_index; j < end_row; ++j)
+          // go through the column from the end towards the diagonal in order
+          // to delay the use of the newly computed "dst" values on
+          // out-of-order-execution hardware
+          for (size_type j = end_row - 1; j >= first_right_of_diagonal_index;
+               --j)
             s += val[j] * number(dst(cols->colnums[j]));
 
           *dst_ptr -= s * omega;


### PR DESCRIPTION
When looking at the performance test step-3, I realized that our implementation in the precondition_SSOR did not really exploit all possible instruction-level parallelism for modern out-of-order processors: Since we are bound to the order of addition, we should start the summation with those values in the `dst` vector that have been computed a long time ago, i.e., the ones with the highest index that come at the end of the row. Once we get close to the diagonal, an out-of-order processor might still be working on one or a few rows before the current one. If I did the tests correctly, this reduces the time for the `timing_step_3 solve` stage from 2.38 seconds to 2.25 seconds on my laptop (AMD Zen2, 4.2 GHz) or from 2.80 to 2.67 seconds on a server (Intel Ice Lake, 3.5 GHz). Not a big change, but still consistently better.