### PR TITLE
CMake: Do not use "\." in CMake regular expression

### DIFF
--- a/cmake/macros/macro_deal_ii_add_test.cmake
+++ b/cmake/macros/macro_deal_ii_add_test.cmake
@@ -279,12 +279,12 @@ FUNCTION(DEAL_II_ADD_TEST _category _test_name _comparison_file)
   ENDIF()
 
   #
-  # Run CONFIGURE_FILE on every parameter file ending in ".in":
+  # Run CONFIGURE_FILE on every parameter file ending in "in"
   #
 
-  IF("${_source_file}" MATCHES "\.in$")
+  IF("${_source_file}" MATCHES ".in$")
     SET(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
-    STRING(REGEX MATCH "(json|prm)\.in$" _suffix "${_source_file}")
+    STRING(REGEX MATCH "(json|prm).in$" _suffix "${_source_file}")
     STRING(REPLACE ".in" "" _suffix "${_suffix}")
     CONFIGURE_FILE(
       "${_source_file}"


### PR DESCRIPTION
@blaisb *ping*

I have not been able to reproduce the CMake issue but would you mind testing quickly whether this workaround does the trick for you?