### PR TITLE
Improve indentation in a few tutorials

### DIFF
--- a/examples/step-37/step-37.cc
+++ b/examples/step-37/step-37.cc
@@ -720,29 +720,26 @@ namespace Step37
   // grid, we also need to specifically enable the multigrid hierarchy.
   template <int dim>
   LaplaceProblem<dim>::LaplaceProblem()
-    :
 #ifdef DEAL_II_WITH_P4EST
-    triangulation(
-      MPI_COMM_WORLD,
-      Triangulation<dim>::limit_level_difference_at_vertices,
-      parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy)
-    ,
+    : triangulation(MPI_COMM_WORLD,
+                    Triangulation<dim>::limit_level_difference_at_vertices,
+                    parallel::distributed::Triangulation<
+                      dim>::construct_multigrid_hierarchy)
 #else
-    triangulation(Triangulation<dim>::limit_level_difference_at_vertices)
-    ,
+    : triangulation(Triangulation<dim>::limit_level_difference_at_vertices)
 #endif
-    fe(degree_finite_element)
+    , fe(degree_finite_element)
     , dof_handler(triangulation)
     , setup_time(0.)
     , pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    ,
     // The LaplaceProblem class holds an additional output stream that
     // collects detailed timings about the setup phase. This stream, called
     // time_details, is disabled by default through the @p false argument
     // specified here. For detailed timings, removing the @p false argument
     // prints all the details.
-    time_details(std::cout,
-                 false && Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
+    , time_details(std::cout,
+                   false &&
+                     Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
   {}
 
 

--- a/examples/step-48/step-48.cc
+++ b/examples/step-48/step-48.cc
@@ -345,12 +345,10 @@ namespace Step48
   template <int dim>
   SineGordonProblem<dim>::SineGordonProblem()
     : pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)
-    ,
 #ifdef DEAL_II_WITH_P4EST
-    triangulation(MPI_COMM_WORLD)
-    ,
+    , triangulation(MPI_COMM_WORLD)
 #endif
-    fe(QGaussLobatto<1>(fe_degree + 1))
+    , fe(QGaussLobatto<1>(fe_degree + 1))
     , dof_handler(triangulation)
     , n_global_refinements(10 - 2 * dim)
     , time(-10)

--- a/examples/step-59/step-59.cc
+++ b/examples/step-59/step-59.cc
@@ -949,18 +949,15 @@ namespace Step59
 
   template <int dim, int fe_degree>
   LaplaceProblem<dim, fe_degree>::LaplaceProblem()
-    :
 #ifdef DEAL_II_WITH_P4EST
-    triangulation(
-      MPI_COMM_WORLD,
-      Triangulation<dim>::limit_level_difference_at_vertices,
-      parallel::distributed::Triangulation<dim>::construct_multigrid_hierarchy)
-    ,
+    : triangulation(MPI_COMM_WORLD,
+                    Triangulation<dim>::limit_level_difference_at_vertices,
+                    parallel::distributed::Triangulation<
+                      dim>::construct_multigrid_hierarchy)
 #else
-    triangulation(Triangulation<dim>::limit_level_difference_at_vertices)
-    ,
+    : triangulation(Triangulation<dim>::limit_level_difference_at_vertices)
 #endif
-    fe(fe_degree)
+    , fe(fe_degree)
     , dof_handler(triangulation)
     , setup_time(0.)
     , pcout(std::cout, Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0)


### PR DESCRIPTION
While working on #13405, I realized that there are some ugly code parts that came up when we switched to clang-format indentation.